### PR TITLE
perf: reduce code splitter and module reference overhead

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2463,7 +2463,7 @@ fn extract_block_modules(
     .expect("should have outgoing deps");
 
   for ((block_id, module_identifier), connections) in connection_map {
-    if map.contains_key(&block_id) {
+    if map.contains_key(block_id) {
       continue;
     }
     let modules = module_map

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1364,8 +1364,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let blocks = self
       .prepared_blocks_map
       .get(&item.block.into())
-      .expect("should have blocks")
-      .clone();
+      .cloned()
+      .unwrap_or_default();
 
     for block in blocks {
       self.make_chunk_group(
@@ -1445,8 +1445,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let blocks = self
       .prepared_blocks_map
       .get(&item.block)
-      .expect("should have blocks")
-      .clone();
+      .cloned()
+      .unwrap_or_default();
 
     for block in blocks {
       self.make_chunk_group(
@@ -2308,6 +2308,10 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         while let Some(module) = queue.pop_front() {
           let blocks = module.get_blocks(compilation);
 
+          if blocks.is_empty() {
+            continue;
+          }
+
           for block in blocks.iter() {
             queue.push_back((*block).into());
           }
@@ -2446,18 +2450,13 @@ fn extract_block_modules(
   map: &mut BlockConnectionMap,
 ) {
   let block = module.into();
-  let blocks = prepared_blocks_map.get(&block).expect("should have blocks");
+  let blocks = prepared_blocks_map.get(&block).cloned().unwrap_or_default();
   let mut module_map: DependenciesBlockIdentifierMap<
     Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>,
   > =
     DependenciesBlockIdentifierMap::with_capacity_and_hasher(blocks.len() + 1, Default::default());
   module_map.insert(block, Vec::new());
-  module_map.extend(
-    blocks
-      .iter()
-      .copied()
-      .map(|block| (block.into(), Vec::new())),
-  );
+  module_map.extend(blocks.into_iter().map(|block| (block.into(), Vec::new())));
 
   let connection_map = prepared_connection_map
     .get(&module)

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2255,17 +2255,29 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           Vec<DependencyId>,
         >::default();
 
-        let mut deps = mg
+        let mut ordered_deps = Vec::new();
+        let mut unordered_deps = Vec::new();
+        for dep in mg
           .get_outgoing_deps_in_order(module)
           .map(|dep_id| mg.dependency_by_id(dep_id))
           .filter(|dep| {
             dep.as_module_dependency().is_some() || dep.as_context_dependency().is_some()
           })
           .filter(|dep| !matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)))
-          .collect::<Vec<_>>();
-        deps.sort_by_key(|a| (a.source_order().is_none(), a.source_order()));
+        {
+          if let Some(source_order) = dep.source_order() {
+            ordered_deps.push((source_order, dep));
+          } else {
+            unordered_deps.push(dep);
+          }
+        }
+        ordered_deps.sort_by_key(|(source_order, _)| *source_order);
 
-        for dep in deps {
+        for dep in ordered_deps
+          .into_iter()
+          .map(|(_, dep)| dep)
+          .chain(unordered_deps)
+        {
           let dep_id = dep.id();
 
           // Dependency created but no module is available.

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2263,7 +2263,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           })
           .filter(|dep| !matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)))
           .collect::<Vec<_>>();
-        deps.sort_unstable_by_key(|a| (a.source_order().is_none(), a.source_order()));
+        deps.sort_by_key(|a| (a.source_order().is_none(), a.source_order()));
 
         for dep in deps {
           let dep_id = dep.id();

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -37,10 +37,11 @@ pub(crate) type DependenciesBlockIdentifierMap<V> =
 pub(crate) type DependenciesBlockIdentifierSet =
   std::collections::HashSet<DependenciesBlockIdentifier, BuildHasherDefault<FxHasher>>;
 
+type ConnectionIdList = Arc<Vec<DependencyId>>;
 type PreparedBlockConnectionMap =
-  IndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), Vec<DependencyId>>;
+  IndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
 type BlockConnectionMap =
-  DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, Vec<DependencyId>)>>>;
+  DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
 
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGroupInfo {
@@ -55,7 +56,7 @@ pub struct ChunkGroupInfo {
   pub available_modules_to_be_merged: Vec<Arc<BigUint>>,
 
   pub skipped_items: IdentifierIndexSet,
-  pub skipped_module_connections: IndexSet<(ModuleIdentifier, Vec<DependencyId>)>,
+  pub skipped_module_connections: IndexSet<(ModuleIdentifier, ConnectionIdList)>,
   // set of children chunk groups, that will be revisited when available_modules shrink
   pub children: FxIndexSet<CgiUkey>,
   // set of chunk groups that are the source for min_available_modules
@@ -1792,7 +1793,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     module: DependenciesBlockIdentifier,
     runtime: Option<Arc<RuntimeSpec>>,
     compilation: &Compilation,
-  ) -> Arc<Vec<(ModuleIdentifier, ConnectionState, Vec<DependencyId>)>> {
+  ) -> Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>> {
     let runtime_map = self
       .block_modules_runtime_map
       .entry(runtime.clone())
@@ -2263,7 +2264,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           })
           .filter(|dep| !matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)))
           .collect::<Vec<_>>();
-        deps.sort_by_key(|a| (a.source_order().is_none(), a.source_order()));
+        deps.sort_unstable_by_key(|a| (a.source_order().is_none(), a.source_order()));
 
         for dep in deps {
           let dep_id = dep.id();
@@ -2285,7 +2286,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             .or_insert_with(|| vec![*dep_id]);
         }
 
-        (*module, connection_map)
+        (
+          *module,
+          connection_map
+            .into_iter()
+            .map(|(key, connections)| (key, Arc::new(connections)))
+            .collect(),
+        )
       })
       .collect::<IdentifierMap<_>>();
 
