### PR TITLE
refactor: Remove loaders from NormalModule persistent cache

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -51,6 +51,14 @@ impl Task<TaskContext> for AddTask {
       .module_graph_module_by_identifier(&module_identifier)
       .is_some()
     {
+      if let Some(new_normal_module) = self.module.as_normal_module()
+        && let Some(old_normal_module) = module_graph
+          .module_by_identifier_mut(&module_identifier)
+          .and_then(|module| module.as_normal_module_mut())
+      {
+        old_normal_module.set_loaders(new_normal_module.loaders().to_vec());
+      }
+
       set_resolved_module(
         module_graph,
         self.original_module_identifier,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -10,7 +10,7 @@ use std::{
 use derive_more::Debug;
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
-  with::{As, AsOption, AsPreset},
+  with::{As, AsOption, AsPreset, Skip},
 };
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result, error};
@@ -122,6 +122,7 @@ pub struct NormalModule {
   resource_data: Arc<ResourceData>,
   /// Loaders for the module
   #[debug(skip)]
+  #[cacheable(with=Skip)]
   loaders: Vec<BoxLoader>,
 
   /// Built source of this module (passed with loaders)
@@ -257,6 +258,10 @@ impl NormalModule {
 
   pub fn loaders(&self) -> &[BoxLoader] {
     &self.loaders
+  }
+
+  pub fn set_loaders(&mut self, loaders: Vec<BoxLoader>) {
+    self.loaders = loaders;
   }
 
   pub fn parser_and_generator(&self) -> &dyn ParserAndGenerator {


### PR DESCRIPTION
## Summary
- Skip `NormalModule.loaders` during persistent cache serialization
- Restore loaders from the freshly factorized module when a cached module is reused
- Add a setter on `NormalModule` to support loader refresh

## Testing
- `cargo fmt --package rspack_core`
- `cargo check -p rspack_core`