### PR TITLE
Move cac from a devDependency to dependency of @rspack/cli as it's needed for the published types

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -33,13 +33,15 @@
     "prepare": "prebundle",
     "test": "rstest"
   },
+  "dependencies": {
+    "cac": "^7.0.0"
+  },
   "devDependencies": {
     "@discoveryjs/json-ext": "^0.5.7",
     "@rslib/core": "0.21.2",
     "@rspack/core": "workspace:*",
     "@rspack/dev-server": "^2.0.0",
     "@rspack/test-tools": "workspace:*",
-    "cac": "^7.0.0",
     "concat-stream": "^2.0.0",
     "cross-env": "^10.1.0",
     "execa": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,10 @@ importers:
         version: 3.3.4(patch_hash=0d62122aa5f9ac77d9ad3b4959c3c0492778a5948c0b00b45a673f3facfca327)
 
   packages/rspack-cli:
+    dependencies:
+      cac:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@discoveryjs/json-ext':
         specifier: ^0.5.7
@@ -357,9 +361,6 @@ importers:
       '@rspack/test-tools':
         specifier: workspace:*
         version: link:../rspack-test-tools
-      cac:
-        specifier: ^7.0.0
-        version: 7.0.0
       concat-stream:
         specifier: ^2.0.0
         version: 2.0.0


### PR DESCRIPTION
## Summary

cac is imported in the published types, so needs to be a dependency instead of a devDependency.  Otherwise usage of `import {defineConfig} from '@rspack/cli'` in typescript files can cause type errors when `cac` isn't installed or otherwise unable to be resolved.

usage in the published package:
```
    node_modules/@rspack/cli/dist/cli.d.ts:import { type CAC } from 'cac';
    node_modules/@rspack/cli/dist/utils/options.d.ts:import type { Command } from 'cac';
```

FYI this was also an issue in rspack 1.x as well

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
