### PR TITLE
feat(pure-functions): accept any top-level binding and trust consumer-side hints

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -13,9 +13,10 @@ use swc_core::{
   },
   ecma::{
     ast::{
-      ArrowExpr, BlockStmt, BlockStmtOrExpr, Class, ClassMember, Decl, Expr, ExportSpecifier,
-      ExprOrSpread, Function, ImportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, Pat,
-      Program, PropName, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr,
+      ArrayPat, ArrowExpr, AssignPat, AssignPatProp, BlockStmt, BlockStmtOrExpr, Class,
+      ClassMember, Decl, ExportSpecifier, Expr, ExprOrSpread, Function, ImportSpecifier,
+      KeyValuePatProp, ModuleDecl, ModuleExportName, ModuleItem, ObjectPat, ObjectPatProp, Pat,
+      Program, PropName, RestPat, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr,
     },
     utils::{ExprCtx, ExprExt},
     visit::{Visit, VisitWith},
@@ -255,17 +256,38 @@ fn collect_defined_configured_side_effects_free(
     .collect()
 }
 
+fn visit_pat_binding_names(pat: &Pat, f: &mut impl FnMut(&Atom)) {
+  match pat {
+    Pat::Ident(ident) => f(&ident.id.sym),
+    Pat::Array(ArrayPat { elems, .. }) => {
+      for elem in elems.iter().flatten() {
+        visit_pat_binding_names(elem, f);
+      }
+    }
+    Pat::Object(ObjectPat { props, .. }) => {
+      for prop in props {
+        match prop {
+          ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
+            visit_pat_binding_names(value, f);
+          }
+          ObjectPatProp::Assign(AssignPatProp { key, .. }) => f(&key.id.sym),
+          ObjectPatProp::Rest(RestPat { arg, .. }) => visit_pat_binding_names(arg, f),
+        }
+      }
+    }
+    Pat::Assign(AssignPat { left, .. }) => visit_pat_binding_names(left, f),
+    Pat::Rest(RestPat { arg, .. }) => visit_pat_binding_names(arg, f),
+    Pat::Expr(_) | Pat::Invalid(_) => {}
+  }
+}
+
 fn visit_decl_binding_names(decl: &Decl, f: &mut impl FnMut(&Atom)) {
   match decl {
     Decl::Fn(fn_decl) => f(&fn_decl.ident.sym),
     Decl::Class(class_decl) => f(&class_decl.ident.sym),
     Decl::Var(var_decl) => {
-      for ident in var_decl
-        .decls
-        .iter()
-        .filter_map(|declarator| declarator.name.as_ident())
-      {
-        f(&ident.sym);
+      for declarator in &var_decl.decls {
+        visit_pat_binding_names(&declarator.name, f);
       }
     }
     _ => {}
@@ -910,18 +932,21 @@ fn resolve_explicit_side_effects_free_callee(
     return ExplicitSideEffectsFreeCallee::NotMarked;
   }
 
-  // When the user listed this name in `pureFunctions`, trust the assertion at
-  // the call site instead of deferring to the import target. This lets users
-  // mark imported helpers (e.g. `import { cva } from 'cva'`) as pure on the
-  // consumer side without having to also configure the source module.
-  let is_user_configured = parser
-    .javascript_options
-    .side_effects_free
-    .as_ref()
-    .is_some_and(|names| names.iter().any(|name| name.as_str() == ident.as_str()));
-
-  if !is_user_configured && try_extract_deferred_check(parser, ident.clone(), span).is_some() {
-    return ExplicitSideEffectsFreeCallee::Deferred;
+  // For non-imports the deferred path doesn't apply at all, so we skip the
+  // user-config lookup and fall straight through to Direct/Invalid.
+  if try_extract_deferred_check(parser, ident.clone(), span).is_some() {
+    // When the user explicitly listed this name in `pureFunctions`, trust the
+    // assertion at the call site instead of deferring to the import target.
+    // This lets users mark imported helpers (e.g. `import { cva } from 'cva'`)
+    // as pure on the consumer side without also configuring the source module.
+    let is_user_configured = parser
+      .javascript_options
+      .side_effects_free
+      .as_ref()
+      .is_some_and(|names| names.iter().any(|name| name.as_str() == ident.as_str()));
+    if !is_user_configured {
+      return ExplicitSideEffectsFreeCallee::Deferred;
+    }
   }
 
   if parser.get_variable_info(ident).is_some() || allow_unresolved_marked {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -13,9 +13,9 @@ use swc_core::{
   },
   ecma::{
     ast::{
-      ArrowExpr, BlockStmt, BlockStmtOrExpr, Class, ClassMember, Decl, Expr, ExprOrSpread,
-      Function, ImportSpecifier, ModuleDecl, ModuleItem, Pat, Program, PropName, Stmt, VarDecl,
-      VarDeclKind, VarDeclOrExpr,
+      ArrowExpr, BlockStmt, BlockStmtOrExpr, Class, ClassMember, Decl, Expr, ExportSpecifier,
+      ExprOrSpread, Function, ImportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, Pat,
+      Program, PropName, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr,
     },
     utils::{ExprCtx, ExprExt},
     visit::{Visit, VisitWith},
@@ -158,178 +158,99 @@ impl<'a> Visit for PureAnnotation<'a> {
   }
 }
 
-fn insert_module_export_name(
-  name: &swc_core::ecma::ast::ModuleExportName,
-  refs: &mut FxHashSet<Atom>,
-) {
-  match name {
-    swc_core::ecma::ast::ModuleExportName::Ident(ident) => {
-      refs.insert(ident.sym.clone());
-    }
-    swc_core::ecma::ast::ModuleExportName::Str(str) => {
-      if let Some(atom) = str.value.as_atom() {
-        refs.insert(atom.clone());
-      }
-    }
-  }
-}
-
-fn function_like_var_decl_names(var_decl: &VarDecl, refs: &mut FxHashSet<Atom>) {
-  if !matches!(var_decl.kind, VarDeclKind::Const) {
-    return;
-  }
-
-  for declarator in &var_decl.decls {
-    let Some(ident) = declarator.name.as_ident() else {
-      continue;
-    };
-
-    if matches!(
-      declarator.init.as_deref(),
-      Some(Expr::Fn(_) | Expr::Arrow(_))
-    ) {
-      refs.insert(ident.sym.clone());
-    }
-  }
-}
-
-fn collect_top_level_function_like_local_refs(program: &Program) -> FxHashSet<Atom> {
-  let mut refs = FxHashSet::default();
+fn collect_pure_function_acceptable_names(program: &Program) -> FxHashSet<Atom> {
+  // Names a user can list in `pureFunctions` and have actually take effect:
+  //   - any top-level binding (function/class/var decl or import) — so calls
+  //     to local helpers and imported identifiers can be marked pure;
+  //   - export aliases of local bindings (`export { foo as bar }`) and the
+  //     `default` keyword for default-exported functions/arrows — preserves
+  //     the original "configure on the source module" workflow.
+  let mut names = FxHashSet::default();
+  let mut insert = |name: &Atom| {
+    names.insert(name.clone());
+  };
 
   match program {
     Program::Module(module) => {
+      // First pass: collect every actual top-level binding name.
       for item in &module.body {
         match item {
-          ModuleItem::Stmt(stmt) => {
-            if let Stmt::Decl(decl) = stmt {
-              match decl {
-                Decl::Fn(fn_decl) => {
-                  refs.insert(fn_decl.ident.sym.clone());
-                }
-                Decl::Var(var_decl) => {
-                  function_like_var_decl_names(var_decl, &mut refs);
-                }
-                _ => {}
-              }
-            }
-          }
+          ModuleItem::Stmt(Stmt::Decl(decl)) => visit_decl_binding_names(decl, &mut insert),
           ModuleItem::ModuleDecl(decl) => {
-            if let ModuleDecl::ExportDecl(export_decl) = decl {
-              match &export_decl.decl {
-                Decl::Fn(fn_decl) => {
-                  refs.insert(fn_decl.ident.sym.clone());
+            visit_module_decl_defined_binding_names(decl, &mut insert)
+          }
+          _ => {}
+        }
+      }
+
+      // Second pass: re-export aliases and `default` for default-exported fns.
+      let local_bindings = names.clone();
+      for item in &module.body {
+        let ModuleItem::ModuleDecl(decl) = item else {
+          continue;
+        };
+        match decl {
+          ModuleDecl::ExportNamed(named_export) if named_export.src.is_none() => {
+            for specifier in &named_export.specifiers {
+              let ExportSpecifier::Named(named) = specifier else {
+                continue;
+              };
+              let orig_atom = match &named.orig {
+                ModuleExportName::Ident(ident) => &ident.sym,
+                ModuleExportName::Str(_) => continue,
+              };
+              if !local_bindings.contains(orig_atom) {
+                continue;
+              }
+              match named.exported.as_ref().unwrap_or(&named.orig) {
+                ModuleExportName::Ident(ident) => {
+                  names.insert(ident.sym.clone());
                 }
-                Decl::Var(var_decl) => {
-                  function_like_var_decl_names(var_decl, &mut refs);
+                ModuleExportName::Str(s) => {
+                  if let Some(atom) = s.value.as_atom() {
+                    names.insert(atom.clone());
+                  }
                 }
-                _ => {}
               }
             }
           }
+          ModuleDecl::ExportDefaultDecl(default_decl)
+            if matches!(default_decl.decl, swc_core::ecma::ast::DefaultDecl::Fn(_)) =>
+          {
+            names.insert(Atom::from("default"));
+          }
+          ModuleDecl::ExportDefaultExpr(default_expr)
+            if default_expr.expr.is_fn_expr() || default_expr.expr.is_arrow() =>
+          {
+            names.insert(Atom::from("default"));
+          }
+          _ => {}
         }
       }
     }
     Program::Script(script) => {
       for stmt in &script.body {
         if let Stmt::Decl(decl) = stmt {
-          match decl {
-            Decl::Fn(fn_decl) => {
-              refs.insert(fn_decl.ident.sym.clone());
-            }
-            Decl::Var(var_decl) => {
-              function_like_var_decl_names(var_decl, &mut refs);
-            }
-            _ => {}
-          }
+          visit_decl_binding_names(decl, &mut insert);
         }
       }
     }
   }
 
-  refs
-}
-
-fn collect_exported_side_effects_free_refs(program: &Program) -> FxHashSet<Atom> {
-  let mut refs = FxHashSet::default();
-  let local_function_like_refs = collect_top_level_function_like_local_refs(program);
-
-  let Program::Module(module) = program else {
-    return refs;
-  };
-
-  for item in &module.body {
-    let ModuleItem::ModuleDecl(decl) = item else {
-      continue;
-    };
-
-    #[allow(clippy::collapsible_match)]
-    match decl {
-      ModuleDecl::ExportDecl(export_decl) => match &export_decl.decl {
-        Decl::Fn(fn_decl) => {
-          refs.insert(fn_decl.ident.sym.clone());
-        }
-        Decl::Var(var_decl) => {
-          function_like_var_decl_names(var_decl, &mut refs);
-        }
-        _ => {}
-      },
-      ModuleDecl::ExportDefaultDecl(default_decl) => match &default_decl.decl {
-        swc_core::ecma::ast::DefaultDecl::Fn(fn_expr) => {
-          refs.insert(Atom::from("default"));
-          if let Some(ident) = &fn_expr.ident {
-            refs.insert(ident.sym.clone());
-          }
-        }
-        swc_core::ecma::ast::DefaultDecl::Class(_)
-        | swc_core::ecma::ast::DefaultDecl::TsInterfaceDecl(_) => {}
-      },
-      ModuleDecl::ExportDefaultExpr(default_expr) => {
-        if default_expr.expr.is_fn_expr() || default_expr.expr.is_arrow() {
-          refs.insert(Atom::from("default"));
-        }
-      }
-      ModuleDecl::ExportNamed(named_export) => {
-        if named_export.src.is_none() {
-          for specifier in &named_export.specifiers {
-            let swc_core::ecma::ast::ExportSpecifier::Named(named) = specifier else {
-              continue;
-            };
-
-            let orig = match &named.orig {
-              swc_core::ecma::ast::ModuleExportName::Ident(ident) => &ident.sym,
-              swc_core::ecma::ast::ModuleExportName::Str(_) => continue,
-            };
-
-            if !local_function_like_refs.contains(orig) {
-              continue;
-            }
-
-            if let Some(exported) = &named.exported {
-              insert_module_export_name(exported, &mut refs);
-            } else {
-              refs.insert(orig.clone());
-            }
-          }
-        }
-      }
-      _ => {}
-    }
-  }
-
-  refs
+  names
 }
 
 fn collect_defined_configured_side_effects_free(
   program: &Program,
   configured_side_effects_free: &[String],
 ) -> FxHashSet<Atom> {
-  let exported_refs = collect_exported_side_effects_free_refs(program);
+  let acceptable = collect_pure_function_acceptable_names(program);
 
   configured_side_effects_free
     .iter()
     .filter_map(|name| {
       let atom = Atom::from(name.clone());
-      exported_refs.contains(&atom).then_some(atom)
+      acceptable.contains(&atom).then_some(atom)
     })
     .collect()
 }
@@ -989,7 +910,17 @@ fn resolve_explicit_side_effects_free_callee(
     return ExplicitSideEffectsFreeCallee::NotMarked;
   }
 
-  if try_extract_deferred_check(parser, ident.clone(), span).is_some() {
+  // When the user listed this name in `pureFunctions`, trust the assertion at
+  // the call site instead of deferring to the import target. This lets users
+  // mark imported helpers (e.g. `import { cva } from 'cva'`) as pure on the
+  // consumer side without having to also configure the source module.
+  let is_user_configured = parser
+    .javascript_options
+    .side_effects_free
+    .as_ref()
+    .is_some_and(|names| names.iter().any(|name| name.as_str() == ident.as_str()));
+
+  if !is_user_configured && try_extract_deferred_check(parser, ident.clone(), span).is_some() {
     return ExplicitSideEffectsFreeCallee::Deferred;
   }
 

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-destructuring/dep.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-destructuring/dep.js
@@ -1,0 +1,10 @@
+const lib = {
+  fromObject: () => { unreachable(); },
+};
+const tuple = [() => { unreachable(); }];
+
+const { fromObject } = lib;
+const [fromArray] = tuple;
+
+fromObject();
+fromArray();

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-destructuring/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-destructuring/index.js
@@ -1,0 +1,5 @@
+import './dep';
+
+it('should accept destructured top-level bindings as pureFunctions', () => {
+  expect(Reflect.ownKeys(__webpack_modules__).length).toBe(1);
+});

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-destructuring/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-destructuring/rspack.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  mode: 'production',
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /dep\.js$/,
+        parser: {
+          pureFunctions: ['fromObject', 'fromArray'],
+        },
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/consumer.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/consumer.js
@@ -1,0 +1,3 @@
+import { libFn } from './dep';
+
+libFn();

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/dep.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/dep.js
@@ -1,0 +1,3 @@
+export function libFn() {
+  unreachable();
+}

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/index.js
@@ -1,0 +1,5 @@
+import './consumer';
+
+it('should drop pure imported call when marked on consumer', () => {
+  expect(Reflect.ownKeys(__webpack_modules__).length).toBe(1);
+});

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-imported/rspack.config.js
@@ -12,9 +12,9 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /decl\.js/,
+        test: /consumer\.js$/,
         parser: {
-          pureFunctions: ['notExistFunction'],
+          pureFunctions: ['libFn'],
         },
       },
     ],

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-local/dep.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-local/dep.js
@@ -1,0 +1,5 @@
+function privateHelper() {
+  unreachable();
+}
+
+privateHelper();

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-local/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-local/index.js
@@ -1,0 +1,5 @@
+import './dep';
+
+it('should treat non-exported local fn marked via pureFunctions as pure', () => {
+  expect(Reflect.ownKeys(__webpack_modules__).length).toBe(1);
+});

--- a/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-local/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/user-mark-pure-functions-local/rspack.config.js
@@ -12,9 +12,9 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /decl\.js/,
+        test: /dep\.js$/,
         parser: {
-          pureFunctions: ['notExistFunction'],
+          pureFunctions: ['privateHelper'],
         },
       },
     ],

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -197,7 +197,7 @@ Enables cross-module side-effect-free function call optimization, including the 
 
 For more background, see [pureFunctions](/guide/optimization/tree-shaking#purefunctions) and [NO_SIDE_EFFECTS annotation](/guide/optimization/tree-shaking#no_side_effects-annotation).
 
-Use this option to turn on the capability itself. To manually mark exported functions in matched third-party modules, configure [`module.parser.javascript.pureFunctions`](/config/module#moduleparserjavascriptpurefunctions) through `module.rules[i].parser` so the rule only applies to the intended modules.
+Use this option to turn on the capability itself. To manually mark identifiers in matched modules — exported functions in a third-party module, or imports/locals in your own files — configure [`module.parser.javascript.pureFunctions`](/config/module#moduleparserjavascriptpurefunctions) through `module.rules[i].parser` so the rule only applies to the intended modules.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1673,11 +1673,11 @@ This option is experimental in Rspack and may change or be removed.
 
 <PropertyType type="string[]" />
 
-Manually mark top-level exported functions in matched modules as side-effect-free for pure-function-based tree shaking.
+Manually mark top-level identifiers in matched modules as side-effect-free for pure-function-based tree shaking. Each name must resolve to a top-level binding in the module — a function/class/variable declaration, or an `import` specifier.
 
-This option is mainly intended for third-party libraries whose source cannot be annotated directly, such as packages in `node_modules`.
+This option is mainly intended for third-party libraries whose source cannot be annotated directly. You can either configure it on the library file itself, or on a consumer file to assert that calls to a particular import are pure.
 
-Although the option lives under `module.parser.javascript`, in practice it is usually better to apply it through `module.rules[i].parser` so you can configure `pureFunctions` more precisely for specific third-party modules.
+Although the option lives under `module.parser.javascript`, in practice it is usually better to apply it through `module.rules[i].parser` so you can configure `pureFunctions` more precisely for specific modules.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1686,10 +1686,19 @@ export default {
   },
   module: {
     rules: [
+      // Mark exports of a third-party library as pure.
       {
         test: /node_modules\/some-library\/index\.js$/,
         parser: {
           pureFunctions: ['isString'],
+        },
+      },
+      // Or mark imports on the consumer side: calls to `cva` in this file
+      // are treated as pure regardless of how the library declares itself.
+      {
+        test: /src\/styles\.js$/,
+        parser: {
+          pureFunctions: ['cva'],
         },
       },
     ],
@@ -1698,11 +1707,11 @@ export default {
 ```
 
 :::note
-Only top-level exported function definitions are supported. For default exports, use `default` as the exported name.
+For default exports configured on the source module, use `default` as the name.
 :::
 
 :::warning
-This option only takes effect when `experiments.pureFunctions` is enabled, and Rspack emits a warning if a configured exported function name cannot be found in the matched module.
+This option only takes effect when `experiments.pureFunctions` is enabled, and Rspack emits a warning if a configured name does not appear as a top-level binding in the matched module.
 :::
 
 ### module.parser["javascript/auto"]

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -1673,7 +1673,7 @@ This option is experimental in Rspack and may change or be removed.
 
 <PropertyType type="string[]" />
 
-Manually mark top-level identifiers in matched modules as side-effect-free for pure-function-based tree shaking. Each name must resolve to a top-level binding in the module — a function/class/variable declaration, or an `import` specifier.
+Manually mark top-level identifiers in matched modules as side-effect-free for pure-function-based tree shaking. Each name must resolve to a supported top-level name in the module — a function/class/variable declaration, an `import` specifier, an exported alias such as `export { foo as bar }`, or `default` for a default-exported function or arrow.
 
 This option is mainly intended for third-party libraries whose source cannot be annotated directly. You can either configure it on the library file itself, or on a consumer file to assert that calls to a particular import are pure.
 
@@ -1705,10 +1705,6 @@ export default {
   },
 };
 ```
-
-:::note
-For default exports configured on the source module, use `default` as the name.
-:::
 
 :::warning
 This option only takes effect when `experiments.pureFunctions` is enabled, and Rspack emits a warning if a configured name does not appear as a top-level binding in the matched module.

--- a/website/docs/en/guide/optimization/tree-shaking.mdx
+++ b/website/docs/en/guide/optimization/tree-shaking.mdx
@@ -225,7 +225,7 @@ If a function is marked as side-effect-free and its return value is unused, Rspa
 
 ## pureFunctions
 
-`pureFunctions` lets you manually mark top-level exported functions in matched modules as side-effect-free for pure-function-based tree shaking. This is useful for third-party libraries where source code cannot be modified, such as packages in `node_modules`.
+`pureFunctions` lets you manually mark top-level identifiers in matched modules as side-effect-free for pure-function-based tree shaking. Each name must resolve to a top-level binding in the module — a function/class/variable declaration, an `import` specifier, or an export alias of one. This is useful for third-party libraries where source code cannot be modified, such as packages in `node_modules`, and for asserting that a particular import is pure on the consumer side.
 
 For configuration details, see [`experiments.pureFunctions`](/config/experiments#experimentspurefunctions) and [`module.parser.javascript.pureFunctions`](/config/module#moduleparserjavascriptpurefunctions).
 
@@ -234,7 +234,7 @@ This option is experimental and only takes effect when `experiments.pureFunction
 :::
 
 :::note
-Only top-level exported function definitions are supported. For default exports, use `default` as the exported name.
+For default exports configured on the source module, use `default` as the name.
 :::
 
 For business source code where modification is possible, it is recommended to use the `/*#__NO_SIDE_EFFECTS__*/` annotation.
@@ -250,10 +250,18 @@ export default {
   },
   module: {
     rules: [
+      // Mark exports of a third-party library as pure.
       {
         test: /node_modules\/some-library\/index.js/,
         parser: {
           pureFunctions: ['isString', 'default'],
+        },
+      },
+      // Or mark the import on the consumer side.
+      {
+        test: /src\/styles\.js$/,
+        parser: {
+          pureFunctions: ['cva'],
         },
       },
     ],
@@ -261,4 +269,4 @@ export default {
 };
 ```
 
-Rspack validates each configured name against the matched module. If a configured exported function name cannot be found, Rspack emits a warning.
+Rspack validates each configured name against the matched module. If a configured name does not appear as a top-level binding in the module, Rspack emits a warning.

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -197,7 +197,7 @@ export default {
 
 更多背景可参考 [pureFunctions](/guide/optimization/tree-shaking#purefunctions) 和 [NO_SIDE_EFFECTS 注解](/guide/optimization/tree-shaking#no_side_effects-注解)。
 
-这个选项用于开启能力本身。若要手动为命中的第三方模块标记导出函数，推荐通过 `module.rules[i].parser` 来配置 [`module.parser.javascript.pureFunctions`](/config/module#moduleparserjavascriptpurefunctions)，这样规则只会作用于目标模块。
+这个选项用于开启能力本身。若要手动为命中的模块标记标识符 —— 既可以是第三方库中的导出函数，也可以是你自己代码中的 import 或本地声明 —— 推荐通过 `module.rules[i].parser` 来配置 [`module.parser.javascript.pureFunctions`](/config/module#moduleparserjavascriptpurefunctions)，这样规则只会作用于目标模块。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1670,11 +1670,11 @@ export default {
 
 <PropertyType type="string[]" />
 
-手动将命中模块中的顶层导出函数标记为“调用无副作用”，供基于 pure function 的 tree shaking 使用。
+手动将命中模块中的顶层标识符标记为“调用无副作用”，供基于 pure function 的 tree shaking 使用。配置的名字必须能解析到该模块中的顶层绑定 —— 即顶层的 function/class/变量声明，或者 `import` 引入的标识符。
 
-这个选项主要面向无法直接修改源码的第三方库，例如 `node_modules` 中的包。
+这个选项主要面向无法直接修改源码的第三方库。你既可以将其配置在第三方库源文件上，也可以配置在消费侧文件上以断言对某个 import 的调用是 pure 的。
 
-虽然这个选项定义在 `module.parser.javascript` 下，但在实际使用时通常更推荐通过 `module.rules[i].parser` 应用它，这样可以更细粒度地为特定第三方模块配置 `pureFunctions`。
+虽然这个选项定义在 `module.parser.javascript` 下，但在实际使用时通常更推荐通过 `module.rules[i].parser` 应用它，这样可以更细粒度地为特定模块配置 `pureFunctions`。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1683,10 +1683,19 @@ export default {
   },
   module: {
     rules: [
+      // 将第三方库中的导出标记为 pure
       {
         test: /node_modules\/some-library\/index\.js$/,
         parser: {
           pureFunctions: ['isString'],
+        },
+      },
+      // 也可以在消费侧标记 import：该文件中对 `cva` 的调用都被视为 pure，
+      // 不依赖库本身的声明。
+      {
+        test: /src\/styles\.js$/,
+        parser: {
+          pureFunctions: ['cva'],
         },
       },
     ],
@@ -1695,11 +1704,11 @@ export default {
 ```
 
 :::note
-目前仅支持顶层导出函数定义；对于默认导出，请使用 `default` 作为导出名。
+对于配置在源模块上的默认导出，请使用 `default` 作为名字。
 :::
 
 :::warning
-该选项只有在启用 `experiments.pureFunctions` 时才会生效；如果在命中的模块中找不到配置的导出函数名，Rspack 会发出警告。
+该选项只有在启用 `experiments.pureFunctions` 时才会生效；如果在命中的模块中找不到对应的顶层绑定，Rspack 会发出警告。
 :::
 
 ### module.parser["javascript/auto"]

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -1670,7 +1670,7 @@ export default {
 
 <PropertyType type="string[]" />
 
-手动将命中模块中的顶层标识符标记为“调用无副作用”，供基于 pure function 的 tree shaking 使用。配置的名字必须能解析到该模块中的顶层绑定 —— 即顶层的 function/class/变量声明，或者 `import` 引入的标识符。
+手动将命中模块中的顶层标识符标记为“调用无副作用”，供基于 pure function 的 tree shaking 使用。配置的名字必须能解析到该模块中的某个顶层名 —— 包括顶层的 function/class/变量声明、`import` 引入的标识符、`export { foo as bar }` 这类导出别名，以及匹配源模块默认导出（fn 或 arrow）时使用的 `default`。
 
 这个选项主要面向无法直接修改源码的第三方库。你既可以将其配置在第三方库源文件上，也可以配置在消费侧文件上以断言对某个 import 的调用是 pure 的。
 
@@ -1702,10 +1702,6 @@ export default {
   },
 };
 ```
-
-:::note
-对于配置在源模块上的默认导出，请使用 `default` 作为名字。
-:::
 
 :::warning
 该选项只有在启用 `experiments.pureFunctions` 时才会生效；如果在命中的模块中找不到对应的顶层绑定，Rspack 会发出警告。

--- a/website/docs/zh/guide/optimization/tree-shaking.mdx
+++ b/website/docs/zh/guide/optimization/tree-shaking.mdx
@@ -226,7 +226,7 @@ export function baz() {}
 
 ## pureFunctions
 
-`pureFunctions` 允许你在命中的模块中，手动将顶层导出函数标记为“调用无副作用”，供基于 pure function 的 tree shaking 使用。这在处理无法修改源码的第三方库（例如 `node_modules` 中的包）时非常有用。
+`pureFunctions` 允许你在命中的模块中，手动将顶层标识符标记为“调用无副作用”，供基于 pure function 的 tree shaking 使用。配置的名字必须能解析到该模块中的顶层绑定 —— 即顶层的 function/class/变量声明、`import` 引入的标识符，或它们的 export 别名。这既适用于无法修改源码的第三方库（例如 `node_modules` 中的包），也适用于在消费侧直接断言某个 import 调用是 pure 的场景。
 
 配置方式请参考 [`experiments.pureFunctions`](/config/experiments#experimentspurefunctions) 和 [`module.parser.javascript.pureFunctions`](/config/module#moduleparserjavascriptpurefunctions)。
 
@@ -235,7 +235,7 @@ export function baz() {}
 :::
 
 :::note
-目前仅支持顶层导出函数定义；对于默认导出，请使用 `default` 作为导出名。
+对于配置在源模块上的默认导出，请使用 `default` 作为名字。
 :::
 
 对于可以修改源码的业务代码，优先使用 `/*#__NO_SIDE_EFFECTS__*/` 注解。
@@ -251,10 +251,18 @@ export default {
   },
   module: {
     rules: [
+      // 将第三方库中的导出标记为 pure
       {
         test: /node_modules\/some-library\/index.js/,
         parser: {
           pureFunctions: ['isString', 'default'],
+        },
+      },
+      // 也可以在消费侧标记 import
+      {
+        test: /src\/styles\.js$/,
+        parser: {
+          pureFunctions: ['cva'],
         },
       },
     ],
@@ -262,4 +270,4 @@ export default {
 };
 ```
 
-Rspack 会校验 `pureFunctions` 中配置的每个名字是否确实存在于命中的模块中；如果找不到对应的导出函数名，就会发出警告。
+Rspack 会校验 `pureFunctions` 中配置的每个名字是否能在命中模块中解析到顶层绑定；如果找不到，就会发出警告。


### PR DESCRIPTION
## What

Relax the matching scope of `module.parser.javascript.pureFunctions`: in addition to the previously supported "locally defined exported functions", any top-level binding is now accepted — including `function`/`class`/`var` declarations, `import` specifiers, and `export { foo as bar }` aliases. Also adjust call-site resolution: when a name comes from the user's `pureFunctions` config, skip the deferred check against the source module and treat it as Direct.

Related: #13728

In addition:

- Update the existing `user-mark-pure-functions-undefined` test to drop `localOnly` / `importedOnly`, which are now valid.
- Add `user-mark-pure-functions-imported` to verify marking imports on the consumer side.
- Add `user-mark-pure-functions-local` to verify that non-exported local functions can be marked.
- Update the English and Chinese docs in sync (config/module, config/experiments, guide/optimization/tree-shaking).

## Why

The previous implementation only honored `pureFunctions` for functions exported by the module itself, which is too narrow:

- The most common real-world use case is marking calls into third-party libraries (e.g. `import { cva } from 'cva'`). The old behavior required configuring `pureFunctions` on the third-party source file, which is awkward when you can't (or don't want to) match by file path. In practice it degraded to the same expressiveness as a `/* #__NO_SIDE_EFFECTS__ */` annotation.
- Non-exported helpers inside a module (`function privateHelper() {...}`) couldn't be marked at all.
- webpack has no equivalent option, but the existing rspack restriction made this config noticeably less useful than users expect, and weaker than the intuition webpack users carry over from similar hint options.

After the change, users can either mark exports on the source module or assert "I claim this import call is pure" on the consumer side.

## How

Core change lives in `crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs`:

- Introduce `collect_pure_function_acceptable_names` that walks the program in two passes: pass 1 collects every top-level binding name (fn/class/var decls + import specifiers + the local name introduced by export decls); pass 2 fills in `export { x as y }` aliases and the `default` keyword (only when the default export is a fn/arrow). `collect_defined_configured_side_effects_free` uses this set for matching, leaving the "not found" warning path unchanged.
- Add a user-configured bypass in `resolve_explicit_side_effects_free_callee`: when the name appears in `parser.javascript_options.side_effects_free`, skip `try_extract_deferred_check` and resolve the binding directly to return Direct. This is what makes a consumer-side `pureFunctions: ['cva']` actually treat `cva()` as pure, instead of silently deferring to the source module's marker.
- Remove the now-unused helpers (`collect_exported_side_effects_free_refs`, `collect_top_level_function_like_local_refs`, `function_like_var_decl_names`, `insert_module_export_name`), eliminating a duplicate program walk.

Compatibility: the original "configure `pureFunctions` on the source module" workflow (including `export { impl as Public }` aliases and `default` exports) is preserved by the two-pass collection plus alias handling. `user-mark-pure-functions` / `user-mark-pure-functions-import-alias` keep their existing assertions.