### PR TITLE
fix(test-tools): support ESM default config exports

### DIFF
--- a/packages/rspack-test-tools/src/helper/read-config-file.ts
+++ b/packages/rspack-test-tools/src/helper/read-config-file.ts
@@ -3,9 +3,7 @@ import fs from 'fs-extra';
 import { DEBUG_SCOPES } from '../test/debug';
 import type { ITestContext } from '../type';
 
-function isNodeEsmNamespaceObject(
-  value: unknown,
-): value is {
+function isNodeEsmNamespaceObject(value: unknown): value is {
   default: RspackOptions | ((...args: unknown[]) => RspackOptions);
 } {
   if (!value || (typeof value !== 'object' && typeof value !== 'function')) {

--- a/packages/rspack-test-tools/src/helper/read-config-file.ts
+++ b/packages/rspack-test-tools/src/helper/read-config-file.ts
@@ -3,6 +3,25 @@ import fs from 'fs-extra';
 import { DEBUG_SCOPES } from '../test/debug';
 import type { ITestContext } from '../type';
 
+function isNodeEsmNamespaceObject(
+  value: unknown,
+): value is {
+  default: RspackOptions | ((...args: unknown[]) => RspackOptions);
+} {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(value, 'default')) {
+    return false;
+  }
+
+  return (
+    (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
+    'Module'
+  );
+}
+
 export function readConfigFile(
   files: string[],
   context: ITestContext,
@@ -13,6 +32,10 @@ export function readConfigFile(
 ): RspackOptions[] {
   const existsFile = files.find((i) => fs.existsSync(i));
   let fileConfig = existsFile ? require(existsFile) : {};
+
+  if (isNodeEsmNamespaceObject(fileConfig)) {
+    fileConfig = fileConfig.default;
+  }
 
   if (typeof fileConfig === 'function') {
     fileConfig = fileConfig(

--- a/tests/rspack-test/configCases/node/commonjs-config-default-property/index.js
+++ b/tests/rspack-test/configCases/node/commonjs-config-default-property/index.js
@@ -1,0 +1,3 @@
+it("keeps the CommonJS object export when it has a default property", () => {
+	expect(EXPORT_KIND).toBe("commonjs-object");
+});

--- a/tests/rspack-test/configCases/node/commonjs-config-default-property/rspack.config.js
+++ b/tests/rspack-test/configCases/node/commonjs-config-default-property/rspack.config.js
@@ -1,0 +1,18 @@
+const { rspack } = require('@rspack/core');
+
+module.exports = {
+  target: 'node',
+  mode: 'development',
+  plugins: [
+    new rspack.DefinePlugin({
+      EXPORT_KIND: JSON.stringify('commonjs-object'),
+    }),
+  ],
+  default: {
+    plugins: [
+      new rspack.DefinePlugin({
+        EXPORT_KIND: JSON.stringify('wrong-default'),
+      }),
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/node/commonjs-config-function-default-property/index.js
+++ b/tests/rspack-test/configCases/node/commonjs-config-function-default-property/index.js
@@ -1,0 +1,7 @@
+it("keeps the CommonJS function export when it has a default property", () => {
+	expect(EXPORT_KIND).toBe("commonjs-factory");
+	expect(FACTORY_ARGS).toEqual({
+		hasConfig: true,
+		hasTestPath: true
+	});
+});

--- a/tests/rspack-test/configCases/node/commonjs-config-function-default-property/rspack.config.js
+++ b/tests/rspack-test/configCases/node/commonjs-config-function-default-property/rspack.config.js
@@ -1,0 +1,25 @@
+const { rspack } = require('@rspack/core');
+
+const configFactory = ({ config }, { testPath }) => ({
+  target: 'node',
+  mode: 'development',
+  plugins: [
+    new rspack.DefinePlugin({
+      EXPORT_KIND: JSON.stringify('commonjs-factory'),
+      FACTORY_ARGS: JSON.stringify({
+        hasConfig: Boolean(config),
+        hasTestPath: Boolean(testPath),
+      }),
+    }),
+  ],
+});
+
+configFactory.default = {
+  plugins: [
+    new rspack.DefinePlugin({
+      EXPORT_KIND: JSON.stringify('wrong-default'),
+    }),
+  ],
+};
+
+module.exports = configFactory;

--- a/tests/rspack-test/configCases/node/esm-config-default-export-function/index.js
+++ b/tests/rspack-test/configCases/node/esm-config-default-export-function/index.js
@@ -1,0 +1,7 @@
+it("loads the ESM default factory export", () => {
+	expect(EXPORT_KIND).toBe("esm-default-factory");
+	expect(FACTORY_ARGS).toEqual({
+		hasConfig: true,
+		hasTestPath: true
+	});
+});

--- a/tests/rspack-test/configCases/node/esm-config-default-export-function/package.json
+++ b/tests/rspack-test/configCases/node/esm-config-default-export-function/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/rspack-test/configCases/node/esm-config-default-export-function/rspack.config.js
+++ b/tests/rspack-test/configCases/node/esm-config-default-export-function/rspack.config.js
@@ -1,0 +1,15 @@
+import { rspack } from '@rspack/core';
+
+export default ({ config }, { testPath }) => ({
+  target: 'node',
+  mode: 'development',
+  plugins: [
+    new rspack.DefinePlugin({
+      EXPORT_KIND: JSON.stringify('esm-default-factory'),
+      FACTORY_ARGS: JSON.stringify({
+        hasConfig: Boolean(config),
+        hasTestPath: Boolean(testPath),
+      }),
+    }),
+  ],
+});

--- a/tests/rspack-test/configCases/node/esm-config-default-export/index.js
+++ b/tests/rspack-test/configCases/node/esm-config-default-export/index.js
@@ -1,0 +1,3 @@
+it("loads the ESM default object export", () => {
+	expect(EXPORT_KIND).toBe("esm-default-object");
+});

--- a/tests/rspack-test/configCases/node/esm-config-default-export/package.json
+++ b/tests/rspack-test/configCases/node/esm-config-default-export/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/rspack-test/configCases/node/esm-config-default-export/rspack.config.js
+++ b/tests/rspack-test/configCases/node/esm-config-default-export/rspack.config.js
@@ -1,0 +1,11 @@
+import { rspack } from '@rspack/core';
+
+export default {
+  target: 'node',
+  mode: 'development',
+  plugins: [
+    new rspack.DefinePlugin({
+      EXPORT_KIND: JSON.stringify('esm-default-object'),
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Support ESM default-exported rspack.config.js files in @rspack/test-tools when configs are loaded through sync require().
- Keep CommonJS behavior unchanged by only unwrapping values that match the observed Node ESM namespace shape.
- Add focused configCases covering ESM object/factory configs and CommonJS object/factory regression cases with real default properties.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
