### PR TITLE
chore: Refactor parser and generator reuse through module factory cache

### DIFF
--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -115,7 +115,7 @@ pub struct NormalModule {
   /// Layer of the module
   layer: Option<ModuleLayer>,
   /// Affiliated parser and generator to the module type
-  parser_and_generator: Box<dyn ParserAndGenerator>,
+  parser_and_generator: Arc<dyn ParserAndGenerator>,
   /// Resource matched with inline match resource, (`!=!` syntax)
   match_resource: Option<ResourceData>,
   /// Resource data (path, query, fragment etc.)
@@ -178,7 +178,7 @@ impl NormalModule {
     raw_request: String,
     module_type: impl Into<ModuleType>,
     layer: Option<ModuleLayer>,
-    parser_and_generator: Box<dyn ParserAndGenerator>,
+    parser_and_generator: Arc<dyn ParserAndGenerator>,
     parser_options: Option<ParserOptions>,
     generator_options: Option<GeneratorOptions>,
     match_resource: Option<ResourceData>,
@@ -261,10 +261,6 @@ impl NormalModule {
 
   pub fn parser_and_generator(&self) -> &dyn ParserAndGenerator {
     &*self.parser_and_generator
-  }
-
-  pub fn parser_and_generator_mut(&mut self) -> &mut dyn ParserAndGenerator {
-    &mut *self.parser_and_generator
   }
 
   pub fn code_generation_dependencies(&self) -> &Option<Vec<BoxModuleDependency>> {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -1,9 +1,13 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{
+  borrow::Cow,
+  hash::{Hash, Hasher},
+  sync::Arc,
+};
 
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{Loader, Scheme, get_scheme};
-use rspack_util::MergeFrom;
+use rspack_util::{MergeFrom, fx_hash::FxDashMap};
 use sugar_path::SugarPath;
 use winnow::prelude::*;
 
@@ -62,6 +66,7 @@ pub struct NormalModuleFactory {
   options: Arc<CompilerOptions>,
   loader_resolver_factory: Arc<ResolverFactory>,
   plugin_driver: SharedPluginDriver,
+  parser_and_generator_cache: FxDashMap<ParserAndGeneratorCacheKey, Arc<dyn ParserAndGenerator>>,
 }
 
 #[async_trait::async_trait]
@@ -101,6 +106,7 @@ impl NormalModuleFactory {
       options,
       loader_resolver_factory,
       plugin_driver,
+      parser_and_generator_cache: Default::default(),
     }
   }
 
@@ -131,6 +137,42 @@ impl NormalModuleFactory {
         resolve_to_context: false,
         dependency_category: DependencyCategory::CommonJS,
       })
+  }
+
+  async fn get_parser_and_generator(
+    &self,
+    module_type: &ModuleType,
+    parser_options: Option<&ParserOptions>,
+    generator_options: Option<&GeneratorOptions>,
+  ) -> Result<Arc<dyn ParserAndGenerator>> {
+    let cache_key = parser_and_generator_cache_key(module_type, parser_options, generator_options);
+    if let Some(parser_and_generator) = self.parser_and_generator_cache.get(&cache_key) {
+      return Ok(parser_and_generator.clone());
+    }
+
+    let mut parser_and_generator = self
+      .plugin_driver
+      .registered_parser_and_generator_builder
+      .get(module_type)
+      .ok_or_else(|| error!("No parser registered for '{}'", module_type.as_str()))?(
+      parser_options,
+      generator_options,
+    );
+    self
+      .plugin_driver
+      .normal_module_factory_hooks
+      .parser
+      .call(module_type, &mut parser_and_generator, parser_options)
+      .await?;
+
+    let parser_and_generator: Arc<dyn ParserAndGenerator> = parser_and_generator.into();
+    match self.parser_and_generator_cache.entry(cache_key) {
+      dashmap::mapref::entry::Entry::Occupied(entry) => Ok(entry.get().clone()),
+      dashmap::mapref::entry::Entry::Vacant(entry) => {
+        entry.insert(parser_and_generator.clone());
+        Ok(parser_and_generator)
+      }
+    }
   }
 
   async fn resolve_normal_module(
@@ -523,27 +565,11 @@ module.exports = "data:,";
       );
     let resolved_side_effects = self.calculate_side_effects(&resolved_module_rules);
     let resolved_extract_source_map = self.calculate_extract_source_map(&resolved_module_rules);
-    let mut resolved_parser_and_generator = self
-      .plugin_driver
-      .registered_parser_and_generator_builder
-      .get(&resolved_module_type)
-      .ok_or_else(|| {
-        error!(
-          "No parser registered for '{}'",
-          resolved_module_type.as_str()
-        )
-      })?(
-      resolved_parser_options.as_ref(),
-      resolved_generator_options.as_ref(),
-    );
-    self
-      .plugin_driver
-      .normal_module_factory_hooks
-      .parser
-      .call(
+    let resolved_parser_and_generator = self
+      .get_parser_and_generator(
         &resolved_module_type,
-        &mut resolved_parser_and_generator,
         resolved_parser_options.as_ref(),
+        resolved_generator_options.as_ref(),
       )
       .await?;
 
@@ -894,6 +920,31 @@ module.exports = "data:,";
     Err(error!(
       "Failed to factorize module, neither hook nor factorize method returns"
     ))
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParserAndGeneratorCacheKey {
+  module_type: ModuleType,
+  parser_options: Option<ParserOptions>,
+  generator_options: Option<GeneratorOptions>,
+}
+
+impl Hash for ParserAndGeneratorCacheKey {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.module_type.hash(state);
+  }
+}
+
+fn parser_and_generator_cache_key(
+  module_type: &ModuleType,
+  parser_options: Option<&ParserOptions>,
+  generator_options: Option<&GeneratorOptions>,
+) -> ParserAndGeneratorCacheKey {
+  ParserAndGeneratorCacheKey {
+    module_type: *module_type,
+    parser_options: parser_options.cloned(),
+    generator_options: generator_options.cloned(),
   }
 }
 

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -48,7 +48,7 @@ impl ParserOptionsMap {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub enum ParserOptions {
   Asset(AssetParserOptions),
   Css(CssParserOptions),
@@ -90,7 +90,7 @@ impl ParserOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum DynamicImportMode {
   Lazy,
   Weak,
@@ -143,7 +143,7 @@ impl fmt::Display for DynamicImportFetchPriority {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum JavascriptParserUrl {
   Enable,
   Disable,
@@ -163,7 +163,7 @@ impl From<&str> for JavascriptParserUrl {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum JavascriptParserOrder {
   Disable,
   Order(i32),
@@ -209,13 +209,13 @@ impl From<bool> for JavascriptParserCommonjsExportsOption {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct JavascriptParserCommonjsOptions {
   pub exports: JavascriptParserCommonjsExportsOption,
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum ExportPresenceMode {
   None,
   Warn,
@@ -246,7 +246,7 @@ impl ExportPresenceMode {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone, Copy, MergeFrom)]
+#[derive(Debug, Default, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum TypeReexportPresenceMode {
   #[default]
   NoTolerant,
@@ -265,7 +265,7 @@ impl From<&str> for TypeReexportPresenceMode {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum OverrideStrict {
   Strict,
   NoneStrict,
@@ -282,7 +282,7 @@ impl From<&str> for OverrideStrict {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub enum ImportMeta {
   PreserveUnknown,
   Enabled,
@@ -300,7 +300,7 @@ impl From<&str> for ImportMeta {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom, Default)]
+#[derive(Debug, Clone, MergeFrom, Default, PartialEq, Eq)]
 pub struct JavascriptParserOptions {
   pub dynamic_import_mode: Option<DynamicImportMode>,
   pub dynamic_import_preload: Option<JavascriptParserOrder>,
@@ -333,13 +333,13 @@ pub struct JavascriptParserOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct AssetParserOptions {
   pub data_url_condition: Option<AssetParserDataUrl>,
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub enum AssetParserDataUrl {
   Options(AssetParserDataUrlOptions),
   // TODO: Function
@@ -350,6 +350,14 @@ pub enum AssetParserDataUrl {
 pub struct AssetParserDataUrlOptions {
   pub max_size: Option<f64>,
 }
+
+impl PartialEq for AssetParserDataUrlOptions {
+  fn eq(&self, other: &Self) -> bool {
+    self.max_size.map(f64::to_bits) == other.max_size.map(f64::to_bits)
+  }
+}
+
+impl Eq for AssetParserDataUrlOptions {}
 
 /// Context passed to the CSS parser import filter function
 pub struct CssParserImportContext {
@@ -368,6 +376,18 @@ pub enum CssParserImport {
   Bool(bool),
   Func(#[cacheable(with=Unsupported)] CssParserImportFn),
 }
+
+impl PartialEq for CssParserImport {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Self::Bool(a), Self::Bool(b)) => a == b,
+      (Self::Func(a), Self::Func(b)) => Arc::ptr_eq(a, b),
+      _ => false,
+    }
+  }
+}
+
+impl Eq for CssParserImport {}
 
 impl Default for CssParserImport {
   fn default() -> Self {
@@ -400,7 +420,7 @@ impl MergeFrom for CssParserImport {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct CssParserOptions {
   pub named_exports: Option<bool>,
   pub url: Option<bool>,
@@ -408,7 +428,7 @@ pub struct CssParserOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct CssAutoParserOptions {
   pub named_exports: Option<bool>,
   pub url: Option<bool>,
@@ -426,7 +446,7 @@ impl From<CssParserOptions> for CssAutoParserOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct CssModuleParserOptions {
   pub named_exports: Option<bool>,
   pub url: Option<bool>,
@@ -450,6 +470,18 @@ pub enum ParseOption {
   Func(#[cacheable(with=Unsupported)] JsonParseFn),
   None,
 }
+
+impl PartialEq for ParseOption {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Self::Func(a), Self::Func(b)) => Arc::ptr_eq(a, b),
+      (Self::None, Self::None) => true,
+      _ => false,
+    }
+  }
+}
+
+impl Eq for ParseOption {}
 
 impl fmt::Debug for ParseOption {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -476,7 +508,7 @@ impl MergeFrom for ParseOption {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct JsonParserOptions {
   pub exports_depth: Option<u32>,
   pub parse: ParseOption,
@@ -512,7 +544,7 @@ impl GeneratorOptionsMap {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub enum GeneratorOptions {
   Asset(AssetGeneratorOptions),
   AssetInline(AssetInlineGeneratorOptions),
@@ -591,7 +623,7 @@ impl GeneratorOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct AssetInlineGeneratorOptions {
   pub data_url: Option<AssetGeneratorDataUrl>,
   pub binary: Option<bool>,
@@ -607,7 +639,7 @@ impl From<AssetGeneratorOptions> for AssetInlineGeneratorOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 struct AssetGeneratorImportModeFlags(u8);
 bitflags! {
   impl AssetGeneratorImportModeFlags: u8 {
@@ -617,7 +649,7 @@ bitflags! {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub struct AssetGeneratorImportMode(AssetGeneratorImportModeFlags);
 
 impl AssetGeneratorImportMode {
@@ -646,7 +678,7 @@ impl Default for AssetGeneratorImportMode {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Default, MergeFrom)]
+#[derive(Debug, Clone, Default, MergeFrom, PartialEq, Eq)]
 pub struct AssetResourceGeneratorOptions {
   pub emit: Option<bool>,
   pub filename: Option<Filename>,
@@ -670,7 +702,7 @@ impl From<AssetGeneratorOptions> for AssetResourceGeneratorOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Default, MergeFrom)]
+#[derive(Debug, Clone, Default, MergeFrom, PartialEq, Eq)]
 pub struct AssetGeneratorOptions {
   pub emit: Option<bool>,
   pub filename: Option<Filename>,
@@ -697,6 +729,18 @@ pub enum AssetGeneratorDataUrl {
   Func(#[cacheable(with=Unsupported)] AssetGeneratorDataUrlFn),
 }
 
+impl PartialEq for AssetGeneratorDataUrl {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Self::Options(a), Self::Options(b)) => a == b,
+      (Self::Func(a), Self::Func(b)) => Arc::ptr_eq(a, b),
+      _ => false,
+    }
+  }
+}
+
+impl Eq for AssetGeneratorDataUrl {}
+
 impl fmt::Debug for AssetGeneratorDataUrl {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
@@ -722,14 +766,14 @@ impl MergeFrom for AssetGeneratorDataUrl {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom, Hash)]
+#[derive(Debug, Clone, MergeFrom, Hash, PartialEq, Eq)]
 pub struct AssetGeneratorDataUrlOptions {
   pub encoding: Option<DataUrlEncoding>,
   pub mimetype: Option<String>,
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom, Hash)]
+#[derive(Debug, Clone, MergeFrom, Hash, PartialEq, Eq)]
 pub enum DataUrlEncoding {
   None,
   Base64,
@@ -755,14 +799,14 @@ impl From<String> for DataUrlEncoding {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct CssGeneratorOptions {
   pub exports_only: Option<bool>,
   pub es_module: Option<bool>,
 }
 
 #[cacheable]
-#[derive(Default, Debug, Clone, MergeFrom)]
+#[derive(Default, Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct CssAutoGeneratorOptions {
   pub exports_convention: Option<CssExportsConvention>,
   pub exports_only: Option<bool>,
@@ -781,7 +825,7 @@ impl From<CssGeneratorOptions> for CssAutoGeneratorOptions {
 }
 
 #[cacheable]
-#[derive(Default, Debug, Clone, MergeFrom)]
+#[derive(Default, Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct CssModuleGeneratorOptions {
   pub exports_convention: Option<CssExportsConvention>,
   pub exports_only: Option<bool>,
@@ -800,13 +844,13 @@ impl From<CssGeneratorOptions> for CssModuleGeneratorOptions {
 }
 
 #[cacheable]
-#[derive(Default, Debug, Clone, MergeFrom)]
+#[derive(Default, Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct JsonGeneratorOptions {
   pub json_parse: Option<bool>,
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom, PartialEq, Eq)]
 pub struct LocalIdentName {
   pub template: Filename,
 }
@@ -828,7 +872,7 @@ impl From<&str> for LocalIdentName {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ExportsConventionFlags(u8);
 bitflags! {
   impl ExportsConventionFlags: u8 {
@@ -845,7 +889,7 @@ impl MergeFrom for ExportsConventionFlags {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, Copy, MergeFrom, PartialEq, Eq)]
 pub struct CssExportsConvention(ExportsConventionFlags);
 
 impl CssExportsConvention {

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -129,7 +129,7 @@ pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
   fn source_types(&self, module: &dyn Module, module_graph: &ModuleGraph) -> &[SourceType];
   /// Parse the source and return the dependencies and the ast or source
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>>;
   /// Size of the original source

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -428,7 +428,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
   }
 
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: rspack_core::ParseContext<'a>,
   ) -> Result<rspack_error::TWithDiagnosticArray<rspack_core::ParseResult>> {
     let ParseContext {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -111,7 +111,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
   }
 
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>> {
     let ParseContext {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -7,10 +7,11 @@ use regex::Regex;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
-  ChunkGraph, CollectedTypeScriptInfo, Compilation, DependenciesBlock, DependencyId,
-  GenerateContext, Module, ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  ParseContext, ParseResult, ParserAndGenerator, RuntimeGlobals, RuntimeVariable,
-  SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
+  ChunkGraph, CollectedTypeScriptInfo, Compilation, CompilerOptions, DependenciesBlock,
+  DependencyId, GenerateContext, ImportMeta, JavascriptParserCommonjsExportsOption, Module,
+  ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult,
+  ParserAndGenerator, ParserOptions, RuntimeGlobals, RuntimeVariable, SideEffectsBailoutItem,
+  SourceType, TemplateContext, TemplateReplaceSource,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   remove_bom, render_init_fragments,
   rspack_sources::{BoxSource, ReplaceSource, Source, SourceExt},
@@ -28,8 +29,9 @@ use swc_core::{
 };
 
 use crate::{
-  BoxJavascriptParserPlugin,
+  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
   dependency::ESMCompatibilityDependency,
+  parser_plugin,
   visitors::{ScanDependenciesResult, scan_dependencies, semicolon, swc_visitor::resolver},
 };
 
@@ -92,21 +94,155 @@ impl ParserRuntimeRequirementsData {
 #[cacheable]
 #[derive(Default)]
 pub struct JavaScriptParserAndGenerator {
+  // Plugins added by NormalModuleFactoryParser hooks, for example DefinePlugin,
+  // ProvidePlugin, HMR, and ExtractCss. They live on the shared parser/generator
+  // instance and are cloned by Arc for each parse.
   #[cacheable(with=Skip)]
-  parser_plugins: Vec<BoxJavascriptParserPlugin>,
+  hook_parser_plugins: Vec<ArcJavascriptParserPlugin>,
+  // Rspack's built-in JS parser plugins. They are created once with this shared
+  // parser/generator and borrowed by each parse; dynamic per-parse plugins are
+  // still created in JavascriptParser::new.
+  #[cacheable(with=Skip)]
+  builtin_parser_plugins: Vec<BoxJavascriptParserPlugin>,
 }
 
 impl std::fmt::Debug for JavaScriptParserAndGenerator {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("JavaScriptParserAndGenerator")
-      .field("parser_plugins", &"...")
+      .field("hook_parser_plugins", &"...")
+      .field("builtin_parser_plugins", &"...")
       .finish()
   }
 }
 
+#[derive(Clone, Copy)]
+pub struct JavaScriptParserAndGeneratorOptions {
+  amd: bool,
+  node: bool,
+  output_module: bool,
+  inline_exports: bool,
+}
+
+impl From<&CompilerOptions> for JavaScriptParserAndGeneratorOptions {
+  fn from(value: &CompilerOptions) -> Self {
+    Self {
+      amd: value.amd.is_some(),
+      node: value.node.is_some(),
+      output_module: value.output.module,
+      inline_exports: value.optimization.inline_exports,
+    }
+  }
+}
+
 impl JavaScriptParserAndGenerator {
+  pub fn new(
+    module_type: ModuleType,
+    parser_options: Option<&ParserOptions>,
+    options: JavaScriptParserAndGeneratorOptions,
+  ) -> Self {
+    let javascript_options = parser_options
+      .and_then(|p| p.get_javascript())
+      .expect("should at least have a global javascript parser options");
+    let mut builtin_parser_plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(32);
+
+    builtin_parser_plugins.push(Box::new(parser_plugin::InitializeEvaluating));
+    builtin_parser_plugins.push(Box::new(parser_plugin::JavascriptMetaInfoPlugin));
+    builtin_parser_plugins.push(Box::new(parser_plugin::ConstPlugin));
+    builtin_parser_plugins.push(Box::new(parser_plugin::UseStrictPlugin));
+
+    if matches!(module_type, ModuleType::JsAuto | ModuleType::JsDynamic) {
+      builtin_parser_plugins.push(Box::new(
+        parser_plugin::RequireContextDependencyParserPlugin,
+      ));
+      builtin_parser_plugins.push(Box::new(
+        parser_plugin::RequireEnsureDependenciesBlockParserPlugin,
+      ));
+    }
+    builtin_parser_plugins.push(Box::new(parser_plugin::CompatibilityPlugin));
+
+    if module_type.is_js_auto() || module_type.is_js_esm() {
+      builtin_parser_plugins.push(Box::new(parser_plugin::ESMTopLevelThisParserPlugin));
+      builtin_parser_plugins.push(Box::<parser_plugin::ESMDetectionParserPlugin>::default());
+      builtin_parser_plugins.push(Box::new(
+        parser_plugin::ImportMetaContextDependencyParserPlugin,
+      ));
+      if matches!(
+        javascript_options.import_meta,
+        Some(ImportMeta::Enabled | ImportMeta::PreserveUnknown)
+      ) {
+        builtin_parser_plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
+          javascript_options.import_meta.expect("should have value"),
+        )));
+      } else {
+        builtin_parser_plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
+      }
+
+      builtin_parser_plugins.push(Box::new(parser_plugin::ESMImportDependencyParserPlugin));
+      builtin_parser_plugins.push(Box::new(parser_plugin::ESMExportDependencyParserPlugin));
+    }
+
+    if options.amd && (module_type.is_js_auto() || module_type.is_js_dynamic()) {
+      builtin_parser_plugins.push(Box::new(
+        parser_plugin::AMDRequireDependenciesBlockParserPlugin,
+      ));
+      builtin_parser_plugins.push(Box::new(parser_plugin::AMDDefineDependencyParserPlugin));
+      builtin_parser_plugins.push(Box::new(parser_plugin::AMDParserPlugin));
+    }
+
+    if module_type.is_js_auto() || module_type.is_js_dynamic() {
+      builtin_parser_plugins.push(Box::new(parser_plugin::CommonJsImportsParserPlugin));
+      builtin_parser_plugins.push(Box::new(parser_plugin::CommonJsPlugin));
+      let commonjs_exports = javascript_options
+        .commonjs
+        .as_ref()
+        .map_or(JavascriptParserCommonjsExportsOption::Enable, |commonjs| {
+          commonjs.exports
+        });
+      if commonjs_exports != JavascriptParserCommonjsExportsOption::Disable {
+        builtin_parser_plugins.push(Box::new(parser_plugin::CommonJsExportsParserPlugin::new(
+          commonjs_exports == JavascriptParserCommonjsExportsOption::SkipInEsm,
+        )));
+      }
+    }
+
+    // NodeStuffPlugin: handle __dirname/__filename/global (CJS) and import.meta.dirname/filename (ESM)
+    // CJS features require node options; ESM features are always available for ESM-capable modules
+    let handle_cjs = (module_type.is_js_auto() || module_type.is_js_dynamic()) && options.node;
+    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
+    if handle_cjs || handle_esm {
+      builtin_parser_plugins.push(Box::new(parser_plugin::NodeStuffPlugin::new(
+        handle_cjs, handle_esm,
+      )));
+    }
+
+    if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {
+      builtin_parser_plugins.push(Box::new(parser_plugin::IsIncludedPlugin));
+      builtin_parser_plugins.push(Box::new(parser_plugin::ExportsInfoApiPlugin));
+      builtin_parser_plugins.push(Box::new(parser_plugin::APIPlugin::new(
+        options.output_module,
+      )));
+      builtin_parser_plugins.push(Box::new(parser_plugin::ImportParserPlugin));
+      builtin_parser_plugins.push(Box::new(parser_plugin::WorkerPlugin::new(
+        javascript_options
+          .worker
+          .as_ref()
+          .expect("should have worker"),
+      )));
+      builtin_parser_plugins.push(Box::new(parser_plugin::OverrideStrictPlugin));
+    }
+
+    if options.inline_exports {
+      builtin_parser_plugins.push(Box::new(parser_plugin::InlineConstPlugin));
+    }
+
+    Self {
+      hook_parser_plugins: Vec::new(),
+      builtin_parser_plugins,
+    }
+  }
+
   pub fn add_parser_plugin(&mut self, parser_plugin: BoxJavascriptParserPlugin) {
-    self.parser_plugins.push(parser_plugin);
+    self.hook_parser_plugins.push(parser_plugin.into());
   }
 
   fn source_block(
@@ -174,7 +310,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     resource = parse_context.resource_data.resource()
   ))]
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>> {
     let ParseContext {
@@ -305,7 +441,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         module_parser_options,
         &mut semicolons,
         unresolved_mark,
-        &mut self.parser_plugins,
+        &self.hook_parser_plugins,
+        &self.builtin_parser_plugins,
         parse_meta,
         &parser_runtime_requirements,
       )

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -20,7 +20,7 @@ use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnostic
 use rspack_javascript_compiler::JavaScriptCompiler;
 use swc_core::{
   base::config::IsModule,
-  common::{BytePos, comments::SingleThreadedComments, input::SourceFileInput},
+  common::{BytePos, Mark, comments::SingleThreadedComments, input::SourceFileInput},
   ecma::{
     ast,
     parser::{EsSyntax, Syntax, lexer::Lexer},
@@ -101,7 +101,7 @@ pub struct JavaScriptParserAndGenerator {
   hook_parser_plugins: Vec<ArcJavascriptParserPlugin>,
   // Rspack's built-in JS parser plugins. They are created once with this shared
   // parser/generator and borrowed by each parse; dynamic per-parse plugins are
-  // still created in JavascriptParser::new.
+  // created after each SWC parse because they depend on parse-local marks.
   #[cacheable(with=Skip)]
   builtin_parser_plugins: Vec<BoxJavascriptParserPlugin>,
 }
@@ -251,6 +251,30 @@ impl JavaScriptParserAndGenerator {
 
   pub fn builtin_parser_plugins(&self) -> &[BoxJavascriptParserPlugin] {
     &self.builtin_parser_plugins
+  }
+
+  pub fn create_parse_local_parser_plugins(
+    &self,
+    compiler_options: &CompilerOptions,
+    unresolved_mark: Mark,
+  ) -> Vec<BoxJavascriptParserPlugin> {
+    let mut parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(2);
+
+    if compiler_options.optimization.inner_graph {
+      parse_local_parser_plugins.push(Box::new(parser_plugin::InnerGraphParserPlugin::new(
+        unresolved_mark,
+        compiler_options.experiments.pure_functions,
+      )));
+    }
+
+    if compiler_options.optimization.side_effects.is_true() {
+      parse_local_parser_plugins.push(Box::new(parser_plugin::SideEffectsParserPlugin::new(
+        unresolved_mark,
+        compiler_options.experiments.pure_functions,
+      )));
+    }
+
+    parse_local_parser_plugins
   }
 
   fn source_block(
@@ -427,6 +451,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     let unresolved_mark = ast.get_context().unresolved_mark;
     let parser_runtime_requirements = ParserRuntimeRequirementsData::new(runtime_template);
+    let parse_local_parser_plugins =
+      self.create_parse_local_parser_plugins(compiler_options, unresolved_mark);
 
     let ScanDependenciesResult {
       dependencies,
@@ -448,9 +474,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         module_identifier,
         module_parser_options,
         &mut semicolons,
-        unresolved_mark,
         &self.hook_parser_plugins,
         &self.builtin_parser_plugins,
+        parse_local_parser_plugins,
         parse_meta,
         &parser_runtime_requirements,
       )

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -7,11 +7,10 @@ use regex::Regex;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
-  ChunkGraph, CollectedTypeScriptInfo, Compilation, CompilerOptions, DependenciesBlock,
-  DependencyId, GenerateContext, ImportMeta, JavascriptParserCommonjsExportsOption, Module,
-  ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult,
-  ParserAndGenerator, ParserOptions, RuntimeGlobals, RuntimeVariable, SideEffectsBailoutItem,
-  SourceType, TemplateContext, TemplateReplaceSource,
+  ChunkGraph, CollectedTypeScriptInfo, Compilation, DependenciesBlock, DependencyId,
+  GenerateContext, Module, ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType,
+  ParseContext, ParseResult, ParserAndGenerator, RuntimeGlobals, RuntimeVariable,
+  SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   remove_bom, render_init_fragments,
   rspack_sources::{BoxSource, ReplaceSource, Source, SourceExt},
@@ -20,7 +19,7 @@ use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnostic
 use rspack_javascript_compiler::JavaScriptCompiler;
 use swc_core::{
   base::config::IsModule,
-  common::{BytePos, Mark, comments::SingleThreadedComments, input::SourceFileInput},
+  common::{BytePos, comments::SingleThreadedComments, input::SourceFileInput},
   ecma::{
     ast,
     parser::{EsSyntax, Syntax, lexer::Lexer},
@@ -31,7 +30,6 @@ use swc_core::{
 use crate::{
   ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
   dependency::ESMCompatibilityDependency,
-  parser_plugin,
   visitors::{ScanDependenciesResult, scan_dependencies, semicolon, swc_visitor::resolver},
 };
 
@@ -98,183 +96,20 @@ pub struct JavaScriptParserAndGenerator {
   // ProvidePlugin, HMR, and ExtractCss. They live on the shared parser/generator
   // instance and are cloned by Arc for each parse.
   #[cacheable(with=Skip)]
-  hook_parser_plugins: Vec<ArcJavascriptParserPlugin>,
-  // Rspack's built-in JS parser plugins. They are created once with this shared
-  // parser/generator and borrowed by each parse; dynamic per-parse plugins are
-  // created after each SWC parse because they depend on parse-local marks.
-  #[cacheable(with=Skip)]
-  builtin_parser_plugins: Vec<BoxJavascriptParserPlugin>,
+  parser_plugins: Vec<ArcJavascriptParserPlugin>,
 }
 
 impl std::fmt::Debug for JavaScriptParserAndGenerator {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("JavaScriptParserAndGenerator")
-      .field("hook_parser_plugins", &"...")
-      .field("builtin_parser_plugins", &"...")
+      .field("parser_plugins", &"...")
       .finish()
   }
 }
 
-#[derive(Clone, Copy)]
-pub struct JavaScriptParserAndGeneratorOptions {
-  amd: bool,
-  node: bool,
-  output_module: bool,
-  inline_exports: bool,
-}
-
-impl From<&CompilerOptions> for JavaScriptParserAndGeneratorOptions {
-  fn from(value: &CompilerOptions) -> Self {
-    Self {
-      amd: value.amd.is_some(),
-      node: value.node.is_some(),
-      output_module: value.output.module,
-      inline_exports: value.optimization.inline_exports,
-    }
-  }
-}
-
 impl JavaScriptParserAndGenerator {
-  pub fn new(
-    module_type: ModuleType,
-    parser_options: Option<&ParserOptions>,
-    options: JavaScriptParserAndGeneratorOptions,
-  ) -> Self {
-    let javascript_options = parser_options
-      .and_then(|p| p.get_javascript())
-      .expect("should at least have a global javascript parser options");
-    let mut builtin_parser_plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(32);
-
-    builtin_parser_plugins.push(Box::new(parser_plugin::InitializeEvaluating));
-    builtin_parser_plugins.push(Box::new(parser_plugin::JavascriptMetaInfoPlugin));
-    builtin_parser_plugins.push(Box::new(parser_plugin::ConstPlugin));
-    builtin_parser_plugins.push(Box::new(parser_plugin::UseStrictPlugin));
-
-    if matches!(module_type, ModuleType::JsAuto | ModuleType::JsDynamic) {
-      builtin_parser_plugins.push(Box::new(
-        parser_plugin::RequireContextDependencyParserPlugin,
-      ));
-      builtin_parser_plugins.push(Box::new(
-        parser_plugin::RequireEnsureDependenciesBlockParserPlugin,
-      ));
-    }
-    builtin_parser_plugins.push(Box::new(parser_plugin::CompatibilityPlugin));
-
-    if module_type.is_js_auto() || module_type.is_js_esm() {
-      builtin_parser_plugins.push(Box::new(parser_plugin::ESMTopLevelThisParserPlugin));
-      builtin_parser_plugins.push(Box::<parser_plugin::ESMDetectionParserPlugin>::default());
-      builtin_parser_plugins.push(Box::new(
-        parser_plugin::ImportMetaContextDependencyParserPlugin,
-      ));
-      if matches!(
-        javascript_options.import_meta,
-        Some(ImportMeta::Enabled | ImportMeta::PreserveUnknown)
-      ) {
-        builtin_parser_plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
-          javascript_options.import_meta.expect("should have value"),
-        )));
-      } else {
-        builtin_parser_plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
-      }
-
-      builtin_parser_plugins.push(Box::new(parser_plugin::ESMImportDependencyParserPlugin));
-      builtin_parser_plugins.push(Box::new(parser_plugin::ESMExportDependencyParserPlugin));
-    }
-
-    if options.amd && (module_type.is_js_auto() || module_type.is_js_dynamic()) {
-      builtin_parser_plugins.push(Box::new(
-        parser_plugin::AMDRequireDependenciesBlockParserPlugin,
-      ));
-      builtin_parser_plugins.push(Box::new(parser_plugin::AMDDefineDependencyParserPlugin));
-      builtin_parser_plugins.push(Box::new(parser_plugin::AMDParserPlugin));
-    }
-
-    if module_type.is_js_auto() || module_type.is_js_dynamic() {
-      builtin_parser_plugins.push(Box::new(parser_plugin::CommonJsImportsParserPlugin));
-      builtin_parser_plugins.push(Box::new(parser_plugin::CommonJsPlugin));
-      let commonjs_exports = javascript_options
-        .commonjs
-        .as_ref()
-        .map_or(JavascriptParserCommonjsExportsOption::Enable, |commonjs| {
-          commonjs.exports
-        });
-      if commonjs_exports != JavascriptParserCommonjsExportsOption::Disable {
-        builtin_parser_plugins.push(Box::new(parser_plugin::CommonJsExportsParserPlugin::new(
-          commonjs_exports == JavascriptParserCommonjsExportsOption::SkipInEsm,
-        )));
-      }
-    }
-
-    // NodeStuffPlugin: handle __dirname/__filename/global (CJS) and import.meta.dirname/filename (ESM)
-    // CJS features require node options; ESM features are always available for ESM-capable modules
-    let handle_cjs = (module_type.is_js_auto() || module_type.is_js_dynamic()) && options.node;
-    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
-    if handle_cjs || handle_esm {
-      builtin_parser_plugins.push(Box::new(parser_plugin::NodeStuffPlugin::new(
-        handle_cjs, handle_esm,
-      )));
-    }
-
-    if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {
-      builtin_parser_plugins.push(Box::new(parser_plugin::IsIncludedPlugin));
-      builtin_parser_plugins.push(Box::new(parser_plugin::ExportsInfoApiPlugin));
-      builtin_parser_plugins.push(Box::new(parser_plugin::APIPlugin::new(
-        options.output_module,
-      )));
-      builtin_parser_plugins.push(Box::new(parser_plugin::ImportParserPlugin));
-      builtin_parser_plugins.push(Box::new(parser_plugin::WorkerPlugin::new(
-        javascript_options
-          .worker
-          .as_ref()
-          .expect("should have worker"),
-      )));
-      builtin_parser_plugins.push(Box::new(parser_plugin::OverrideStrictPlugin));
-    }
-
-    if options.inline_exports {
-      builtin_parser_plugins.push(Box::new(parser_plugin::InlineConstPlugin));
-    }
-
-    Self {
-      hook_parser_plugins: Vec::new(),
-      builtin_parser_plugins,
-    }
-  }
-
   pub fn add_parser_plugin(&mut self, parser_plugin: BoxJavascriptParserPlugin) {
-    self.hook_parser_plugins.push(parser_plugin.into());
-  }
-
-  pub fn hook_parser_plugins(&self) -> &[ArcJavascriptParserPlugin] {
-    &self.hook_parser_plugins
-  }
-
-  pub fn builtin_parser_plugins(&self) -> &[BoxJavascriptParserPlugin] {
-    &self.builtin_parser_plugins
-  }
-
-  pub fn create_parse_local_parser_plugins(
-    &self,
-    compiler_options: &CompilerOptions,
-    unresolved_mark: Mark,
-  ) -> Vec<BoxJavascriptParserPlugin> {
-    let mut parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(2);
-
-    if compiler_options.optimization.inner_graph {
-      parse_local_parser_plugins.push(Box::new(parser_plugin::InnerGraphParserPlugin::new(
-        unresolved_mark,
-        compiler_options.experiments.pure_functions,
-      )));
-    }
-
-    if compiler_options.optimization.side_effects.is_true() {
-      parse_local_parser_plugins.push(Box::new(parser_plugin::SideEffectsParserPlugin::new(
-        unresolved_mark,
-        compiler_options.experiments.pure_functions,
-      )));
-    }
-
-    parse_local_parser_plugins
+    self.parser_plugins.push(parser_plugin.into());
   }
 
   fn source_block(
@@ -459,9 +294,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       mut warning_diagnostics,
       mut side_effects_item,
     } = match ast.visit(|program, _| {
-      let parse_local_parser_plugins =
-        self.create_parse_local_parser_plugins(compiler_options, unresolved_mark);
-
       scan_dependencies(
         &source_string,
         program,
@@ -475,9 +307,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         module_identifier,
         module_parser_options,
         &mut semicolons,
-        &self.hook_parser_plugins,
-        &self.builtin_parser_plugins,
-        parse_local_parser_plugins,
+        unresolved_mark,
+        &self.parser_plugins,
         parse_meta,
         &parser_runtime_requirements,
       )

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -451,8 +451,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     let unresolved_mark = ast.get_context().unresolved_mark;
     let parser_runtime_requirements = ParserRuntimeRequirementsData::new(runtime_template);
-    let parse_local_parser_plugins =
-      self.create_parse_local_parser_plugins(compiler_options, unresolved_mark);
 
     let ScanDependenciesResult {
       dependencies,
@@ -461,6 +459,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       mut warning_diagnostics,
       mut side_effects_item,
     } = match ast.visit(|program, _| {
+      let parse_local_parser_plugins =
+        self.create_parse_local_parser_plugins(compiler_options, unresolved_mark);
+
       scan_dependencies(
         &source_string,
         program,

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -245,6 +245,14 @@ impl JavaScriptParserAndGenerator {
     self.hook_parser_plugins.push(parser_plugin.into());
   }
 
+  pub fn hook_parser_plugins(&self) -> &[ArcJavascriptParserPlugin] {
+    &self.hook_parser_plugins
+  }
+
+  pub fn builtin_parser_plugins(&self) -> &[BoxJavascriptParserPlugin] {
+    &self.builtin_parser_plugins
+  }
+
   fn source_block(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -23,36 +23,34 @@ use crate::{
 
 const PLUGIN_BITMASK_BITS: usize = u64::BITS as usize;
 
-enum JavaScriptParserPluginItem<'a> {
+pub(crate) enum JavaScriptParserPluginItem {
   Shared(ArcJavascriptParserPlugin),
-  BorrowedBuiltin(&'a (dyn JavascriptParserPlugin + Send + Sync)),
   Owned(BoxJavascriptParserPlugin),
 }
 
-impl JavaScriptParserPluginItem<'_> {
+impl JavaScriptParserPluginItem {
   #[inline]
   fn as_plugin(&self) -> &(dyn JavascriptParserPlugin + Send + Sync) {
     match self {
       Self::Shared(plugin) => plugin.as_ref(),
-      Self::BorrowedBuiltin(plugin) => *plugin,
       Self::Owned(plugin) => plugin.as_ref(),
     }
   }
 }
 
-pub struct JavaScriptParserPluginDrive<'a> {
-  plugins: Vec<JavaScriptParserPluginItem<'a>>,
+pub struct JavaScriptParserPluginDrive {
+  plugins: Vec<JavaScriptParserPluginItem>,
   // Each bit stores whether the plugin at the same index implements the hook.
   // This keeps hook dispatch allocation-free for the common case while preserving plugin order.
   plugins_by_hook: [u64; JavascriptParserPluginHook::COUNT],
 }
 
-struct PluginBitmaskIter<'a, 'plugin> {
-  plugins: &'a [JavaScriptParserPluginItem<'plugin>],
+struct PluginBitmaskIter<'a> {
+  plugins: &'a [JavaScriptParserPluginItem],
   plugin_bitmask: u64,
 }
 
-impl<'a, 'plugin> Iterator for PluginBitmaskIter<'a, 'plugin> {
+impl<'a> Iterator for PluginBitmaskIter<'a> {
   type Item = &'a (dyn JavascriptParserPlugin + Send + Sync);
 
   fn next(&mut self) -> Option<Self::Item> {
@@ -66,35 +64,8 @@ impl<'a, 'plugin> Iterator for PluginBitmaskIter<'a, 'plugin> {
   }
 }
 
-impl<'plugin> JavaScriptParserPluginDrive<'plugin> {
-  pub fn new(
-    hook_parser_plugins: &[ArcJavascriptParserPlugin],
-    builtin_parser_plugins: &'plugin [BoxJavascriptParserPlugin],
-    parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin>,
-  ) -> Self {
-    // Merge the three plugin sources into one ordered drive:
-    // - hook_parser_plugins: added by external hooks and shared by Arc.
-    // - builtin_parser_plugins: built into the shared parser/generator and borrowed here.
-    // - parse_local_parser_plugins: created per parse because they depend on parse-local state.
-    let mut plugins = Vec::with_capacity(
-      hook_parser_plugins.len() + builtin_parser_plugins.len() + parse_local_parser_plugins.len(),
-    );
-    plugins.extend(
-      hook_parser_plugins
-        .iter()
-        .cloned()
-        .map(JavaScriptParserPluginItem::Shared),
-    );
-    plugins.extend(
-      builtin_parser_plugins
-        .iter()
-        .map(|plugin| JavaScriptParserPluginItem::BorrowedBuiltin(plugin.as_ref())),
-    );
-    plugins.extend(
-      parse_local_parser_plugins
-        .into_iter()
-        .map(JavaScriptParserPluginItem::Owned),
-    );
+impl JavaScriptParserPluginDrive {
+  pub fn new(plugins: Vec<JavaScriptParserPluginItem>) -> Self {
     assert!(
       plugins.len() <= PLUGIN_BITMASK_BITS,
       "JavaScript parser plugin bitmask supports at most {PLUGIN_BITMASK_BITS} parser plugins"
@@ -121,7 +92,7 @@ impl<'plugin> JavaScriptParserPluginDrive<'plugin> {
   }
 
   #[inline]
-  fn plugins_for(&self, hook: JavascriptParserPluginHook) -> PluginBitmaskIter<'_, 'plugin> {
+  fn plugins_for(&self, hook: JavascriptParserPluginHook) -> PluginBitmaskIter<'_> {
     let hook_idx = hook as usize;
     PluginBitmaskIter {
       plugins: &self.plugins,
@@ -130,7 +101,7 @@ impl<'plugin> JavaScriptParserPluginDrive<'plugin> {
   }
 }
 
-impl JavascriptParserPlugin for JavaScriptParserPluginDrive<'_> {
+impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn top_level_await_expr(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -7,7 +7,10 @@ use swc_core::{
   },
 };
 
-use super::{BoxJavascriptParserPlugin, JavascriptParserPlugin, JavascriptParserPluginHook};
+use super::{
+  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin, JavascriptParserPlugin,
+  JavascriptParserPluginHook,
+};
 use crate::{
   parser_plugin::r#const::is_logic_op,
   utils::eval::BasicEvaluatedExpression,
@@ -20,34 +23,76 @@ use crate::{
 
 const PLUGIN_BITMASK_BITS: usize = u64::BITS as usize;
 
-pub struct JavaScriptParserPluginDrive {
-  plugins: Vec<BoxJavascriptParserPlugin>,
+enum JavaScriptParserPluginItem<'a> {
+  Shared(ArcJavascriptParserPlugin),
+  BorrowedBuiltin(&'a (dyn JavascriptParserPlugin + Send + Sync)),
+}
+
+impl JavaScriptParserPluginItem<'_> {
+  #[inline]
+  fn as_plugin(&self) -> &(dyn JavascriptParserPlugin + Send + Sync) {
+    match self {
+      Self::Shared(plugin) => plugin.as_ref(),
+      Self::BorrowedBuiltin(plugin) => *plugin,
+    }
+  }
+}
+
+pub struct JavaScriptParserPluginDrive<'a> {
+  plugins: Vec<JavaScriptParserPluginItem<'a>>,
   // Each bit stores whether the plugin at the same index implements the hook.
   // This keeps hook dispatch allocation-free for the common case while preserving plugin order.
   plugins_by_hook: [u64; JavascriptParserPluginHook::COUNT],
 }
 
-struct PluginBitmaskIter<'a> {
-  plugins: &'a [BoxJavascriptParserPlugin],
+struct PluginBitmaskIter<'a, 'plugin> {
+  plugins: &'a [JavaScriptParserPluginItem<'plugin>],
   plugin_bitmask: u64,
 }
 
-impl<'a> Iterator for PluginBitmaskIter<'a> {
-  type Item = &'a BoxJavascriptParserPlugin;
+impl<'a, 'plugin> Iterator for PluginBitmaskIter<'a, 'plugin> {
+  type Item = &'a (dyn JavascriptParserPlugin + Send + Sync);
 
   fn next(&mut self) -> Option<Self::Item> {
     if self.plugin_bitmask != 0 {
       let idx = self.plugin_bitmask.trailing_zeros() as usize;
       self.plugin_bitmask &= self.plugin_bitmask - 1;
-      return Some(unsafe { self.plugins.get_unchecked(idx) });
+      return Some(unsafe { self.plugins.get_unchecked(idx) }.as_plugin());
     }
 
     None
   }
 }
 
-impl JavaScriptParserPluginDrive {
-  pub fn new(plugins: Vec<BoxJavascriptParserPlugin>) -> Self {
+impl<'plugin> JavaScriptParserPluginDrive<'plugin> {
+  pub fn new(
+    hook_parser_plugins: &[ArcJavascriptParserPlugin],
+    builtin_parser_plugins: &'plugin [BoxJavascriptParserPlugin],
+    parse_local_parser_plugins: Vec<ArcJavascriptParserPlugin>,
+  ) -> Self {
+    // Merge the three plugin sources into one ordered drive:
+    // - hook_parser_plugins: added by external hooks and shared by Arc.
+    // - builtin_parser_plugins: built into the shared parser/generator and borrowed here.
+    // - parse_local_parser_plugins: created per parse because they depend on parse-local state.
+    let mut plugins = Vec::with_capacity(
+      hook_parser_plugins.len() + builtin_parser_plugins.len() + parse_local_parser_plugins.len(),
+    );
+    plugins.extend(
+      hook_parser_plugins
+        .iter()
+        .cloned()
+        .map(JavaScriptParserPluginItem::Shared),
+    );
+    plugins.extend(
+      builtin_parser_plugins
+        .iter()
+        .map(|plugin| JavaScriptParserPluginItem::BorrowedBuiltin(plugin.as_ref())),
+    );
+    plugins.extend(
+      parse_local_parser_plugins
+        .into_iter()
+        .map(JavaScriptParserPluginItem::Shared),
+    );
     assert!(
       plugins.len() <= PLUGIN_BITMASK_BITS,
       "JavaScript parser plugin bitmask supports at most {PLUGIN_BITMASK_BITS} parser plugins"
@@ -57,7 +102,7 @@ impl JavaScriptParserPluginDrive {
 
     for (idx, plugin) in plugins.iter().enumerate() {
       let plugin_bit = 1u64 << idx;
-      let mut implemented_hooks = plugin.implemented_hooks().bits();
+      let mut implemented_hooks = plugin.as_plugin().implemented_hooks().bits();
 
       while implemented_hooks != 0 {
         let hook_idx = implemented_hooks.trailing_zeros() as usize;
@@ -74,7 +119,7 @@ impl JavaScriptParserPluginDrive {
   }
 
   #[inline]
-  fn plugins_for(&self, hook: JavascriptParserPluginHook) -> PluginBitmaskIter<'_> {
+  fn plugins_for(&self, hook: JavascriptParserPluginHook) -> PluginBitmaskIter<'_, 'plugin> {
     let hook_idx = hook as usize;
     PluginBitmaskIter {
       plugins: &self.plugins,
@@ -83,7 +128,7 @@ impl JavaScriptParserPluginDrive {
   }
 }
 
-impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
+impl JavascriptParserPlugin for JavaScriptParserPluginDrive<'_> {
   fn top_level_await_expr(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -26,6 +26,7 @@ const PLUGIN_BITMASK_BITS: usize = u64::BITS as usize;
 enum JavaScriptParserPluginItem<'a> {
   Shared(ArcJavascriptParserPlugin),
   BorrowedBuiltin(&'a (dyn JavascriptParserPlugin + Send + Sync)),
+  Owned(BoxJavascriptParserPlugin),
 }
 
 impl JavaScriptParserPluginItem<'_> {
@@ -34,6 +35,7 @@ impl JavaScriptParserPluginItem<'_> {
     match self {
       Self::Shared(plugin) => plugin.as_ref(),
       Self::BorrowedBuiltin(plugin) => *plugin,
+      Self::Owned(plugin) => plugin.as_ref(),
     }
   }
 }
@@ -68,7 +70,7 @@ impl<'plugin> JavaScriptParserPluginDrive<'plugin> {
   pub fn new(
     hook_parser_plugins: &[ArcJavascriptParserPlugin],
     builtin_parser_plugins: &'plugin [BoxJavascriptParserPlugin],
-    parse_local_parser_plugins: Vec<ArcJavascriptParserPlugin>,
+    parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin>,
   ) -> Self {
     // Merge the three plugin sources into one ordered drive:
     // - hook_parser_plugins: added by external hooks and shared by Arc.
@@ -91,7 +93,7 @@ impl<'plugin> JavaScriptParserPluginDrive<'plugin> {
     plugins.extend(
       parse_local_parser_plugins
         .into_iter()
-        .map(JavaScriptParserPluginItem::Shared),
+        .map(JavaScriptParserPluginItem::Owned),
     );
     assert!(
       plugins.len() <= PLUGIN_BITMASK_BITS,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -34,8 +34,8 @@ pub mod provide_plugin;
 pub mod side_effects_parser_plugin;
 
 pub use self::r#trait::{
-  BoxJavascriptParserPlugin, JavascriptParserPlugin, JavascriptParserPluginHook,
-  JavascriptParserPluginHooks,
+  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin, JavascriptParserPlugin,
+  JavascriptParserPluginHook, JavascriptParserPluginHooks,
 };
 pub(crate) use self::{
   amd::{

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use self::{
   common_js_plugin::CommonJsPlugin,
   compatibility_plugin::CompatibilityPlugin,
   r#const::{ConstPlugin, is_logic_op},
-  drive::JavaScriptParserPluginDrive,
+  drive::{JavaScriptParserPluginDrive, JavaScriptParserPluginItem},
   esm_detection_parser_plugin::ESMDetectionParserPlugin,
   esm_export_dependency_parser_plugin::ESMExportDependencyParserPlugin,
   esm_import_dependency_parser_plugin::ESMImportDependencyParserPlugin,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use swc_core::{
   atoms::Atom,
   common::Span,
@@ -674,3 +676,4 @@ Please annotate your `impl JavascriptParserPlugin for ...` block with `#[rspack_
 }
 
 pub type BoxJavascriptParserPlugin = Box<dyn JavascriptParserPlugin + Send + Sync>;
+pub type ArcJavascriptParserPlugin = Arc<dyn JavascriptParserPlugin + Send + Sync>;

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -46,7 +46,7 @@ use crate::{
     local_module_dependency::LocalModuleDependencyTemplate,
     unsupported_dependency::UnsupportedDependencyTemplate,
   },
-  parser_and_generator::{JavaScriptParserAndGenerator, JavaScriptParserAndGeneratorOptions},
+  parser_and_generator::JavaScriptParserAndGenerator,
 };
 
 #[plugin_hook(CompilerCompilation for JsPlugin)]
@@ -646,34 +646,14 @@ impl Plugin for JsPlugin {
       .render_manifest
       .tap(render_manifest::new(self));
 
-    let parser_and_generator_options =
-      JavaScriptParserAndGeneratorOptions::from(ctx.compiler_options);
     ctx.register_parser_and_generator_builder(ModuleType::JsAuto, {
-      Box::new(move |parser_options, _| {
-        Box::new(JavaScriptParserAndGenerator::new(
-          ModuleType::JsAuto,
-          parser_options,
-          parser_and_generator_options,
-        )) as Box<dyn ParserAndGenerator>
-      })
+      Box::new(|_, _| Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>)
     });
     ctx.register_parser_and_generator_builder(ModuleType::JsEsm, {
-      Box::new(move |parser_options, _| {
-        Box::new(JavaScriptParserAndGenerator::new(
-          ModuleType::JsEsm,
-          parser_options,
-          parser_and_generator_options,
-        )) as Box<dyn ParserAndGenerator>
-      })
+      Box::new(|_, _| Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>)
     });
     ctx.register_parser_and_generator_builder(ModuleType::JsDynamic, {
-      Box::new(move |parser_options, _| {
-        Box::new(JavaScriptParserAndGenerator::new(
-          ModuleType::JsDynamic,
-          parser_options,
-          parser_and_generator_options,
-        )) as Box<dyn ParserAndGenerator>
-      })
+      Box::new(|_, _| Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>)
     });
 
     Ok(())

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -46,7 +46,7 @@ use crate::{
     local_module_dependency::LocalModuleDependencyTemplate,
     unsupported_dependency::UnsupportedDependencyTemplate,
   },
-  parser_and_generator::JavaScriptParserAndGenerator,
+  parser_and_generator::{JavaScriptParserAndGenerator, JavaScriptParserAndGeneratorOptions},
 };
 
 #[plugin_hook(CompilerCompilation for JsPlugin)]
@@ -646,19 +646,33 @@ impl Plugin for JsPlugin {
       .render_manifest
       .tap(render_manifest::new(self));
 
+    let parser_and_generator_options =
+      JavaScriptParserAndGeneratorOptions::from(ctx.compiler_options);
     ctx.register_parser_and_generator_builder(ModuleType::JsAuto, {
-      Box::new(move |_, _| {
-        Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>
+      Box::new(move |parser_options, _| {
+        Box::new(JavaScriptParserAndGenerator::new(
+          ModuleType::JsAuto,
+          parser_options,
+          parser_and_generator_options,
+        )) as Box<dyn ParserAndGenerator>
       })
     });
     ctx.register_parser_and_generator_builder(ModuleType::JsEsm, {
-      Box::new(move |_, _| {
-        Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>
+      Box::new(move |parser_options, _| {
+        Box::new(JavaScriptParserAndGenerator::new(
+          ModuleType::JsEsm,
+          parser_options,
+          parser_and_generator_options,
+        )) as Box<dyn ParserAndGenerator>
       })
     });
     ctx.register_parser_and_generator_builder(ModuleType::JsDynamic, {
-      Box::new(move |_, _| {
-        Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>
+      Box::new(move |parser_options, _| {
+        Box::new(JavaScriptParserAndGenerator::new(
+          ModuleType::JsDynamic,
+          parser_options,
+          parser_and_generator_options,
+        )) as Box<dyn ParserAndGenerator>
       })
     });
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -22,7 +22,10 @@ pub use self::{
   },
   util::*,
 };
-use crate::{BoxJavascriptParserPlugin, parser_and_generator::ParserRuntimeRequirementsData};
+use crate::{
+  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
+  parser_and_generator::ParserRuntimeRequirementsData,
+};
 
 pub struct ScanDependenciesResult {
   pub dependencies: Vec<BoxDependency>,
@@ -47,7 +50,8 @@ pub fn scan_dependencies(
   module_parser_options: Option<&ParserOptions>,
   semicolons: &mut FxHashSet<BytePos>,
   unresolved_mark: Mark,
-  parser_plugins: &mut Vec<BoxJavascriptParserPlugin>,
+  hook_parser_plugins: &[ArcJavascriptParserPlugin],
+  builtin_parser_plugins: &[BoxJavascriptParserPlugin],
   parse_meta: ParseMeta,
   parser_runtime_requirements: &ParserRuntimeRequirementsData,
 ) -> Result<ScanDependenciesResult, Vec<Diagnostic>> {
@@ -67,7 +71,8 @@ pub fn scan_dependencies(
     build_info,
     semicolons,
     unresolved_mark,
-    parser_plugins,
+    hook_parser_plugins,
+    builtin_parser_plugins,
     parse_meta,
     parser_runtime_requirements,
   );

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -10,7 +10,7 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_javascript_compiler::ast::Program;
 use rustc_hash::FxHashSet;
-use swc_core::common::{BytePos, Mark, comments::Comments};
+use swc_core::common::{BytePos, comments::Comments};
 
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
@@ -49,9 +49,9 @@ pub fn scan_dependencies(
   module_identifier: ModuleIdentifier,
   module_parser_options: Option<&ParserOptions>,
   semicolons: &mut FxHashSet<BytePos>,
-  unresolved_mark: Mark,
   hook_parser_plugins: &[ArcJavascriptParserPlugin],
   builtin_parser_plugins: &[BoxJavascriptParserPlugin],
+  parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin>,
   parse_meta: ParseMeta,
   parser_runtime_requirements: &ParserRuntimeRequirementsData,
 ) -> Result<ScanDependenciesResult, Vec<Diagnostic>> {
@@ -70,9 +70,9 @@ pub fn scan_dependencies(
     build_meta,
     build_info,
     semicolons,
-    unresolved_mark,
     hook_parser_plugins,
     builtin_parser_plugins,
+    parse_local_parser_plugins,
     parse_meta,
     parser_runtime_requirements,
   );

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -10,7 +10,7 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_javascript_compiler::ast::Program;
 use rustc_hash::FxHashSet;
-use swc_core::common::{BytePos, comments::Comments};
+use swc_core::common::{BytePos, Mark, comments::Comments};
 
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
@@ -22,10 +22,7 @@ pub use self::{
   },
   util::*,
 };
-use crate::{
-  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
-  parser_and_generator::ParserRuntimeRequirementsData,
-};
+use crate::{ArcJavascriptParserPlugin, parser_and_generator::ParserRuntimeRequirementsData};
 
 pub struct ScanDependenciesResult {
   pub dependencies: Vec<BoxDependency>,
@@ -49,9 +46,8 @@ pub fn scan_dependencies(
   module_identifier: ModuleIdentifier,
   module_parser_options: Option<&ParserOptions>,
   semicolons: &mut FxHashSet<BytePos>,
-  hook_parser_plugins: &[ArcJavascriptParserPlugin],
-  builtin_parser_plugins: &[BoxJavascriptParserPlugin],
-  parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin>,
+  unresolved_mark: Mark,
+  parser_plugins: &[ArcJavascriptParserPlugin],
   parse_meta: ParseMeta,
   parser_runtime_requirements: &ParserRuntimeRequirementsData,
 ) -> Result<ScanDependenciesResult, Vec<Diagnostic>> {
@@ -70,9 +66,8 @@ pub fn scan_dependencies(
     build_meta,
     build_info,
     semicolons,
-    hook_parser_plugins,
-    builtin_parser_plugins,
-    parse_local_parser_plugins,
+    unresolved_mark,
+    parser_plugins,
     parse_meta,
     parser_runtime_requirements,
   );

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -12,6 +12,7 @@ use std::{
   fmt::Display,
   hash::{Hash, Hasher},
   rc::Rc,
+  sync::Arc,
 };
 
 use bitflags::bitflags;
@@ -22,9 +23,9 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
-  JavascriptParserCommonjsExportsOption, JavascriptParserOptions, ModuleIdentifier, ModuleLayer,
-  ModuleType, ParseMeta, ResourceData, SideEffectsBailoutItemWithSpan,
+  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta, JavascriptParserOptions,
+  ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResourceData,
+  SideEffectsBailoutItemWithSpan,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_util::{SpanExt, fx_hash::FxIndexSet};
@@ -44,7 +45,7 @@ use swc_core::{
 };
 
 use crate::{
-  BoxJavascriptParserPlugin,
+  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
   dependency::local_module::LocalModule,
   parser_and_generator::ParserRuntimeRequirementsData,
   parser_plugin::{
@@ -360,7 +361,7 @@ pub struct JavascriptParser<'parser> {
   pub module_type: &'parser ModuleType,
   pub(crate) module_layer: Option<&'parser ModuleLayer>,
   pub module_identifier: &'parser ModuleIdentifier,
-  pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive>,
+  pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive<'parser>>,
   // ===== states =======
   pub(crate) definitions_db: ScopeInfoDB,
   pub(crate) definitions: ScopeInfoId,
@@ -406,7 +407,8 @@ impl<'parser> JavascriptParser<'parser> {
     build_info: &'parser mut BuildInfo,
     semicolons: &'parser mut FxHashSet<BytePos>,
     unresolved_mark: Mark,
-    parser_plugins: &'parser mut Vec<BoxJavascriptParserPlugin>,
+    hook_parser_plugins: &'parser [ArcJavascriptParserPlugin],
+    builtin_parser_plugins: &'parser [BoxJavascriptParserPlugin],
     parse_meta: ParseMeta,
     parser_runtime_requirements: &'parser ParserRuntimeRequirementsData,
   ) -> Self {
@@ -417,116 +419,30 @@ impl<'parser> JavascriptParser<'parser> {
     let presentational_dependencies = Vec::with_capacity(64);
     let parser_exports_state: Option<bool> = None;
 
-    let mut plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(32 + parser_plugins.len());
-
-    plugins.append(parser_plugins);
-
-    plugins.push(Box::new(parser_plugin::InitializeEvaluating));
-    plugins.push(Box::new(parser_plugin::JavascriptMetaInfoPlugin));
-    plugins.push(Box::new(parser_plugin::ConstPlugin));
-    plugins.push(Box::new(parser_plugin::UseStrictPlugin));
-
-    if matches!(module_type, ModuleType::JsAuto | ModuleType::JsDynamic) {
-      plugins.push(Box::new(
-        parser_plugin::RequireContextDependencyParserPlugin,
-      ));
-      plugins.push(Box::new(
-        parser_plugin::RequireEnsureDependenciesBlockParserPlugin,
-      ));
-    }
-    plugins.push(Box::new(parser_plugin::CompatibilityPlugin));
-
-    if module_type.is_js_auto() || module_type.is_js_esm() {
-      plugins.push(Box::new(parser_plugin::ESMTopLevelThisParserPlugin));
-      plugins.push(Box::<parser_plugin::ESMDetectionParserPlugin>::default());
-      plugins.push(Box::new(
-        parser_plugin::ImportMetaContextDependencyParserPlugin,
-      ));
-      if matches!(
-        javascript_options.import_meta,
-        Some(ImportMeta::Enabled | ImportMeta::PreserveUnknown)
-      ) {
-        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
-          javascript_options.import_meta.expect("should have value"),
-        )));
-      } else {
-        plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
-      }
-
-      plugins.push(Box::new(parser_plugin::ESMImportDependencyParserPlugin));
-      plugins.push(Box::new(parser_plugin::ESMExportDependencyParserPlugin));
-    }
-
-    if compiler_options.amd.is_some() && (module_type.is_js_auto() || module_type.is_js_dynamic()) {
-      plugins.push(Box::new(
-        parser_plugin::AMDRequireDependenciesBlockParserPlugin,
-      ));
-      plugins.push(Box::new(parser_plugin::AMDDefineDependencyParserPlugin));
-      plugins.push(Box::new(parser_plugin::AMDParserPlugin));
-    }
-
-    if module_type.is_js_auto() || module_type.is_js_dynamic() {
-      plugins.push(Box::new(parser_plugin::CommonJsImportsParserPlugin));
-      plugins.push(Box::new(parser_plugin::CommonJsPlugin));
-      let commonjs_exports = javascript_options
-        .commonjs
-        .as_ref()
-        .map_or(JavascriptParserCommonjsExportsOption::Enable, |commonjs| {
-          commonjs.exports
-        });
-      if commonjs_exports != JavascriptParserCommonjsExportsOption::Disable {
-        plugins.push(Box::new(parser_plugin::CommonJsExportsParserPlugin::new(
-          commonjs_exports == JavascriptParserCommonjsExportsOption::SkipInEsm,
-        )));
-      }
-    }
-
-    // NodeStuffPlugin: handle __dirname/__filename/global (CJS) and import.meta.dirname/filename (ESM)
-    // CJS features require node options; ESM features are always available for ESM-capable modules
-    let handle_cjs =
-      (module_type.is_js_auto() || module_type.is_js_dynamic()) && compiler_options.node.is_some();
-    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
-    if handle_cjs || handle_esm {
-      plugins.push(Box::new(parser_plugin::NodeStuffPlugin::new(
-        handle_cjs, handle_esm,
-      )));
-    }
-
-    if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {
-      plugins.push(Box::new(parser_plugin::IsIncludedPlugin));
-      plugins.push(Box::new(parser_plugin::ExportsInfoApiPlugin));
-      plugins.push(Box::new(parser_plugin::APIPlugin::new(
-        compiler_options.output.module,
-      )));
-      plugins.push(Box::new(parser_plugin::ImportParserPlugin));
-      plugins.push(Box::new(parser_plugin::WorkerPlugin::new(
-        javascript_options
-          .worker
-          .as_ref()
-          .expect("should have worker"),
-      )));
-      plugins.push(Box::new(parser_plugin::OverrideStrictPlugin));
-    }
+    let mut parse_local_parser_plugins: Vec<ArcJavascriptParserPlugin> = Vec::with_capacity(2);
 
     if compiler_options.optimization.inline_exports {
       build_info.inline_exports = true;
-      plugins.push(Box::new(parser_plugin::InlineConstPlugin));
     }
     if compiler_options.optimization.inner_graph {
-      plugins.push(Box::new(parser_plugin::InnerGraphParserPlugin::new(
+      parse_local_parser_plugins.push(Arc::new(parser_plugin::InnerGraphParserPlugin::new(
         unresolved_mark,
         compiler_options.experiments.pure_functions,
       )));
     }
 
     if compiler_options.optimization.side_effects.is_true() {
-      plugins.push(Box::new(parser_plugin::SideEffectsParserPlugin::new(
+      parse_local_parser_plugins.push(Arc::new(parser_plugin::SideEffectsParserPlugin::new(
         unresolved_mark,
         compiler_options.experiments.pure_functions,
       )));
     }
 
-    let plugin_drive = Rc::new(JavaScriptParserPluginDrive::new(plugins));
+    let plugin_drive = Rc::new(JavaScriptParserPluginDrive::new(
+      hook_parser_plugins,
+      builtin_parser_plugins,
+      parse_local_parser_plugins,
+    ));
     let mut db = ScopeInfoDB::new();
 
     Self {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -22,9 +22,9 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta, JavascriptParserOptions,
-  ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResourceData,
-  SideEffectsBailoutItemWithSpan,
+  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
+  JavascriptParserCommonjsExportsOption, JavascriptParserOptions, ModuleIdentifier, ModuleLayer,
+  ModuleType, ParseMeta, ResourceData, SideEffectsBailoutItemWithSpan,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_util::{SpanExt, fx_hash::FxIndexSet};
@@ -32,7 +32,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
   atoms::Atom,
-  common::{BytePos, Span, Spanned, comments::Comments},
+  common::{BytePos, Mark, Span, Spanned, comments::Comments},
   ecma::{
     ast::{
       ArrayPat, AssignPat, AssignTargetPat, CallExpr, Decl, Expr, Ident, Lit, MemberExpr,
@@ -44,12 +44,13 @@ use swc_core::{
 };
 
 use crate::{
-  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
+  ArcJavascriptParserPlugin,
   dependency::local_module::LocalModule,
   parser_and_generator::ParserRuntimeRequirementsData,
   parser_plugin::{
-    ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
-    JavascriptParserPlugin, RequireReferencesState, inner_graph::state::InnerGraphState,
+    self, ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
+    JavaScriptParserPluginItem, JavascriptParserPlugin, RequireReferencesState,
+    inner_graph::state::InnerGraphState,
   },
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{
@@ -360,7 +361,7 @@ pub struct JavascriptParser<'parser> {
   pub module_type: &'parser ModuleType,
   pub(crate) module_layer: Option<&'parser ModuleLayer>,
   pub module_identifier: &'parser ModuleIdentifier,
-  pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive<'parser>>,
+  pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive>,
   // ===== states =======
   pub(crate) definitions_db: ScopeInfoDB,
   pub(crate) definitions: ScopeInfoId,
@@ -405,9 +406,8 @@ impl<'parser> JavascriptParser<'parser> {
     build_meta: &'parser mut BuildMeta,
     build_info: &'parser mut BuildInfo,
     semicolons: &'parser mut FxHashSet<BytePos>,
-    hook_parser_plugins: &'parser [ArcJavascriptParserPlugin],
-    builtin_parser_plugins: &'parser [BoxJavascriptParserPlugin],
-    parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin>,
+    unresolved_mark: Mark,
+    parser_plugins: &'parser [ArcJavascriptParserPlugin],
     parse_meta: ParseMeta,
     parser_runtime_requirements: &'parser ParserRuntimeRequirementsData,
   ) -> Self {
@@ -418,15 +418,168 @@ impl<'parser> JavascriptParser<'parser> {
     let presentational_dependencies = Vec::with_capacity(64);
     let parser_exports_state: Option<bool> = None;
 
-    if compiler_options.optimization.inline_exports {
-      build_info.inline_exports = true;
+    let mut plugins: Vec<JavaScriptParserPluginItem> =
+      Vec::with_capacity(32 + parser_plugins.len());
+    plugins.extend(
+      parser_plugins
+        .iter()
+        .cloned()
+        .map(JavaScriptParserPluginItem::Shared),
+    );
+    plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+      parser_plugin::InitializeEvaluating,
+    )));
+    plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+      parser_plugin::JavascriptMetaInfoPlugin,
+    )));
+    plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+      parser_plugin::ConstPlugin,
+    )));
+    plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+      parser_plugin::UseStrictPlugin,
+    )));
+
+    if matches!(module_type, ModuleType::JsAuto | ModuleType::JsDynamic) {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::RequireContextDependencyParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::RequireEnsureDependenciesBlockParserPlugin,
+      )));
+    }
+    plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+      parser_plugin::CompatibilityPlugin,
+    )));
+
+    if module_type.is_js_auto() || module_type.is_js_esm() {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::ESMTopLevelThisParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::<
+        parser_plugin::ESMDetectionParserPlugin,
+      >::default()));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::ImportMetaContextDependencyParserPlugin,
+      )));
+      if matches!(
+        javascript_options.import_meta,
+        Some(ImportMeta::Enabled | ImportMeta::PreserveUnknown)
+      ) {
+        plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+          parser_plugin::ImportMetaPlugin(
+            javascript_options.import_meta.expect("should have value"),
+          ),
+        )));
+      } else {
+        plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+          parser_plugin::ImportMetaDisabledPlugin,
+        )));
+      }
+
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::ESMImportDependencyParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::ESMExportDependencyParserPlugin,
+      )));
     }
 
-    let plugin_drive = Rc::new(JavaScriptParserPluginDrive::new(
-      hook_parser_plugins,
-      builtin_parser_plugins,
-      parse_local_parser_plugins,
-    ));
+    if compiler_options.amd.is_some() && (module_type.is_js_auto() || module_type.is_js_dynamic()) {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::AMDRequireDependenciesBlockParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::AMDDefineDependencyParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::AMDParserPlugin,
+      )));
+    }
+
+    if module_type.is_js_auto() || module_type.is_js_dynamic() {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::CommonJsImportsParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::CommonJsPlugin,
+      )));
+      let commonjs_exports = javascript_options
+        .commonjs
+        .as_ref()
+        .map_or(JavascriptParserCommonjsExportsOption::Enable, |commonjs| {
+          commonjs.exports
+        });
+      if commonjs_exports != JavascriptParserCommonjsExportsOption::Disable {
+        plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+          parser_plugin::CommonJsExportsParserPlugin::new(
+            commonjs_exports == JavascriptParserCommonjsExportsOption::SkipInEsm,
+          ),
+        )));
+      }
+    }
+
+    // NodeStuffPlugin: handle __dirname/__filename/global (CJS) and import.meta.dirname/filename (ESM)
+    // CJS features require node options; ESM features are always available for ESM-capable modules
+    let handle_cjs =
+      (module_type.is_js_auto() || module_type.is_js_dynamic()) && compiler_options.node.is_some();
+    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
+    if handle_cjs || handle_esm {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::NodeStuffPlugin::new(handle_cjs, handle_esm),
+      )));
+    }
+
+    if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::IsIncludedPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::ExportsInfoApiPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::APIPlugin::new(compiler_options.output.module),
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::ImportParserPlugin,
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::WorkerPlugin::new(
+          javascript_options
+            .worker
+            .as_ref()
+            .expect("should have worker"),
+        ),
+      )));
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::OverrideStrictPlugin,
+      )));
+    }
+
+    if compiler_options.optimization.inline_exports {
+      build_info.inline_exports = true;
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::InlineConstPlugin,
+      )));
+    }
+    if compiler_options.optimization.inner_graph {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::InnerGraphParserPlugin::new(
+          unresolved_mark,
+          compiler_options.experiments.pure_functions,
+        ),
+      )));
+    }
+
+    if compiler_options.optimization.side_effects.is_true() {
+      plugins.push(JavaScriptParserPluginItem::Owned(Box::new(
+        parser_plugin::SideEffectsParserPlugin::new(
+          unresolved_mark,
+          compiler_options.experiments.pure_functions,
+        ),
+      )));
+    }
+
+    let plugin_drive = Rc::new(JavaScriptParserPluginDrive::new(plugins));
     let mut db = ScopeInfoDB::new();
 
     Self {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -12,7 +12,6 @@ use std::{
   fmt::Display,
   hash::{Hash, Hasher},
   rc::Rc,
-  sync::Arc,
 };
 
 use bitflags::bitflags;
@@ -33,7 +32,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
   atoms::Atom,
-  common::{BytePos, Mark, Span, Spanned, comments::Comments},
+  common::{BytePos, Span, Spanned, comments::Comments},
   ecma::{
     ast::{
       ArrayPat, AssignPat, AssignTargetPat, CallExpr, Decl, Expr, Ident, Lit, MemberExpr,
@@ -49,7 +48,7 @@ use crate::{
   dependency::local_module::LocalModule,
   parser_and_generator::ParserRuntimeRequirementsData,
   parser_plugin::{
-    self, ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
+    ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
     JavascriptParserPlugin, RequireReferencesState, inner_graph::state::InnerGraphState,
   },
   utils::eval::{self, BasicEvaluatedExpression},
@@ -406,9 +405,9 @@ impl<'parser> JavascriptParser<'parser> {
     build_meta: &'parser mut BuildMeta,
     build_info: &'parser mut BuildInfo,
     semicolons: &'parser mut FxHashSet<BytePos>,
-    unresolved_mark: Mark,
     hook_parser_plugins: &'parser [ArcJavascriptParserPlugin],
     builtin_parser_plugins: &'parser [BoxJavascriptParserPlugin],
+    parse_local_parser_plugins: Vec<BoxJavascriptParserPlugin>,
     parse_meta: ParseMeta,
     parser_runtime_requirements: &'parser ParserRuntimeRequirementsData,
   ) -> Self {
@@ -419,23 +418,8 @@ impl<'parser> JavascriptParser<'parser> {
     let presentational_dependencies = Vec::with_capacity(64);
     let parser_exports_state: Option<bool> = None;
 
-    let mut parse_local_parser_plugins: Vec<ArcJavascriptParserPlugin> = Vec::with_capacity(2);
-
     if compiler_options.optimization.inline_exports {
       build_info.inline_exports = true;
-    }
-    if compiler_options.optimization.inner_graph {
-      parse_local_parser_plugins.push(Arc::new(parser_plugin::InnerGraphParserPlugin::new(
-        unresolved_mark,
-        compiler_options.experiments.pure_functions,
-      )));
-    }
-
-    if compiler_options.optimization.side_effects.is_true() {
-      parse_local_parser_plugins.push(Arc::new(parser_plugin::SideEffectsParserPlugin::new(
-        unresolved_mark,
-        compiler_options.experiments.pure_functions,
-      )));
     }
 
     let plugin_drive = Rc::new(JavaScriptParserPluginDrive::new(

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -50,7 +50,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
   }
 
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: rspack_core::ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<rspack_core::ParseResult>> {
     let rspack_core::ParseContext {

--- a/crates/rspack_plugin_rslib/src/asset.rs
+++ b/crates/rspack_plugin_rslib/src/asset.rs
@@ -45,7 +45,7 @@ impl ParserAndGenerator for RslibAssetParserAndGenerator {
   }
 
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>> {
     self.0.parse(parse_context).await

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -37,7 +37,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
   }
 
   async fn parse<'a>(
-    &mut self,
+    &self,
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>> {
     parse_context.build_info.strict = true;

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -62,6 +62,7 @@ struct PreparedScanDependenciesBenchmarkCase {
   module_type: ModuleType,
   resource_data: ResourceData,
   unresolved_mark: Mark,
+  globals: Globals,
   parser_and_generator: JavaScriptParserAndGenerator,
   parser_runtime_requirements: ParserRuntimeRequirementsData,
 }
@@ -69,6 +70,7 @@ struct PreparedScanDependenciesBenchmarkCase {
 struct PreparedScanDependenciesProgram {
   program: Program,
   unresolved_mark: Mark,
+  globals: Globals,
   semicolons: FxHashSet<BytePos>,
 }
 
@@ -155,6 +157,7 @@ fn prepare_scan_dependencies_benchmark_case(
   let PreparedScanDependenciesProgram {
     program,
     unresolved_mark,
+    globals,
     semicolons,
   } = parse_benchmark_program(resource_path, &source_text, &module_type);
   let compiler_options = compiler.options.clone();
@@ -183,6 +186,7 @@ fn prepare_scan_dependencies_benchmark_case(
     module_type,
     resource_data: ResourceData::new_with_resource(resource_path.to_string()),
     unresolved_mark,
+    globals,
     parser_and_generator,
     parser_runtime_requirements: ParserRuntimeRequirementsData::new(&ModuleCodeTemplate::new(
       compiler_options,
@@ -244,9 +248,11 @@ fn parse_benchmark_program(
 
   let (program, unresolved_mark) =
     ast.visit(|program, context| (program.clone(), context.unresolved_mark));
+  let globals = ast.get_context().globals.clone_data();
   PreparedScanDependenciesProgram {
     program,
     unresolved_mark,
+    globals,
     semicolons,
   }
 }
@@ -271,35 +277,38 @@ impl PreparedScanDependenciesBenchmarkCase {
     &self,
     iteration_state: &mut ScanDependenciesIterationState,
   ) -> ScanDependenciesResult {
-    let parse_local_parser_plugins = self
-      .parser_and_generator
-      .create_parse_local_parser_plugins(self.compiler_options.as_ref(), self.unresolved_mark);
+    GLOBALS
+      .set(&self.globals, || {
+        let parse_local_parser_plugins = self
+          .parser_and_generator
+          .create_parse_local_parser_plugins(self.compiler_options.as_ref(), self.unresolved_mark);
 
-    run_scan_dependencies(
-      &self.source_text,
-      &self.program,
-      &self.resource_data,
-      self.compiler_options.as_ref(),
-      &self.module_type,
-      None,
-      None,
-      &mut iteration_state.build_meta,
-      &mut iteration_state.build_info,
-      self.module_identifier,
-      Some(&self.parser_options),
-      &mut iteration_state.semicolons,
-      self.parser_and_generator.hook_parser_plugins(),
-      self.parser_and_generator.builtin_parser_plugins(),
-      parse_local_parser_plugins,
-      std::mem::take(&mut iteration_state.parse_meta),
-      &self.parser_runtime_requirements,
-    )
-    .unwrap_or_else(|diagnostics| {
-      panic!(
-        "{} should execute without scan errors. Diagnostics: {diagnostics:#?}",
-        self.benchmark_id
-      )
-    })
+        run_scan_dependencies(
+          &self.source_text,
+          &self.program,
+          &self.resource_data,
+          self.compiler_options.as_ref(),
+          &self.module_type,
+          None,
+          None,
+          &mut iteration_state.build_meta,
+          &mut iteration_state.build_info,
+          self.module_identifier,
+          Some(&self.parser_options),
+          &mut iteration_state.semicolons,
+          self.parser_and_generator.hook_parser_plugins(),
+          self.parser_and_generator.builtin_parser_plugins(),
+          parse_local_parser_plugins,
+          std::mem::take(&mut iteration_state.parse_meta),
+          &self.parser_runtime_requirements,
+        )
+      })
+      .unwrap_or_else(|diagnostics| {
+        panic!(
+          "{} should execute without scan errors. Diagnostics: {diagnostics:#?}",
+          self.benchmark_id
+        )
+      })
   }
 
   fn assert_can_execute(&self) {

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -16,7 +16,7 @@ use rspack_core::{
 };
 use rspack_javascript_compiler::{JavaScriptCompiler, ast::Program};
 use rspack_plugin_javascript::{
-  BoxJavascriptParserPlugin,
+  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
   parser_and_generator::ParserRuntimeRequirementsData,
   visitors::{
     ScanDependenciesResult, scan_dependencies as run_scan_dependencies,
@@ -74,7 +74,8 @@ struct ScanDependenciesIterationState {
   build_meta: BuildMeta,
   build_info: BuildInfo,
   semicolons: FxHashSet<BytePos>,
-  parser_plugins: Vec<BoxJavascriptParserPlugin>,
+  hook_parser_plugins: Vec<ArcJavascriptParserPlugin>,
+  builtin_parser_plugins: Vec<BoxJavascriptParserPlugin>,
   parse_meta: ParseMeta,
 }
 
@@ -277,7 +278,8 @@ impl PreparedScanDependenciesBenchmarkCase {
       Some(&self.parser_options),
       &mut iteration_state.semicolons,
       self.unresolved_mark,
-      &mut iteration_state.parser_plugins,
+      &iteration_state.hook_parser_plugins,
+      &iteration_state.builtin_parser_plugins,
       std::mem::take(&mut iteration_state.parse_meta),
       &self.parser_runtime_requirements,
     )

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -16,10 +16,8 @@ use rspack_core::{
 };
 use rspack_javascript_compiler::{JavaScriptCompiler, ast::Program};
 use rspack_plugin_javascript::{
-  parser_and_generator::{
-    JavaScriptParserAndGenerator, JavaScriptParserAndGeneratorOptions,
-    ParserRuntimeRequirementsData,
-  },
+  ArcJavascriptParserPlugin,
+  parser_and_generator::ParserRuntimeRequirementsData,
   visitors::{
     ScanDependenciesResult, scan_dependencies as run_scan_dependencies,
     semicolon::InsertedSemicolons, swc_visitor::resolver,
@@ -62,15 +60,12 @@ struct PreparedScanDependenciesBenchmarkCase {
   module_type: ModuleType,
   resource_data: ResourceData,
   unresolved_mark: Mark,
-  globals: Globals,
-  parser_and_generator: JavaScriptParserAndGenerator,
   parser_runtime_requirements: ParserRuntimeRequirementsData,
 }
 
 struct PreparedScanDependenciesProgram {
   program: Program,
   unresolved_mark: Mark,
-  globals: Globals,
   semicolons: FxHashSet<BytePos>,
 }
 
@@ -79,6 +74,7 @@ struct ScanDependenciesIterationState {
   build_meta: BuildMeta,
   build_info: BuildInfo,
   semicolons: FxHashSet<BytePos>,
+  parser_plugins: Vec<ArcJavascriptParserPlugin>,
   parse_meta: ParseMeta,
 }
 
@@ -157,7 +153,6 @@ fn prepare_scan_dependencies_benchmark_case(
   let PreparedScanDependenciesProgram {
     program,
     unresolved_mark,
-    globals,
     semicolons,
   } = parse_benchmark_program(resource_path, &source_text, &module_type);
   let compiler_options = compiler.options.clone();
@@ -169,11 +164,6 @@ fn prepare_scan_dependencies_benchmark_case(
     .and_then(|parser_map| parser_map.get("javascript"))
     .cloned()
     .expect("scan_dependencies benchmark compiler should include javascript parser options");
-  let parser_and_generator = JavaScriptParserAndGenerator::new(
-    module_type.clone(),
-    Some(&parser_options),
-    JavaScriptParserAndGeneratorOptions::from(compiler_options.as_ref()),
-  );
 
   PreparedScanDependenciesBenchmarkCase {
     benchmark_id,
@@ -186,8 +176,6 @@ fn prepare_scan_dependencies_benchmark_case(
     module_type,
     resource_data: ResourceData::new_with_resource(resource_path.to_string()),
     unresolved_mark,
-    globals,
-    parser_and_generator,
     parser_runtime_requirements: ParserRuntimeRequirementsData::new(&ModuleCodeTemplate::new(
       compiler_options,
     )),
@@ -248,11 +236,9 @@ fn parse_benchmark_program(
 
   let (program, unresolved_mark) =
     ast.visit(|program, context| (program.clone(), context.unresolved_mark));
-  let globals = ast.get_context().globals.clone_data();
   PreparedScanDependenciesProgram {
     program,
     unresolved_mark,
-    globals,
     semicolons,
   }
 }
@@ -277,38 +263,30 @@ impl PreparedScanDependenciesBenchmarkCase {
     &self,
     iteration_state: &mut ScanDependenciesIterationState,
   ) -> ScanDependenciesResult {
-    GLOBALS
-      .set(&self.globals, || {
-        let parse_local_parser_plugins = self
-          .parser_and_generator
-          .create_parse_local_parser_plugins(self.compiler_options.as_ref(), self.unresolved_mark);
-
-        run_scan_dependencies(
-          &self.source_text,
-          &self.program,
-          &self.resource_data,
-          self.compiler_options.as_ref(),
-          &self.module_type,
-          None,
-          None,
-          &mut iteration_state.build_meta,
-          &mut iteration_state.build_info,
-          self.module_identifier,
-          Some(&self.parser_options),
-          &mut iteration_state.semicolons,
-          self.parser_and_generator.hook_parser_plugins(),
-          self.parser_and_generator.builtin_parser_plugins(),
-          parse_local_parser_plugins,
-          std::mem::take(&mut iteration_state.parse_meta),
-          &self.parser_runtime_requirements,
-        )
-      })
-      .unwrap_or_else(|diagnostics| {
-        panic!(
-          "{} should execute without scan errors. Diagnostics: {diagnostics:#?}",
-          self.benchmark_id
-        )
-      })
+    run_scan_dependencies(
+      &self.source_text,
+      &self.program,
+      &self.resource_data,
+      self.compiler_options.as_ref(),
+      &self.module_type,
+      None,
+      None,
+      &mut iteration_state.build_meta,
+      &mut iteration_state.build_info,
+      self.module_identifier,
+      Some(&self.parser_options),
+      &mut iteration_state.semicolons,
+      self.unresolved_mark,
+      &iteration_state.parser_plugins,
+      std::mem::take(&mut iteration_state.parse_meta),
+      &self.parser_runtime_requirements,
+    )
+    .unwrap_or_else(|diagnostics| {
+      panic!(
+        "{} should execute without scan errors. Diagnostics: {diagnostics:#?}",
+        self.benchmark_id
+      )
+    })
   }
 
   fn assert_can_execute(&self) {

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -16,8 +16,10 @@ use rspack_core::{
 };
 use rspack_javascript_compiler::{JavaScriptCompiler, ast::Program};
 use rspack_plugin_javascript::{
-  ArcJavascriptParserPlugin, BoxJavascriptParserPlugin,
-  parser_and_generator::ParserRuntimeRequirementsData,
+  parser_and_generator::{
+    JavaScriptParserAndGenerator, JavaScriptParserAndGeneratorOptions,
+    ParserRuntimeRequirementsData,
+  },
   visitors::{
     ScanDependenciesResult, scan_dependencies as run_scan_dependencies,
     semicolon::InsertedSemicolons, swc_visitor::resolver,
@@ -60,6 +62,7 @@ struct PreparedScanDependenciesBenchmarkCase {
   module_type: ModuleType,
   resource_data: ResourceData,
   unresolved_mark: Mark,
+  parser_and_generator: JavaScriptParserAndGenerator,
   parser_runtime_requirements: ParserRuntimeRequirementsData,
 }
 
@@ -74,8 +77,6 @@ struct ScanDependenciesIterationState {
   build_meta: BuildMeta,
   build_info: BuildInfo,
   semicolons: FxHashSet<BytePos>,
-  hook_parser_plugins: Vec<ArcJavascriptParserPlugin>,
-  builtin_parser_plugins: Vec<BoxJavascriptParserPlugin>,
   parse_meta: ParseMeta,
 }
 
@@ -165,6 +166,11 @@ fn prepare_scan_dependencies_benchmark_case(
     .and_then(|parser_map| parser_map.get("javascript"))
     .cloned()
     .expect("scan_dependencies benchmark compiler should include javascript parser options");
+  let parser_and_generator = JavaScriptParserAndGenerator::new(
+    module_type.clone(),
+    Some(&parser_options),
+    JavaScriptParserAndGeneratorOptions::from(compiler_options.as_ref()),
+  );
 
   PreparedScanDependenciesBenchmarkCase {
     benchmark_id,
@@ -177,6 +183,7 @@ fn prepare_scan_dependencies_benchmark_case(
     module_type,
     resource_data: ResourceData::new_with_resource(resource_path.to_string()),
     unresolved_mark,
+    parser_and_generator,
     parser_runtime_requirements: ParserRuntimeRequirementsData::new(&ModuleCodeTemplate::new(
       compiler_options,
     )),
@@ -278,8 +285,8 @@ impl PreparedScanDependenciesBenchmarkCase {
       Some(&self.parser_options),
       &mut iteration_state.semicolons,
       self.unresolved_mark,
-      &iteration_state.hook_parser_plugins,
-      &iteration_state.builtin_parser_plugins,
+      self.parser_and_generator.hook_parser_plugins(),
+      self.parser_and_generator.builtin_parser_plugins(),
       std::mem::take(&mut iteration_state.parse_meta),
       &self.parser_runtime_requirements,
     )

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -271,6 +271,10 @@ impl PreparedScanDependenciesBenchmarkCase {
     &self,
     iteration_state: &mut ScanDependenciesIterationState,
   ) -> ScanDependenciesResult {
+    let parse_local_parser_plugins = self
+      .parser_and_generator
+      .create_parse_local_parser_plugins(self.compiler_options.as_ref(), self.unresolved_mark);
+
     run_scan_dependencies(
       &self.source_text,
       &self.program,
@@ -284,9 +288,9 @@ impl PreparedScanDependenciesBenchmarkCase {
       self.module_identifier,
       Some(&self.parser_options),
       &mut iteration_state.semicolons,
-      self.unresolved_mark,
       self.parser_and_generator.hook_parser_plugins(),
       self.parser_and_generator.builtin_parser_plugins(),
+      parse_local_parser_plugins,
       std::mem::take(&mut iteration_state.parse_meta),
       &self.parser_runtime_requirements,
     )


### PR DESCRIPTION
## Summary
- Cache `parser_and_generator` instances in `NormalModuleFactory` so modules with the same type and options can share them.
- Switch `ParserAndGenerator::parse` to shared access and store modules with `Arc<dyn ParserAndGenerator>`.
- Adjust JavaScript parser plugin plumbing to borrow shared plugin state instead of consuming it during parse.

## Testing
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p rspack_core -p rspack_plugin_javascript -p rspack_plugin_asset -p rspack_plugin_css -p rspack_plugin_json -p rspack_plugin_wasm -p rspack_plugin_rslib`