### PR TITLE
fix: exports info update hash should stable

### DIFF
--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -146,7 +146,11 @@ impl ModuleGraphCacheArtifactInner {
     }
   }
 
-  pub fn cached_module_graph_hash<F: FnOnce() -> u64>(&self, key: ModuleIdentifier, f: F) -> u64 {
+  pub fn cached_module_graph_hash<F: FnOnce() -> u64>(
+    &self,
+    key: ModuleGraphHashCacheKey,
+    f: F,
+  ) -> u64 {
     if !self.freezed.load(Ordering::Acquire) {
       return f();
     }
@@ -163,13 +167,15 @@ impl ModuleGraphCacheArtifactInner {
 }
 
 pub(super) mod module_graph_hash {
-  use rspack_collections::IdentifierDashMap;
+  use rspack_util::fx_hash::FxDashMap;
 
-  use crate::ModuleIdentifier;
+  use crate::{ModuleIdentifier, RuntimeKey};
+
+  pub type ModuleGraphHashCacheKey = (ModuleIdentifier, Option<RuntimeKey>);
 
   #[derive(Debug, Default)]
   pub struct ModuleGraphHashCache {
-    cache: IdentifierDashMap<u64>,
+    cache: FxDashMap<ModuleGraphHashCacheKey, u64>,
   }
 
   impl ModuleGraphHashCache {
@@ -177,11 +183,11 @@ pub(super) mod module_graph_hash {
       self.cache.clear();
     }
 
-    pub fn get(&self, key: &ModuleIdentifier) -> Option<u64> {
+    pub fn get(&self, key: &ModuleGraphHashCacheKey) -> Option<u64> {
       self.cache.get(key).map(|v| *v.value())
     }
 
-    pub fn set(&self, key: ModuleIdentifier, value: u64) {
+    pub fn set(&self, key: ModuleGraphHashCacheKey, value: u64) {
       self.cache.insert(key, value);
     }
   }

--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -14,8 +14,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::atoms::Atom;
 
 use crate::{
-  ConcatenationEntry, ConnectionState, DependencyId, ExportInfo, ExportsInfo, ExportsType,
-  ModuleIdentifier, RuntimeKey,
+  ConcatenationEntry, ConnectionState, DependencyId, ExportInfo, ExportsType, ModuleIdentifier,
+  RuntimeKey,
 };
 pub type ModuleGraphCacheArtifact = Arc<ModuleGraphCacheArtifactInner>;
 
@@ -146,11 +146,7 @@ impl ModuleGraphCacheArtifactInner {
     }
   }
 
-  pub fn cached_module_graph_hash<F: FnOnce() -> (u64, ExportsInfo, Vec<ExportsInfo>)>(
-    &self,
-    key: ModuleIdentifier,
-    f: F,
-  ) -> (u64, ExportsInfo, Vec<ExportsInfo>) {
+  pub fn cached_module_graph_hash<F: FnOnce() -> u64>(&self, key: ModuleIdentifier, f: F) -> u64 {
     if !self.freezed.load(Ordering::Acquire) {
       return f();
     }
@@ -159,7 +155,7 @@ impl ModuleGraphCacheArtifactInner {
       Some(value) => value,
       None => {
         let value = f();
-        self.module_graph_hash_cache.set(key, value.clone());
+        self.module_graph_hash_cache.set(key, value);
         value
       }
     }
@@ -169,11 +165,11 @@ impl ModuleGraphCacheArtifactInner {
 pub(super) mod module_graph_hash {
   use rspack_collections::IdentifierDashMap;
 
-  use crate::{ExportsInfo, ModuleIdentifier};
+  use crate::ModuleIdentifier;
 
   #[derive(Debug, Default)]
   pub struct ModuleGraphHashCache {
-    cache: IdentifierDashMap<(u64, ExportsInfo, Vec<ExportsInfo>)>,
+    cache: IdentifierDashMap<u64>,
   }
 
   impl ModuleGraphHashCache {
@@ -181,11 +177,11 @@ pub(super) mod module_graph_hash {
       self.cache.clear();
     }
 
-    pub fn get(&self, key: &ModuleIdentifier) -> Option<(u64, ExportsInfo, Vec<ExportsInfo>)> {
-      self.cache.get(key).map(|v| v.value().clone())
+    pub fn get(&self, key: &ModuleIdentifier) -> Option<u64> {
+      self.cache.get(key).map(|v| *v.value())
     }
 
-    pub fn set(&self, key: ModuleIdentifier, value: (u64, ExportsInfo, Vec<ExportsInfo>)) {
+    pub fn set(&self, key: ModuleIdentifier, value: u64) {
       self.cache.insert(key, value);
     }
   }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -16,7 +16,7 @@ use ustr::Ustr;
 use crate::{
   AsyncDependenciesBlockIdentifier, ChunkByUkey, ChunkGraph, ChunkGroup, ChunkGroupByUkey,
   ChunkGroupUkey, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier, ModuleIdsArtifact,
-  RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, RuntimeSpecSet, for_each_runtime,
+  RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, RuntimeSpecSet, for_each_runtime, get_runtime_key,
 };
 
 pub type ModuleIdMap<V> =
@@ -402,22 +402,36 @@ impl ChunkGraph {
     let mg = compilation.get_module_graph();
     compilation
       .module_graph_cache_artifact
-      .cached_module_graph_hash(module.identifier(), || {
-        let mut hasher = FxHasher::default();
-        let module_identifier = module.identifier();
-        Self::get_module_id(&compilation.module_ids_artifact, module_identifier)
-          .dyn_hash(&mut hasher);
-        module.source_types(mg).dyn_hash(&mut hasher);
+      .cached_module_graph_hash(
+        (
+          module.identifier(),
+          runtime.map(|r| get_runtime_key(r).clone()),
+        ),
+        || {
+          let mut hasher = FxHasher::default();
+          let module_identifier = module.identifier();
+          Self::get_module_id(&compilation.module_ids_artifact, module_identifier)
+            .dyn_hash(&mut hasher);
+          module
+            .get_exports_type(
+              mg,
+              &compilation.module_graph_cache_artifact,
+              &compilation.exports_info_artifact,
+              strict,
+            )
+            .hash(&mut hasher);
+          module.source_types(mg).dyn_hash(&mut hasher);
 
-        ModuleGraph::is_async(&compilation.async_modules_artifact, &module_identifier)
-          .dyn_hash(&mut hasher);
-        let exports_info = compilation
-          .exports_info_artifact
-          .get_exports_info(&module_identifier);
-        exports_info
-          .as_data(&compilation.exports_info_artifact)
-          .update_hash(&compilation.exports_info_artifact, &mut hasher, runtime);
-        hasher.finish()
-      })
+          ModuleGraph::is_async(&compilation.async_modules_artifact, &module_identifier)
+            .dyn_hash(&mut hasher);
+          let exports_info = compilation
+            .exports_info_artifact
+            .get_exports_info(&module_identifier);
+          exports_info
+            .as_data(&compilation.exports_info_artifact)
+            .update_hash(&compilation.exports_info_artifact, &mut hasher, runtime);
+          hasher.finish()
+        },
+      )
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -410,20 +410,13 @@ impl ChunkGraph {
         || {
           let mut hasher = FxHasher::default();
           let module_identifier = module.identifier();
+
           Self::get_module_id(&compilation.module_ids_artifact, module_identifier)
             .dyn_hash(&mut hasher);
-          module
-            .get_exports_type(
-              mg,
-              &compilation.module_graph_cache_artifact,
-              &compilation.exports_info_artifact,
-              strict,
-            )
-            .hash(&mut hasher);
           module.source_types(mg).dyn_hash(&mut hasher);
-
           ModuleGraph::is_async(&compilation.async_modules_artifact, &module_identifier)
             .dyn_hash(&mut hasher);
+
           let exports_info = compilation
             .exports_info_artifact
             .get_exports_info(&module_identifier);

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -15,9 +15,8 @@ use ustr::Ustr;
 
 use crate::{
   AsyncDependenciesBlockIdentifier, ChunkByUkey, ChunkGraph, ChunkGroup, ChunkGroupByUkey,
-  ChunkGroupUkey, ChunkUkey, Compilation, ExportsInfoGetter, Module, ModuleGraph, ModuleIdentifier,
-  ModuleIdsArtifact, PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, RuntimeSpecMap,
-  RuntimeSpecSet, for_each_runtime,
+  ChunkGroupUkey, ChunkUkey, Compilation, Module, ModuleGraph, ModuleIdentifier, ModuleIdsArtifact,
+  RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, RuntimeSpecSet, for_each_runtime,
 };
 
 pub type ModuleIdMap<V> =
@@ -401,9 +400,7 @@ impl ChunkGraph {
     runtime: Option<&RuntimeSpec>,
   ) -> u64 {
     let mg = compilation.get_module_graph();
-    let mut hasher = FxHasher::default();
-
-    let (hash, exports_info_entry, exports_info_exports) = compilation
+    compilation
       .module_graph_cache_artifact
       .cached_module_graph_hash(module.identifier(), || {
         let mut hasher = FxHasher::default();
@@ -416,17 +413,11 @@ impl ChunkGraph {
           .dyn_hash(&mut hasher);
         let exports_info = compilation
           .exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Full);
-        let (entry, exports) = exports_info.meta();
-        (hasher.finish(), entry, exports)
-      });
-
-    hasher.write_u64(hash);
-    let exports_info = ExportsInfoGetter::from_meta(
-      (exports_info_entry, exports_info_exports),
-      &compilation.exports_info_artifact,
-    );
-    exports_info.update_hash(&mut hasher, runtime);
-    hasher.finish()
+          .get_exports_info(&module_identifier);
+        exports_info
+          .as_data(&compilation.exports_info_artifact)
+          .update_hash(&compilation.exports_info_artifact, &mut hasher, runtime);
+        hasher.finish()
+      })
   }
 }

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -1,11 +1,12 @@
 use std::{collections::BTreeMap, hash::Hash, sync::atomic::Ordering::Relaxed};
 
 use rspack_cacheable::cacheable;
-use rspack_util::atom::Atom;
+use rspack_util::{atom::Atom, ext::DynHash};
+use rustc_hash::FxHashSet;
 use serde::Serialize;
 
 use super::{ExportInfoData, NEXT_EXPORTS_INFO_UKEY};
-use crate::ExportsInfoArtifact;
+use crate::{ExportsInfoArtifact, RuntimeSpec};
 
 #[cacheable]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
@@ -99,5 +100,77 @@ impl ExportsInfoData {
 
   pub fn exports_mut(&mut self) -> &mut BTreeMap<Atom, ExportInfoData> {
     &mut self.exports
+  }
+
+  pub fn update_hash(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    hasher: &mut dyn std::hash::Hasher,
+    runtime: Option<&RuntimeSpec>,
+  ) {
+    fn export_info_update_hash(
+      export_info: &ExportInfoData,
+      exports_info_artifact: &ExportsInfoArtifact,
+      hasher: &mut dyn std::hash::Hasher,
+      runtime: Option<&RuntimeSpec>,
+      visited: &mut FxHashSet<ExportsInfo>,
+    ) {
+      if let Some(used_name) = export_info.used_name() {
+        used_name.dyn_hash(hasher);
+      } else {
+        export_info.name().dyn_hash(hasher);
+      }
+      export_info.get_used(runtime).dyn_hash(hasher);
+      export_info.provided().dyn_hash(hasher);
+      export_info.terminal_binding().dyn_hash(hasher);
+      export_info.ns_access().dyn_hash(hasher);
+      if let Some(exports_info) = export_info.exports_info()
+        && !visited.contains(&exports_info)
+      {
+        exports_info_update_hash(
+          exports_info.as_data(exports_info_artifact),
+          exports_info_artifact,
+          hasher,
+          runtime,
+          visited,
+        );
+      }
+    }
+
+    fn exports_info_update_hash(
+      exports_info: &ExportsInfoData,
+      exports_info_artifact: &ExportsInfoArtifact,
+      hasher: &mut dyn std::hash::Hasher,
+      runtime: Option<&RuntimeSpec>,
+      visited: &mut FxHashSet<ExportsInfo>,
+    ) {
+      visited.insert(exports_info.id());
+      let other_export_info = exports_info.other_exports_info();
+      let side_effects_only_info = exports_info.side_effects_only_info();
+
+      for export_info in exports_info.exports().values() {
+        if export_info.has_info(other_export_info, runtime) {
+          export_info_update_hash(export_info, exports_info_artifact, hasher, runtime, visited);
+        }
+      }
+
+      export_info_update_hash(
+        side_effects_only_info,
+        exports_info_artifact,
+        hasher,
+        runtime,
+        visited,
+      );
+      export_info_update_hash(
+        other_export_info,
+        exports_info_artifact,
+        hasher,
+        runtime,
+        visited,
+      );
+    }
+
+    let mut visited = FxHashSet::default();
+    exports_info_update_hash(self, exports_info_artifact, hasher, runtime, &mut visited);
   }
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -1,8 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use either::Either;
-use itertools::Itertools;
-use rspack_util::{atom::Atom, ext::DynHash};
+use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap;
 
 use super::{
@@ -318,43 +317,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     ))
   }
 
-  pub fn update_hash(&self, hasher: &mut dyn std::hash::Hasher, runtime: Option<&RuntimeSpec>) {
-    if !matches!(self.mode, PrefetchExportsInfoMode::Full) {
-      panic!("should not update hash when mode is not Full");
-    }
-
-    fn handle_export_info(
-      export_info: &ExportInfoData,
-      hasher: &mut dyn std::hash::Hasher,
-      runtime: Option<&RuntimeSpec>,
-    ) {
-      if let Some(used_name) = export_info.used_name() {
-        used_name.dyn_hash(hasher);
-      } else {
-        export_info.name().dyn_hash(hasher);
-      }
-      export_info.get_used(runtime).dyn_hash(hasher);
-      export_info.provided().dyn_hash(hasher);
-      export_info.terminal_binding().dyn_hash(hasher);
-      export_info.ns_access().dyn_hash(hasher);
-    }
-
-    let mut exports = self.exports.values().collect_vec();
-    exports.sort_unstable_by_key(|a| a.id());
-
-    for exports_info in exports {
-      let other_export_info = exports_info.other_exports_info();
-      let side_effects_only_info = exports_info.side_effects_only_info();
-      for export_info in exports_info.exports().values() {
-        if export_info.has_info(other_export_info, runtime) {
-          handle_export_info(export_info, hasher, runtime);
-        }
-      }
-      handle_export_info(side_effects_only_info, hasher, runtime);
-      handle_export_info(other_export_info, hasher, runtime);
-    }
-  }
-
   pub fn is_module_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
     if self.is_used_impl(self.entry, runtime) {
       return true;
@@ -464,51 +426,6 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     }
 
     key
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use std::{collections::hash_map::DefaultHasher, hash::Hasher};
-
-  use rspack_util::atom::Atom;
-
-  use super::{ExportsInfoGetter, PrefetchExportsInfoMode};
-  use crate::{ExportProvided, ExportsInfoArtifact, ExportsInfoData, UsageState};
-
-  fn hash_with_ns_access(ns_access: bool) -> u64 {
-    let mut exports_info_artifact = ExportsInfoArtifact::default();
-    let exports_info_data = ExportsInfoData::default();
-    let exports_info = exports_info_data.id();
-    exports_info_artifact.set_exports_info_by_id(exports_info, exports_info_data);
-
-    {
-      let exports_info_data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
-      let other_exports_info = exports_info_data.other_exports_info_mut();
-      other_exports_info.set_has_use_info();
-      other_exports_info.set_used(UsageState::OnlyPropertiesUsed, None);
-      other_exports_info.set_provided(Some(ExportProvided::Provided));
-    }
-
-    {
-      let exports_info_data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
-      let export_info = exports_info_data.ensure_owned_export_info(&Atom::from("test"));
-      export_info.set_ns_access(ns_access);
-    }
-
-    let exports_info = ExportsInfoGetter::prefetch(
-      &exports_info,
-      &exports_info_artifact,
-      PrefetchExportsInfoMode::Full,
-    );
-    let mut hasher = DefaultHasher::new();
-    exports_info.update_hash(&mut hasher, None);
-    hasher.finish()
-  }
-
-  #[test]
-  fn update_hash_should_include_namespace_access() {
-    assert_ne!(hash_with_ns_access(false), hash_with_ns_access(true));
   }
 }
 

--- a/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/a.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/a.js
@@ -1,0 +1,5 @@
+import { getA } from "./shared";
+
+it("should load export a", () => {
+  expect(getA()).toBe("a");
+});

--- a/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/b.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/b.js
@@ -1,0 +1,5 @@
+import { getB } from "./shared";
+
+it("should load export b", () => {
+  expect(getB()).toBe("b");
+});

--- a/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/rspack.config.js
@@ -1,0 +1,40 @@
+class Plugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('Test', (compilation) => {
+      compilation.hooks.processAssets.tap('Test', () => {
+        const sharedModule = Array.from(compilation.modules).find((module) =>
+          module.resource?.endsWith('shared.js'),
+        );
+
+        expect(sharedModule).toBeTruthy();
+
+        const hashA = compilation.chunkGraph.getModuleHash(sharedModule, 'a');
+        const hashB = compilation.chunkGraph.getModuleHash(sharedModule, 'b');
+
+        expect(hashA).toBeTruthy();
+        expect(hashB).toBeTruthy();
+        expect(hashA).not.toEqual(hashB);
+      });
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  entry: {
+    a: './a.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    chunkIds: 'named',
+    concatenateModules: false,
+    minimize: false,
+    moduleIds: 'named',
+    usedExports: true,
+  },
+  plugins: [new Plugin()],
+};

--- a/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/shared.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/shared.js
@@ -1,0 +1,12 @@
+const values = {
+  a: "a",
+  b: "b",
+};
+
+export function getA() {
+  return values.a;
+}
+
+export function getB() {
+  return values.b;
+}

--- a/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/test.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-module-hash-runtime-specific-used-exports/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle() {
+    return ["a.js", "b.js"];
+  },
+};

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/barrel.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/barrel.js
@@ -1,0 +1,7 @@
+export * as Tree01 from "./tree-01.js";
+export * as Tree02 from "./tree-02.js";
+export * as Tree03 from "./tree-03.js";
+
+Tree01;
+Tree02;
+Tree03;

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-a-01.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-a-01.js
@@ -1,0 +1,1 @@
+export const a01 = "a01";

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-a-02.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-a-02.js
@@ -1,0 +1,1 @@
+export const a02 = "a02";

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-a-03.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-a-03.js
@@ -1,0 +1,1 @@
+export const a03 = "a03";

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-b.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/leaf-b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/package.json
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/rspack.config.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/rspack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const rspack = require('@rspack/core');
 
 const hashes = new Set();
 

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/rspack.config.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/rspack.config.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const rspack = require('@rspack/core');
+
+const hashes = new Set();
+
+class CheckHashPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(CheckHashPlugin.name, (compilation) => {
+      compilation.hooks.processAssets.tap(CheckHashPlugin.name, () => {
+        const barrelModule = Array.from(compilation.modules).find((module) =>
+          module.resource?.endsWith('barrel.js'),
+        );
+        expect(barrelModule).toBeTruthy();
+
+        const moduleHash = compilation.chunkGraph.getModuleHash(
+          barrelModule,
+          'main',
+        );
+        expect(moduleHash).toBeTruthy();
+
+        hashes.add(moduleHash);
+        expect(hashes.size).toBe(1);
+      });
+    });
+  }
+}
+
+function config(name) {
+  return {
+    mode: 'production',
+    entry: './barrel.js',
+    devtool: false,
+    output: {
+      path: path.join(__dirname, 'dist', name),
+      filename: '[name].[contenthash].js',
+    },
+    optimization: {
+      chunkIds: 'named',
+      moduleIds: 'named',
+      minimize: false,
+      realContentHash: false,
+    },
+    plugins: [new CheckHashPlugin()],
+  };
+}
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = Array.from({ length: 4 }, (_, i) => config(String(i)));

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/test.config.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/test.config.js
@@ -2,7 +2,7 @@
 module.exports = {
 	validate(stats) {
 		const first = stats.stats[0].toJson({ assets: true, hash: true });
-    expect(first.assetsByChunkName.main).toBeTruthy();
+		expect(first.assetsByChunkName.main).toBeTruthy();
 		for (let i = 1; i < 4; i += 1) {
 			const current = stats.stats[i].toJson({ assets: true, hash: true });
 			expect(current.hash).toEqual(first.hash);

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/test.config.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/test.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@rspack/test-tools').THashCaseConfig} */
+module.exports = {
+	validate(stats) {
+		const first = stats.stats[0].toJson({ assets: true, hash: true });
+    expect(first.assetsByChunkName.main).toBeTruthy();
+		for (let i = 1; i < 4; i += 1) {
+			const current = stats.stats[i].toJson({ assets: true, hash: true });
+			expect(current.hash).toEqual(first.hash);
+			expect(current.assetsByChunkName.main).toEqual(first.assetsByChunkName.main);
+		}
+	}
+};

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/tree-01.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/tree-01.js
@@ -1,0 +1,2 @@
+export * as left from "./leaf-a-01.js";
+export * as right from "./leaf-b.js";

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/tree-02.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/tree-02.js
@@ -1,0 +1,2 @@
+export * as left from "./leaf-a-02.js";
+export * as right from "./leaf-b.js";

--- a/tests/rspack-test/hashCases/exports-info-reexport-order/tree-03.js
+++ b/tests/rspack-test/hashCases/exports-info-reexport-order/tree-03.js
@@ -1,0 +1,2 @@
+export * as left from "./leaf-a-03.js";
+export * as right from "./leaf-b.js";

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 24207b3fec5f5707,
+			      hash: fb0d3e29fe9f1df3,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 142f861beb2d1369,
+			  hash: 8a6cffec89eed4fa,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (072e090fa3782955)
+Rspack compiled successfully (f33764317b131701)


### PR DESCRIPTION
## Summary

Fix `exports_info.update_hash()` unstable.

(This is another of reason why [recently our eco-ci benchmark unstable](https://github.com/web-infra-dev/rspack/commit/02b0bfa370dedefe421d4cd2e616233aa4f85d80#:~:text=arco%2Dpro_production%2Dmode_persistent%2Dhot,%2B21.47%20%25) (2/2), because: unstable hash -> unstable chunk content -> unstable minimizer persistent cache hit rate -> unstable compile time

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