@@ -2440,17 +2447,18 @@ fn extract_block_modules(
   map: &mut BlockConnectionMap,
 ) {
   let block = module.into();
+  let blocks = prepared_blocks_map.get(&block).expect("should have blocks");
   let mut module_map: DependenciesBlockIdentifierMap<
-    Vec<(ModuleIdentifier, ConnectionState, Vec<DependencyId>)>,
-  > = DependenciesBlockIdentifierMap::default();
+    Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>,
+  > =
+    DependenciesBlockIdentifierMap::with_capacity_and_hasher(blocks.len() + 1, Default::default());
   module_map.insert(block, Vec::new());
-  for b in prepared_blocks_map
-    .get(&block)
-    .expect("should have blocks")
-    .clone()
-  {
-    module_map.insert(b.into(), Vec::new());
-  }
+  module_map.extend(
+    blocks
+      .iter()
+      .copied()
+      .map(|block| (block.into(), Vec::new())),
+  );
 
   let connection_map = prepared_connection_map
     .get(&module)

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -4,7 +4,6 @@ use std::{
   sync::{Arc, atomic::AtomicU32},
 };
 
-use indexmap::{IndexMap as RawIndexMap, IndexSet as RawIndexSet};
 use itertools::Itertools;
 use num_bigint::BigUint;
 use rayon::prelude::*;
@@ -30,8 +29,6 @@ use crate::{
   merge_runtime,
 };
 
-type IndexMap<K, V, H = FxHasher> = RawIndexMap<K, V, BuildHasherDefault<H>>;
-type IndexSet<K, H = FxHasher> = RawIndexSet<K, BuildHasherDefault<H>>;
 pub(crate) type DependenciesBlockIdentifierMap<V> =
   std::collections::HashMap<DependenciesBlockIdentifier, V, BuildHasherDefault<FxHasher>>;
 pub(crate) type DependenciesBlockIdentifierSet =
@@ -39,7 +36,7 @@ pub(crate) type DependenciesBlockIdentifierSet =
 
 type ConnectionIdList = Arc<Vec<DependencyId>>;
 type PreparedBlockConnectionMap =
-  IndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
+  FxIndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
 
@@ -56,7 +53,7 @@ pub struct ChunkGroupInfo {
   pub available_modules_to_be_merged: Vec<Arc<BigUint>>,
 
   pub skipped_items: IdentifierIndexSet,
-  pub skipped_module_connections: IndexSet<(ModuleIdentifier, ConnectionIdList)>,
+  pub skipped_module_connections: FxIndexSet<(ModuleIdentifier, ConnectionIdList)>,
   // set of children chunk groups, that will be revisited when available_modules shrink
   pub children: FxIndexSet<CgiUkey>,
   // set of chunk groups that are the source for min_available_modules
@@ -223,10 +220,10 @@ pub(crate) struct CodeSplitter {
   next_chunk_group_index: u32,
   queue: Vec<QueueAction>,
   queue_delayed: Vec<QueueAction>,
-  queue_connect: FxIndexMap<CgiUkey, IndexSet<(CgiUkey, Option<ProcessBlock>)>>,
+  queue_connect: FxIndexMap<CgiUkey, FxIndexSet<(CgiUkey, Option<ProcessBlock>)>>,
   chunk_groups_for_combining: FxIndexSet<CgiUkey>,
   pub(crate) outdated_chunk_group_info: FxIndexSet<CgiUkey>,
-  chunk_groups_for_merging: IndexSet<(CgiUkey, Option<ProcessBlock>)>,
+  chunk_groups_for_merging: FxIndexSet<(CgiUkey, Option<ProcessBlock>)>,
   pub(crate) block_to_chunk_group: DependenciesBlockIdentifierMap<CgiUkey>,
 
   // outgoing blocks for a chunk group
@@ -1096,7 +1093,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     module_identifier: ModuleIdentifier,
     runtime: Arc<RuntimeSpec>,
     visited: &mut IdentifierSet,
-    ctx: &mut (u32, u32, IndexMap<ModuleIdentifier, (u32, u32)>),
+    ctx: &mut (u32, u32, FxIndexMap<ModuleIdentifier, (u32, u32)>),
     compilation: &Compilation,
   ) {
     if !visited.insert(module_identifier) {
@@ -2253,8 +2250,10 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     self.prepared_connection_map = all_modules
       .par_iter()
       .map(|module| {
-        let mut connection_map =
-          IndexMap::<(DependenciesBlockIdentifier, ModuleIdentifier), Vec<DependencyId>>::default();
+        let mut connection_map = FxIndexMap::<
+          (DependenciesBlockIdentifier, ModuleIdentifier),
+          Vec<DependencyId>,
+        >::default();
 
         let mut deps = mg
           .get_outgoing_deps_in_order(module)

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2463,6 +2463,9 @@ fn extract_block_modules(
     .expect("should have outgoing deps");
 
   for ((block_id, module_identifier), connections) in connection_map {
+    if map.contains_key(&block_id) {
+      continue;
+    }
     let modules = module_map
       .get_mut(block_id)
       .expect("should have modules in block_modules_runtime_map");

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2443,18 +2443,19 @@ impl ConcatenatedModule {
             to_reference(connection, module_id, self.runtime.as_ref(), mg, artifacts)
           }),
       );
-      references.sort_by(|a, b| {
-        if a.source_order != b.source_order {
-          return a.source_order.cmp(&b.source_order);
-        }
-        match (a.range_start, b.range_start) {
-          (None, None) => std::cmp::Ordering::Equal,
-          (None, Some(_)) => std::cmp::Ordering::Greater,
-          (Some(_), None) => std::cmp::Ordering::Less,
-          (Some(a), Some(b)) => a.cmp(&b),
-        }
-      });
     }
+
+    references.sort_by(|a, b| {
+      if a.source_order != b.source_order {
+        return a.source_order.cmp(&b.source_order);
+      }
+      match (a.range_start, b.range_start) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (Some(a), Some(b)) => a.cmp(&b),
+      }
+    });
 
     let mut references_map: IdentifierIndexMap<ConcatenatedImport> = IdentifierIndexMap::default();
     for reference in references {

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -17,6 +17,7 @@ pub static DEFAULT_EXPORT_ATOM: LazyLock<Atom> = LazyLock::new(|| "__rspack_defa
 pub const NAMESPACE_OBJECT_EXPORT: &str = "__rspack_ns_object";
 pub const DEFAULT_EXPORT: &str = "__rspack_default_export";
 const MODULE_REFERENCE_PREFIX: &str = "__rspack_module_ref";
+const MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX: &str = "._";
 
 #[derive(Default, Debug, Clone)]
 pub struct ModuleReferenceOptions {
@@ -160,6 +161,9 @@ impl ConcatenationScope {
   }
 
   pub fn match_module_reference(name: &str) -> Option<ModuleReferenceOptions> {
+    let name = name
+      .strip_suffix(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX)
+      .unwrap_or(name);
     let encoded = name
       .strip_prefix(MODULE_REFERENCE_PREFIX)?
       .strip_suffix("__")?;
@@ -223,5 +227,94 @@ impl ConcatenationScope {
       self.modules_map.get(module).expect("should have module"),
       ModuleInfo::Concatenated(_)
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::concatenated_module::ExternalModuleInfo;
+
+  fn create_test_scope(index: usize) -> (ConcatenationScope, ModuleIdentifier) {
+    let concat_module_id: ModuleIdentifier = "concat-module".into();
+    let referenced_module_id: ModuleIdentifier = "referenced-module".into();
+
+    let mut current_module = ConcatenatedModuleInfo::default();
+    current_module.module = concat_module_id;
+
+    let mut modules_map = IdentifierIndexMap::default();
+    modules_map.insert(
+      referenced_module_id,
+      ModuleInfo::External(ExternalModuleInfo::new(index, referenced_module_id)),
+    );
+
+    (
+      ConcatenationScope::new(concat_module_id, Arc::new(modules_map), current_module),
+      referenced_module_id,
+    )
+  }
+
+  fn assert_module_reference_options_eq(
+    actual: &ModuleReferenceOptions,
+    expected: &ModuleReferenceOptions,
+  ) {
+    assert_eq!(actual.ids, expected.ids);
+    assert_eq!(actual.call, expected.call);
+    assert_eq!(actual.direct_import, expected.direct_import);
+    assert_eq!(actual.deferred_import, expected.deferred_import);
+    assert_eq!(actual.asi_safe, expected.asi_safe);
+    assert_eq!(actual.index, expected.index);
+  }
+
+  #[test]
+  fn create_module_reference_round_trips_through_matcher() {
+    let (mut scope, referenced_module_id) = create_test_scope(7);
+    let options = ModuleReferenceOptions {
+      ids: vec![Atom::from("default"), Atom::from("named")],
+      call: true,
+      direct_import: true,
+      deferred_import: true,
+      asi_safe: Some(false),
+      ..Default::default()
+    };
+
+    let module_ref = scope.create_module_reference(&referenced_module_id, options.clone());
+
+    let stored = scope
+      .refs
+      .get(&referenced_module_id)
+      .and_then(|refs| refs.get(&module_ref))
+      .expect("should store created module reference");
+    assert_module_reference_options_eq(stored, &options);
+
+    let parsed = ConcatenationScope::match_module_reference(&module_ref)
+      .expect("should parse full module reference");
+    let expected = ModuleReferenceOptions {
+      index: 7,
+      ..options
+    };
+    assert_module_reference_options_eq(&parsed, &expected);
+  }
+
+  #[test]
+  fn match_module_reference_accepts_identifier_without_property_access_suffix() {
+    let parsed = ConcatenationScope::match_module_reference(
+      "__rspack_module_ref3_ns_call_directImport_deferredImport_asiSafe1__",
+    )
+    .expect("should parse identifier-only module reference");
+
+    assert!(parsed.ids.is_empty());
+    assert!(parsed.call);
+    assert!(parsed.direct_import);
+    assert!(parsed.deferred_import);
+    assert_eq!(parsed.asi_safe, Some(true));
+    assert_eq!(parsed.index, 3);
+  }
+
+  #[test]
+  fn match_module_reference_rejects_invalid_suffix() {
+    assert!(
+      ConcatenationScope::match_module_reference("__rspack_module_ref1_ns_asiSafe2__").is_none()
+    );
   }
 }

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -239,8 +239,10 @@ mod tests {
     let concat_module_id: ModuleIdentifier = "concat-module".into();
     let referenced_module_id: ModuleIdentifier = "referenced-module".into();
 
-    let mut current_module = ConcatenatedModuleInfo::default();
-    current_module.module = concat_module_id;
+    let current_module = ConcatenatedModuleInfo {
+      module: concat_module_id,
+      ..Default::default()
+    };
 
     let mut modules_map = IdentifierIndexMap::default();
     modules_map.insert(

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -127,30 +127,12 @@ impl ConcatenationScope {
   pub fn create_module_reference(
     &mut self,
     module: &ModuleIdentifier,
-    options: &ModuleReferenceOptions,
+    options: ModuleReferenceOptions,
   ) -> String {
     let info = self
       .modules_map
       .get(module)
       .expect("should have module info");
-
-    let call_flag = match options.call {
-      true => "_call",
-      _ => "",
-    };
-    let direct_import_flag = match options.direct_import {
-      true => "_directImport",
-      _ => "",
-    };
-    let deferred_import_flag = match options.deferred_import {
-      true => "_deferredImport",
-      _ => "",
-    };
-    let asi_safe_flag = match options.asi_safe {
-      Some(true) => "_asiSafe1",
-      Some(false) => "_asiSafe0",
-      None => "",
-    };
 
     let export_data = if !options.ids.is_empty() {
       hex::encode(serde_json::to_string(&options.ids).expect("should serialize to json string"))
@@ -160,11 +142,26 @@ impl ConcatenationScope {
 
     let mut index_buffer = itoa::Buffer::new();
     let index_str = index_buffer.format(info.index());
-    let module_ref = format!(
-      "__rspack_module_ref{index_str}_{export_data}{call_flag}{direct_import_flag}{deferred_import_flag}{asi_safe_flag}__._"
-    );
+    let mut module_ref = String::with_capacity(index_str.len() + export_data.len() + 64);
+    module_ref.push_str("__rspack_module_ref");
+    module_ref.push_str(index_str);
+    module_ref.push('_');
+    module_ref.push_str(&export_data);
+    if options.call {
+      module_ref.push_str("_call");
+    }
+    if options.direct_import {
+      module_ref.push_str("_directImport");
+    }
+    if options.deferred_import {
+      module_ref.push_str("_deferredImport");
+    }
+    if let Some(asi_safe) = options.asi_safe {
+      module_ref.push_str(if asi_safe { "_asiSafe1" } else { "_asiSafe0" });
+    }
+    module_ref.push_str("__._");
     let entry = self.refs.entry(*module).or_default();
-    entry.insert(module_ref.clone(), options.clone());
+    entry.insert(module_ref.clone(), options);
 
     module_ref
   }

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, LazyLock};
 
 use anymap::CloneAny;
-use regex::Regex;
 use rspack_collections::IdentifierIndexMap;
 use rspack_util::{
   fx_hash::{FxIndexMap, FxIndexSet},
@@ -17,13 +16,7 @@ use crate::{
 pub static DEFAULT_EXPORT_ATOM: LazyLock<Atom> = LazyLock::new(|| "__rspack_default_export".into());
 pub const NAMESPACE_OBJECT_EXPORT: &str = "__rspack_ns_object";
 pub const DEFAULT_EXPORT: &str = "__rspack_default_export";
-
-static MODULE_REFERENCE_REGEXP: LazyLock<Regex> = LazyLock::new(|| {
-  Regex::new(
-    r"^__rspack_module_ref(\d+)_([\da-f]+|ns)(_call)?(_directImport)?(_deferredImport)?(?:_asiSafe(\d))?__$",
-  )
-  .expect("should initialized regex")
-});
+const MODULE_REFERENCE_PREFIX: &str = "__rspack_module_ref";
 
 #[derive(Default, Debug, Clone)]
 pub struct ModuleReferenceOptions {
@@ -167,29 +160,62 @@ impl ConcatenationScope {
   }
 
   pub fn match_module_reference(name: &str) -> Option<ModuleReferenceOptions> {
-    if let Some(captures) = MODULE_REFERENCE_REGEXP.captures(name) {
-      let index: usize = captures[1].parse().expect("");
-      let ids: Vec<Atom> = if &captures[2] == "ns" {
-        vec![]
-      } else {
-        serde_json::from_slice(&hex::decode(&captures[2]).expect("should decode hex"))
-          .expect("should have deserialize")
-      };
-      let call = captures.get(3).is_some();
-      let direct_import = captures.get(4).is_some();
-      let deferred_import = captures.get(5).is_some();
-      let asi_safe = captures.get(6).map(|s| s.as_str() == "1");
-      Some(ModuleReferenceOptions {
-        ids,
-        call,
-        direct_import,
-        deferred_import,
-        asi_safe,
-        index,
-      })
+    let encoded = name
+      .strip_prefix(MODULE_REFERENCE_PREFIX)?
+      .strip_suffix("__")?;
+    let (index, encoded) = encoded.split_once('_')?;
+    let index = index.parse().ok()?;
+
+    let export_data_len = encoded.find('_').unwrap_or(encoded.len());
+    let (export_data, mut flags) = encoded.split_at(export_data_len);
+    let ids = if export_data == "ns" {
+      vec![]
+    } else {
+      serde_json::from_slice(&hex::decode(export_data).ok()?).ok()?
+    };
+
+    let call = if let Some(stripped) = flags.strip_prefix("_call") {
+      flags = stripped;
+      true
+    } else {
+      false
+    };
+    let direct_import = if let Some(stripped) = flags.strip_prefix("_directImport") {
+      flags = stripped;
+      true
+    } else {
+      false
+    };
+    let deferred_import = if let Some(stripped) = flags.strip_prefix("_deferredImport") {
+      flags = stripped;
+      true
+    } else {
+      false
+    };
+    let asi_safe = if let Some(stripped) = flags.strip_prefix("_asiSafe") {
+      let (flag, rest) = stripped.split_at(1);
+      flags = rest;
+      match flag {
+        "0" => Some(false),
+        "1" => Some(true),
+        _ => return None,
+      }
     } else {
       None
+    };
+
+    if !flags.is_empty() {
+      return None;
     }
+
+    Some(ModuleReferenceOptions {
+      ids,
+      call,
+      direct_import,
+      deferred_import,
+      asi_safe,
+      index,
+    })
   }
 
   pub fn is_module_concatenated(&self, module: &ModuleIdentifier) -> bool {

--- a/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
+++ b/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
@@ -257,7 +257,7 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
       // module's namespace object (e.g., `Promise.resolve(dynamic_namespaceObject)`).
       let ns_ref = concatenation_scope.create_module_reference(
         &ref_module.identifier(),
-        &ModuleReferenceOptions {
+        ModuleReferenceOptions {
           ids: vec![],
           call: false,
           direct_import: true,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -392,7 +392,7 @@ impl ESMImportSpecifierDependencyTemplate {
       if ids.is_empty() {
         scope.create_module_reference(
           con.module_identifier(),
-          &ModuleReferenceOptions {
+          ModuleReferenceOptions {
             asi_safe: Some(dep.asi_safe),
             deferred_import: dep.phase.is_defer(),
             ..Default::default()
@@ -414,7 +414,7 @@ impl ESMImportSpecifierDependencyTemplate {
           Some(UsedName::Normal(used_name)) => {
             scope.create_module_reference(
               con.module_identifier(),
-              &ModuleReferenceOptions {
+              ModuleReferenceOptions {
                 asi_safe: Some(dep.asi_safe),
                 deferred_import: dep.phase.is_defer(),
                 ..Default::default()
@@ -435,7 +435,7 @@ impl ESMImportSpecifierDependencyTemplate {
       } else {
         scope.create_module_reference(
           con.module_identifier(),
-          &ModuleReferenceOptions {
+          ModuleReferenceOptions {
             asi_safe: Some(dep.asi_safe),
             ids: ids.to_vec(),
             call: dep.call,


### PR DESCRIPTION
## Summary
- replace indexmap-based connection tracking in the code splitter with fxhash-based containers and share dependency id lists through `Arc<Vec<_>>`
- avoid redundant block traversal work when building chunk groups, including empty-block fast paths and duplicate extraction guards
- move concatenated module reference sorting out of the inner collection loop
- replace regex-based module reference encoding/parsing in `ConcatenationScope` with a cheaper string-based path and add parser coverage
- update ESM import and ESM library dynamic import call sites to use the new module reference option flow