### PR TITLE
fix(esm): rewrite evaluated in operator for externals

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -574,13 +574,6 @@ impl ESMImportSpecifierDependencyTemplate {
         .and_then(|used_name| match used_name {
           UsedName::Normal(names) => names.last().cloned(),
           UsedName::Inlined(_) => unreachable!("Inlined must be provided"),
-        })
-        .or_else(|| {
-          // External modules can legitimately lack nested exports usage info here.
-          // Fall back to the requested property name so we still rewrite the import binding.
-          module
-            .as_external_module()
-            .and_then(|_| ids.last().cloned())
         }) else {
           return;
         };

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -558,14 +558,29 @@ impl ESMImportSpecifierDependencyTemplate {
         source.replace_static(dep.range.start, dep.range.end, " false", None)
       }
       _ => {
+        let used_name_ids = if matches!(exports_type, ExportsType::DefaultWithNamed)
+          && first == "default"
+          && ids.len() > 1
+        {
+          &ids[1..]
+        } else {
+          ids
+        };
         let Some(used_name) = ExportsInfoGetter::get_used_name(
           GetUsedNameParam::WithNames(&exports_info),
           *runtime,
-          ids,
+          used_name_ids,
         )
         .and_then(|used_name| match used_name {
           UsedName::Normal(names) => names.last().cloned(),
           UsedName::Inlined(_) => unreachable!("Inlined must be provided"),
+        })
+        .or_else(|| {
+          // External modules can legitimately lack nested exports usage info here.
+          // Fall back to the requested property name so we still rewrite the import binding.
+          module
+            .as_external_module()
+            .and_then(|_| ids.last().cloned())
         }) else {
           return;
         };

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-concatenated/index.js
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-concatenated/index.js
@@ -1,0 +1,6 @@
+import { colorize, supportsBasicColor } from "./lib";
+
+it("should handle `in` operator on concatenated external default imports", () => {
+	expect(colorize("ok")).toBeTruthy();
+	expect(typeof supportsBasicColor()).toBe("boolean");
+});

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-concatenated/lib.js
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-concatenated/lib.js
@@ -1,0 +1,30 @@
+import nodeUtil from "node:util";
+import nodeProcess from "node:process";
+import nodeOs from "node:os";
+import nodeTty from "node:tty";
+
+function checkNodeVersion() {
+	const { versions } = process;
+	if ("styleText" in nodeUtil || !versions.node || versions.bun || versions.deno) {
+		return;
+	}
+	throw new Error(
+		`Unsupported Node.js version: "${process.versions.node || "unknown"}". Expected Node.js >= 20.`
+	);
+}
+
+checkNodeVersion();
+
+export const colorize = (text) => nodeUtil.styleText("blue", String(text));
+
+export function supportsBasicColor() {
+	if ("FORCE_COLOR" in nodeProcess.env) {
+		return true;
+	}
+
+	if (nodeProcess.platform === "win32") {
+		return nodeOs.release().length > 0;
+	}
+
+	return Boolean(nodeTty.isatty?.(1));
+}

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-concatenated/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-concatenated/rspack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node14',
+  externalsPresets: {
+    node: true,
+  },
+  optimization: {
+    concatenateModules: true,
+    usedExports: true,
+    providedExports: true,
+    mangleExports: true,
+  },
+};

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/index.js
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/index.js
@@ -1,0 +1,6 @@
+import { logger } from "rslog";
+
+it("should keep evaluated `in` operator imports bound for rslog-like packages", () => {
+	expect(logger).toBeDefined();
+	expect(typeof logger.info).toBe("function");
+});

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/node_modules/rslog/dist/index.js
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/node_modules/rslog/dist/index.js
@@ -1,0 +1,404 @@
+import node_util from "node:util";
+import node_process from "node:process";
+import node_os from "node:os";
+import node_tty from "node:tty";
+
+function checkNodeVersion() {
+	const { versions } = process;
+	if ("styleText" in node_util || !versions.node || versions.bun || versions.deno) {
+		return;
+	}
+	throw new Error(
+		`Unsupported Node.js version: "${process.versions.node || "unknown"}". Expected Node.js >= 20.`
+	);
+}
+
+checkNodeVersion();
+
+const createStyler = (style) => (text) => node_util.styleText(style, String(text));
+
+const color = {
+	dim: createStyler("dim"),
+	red: createStyler("red"),
+	bold: createStyler("bold"),
+	blue: createStyler("blue"),
+	cyan: createStyler("cyan"),
+	gray: createStyler("gray"),
+	black: createStyler("black"),
+	green: createStyler("green"),
+	white: createStyler("white"),
+	reset: createStyler("reset"),
+	yellow: createStyler("yellow"),
+	magenta: createStyler("magenta"),
+	underline: createStyler("underline"),
+	strikethrough: createStyler("strikethrough")
+};
+
+function hasFlag(flag, argv = globalThis.Deno ? globalThis.Deno.args : node_process.argv) {
+	const prefix = flag.startsWith("-") ? "" : flag.length === 1 ? "-" : "--";
+	const position = argv.indexOf(prefix + flag);
+	const terminatorPosition = argv.indexOf("--");
+
+	return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
+}
+
+const { env } = node_process;
+let flagForceColor;
+
+if (
+	hasFlag("no-color") ||
+	hasFlag("no-colors") ||
+	hasFlag("color=false") ||
+	hasFlag("color=never")
+) {
+	flagForceColor = 0;
+} else if (
+	hasFlag("color") ||
+	hasFlag("colors") ||
+	hasFlag("color=true") ||
+	hasFlag("color=always")
+) {
+	flagForceColor = 1;
+}
+
+function envForceColor() {
+	if (!("FORCE_COLOR" in env)) {
+		return;
+	}
+
+	if (env.FORCE_COLOR === "true") {
+		return 1;
+	}
+
+	if (env.FORCE_COLOR === "false") {
+		return 0;
+	}
+
+	if (env.FORCE_COLOR.length === 0) {
+		return 1;
+	}
+
+	const level = Math.min(Number.parseInt(env.FORCE_COLOR, 10), 3);
+
+	if (![0, 1, 2, 3].includes(level)) {
+		return;
+	}
+
+	return level;
+}
+
+function translateLevel(level) {
+	if (level === 0) {
+		return false;
+	}
+
+	return {
+		level,
+		hasBasic: true,
+		has256: level >= 2,
+		has16m: level >= 3
+	};
+}
+
+function _supportsColor(haveStream, { streamIsTTY, sniffFlags = true } = {}) {
+	const noFlagForceColor = envForceColor();
+
+	if (noFlagForceColor !== undefined) {
+		flagForceColor = noFlagForceColor;
+	}
+
+	const forceColor = sniffFlags ? flagForceColor : noFlagForceColor;
+
+	if (forceColor === 0) {
+		return 0;
+	}
+
+	if (sniffFlags) {
+		if (
+			hasFlag("color=16m") ||
+			hasFlag("color=full") ||
+			hasFlag("color=truecolor")
+		) {
+			return 3;
+		}
+
+		if (hasFlag("color=256")) {
+			return 2;
+		}
+	}
+
+	if ("TF_BUILD" in env && "AGENT_NAME" in env) {
+		return 1;
+	}
+
+	if (haveStream && !streamIsTTY && forceColor === undefined) {
+		return 0;
+	}
+
+	const min = forceColor || 0;
+
+	if (env.TERM === "dumb") {
+		return min;
+	}
+
+	if (node_process.platform === "win32") {
+		const osRelease = node_os.release().split(".");
+
+		if (Number(osRelease[0]) >= 10 && Number(osRelease[2]) >= 10586) {
+			return Number(osRelease[2]) >= 14931 ? 3 : 2;
+		}
+
+		return 1;
+	}
+
+	if ("CI" in env) {
+		if (["GITHUB_ACTIONS", "GITEA_ACTIONS", "CIRCLECI"].some((key) => key in env)) {
+			return 3;
+		}
+
+		if (
+			["TRAVIS", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"].some(
+				(sign) => sign in env
+			) ||
+			env.CI_NAME === "codeship"
+		) {
+			return 1;
+		}
+
+		return min;
+	}
+
+	if ("TEAMCITY_VERSION" in env) {
+		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
+	}
+
+	if (env.COLORTERM === "truecolor") {
+		return 3;
+	}
+
+	if (env.TERM === "xterm-kitty" || env.TERM === "xterm-ghostty" || env.TERM === "wezterm") {
+		return 3;
+	}
+
+	if ("TERM_PROGRAM" in env) {
+		const version = Number.parseInt((env.TERM_PROGRAM_VERSION || "").split(".")[0], 10);
+
+		switch (env.TERM_PROGRAM) {
+			case "iTerm.app":
+				return version >= 3 ? 3 : 2;
+			case "Apple_Terminal":
+				return 2;
+		}
+	}
+
+	if (/-256(color)?$/i.test(env.TERM)) {
+		return 2;
+	}
+
+	if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
+		return 1;
+	}
+
+	if ("COLORTERM" in env) {
+		return 1;
+	}
+
+	return min;
+}
+
+function createSupportsColor(stream, options = {}) {
+	const level = _supportsColor(stream, {
+		streamIsTTY: stream && stream.isTTY,
+		...options
+	});
+
+	return translateLevel(level);
+}
+
+const supportsColor = {
+	stdout: createSupportsColor({
+		isTTY: node_tty.isatty(1)
+	}),
+	stderr: createSupportsColor({
+		isTTY: node_tty.isatty(2)
+	})
+};
+
+const colorLevel = supportsColor.stdout ? supportsColor.stdout.level : 0;
+const errorStackRegExp = /at [^\r\n]{0,200}:\d+:\d+[\s\)]*$/;
+const anonymousErrorStackRegExp = /at [^\r\n]{0,200}\(<anonymous>\)$/;
+const indexErrorStackRegExp = /at [^\r\n]{0,200}\(index\s\d+\)$/;
+
+const isErrorStackMessage = (message) =>
+	errorStackRegExp.test(message) ||
+	anonymousErrorStackRegExp.test(message) ||
+	indexErrorStackRegExp.test(message);
+
+const startColor = [189, 255, 243];
+const endColor = [74, 194, 154];
+const isWord = (char) => !/[\s\n]/.test(char);
+
+const gradient = (message) => {
+	if (colorLevel < 3) {
+		return colorLevel === 2 ? color.cyan(message) : message;
+	}
+
+	const chars = [...message];
+	const steps = chars.filter(isWord).length;
+	let [r, g, b] = startColor;
+	const rStep = (endColor[0] - r) / steps;
+	const gStep = (endColor[1] - g) / steps;
+	const bStep = (endColor[2] - b) / steps;
+	let output = "";
+
+	for (const char of chars) {
+		if (isWord(char)) {
+			r += rStep;
+			g += gStep;
+			b += bStep;
+		}
+		output += `\x1b[38;2;${Math.round(r)};${Math.round(g)};${Math.round(b)}m${char}\x1b[39m`;
+	}
+
+	return color.bold(output);
+};
+
+const LOG_LEVEL = {
+	silent: -1,
+	error: 0,
+	warn: 1,
+	info: 2,
+	log: 2,
+	verbose: 3
+};
+
+const LOG_TYPES = {
+	error: {
+		label: "error",
+		level: "error",
+		color: color.red
+	},
+	warn: {
+		label: "warn",
+		level: "warn",
+		color: color.yellow
+	},
+	info: {
+		label: "info",
+		level: "info",
+		color: color.cyan
+	},
+	start: {
+		label: "start",
+		level: "info",
+		color: color.cyan
+	},
+	ready: {
+		label: "ready",
+		level: "info",
+		color: color.green
+	},
+	success: {
+		label: "success",
+		level: "info",
+		color: color.green
+	},
+	log: {
+		level: "info"
+	},
+	debug: {
+		label: "debug",
+		level: "verbose",
+		color: color.magenta
+	}
+};
+
+const normalizeErrorMessage = (err) => {
+	if (err.stack) {
+		let [name, ...rest] = err.stack.split("\n");
+		if (name.startsWith("Error: ")) {
+			name = name.slice(7);
+		}
+		return `${name}\n${color.gray(rest.join("\n"))}`;
+	}
+
+	return err.message;
+};
+
+const createLogger = (options = {}) => {
+	const { level = "info", prefix, console = globalThis.console } = options;
+	let maxLevel = level;
+
+	const log = (type, message, ...args) => {
+		const logType = LOG_TYPES[type];
+		const { level } = logType;
+		if (LOG_LEVEL[level] > LOG_LEVEL[maxLevel]) {
+			return;
+		}
+		if (message == null) {
+			return console.log();
+		}
+
+		let label = "";
+		let text = "";
+
+		if ("label" in logType) {
+			label = (logType.label || "").padEnd(7);
+			label = color.bold(logType.color ? logType.color(label) : label);
+		}
+
+		if (message instanceof Error) {
+			text += normalizeErrorMessage(message);
+			const { cause } = message;
+			if (cause) {
+				text += color.yellow("\n  [cause]: ");
+				text += cause instanceof Error ? normalizeErrorMessage(cause) : String(cause);
+			}
+		} else if (level === "error" && typeof message === "string") {
+			const lines = message.split("\n");
+			text = lines
+				.map((line) => (isErrorStackMessage(line) ? color.gray(line) : line))
+				.join("\n");
+		} else {
+			text = `${message}`;
+		}
+
+		if (prefix) {
+			text = `${prefix} ${text}`;
+		}
+
+		const method = level === "error" || level === "warn" ? level : "log";
+		console[method](label.length ? `${label} ${text}` : text, ...args);
+	};
+
+	const logger = {
+		greet: (message) => log("log", gradient(message))
+	};
+
+	Object.keys(LOG_TYPES).forEach((key) => {
+		logger[key] = (...args) => log(key, ...args);
+	});
+
+	Object.defineProperty(logger, "level", {
+		get: () => maxLevel,
+		set(val) {
+			maxLevel = val;
+		}
+	});
+
+	Object.defineProperty(logger, "options", {
+		get: () => ({
+			...options
+		})
+	});
+
+	logger.override = (customLogger) => {
+		Object.assign(logger, customLogger);
+	};
+
+	return logger;
+};
+
+const logger = createLogger();
+
+export { color, createLogger, logger };

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/node_modules/rslog/package.json
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/node_modules/rslog/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "rslog",
+	"version": "2.1.1",
+	"type": "module",
+	"exports": {
+		".": {
+			"default": "./dist/index.js"
+		}
+	}
+}

--- a/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/evaluated-in-operator-rslog-like/rspack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node14',
+  externalsPresets: {
+    node: true,
+  },
+  optimization: {
+    concatenateModules: true,
+    usedExports: true,
+    providedExports: true,
+    mangleExports: true,
+  },
+};


### PR DESCRIPTION
## Summary

- normalize `DefaultWithNamed` ids before `get_used_name` in `render_evaluated_in_operator`
- remove the external-only fallback and keep this path aligned with the actual usage-info model
- add regression coverage for the rslog-like repro and the concatenated externals case

## Related links

- fixes the `node_util is not defined` repro from `rstest/packages/vscode`
- related to `63ec093274df733e317071b076a4a8639860087b` (`fix(esm): deconflict external bindings in module output`)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).