### PR TITLE
perf(module-concatenation): reuse cached readable identifiers

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -136,7 +136,6 @@ fn subtract_non_defer_access(a: NonDeferAccess, b: NonDeferAccess) -> NonDeferAc
 pub struct ConcatenatedInnerModule {
   pub id: ModuleIdentifier,
   pub size: f64,
-  pub shorten_id: String,
 }
 
 static REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -653,30 +652,37 @@ impl ConcatenatedModule {
   // TODO: caching https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L663-L664
   pub fn create(
     root_module_ctxt: RootModuleContext,
-    mut modules: Vec<ConcatenatedInnerModule>,
+    mut modules_with_readable_identifiers: Vec<(ConcatenatedInnerModule, Arc<str>)>,
     hash_function: Option<HashFunction>,
     runtime: Option<RuntimeSpec>,
-    compilation: &Compilation,
+    _compilation: &Compilation,
   ) -> Self {
-    modules.sort_unstable_by_key(|a| a.id);
-    let id = Self::create_identifier(&root_module_ctxt, &modules, hash_function);
+    modules_with_readable_identifiers.sort_unstable_by_key(|(module, _)| module.id);
+    let id = Self::create_identifier_from_readable_identifiers(
+      &root_module_ctxt,
+      modules_with_readable_identifiers
+        .iter()
+        .map(|(_, readable_identifier)| readable_identifier.as_ref()),
+      hash_function,
+    );
+    let modules = modules_with_readable_identifiers
+      .into_iter()
+      .map(|(module, _)| module)
+      .collect();
     Self::new(id.as_str().into(), root_module_ctxt, modules, runtime)
   }
 
-  fn create_identifier(
+  fn create_identifier_from_readable_identifiers<'a>(
     root_module_ctxt: &RootModuleContext,
-    modules: &Vec<ConcatenatedInnerModule>,
+    readable_identifiers: impl IntoIterator<Item = &'a str>,
     hash_function: Option<HashFunction>,
   ) -> String {
-    let mut identifiers = vec![];
-    for m in modules {
-      identifiers.push(m.shorten_id.as_str());
-    }
     let mut hash = RspackHash::new(&hash_function.unwrap_or(HashFunction::MD4));
-    if let Some(id) = identifiers.first() {
+    let mut readable_identifiers = readable_identifiers.into_iter();
+    if let Some(id) = readable_identifiers.next() {
       hash.write(id.as_bytes());
     }
-    for id in identifiers.iter().skip(1) {
+    for id in readable_identifiers {
       hash.write(b" ");
       hash.write(id.as_bytes());
     }
@@ -868,7 +874,6 @@ impl Module for ConcatenatedModule {
     let compilation = compilation.expect("should pass compilation");
 
     let module_graph = compilation.get_module_graph();
-    let modules: IdentifierSet = self.modules.iter().map(|item| item.id).collect();
 
     let root_module = module_graph
       .module_by_identifier(&self.root_module_ctxt.id)
@@ -892,8 +897,7 @@ impl Module for ConcatenatedModule {
           .filter(|dep_id| {
             let dep = module_graph.dependency_by_id(dep_id);
             let module_id_of_dep = module_graph.module_identifier_by_dependency_id(dep_id);
-            !is_esm_dep_like(dep)
-              || module_id_of_dep.is_none_or(|module_id| !modules.contains(module_id))
+            !is_esm_dep_like(dep) || !contains_inner_module(&self.modules, module_id_of_dep)
           })
           .collect::<Vec<_>>()
       })
@@ -912,13 +916,15 @@ impl Module for ConcatenatedModule {
       if !cur_build_info.cacheable {
         self.build_info.cacheable = false;
       }
-
       // populate blocks
       for b in module.get_blocks() {
         self.blocks.push(*b);
       }
       // populate diagnostic
-      self.diagnostics.extend(module.diagnostics().into_owned());
+      match module.diagnostics() {
+        Cow::Borrowed(diagnostics) => self.diagnostics.extend_from_slice(diagnostics),
+        Cow::Owned(diagnostics) => self.diagnostics.extend(diagnostics),
+      }
 
       // populate topLevelDeclarations
       let module_build_info = module.build_info();
@@ -935,10 +941,9 @@ impl Module for ConcatenatedModule {
       }
 
       // populate assets
-      self
-        .build_info
-        .assets
-        .extend(module_build_info.assets.as_ref().clone());
+      for (name, asset) in module_build_info.assets.as_ref().iter() {
+        self.build_info.assets.insert(name.clone(), asset.clone());
+      }
     }
     // return a dummy result is enough, since we don't build the ConcatenatedModule in make phase
     Ok(BuildResult {
@@ -1106,8 +1111,10 @@ impl Module for ConcatenatedModule {
             if let Some(import_map) = &info.import_map {
               for ((source, _), imported) in import_map.iter() {
                 let specifiers = &imported.specifiers;
-                escaped_identifiers
-                  .push((source.clone(), split_readable_identifier(source.as_str())));
+                escaped_identifiers.push((
+                  source.clone().into(),
+                  split_readable_identifier(source.as_str()),
+                ));
                 for atom in specifiers {
                   escaped_names
                     .entry(atom.clone())
@@ -1215,7 +1222,7 @@ impl Module for ConcatenatedModule {
           if let Some(import_map) = info.import_map.take() {
             for ((source, attr), imported) in import_map {
               let source_parts = escaped_identifiers
-                .get(&source)
+                .get(source.as_str())
                 .expect("should have escaped identifier");
               let total_imported_atoms = import_stmts.entry((source, attr)).or_default();
 
@@ -3439,11 +3446,24 @@ pub fn get_cached_readable_identifier(
   mg: &ModuleGraph,
   module_static_cache: &ModuleStaticCache,
   compilation_context: &Context,
-) -> String {
+) -> Arc<str> {
   module_static_cache.cached_readable_identifier((*mid, None), || {
     let module = mg.module_by_identifier(mid).expect("should have module");
     module.readable_identifier(compilation_context).to_string()
   })
+}
+
+fn contains_inner_module(
+  modules: &[ConcatenatedInnerModule],
+  module_id: Option<&ModuleIdentifier>,
+) -> bool {
+  let Some(module_id) = module_id else {
+    return false;
+  };
+
+  modules
+    .binary_search_by_key(module_id, |module| module.id)
+    .is_ok()
 }
 
 pub fn split_readable_identifier(extra_info: &str) -> Vec<Atom> {
@@ -3468,6 +3488,51 @@ fn escaped_name(name: &str) -> Cow<'_, str> {
   }
 
   escape_identifier(name)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn test_root_module_context() -> RootModuleContext {
+    RootModuleContext {
+      id: ModuleIdentifier::from("root"),
+      readable_identifier: "root".to_string(),
+      name_for_condition: None,
+      lib_indent: None,
+      resolve_options: None,
+      code_generation_dependencies: None,
+      presentational_dependencies: None,
+      context: None,
+      layer: None,
+      side_effect_connection_state: ConnectionState::Active(true),
+      factory_meta: None,
+      build_meta: BuildMeta::default(),
+      exports_argument: ExportsArgument::default(),
+      module_argument: ModuleArgument::default(),
+    }
+  }
+
+  #[test]
+  fn concatenated_module_identifier_is_stable_after_create() {
+    let root_module_ctxt = test_root_module_context();
+    let id = ConcatenatedModule::create_identifier_from_readable_identifiers(
+      &root_module_ctxt,
+      ["alpha/readable", "beta/readable"],
+      Some(HashFunction::MD4),
+    );
+    let mut hash = RspackHash::new(&HashFunction::MD4);
+    hash.write("alpha/readable".as_bytes());
+    hash.write(b" ");
+    hash.write("beta/readable".as_bytes());
+    let expected = format!(
+      "{}|{}",
+      root_module_ctxt.id,
+      hash.digest(&HashDigest::Hex).encoded()
+    );
+
+    assert_eq!(id, expected);
+  }
 }
 
 pub fn escape_name(name: &str) -> String {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -136,6 +136,7 @@ fn subtract_non_defer_access(a: NonDeferAccess, b: NonDeferAccess) -> NonDeferAc
 pub struct ConcatenatedInnerModule {
   pub id: ModuleIdentifier,
   pub size: f64,
+  pub shorten_id: Arc<str>,
 }
 
 static REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -623,6 +624,7 @@ impl ConcatenatedModule {
     mut modules: Vec<ConcatenatedInnerModule>,
     runtime: Option<RuntimeSpec>,
   ) -> Self {
+    modules.sort_unstable_by_key(|module| module.id);
     let RootModuleContext {
       module_argument,
       exports_argument,
@@ -652,23 +654,17 @@ impl ConcatenatedModule {
   // TODO: caching https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L663-L664
   pub fn create(
     root_module_ctxt: RootModuleContext,
-    mut modules_with_readable_identifiers: Vec<(ConcatenatedInnerModule, Arc<str>)>,
+    mut modules: Vec<ConcatenatedInnerModule>,
     hash_function: Option<HashFunction>,
     runtime: Option<RuntimeSpec>,
     _compilation: &Compilation,
   ) -> Self {
-    modules_with_readable_identifiers.sort_unstable_by_key(|(module, _)| module.id);
+    modules.sort_unstable_by_key(|module| module.id);
     let id = Self::create_identifier_from_readable_identifiers(
       &root_module_ctxt,
-      modules_with_readable_identifiers
-        .iter()
-        .map(|(_, readable_identifier)| readable_identifier.as_ref()),
+      modules.iter().map(|module| module.shorten_id.as_ref()),
       hash_function,
     );
-    let modules = modules_with_readable_identifiers
-      .into_iter()
-      .map(|(module, _)| module)
-      .collect();
     Self::new(id.as_str().into(), root_module_ctxt, modules, runtime)
   }
 

--- a/crates/rspack_core/src/transient_cache/module_static_cache.rs
+++ b/crates/rspack_core/src/transient_cache/module_static_cache.rs
@@ -31,16 +31,18 @@ impl ModuleStaticCacheInner {
     &self,
     key: ReadableIdentifierCacheKey,
     f: F,
-  ) -> String {
+  ) -> Arc<str> {
     if !self.cache_enabled.load(Ordering::Acquire) {
-      return f();
+      return Arc::<str>::from(f());
     }
 
-    match self.readable_identifier_cache.get(&key) {
+    match self.readable_identifier_cache.get_arc(&key) {
       Some(value) => value,
       None => {
-        let value = f();
-        self.readable_identifier_cache.set(key, value.clone());
+        let value = Arc::<str>::from(f());
+        self
+          .readable_identifier_cache
+          .set_arc(key, Arc::clone(&value));
         value
       }
     }
@@ -56,7 +58,7 @@ pub(super) mod readable_identifier {
 
   #[derive(Debug, Default)]
   pub struct ReadableIdentifierCache {
-    cache: RwLock<HashMap<ReadableIdentifierCacheKey, String>>,
+    cache: RwLock<HashMap<ReadableIdentifierCacheKey, Arc<str>>>,
   }
 
   impl ReadableIdentifierCache {
@@ -64,17 +66,39 @@ pub(super) mod readable_identifier {
       self.cache.write().expect("should get lock").clear();
     }
 
-    pub fn get(&self, key: &ReadableIdentifierCacheKey) -> Option<String> {
+    pub fn get_arc(&self, key: &ReadableIdentifierCacheKey) -> Option<Arc<str>> {
       let inner = self.cache.read().expect("should get lock");
       inner.get(key).cloned()
     }
 
-    pub fn set(&self, key: ReadableIdentifierCacheKey, value: String) {
+    pub fn set_arc(&self, key: ReadableIdentifierCacheKey, value: Arc<str>) {
       self
         .cache
         .write()
         .expect("should get lock")
         .insert(key, value);
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use super::ModuleStaticCacheInner;
+  use crate::ModuleIdentifier;
+
+  #[test]
+  fn cached_readable_identifier_reuses_the_same_allocation() {
+    let cache = ModuleStaticCacheInner::default();
+    cache.enable_new_cache();
+
+    let key = (ModuleIdentifier::from("module-a"), None);
+    let first = cache.cached_readable_identifier(key.clone(), || "alpha".to_string());
+    let second = cache.cached_readable_identifier(key, || "beta".to_string());
+
+    assert_eq!(&*first, "alpha");
+    assert_eq!(&*second, "alpha");
+    assert!(Arc::ptr_eq(&first, &second));
   }
 }

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -235,7 +235,7 @@ impl EsmLibraryPlugin {
   fn assign_external_candidate_name(
     readable_identifier: &str,
     candidate_used_names: &mut FxHashSet<Atom>,
-    escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
+    escaped_identifiers: &FxHashMap<Arc<str>, Vec<Atom>>,
   ) -> Atom {
     let name = find_new_name(
       "",
@@ -543,8 +543,10 @@ impl EsmLibraryPlugin {
 
             if let Some(import_map) = &info.import_map {
               for ((source, _), imported_atoms) in import_map.iter() {
-                escaped_identifiers
-                  .push((source.clone(), split_readable_identifier(source.as_str())));
+                escaped_identifiers.push((
+                  source.clone().into(),
+                  split_readable_identifier(source.as_str()),
+                ));
                 for atom in &imported_atoms.specifiers {
                   escaped_names
                     .entry(atom.clone())
@@ -946,7 +948,7 @@ var {} = {{}};
     external_module_init_fragments: &IdentifierMap<ChunkInitFragments>,
     chunk_link: &mut ChunkLinkContext,
     escaped_names: &FxHashMap<Atom, Atom>,
-    escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
+    escaped_identifiers: &FxHashMap<Arc<str>, Vec<Atom>>,
   ) {
     let context = &compilation.options.context;
 
@@ -1115,7 +1117,7 @@ var {} = {{}};
 
               let new_name = if all_used_names.contains(atom) {
                 let new_name = if atom == "default" {
-                  find_new_name("", &all_used_names, &escaped_identifiers[source])
+                  find_new_name("", &all_used_names, &escaped_identifiers[source.as_str()])
                 } else {
                   find_new_name(
                     escaped_names
@@ -1123,7 +1125,7 @@ var {} = {{}};
                       .expect("should have escaped name")
                       .as_ref(),
                     &all_used_names,
-                    &escaped_identifiers[&readable_identifier],
+                    &escaped_identifiers[readable_identifier.as_ref()],
                   )
                 };
                 all_used_names.insert(new_name.clone());
@@ -1165,7 +1167,7 @@ var {} = {{}};
                 .expect("should have escaped name")
                 .as_ref(),
               &all_used_names,
-              &escaped_identifiers[&readable_identifier],
+              &escaped_identifiers[readable_identifier.as_ref()],
             );
 
             all_used_names.insert(new_name.clone());
@@ -1208,14 +1210,14 @@ var {} = {{}};
                 find_new_name(
                   "namespaceObject",
                   &all_used_names,
-                  &escaped_identifiers[&readable_identifier],
+                  &escaped_identifiers[readable_identifier.as_ref()],
                 )
               })
           } else {
             find_new_name(
               "namespaceObject",
               &all_used_names,
-              &escaped_identifiers[&readable_identifier],
+              &escaped_identifiers[readable_identifier.as_ref()],
             )
           }
         };
@@ -1227,7 +1229,7 @@ var {} = {{}};
           let external_name_interop: Atom = find_new_name(
             "namespaceObject",
             &all_used_names,
-            &escaped_identifiers[&readable_identifier],
+            &escaped_identifiers[readable_identifier.as_ref()],
           );
           all_used_names.insert(external_name_interop.clone());
           info.set_interop_namespace_object_name(Some(external_name_interop.clone()));
@@ -1239,7 +1241,7 @@ var {} = {{}};
           let external_name_interop: Atom = find_new_name(
             "namespaceObject2",
             &all_used_names,
-            &escaped_identifiers[&readable_identifier],
+            &escaped_identifiers[readable_identifier.as_ref()],
           );
           all_used_names.insert(external_name_interop.clone());
           info.set_interop_namespace_object2_name(Some(external_name_interop.clone()));
@@ -1252,7 +1254,7 @@ var {} = {{}};
           let external_name_interop: Atom = find_new_name(
             "default",
             &all_used_names,
-            &escaped_identifiers[&readable_identifier],
+            &escaped_identifiers[readable_identifier.as_ref()],
           );
           all_used_names.insert(external_name_interop.clone());
           info.set_interop_default_access_name(Some(external_name_interop.clone()));
@@ -1887,7 +1889,7 @@ var {} = {{}};
     needed_namespace_objects: &mut IdentifierIndexSet,
     entry_imports: &mut IdentifierIndexMap<FxHashMap<Atom, Atom>>,
     exports: &mut FxHashMap<ChunkUkey, ExportsContext>,
-    escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
+    escaped_identifiers: &FxHashMap<Arc<str>, Vec<Atom>>,
     allow_rename: bool,
     filter_unused: bool,
     re_export_star_cache: &mut IdentifierMap<FxIndexSet<Either<Atom, ModuleIdentifier>>>,
@@ -2088,12 +2090,13 @@ var {} = {{}};
             let new_name = find_new_name(
               &name,
               &entry_chunk_link.used_names,
-              &escaped_identifiers[&get_cached_readable_identifier(
+              &escaped_identifiers[get_cached_readable_identifier(
                 &entry_module,
                 module_graph,
                 &compilation.module_static_cache,
                 context,
-              )],
+              )
+              .as_ref()],
             );
             entry_chunk_link.used_names.insert(new_name.clone());
             entry_chunk_link
@@ -2162,7 +2165,7 @@ var {} = {{}};
     runtime_chunks_exporting_require_via_runtime_module: &FxHashSet<ChunkUkey>,
     concate_modules_map: &mut IdentifierIndexMap<ModuleInfo>,
     needed_namespace_objects_by_ukey: &mut FxHashMap<ChunkUkey, IdentifierIndexSet>,
-    escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
+    escaped_identifiers: &FxHashMap<Arc<str>, Vec<Atom>>,
   ) -> Vec<Diagnostic> {
     let mut errors = vec![];
     let context = &compilation.options.context;
@@ -2704,7 +2707,7 @@ var {} = {{}};
             let new_symbol = find_new_name(
               &symbol,
               all_used_names,
-              &escaped_identifiers[&readable_identifier],
+              &escaped_identifiers[readable_identifier.as_ref()],
             );
             all_used_names.insert(new_symbol.clone());
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -3360,6 +3360,8 @@ fn normal_render(
 
 #[cfg(test)]
 mod tests {
+  use std::sync::Arc;
+
   use rspack_core::{ChunkInitFragments, ChunkUkey, InitFragmentKey, ModuleIdentifier};
   use rspack_util::{
     atom::Atom,
@@ -3716,7 +3718,7 @@ mod tests {
     let mut chunk_used_names = FxHashSet::default();
     let mut required = Default::default();
     let escaped_identifiers =
-      FxHashMap::from_iter([("./lib.js".to_string(), vec![Atom::from("lib")])]);
+      FxHashMap::from_iter([(Arc::<str>::from("./lib.js"), vec![Atom::from("lib")])]);
 
     let candidate = EsmLibraryPlugin::assign_external_candidate_name(
       "./lib.js",

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1368,7 +1368,8 @@ async fn create_concatenated_module(
       module_graph,
       &compilation.module_static_cache,
       &compilation.options.context,
-    ),
+    )
+    .to_string(),
     name_for_condition: root_module.name_for_condition(),
     lib_indent: root_module
       .lib_ident(LibIdentOptions {
@@ -1405,19 +1406,21 @@ async fn create_concatenated_module(
         .module_by_identifier(id)
         .unwrap_or_else(|| panic!("should have module {id}"));
 
-      ConcatenatedInnerModule {
-        id: *id,
-        size: module.size(
-          Some(&rspack_core::SourceType::JavaScript),
-          Some(compilation),
-        ),
-        shorten_id: get_cached_readable_identifier(
+      (
+        ConcatenatedInnerModule {
+          id: *id,
+          size: module.size(
+            Some(&rspack_core::SourceType::JavaScript),
+            Some(compilation),
+          ),
+        },
+        get_cached_readable_identifier(
           id,
           module_graph,
           &compilation.module_static_cache,
           &compilation.options.context,
         ),
-      }
+      )
     })
     .collect::<Vec<_>>();
   let mut new_module = BoxModule::new(Box::from(ConcatenatedModule::create(
@@ -1456,7 +1459,6 @@ where
   F: Fn(&ModuleIdentifier, &ModuleGraphConnection, &BoxDependency) -> bool + Sync,
 {
   let mg = compilation.get_module_graph();
-
   let dependency_parts = modules_set
     .par_iter()
     .filter_map(|m| {
@@ -1468,7 +1470,7 @@ where
         .expect("should have mgm")
         .outgoing_connections();
 
-      let mut part = vec![];
+      let mut part = Vec::with_capacity(old_mgm_connections.len());
       for dep_id in old_mgm_connections {
         let connection = mg
           .connection_by_dependency_id(dep_id)
@@ -1498,11 +1500,11 @@ where
   F: Fn(&ModuleIdentifier, &ModuleGraphConnection, &BoxDependency) -> bool,
 {
   let mg = compilation.get_module_graph();
-  let mut outgoings = vec![];
   let old_mgm_connections = mg
     .module_graph_module_by_identifier(root_module_id)
     .expect("should have mgm")
     .outgoing_connections();
+  let mut outgoings = Vec::with_capacity(old_mgm_connections.len());
 
   for dep_id in old_mgm_connections {
     let connection = mg
@@ -1515,11 +1517,11 @@ where
     }
   }
 
-  let mut incomings = vec![];
   let incoming_connections = mg
     .module_graph_module_by_identifier(root_module_id)
     .expect("should have mgm")
     .incoming_connections();
+  let mut incomings = Vec::with_capacity(incoming_connections.len());
 
   for dep_id in incoming_connections {
     let connection = mg

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1406,21 +1406,19 @@ async fn create_concatenated_module(
         .module_by_identifier(id)
         .unwrap_or_else(|| panic!("should have module {id}"));
 
-      (
-        ConcatenatedInnerModule {
-          id: *id,
-          size: module.size(
-            Some(&rspack_core::SourceType::JavaScript),
-            Some(compilation),
-          ),
-        },
-        get_cached_readable_identifier(
+      ConcatenatedInnerModule {
+        id: *id,
+        size: module.size(
+          Some(&rspack_core::SourceType::JavaScript),
+          Some(compilation),
+        ),
+        shorten_id: get_cached_readable_identifier(
           id,
           module_graph,
           &compilation.module_static_cache,
           &compilation.options.context,
         ),
-      )
+      }
     })
     .collect::<Vec<_>>();
   let mut new_module = BoxModule::new(Box::from(ConcatenatedModule::create(


### PR DESCRIPTION
## Summary
- return `Arc<str>` from `cached_readable_identifier` so hot paths can share cached readable identifier allocations through a single API
- update module concatenation and ESM library call sites to use shared readable identifiers while preserving owned `String` conversion only where it is still required
- keep the concatenated module allocation reductions around identifier hashing, dependency membership checks, diagnostics, assets, and connection collection

## Test Plan
- `pnpm run build:binding:dev`
- `cargo test -p rspack_core cached_readable_identifier_reuses_the_same_allocation --lib`
- `cargo test -p rspack_plugin_javascript --lib --no-run`
- `cargo bench -p rspack_benchmark --bench benches --no-run`
