### PR TITLE
perf: reuse cached module dependency lists in finish_modules

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -93,7 +93,7 @@ impl BuildChunkGraphArtifact {
           .module_graph_module_by_identifier(&module)
           .expect("should have module");
         module
-          .all_dependencies
+          .all_dependencies()
           .iter()
           .filter(|dep_id| {
             module_graph

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -120,12 +120,13 @@ impl BuildModuleGraphArtifact {
     let mgm = mg
       .module_graph_module_by_identifier(module_identifier)
       .expect("should have mgm");
-    for dep_id in mgm
-      .all_dependencies
-      .clone()
-      .into_iter()
+    let dep_ids = mgm
+      .all_dependencies()
+      .iter()
+      .copied()
       .chain(mgm.incoming_connections().clone())
-    {
+      .collect::<Vec<_>>();
+    for dep_id in dep_ids {
       self.make_failed_dependencies.remove(&dep_id);
 
       let dep = mg.dependency_by_id_mut(&dep_id);

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -61,7 +61,7 @@ pub fn save_module_graph(
         .map(|block_id| mg.block_by_id(block_id).expect("should have block").into())
         .collect::<Vec<_>>();
       let dependencies = mgm
-        .all_dependencies
+        .all_dependencies()
         .par_iter()
         .map(|dep_id| {
           (

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -182,7 +182,7 @@ impl Task<TaskContext> for BuildResultTask {
 
     {
       let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
-      mgm.all_dependencies.clone_from(&all_dependencies);
+      mgm.all_dependencies_mut().clone_from(&all_dependencies);
     }
 
     let module_identifier = module.identifier();

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -206,7 +206,7 @@ fn collect_dependencies_diagnostics(
         .module_graph_module_by_identifier(module_identifier)
         .expect("should have mgm");
       let diagnostics = mgm
-        .all_dependencies
+        .all_dependencies()
         .iter()
         .filter_map(|dependency_id| {
           let dependency = module_graph.dependency_by_id(dependency_id);

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -327,7 +327,7 @@ impl ModuleGraph {
     {
       mgm.remove_outgoing_connection(dep_id);
       if force {
-        mgm.all_dependencies.retain(|id| id != dep_id);
+        mgm.all_dependencies_mut().retain(|id| id != dep_id);
       }
     }
     // remove incoming from module graph module
@@ -351,7 +351,7 @@ impl ModuleGraph {
       .map(|mgm| {
         (
           mgm.incoming_connections().clone(),
-          mgm.all_dependencies.clone(),
+          mgm.all_dependencies().to_vec(),
         )
       })
       .unwrap_or_default();
@@ -798,7 +798,7 @@ impl ModuleGraph {
     self
       .module_graph_module_by_identifier(module_identifier)
       .map(|m| {
-        m.all_dependencies
+        m.all_dependencies()
           .iter()
           .filter_map(|dep_id| self.connection_by_dependency_id(dep_id))
       })
@@ -813,7 +813,7 @@ impl ModuleGraph {
     self
       .module_graph_module_by_identifier(module_identifier)
       .map(|m| {
-        m.all_dependencies
+        m.all_dependencies()
           .iter()
           .filter(|dep_id| self.connection_by_dependency_id(dep_id).is_some())
       })

--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -49,7 +49,7 @@ pub struct ModuleGraphModule {
   pub module_identifier: ModuleIdentifier,
   // an quick way to get a module's all dependencies (including its blocks' dependencies)
   // and it is ordered by dependency creation order
-  pub(crate) all_dependencies: Vec<DependencyId>,
+  all_dependencies: Vec<DependencyId>,
   pub(crate) pre_order_index: Option<u32>,
   pub post_order_index: Option<u32>,
   pub depth: Option<usize>,
@@ -94,6 +94,14 @@ impl ModuleGraphModule {
 
   pub fn outgoing_connections(&self) -> &FxHashSet<DependencyId> {
     &self.outgoing_connections
+  }
+
+  pub fn all_dependencies(&self) -> &[DependencyId] {
+    &self.all_dependencies
+  }
+
+  pub(crate) fn all_dependencies_mut(&mut self) -> &mut Vec<DependencyId> {
+    &mut self.all_dependencies
   }
 
   pub fn set_issuer_if_unset(&mut self, issuer: Option<ModuleIdentifier>) {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
+use rspack_util::fx_hash::FxIndexSet;
 use swc_core::ecma::atoms::Atom;
 
 struct FlagDependencyExportsState<'a> {
@@ -251,8 +251,7 @@ fn collect_module_exports_specs(
   mg: &ModuleGraph,
   mg_cache: &ModuleGraphCacheArtifact,
   exports_info_artifact: &ExportsInfoArtifact,
-) -> Option<(FxIndexMap<DependencyId, ExportsSpec>, bool)> {
-  let mut has_nested_exports = false;
+) -> Option<(Vec<(DependencyId, ExportsSpec)>, bool)> {
   fn walk_block<B: DependenciesBlock + ?Sized>(
     block: &B,
     dep_ids: &mut FxIndexSet<DependencyId>,
@@ -273,15 +272,18 @@ fn collect_module_exports_specs(
   // There is no need to use the cache here
   // because the `get_exports` of each dependency will only be called once
   // mg_cache.freeze();
-  let res = dep_ids
-    .into_iter()
-    .filter_map(|id| {
-      let dep = mg.dependency_by_id(&id);
-      let exports_spec = dep.get_exports(mg, mg_cache, exports_info_artifact)?;
-      has_nested_exports |= exports_spec.has_nested_exports();
-      Some((id, exports_spec))
-    })
-    .collect::<FxIndexMap<DependencyId, ExportsSpec>>();
+  let mut has_nested_exports = false;
+  let mut res = Vec::new();
+  for id in dep_ids {
+    let Some(exports_spec) =
+      mg.dependency_by_id(&id)
+        .get_exports(mg, mg_cache, exports_info_artifact)
+    else {
+      continue;
+    };
+    has_nested_exports |= exports_spec.has_nested_exports();
+    res.push((id, exports_spec));
+  }
   // mg_cache.unfreeze();
   Some((res, has_nested_exports))
 }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,17 +1,16 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules,
-  DependenciesBlock, DependencyId, EvaluatedInlinableValue, ExportInfo, ExportInfoData,
-  ExportNameOrSpec, ExportProvided, ExportsInfo, ExportsInfoArtifact, ExportsInfoData,
-  ExportsOfExportsSpec, ExportsSpec, GetTargetResult, Logger, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, Nullable, Plugin,
-  PrefetchExportsInfoMode, SideEffectsStateArtifact, get_target,
+  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules, DependencyId,
+  EvaluatedInlinableValue, ExportInfo, ExportInfoData, ExportNameOrSpec, ExportProvided,
+  ExportsInfo, ExportsInfoArtifact, ExportsInfoData, ExportsOfExportsSpec, ExportsSpec,
+  GetTargetResult, Logger, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
+  ModuleIdentifier, Nullable, Plugin, PrefetchExportsInfoMode, SideEffectsStateArtifact,
+  get_target,
   incremental::{self, IncrementalPasses},
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::fx_hash::FxIndexSet;
 use swc_core::ecma::atoms::Atom;
 
 struct FlagDependencyExportsState<'a> {
@@ -252,29 +251,14 @@ fn collect_module_exports_specs(
   mg_cache: &ModuleGraphCacheArtifact,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> Option<(Vec<(DependencyId, ExportsSpec)>, bool)> {
-  fn walk_block<B: DependenciesBlock + ?Sized>(
-    block: &B,
-    dep_ids: &mut FxIndexSet<DependencyId>,
-    mg: &ModuleGraph,
-  ) {
-    dep_ids.extend(block.get_dependencies().iter().copied());
-    for block_id in block.get_blocks() {
-      if let Some(block) = mg.block_by_id(block_id) {
-        walk_block(block, dep_ids, mg);
-      }
-    }
-  }
-
-  let block = mg.module_by_identifier(module_id)?.as_ref();
-  let mut dep_ids = FxIndexSet::default();
-  walk_block(block, &mut dep_ids, mg);
+  let mgm = mg.module_graph_module_by_identifier(module_id)?;
 
   // There is no need to use the cache here
   // because the `get_exports` of each dependency will only be called once
   // mg_cache.freeze();
   let mut has_nested_exports = false;
   let mut res = Vec::new();
-  for id in dep_ids {
+  for id in mgm.all_dependencies().iter().copied() {
     let Some(exports_spec) =
       mg.dependency_by_id(&id)
         .get_exports(mg, mg_cache, exports_info_artifact)

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -252,13 +252,14 @@ fn collect_module_exports_specs(
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> Option<(Vec<(DependencyId, ExportsSpec)>, bool)> {
   let mgm = mg.module_graph_module_by_identifier(module_id)?;
+  let all_dependencies = mgm.all_dependencies();
 
   // There is no need to use the cache here
   // because the `get_exports` of each dependency will only be called once
   // mg_cache.freeze();
   let mut has_nested_exports = false;
-  let mut res = Vec::new();
-  for id in mgm.all_dependencies().iter().copied() {
+  let mut res = Vec::with_capacity(all_dependencies.len());
+  for id in all_dependencies.iter().copied() {
     let Some(exports_spec) =
       mg.dependency_by_id(&id)
         .get_exports(mg, mg_cache, exports_info_artifact)

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -95,7 +95,7 @@ fn set_sync_modules(
   modules: IdentifierLinkedSet,
   mutations: &mut Option<Mutations>,
 ) {
-  let outgoing_connections = modules
+  let mut outgoing_connections = modules
     .iter()
     .par_bridge()
     .map(|mid| {
@@ -113,17 +113,15 @@ fn set_sync_modules(
 
   let mut queue = modules;
   while let Some(module) = queue.pop_front() {
-    if outgoing_connections
-      .get(&module)
-      .cloned()
-      .unwrap_or_else(|| {
-        module_graph
-          .get_outgoing_connections(&module)
-          .filter_map(|con| module_graph.module_identifier_by_dependency_id(&con.dependency_id))
-          .filter(|&out| &module != out)
-          .copied()
-          .collect::<Vec<_>>()
-      })
+    let module_outgoing_connections = outgoing_connections.entry(module).or_insert_with(|| {
+      module_graph
+        .get_outgoing_connections(&module)
+        .filter_map(|con| module_graph.module_identifier_by_dependency_id(&con.dependency_id))
+        .filter(|&out| &module != out)
+        .copied()
+        .collect::<Vec<_>>()
+    });
+    if module_outgoing_connections
       .iter()
       .any(|out| ModuleGraph::is_async(async_modules_artifact, out))
     {


### PR DESCRIPTION
## Summary

This PR reduces repeated work in the `finish_modules` path by reusing dependency data that is already maintained in the module graph.

## What Changed

- Cache outgoing module identifiers inside `InferAsyncModulesPlugin::set_sync_modules`, and write fallback results back into the cache instead of recomputing them repeatedly.
- Change `collect_module_exports_specs` to iterate `ModuleGraphModule::all_dependencies()` directly instead of recursively walking blocks and deduplicating dependency ids again.
- Expose `ModuleGraphModule::all_dependencies()` as the accessor for the precomputed dependency list and update related core call sites to use it consistently.
- Store collected export specs as `Vec<(DependencyId, ExportsSpec)>`, since the result is only consumed sequentially and does not need map lookups.

## Result

The finish-modules flow now reuses the module graph's precomputed dependency ordering in more places and avoids extra hashing, block traversal, and repeated temporary allocations.
