### PR TITLE
refactor: remove prefetch functions for exports info

### DIFF
--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -45,7 +45,8 @@ impl JsExportsInfo {
     Ok(
       self
         .exports_info
-        .is_used(&compilation.exports_info_artifact, runtime.as_ref()),
+        .as_data(&compilation.exports_info_artifact)
+        .is_used(runtime.as_ref()),
     )
   }
 
@@ -59,7 +60,8 @@ impl JsExportsInfo {
     Ok(
       self
         .exports_info
-        .is_module_used(&compilation.exports_info_artifact, runtime.as_ref()),
+        .as_data(&compilation.exports_info_artifact)
+        .is_module_used(runtime.as_ref()),
     )
   }
 
@@ -97,7 +99,9 @@ impl JsExportsInfo {
       Either::B(v) => v.into_iter().map(Into::into).collect::<Vec<_>>(),
     };
     let exports_info = self.exports_info;
-    let used = exports_info.get_used(&compilation.exports_info_artifact, &names, runtime.as_ref());
+    let used = exports_info
+      .as_data(&compilation.exports_info_artifact)
+      .get_used(&compilation.exports_info_artifact, &names, runtime.as_ref());
     Ok(used as u32)
   }
 }

--- a/crates/rspack_binding_api/src/exports_info.rs
+++ b/crates/rspack_binding_api/src/exports_info.rs
@@ -2,9 +2,7 @@ use std::ptr::NonNull;
 
 use napi::Either;
 use napi_derive::napi;
-use rspack_core::{
-  Compilation, ExportsInfo, ExportsInfoGetter, ModuleGraph, PrefetchExportsInfoMode, RuntimeSpec,
-};
+use rspack_core::{Compilation, ExportsInfo, ModuleGraph, RuntimeSpec};
 use rspack_util::atom::Atom;
 
 use crate::runtime::JsRuntimeSpec;
@@ -44,12 +42,11 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
-      &self.exports_info,
-      &compilation.exports_info_artifact,
-      runtime.as_ref(),
-    );
-    Ok(exports_info.is_used())
+    Ok(
+      self
+        .exports_info
+        .is_used(&compilation.exports_info_artifact, runtime.as_ref()),
+    )
   }
 
   #[napi(ts_args_type = "runtime: string | string[] | undefined")]
@@ -59,12 +56,11 @@ impl JsExportsInfo {
       Either::A(str) => std::iter::once(str).map(Into::into).collect(),
       Either::B(vec) => vec.into_iter().map(Into::into).collect(),
     });
-    let exports_info = ExportsInfoGetter::prefetch_used_info_without_name(
-      &self.exports_info,
-      &compilation.exports_info_artifact,
-      runtime.as_ref(),
-    );
-    Ok(exports_info.is_module_used())
+    Ok(
+      self
+        .exports_info
+        .is_module_used(&compilation.exports_info_artifact, runtime.as_ref()),
+    )
   }
 
   #[napi(ts_args_type = "runtime: string | string[] | undefined")]
@@ -100,12 +96,8 @@ impl JsExportsInfo {
       Either::A(s) => vec![Atom::from(s)],
       Either::B(v) => v.into_iter().map(Into::into).collect::<Vec<_>>(),
     };
-    let exports_info = ExportsInfoGetter::prefetch(
-      &self.exports_info,
-      &compilation.exports_info_artifact,
-      PrefetchExportsInfoMode::Nested(&names),
-    );
-    let used = exports_info.get_used(&names, runtime.as_ref());
+    let exports_info = self.exports_info;
+    let used = exports_info.get_used(&compilation.exports_info_artifact, &names, runtime.as_ref());
     Ok(used as u32)
   }
 }

--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -101,11 +101,8 @@ impl JsModuleGraph {
     };
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&js_module.identifier);
-    let used_exports = exports_info.get_used_exports(
-      &compilation.exports_info_artifact,
-      Some(&RuntimeSpec::new(runtime)),
-    );
+      .get_exports_info_data(&js_module.identifier);
+    let used_exports = exports_info.get_used_exports(Some(&RuntimeSpec::new(runtime)));
     Ok(match used_exports {
       rspack_core::UsedExports::Unknown => None,
       rspack_core::UsedExports::UsedNamespace(b) => Some(Either::A(b)),

--- a/crates/rspack_binding_api/src/module_graph.rs
+++ b/crates/rspack_binding_api/src/module_graph.rs
@@ -2,7 +2,7 @@ use std::ptr::NonNull;
 
 use napi::{Either, Env, JsString, bindgen_prelude::Array};
 use napi_derive::napi;
-use rspack_core::{Compilation, ModuleGraph, PrefetchExportsInfoMode, RuntimeSpec};
+use rspack_core::{Compilation, ModuleGraph, RuntimeSpec};
 
 use crate::{
   dependencies::DependencyObject,
@@ -101,8 +101,11 @@ impl JsModuleGraph {
     };
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(&js_module.identifier, PrefetchExportsInfoMode::Default);
-    let used_exports = exports_info.get_used_exports(Some(&RuntimeSpec::new(runtime)));
+      .get_exports_info(&js_module.identifier);
+    let used_exports = exports_info.get_used_exports(
+      &compilation.exports_info_artifact,
+      Some(&RuntimeSpec::new(runtime)),
+    );
     Ok(match used_exports {
       rspack_core::UsedExports::Unknown => None,
       rspack_core::UsedExports::UsedNamespace(b) => Some(Either::A(b)),

--- a/crates/rspack_core/src/artifacts/exports_info_artifact.rs
+++ b/crates/rspack_core/src/artifacts/exports_info_artifact.rs
@@ -2,8 +2,7 @@ use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 
 use crate::{
-  ArtifactExt, ExportsInfo, ExportsInfoData, ExportsInfoGetter, ModuleIdentifier,
-  PrefetchExportsInfoMode, PrefetchedExportsInfoUsed, PrefetchedExportsInfoWrapper, RuntimeSpec,
+  ArtifactExt, ExportsInfo, ExportsInfoData, ModuleIdentifier,
   incremental::{Incremental, IncrementalPasses},
   module_graph::rollback,
 };
@@ -50,6 +49,13 @@ impl ExportsInfoArtifact {
       .unwrap_or_else(|| panic!("{} {:#?}", module_identifier, &self))
   }
 
+  pub fn get_exports_info_optional(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<ExportsInfo> {
+    self.module_exports_info.get(module_identifier).copied()
+  }
+
   pub fn get_exports_info_data(&self, module_identifier: &ModuleIdentifier) -> &ExportsInfoData {
     self
       .exports_info_map
@@ -66,38 +72,6 @@ impl ExportsInfoArtifact {
       .exports_info_map
       .get_mut(&id)
       .expect("should have exports info")
-  }
-
-  pub fn get_prefetched_exports_info_optional<'b>(
-    &'b self,
-    module_identifier: &ModuleIdentifier,
-    mode: PrefetchExportsInfoMode<'b>,
-  ) -> Option<PrefetchedExportsInfoWrapper<'b>> {
-    self
-      .module_exports_info
-      .get(module_identifier)
-      .map(move |exports_info| ExportsInfoGetter::prefetch(exports_info, self, mode))
-  }
-
-  pub fn get_prefetched_exports_info<'b>(
-    &'b self,
-    module_identifier: &ModuleIdentifier,
-    mode: PrefetchExportsInfoMode<'b>,
-  ) -> PrefetchedExportsInfoWrapper<'b> {
-    let exports_info = self.get_exports_info(module_identifier);
-    ExportsInfoGetter::prefetch(&exports_info, self, mode)
-  }
-
-  pub fn get_prefetched_exports_info_used(
-    &self,
-    module_identifier: &ModuleIdentifier,
-    runtime: Option<&RuntimeSpec>,
-  ) -> PrefetchedExportsInfoUsed {
-    ExportsInfoGetter::prefetch_used_info_without_name(
-      &self.get_exports_info(module_identifier),
-      self,
-      runtime,
-    )
   }
 
   pub fn set_exports_info_by_id(&mut self, id: ExportsInfo, info: ExportsInfoData) {

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -419,10 +419,8 @@ impl ChunkGraph {
 
           let exports_info = compilation
             .exports_info_artifact
-            .get_exports_info(&module_identifier);
-          exports_info
-            .as_data(&compilation.exports_info_artifact)
-            .update_hash(&compilation.exports_info_artifact, &mut hasher, runtime);
+            .get_exports_info_data(&module_identifier);
+          exports_info.update_hash(&compilation.exports_info_artifact, &mut hasher, runtime);
           hasher.finish()
         },
       )

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1537,7 +1537,7 @@ impl Module for ConcatenatedModule {
       .get_exports_info_data(&root_module_id);
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
-    for (_, export_info) in exports_info.exports() {
+    for export_info in exports_info.exports().values() {
       let name = export_info.name().cloned().unwrap_or_else(|| "".into());
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
@@ -1707,7 +1707,7 @@ impl Module for ConcatenatedModule {
       let exports_info = compilation
         .exports_info_artifact
         .get_exports_info_data(&module_info_id);
-      for (_, export_info) in exports_info.exports() {
+      for export_info in exports_info.exports().values() {
         if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
           continue;
         }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -43,15 +43,15 @@ use crate::{
   CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConditionalInitFragment, ConnectionState, Context, DEFAULT_EXPORT,
   DEFAULT_EXPORT_ATOM, DependenciesBlock, DependencyId, DependencyType, ExportInfoHashKey,
-  ExportProvided, ExportsArgument, ExportsInfoArtifact, ExportsInfoGetter, ExportsType,
-  FactoryMeta, GetUsedNameParam, ImportedByDeferModulesArtifact, InitFragment, InitFragmentStage,
-  LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
-  ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT, ParserOptions, PrefetchExportsInfoMode,
-  Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType,
-  URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set, filter_runtime,
-  find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
+  ExportProvided, ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta,
+  ImportedByDeferModulesArtifact, InitFragment, InitFragmentStage, LibIdentOptions, Module,
+  ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType,
+  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
+  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
+  escape_identifier, fast_set, filter_runtime, find_target, get_runtime_key,
+  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
+  module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -1535,10 +1535,10 @@ impl Module for ConcatenatedModule {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(&root_module_id, PrefetchExportsInfoMode::Default);
+      .get_exports_info(&root_module_id);
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
-    for (_, export_info) in exports_info.exports() {
+    for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
       let name = export_info.name().cloned().unwrap_or_else(|| "".into());
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
@@ -1607,11 +1607,14 @@ impl Module for ConcatenatedModule {
 
     let root_exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(&self.id(), PrefetchExportsInfoMode::Default);
+      .get_exports_info(&self.id());
     // Add ESM compatibility flag (must be first because of possible circular dependencies)
-    if root_exports_info.other_exports_info().get_used(runtime) != UsageState::Unused
+    if root_exports_info
+      .other_exports_info(&compilation.exports_info_artifact)
+      .get_used(runtime)
+      != UsageState::Unused
       || root_exports_info
-        .get_read_only_export_info(&"__esModule".into())
+        .get_read_only_export_info(&compilation.exports_info_artifact, &"__esModule".into())
         .get_used(runtime)
         != UsageState::Unused
     {
@@ -1707,8 +1710,8 @@ impl Module for ConcatenatedModule {
       let mut ns_obj = Vec::new();
       let exports_info = compilation
         .exports_info_artifact
-        .get_prefetched_exports_info(&module_info_id, PrefetchExportsInfoMode::Default);
-      for (_, export_info) in exports_info.exports() {
+        .get_exports_info(&module_info_id);
+      for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
         if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
           continue;
         }
@@ -3019,11 +3022,11 @@ impl ConcatenatedModule {
       }
     }
 
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(&info.id(), PrefetchExportsInfoMode::Nested(&export_name));
+    let exports_info = exports_info_artifact.get_exports_info(&info.id());
     // webpack use `get_exports_info` here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
     // But in our arch, there is no way to modify module graph during code_generation phase, so we use `get_export_info_without_mut_module_graph` instead.`
-    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
+    let export_info =
+      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, &export_name[0]);
     let export_info_hash_key = export_info.as_hash_key();
 
     if already_visited.contains(&export_info_hash_key) {
@@ -3067,11 +3070,9 @@ impl ConcatenatedModule {
         if let Some(ref export_id) = export_id
           && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
         {
-          if let Some(used_name) = ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithNames(&exports_info),
-            runtime,
-            &export_name,
-          ) {
+          if let Some(used_name) =
+            exports_info.get_used_name(exports_info_artifact, runtime, &export_name)
+          {
             match used_name {
               UsedName::Normal(used_name) => {
                 // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L402-L404
@@ -3136,15 +3137,10 @@ impl ConcatenatedModule {
           crate::FindTargetResult::NoTarget => {}
           crate::FindTargetResult::InvalidTarget(target) => {
             if let Some(export) = target.export {
-              let exports_info = exports_info_artifact.get_prefetched_exports_info(
-                &target.module,
-                PrefetchExportsInfoMode::Nested(&export),
-              );
-              if let Some(UsedName::Inlined(inlined)) = ExportsInfoGetter::get_used_name(
-                GetUsedNameParam::WithNames(&exports_info),
-                runtime,
-                &export,
-              ) {
+              let exports_info = exports_info_artifact.get_exports_info(&target.module);
+              if let Some(UsedName::Inlined(inlined)) =
+                exports_info.get_used_name(exports_info_artifact, runtime, &export)
+              {
                 return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
                   raw_name: inlined
                     .inlined_value()
@@ -3193,12 +3189,9 @@ impl ConcatenatedModule {
 
         if info.namespace_export_symbol.is_some() {
           // That's how webpack write https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L463-L471
-          let used_name = ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithNames(&exports_info),
-            runtime,
-            &export_name,
-          )
-          .expect("should have export name");
+          let used_name = exports_info
+            .get_used_name(exports_info_artifact, runtime, &export_name)
+            .expect("should have export name");
           return FinalBindingResult::from_binding(match used_name {
             UsedName::Normal(used_name) => Binding::Raw(RawBinding {
               info_id: info.module,
@@ -3236,11 +3229,9 @@ impl ConcatenatedModule {
         );
       }
       ModuleInfo::External(info) => {
-        let binding = if let Some(used_name) = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
-          runtime,
-          &export_name,
-        ) {
+        let binding = if let Some(used_name) =
+          exports_info.get_used_name(exports_info_artifact, runtime, &export_name)
+        {
           match used_name {
             UsedName::Normal(used_name) => {
               let comment = if used_name == export_name {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -42,16 +42,15 @@ use crate::{
   CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
   CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConditionalInitFragment, ConnectionState, Context, DEFAULT_EXPORT,
-  DEFAULT_EXPORT_ATOM, DependenciesBlock, DependencyId, DependencyType, ExportInfoHashKey,
-  ExportProvided, ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta,
-  ImportedByDeferModulesArtifact, InitFragment, InitFragmentStage, LibIdentOptions, Module,
-  ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType,
-  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
-  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
-  escape_identifier, fast_set, filter_runtime, find_target, get_runtime_key,
-  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
-  module_update_hash, property_access, property_name,
+  DEFAULT_EXPORT_ATOM, DependenciesBlock, DependencyId, DependencyType, ExportInfo, ExportProvided,
+  ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta, ImportedByDeferModulesArtifact,
+  InitFragment, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
+  ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
+  ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT,
+  ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
+  SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set,
+  filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
+  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -1535,10 +1534,10 @@ impl Module for ConcatenatedModule {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&root_module_id);
+      .get_exports_info_data(&root_module_id);
     let mut exports_final_names: Vec<(String, String)> = vec![];
 
-    for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
+    for (_, export_info) in exports_info.exports() {
       let name = export_info.name().cloned().unwrap_or_else(|| "".into());
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
@@ -1607,14 +1606,11 @@ impl Module for ConcatenatedModule {
 
     let root_exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&self.id());
+      .get_exports_info_data(&self.id());
     // Add ESM compatibility flag (must be first because of possible circular dependencies)
-    if root_exports_info
-      .other_exports_info(&compilation.exports_info_artifact)
-      .get_used(runtime)
-      != UsageState::Unused
+    if root_exports_info.other_exports_info().get_used(runtime) != UsageState::Unused
       || root_exports_info
-        .get_read_only_export_info(&compilation.exports_info_artifact, &"__esModule".into())
+        .get_read_only_export_info(&"__esModule".into())
         .get_used(runtime)
         != UsageState::Unused
     {
@@ -1710,8 +1706,8 @@ impl Module for ConcatenatedModule {
       let mut ns_obj = Vec::new();
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(&module_info_id);
-      for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
+        .get_exports_info_data(&module_info_id);
+      for (_, export_info) in exports_info.exports() {
         if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
           continue;
         }
@@ -2793,7 +2789,7 @@ impl ConcatenatedModule {
     dep_deferred: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    already_visited: &mut HashSet<ExportInfoHashKey>,
+    already_visited: &mut HashSet<ExportInfo>,
   ) -> FinalBindingResult {
     let info = module_to_info_map
       .get(info_id)
@@ -3022,14 +3018,13 @@ impl ConcatenatedModule {
       }
     }
 
-    let exports_info = exports_info_artifact.get_exports_info(&info.id());
+    let exports_info = exports_info_artifact.get_exports_info_data(&info.id());
     // webpack use `get_exports_info` here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
     // But in our arch, there is no way to modify module graph during code_generation phase, so we use `get_export_info_without_mut_module_graph` instead.`
-    let export_info =
-      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, &export_name[0]);
-    let export_info_hash_key = export_info.as_hash_key();
+    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
+    let export_info_id = export_info.id();
 
-    if already_visited.contains(&export_info_hash_key) {
+    if already_visited.contains(&export_info_id) {
       return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
         raw_name: "/* circular reexport */ Object(function x() { x() }())".into(),
         ids: Vec::new(),
@@ -3039,7 +3034,7 @@ impl ConcatenatedModule {
       }));
     }
 
-    already_visited.insert(export_info_hash_key);
+    already_visited.insert(export_info_id);
 
     match info {
       ModuleInfo::Concatenated(info) => {
@@ -3137,7 +3132,7 @@ impl ConcatenatedModule {
           crate::FindTargetResult::NoTarget => {}
           crate::FindTargetResult::InvalidTarget(target) => {
             if let Some(export) = target.export {
-              let exports_info = exports_info_artifact.get_exports_info(&target.module);
+              let exports_info = exports_info_artifact.get_exports_info_data(&target.module);
               if let Some(UsedName::Inlined(inlined)) =
                 exports_info.get_used_name(exports_info_artifact, runtime, &export)
               {

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -1,56 +1,40 @@
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashMap as HashMap;
 
-use super::{ExportInfoTargetValue, ExportProvided, ExportsInfo, UsageState};
+use super::{ExportInfoTargetValue, ExportProvided, ExportsInfo, ExportsInfoData, UsageState};
 use crate::{
   CanInlineUse, DependencyId, EvaluatedInlinableValue, ExportsInfoArtifact, UsedNameItem,
 };
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub enum ExportName {
+enum ExportName {
   Other,
   SideEffects,
   Named(Atom),
 }
 
-#[derive(Debug, Hash, PartialEq, Eq)]
-pub struct ExportInfoHashKey {
-  name: Option<Atom>,
-  belongs_to: ExportsInfo,
-}
-
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ExportInfo {
-  pub exports_info: ExportsInfo,
-  pub export_name: ExportName,
+  exports_info: ExportsInfo,
+  export_name: ExportName,
 }
 
 impl ExportInfo {
   pub fn as_data<'a>(&self, exports_info_artifact: &'a ExportsInfoArtifact) -> &'a ExportInfoData {
-    let exports_info = self.exports_info.as_data(exports_info_artifact);
-
-    (match &self.export_name {
-      ExportName::Other => exports_info.other_exports_info(),
-      ExportName::SideEffects => exports_info.side_effects_only_info(),
-      ExportName::Named(name) => exports_info
-        .named_exports(name)
-        .expect("should have named export"),
-    }) as _
+    self
+      .exports_info
+      .as_data(exports_info_artifact)
+      .get_export_info_data(self)
   }
 
   pub fn as_data_mut<'a>(
     &self,
     exports_info_artifact: &'a mut ExportsInfoArtifact,
   ) -> &'a mut ExportInfoData {
-    let exports_info = self.exports_info.as_data_mut(exports_info_artifact);
-
-    (match &self.export_name {
-      ExportName::Other => exports_info.other_exports_info_mut(),
-      ExportName::SideEffects => exports_info.side_effects_only_info_mut(),
-      ExportName::Named(name) => exports_info
-        .named_exports_mut(name)
-        .expect("should have named export"),
-    }) as _
+    self
+      .exports_info
+      .as_data_mut(exports_info_artifact)
+      .get_export_info_data_mut(self)
   }
 }
 
@@ -297,11 +281,28 @@ impl ExportInfoData {
   pub fn set_ns_access(&mut self, value: bool) {
     self.ns_access = value;
   }
+}
 
-  pub fn as_hash_key(&self) -> ExportInfoHashKey {
-    ExportInfoHashKey {
-      name: self.name().cloned(),
-      belongs_to: *self.belongs_to(),
+impl ExportsInfoData {
+  pub fn get_export_info_data(&self, export_info: &ExportInfo) -> &ExportInfoData {
+    debug_assert_eq!(export_info.exports_info, self.id());
+
+    match &export_info.export_name {
+      ExportName::Other => self.other_exports_info(),
+      ExportName::SideEffects => self.side_effects_only_info(),
+      ExportName::Named(name) => self.named_exports(name).expect("should have named export"),
+    }
+  }
+
+  pub fn get_export_info_data_mut(&mut self, export_info: &ExportInfo) -> &mut ExportInfoData {
+    debug_assert_eq!(export_info.exports_info, self.id());
+
+    match &export_info.export_name {
+      ExportName::Other => self.other_exports_info_mut(),
+      ExportName::SideEffects => self.side_effects_only_info_mut(),
+      ExportName::Named(name) => self
+        .named_exports_mut(name)
+        .expect("should have named export"),
     }
   }
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -1,8 +1,7 @@
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 use either::Either;
 use rspack_util::atom::Atom;
-use rustc_hash::FxHashMap;
 
 use super::{
   ExportInfoData, ExportProvided, ExportsInfo, ProvidedExports, UsageState, UsedName, UsedNameItem,
@@ -11,179 +10,160 @@ use crate::{
   ExportsInfoArtifact, ExportsInfoData, InlinedUsedName, RuntimeSpec, UsageKey, UsedExports,
 };
 
-#[derive(Debug, Clone)]
-pub enum PrefetchExportsInfoMode<'a> {
-  Default,            // prefetch with all export items
-  Nested(&'a [Atom]), // prefetch with all export items and all the export items on its chain
-  Full, // prefetch with all related data, this should only be used in hash calculation
-}
-
-/**
- * Used to store data pre-fetched from Module Graph
- * so that subsequent exports data reads don't need to access Module Graph
- */
-#[derive(Debug, Clone)]
-pub struct PrefetchedExportsInfoWrapper<'a> {
-  /**
-   * The exports info data that will be accessed from the entry
-   * stored in a map to prevent circular references
-   * When redirect, this data can be cloned to generate a new PrefetchedExportsInfoWrapper with a new entry
-   */
-  exports: Arc<FxHashMap<ExportsInfo, &'a ExportsInfoData>>,
-  /**
-   * The entry of the current exports info
-   */
-  entry: ExportsInfo,
-  /**
-   * The prefetch mode of the current exports info
-   */
-  mode: PrefetchExportsInfoMode<'a>,
-}
-
-impl<'a> PrefetchedExportsInfoWrapper<'a> {
-  /**
-   * Generate a new PrefetchedExportsInfoWrapper with a new entry
-   */
-  pub fn redirect(&self, entry: ExportsInfo, nested: bool) -> Self {
-    Self {
-      exports: self.exports.clone(),
-      entry,
-      mode: if nested {
-        match self.mode {
-          PrefetchExportsInfoMode::Default => {
-            panic!("should not redirect to nested");
-          }
-          PrefetchExportsInfoMode::Nested(names) => PrefetchExportsInfoMode::Nested(&names[1..]),
-          PrefetchExportsInfoMode::Full => PrefetchExportsInfoMode::Full,
-        }
-      } else {
-        self.mode.clone()
-      },
-    }
-  }
-  /**
-   * Get the data of the current exports info
-   */
-  pub fn data(&self) -> &ExportsInfoData {
-    self.data_in_exports_info(&self.entry)
+impl ExportsInfo {
+  pub fn data<'a>(&self, exports_info_artifact: &'a ExportsInfoArtifact) -> &'a ExportsInfoData {
+    Self::data_in_exports_info(self, exports_info_artifact)
   }
 
-  pub fn meta(&self) -> (ExportsInfo, Vec<ExportsInfo>) {
-    (self.entry, self.exports.keys().copied().collect())
-  }
-
-  pub fn other_exports_info(&self) -> &ExportInfoData {
-    self.get_other_in_exports_info(&self.entry)
-  }
-
-  pub fn side_effects_only_info(&self) -> &ExportInfoData {
-    self.get_side_effects_in_exports_info(&self.entry)
-  }
-
-  pub fn exports(&self) -> impl Iterator<Item = (&Atom, &ExportInfoData)> {
-    self.get_exports_in_exports_info(&self.entry)
-  }
-
-  fn data_in_exports_info(&self, exports_info: &ExportsInfo) -> &ExportsInfoData {
-    self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info")
-  }
-
-  fn get_other_in_exports_info(&self, exports_info: &ExportsInfo) -> &ExportInfoData {
-    self.data_in_exports_info(exports_info).other_exports_info()
-  }
-
-  fn get_side_effects_in_exports_info(&self, exports_info: &ExportsInfo) -> &ExportInfoData {
-    self
-      .data_in_exports_info(exports_info)
-      .side_effects_only_info()
-  }
-
-  fn get_exports_in_exports_info(
+  pub fn other_exports_info<'a>(
     &self,
-    exports_info: &ExportsInfo,
-  ) -> impl Iterator<Item = (&Atom, &ExportInfoData)> {
-    self.data_in_exports_info(exports_info).exports().iter()
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> &'a ExportInfoData {
+    Self::get_other_in_exports_info(self, exports_info_artifact)
   }
 
-  fn get_named_export_in_exports_info(
+  pub fn side_effects_only_info<'a>(
     &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> &'a ExportInfoData {
+    Self::get_side_effects_in_exports_info(self, exports_info_artifact)
+  }
+
+  pub fn exports<'a>(
+    &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> impl Iterator<Item = (&'a Atom, &'a ExportInfoData)> {
+    Self::get_exports_in_exports_info(self, exports_info_artifact)
+  }
+
+  fn data_in_exports_info<'a>(
     exports_info: &ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> &'a ExportsInfoData {
+    exports_info_artifact.get_exports_info_by_id(exports_info)
+  }
+
+  fn get_other_in_exports_info<'a>(
+    exports_info: &ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> &'a ExportInfoData {
+    Self::data_in_exports_info(exports_info, exports_info_artifact).other_exports_info()
+  }
+
+  fn get_side_effects_in_exports_info<'a>(
+    exports_info: &ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> &'a ExportInfoData {
+    Self::data_in_exports_info(exports_info, exports_info_artifact).side_effects_only_info()
+  }
+
+  fn get_exports_in_exports_info<'a>(
+    exports_info: &ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+  ) -> impl Iterator<Item = (&'a Atom, &'a ExportInfoData)> {
+    Self::data_in_exports_info(exports_info, exports_info_artifact)
+      .exports()
+      .iter()
+  }
+
+  fn get_named_export_in_exports_info<'a>(
+    exports_info: &ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
     name: &Atom,
-  ) -> Option<&ExportInfoData> {
-    self.data_in_exports_info(exports_info).exports().get(name)
+  ) -> Option<&'a ExportInfoData> {
+    Self::data_in_exports_info(exports_info, exports_info_artifact)
+      .exports()
+      .get(name)
   }
 
-  pub fn get_read_only_export_info(&self, name: &Atom) -> &ExportInfoData {
-    self.get_read_only_export_info_impl(self.entry, name)
-  }
-
-  fn get_read_only_export_info_impl(
+  pub fn get_read_only_export_info<'a>(
     &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+    name: &Atom,
+  ) -> &'a ExportInfoData {
+    Self::get_read_only_export_info_impl(*self, exports_info_artifact, name)
+  }
+
+  fn get_read_only_export_info_impl<'a>(
     exports_info: ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
     name: &Atom,
-  ) -> &ExportInfoData {
-    if let Some(export_info) = self.get_named_export_in_exports_info(&exports_info, name) {
+  ) -> &'a ExportInfoData {
+    if let Some(export_info) =
+      Self::get_named_export_in_exports_info(&exports_info, exports_info_artifact, name)
+    {
       return export_info;
     }
-    self.get_other_in_exports_info(&exports_info)
+    Self::get_other_in_exports_info(&exports_info, exports_info_artifact)
   }
 
-  pub fn get_read_only_export_info_recursive(&self, names: &[Atom]) -> Option<&ExportInfoData> {
-    let (exports_info, name) = self.get_read_only_export_info_recursive_impl(names)?;
-    self
-      .data_in_exports_info(&exports_info)
-      .exports()
-      .get(&name)
-  }
-
-  fn get_read_only_export_info_recursive_impl(
+  pub fn get_read_only_export_info_recursive<'a>(
     &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
     names: &[Atom],
-  ) -> Option<(ExportsInfo, Atom)> {
-    self.get_read_only_export_info_recursive_in_exports_info(self.entry, names)
+  ) -> Option<&'a ExportInfoData> {
+    Self::get_read_only_export_info_recursive_in_exports_info(*self, exports_info_artifact, names)
   }
 
-  fn get_read_only_export_info_recursive_in_exports_info(
-    &self,
+  fn get_read_only_export_info_recursive_in_exports_info<'a>(
     exports_info: ExportsInfo,
+    exports_info_artifact: &'a ExportsInfoArtifact,
     names: &[Atom],
-  ) -> Option<(ExportsInfo, Atom)> {
+  ) -> Option<&'a ExportInfoData> {
     if names.is_empty() {
       return None;
     }
-    let export_info = self.get_read_only_export_info_impl(exports_info, &names[0]);
+    let export_info =
+      Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &names[0]);
     if names.len() == 1 {
-      return Some((exports_info, names[0].clone()));
+      return Some(export_info);
     }
 
     export_info.exports_info().and_then(|nested_exports_info| {
-      self.get_read_only_export_info_recursive_in_exports_info(nested_exports_info, &names[1..])
+      Self::get_read_only_export_info_recursive_in_exports_info(
+        nested_exports_info,
+        exports_info_artifact,
+        &names[1..],
+      )
     })
   }
 
-  pub fn get_nested_exports_info(&self, name: Option<&[Atom]>) -> Option<&ExportsInfoData> {
-    let exports_info = self.get_nested_exports_info_impl(name)?;
-    self.exports.get(&exports_info).copied()
+  pub fn get_nested_exports_info<'a>(
+    &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+    name: Option<&[Atom]>,
+  ) -> Option<&'a ExportsInfoData> {
+    let exports_info = self.get_nested_exports_info_impl(exports_info_artifact, name)?;
+    Some(Self::data_in_exports_info(
+      &exports_info,
+      exports_info_artifact,
+    ))
   }
 
-  fn get_nested_exports_info_impl(&self, name: Option<&[Atom]>) -> Option<ExportsInfo> {
-    self.get_nested_exports_info_in_exports_info(self.entry, name)
+  fn get_nested_exports_info_impl(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    name: Option<&[Atom]>,
+  ) -> Option<ExportsInfo> {
+    Self::get_nested_exports_info_in_exports_info(*self, exports_info_artifact, name)
   }
 
   fn get_nested_exports_info_in_exports_info(
-    &self,
     exports_info: ExportsInfo,
+    exports_info_artifact: &ExportsInfoArtifact,
     name: Option<&[Atom]>,
   ) -> Option<ExportsInfo> {
     if let Some(name) = name
       && !name.is_empty()
     {
-      let info = self.get_read_only_export_info_impl(exports_info, &name[0]);
+      let info =
+        Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &name[0]);
       if let Some(nested_exports_info) = info.exports_info() {
-        return self.get_nested_exports_info_in_exports_info(nested_exports_info, Some(&name[1..]));
+        return Self::get_nested_exports_info_in_exports_info(
+          nested_exports_info,
+          exports_info_artifact,
+          Some(&name[1..]),
+        );
       } else {
         return None;
       }
@@ -191,19 +171,21 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     Some(exports_info)
   }
 
-  pub fn get_relevant_exports(&self, runtime: Option<&RuntimeSpec>) -> Vec<&ExportInfoData> {
-    self.get_relevant_exports_impl(&self.entry, runtime)
+  pub fn get_relevant_exports<'a>(
+    &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+    runtime: Option<&RuntimeSpec>,
+  ) -> Vec<&'a ExportInfoData> {
+    self.get_relevant_exports_impl(exports_info_artifact, self, runtime)
   }
 
-  fn get_relevant_exports_impl(
+  fn get_relevant_exports_impl<'a>(
     &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
     exports_info: &ExportsInfo,
     runtime: Option<&RuntimeSpec>,
-  ) -> Vec<&ExportInfoData> {
-    let data = self
-      .exports
-      .get(exports_info)
-      .expect("should have nested exports info");
+  ) -> Vec<&'a ExportInfoData> {
+    let data = Self::data_in_exports_info(exports_info, exports_info_artifact);
     let mut list = Vec::with_capacity(data.exports().len() + 1);
     for export_info in data.exports().values() {
       let used = export_info.get_used(runtime);
@@ -216,7 +198,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
       list.push(export_info);
     }
 
-    let other_export_info = self.get_other_in_exports_info(exports_info);
+    let other_export_info = Self::get_other_in_exports_info(exports_info, exports_info_artifact);
     if !matches!(
       other_export_info.provided(),
       Some(ExportProvided::NotProvided)
@@ -227,19 +209,21 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     list
   }
 
-  pub fn get_used_exports(&self, runtime: Option<&RuntimeSpec>) -> UsedExports {
-    self.get_used_exports_impl(&self.entry, runtime)
+  pub fn get_used_exports(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    runtime: Option<&RuntimeSpec>,
+  ) -> UsedExports {
+    self.get_used_exports_impl(exports_info_artifact, self, runtime)
   }
 
   fn get_used_exports_impl(
     &self,
+    exports_info_artifact: &ExportsInfoArtifact,
     exports_info: &ExportsInfo,
     runtime: Option<&RuntimeSpec>,
   ) -> UsedExports {
-    match self
-      .get_other_in_exports_info(exports_info)
-      .get_used(runtime)
-    {
+    match Self::get_other_in_exports_info(exports_info, exports_info_artifact).get_used(runtime) {
       UsageState::NoInfo => return UsedExports::Unknown,
       UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
         return UsedExports::UsedNamespace(true);
@@ -248,7 +232,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     }
 
     let mut res = vec![];
-    for (_, export_info) in self.get_exports_in_exports_info(exports_info) {
+    for (_, export_info) in Self::get_exports_in_exports_info(exports_info, exports_info_artifact) {
       let used = export_info.get_used(runtime);
       match used {
         UsageState::NoInfo => return UsedExports::Unknown,
@@ -263,8 +247,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     }
 
     if res.is_empty() {
-      let used = self
-        .get_side_effects_in_exports_info(exports_info)
+      let used = Self::get_side_effects_in_exports_info(exports_info, exports_info_artifact)
         .get_used(runtime);
       match used {
         UsageState::NoInfo => return UsedExports::Unknown,
@@ -276,12 +259,19 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     UsedExports::UsedNames(res)
   }
 
-  pub fn get_provided_exports(&self) -> ProvidedExports {
-    self.get_provided_exports_impl(&self.entry)
+  pub fn get_provided_exports(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+  ) -> ProvidedExports {
+    self.get_provided_exports_impl(exports_info_artifact, self)
   }
 
-  fn get_provided_exports_impl(&self, exports_info: &ExportsInfo) -> ProvidedExports {
-    match self.get_other_in_exports_info(exports_info).provided() {
+  fn get_provided_exports_impl(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    exports_info: &ExportsInfo,
+  ) -> ProvidedExports {
+    match Self::get_other_in_exports_info(exports_info, exports_info_artifact).provided() {
       Some(ExportProvided::Unknown) => {
         return ProvidedExports::ProvidedAll;
       }
@@ -295,7 +285,7 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     }
 
     let mut ret = vec![];
-    for (_, export_info) in self.get_exports_in_exports_info(exports_info) {
+    for (_, export_info) in Self::get_exports_in_exports_info(exports_info, exports_info_artifact) {
       match export_info.provided() {
         Some(ExportProvided::Provided | ExportProvided::Unknown) | None => {
           ret.push(export_info.name().cloned().unwrap_or_else(|| "".into()));
@@ -306,26 +296,45 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     ProvidedExports::ProvidedNames(ret)
   }
 
-  pub fn get_export_info_without_mut_module_graph(&self, name: &Atom) -> Cow<'_, ExportInfoData> {
-    if let Some(export_info) = self.get_named_export_in_exports_info(&self.entry, name) {
+  pub fn get_export_info_without_mut_module_graph<'a>(
+    &self,
+    exports_info_artifact: &'a ExportsInfoArtifact,
+    name: &Atom,
+  ) -> Cow<'a, ExportInfoData> {
+    if let Some(export_info) =
+      Self::get_named_export_in_exports_info(self, exports_info_artifact, name)
+    {
       return Cow::Borrowed(export_info);
     }
     Cow::Owned(ExportInfoData::new(
-      self.entry,
+      *self,
       Some(name.clone()),
-      Some(self.get_other_in_exports_info(&self.entry)),
+      Some(Self::get_other_in_exports_info(self, exports_info_artifact)),
     ))
   }
 
-  pub fn is_module_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
-    if self.is_used_impl(self.entry, runtime) {
+  pub fn update_hash(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    hasher: &mut dyn std::hash::Hasher,
+    runtime: Option<&RuntimeSpec>,
+  ) {
+    self
+      .as_data(exports_info_artifact)
+      .update_hash(exports_info_artifact, hasher, runtime);
+  }
+
+  pub fn is_module_used(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    if self.is_used_impl(exports_info_artifact, *self, runtime) {
       return true;
     }
 
     if !matches!(
-      self
-        .get_side_effects_in_exports_info(&self.entry)
-        .get_used(runtime),
+      Self::get_side_effects_in_exports_info(self, exports_info_artifact).get_used(runtime),
       UsageState::Unused
     ) {
       return true;
@@ -333,19 +342,26 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     false
   }
 
-  pub fn is_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
-    self.is_used_impl(self.entry, runtime)
+  pub fn is_used(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    self.is_used_impl(exports_info_artifact, *self, runtime)
   }
 
-  fn is_used_impl(&self, exports_info: ExportsInfo, runtime: Option<&RuntimeSpec>) -> bool {
-    if self
-      .get_other_in_exports_info(&exports_info)
-      .is_used(runtime)
-    {
+  fn is_used_impl(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    exports_info: ExportsInfo,
+    runtime: Option<&RuntimeSpec>,
+  ) -> bool {
+    if Self::get_other_in_exports_info(&exports_info, exports_info_artifact).is_used(runtime) {
       return true;
     }
 
-    for (_, export_info) in self.get_exports_in_exports_info(&exports_info) {
+    for (_, export_info) in Self::get_exports_in_exports_info(&exports_info, exports_info_artifact)
+    {
       if export_info.is_used(runtime) {
         return true;
       }
@@ -353,21 +369,26 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     false
   }
 
-  pub fn is_export_provided(&self, names: &[Atom]) -> Option<ExportProvided> {
-    self.is_export_provided_impl(self.entry, names)
+  pub fn is_export_provided(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    names: &[Atom],
+  ) -> Option<ExportProvided> {
+    self.is_export_provided_impl(exports_info_artifact, *self, names)
   }
 
   fn is_export_provided_impl(
     &self,
+    exports_info_artifact: &ExportsInfoArtifact,
     exports_info: ExportsInfo,
     names: &[Atom],
   ) -> Option<ExportProvided> {
     let name = names.first()?;
-    let info_data = self.get_read_only_export_info_impl(exports_info, name);
+    let info_data = Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, name);
     if let Some(nested_exports_info) = info_data.exports_info()
       && names.len() > 1
     {
-      return self.is_export_provided_impl(nested_exports_info, &names[1..]);
+      return self.is_export_provided_impl(exports_info_artifact, nested_exports_info, &names[1..]);
     }
     let provided = info_data.provided()?;
 
@@ -383,45 +404,68 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
     }
   }
 
-  pub fn get_used(&self, names: &[Atom], runtime: Option<&RuntimeSpec>) -> UsageState {
-    self.get_used_impl(self.entry, names, runtime)
+  pub fn get_used(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    names: &[Atom],
+    runtime: Option<&RuntimeSpec>,
+  ) -> UsageState {
+    self.get_used_impl(exports_info_artifact, *self, names, runtime)
   }
 
   fn get_used_impl(
     &self,
+    exports_info_artifact: &ExportsInfoArtifact,
     exports_info: ExportsInfo,
     names: &[Atom],
     runtime: Option<&RuntimeSpec>,
   ) -> UsageState {
     if names.len() == 1 {
       let value = &names[0];
-      let info = self.get_read_only_export_info_impl(exports_info, value);
+      let info = Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, value);
       let used = info.get_used(runtime);
       return used;
     }
     if names.is_empty() {
-      return self
-        .get_other_in_exports_info(&exports_info)
+      return Self::get_other_in_exports_info(&exports_info, exports_info_artifact)
         .get_used(runtime);
     }
-    let info_data = self.get_read_only_export_info_impl(exports_info, &names[0]);
+    let info_data =
+      Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &names[0]);
     if let Some(nested_exports_info) = info_data.exports_info()
       && names.len() > 1
     {
-      return self.get_used_impl(nested_exports_info, &names[1..], runtime);
+      return self.get_used_impl(
+        exports_info_artifact,
+        nested_exports_info,
+        &names[1..],
+        runtime,
+      );
     }
     info_data.get_used(runtime)
   }
 
-  pub fn get_usage_key(&self, runtime: Option<&RuntimeSpec>) -> UsageKey {
-    let mut key = UsageKey(Vec::with_capacity(self.exports().count() + 2));
-
-    key.add(Either::Right(self.other_exports_info().get_used(runtime)));
-    key.add(Either::Right(
-      self.side_effects_only_info().get_used(runtime),
+  pub fn get_usage_key(
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
+    runtime: Option<&RuntimeSpec>,
+  ) -> UsageKey {
+    let mut key = UsageKey(Vec::with_capacity(
+      self.exports(exports_info_artifact).count() + 2,
     ));
 
-    for (_, export_info) in self.exports() {
+    key.add(Either::Right(
+      self
+        .other_exports_info(exports_info_artifact)
+        .get_used(runtime),
+    ));
+    key.add(Either::Right(
+      self
+        .side_effects_only_info(exports_info_artifact)
+        .get_used(runtime),
+    ));
+
+    for (_, export_info) in self.exports(exports_info_artifact) {
       key.add(Either::Right(export_info.get_used(runtime)));
     }
 
@@ -429,209 +473,72 @@ impl<'a> PrefetchedExportsInfoWrapper<'a> {
   }
 }
 
-/**
- * The used info of the exports info
- * This should be used when you need to call `get_used_name` or `is_used` or `is_module_used`
- * that should avoid the unnecessary prefetch of the whole named exports
- */
-#[derive(Debug, Clone)]
-pub struct PrefetchedExportsInfoUsed {
-  // if this exports info is used
-  is_used: bool,
-  // if this exports info is used or this module is used
-  is_module_used: bool,
+#[cfg(test)]
+mod tests {
+  use std::{collections::hash_map::DefaultHasher, hash::Hasher};
+
+  use rspack_util::atom::Atom;
+
+  use crate::{ExportProvided, ExportsInfoArtifact, ExportsInfoData, UsageState};
+
+  fn hash_with_ns_access(ns_access: bool) -> u64 {
+    let mut exports_info_artifact = ExportsInfoArtifact::default();
+    let exports_info_data = ExportsInfoData::default();
+    let exports_info = exports_info_data.id();
+    exports_info_artifact.set_exports_info_by_id(exports_info, exports_info_data);
+
+    {
+      let exports_info_data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
+      let other_exports_info = exports_info_data.other_exports_info_mut();
+      other_exports_info.set_has_use_info();
+      other_exports_info.set_used(UsageState::OnlyPropertiesUsed, None);
+      other_exports_info.set_provided(Some(ExportProvided::Provided));
+    }
+
+    {
+      let exports_info_data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
+      let export_info = exports_info_data.ensure_owned_export_info(&Atom::from("test"));
+      export_info.set_ns_access(ns_access);
+    }
+
+    let mut hasher = DefaultHasher::new();
+    exports_info.update_hash(&exports_info_artifact, &mut hasher, None);
+    hasher.finish()
+  }
+
+  #[test]
+  fn update_hash_should_include_namespace_access() {
+    assert_ne!(hash_with_ns_access(false), hash_with_ns_access(true));
+  }
 }
 
-impl PrefetchedExportsInfoUsed {
-  pub fn is_used(&self) -> bool {
-    self.is_used
-  }
-
-  pub fn is_module_used(&self) -> bool {
-    self.is_module_used
-  }
-}
-
-pub struct ExportsInfoGetter;
-
-impl ExportsInfoGetter {
-  /**
-   * Generate a PrefetchedExportsInfoWrapper from the entry
-   * if names is provided, it will pre-fetch the exports info data of the export info items of specific names
-   * if names is not provided, it will not pre-fetch any export info item
-   */
-  pub fn prefetch<'a>(
-    id: &ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    mode: PrefetchExportsInfoMode<'a>,
-  ) -> PrefetchedExportsInfoWrapper<'a> {
-    fn prefetch_exports<'a>(
-      id: &ExportsInfo,
-      exports_info_artifact: &'a ExportsInfoArtifact,
-      res: &mut FxHashMap<ExportsInfo, &'a ExportsInfoData>,
-      mode: PrefetchExportsInfoMode<'a>,
-    ) {
-      if res.contains_key(id) {
-        return;
-      }
-
-      let exports_info = id.as_data(exports_info_artifact);
-      res.insert(*id, exports_info);
-
-      match mode {
-        PrefetchExportsInfoMode::Default => {}
-        PrefetchExportsInfoMode::Nested(names) => {
-          if let Some(nested) = names
-            .first()
-            .and_then(|name| exports_info.exports().get(name))
-            .and_then(|export_info| export_info.exports_info())
-          {
-            prefetch_exports(
-              &nested,
-              exports_info_artifact,
-              res,
-              PrefetchExportsInfoMode::Nested(&names[1..]),
-            );
-          }
-        }
-        PrefetchExportsInfoMode::Full => {
-          for export_info in exports_info.exports().values() {
-            if let Some(nested_exports_info) = export_info.exports_info() {
-              prefetch_exports(
-                &nested_exports_info,
-                exports_info_artifact,
-                res,
-                PrefetchExportsInfoMode::Full,
-              );
-            }
-          }
-        }
-      }
-
-      if let Some(other_exports) = exports_info.other_exports_info().exports_info() {
-        prefetch_exports(
-          &other_exports,
-          exports_info_artifact,
-          res,
-          PrefetchExportsInfoMode::Default,
-        );
-      }
-
-      if let Some(side_exports) = exports_info.side_effects_only_info().exports_info() {
-        prefetch_exports(
-          &side_exports,
-          exports_info_artifact,
-          res,
-          PrefetchExportsInfoMode::Default,
-        );
-      }
-    }
-
-    let initial_capacity = {
-      let exports_info = id.as_data(exports_info_artifact);
-      let extra_nested_exports =
-        usize::from(exports_info.other_exports_info().exports_info().is_some())
-          + usize::from(
-            exports_info
-              .side_effects_only_info()
-              .exports_info()
-              .is_some(),
-          );
-      match mode {
-        PrefetchExportsInfoMode::Default => 1 + extra_nested_exports,
-        PrefetchExportsInfoMode::Nested(names) => {
-          1 + extra_nested_exports
-            + usize::from(
-              names
-                .first()
-                .and_then(|name| exports_info.exports().get(name))
-                .and_then(|export_info| export_info.exports_info())
-                .is_some(),
-            )
-        }
-        PrefetchExportsInfoMode::Full => 1 + exports_info.exports().len() + extra_nested_exports,
-      }
-    };
-    let mut res = FxHashMap::with_capacity_and_hasher(initial_capacity, Default::default());
-    prefetch_exports(id, exports_info_artifact, &mut res, mode.clone());
-    PrefetchedExportsInfoWrapper {
-      exports: Arc::new(res),
-      entry: *id,
-      mode,
-    }
-  }
-
-  pub fn prefetch_used_info_without_name(
-    id: &ExportsInfo,
-    exports_info_artifact: &ExportsInfoArtifact,
-    runtime: Option<&RuntimeSpec>,
-  ) -> PrefetchedExportsInfoUsed {
-    fn is_exports_info_used(
-      info: &ExportsInfo,
-      runtime: Option<&RuntimeSpec>,
-      exports_info_artifact: &ExportsInfoArtifact,
-    ) -> bool {
-      let exports_info = info.as_data(exports_info_artifact);
-      if exports_info.other_exports_info().is_used(runtime) {
-        return true;
-      }
-      exports_info
-        .exports()
-        .values()
-        .any(|export_info| export_info.is_used(runtime))
-    }
-
-    let is_used = is_exports_info_used(id, runtime, exports_info_artifact);
-    let is_module_used = if is_used {
-      true
-    } else {
-      id.as_data(exports_info_artifact)
-        .side_effects_only_info()
-        .is_used(runtime)
-    };
-
-    PrefetchedExportsInfoUsed {
-      is_used,
-      is_module_used,
-    }
-  }
-
+impl ExportsInfo {
   /// `Option<UsedName>` correspond to webpack `string | string[] | false`
   pub fn get_used_name(
-    info: GetUsedNameParam<'_>,
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
     runtime: Option<&RuntimeSpec>,
     names: &[Atom],
   ) -> Option<UsedName> {
-    match info {
-      GetUsedNameParam::WithoutNames(info) => {
-        if !names.is_empty() {
-          unreachable!();
-        }
-        if !info.is_used {
-          return None;
-        }
-        Some(UsedName::Normal(vec![]))
-      }
-      GetUsedNameParam::WithNames(info) => {
-        Self::get_used_name_in_exports_info(info, info.entry, runtime, names)
-      }
-    }
+    self.get_used_name_in_exports_info(exports_info_artifact, *self, runtime, names)
   }
 
   fn get_used_name_in_exports_info(
-    info: &PrefetchedExportsInfoWrapper<'_>,
+    &self,
+    exports_info_artifact: &ExportsInfoArtifact,
     exports_info: ExportsInfo,
     runtime: Option<&RuntimeSpec>,
     names: &[Atom],
   ) -> Option<UsedName> {
     if names.is_empty() {
-      if !info.is_used_impl(exports_info, runtime) {
+      if !self.is_used_impl(exports_info_artifact, exports_info, runtime) {
         return None;
       }
       return Some(UsedName::Normal(vec![]));
     }
 
-    let export_info = info.get_read_only_export_info_impl(exports_info, &names[0]);
+    let export_info =
+      Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &names[0]);
     let first = export_info.get_used_name(Some(&names[0]), runtime)?;
     let mut arr = match first {
       UsedNameItem::Str(first) => UsedName::Normal(vec![first]),
@@ -643,8 +550,12 @@ impl ExportsInfoGetter {
     if let Some(nested_exports_info) = export_info.exports_info()
       && export_info.get_used(runtime) == UsageState::OnlyPropertiesUsed
     {
-      let nested =
-        Self::get_used_name_in_exports_info(info, nested_exports_info, runtime, &names[1..])?;
+      let nested = self.get_used_name_in_exports_info(
+        exports_info_artifact,
+        nested_exports_info,
+        runtime,
+        &names[1..],
+      )?;
       let nested = match nested {
         UsedName::Inlined(_) => return Some(nested),
         UsedName::Normal(names) => names,
@@ -655,26 +566,4 @@ impl ExportsInfoGetter {
     arr.append(names.iter().skip(1).cloned());
     Some(arr)
   }
-
-  pub fn from_meta<'a>(
-    meta: (ExportsInfo, Vec<ExportsInfo>),
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> PrefetchedExportsInfoWrapper<'a> {
-    let (entry, exports) = meta;
-    let exports = exports
-      .into_iter()
-      .map(|e| (e, exports_info_artifact.get_exports_info_by_id(&e)))
-      .collect::<FxHashMap<_, _>>();
-
-    PrefetchedExportsInfoWrapper {
-      exports: Arc::new(exports),
-      entry,
-      mode: PrefetchExportsInfoMode::Full,
-    }
-  }
-}
-
-pub enum GetUsedNameParam<'a> {
-  WithoutNames(&'a PrefetchedExportsInfoUsed),
-  WithNames(&'a PrefetchedExportsInfoWrapper<'a>),
 }

--- a/crates/rspack_core/src/exports/exports_info_getter.rs
+++ b/crates/rspack_core/src/exports/exports_info_getter.rs
@@ -3,191 +3,63 @@ use std::borrow::Cow;
 use either::Either;
 use rspack_util::atom::Atom;
 
-use super::{
-  ExportInfoData, ExportProvided, ExportsInfo, ProvidedExports, UsageState, UsedName, UsedNameItem,
-};
+use super::{ExportInfoData, ExportProvided, ExportsInfoData, UsageState, UsedName, UsedNameItem};
 use crate::{
-  ExportsInfoArtifact, ExportsInfoData, InlinedUsedName, RuntimeSpec, UsageKey, UsedExports,
+  ExportsInfoArtifact, InlinedUsedName, ProvidedExports, RuntimeSpec, UsageKey, UsedExports,
 };
 
-impl ExportsInfo {
-  pub fn data<'a>(&self, exports_info_artifact: &'a ExportsInfoArtifact) -> &'a ExportsInfoData {
-    Self::data_in_exports_info(self, exports_info_artifact)
-  }
-
-  pub fn other_exports_info<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> &'a ExportInfoData {
-    Self::get_other_in_exports_info(self, exports_info_artifact)
-  }
-
-  pub fn side_effects_only_info<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> &'a ExportInfoData {
-    Self::get_side_effects_in_exports_info(self, exports_info_artifact)
-  }
-
-  pub fn exports<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> impl Iterator<Item = (&'a Atom, &'a ExportInfoData)> {
-    Self::get_exports_in_exports_info(self, exports_info_artifact)
-  }
-
-  fn data_in_exports_info<'a>(
-    exports_info: &ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> &'a ExportsInfoData {
-    exports_info_artifact.get_exports_info_by_id(exports_info)
-  }
-
-  fn get_other_in_exports_info<'a>(
-    exports_info: &ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> &'a ExportInfoData {
-    Self::data_in_exports_info(exports_info, exports_info_artifact).other_exports_info()
-  }
-
-  fn get_side_effects_in_exports_info<'a>(
-    exports_info: &ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> &'a ExportInfoData {
-    Self::data_in_exports_info(exports_info, exports_info_artifact).side_effects_only_info()
-  }
-
-  fn get_exports_in_exports_info<'a>(
-    exports_info: &ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-  ) -> impl Iterator<Item = (&'a Atom, &'a ExportInfoData)> {
-    Self::data_in_exports_info(exports_info, exports_info_artifact)
-      .exports()
-      .iter()
-  }
-
-  fn get_named_export_in_exports_info<'a>(
-    exports_info: &ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    name: &Atom,
-  ) -> Option<&'a ExportInfoData> {
-    Self::data_in_exports_info(exports_info, exports_info_artifact)
-      .exports()
-      .get(name)
-  }
-
-  pub fn get_read_only_export_info<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    name: &Atom,
-  ) -> &'a ExportInfoData {
-    Self::get_read_only_export_info_impl(*self, exports_info_artifact, name)
-  }
-
-  fn get_read_only_export_info_impl<'a>(
-    exports_info: ExportsInfo,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    name: &Atom,
-  ) -> &'a ExportInfoData {
-    if let Some(export_info) =
-      Self::get_named_export_in_exports_info(&exports_info, exports_info_artifact, name)
-    {
-      return export_info;
-    }
-    Self::get_other_in_exports_info(&exports_info, exports_info_artifact)
+impl ExportsInfoData {
+  pub fn get_read_only_export_info(&self, name: &Atom) -> &ExportInfoData {
+    self
+      .named_exports(name)
+      .unwrap_or_else(|| self.other_exports_info())
   }
 
   pub fn get_read_only_export_info_recursive<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    names: &[Atom],
-  ) -> Option<&'a ExportInfoData> {
-    Self::get_read_only_export_info_recursive_in_exports_info(*self, exports_info_artifact, names)
-  }
-
-  fn get_read_only_export_info_recursive_in_exports_info<'a>(
-    exports_info: ExportsInfo,
+    &'a self,
     exports_info_artifact: &'a ExportsInfoArtifact,
     names: &[Atom],
   ) -> Option<&'a ExportInfoData> {
     if names.is_empty() {
       return None;
     }
-    let export_info =
-      Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &names[0]);
+
+    let export_info = self.get_read_only_export_info(&names[0]);
     if names.len() == 1 {
       return Some(export_info);
     }
 
     export_info.exports_info().and_then(|nested_exports_info| {
-      Self::get_read_only_export_info_recursive_in_exports_info(
-        nested_exports_info,
-        exports_info_artifact,
-        &names[1..],
-      )
+      nested_exports_info
+        .as_data(exports_info_artifact)
+        .get_read_only_export_info_recursive(exports_info_artifact, &names[1..])
     })
   }
 
   pub fn get_nested_exports_info<'a>(
-    &self,
+    &'a self,
     exports_info_artifact: &'a ExportsInfoArtifact,
     name: Option<&[Atom]>,
   ) -> Option<&'a ExportsInfoData> {
-    let exports_info = self.get_nested_exports_info_impl(exports_info_artifact, name)?;
-    Some(Self::data_in_exports_info(
-      &exports_info,
-      exports_info_artifact,
-    ))
-  }
-
-  fn get_nested_exports_info_impl(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    name: Option<&[Atom]>,
-  ) -> Option<ExportsInfo> {
-    Self::get_nested_exports_info_in_exports_info(*self, exports_info_artifact, name)
-  }
-
-  fn get_nested_exports_info_in_exports_info(
-    exports_info: ExportsInfo,
-    exports_info_artifact: &ExportsInfoArtifact,
-    name: Option<&[Atom]>,
-  ) -> Option<ExportsInfo> {
     if let Some(name) = name
       && !name.is_empty()
     {
-      let info =
-        Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &name[0]);
+      let info = self.get_read_only_export_info(&name[0]);
       if let Some(nested_exports_info) = info.exports_info() {
-        return Self::get_nested_exports_info_in_exports_info(
-          nested_exports_info,
-          exports_info_artifact,
-          Some(&name[1..]),
-        );
-      } else {
-        return None;
+        return nested_exports_info
+          .as_data(exports_info_artifact)
+          .get_nested_exports_info(exports_info_artifact, Some(&name[1..]));
       }
+
+      return None;
     }
-    Some(exports_info)
+
+    Some(self)
   }
 
-  pub fn get_relevant_exports<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    runtime: Option<&RuntimeSpec>,
-  ) -> Vec<&'a ExportInfoData> {
-    self.get_relevant_exports_impl(exports_info_artifact, self, runtime)
-  }
-
-  fn get_relevant_exports_impl<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    exports_info: &ExportsInfo,
-    runtime: Option<&RuntimeSpec>,
-  ) -> Vec<&'a ExportInfoData> {
-    let data = Self::data_in_exports_info(exports_info, exports_info_artifact);
-    let mut list = Vec::with_capacity(data.exports().len() + 1);
-    for export_info in data.exports().values() {
+  pub fn get_relevant_exports(&self, runtime: Option<&RuntimeSpec>) -> Vec<&ExportInfoData> {
+    let mut list = Vec::with_capacity(self.exports().len() + 1);
+    for export_info in self.exports().values() {
       let used = export_info.get_used(runtime);
       if matches!(used, UsageState::Unused) {
         continue;
@@ -198,7 +70,7 @@ impl ExportsInfo {
       list.push(export_info);
     }
 
-    let other_export_info = Self::get_other_in_exports_info(exports_info, exports_info_artifact);
+    let other_export_info = self.other_exports_info();
     if !matches!(
       other_export_info.provided(),
       Some(ExportProvided::NotProvided)
@@ -209,21 +81,8 @@ impl ExportsInfo {
     list
   }
 
-  pub fn get_used_exports(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    runtime: Option<&RuntimeSpec>,
-  ) -> UsedExports {
-    self.get_used_exports_impl(exports_info_artifact, self, runtime)
-  }
-
-  fn get_used_exports_impl(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    exports_info: &ExportsInfo,
-    runtime: Option<&RuntimeSpec>,
-  ) -> UsedExports {
-    match Self::get_other_in_exports_info(exports_info, exports_info_artifact).get_used(runtime) {
+  pub fn get_used_exports(&self, runtime: Option<&RuntimeSpec>) -> UsedExports {
+    match self.other_exports_info().get_used(runtime) {
       UsageState::NoInfo => return UsedExports::Unknown,
       UsageState::Unknown | UsageState::OnlyPropertiesUsed | UsageState::Used => {
         return UsedExports::UsedNamespace(true);
@@ -232,7 +91,7 @@ impl ExportsInfo {
     }
 
     let mut res = vec![];
-    for (_, export_info) in Self::get_exports_in_exports_info(exports_info, exports_info_artifact) {
+    for export_info in self.exports().values() {
       let used = export_info.get_used(runtime);
       match used {
         UsageState::NoInfo => return UsedExports::Unknown,
@@ -247,8 +106,7 @@ impl ExportsInfo {
     }
 
     if res.is_empty() {
-      let used = Self::get_side_effects_in_exports_info(exports_info, exports_info_artifact)
-        .get_used(runtime);
+      let used = self.side_effects_only_info().get_used(runtime);
       match used {
         UsageState::NoInfo => return UsedExports::Unknown,
         UsageState::Unused => return UsedExports::UsedNamespace(false),
@@ -259,23 +117,9 @@ impl ExportsInfo {
     UsedExports::UsedNames(res)
   }
 
-  pub fn get_provided_exports(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-  ) -> ProvidedExports {
-    self.get_provided_exports_impl(exports_info_artifact, self)
-  }
-
-  fn get_provided_exports_impl(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    exports_info: &ExportsInfo,
-  ) -> ProvidedExports {
-    match Self::get_other_in_exports_info(exports_info, exports_info_artifact).provided() {
-      Some(ExportProvided::Unknown) => {
-        return ProvidedExports::ProvidedAll;
-      }
-      Some(ExportProvided::Provided) => {
+  pub fn get_provided_exports(&self) -> ProvidedExports {
+    match self.other_exports_info().provided() {
+      Some(ExportProvided::Unknown | ExportProvided::Provided) => {
         return ProvidedExports::ProvidedAll;
       }
       None => {
@@ -285,7 +129,7 @@ impl ExportsInfo {
     }
 
     let mut ret = vec![];
-    for (_, export_info) in Self::get_exports_in_exports_info(exports_info, exports_info_artifact) {
+    for export_info in self.exports().values() {
       match export_info.provided() {
         Some(ExportProvided::Provided | ExportProvided::Unknown) | None => {
           ret.push(export_info.name().cloned().unwrap_or_else(|| "".into()));
@@ -296,77 +140,38 @@ impl ExportsInfo {
     ProvidedExports::ProvidedNames(ret)
   }
 
-  pub fn get_export_info_without_mut_module_graph<'a>(
-    &self,
-    exports_info_artifact: &'a ExportsInfoArtifact,
-    name: &Atom,
-  ) -> Cow<'a, ExportInfoData> {
-    if let Some(export_info) =
-      Self::get_named_export_in_exports_info(self, exports_info_artifact, name)
-    {
+  pub fn get_export_info_without_mut_module_graph(&self, name: &Atom) -> Cow<'_, ExportInfoData> {
+    if let Some(export_info) = self.named_exports(name) {
       return Cow::Borrowed(export_info);
     }
+
     Cow::Owned(ExportInfoData::new(
-      *self,
+      self.id(),
       Some(name.clone()),
-      Some(Self::get_other_in_exports_info(self, exports_info_artifact)),
+      Some(self.other_exports_info()),
     ))
   }
 
-  pub fn update_hash(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    hasher: &mut dyn std::hash::Hasher,
-    runtime: Option<&RuntimeSpec>,
-  ) {
-    self
-      .as_data(exports_info_artifact)
-      .update_hash(exports_info_artifact, hasher, runtime);
-  }
-
-  pub fn is_module_used(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    runtime: Option<&RuntimeSpec>,
-  ) -> bool {
-    if self.is_used_impl(exports_info_artifact, *self, runtime) {
+  pub fn is_module_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
+    if self.is_used(runtime) {
       return true;
     }
 
-    if !matches!(
-      Self::get_side_effects_in_exports_info(self, exports_info_artifact).get_used(runtime),
+    !matches!(
+      self.side_effects_only_info().get_used(runtime),
       UsageState::Unused
-    ) {
-      return true;
-    }
-    false
+    )
   }
 
-  pub fn is_used(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    runtime: Option<&RuntimeSpec>,
-  ) -> bool {
-    self.is_used_impl(exports_info_artifact, *self, runtime)
-  }
-
-  fn is_used_impl(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    exports_info: ExportsInfo,
-    runtime: Option<&RuntimeSpec>,
-  ) -> bool {
-    if Self::get_other_in_exports_info(&exports_info, exports_info_artifact).is_used(runtime) {
+  pub fn is_used(&self, runtime: Option<&RuntimeSpec>) -> bool {
+    if self.other_exports_info().is_used(runtime) {
       return true;
     }
 
-    for (_, export_info) in Self::get_exports_in_exports_info(&exports_info, exports_info_artifact)
-    {
-      if export_info.is_used(runtime) {
-        return true;
-      }
-    }
-    false
+    self
+      .exports()
+      .values()
+      .any(|export_info| export_info.is_used(runtime))
   }
 
   pub fn is_export_provided(
@@ -374,24 +179,17 @@ impl ExportsInfo {
     exports_info_artifact: &ExportsInfoArtifact,
     names: &[Atom],
   ) -> Option<ExportProvided> {
-    self.is_export_provided_impl(exports_info_artifact, *self, names)
-  }
-
-  fn is_export_provided_impl(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    exports_info: ExportsInfo,
-    names: &[Atom],
-  ) -> Option<ExportProvided> {
     let name = names.first()?;
-    let info_data = Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, name);
+    let info_data = self.get_read_only_export_info(name);
     if let Some(nested_exports_info) = info_data.exports_info()
       && names.len() > 1
     {
-      return self.is_export_provided_impl(exports_info_artifact, nested_exports_info, &names[1..]);
+      return nested_exports_info
+        .as_data(exports_info_artifact)
+        .is_export_provided(exports_info_artifact, &names[1..]);
     }
-    let provided = info_data.provided()?;
 
+    let provided = info_data.provided()?;
     match provided {
       ExportProvided::Provided => {
         if names.len() == 1 {
@@ -410,109 +208,42 @@ impl ExportsInfo {
     names: &[Atom],
     runtime: Option<&RuntimeSpec>,
   ) -> UsageState {
-    self.get_used_impl(exports_info_artifact, *self, names, runtime)
-  }
-
-  fn get_used_impl(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    exports_info: ExportsInfo,
-    names: &[Atom],
-    runtime: Option<&RuntimeSpec>,
-  ) -> UsageState {
     if names.len() == 1 {
-      let value = &names[0];
-      let info = Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, value);
-      let used = info.get_used(runtime);
-      return used;
+      return self.get_read_only_export_info(&names[0]).get_used(runtime);
     }
     if names.is_empty() {
-      return Self::get_other_in_exports_info(&exports_info, exports_info_artifact)
-        .get_used(runtime);
+      return self.other_exports_info().get_used(runtime);
     }
-    let info_data =
-      Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &names[0]);
+
+    let info_data = self.get_read_only_export_info(&names[0]);
     if let Some(nested_exports_info) = info_data.exports_info()
       && names.len() > 1
     {
-      return self.get_used_impl(
+      return nested_exports_info.as_data(exports_info_artifact).get_used(
         exports_info_artifact,
-        nested_exports_info,
         &names[1..],
         runtime,
       );
     }
+
     info_data.get_used(runtime)
   }
 
-  pub fn get_usage_key(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    runtime: Option<&RuntimeSpec>,
-  ) -> UsageKey {
-    let mut key = UsageKey(Vec::with_capacity(
-      self.exports(exports_info_artifact).count() + 2,
+  pub fn get_usage_key(&self, runtime: Option<&RuntimeSpec>) -> UsageKey {
+    let mut key = UsageKey(Vec::with_capacity(self.exports().len() + 2));
+
+    key.add(Either::Right(self.other_exports_info().get_used(runtime)));
+    key.add(Either::Right(
+      self.side_effects_only_info().get_used(runtime),
     ));
 
-    key.add(Either::Right(
-      self
-        .other_exports_info(exports_info_artifact)
-        .get_used(runtime),
-    ));
-    key.add(Either::Right(
-      self
-        .side_effects_only_info(exports_info_artifact)
-        .get_used(runtime),
-    ));
-
-    for (_, export_info) in self.exports(exports_info_artifact) {
+    for export_info in self.exports().values() {
       key.add(Either::Right(export_info.get_used(runtime)));
     }
 
     key
   }
-}
 
-#[cfg(test)]
-mod tests {
-  use std::{collections::hash_map::DefaultHasher, hash::Hasher};
-
-  use rspack_util::atom::Atom;
-
-  use crate::{ExportProvided, ExportsInfoArtifact, ExportsInfoData, UsageState};
-
-  fn hash_with_ns_access(ns_access: bool) -> u64 {
-    let mut exports_info_artifact = ExportsInfoArtifact::default();
-    let exports_info_data = ExportsInfoData::default();
-    let exports_info = exports_info_data.id();
-    exports_info_artifact.set_exports_info_by_id(exports_info, exports_info_data);
-
-    {
-      let exports_info_data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
-      let other_exports_info = exports_info_data.other_exports_info_mut();
-      other_exports_info.set_has_use_info();
-      other_exports_info.set_used(UsageState::OnlyPropertiesUsed, None);
-      other_exports_info.set_provided(Some(ExportProvided::Provided));
-    }
-
-    {
-      let exports_info_data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
-      let export_info = exports_info_data.ensure_owned_export_info(&Atom::from("test"));
-      export_info.set_ns_access(ns_access);
-    }
-
-    let mut hasher = DefaultHasher::new();
-    exports_info.update_hash(&exports_info_artifact, &mut hasher, None);
-    hasher.finish()
-  }
-
-  #[test]
-  fn update_hash_should_include_namespace_access() {
-    assert_ne!(hash_with_ns_access(false), hash_with_ns_access(true));
-  }
-}
-
-impl ExportsInfo {
   /// `Option<UsedName>` correspond to webpack `string | string[] | false`
   pub fn get_used_name(
     &self,
@@ -520,25 +251,14 @@ impl ExportsInfo {
     runtime: Option<&RuntimeSpec>,
     names: &[Atom],
   ) -> Option<UsedName> {
-    self.get_used_name_in_exports_info(exports_info_artifact, *self, runtime, names)
-  }
-
-  fn get_used_name_in_exports_info(
-    &self,
-    exports_info_artifact: &ExportsInfoArtifact,
-    exports_info: ExportsInfo,
-    runtime: Option<&RuntimeSpec>,
-    names: &[Atom],
-  ) -> Option<UsedName> {
     if names.is_empty() {
-      if !self.is_used_impl(exports_info_artifact, exports_info, runtime) {
+      if !self.is_used(runtime) {
         return None;
       }
       return Some(UsedName::Normal(vec![]));
     }
 
-    let export_info =
-      Self::get_read_only_export_info_impl(exports_info, exports_info_artifact, &names[0]);
+    let export_info = self.get_read_only_export_info(&names[0]);
     let first = export_info.get_used_name(Some(&names[0]), runtime)?;
     let mut arr = match first {
       UsedNameItem::Str(first) => UsedName::Normal(vec![first]),
@@ -547,15 +267,13 @@ impl ExportsInfo {
     if names.len() == 1 {
       return Some(arr);
     }
+
     if let Some(nested_exports_info) = export_info.exports_info()
       && export_info.get_used(runtime) == UsageState::OnlyPropertiesUsed
     {
-      let nested = self.get_used_name_in_exports_info(
-        exports_info_artifact,
-        nested_exports_info,
-        runtime,
-        &names[1..],
-      )?;
+      let nested = nested_exports_info
+        .as_data(exports_info_artifact)
+        .get_used_name(exports_info_artifact, runtime, &names[1..])?;
       let nested = match nested {
         UsedName::Inlined(_) => return Some(nested),
         UsedName::Normal(names) => names,
@@ -563,6 +281,7 @@ impl ExportsInfo {
       arr.append(nested);
       return Some(arr);
     }
+
     arr.append(names.iter().skip(1).cloned());
     Some(arr)
   }

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -10,7 +10,6 @@ mod utils;
 
 pub use export_info::*;
 pub use exports_info::*;
-pub use exports_info_getter::*;
 pub use referenced_export::*;
 pub use target::*;
 pub use utils::*;

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -4,8 +4,8 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  DependencyId, ExportInfo, ExportInfoData, ExportInfoHashKey, ExportsInfo, ExportsInfoArtifact,
-  ModuleGraph, ModuleIdentifier,
+  DependencyId, ExportInfo, ExportInfoData, ExportsInfo, ExportsInfoArtifact, ModuleGraph,
+  ModuleIdentifier,
 };
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
@@ -78,6 +78,7 @@ pub fn get_terminal_binding(
     return Some(TerminalBinding::ExportsInfo(exports_info));
   };
   exports_info
+    .as_data(exports_info_artifact)
     .get_read_only_export_info_recursive(exports_info_artifact, &export)
     .map(|data| TerminalBinding::ExportInfo(data.id()))
 }
@@ -87,7 +88,7 @@ pub fn find_target(
   mg: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
   valid_target_module_filter: Arc<impl Fn(&ModuleIdentifier) -> bool>,
-  visited: &mut HashSet<ExportInfoHashKey>,
+  visited: &mut HashSet<ExportInfo>,
 ) -> FindTargetResult {
   if !export_info.target_is_set() || export_info.target().is_empty() {
     return FindTargetResult::NoTarget;
@@ -117,11 +118,10 @@ pub fn find_target(
       return FindTargetResult::ValidTarget(target);
     }
     let name = &target.export.as_ref().expect("should have export")[0];
-    let exports_info = exports_info_artifact.get_exports_info(&target.module);
-    let export_info =
-      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, name);
-    let export_info_hash_key = export_info.as_hash_key();
-    if !visited.insert(export_info_hash_key) {
+    let exports_info = exports_info_artifact.get_exports_info_data(&target.module);
+    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let export_info_id = export_info.id();
+    if !visited.insert(export_info_id) {
       return FindTargetResult::NoTarget;
     }
     let new_target = find_target(
@@ -169,13 +169,12 @@ pub fn get_target(
   mg: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
   resolve_filter: &ResolveFilterFnTy<'_>,
-  already_visited: &mut HashSet<ExportInfoHashKey>,
+  already_visited: &mut HashSet<ExportInfo>,
 ) -> Option<GetTargetResult> {
   if !export_info.target_is_set() || export_info.target().is_empty() {
     return None;
   }
-  let hash_key = export_info.as_hash_key();
-  if !already_visited.insert(hash_key) {
+  if !already_visited.insert(export_info.id()) {
     return Some(GetTargetResult::Circular);
   }
 
@@ -215,7 +214,7 @@ pub fn get_target(
 
 fn resolve_target(
   input_target: UnResolvedExportInfoTarget,
-  already_visited: &mut HashSet<ExportInfoHashKey>,
+  already_visited: &mut HashSet<ExportInfo>,
   resolve_filter: &ResolveFilterFnTy<'_>,
   mg: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
@@ -240,11 +239,10 @@ fn resolve_target(
       return Some(GetTargetResult::Target(target));
     };
 
-    let exports_info = exports_info_artifact.get_exports_info(&target.module);
-    let maybe_export_info =
-      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, name);
-    let maybe_export_info_hash_key = maybe_export_info.as_hash_key();
-    if already_visited.contains(&maybe_export_info_hash_key) {
+    let exports_info = exports_info_artifact.get_exports_info_data(&target.module);
+    let maybe_export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let maybe_export_info_id = maybe_export_info.id();
+    if already_visited.contains(&maybe_export_info_id) {
       return Some(GetTargetResult::Circular);
     }
     let new_target = get_target(
@@ -283,7 +281,7 @@ fn resolve_target(
     if !resolve_filter(&target) {
       return Some(GetTargetResult::Target(target));
     }
-    already_visited.insert(maybe_export_info_hash_key);
+    already_visited.insert(maybe_export_info_id);
   }
 }
 

--- a/crates/rspack_core/src/exports/target.rs
+++ b/crates/rspack_core/src/exports/target.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   DependencyId, ExportInfo, ExportInfoData, ExportInfoHashKey, ExportsInfo, ExportsInfoArtifact,
-  ExportsInfoGetter, ModuleGraph, ModuleIdentifier, PrefetchExportsInfoMode,
+  ModuleGraph, ModuleIdentifier,
 };
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
@@ -77,13 +77,9 @@ pub fn get_terminal_binding(
   let Some(export) = target.export else {
     return Some(TerminalBinding::ExportsInfo(exports_info));
   };
-  ExportsInfoGetter::prefetch(
-    &exports_info,
-    exports_info_artifact,
-    PrefetchExportsInfoMode::Nested(&export),
-  )
-  .get_read_only_export_info_recursive(&export)
-  .map(|data| TerminalBinding::ExportInfo(data.id()))
+  exports_info
+    .get_read_only_export_info_recursive(exports_info_artifact, &export)
+    .map(|data| TerminalBinding::ExportInfo(data.id()))
 }
 
 pub fn find_target(
@@ -121,9 +117,9 @@ pub fn find_target(
       return FindTargetResult::ValidTarget(target);
     }
     let name = &target.export.as_ref().expect("should have export")[0];
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(&target.module, PrefetchExportsInfoMode::Default);
-    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let exports_info = exports_info_artifact.get_exports_info(&target.module);
+    let export_info =
+      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, name);
     let export_info_hash_key = export_info.as_hash_key();
     if !visited.insert(export_info_hash_key) {
       return FindTargetResult::NoTarget;
@@ -244,9 +240,9 @@ fn resolve_target(
       return Some(GetTargetResult::Target(target));
     };
 
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(&target.module, PrefetchExportsInfoMode::Default);
-    let maybe_export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let exports_info = exports_info_artifact.get_exports_info(&target.module);
+    let maybe_export_info =
+      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, name);
     let maybe_export_info_hash_key = maybe_export_info.as_hash_key();
     if already_visited.contains(&maybe_export_info_hash_key) {
       return Some(GetTargetResult::Circular);

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -16,9 +16,9 @@ use crate::{
   DependenciesBlock, DependencyId, ExternalType, FactoryMeta, ImportAttributes, InitFragmentExt,
   InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  NAMESPACE_OBJECT_EXPORT, NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals,
-  RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, UsedExports,
-  extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
+  NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
+  StaticExportsDependency, StaticExportsSpec, UsedExports, extract_url_and_global,
+  impl_module_meta_info, module_update_hash, property_access,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -507,14 +507,19 @@ impl ExternalModule {
           if let Some(concatenation_scope) = concatenation_scope {
             let exports_info = compilation
               .exports_info_artifact
-              .get_prefetched_exports_info(&self.identifier(), PrefetchExportsInfoMode::Default);
-            let used_exports = exports_info.get_used_exports(runtime);
+              .get_exports_info(&self.identifier());
+            let used_exports =
+              exports_info.get_used_exports(&compilation.exports_info_artifact, runtime);
             let namespace_used_by_named_exports = matches!(
               &used_exports,
               UsedExports::UsedNames(atoms)
                 if atoms
                   .iter()
-                  .any(|atom| exports_info.get_read_only_export_info(atom).ns_access())
+                  .any(|atom| {
+                    exports_info
+                      .get_read_only_export_info(&compilation.exports_info_artifact, atom)
+                      .ns_access()
+                  })
             );
             let meta = &self.dependency_meta.attributes;
             let attributes = meta.as_ref().map(|meta| {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -507,9 +507,8 @@ impl ExternalModule {
           if let Some(concatenation_scope) = concatenation_scope {
             let exports_info = compilation
               .exports_info_artifact
-              .get_exports_info(&self.identifier());
-            let used_exports =
-              exports_info.get_used_exports(&compilation.exports_info_artifact, runtime);
+              .get_exports_info_data(&self.identifier());
+            let used_exports = exports_info.get_used_exports(runtime);
             let namespace_used_by_named_exports = matches!(
               &used_exports,
               UsedExports::UsedNames(atoms)
@@ -517,7 +516,7 @@ impl ExternalModule {
                   .iter()
                   .any(|atom| {
                     exports_info
-                      .get_read_only_export_info(&compilation.exports_info_artifact, atom)
+                      .get_read_only_export_info(atom)
                       .ns_access()
                   })
             );

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -534,10 +534,11 @@ fn get_exports_type_impl(
 
         let name = Atom::from("__esModule");
         let exports_info = exports_info_artifact.get_exports_info_optional(&identifier);
-        if let Some(export_info) = exports_info
-          .as_ref()
-          .map(|info| info.get_read_only_export_info(exports_info_artifact, &name))
-        {
+        if let Some(export_info) = exports_info.as_ref().map(|info| {
+          info
+            .as_data(exports_info_artifact)
+            .get_read_only_export_info(&name)
+        }) {
           if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
             handle_default(default_object)
           } else {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -35,10 +35,10 @@ use crate::{
   ConnectionState, Context, ContextModule, DependenciesBlock, DependencyId, ExportProvided,
   ExportsInfoArtifact, ExternalModule, GetTargetResult, ModuleCodeTemplate, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleLayer, ModuleType, NormalModule, OptimizationBailoutItem,
-  PrefetchExportsInfoMode, RawModule, Resolve, ResolverFactory, RuntimeSpec, SelfModule,
-  SharedPluginDriver, SideEffectsStateArtifact, SourceType,
-  concatenated_module::ConcatenatedModule, dependencies_block::dependencies_block_update_hash,
-  get_target, value_cache_versions::ValueCacheVersions,
+  RawModule, Resolve, ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver,
+  SideEffectsStateArtifact, SourceType, concatenated_module::ConcatenatedModule,
+  dependencies_block::dependencies_block_update_hash, get_target,
+  value_cache_versions::ValueCacheVersions,
 };
 
 pub struct BuildContext {
@@ -533,11 +533,10 @@ fn get_exports_type_impl(
         }
 
         let name = Atom::from("__esModule");
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info_optional(&identifier, PrefetchExportsInfoMode::Default);
+        let exports_info = exports_info_artifact.get_exports_info_optional(&identifier);
         if let Some(export_info) = exports_info
           .as_ref()
-          .map(|info| info.get_read_only_export_info(&name))
+          .map(|info| info.get_read_only_export_info(exports_info_artifact, &name))
         {
           if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
             handle_default(default_object)

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -13,7 +13,7 @@ use swc_core::ecma::atoms::Atom;
 
 use crate::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, AsyncDependenciesBlockIdentifierMap,
-  AsyncModulesArtifact, Compilation, DependenciesBlock, Dependency, ExportInfo, ExportName,
+  AsyncModulesArtifact, Compilation, DependenciesBlock, Dependency, ExportInfo,
   ImportedByDeferModulesArtifact, ModuleGraphCacheArtifact, RuntimeSpec, SideEffectsStateArtifact,
   UsedNameItem,
 };
@@ -1177,26 +1177,9 @@ impl ModuleGraph {
     tasks: Vec<(ExportInfo, UsedNameItem)>,
   ) {
     for (export_info, used_name) in tasks {
-      let ExportInfo {
-        exports_info,
-        export_name,
-      } = export_info;
-
-      let data = exports_info_artifact.get_exports_info_mut_by_id(&exports_info);
-      match export_name {
-        ExportName::Named(name) => {
-          data
-            .named_exports_mut(&name)
-            .expect("should have named export")
-            .set_used_name(used_name);
-        }
-        ExportName::Other => {
-          data.other_exports_info_mut().set_used_name(used_name);
-        }
-        ExportName::SideEffects => {
-          data.side_effects_only_info_mut().set_used_name(used_name);
-        }
-      }
+      export_info
+        .as_data_mut(exports_info_artifact)
+        .set_used_name(used_name);
     }
   }
 }

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1012,7 +1012,7 @@ impl ModuleCodeTemplate {
           let name = &export_name[1..];
           let exports_info = compilation
             .exports_info_artifact
-            .get_exports_info(&target_module_identifier);
+            .get_exports_info_data(&target_module_identifier);
           let Some(used) =
             exports_info.get_used_name(&compilation.exports_info_artifact, runtime, name)
           else {
@@ -1119,7 +1119,7 @@ impl ModuleCodeTemplate {
     if !export_name.is_empty() {
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(&target_module_identifier);
+        .get_exports_info_data(&target_module_identifier);
       let used_name = match exports_info.get_used_name(
         &compilation.exports_info_artifact,
         runtime,

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -18,12 +18,12 @@ use swc_core::atoms::Atom;
 
 use crate::{
   AsyncDependenciesBlockIdentifier, ChunkGraph, Compilation, CompilerOptions, DependenciesBlock,
-  DependencyId, DependencyType, ExportsArgument, ExportsInfoArtifact, ExportsInfoGetter,
-  ExportsType, FakeNamespaceObjectMode, GenerateContext, GetUsedNameParam, ImportPhase,
-  InitFragment, InitFragmentExt, InitFragmentKey, InitFragmentStage, Module, ModuleArgument,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleId, ModuleIdentifier, NormalInitFragment, PathInfo,
-  PrefetchExportsInfoMode, RuntimeCondition, RuntimeGlobals, RuntimeSpec, UsedName,
-  compile_boolean_matcher_from_lists, contextify, property_access,
+  DependencyId, DependencyType, ExportsArgument, ExportsInfoArtifact, ExportsType,
+  FakeNamespaceObjectMode, GenerateContext, ImportPhase, InitFragment, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, Module, ModuleArgument, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleId, ModuleIdentifier, NormalInitFragment, PathInfo,
+  RuntimeCondition, RuntimeGlobals, RuntimeSpec, UsedName, compile_boolean_matcher_from_lists,
+  contextify, property_access,
   runtime_globals::{RuntimeVariable, runtime_globals_to_string, runtime_variable_to_string},
   to_comment, to_normal_comment,
 };
@@ -1010,18 +1010,12 @@ impl ModuleCodeTemplate {
       {
         if is_deferred && !matches!(exports_type, ExportsType::Namespace) {
           let name = &export_name[1..];
-          let Some(used) = ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithNames(
-              &compilation
-                .exports_info_artifact
-                .get_prefetched_exports_info(
-                  &target_module_identifier,
-                  PrefetchExportsInfoMode::Nested(name),
-                ),
-            ),
-            runtime,
-            name,
-          ) else {
+          let exports_info = compilation
+            .exports_info_artifact
+            .get_exports_info(&target_module_identifier);
+          let Some(used) =
+            exports_info.get_used_name(&compilation.exports_info_artifact, runtime, name)
+          else {
             return to_normal_comment(&format!(
               "unused export {}",
               property_access(export_name, 0)
@@ -1123,15 +1117,11 @@ impl ModuleCodeTemplate {
       .as_deref()
       .unwrap_or(export_name);
     if !export_name.is_empty() {
-      let used_name = match ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(
-          &compilation
-            .exports_info_artifact
-            .get_prefetched_exports_info(
-              &target_module_identifier,
-              PrefetchExportsInfoMode::Nested(export_name),
-            ),
-        ),
+      let exports_info = compilation
+        .exports_info_artifact
+        .get_exports_info(&target_module_identifier);
+      let used_name = match exports_info.get_used_name(
+        &compilation.exports_info_artifact,
         runtime,
         export_name,
       ) {

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1437,8 +1437,8 @@ impl Stats<'_> {
 
     if options.used_exports {
       stats.used_exports = if !executed && self.options().optimization.used_exports.is_enable() {
-        let exports_info = exports_info_artifact.get_exports_info(&module.identifier());
-        let used_exports = exports_info.get_used_exports(exports_info_artifact, None);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module.identifier());
+        let used_exports = exports_info.get_used_exports(None);
         match used_exports {
           UsedExports::Unknown => Some(StatsUsedExports::Null),
           UsedExports::UsedNames(v) => Some(StatsUsedExports::Vec(v)),
@@ -1451,8 +1451,8 @@ impl Stats<'_> {
 
     if options.provided_exports {
       stats.provided_exports = if !executed && self.options().optimization.provided_exports {
-        let exports_info = exports_info_artifact.get_exports_info(&module.identifier());
-        let provided_exports = exports_info.get_provided_exports(exports_info_artifact);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module.identifier());
+        let provided_exports = exports_info.get_provided_exports();
         match provided_exports {
           ProvidedExports::ProvidedNames(v) => Some(v),
           _ => None,

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -26,8 +26,7 @@ use crate::{
   ChunkGraph, ChunkGroupOrderKey, ChunkGroupUkey, ChunkHashesArtifact, ChunkUkey, Compilation,
   CompilationAssets, CompilationLogging, CompilerOptions, ExportsInfoArtifact, LogType,
   ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact,
-  OptimizationBailoutItem, PrefetchExportsInfoMode, ProvidedExports, RuntimeSpec, SourceType,
-  StealCell, UsedExports,
+  OptimizationBailoutItem, ProvidedExports, RuntimeSpec, SourceType, StealCell, UsedExports,
   compilation::build_module_graph::{ExecutedRuntimeModule, ModuleExecutor},
   rspack_sources::BoxSource,
 };
@@ -1438,9 +1437,8 @@ impl Stats<'_> {
 
     if options.used_exports {
       stats.used_exports = if !executed && self.options().optimization.used_exports.is_enable() {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
-        let used_exports = exports_info.get_used_exports(None);
+        let exports_info = exports_info_artifact.get_exports_info(&module.identifier());
+        let used_exports = exports_info.get_used_exports(exports_info_artifact, None);
         match used_exports {
           UsedExports::Unknown => Some(StatsUsedExports::Null),
           UsedExports::UsedNames(v) => Some(StatsUsedExports::Vec(v)),
@@ -1453,9 +1451,8 @@ impl Stats<'_> {
 
     if options.provided_exports {
       stats.provided_exports = if !executed && self.options().optimization.provided_exports {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
-        let provided_exports = exports_info.get_provided_exports();
+        let exports_info = exports_info_artifact.get_exports_info(&module.identifier());
+        let provided_exports = exports_info.get_provided_exports(exports_info_artifact);
         match provided_exports {
           ProvidedExports::ProvidedNames(v) => Some(v),
           _ => None,

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -649,10 +649,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
           let exports_info = generate_context
             .compilation
             .exports_info_artifact
-            .get_exports_info(&module.identifier());
+            .get_exports_info_data(&module.identifier());
           let (ns_obj, left, right) = if self.es_module
             && exports_info
-              .other_exports_info(&generate_context.compilation.exports_info_artifact)
+              .other_exports_info()
               .get_used(generate_context.runtime)
               != UsageState::Unused
           {
@@ -755,14 +755,16 @@ fn get_used_exports<'a>(
   runtime: Option<&RuntimeSpec>,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> FxIndexMap<&'a str, &'a FxIndexSet<CssExport>> {
-  let exports_info = exports_info_artifact.get_exports_info_optional(&identifier);
+  let exports_info = exports_info_artifact
+    .get_exports_info_optional(&identifier)
+    .map(|info| info.as_data(exports_info_artifact));
 
   exports
     .iter()
     .filter(|(name, _)| {
-      let export_info = exports_info.as_ref().map(|info| {
-        info.get_read_only_export_info(exports_info_artifact, &Atom::from(name.as_str()))
-      });
+      let export_info = exports_info
+        .as_ref()
+        .map(|info| info.get_read_only_export_info(&Atom::from(name.as_str())));
 
       if let Some(export_info) = export_info {
         export_info.get_used(runtime) != UsageState::Unused
@@ -803,7 +805,9 @@ fn get_unused_local_ident(
     },
   );
 
-  let exports_info = exports_info_artifact.get_exports_info_optional(&identifier);
+  let exports_info = exports_info_artifact
+    .get_exports_info_optional(&identifier)
+    .map(|info| info.as_data(exports_info_artifact));
 
   CodeGenerationDataUnusedLocalIdent {
     idents: exports_names
@@ -812,7 +816,7 @@ fn get_unused_local_ident(
         export_names.iter().all(|export_name| {
           let export_info = exports_info
             .as_ref()
-            .map(|info| info.get_read_only_export_info(exports_info_artifact, export_name));
+            .map(|info| info.get_read_only_export_info(export_name));
 
           if let Some(export_info) = export_info {
             matches!(export_info.get_used(runtime), UsageState::Unused)

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   CssParserImportContext, Dependency, DependencyRange, DependencyType, ExportsInfoArtifact,
   GenerateContext, LocalIdentName, Module, ModuleArgument, ModuleGraph, ModuleIdentifier,
   ModuleInitFragments, ModuleType, NormalModule, ParseContext, ParseResult, ParserAndGenerator,
-  PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext, UsageState,
+  RuntimeGlobals, RuntimeSpec, SourceType, TemplateContext, UsageState,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   remove_bom,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
@@ -649,10 +649,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
           let exports_info = generate_context
             .compilation
             .exports_info_artifact
-            .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
+            .get_exports_info(&module.identifier());
           let (ns_obj, left, right) = if self.es_module
             && exports_info
-              .other_exports_info()
+              .other_exports_info(&generate_context.compilation.exports_info_artifact)
               .get_used(generate_context.runtime)
               != UsageState::Unused
           {
@@ -755,15 +755,14 @@ fn get_used_exports<'a>(
   runtime: Option<&RuntimeSpec>,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> FxIndexMap<&'a str, &'a FxIndexSet<CssExport>> {
-  let exports_info = exports_info_artifact
-    .get_prefetched_exports_info_optional(&identifier, PrefetchExportsInfoMode::Default);
+  let exports_info = exports_info_artifact.get_exports_info_optional(&identifier);
 
   exports
     .iter()
     .filter(|(name, _)| {
-      let export_info = exports_info
-        .as_ref()
-        .map(|info| info.get_read_only_export_info(&Atom::from(name.as_str())));
+      let export_info = exports_info.as_ref().map(|info| {
+        info.get_read_only_export_info(exports_info_artifact, &Atom::from(name.as_str()))
+      });
 
       if let Some(export_info) = export_info {
         export_info.get_used(runtime) != UsageState::Unused
@@ -804,8 +803,7 @@ fn get_unused_local_ident(
     },
   );
 
-  let exports_info = exports_info_artifact
-    .get_prefetched_exports_info_optional(&identifier, PrefetchExportsInfoMode::Default);
+  let exports_info = exports_info_artifact.get_exports_info_optional(&identifier);
 
   CodeGenerationDataUnusedLocalIdent {
     idents: exports_names
@@ -814,7 +812,7 @@ fn get_unused_local_ident(
         export_names.iter().all(|export_name| {
           let export_info = exports_info
             .as_ref()
-            .map(|info| info.get_read_only_export_info(export_name));
+            .map(|info| info.get_read_only_export_info(exports_info_artifact, export_name));
 
           if let Some(export_info) = export_info {
             matches!(export_info.get_used(runtime), UsageState::Unused)

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -195,10 +195,9 @@ pub fn stringified_exports<'a>(
   let module_graph = compilation.get_module_graph();
   let exports_info = compilation
     .exports_info_artifact
-    .get_exports_info(&module.identifier());
+    .get_exports_info_data(&module.identifier());
   for (key, elements) in exports {
-    let export_info =
-      exports_info.get_read_only_export_info(&compilation.exports_info_artifact, &Atom::from(key));
+    let export_info = exports_info.get_read_only_export_info(&Atom::from(key));
     let used_name = export_info.get_used_name(None, runtime);
     let used_name = match used_name {
       Some(UsedNameItem::Str(name)) => name.to_string(),
@@ -237,12 +236,9 @@ pub fn stringified_exports<'a>(
 
             let from_exports_info = compilation
               .exports_info_artifact
-              .get_exports_info(&from.module_identifier);
+              .get_exports_info_data(&from.module_identifier);
             let from_used_name = match from_exports_info
-              .get_read_only_export_info(
-                &compilation.exports_info_artifact,
-                &Atom::from(ident.as_str()),
-              )
+              .get_read_only_export_info(&Atom::from(ident.as_str()))
               .get_used_name(None, runtime)
             {
               Some(UsedNameItem::Str(name)) => json_stringify_str(&unescape(name.as_str())),
@@ -299,10 +295,9 @@ pub fn css_modules_exports_to_concatenate_module_string<'a>(
   let mut used_identifiers = HashSet::default();
   let exports_info = compilation
     .exports_info_artifact
-    .get_exports_info(&module.identifier());
+    .get_exports_info_data(&module.identifier());
   for (key, elements) in exports {
-    let export_info =
-      exports_info.get_read_only_export_info(&compilation.exports_info_artifact, &Atom::from(key));
+    let export_info = exports_info.get_read_only_export_info(&Atom::from(key));
     let used_name = export_info.get_used_name(None, *runtime);
     let used_name = match used_name {
       Some(UsedNameItem::Str(name)) => name.to_string(),
@@ -341,12 +336,9 @@ pub fn css_modules_exports_to_concatenate_module_string<'a>(
 
             let from_exports_info = compilation
               .exports_info_artifact
-              .get_exports_info(&from.module_identifier);
+              .get_exports_info_data(&from.module_identifier);
             let from_used_name = match from_exports_info
-              .get_read_only_export_info(
-                &compilation.exports_info_artifact,
-                &Atom::from(ident.as_str()),
-              )
+              .get_read_only_export_info(&Atom::from(ident.as_str()))
               .get_used_name(None, *runtime)
             {
               Some(UsedNameItem::Str(name)) => json_stringify_str(&name),

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -195,12 +195,10 @@ pub fn stringified_exports<'a>(
   let module_graph = compilation.get_module_graph();
   let exports_info = compilation
     .exports_info_artifact
-    .get_prefetched_exports_info(
-      &module.identifier(),
-      rspack_core::PrefetchExportsInfoMode::Default,
-    );
+    .get_exports_info(&module.identifier());
   for (key, elements) in exports {
-    let export_info = exports_info.get_read_only_export_info(&Atom::from(key));
+    let export_info =
+      exports_info.get_read_only_export_info(&compilation.exports_info_artifact, &Atom::from(key));
     let used_name = export_info.get_used_name(None, runtime);
     let used_name = match used_name {
       Some(UsedNameItem::Str(name)) => name.to_string(),
@@ -239,12 +237,12 @@ pub fn stringified_exports<'a>(
 
             let from_exports_info = compilation
               .exports_info_artifact
-              .get_prefetched_exports_info(
-                &from.module_identifier,
-                rspack_core::PrefetchExportsInfoMode::Default,
-              );
+              .get_exports_info(&from.module_identifier);
             let from_used_name = match from_exports_info
-              .get_read_only_export_info(&Atom::from(ident.as_str()))
+              .get_read_only_export_info(
+                &compilation.exports_info_artifact,
+                &Atom::from(ident.as_str()),
+              )
               .get_used_name(None, runtime)
             {
               Some(UsedNameItem::Str(name)) => json_stringify_str(&unescape(name.as_str())),
@@ -301,12 +299,10 @@ pub fn css_modules_exports_to_concatenate_module_string<'a>(
   let mut used_identifiers = HashSet::default();
   let exports_info = compilation
     .exports_info_artifact
-    .get_prefetched_exports_info(
-      &module.identifier(),
-      rspack_core::PrefetchExportsInfoMode::Default,
-    );
+    .get_exports_info(&module.identifier());
   for (key, elements) in exports {
-    let export_info = exports_info.get_read_only_export_info(&Atom::from(key));
+    let export_info =
+      exports_info.get_read_only_export_info(&compilation.exports_info_artifact, &Atom::from(key));
     let used_name = export_info.get_used_name(None, *runtime);
     let used_name = match used_name {
       Some(UsedNameItem::Str(name)) => name.to_string(),
@@ -345,12 +341,12 @@ pub fn css_modules_exports_to_concatenate_module_string<'a>(
 
             let from_exports_info = compilation
               .exports_info_artifact
-              .get_prefetched_exports_info(
-                &from.module_identifier,
-                rspack_core::PrefetchExportsInfoMode::Default,
-              );
+              .get_exports_info(&from.module_identifier);
             let from_used_name = match from_exports_info
-              .get_read_only_export_info(&Atom::from(ident.as_str()))
+              .get_read_only_export_info(
+                &compilation.exports_info_artifact,
+                &Atom::from(ident.as_str()),
+              )
               .get_used_name(None, *runtime)
             {
               Some(UsedNameItem::Str(name)) => json_stringify_str(&name),

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -128,14 +128,13 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       if let Some(ident) = ident {
         let exports_info = compilation
           .exports_info_artifact
-          .get_exports_info(&module.identifier());
+          .get_exports_info_data(&module.identifier());
 
-        let provided_exports =
-          match exports_info.get_provided_exports(&compilation.exports_info_artifact) {
-            ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),
-            ProvidedExports::ProvidedAll => Some(DllManifestContentItemExports::True),
-            _ => None,
-          };
+        let provided_exports = match exports_info.get_provided_exports() {
+          ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),
+          ProvidedExports::ProvidedAll => Some(DllManifestContentItemExports::True),
+          _ => None,
+        };
 
         let id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier());
 

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   ChunkGraph, Compilation, CompilerEmit, Context, EntryDependency, Filename, LibIdentOptions,
-  PathData, Plugin, PrefetchExportsInfoMode, ProvidedExports, SourceType,
+  PathData, Plugin, ProvidedExports, SourceType,
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
@@ -128,13 +128,14 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       if let Some(ident) = ident {
         let exports_info = compilation
           .exports_info_artifact
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
+          .get_exports_info(&module.identifier());
 
-        let provided_exports = match exports_info.get_provided_exports() {
-          ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),
-          ProvidedExports::ProvidedAll => Some(DllManifestContentItemExports::True),
-          _ => None,
-        };
+        let provided_exports =
+          match exports_info.get_provided_exports(&compilation.exports_info_artifact) {
+            ProvidedExports::ProvidedNames(vec) => Some(DllManifestContentItemExports::Vec(vec)),
+            ProvidedExports::ProvidedAll => Some(DllManifestContentItemExports::True),
+            _ => None,
+          };
 
         let id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier());
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -9,7 +9,7 @@ use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
   ChunkUkey, CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent,
-  ConditionalInitFragment, DependencyType, ExportInfoHashKey, ExportMode, ExportProvided,
+  ConditionalInitFragment, DependencyType, ExportInfo, ExportMode, ExportProvided,
   ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, PathData,
   RuntimeGlobals, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName,
@@ -2919,7 +2919,7 @@ var {} = {{}};
     call_context: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    already_visited: &mut FxHashSet<ExportInfoHashKey>,
+    already_visited: &mut FxHashSet<ExportInfo>,
     required: &mut IdentifierIndexMap<ExternalInterop>,
     all_used_names: &mut FxHashSet<Atom>,
   ) -> Option<Ref> {
@@ -3074,7 +3074,7 @@ var {} = {{}};
       }
     }
 
-    let exports_info = exports_info_artifact.get_exports_info(info_id);
+    let exports_info = exports_info_artifact.get_exports_info_data(info_id);
 
     if export_name.is_empty() {
       let info = module_to_info_map.get_mut_unwrap(info_id);
@@ -3111,17 +3111,16 @@ var {} = {{}};
       }
     }
 
-    let export_info =
-      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, &export_name[0]);
-    let export_info_hash_key = export_info.as_hash_key();
+    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
+    let export_info_id = export_info.id();
 
-    if already_visited.contains(&export_info_hash_key) {
+    if already_visited.contains(&export_info_id) {
       return Some(Ref::Inline(
         "/* circular reexport */ Object(function x() { x() }())".into(),
       ));
     }
 
-    already_visited.insert(export_info_hash_key);
+    already_visited.insert(export_info_id);
 
     let info = &module_to_info_map[info_id];
     match info {
@@ -3204,7 +3203,7 @@ var {} = {{}};
           FindTargetResult::NoTarget => {}
           FindTargetResult::InvalidTarget(target) => {
             if let Some(export) = target.export {
-              let exports_info = exports_info_artifact.get_exports_info(&target.module);
+              let exports_info = exports_info_artifact.get_exports_info_data(&target.module);
               if let Some(UsedName::Inlined(inlined)) =
                 exports_info.get_used_name(exports_info_artifact, None, &export)
               {

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -10,14 +10,13 @@ use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
   ChunkUkey, CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent,
   ConditionalInitFragment, DependencyType, ExportInfoHashKey, ExportMode, ExportProvided,
-  ExportsInfoArtifact, ExportsInfoGetter, ExportsType, FindTargetResult, GetUsedNameParam,
-  ImportSpec, InitFragmentKey, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo,
-  NAMESPACE_OBJECT_EXPORT, PathData, PrefetchExportsInfoMode, RuntimeGlobals,
-  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
-  collect_ident, escape_name_atom_ref, find_new_name, find_target, get_cached_readable_identifier,
-  get_js_chunk_filename_template, get_module_directives, get_module_hashbang, property_access,
-  property_name, reserved_names::RESERVED_NAMES, rspack_sources::ReplaceSource,
-  split_readable_identifier, to_normal_comment,
+  ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, PathData,
+  RuntimeGlobals, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName,
+  UsedNameItem, collect_ident, escape_name_atom_ref, find_new_name, find_target,
+  get_cached_readable_identifier, get_js_chunk_filename_template, get_module_directives,
+  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES,
+  rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_plugin_javascript::{
@@ -3075,8 +3074,7 @@ var {} = {{}};
       }
     }
 
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(info_id, PrefetchExportsInfoMode::Nested(&export_name));
+    let exports_info = exports_info_artifact.get_exports_info(info_id);
 
     if export_name.is_empty() {
       let info = module_to_info_map.get_mut_unwrap(info_id);
@@ -3113,7 +3111,8 @@ var {} = {{}};
       }
     }
 
-    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
+    let export_info =
+      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, &export_name[0]);
     let export_info_hash_key = export_info.as_hash_key();
 
     if already_visited.contains(&export_info_hash_key) {
@@ -3145,11 +3144,7 @@ var {} = {{}};
           )));
         }
 
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
-          None,
-          &export_name,
-        );
+        let used_name = exports_info.get_used_name(exports_info_artifact, None, &export_name);
         if let Some(ref export_id) = export_id
           && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
         {
@@ -3209,15 +3204,10 @@ var {} = {{}};
           FindTargetResult::NoTarget => {}
           FindTargetResult::InvalidTarget(target) => {
             if let Some(export) = target.export {
-              let exports_info = exports_info_artifact.get_prefetched_exports_info(
-                &target.module,
-                PrefetchExportsInfoMode::Nested(&export),
-              );
-              if let Some(UsedName::Inlined(inlined)) = ExportsInfoGetter::get_used_name(
-                GetUsedNameParam::WithNames(&exports_info),
-                None,
-                &export,
-              ) {
+              let exports_info = exports_info_artifact.get_exports_info(&target.module);
+              if let Some(UsedName::Inlined(inlined)) =
+                exports_info.get_used_name(exports_info_artifact, None, &export)
+              {
                 return Some(Ref::Inline(inlined.inlined_value().render(
                   &to_normal_comment(&format!(
                     "inlined export {}",
@@ -3265,12 +3255,9 @@ var {} = {{}};
 
         if info.namespace_export_symbol.is_some() {
           // That's how webpack write https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L463-L471
-          let used_name = ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithNames(&exports_info),
-            None,
-            &export_name,
-          )
-          .expect("should have export name");
+          let used_name = exports_info
+            .get_used_name(exports_info_artifact, None, &export_name)
+            .expect("should have export name");
           return Some(match used_name {
             UsedName::Normal(used_name) => Ref::Symbol(SymbolRef::new(
               info.module,
@@ -3296,11 +3283,9 @@ var {} = {{}};
         None
       }
       ModuleInfo::External(info) => {
-        if let Some(used_name) = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
-          None,
-          &export_name,
-        ) {
+        if let Some(used_name) =
+          exports_info.get_used_name(exports_info_artifact, None, &export_name)
+        {
           Some(match used_name {
             UsedName::Normal(used_name) => Ref::Symbol(SymbolRef::new(
               info.module,

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -570,9 +570,7 @@ pub(crate) fn analyze_dyn_import_targets(
         continue;
       }
 
-      let exports_info = exports_info_artifact
-        .get_exports_info(target)
-        .as_data(exports_info_artifact);
+      let exports_info = exports_info_artifact.get_exports_info_data(target);
 
       if exports_info.other_exports_info().is_used(None) {
         namespace_targets.insert(*target);
@@ -668,9 +666,7 @@ pub(crate) fn analyze_dyn_import_targets(
       if strict_chunks.contains(&chunk_ukey) {
         continue;
       }
-      let exports_info = exports_info_artifact
-        .get_exports_info(module_id)
-        .as_data(exports_info_artifact);
+      let exports_info = exports_info_artifact.get_exports_info_data(module_id);
       let export_names: FxHashSet<Atom> = exports_info
         .exports()
         .iter()

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -139,9 +139,9 @@ impl EsmLibraryPlugin {
 
       // if we reach here, check exports info
       if should_scope_hoisting {
-        let exports_info = exports_info_artifact.get_exports_info(module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);
 
-        let relevant_exports = exports_info.get_relevant_exports(exports_info_artifact, None);
+        let relevant_exports = exports_info.get_relevant_exports(None);
         let unknown_exports = relevant_exports
           .iter()
           .filter(|export_info| {
@@ -339,9 +339,9 @@ async fn finish_modules(
 
     // if we reach here, check exports info
     if should_scope_hoisting {
-      let exports_info = exports_info_artifact.get_exports_info(module_identifier);
+      let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);
 
-      let relevant_exports = exports_info.get_relevant_exports(exports_info_artifact, None);
+      let relevant_exports = exports_info.get_relevant_exports(None);
       let unknown_exports = relevant_exports
         .iter()
         .filter(|export_info| {

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -18,9 +18,9 @@ use rspack_core::{
   ConcatenatedModuleInfo, ConcatenationScope, DependencyType, ExportsInfoArtifact,
   ExternalModuleInfo, GetTargetResult, Logger, ModuleFactoryCreateData, ModuleGraph,
   ModuleIdentifier, ModuleInfo, ModuleType, NormalModuleFactoryAfterFactorize,
-  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, PrefetchExportsInfoMode,
-  REQUIRE_SCOPE_GLOBALS, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  SideEffectsOptimizeArtifact, SideEffectsStateArtifact, get_target, is_esm_dep_like,
+  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, REQUIRE_SCOPE_GLOBALS,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SideEffectsOptimizeArtifact,
+  SideEffectsStateArtifact, get_target, is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
@@ -139,10 +139,9 @@ impl EsmLibraryPlugin {
 
       // if we reach here, check exports info
       if should_scope_hoisting {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::Default);
+        let exports_info = exports_info_artifact.get_exports_info(module_identifier);
 
-        let relevant_exports = exports_info.get_relevant_exports(None);
+        let relevant_exports = exports_info.get_relevant_exports(exports_info_artifact, None);
         let unknown_exports = relevant_exports
           .iter()
           .filter(|export_info| {
@@ -340,10 +339,9 @@ async fn finish_modules(
 
     // if we reach here, check exports info
     if should_scope_hoisting {
-      let exports_info = exports_info_artifact
-        .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::Default);
+      let exports_info = exports_info_artifact.get_exports_info(module_identifier);
 
-      let relevant_exports = exports_info.get_relevant_exports(None);
+      let relevant_exports = exports_info.get_relevant_exports(exports_info_artifact, None);
       let unknown_exports = relevant_exports
         .iter()
         .filter(|export_info| {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -6,12 +6,12 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportNameOrSpec,
-  ExportProvided, ExportSpec, ExportsInfoArtifact, ExportsInfoGetter, ExportsOfExportsSpec,
-  ExportsSpec, ExportsType, ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam,
-  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, Nullable,
-  PrefetchExportsInfoMode, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource,
-  UsageState, UsedName, collect_referenced_export_items, create_exports_object_referenced,
-  create_no_exports_referenced, property_access, to_normal_comment,
+  ExportProvided, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, ExportsType,
+  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, Nullable, ReferencedExport, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource, UsageState, UsedName, collect_referenced_export_items,
+  create_exports_object_referenced, create_no_exports_referenced, property_access,
+  to_normal_comment,
 };
 use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
@@ -73,29 +73,23 @@ impl CommonJsExportRequireDependency {
     imported_module: &ModuleIdentifier,
   ) -> Option<FxHashSet<Atom>> {
     let ids = self.get_ids(mg);
-    let mut imported_exports_info = Some(
-      exports_info_artifact
-        .get_prefetched_exports_info(imported_module, PrefetchExportsInfoMode::Nested(ids)),
-    );
+    let mut imported_exports_info = Some(exports_info_artifact.get_exports_info(imported_module));
 
     if !ids.is_empty() {
       let Some(nested_exports_info) = &imported_exports_info else {
         unreachable!();
       };
       let nested = nested_exports_info
-        .get_nested_exports_info(Some(ids))
+        .get_nested_exports_info(exports_info_artifact, Some(ids))
         .map(|data| data.id());
 
-      imported_exports_info = nested.map(|id| {
-        ExportsInfoGetter::prefetch(&id, exports_info_artifact, PrefetchExportsInfoMode::Default)
-      });
+      imported_exports_info = nested.map(|id| id);
     }
 
     let mut exports_info = Some(
-      exports_info_artifact.get_prefetched_exports_info(
+      exports_info_artifact.get_exports_info(
         mg.get_parent_module(&self.id)
           .expect("Should get parent module"),
-        PrefetchExportsInfoMode::Nested(&self.names),
       ),
     );
 
@@ -104,21 +98,21 @@ impl CommonJsExportRequireDependency {
         unreachable!();
       };
       let nested = nested_exports_info
-        .get_nested_exports_info(Some(&self.names))
+        .get_nested_exports_info(exports_info_artifact, Some(&self.names))
         .map(|data| data.id());
-      exports_info = nested.map(|id| {
-        ExportsInfoGetter::prefetch(&id, exports_info_artifact, PrefetchExportsInfoMode::Default)
-      });
+      exports_info = nested.map(|id| id);
     };
 
     let no_extra_exports = imported_exports_info.as_ref().is_some_and(|data| {
-      let provided = data.other_exports_info().provided();
+      let provided = data.other_exports_info(exports_info_artifact).provided();
       matches!(provided, Some(ExportProvided::NotProvided))
     });
 
     let no_extra_imports = exports_info.as_ref().is_some_and(|data| {
       matches!(
-        data.other_exports_info().get_used(runtime),
+        data
+          .other_exports_info(exports_info_artifact)
+          .get_used(runtime),
         UsageState::Unused
       )
     });
@@ -140,7 +134,7 @@ impl CommonJsExportRequireDependency {
       let Some(exports_info) = &exports_info else {
         unreachable!();
       };
-      for (_, export_info) in exports_info.exports() {
+      for (_, export_info) in exports_info.exports(exports_info_artifact) {
         let name = export_info.name();
         if matches!(export_info.get_used(runtime), UsageState::Unused) {
           continue;
@@ -149,7 +143,8 @@ impl CommonJsExportRequireDependency {
           if name == "__esModule" && is_namespace_import {
             exports.insert(name.to_owned());
           } else if let Some(imported_exports_info) = &imported_exports_info {
-            let imported_export_info = imported_exports_info.get_read_only_export_info(name);
+            let imported_export_info =
+              imported_exports_info.get_read_only_export_info(exports_info_artifact, name);
             if matches!(
               imported_export_info.provided(),
               Some(ExportProvided::NotProvided)
@@ -166,7 +161,7 @@ impl CommonJsExportRequireDependency {
       let Some(imported_exports_info) = &imported_exports_info else {
         unreachable!();
       };
-      for (_, imported_export_info) in imported_exports_info.exports() {
+      for (_, imported_export_info) in imported_exports_info.exports(exports_info_artifact) {
         let name = imported_export_info.name();
         if let Some(name) = name {
           if matches!(
@@ -176,7 +171,7 @@ impl CommonJsExportRequireDependency {
             continue;
           }
           if let Some(exports_info) = &exports_info {
-            let export_info = exports_info.get_read_only_export_info(name);
+            let export_info = exports_info.get_read_only_export_info(exports_info_artifact, name);
             let used = export_info.get_used(runtime);
             if matches!(used, UsageState::Unused) {
               continue;
@@ -329,14 +324,13 @@ impl Dependency for CommonJsExportRequireDependency {
     if self.result_used {
       return get_full_result();
     }
-    let mut exports_info = exports_info_artifact.get_prefetched_exports_info(
+    let mut exports_info = exports_info_artifact.get_exports_info(
       mg.get_parent_module(&self.id)
         .expect("Can not get parent module"),
-      PrefetchExportsInfoMode::Nested(&self.names),
     );
 
     for name in &self.names {
-      let export_info = exports_info.get_read_only_export_info(name);
+      let export_info = exports_info.get_read_only_export_info(exports_info_artifact, name);
       let used = export_info.get_used(runtime);
       if matches!(used, UsageState::Unused) {
         return create_no_exports_referenced();
@@ -346,20 +340,22 @@ impl Dependency for CommonJsExportRequireDependency {
       }
 
       match export_info.exports_info() {
-        Some(v) => exports_info = exports_info.redirect(v, false),
+        Some(v) => exports_info = v,
         None => return get_full_result(),
       };
     }
 
     if !matches!(
-      exports_info.other_exports_info().get_used(runtime),
+      exports_info
+        .other_exports_info(exports_info_artifact)
+        .get_used(runtime),
       UsageState::Unused
     ) {
       return get_full_result();
     }
 
     let mut referenced_exports = vec![];
-    for (_, export_info) in exports_info.exports() {
+    for (_, export_info) in exports_info.exports(exports_info_artifact) {
       let prefix = ids
         .iter()
         .chain(if let Some(name) = export_info.name() {
@@ -468,28 +464,10 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
     let exports_argument = module.get_exports_argument();
     let module_argument = module.get_module_argument();
 
-    let used = if dep.names.is_empty() {
-      let exports_info_used = compilation
-        .exports_info_artifact
-        .get_prefetched_exports_info_used(&module.identifier(), *runtime);
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithoutNames(&exports_info_used),
-        *runtime,
-        &dep.names,
-      )
-    } else {
-      let exports_info = compilation
-        .exports_info_artifact
-        .get_prefetched_exports_info(
-          &module.identifier(),
-          PrefetchExportsInfoMode::Nested(&dep.names),
-        );
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(&exports_info),
-        *runtime,
-        &dep.names,
-      )
-    };
+    let exports_info = compilation
+      .exports_info_artifact
+      .get_exports_info(&module.identifier());
+    let used = exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names);
 
     let base = if dep.base.is_exports() {
       runtime_template.render_exports_argument(exports_argument)
@@ -506,22 +484,11 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
 
     let require_expr = if let Some(imported_module) = mg.get_module_by_dependency_id(&dep.id)
       && let ids = dep.get_ids(mg)
-      && let Some(used_imported) = ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(
-          &compilation
-            .exports_info_artifact
-            .get_prefetched_exports_info(
-              &imported_module.identifier(),
-              if ids.is_empty() {
-                PrefetchExportsInfoMode::Default
-              } else {
-                PrefetchExportsInfoMode::Nested(ids)
-              },
-            ),
-        ),
-        *runtime,
-        ids,
-      ) {
+      && let Some(used_imported) = compilation
+        .exports_info_artifact
+        .get_exports_info(&imported_module.identifier())
+        .get_used_name(&compilation.exports_info_artifact, *runtime, ids)
+    {
       match used_imported {
         UsedName::Normal(used_imported) => {
           format!(

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -73,7 +73,8 @@ impl CommonJsExportRequireDependency {
     imported_module: &ModuleIdentifier,
   ) -> Option<FxHashSet<Atom>> {
     let ids = self.get_ids(mg);
-    let mut imported_exports_info = Some(exports_info_artifact.get_exports_info(imported_module));
+    let mut imported_exports_info =
+      Some(exports_info_artifact.get_exports_info_data(imported_module));
 
     if !ids.is_empty() {
       let Some(nested_exports_info) = &imported_exports_info else {
@@ -83,11 +84,11 @@ impl CommonJsExportRequireDependency {
         .get_nested_exports_info(exports_info_artifact, Some(ids))
         .map(|data| data.id());
 
-      imported_exports_info = nested.map(|id| id);
+      imported_exports_info = nested.map(|id| exports_info_artifact.get_exports_info_by_id(&id));
     }
 
     let mut exports_info = Some(
-      exports_info_artifact.get_exports_info(
+      exports_info_artifact.get_exports_info_data(
         mg.get_parent_module(&self.id)
           .expect("Should get parent module"),
       ),
@@ -100,19 +101,17 @@ impl CommonJsExportRequireDependency {
       let nested = nested_exports_info
         .get_nested_exports_info(exports_info_artifact, Some(&self.names))
         .map(|data| data.id());
-      exports_info = nested.map(|id| id);
+      exports_info = nested.map(|id| exports_info_artifact.get_exports_info_by_id(&id));
     };
 
     let no_extra_exports = imported_exports_info.as_ref().is_some_and(|data| {
-      let provided = data.other_exports_info(exports_info_artifact).provided();
+      let provided = data.other_exports_info().provided();
       matches!(provided, Some(ExportProvided::NotProvided))
     });
 
     let no_extra_imports = exports_info.as_ref().is_some_and(|data| {
       matches!(
-        data
-          .other_exports_info(exports_info_artifact)
-          .get_used(runtime),
+        data.other_exports_info().get_used(runtime),
         UsageState::Unused
       )
     });
@@ -134,7 +133,7 @@ impl CommonJsExportRequireDependency {
       let Some(exports_info) = &exports_info else {
         unreachable!();
       };
-      for (_, export_info) in exports_info.exports(exports_info_artifact) {
+      for export_info in exports_info.exports().values() {
         let name = export_info.name();
         if matches!(export_info.get_used(runtime), UsageState::Unused) {
           continue;
@@ -143,8 +142,7 @@ impl CommonJsExportRequireDependency {
           if name == "__esModule" && is_namespace_import {
             exports.insert(name.to_owned());
           } else if let Some(imported_exports_info) = &imported_exports_info {
-            let imported_export_info =
-              imported_exports_info.get_read_only_export_info(exports_info_artifact, name);
+            let imported_export_info = imported_exports_info.get_read_only_export_info(name);
             if matches!(
               imported_export_info.provided(),
               Some(ExportProvided::NotProvided)
@@ -161,7 +159,7 @@ impl CommonJsExportRequireDependency {
       let Some(imported_exports_info) = &imported_exports_info else {
         unreachable!();
       };
-      for (_, imported_export_info) in imported_exports_info.exports(exports_info_artifact) {
+      for imported_export_info in imported_exports_info.exports().values() {
         let name = imported_export_info.name();
         if let Some(name) = name {
           if matches!(
@@ -171,7 +169,7 @@ impl CommonJsExportRequireDependency {
             continue;
           }
           if let Some(exports_info) = &exports_info {
-            let export_info = exports_info.get_read_only_export_info(exports_info_artifact, name);
+            let export_info = exports_info.get_read_only_export_info(name);
             let used = export_info.get_used(runtime);
             if matches!(used, UsageState::Unused) {
               continue;
@@ -324,13 +322,13 @@ impl Dependency for CommonJsExportRequireDependency {
     if self.result_used {
       return get_full_result();
     }
-    let mut exports_info = exports_info_artifact.get_exports_info(
+    let mut exports_info = exports_info_artifact.get_exports_info_data(
       mg.get_parent_module(&self.id)
         .expect("Can not get parent module"),
     );
 
     for name in &self.names {
-      let export_info = exports_info.get_read_only_export_info(exports_info_artifact, name);
+      let export_info = exports_info.get_read_only_export_info(name);
       let used = export_info.get_used(runtime);
       if matches!(used, UsageState::Unused) {
         return create_no_exports_referenced();
@@ -340,22 +338,20 @@ impl Dependency for CommonJsExportRequireDependency {
       }
 
       match export_info.exports_info() {
-        Some(v) => exports_info = v,
+        Some(v) => exports_info = v.as_data(exports_info_artifact),
         None => return get_full_result(),
       };
     }
 
     if !matches!(
-      exports_info
-        .other_exports_info(exports_info_artifact)
-        .get_used(runtime),
+      exports_info.other_exports_info().get_used(runtime),
       UsageState::Unused
     ) {
       return get_full_result();
     }
 
     let mut referenced_exports = vec![];
-    for (_, export_info) in exports_info.exports(exports_info_artifact) {
+    for export_info in exports_info.exports().values() {
       let prefix = ids
         .iter()
         .chain(if let Some(name) = export_info.name() {
@@ -466,7 +462,7 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&module.identifier());
+      .get_exports_info_data(&module.identifier());
     let used = exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names);
 
     let base = if dep.base.is_exports() {
@@ -486,7 +482,7 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
       && let ids = dep.get_ids(mg)
       && let Some(used_imported) = compilation
         .exports_info_artifact
-        .get_exports_info(&imported_module.identifier())
+        .get_exports_info_data(&imported_module.identifier())
         .get_used_name(&compilation.exports_info_artifact, *runtime, ids)
     {
       match used_imported {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -176,7 +176,7 @@ impl DependencyTemplate for CommonJsExportsDependencyTemplate {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&module.identifier());
+      .get_exports_info_data(&module.identifier());
     let used = exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names);
 
     let exports_argument = module.get_exports_argument();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -6,9 +6,9 @@ use rspack_core::{
   AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact,
-  ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, GetUsedNameParam, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment,
-  PrefetchExportsInfoMode, TemplateContext, TemplateReplaceSource, UsedName, property_access,
+  ExportsOfExportsSpec, ExportsSpec, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment, TemplateContext,
+  TemplateReplaceSource, UsedName, property_access,
 };
 use swc_core::atoms::Atom;
 
@@ -174,28 +174,10 @@ impl DependencyTemplate for CommonJsExportsDependencyTemplate {
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
-    let used = if dep.names.is_empty() {
-      let exports_info_used = compilation
-        .exports_info_artifact
-        .get_prefetched_exports_info_used(&module.identifier(), *runtime);
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithoutNames(&exports_info_used),
-        *runtime,
-        &dep.names,
-      )
-    } else {
-      let exports_info = compilation
-        .exports_info_artifact
-        .get_prefetched_exports_info(
-          &module.identifier(),
-          PrefetchExportsInfoMode::Nested(&dep.names),
-        );
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(&exports_info),
-        *runtime,
-        &dep.names,
-      )
-    };
+    let exports_info = compilation
+      .exports_info_artifact
+      .get_exports_info(&module.identifier());
+    let used = exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names);
 
     let exports_argument = module.get_exports_argument();
     let module_argument = module.get_module_argument();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -190,7 +190,7 @@ impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
       && let Some(used) = {
         let exports_info = compilation
           .exports_info_artifact
-          .get_exports_info(&imported_module.module_identifier);
+          .get_exports_info_data(&imported_module.module_identifier);
         exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names)
       } {
       let mut require_expr = match used {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -5,10 +5,10 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportsInfoArtifact, ExportsInfoGetter, ExportsType, ExtendedReferencedExport, FactorizeInfo,
-  GetUsedNameParam, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  PrefetchExportsInfoMode, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
-  UsedName, create_exports_object_referenced, property_access, to_normal_comment,
+  ExportsInfoArtifact, ExportsType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
+  ModuleGraph, ModuleGraphCacheArtifact, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource, UsedName, create_exports_object_referenced, property_access,
+  to_normal_comment,
 };
 use swc_core::atoms::Atom;
 
@@ -187,32 +187,12 @@ impl DependencyTemplate for CommonJsFullRequireDependencyTemplate {
 
     let require_expr = if let Some(imported_module) =
       module_graph.module_graph_module_by_dependency_id(&dep.id)
-      && let used = {
-        if dep.names.is_empty() {
-          let exports_info_used = compilation
-            .exports_info_artifact
-            .get_prefetched_exports_info_used(&imported_module.module_identifier, *runtime);
-          ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithoutNames(&exports_info_used),
-            *runtime,
-            &dep.names,
-          )
-        } else {
-          let exports_info = compilation
-            .exports_info_artifact
-            .get_prefetched_exports_info(
-              &imported_module.module_identifier,
-              PrefetchExportsInfoMode::Nested(&dep.names),
-            );
-          ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithNames(&exports_info),
-            *runtime,
-            &dep.names,
-          )
-        }
-      }
-      && let Some(used) = used
-    {
+      && let Some(used) = {
+        let exports_info = compilation
+          .exports_info_artifact
+          .get_exports_info(&imported_module.module_identifier);
+        exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names)
+      } {
       let mut require_expr = match used {
         UsedName::Normal(used) => {
           format!(

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -5,9 +5,8 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExportsInfoGetter, ExtendedReferencedExport, FactorizeInfo, GetUsedNameParam, ModuleDependency,
-  ModuleGraph, ModuleGraphCacheArtifact, PrefetchExportsInfoMode, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource, UsedName, property_access_with_optional,
+  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, property_access_with_optional,
 };
 use swc_core::atoms::Atom;
 
@@ -154,16 +153,10 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
     let used = if !dep.names.is_empty() {
       let exports_info = compilation
         .exports_info_artifact
-        .get_prefetched_exports_info(
-          &module.identifier(),
-          PrefetchExportsInfoMode::Nested(&dep.names),
-        );
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(&exports_info),
-        *runtime,
-        &dep.names,
-      )
-      .unwrap_or_else(|| UsedName::Normal(dep.names.clone()))
+        .get_exports_info(&module.identifier());
+      exports_info
+        .get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names)
+        .unwrap_or_else(|| UsedName::Normal(dep.names.clone()))
     } else {
       UsedName::Normal(dep.names.clone())
     };

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -153,7 +153,7 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
     let used = if !dep.names.is_empty() {
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(&module.identifier());
+        .get_exports_info_data(&module.identifier());
       exports_info
         .get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names)
         .unwrap_or_else(|| UsedName::Normal(dep.names.clone()))

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, InitFragmentKey,
-  InitFragmentStage, ModuleGraph, NormalInitFragment, PrefetchExportsInfoMode, RuntimeGlobals,
-  TemplateContext, TemplateReplaceSource, UsageState,
+  InitFragmentStage, ModuleGraph, NormalInitFragment, RuntimeGlobals, TemplateContext,
+  TemplateReplaceSource, UsageState,
 };
 use swc_core::atoms::Atom;
 
@@ -55,9 +55,9 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
     let name = Atom::from("__esModule");
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
+      .get_exports_info(&module.identifier());
     let used = exports_info
-      .get_read_only_export_info(&name)
+      .get_read_only_export_info(&compilation.exports_info_artifact, &name)
       .get_used(*runtime);
     if !matches!(used, UsageState::Unused) {
       init_fragments.push(Box::new(NormalInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -55,9 +55,9 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
     let name = Atom::from("__esModule");
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&module.identifier());
+      .get_exports_info_data(&module.identifier());
     let used = exports_info
-      .get_read_only_export_info(&compilation.exports_info_artifact, &name)
+      .get_read_only_export_info(&name)
       .get_used(*runtime);
     if !matches!(used, UsageState::Unused) {
       init_fragments.push(Box::new(NormalInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -185,7 +185,7 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
         scope.register_export(JS_DEFAULT_KEYWORD.clone(), name.to_string());
       } else if let Some(used) = compilation
         .exports_info_artifact
-        .get_exports_info(&module_identifier)
+        .get_exports_info_data(&module_identifier)
         .get_used_name(
           &compilation.exports_info_artifact,
           *runtime,
@@ -226,7 +226,7 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
         )
       } else if let Some(used) = compilation
         .exports_info_artifact
-        .get_exports_info(&module_identifier)
+        .get_exports_info_data(&module_identifier)
         .get_used_name(
           &compilation.exports_info_artifact,
           *runtime,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -4,10 +4,10 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, DEFAULT_EXPORT, Dependency, DependencyCodeGeneration,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, ESMExportInitFragment, ExportNameOrSpec, ExportsInfoArtifact, ExportsInfoGetter,
-  ExportsOfExportsSpec, ExportsSpec, ForwardId, GetUsedNameParam, ModuleGraph,
-  ModuleGraphCacheArtifact, PrefetchExportsInfoMode, SideEffectsStateArtifact, TemplateContext,
-  TemplateReplaceSource, UsedName, property_access, rspack_sources::ReplacementEnforce,
+  DependencyType, ESMExportInitFragment, ExportNameOrSpec, ExportsInfoArtifact,
+  ExportsOfExportsSpec, ExportsSpec, ForwardId, ModuleGraph, ModuleGraphCacheArtifact,
+  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedName, property_access,
+  rspack_sources::ReplacementEnforce,
 };
 use swc_core::atoms::Atom;
 
@@ -183,15 +183,15 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
 
       if let Some(scope) = concatenation_scope {
         scope.register_export(JS_DEFAULT_KEYWORD.clone(), name.to_string());
-      } else if let Some(used) = ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(
-          &compilation
-            .exports_info_artifact
-            .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default),
-        ),
-        *runtime,
-        std::slice::from_ref(&JS_DEFAULT_KEYWORD),
-      ) && let UsedName::Normal(used) = used
+      } else if let Some(used) = compilation
+        .exports_info_artifact
+        .get_exports_info(&module_identifier)
+        .get_used_name(
+          &compilation.exports_info_artifact,
+          *runtime,
+          std::slice::from_ref(&JS_DEFAULT_KEYWORD),
+        )
+        && let UsedName::Normal(used) = used
       {
         init_fragments.push(Box::new(ESMExportInitFragment::new(
           module.get_exports_argument(),
@@ -224,15 +224,15 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
           "/* export default */ {} {DEFAULT_EXPORT} = ",
           if supports_const { "const" } else { "var" }
         )
-      } else if let Some(used) = ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(
-          &compilation
-            .exports_info_artifact
-            .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default),
-        ),
-        *runtime,
-        std::slice::from_ref(&JS_DEFAULT_KEYWORD),
-      ) {
+      } else if let Some(used) = compilation
+        .exports_info_artifact
+        .get_exports_info(&module_identifier)
+        .get_used_name(
+          &compilation.exports_info_artifact,
+          *runtime,
+          std::slice::from_ref(&JS_DEFAULT_KEYWORD),
+        )
+      {
         if let UsedName::Normal(used) = used {
           if supports_const {
             init_fragments.push(Box::new(ESMExportInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -14,17 +14,16 @@ use rspack_core::{
   ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
   ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
-  ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
-  ExportsInfoGetter, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, ForwardId, GetUsedNameParam, ImportAttributes, ImportPhase, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, JavascriptParserOptions, LazyUntil, ModuleDependency,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, NormalInitFragment, NormalReexportItem,
-  PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, ResourceIdentifier, RuntimeCondition,
-  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, StarReexportsInfo, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedName, collect_referenced_export_items,
-  create_exports_object_referenced, create_no_exports_referenced, filter_runtime, get_exports_type,
-  get_runtime_key, get_terminal_binding, property_access, property_name,
-  render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
+  ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfo,
+  ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
+  FactorizeInfo, ForwardId, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, JavascriptParserOptions, LazyUntil, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, NormalInitFragment, NormalReexportItem,
+  ResourceIdentifier, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
+  StarReexportsInfo, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
+  collect_referenced_export_items, create_exports_object_referenced, create_no_exports_referenced,
+  filter_runtime, get_exports_type, get_runtime_key, get_terminal_binding, property_access,
+  property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_util::json_stringify;
@@ -171,10 +170,9 @@ impl ESMExportImportedSpecifierDependency {
       .expect("should have parent module");
 
     if let Some(name) = name {
-      let exports_info = exports_info_artifact
-        .get_prefetched_exports_info(parent_module, PrefetchExportsInfoMode::Default);
+      let exports_info = exports_info_artifact.get_exports_info(parent_module);
       if !exports_info
-        .get_read_only_export_info(&name)
+        .get_read_only_export_info(exports_info_artifact, &name)
         .is_used(runtime)
       {
         return ExportMode::Unused(ExportModeUnused { name: "*".into() });
@@ -198,7 +196,9 @@ impl ESMExportImportedSpecifierDependency {
           }
           ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
             return ExportMode::ReexportNamedDefault(ExportModeReexportNamedDefault {
-              partial_namespace_export_info: exports_info.get_read_only_export_info(&name).id(),
+              partial_namespace_export_info: exports_info
+                .get_read_only_export_info(exports_info_artifact, &name)
+                .id(),
               name,
             });
           }
@@ -207,7 +207,9 @@ impl ESMExportImportedSpecifierDependency {
       }
 
       // reexporting with a fixed name
-      let export_info = exports_info.get_read_only_export_info(&name).id();
+      let export_info = exports_info
+        .get_read_only_export_info(exports_info_artifact, &name)
+        .id();
       let res = if ids.is_empty() {
         // export * as name
         match imported_exports_type {
@@ -250,9 +252,8 @@ impl ESMExportImportedSpecifierDependency {
       return res;
     }
 
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(parent_module, PrefetchExportsInfoMode::Default);
-    if !exports_info.is_used(runtime) {
+    let exports_info = exports_info_artifact.get_exports_info(parent_module);
+    if !exports_info.is_used(exports_info_artifact, runtime) {
       return ExportMode::Unused(ExportModeUnused { name: "*".into() });
     }
 
@@ -292,7 +293,9 @@ impl ESMExportImportedSpecifierDependency {
           .as_ref()
           .map(|c| c.contains(export_name))
           .unwrap_or_default(),
-        export_info: exports_info.get_read_only_export_info(export_name).id(),
+        export_info: exports_info
+          .get_read_only_export_info(exports_info_artifact, export_name)
+          .id(),
       })
       .collect::<Vec<_>>();
 
@@ -303,7 +306,9 @@ impl ESMExportImportedSpecifierDependency {
           ids: vec![export_name.clone()],
           hidden: true,
           checked: false,
-          export_info: exports_info.get_read_only_export_info(export_name).id(),
+          export_info: exports_info
+            .get_read_only_export_info(exports_info_artifact, export_name)
+            .id(),
         });
       }
     }
@@ -317,18 +322,21 @@ impl ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     runtime: Option<&RuntimeSpec>,
-    exports_info: &PrefetchedExportsInfoWrapper<'_>,
+    exports_info: &ExportsInfo,
     imported_module_identifier: &ModuleIdentifier,
   ) -> StarReexportsInfo {
-    let imported_exports_info = exports_info_artifact
-      .get_prefetched_exports_info(imported_module_identifier, PrefetchExportsInfoMode::Default);
+    let imported_exports_info = exports_info_artifact.get_exports_info(imported_module_identifier);
 
     let no_extra_exports = matches!(
-      imported_exports_info.other_exports_info().provided(),
+      imported_exports_info
+        .other_exports_info(exports_info_artifact)
+        .provided(),
       Some(ExportProvided::NotProvided)
     );
     let no_extra_imports = matches!(
-      exports_info.other_exports_info().get_used(runtime),
+      exports_info
+        .other_exports_info(exports_info_artifact)
+        .get_used(runtime),
       UsageState::Unused
     );
 
@@ -370,13 +378,14 @@ impl ESMExportImportedSpecifierDependency {
     };
 
     if no_extra_imports {
-      for (_name, export_info) in exports_info.exports() {
+      for (_name, export_info) in exports_info.exports(exports_info_artifact) {
         let export_name = export_info.name().expect("should have export name");
         if ignored_exports.contains(export_name) || !export_info.is_used(runtime) {
           continue;
         }
 
-        let imported_export_info = imported_exports_info.get_read_only_export_info(export_name);
+        let imported_export_info =
+          imported_exports_info.get_read_only_export_info(exports_info_artifact, export_name);
         if matches!(
           imported_export_info.provided(),
           Some(ExportProvided::NotProvided)
@@ -402,7 +411,7 @@ impl ESMExportImportedSpecifierDependency {
         checked.insert(export_name.clone());
       }
     } else if no_extra_exports {
-      for (_name, imported_export_info) in imported_exports_info.exports() {
+      for (_name, imported_export_info) in imported_exports_info.exports(exports_info_artifact) {
         let imported_export_info_name = imported_export_info
           .name()
           .expect("should have export name");
@@ -415,7 +424,7 @@ impl ESMExportImportedSpecifierDependency {
           continue;
         }
         if !exports_info
-          .get_read_only_export_info(imported_export_info_name)
+          .get_read_only_export_info(exports_info_artifact, imported_export_info_name)
           .is_used(runtime)
         {
           continue;
@@ -547,13 +556,9 @@ impl ESMExportImportedSpecifierDependency {
         .boxed(),
       ),
       ExportMode::ReexportDynamicDefault(ExportModeReexportDynamicDefault { name }) => {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
-          None,
-          std::slice::from_ref(&name),
-        );
+        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let used_name =
+          exports_info.get_used_name(exports_info_artifact, None, std::slice::from_ref(&name));
         let key = render_used_name(used_name.as_ref());
 
         let init_fragment = self
@@ -568,10 +573,9 @@ impl ESMExportImportedSpecifierDependency {
         ctxt.init_fragments.push(init_fragment);
       }
       ExportMode::ReexportNamedDefault(mode) => {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
+        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let used_name = exports_info.get_used_name(
+          exports_info_artifact,
           None,
           std::slice::from_ref(&mode.name),
         );
@@ -588,10 +592,9 @@ impl ESMExportImportedSpecifierDependency {
         ctxt.init_fragments.push(init_fragment);
       }
       ExportMode::ReexportNamespaceObject(mode) => {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
+        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let used_name = exports_info.get_used_name(
+          exports_info_artifact,
           None,
           std::slice::from_ref(&mode.name),
         );
@@ -634,10 +637,9 @@ impl ESMExportImportedSpecifierDependency {
       }
       ExportMode::ReexportFakeNamespaceObject(mode) => {
         // TODO: reexport fake namespace object
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
+        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let used_name = exports_info.get_used_name(
+          exports_info_artifact,
           None,
           std::slice::from_ref(&mode.name),
         );
@@ -673,10 +675,9 @@ impl ESMExportImportedSpecifierDependency {
         ctxt.init_fragments.push(namespace_expr.boxed());
       }
       ExportMode::ReexportUndefined(mode) => {
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
+        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let used_name = exports_info.get_used_name(
+          exports_info_artifact,
           None,
           std::slice::from_ref(&mode.name),
         );
@@ -697,8 +698,7 @@ impl ESMExportImportedSpecifierDependency {
         let imported_module = mg
           .module_identifier_by_dependency_id(&self.id)
           .expect("should have imported module identifier");
-        let exports_info = exports_info_artifact
-          .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
+        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
         for item in mode.items {
           let NormalReexportItem {
             name,
@@ -712,11 +712,8 @@ impl ESMExportImportedSpecifierDependency {
             continue;
           }
 
-          let used_name = ExportsInfoGetter::get_used_name(
-            GetUsedNameParam::WithNames(&exports_info),
-            None,
-            std::slice::from_ref(&name),
-          );
+          let used_name =
+            exports_info.get_used_name(exports_info_artifact, None, std::slice::from_ref(&name));
           let key = render_used_name(used_name.as_ref());
 
           if checked {
@@ -763,25 +760,8 @@ impl ESMExportImportedSpecifierDependency {
                 runtime_condition,
               )));
           } else {
-            let used_name = if ids.is_empty() {
-              let exports_info_used =
-                exports_info_artifact.get_prefetched_exports_info_used(imported_module, None);
-              ExportsInfoGetter::get_used_name(
-                GetUsedNameParam::WithoutNames(&exports_info_used),
-                None,
-                &ids,
-              )
-            } else {
-              let exports_info = exports_info_artifact.get_prefetched_exports_info(
-                imported_module,
-                PrefetchExportsInfoMode::Nested(&ids),
-              );
-              ExportsInfoGetter::get_used_name(
-                GetUsedNameParam::WithNames(&exports_info),
-                None,
-                &ids,
-              )
-            };
+            let exports_info = exports_info_artifact.get_exports_info(imported_module);
+            let used_name = exports_info.get_used_name(exports_info_artifact, None, &ids);
             let init_fragment = self
               .get_reexport_fragment(ctxt, "reexport safe", key, &import_var, used_name.into())
               .boxed();
@@ -1047,13 +1027,10 @@ impl ESMExportImportedSpecifierDependency {
           ..potential_conflicts.dependency_indices[potential_conflicts.dependency_index]],
       );
       let imported_module = module_graph.get_module_by_dependency_id(&self.id)?;
-      let exports_info = exports_info_artifact.get_prefetched_exports_info(
-        &imported_module.identifier(),
-        PrefetchExportsInfoMode::Default,
-      );
+      let exports_info = exports_info_artifact.get_exports_info(&imported_module.identifier());
       let mut conflicts: IndexMap<&str, Vec<&Atom>, BuildHasherDefault<FxHasher>> =
         IndexMap::default();
-      for (_name, export_info) in exports_info.exports() {
+      for (_name, export_info) in exports_info.exports(exports_info_artifact) {
         if !matches!(export_info.provided(), Some(ExportProvided::Provided)) {
           continue;
         }
@@ -1100,11 +1077,10 @@ impl ESMExportImportedSpecifierDependency {
         if conflicting_module.identifier() == imported_module.identifier() {
           continue;
         }
-        let exports_info = exports_info_artifact.get_prefetched_exports_info(
-          &conflicting_module.identifier(),
-          PrefetchExportsInfoMode::Default,
-        );
-        let Some(conflicting_export_info) = exports_info.data().named_exports(name) else {
+        let exports_info = exports_info_artifact.get_exports_info(&conflicting_module.identifier());
+        let Some(conflicting_export_info) =
+          exports_info.data(exports_info_artifact).named_exports(name)
+        else {
           continue;
         };
         let Some(conflicting_target) =

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -14,8 +14,8 @@ use rspack_core::{
   ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
   ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
-  ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfo,
-  ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
+  ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
+  ExportsInfoData, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
   FactorizeInfo, ForwardId, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey,
   InitFragmentStage, JavascriptParserOptions, LazyUntil, ModuleDependency, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, NormalInitFragment, NormalReexportItem,
@@ -170,9 +170,9 @@ impl ESMExportImportedSpecifierDependency {
       .expect("should have parent module");
 
     if let Some(name) = name {
-      let exports_info = exports_info_artifact.get_exports_info(parent_module);
+      let exports_info = exports_info_artifact.get_exports_info_data(parent_module);
       if !exports_info
-        .get_read_only_export_info(exports_info_artifact, &name)
+        .get_read_only_export_info(&name)
         .is_used(runtime)
       {
         return ExportMode::Unused(ExportModeUnused { name: "*".into() });
@@ -196,9 +196,7 @@ impl ESMExportImportedSpecifierDependency {
           }
           ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
             return ExportMode::ReexportNamedDefault(ExportModeReexportNamedDefault {
-              partial_namespace_export_info: exports_info
-                .get_read_only_export_info(exports_info_artifact, &name)
-                .id(),
+              partial_namespace_export_info: exports_info.get_read_only_export_info(&name).id(),
               name,
             });
           }
@@ -207,9 +205,7 @@ impl ESMExportImportedSpecifierDependency {
       }
 
       // reexporting with a fixed name
-      let export_info = exports_info
-        .get_read_only_export_info(exports_info_artifact, &name)
-        .id();
+      let export_info = exports_info.get_read_only_export_info(&name).id();
       let res = if ids.is_empty() {
         // export * as name
         match imported_exports_type {
@@ -252,8 +248,8 @@ impl ESMExportImportedSpecifierDependency {
       return res;
     }
 
-    let exports_info = exports_info_artifact.get_exports_info(parent_module);
-    if !exports_info.is_used(exports_info_artifact, runtime) {
+    let exports_info = exports_info_artifact.get_exports_info_data(parent_module);
+    if !exports_info.is_used(runtime) {
       return ExportMode::Unused(ExportModeUnused { name: "*".into() });
     }
 
@@ -268,7 +264,7 @@ impl ESMExportImportedSpecifierDependency {
       module_graph_cache,
       exports_info_artifact,
       runtime,
-      &exports_info,
+      exports_info,
       imported_module_identifier,
     );
 
@@ -293,9 +289,7 @@ impl ESMExportImportedSpecifierDependency {
           .as_ref()
           .map(|c| c.contains(export_name))
           .unwrap_or_default(),
-        export_info: exports_info
-          .get_read_only_export_info(exports_info_artifact, export_name)
-          .id(),
+        export_info: exports_info.get_read_only_export_info(export_name).id(),
       })
       .collect::<Vec<_>>();
 
@@ -306,9 +300,7 @@ impl ESMExportImportedSpecifierDependency {
           ids: vec![export_name.clone()],
           hidden: true,
           checked: false,
-          export_info: exports_info
-            .get_read_only_export_info(exports_info_artifact, export_name)
-            .id(),
+          export_info: exports_info.get_read_only_export_info(export_name).id(),
         });
       }
     }
@@ -322,21 +314,18 @@ impl ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     runtime: Option<&RuntimeSpec>,
-    exports_info: &ExportsInfo,
+    exports_info: &ExportsInfoData,
     imported_module_identifier: &ModuleIdentifier,
   ) -> StarReexportsInfo {
-    let imported_exports_info = exports_info_artifact.get_exports_info(imported_module_identifier);
+    let imported_exports_info =
+      exports_info_artifact.get_exports_info_data(imported_module_identifier);
 
     let no_extra_exports = matches!(
-      imported_exports_info
-        .other_exports_info(exports_info_artifact)
-        .provided(),
+      imported_exports_info.other_exports_info().provided(),
       Some(ExportProvided::NotProvided)
     );
     let no_extra_imports = matches!(
-      exports_info
-        .other_exports_info(exports_info_artifact)
-        .get_used(runtime),
+      exports_info.other_exports_info().get_used(runtime),
       UsageState::Unused
     );
 
@@ -378,14 +367,13 @@ impl ESMExportImportedSpecifierDependency {
     };
 
     if no_extra_imports {
-      for (_name, export_info) in exports_info.exports(exports_info_artifact) {
+      for export_info in exports_info.exports().values() {
         let export_name = export_info.name().expect("should have export name");
         if ignored_exports.contains(export_name) || !export_info.is_used(runtime) {
           continue;
         }
 
-        let imported_export_info =
-          imported_exports_info.get_read_only_export_info(exports_info_artifact, export_name);
+        let imported_export_info = imported_exports_info.get_read_only_export_info(export_name);
         if matches!(
           imported_export_info.provided(),
           Some(ExportProvided::NotProvided)
@@ -411,7 +399,7 @@ impl ESMExportImportedSpecifierDependency {
         checked.insert(export_name.clone());
       }
     } else if no_extra_exports {
-      for (_name, imported_export_info) in imported_exports_info.exports(exports_info_artifact) {
+      for imported_export_info in imported_exports_info.exports().values() {
         let imported_export_info_name = imported_export_info
           .name()
           .expect("should have export name");
@@ -424,7 +412,7 @@ impl ESMExportImportedSpecifierDependency {
           continue;
         }
         if !exports_info
-          .get_read_only_export_info(exports_info_artifact, imported_export_info_name)
+          .get_read_only_export_info(imported_export_info_name)
           .is_used(runtime)
         {
           continue;
@@ -556,7 +544,7 @@ impl ESMExportImportedSpecifierDependency {
         .boxed(),
       ),
       ExportMode::ReexportDynamicDefault(ExportModeReexportDynamicDefault { name }) => {
-        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module_identifier);
         let used_name =
           exports_info.get_used_name(exports_info_artifact, None, std::slice::from_ref(&name));
         let key = render_used_name(used_name.as_ref());
@@ -573,7 +561,7 @@ impl ESMExportImportedSpecifierDependency {
         ctxt.init_fragments.push(init_fragment);
       }
       ExportMode::ReexportNamedDefault(mode) => {
-        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module_identifier);
         let used_name = exports_info.get_used_name(
           exports_info_artifact,
           None,
@@ -592,7 +580,7 @@ impl ESMExportImportedSpecifierDependency {
         ctxt.init_fragments.push(init_fragment);
       }
       ExportMode::ReexportNamespaceObject(mode) => {
-        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module_identifier);
         let used_name = exports_info.get_used_name(
           exports_info_artifact,
           None,
@@ -637,7 +625,7 @@ impl ESMExportImportedSpecifierDependency {
       }
       ExportMode::ReexportFakeNamespaceObject(mode) => {
         // TODO: reexport fake namespace object
-        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module_identifier);
         let used_name = exports_info.get_used_name(
           exports_info_artifact,
           None,
@@ -675,7 +663,7 @@ impl ESMExportImportedSpecifierDependency {
         ctxt.init_fragments.push(namespace_expr.boxed());
       }
       ExportMode::ReexportUndefined(mode) => {
-        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module_identifier);
         let used_name = exports_info.get_used_name(
           exports_info_artifact,
           None,
@@ -698,7 +686,7 @@ impl ESMExportImportedSpecifierDependency {
         let imported_module = mg
           .module_identifier_by_dependency_id(&self.id)
           .expect("should have imported module identifier");
-        let exports_info = exports_info_artifact.get_exports_info(&module_identifier);
+        let exports_info = exports_info_artifact.get_exports_info_data(&module_identifier);
         for item in mode.items {
           let NormalReexportItem {
             name,
@@ -760,7 +748,7 @@ impl ESMExportImportedSpecifierDependency {
                 runtime_condition,
               )));
           } else {
-            let exports_info = exports_info_artifact.get_exports_info(imported_module);
+            let exports_info = exports_info_artifact.get_exports_info_data(imported_module);
             let used_name = exports_info.get_used_name(exports_info_artifact, None, &ids);
             let init_fragment = self
               .get_reexport_fragment(ctxt, "reexport safe", key, &import_var, used_name.into())
@@ -1027,10 +1015,10 @@ impl ESMExportImportedSpecifierDependency {
           ..potential_conflicts.dependency_indices[potential_conflicts.dependency_index]],
       );
       let imported_module = module_graph.get_module_by_dependency_id(&self.id)?;
-      let exports_info = exports_info_artifact.get_exports_info(&imported_module.identifier());
+      let exports_info = exports_info_artifact.get_exports_info_data(&imported_module.identifier());
       let mut conflicts: IndexMap<&str, Vec<&Atom>, BuildHasherDefault<FxHasher>> =
         IndexMap::default();
-      for (_name, export_info) in exports_info.exports(exports_info_artifact) {
+      for export_info in exports_info.exports().values() {
         if !matches!(export_info.provided(), Some(ExportProvided::Provided)) {
           continue;
         }
@@ -1077,10 +1065,9 @@ impl ESMExportImportedSpecifierDependency {
         if conflicting_module.identifier() == imported_module.identifier() {
           continue;
         }
-        let exports_info = exports_info_artifact.get_exports_info(&conflicting_module.identifier());
-        let Some(conflicting_export_info) =
-          exports_info.data(exports_info_artifact).named_exports(name)
-        else {
+        let exports_info =
+          exports_info_artifact.get_exports_info_data(&conflicting_module.identifier());
+        let Some(conflicting_export_info) = exports_info.named_exports(name) else {
           continue;
         };
         let Some(conflicting_target) =

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -194,7 +194,7 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&module.identifier());
+      .get_exports_info_data(&module.identifier());
     let Some(used_name) = exports_info.get_used_name(
       &compilation.exports_info_artifact,
       *runtime,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -4,9 +4,8 @@ use rspack_core::{
   AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ESMExportInitFragment, EvaluatedInlinableValue,
-  ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsInfoGetter, ExportsOfExportsSpec,
-  ExportsSpec, GetUsedNameParam, LazyUntil, ModuleGraph, ModuleGraphCacheArtifact,
-  PrefetchExportsInfoMode, SideEffectsStateArtifact, TSEnumValue, TemplateContext,
+  ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, LazyUntil,
+  ModuleGraph, ModuleGraphCacheArtifact, SideEffectsStateArtifact, TSEnumValue, TemplateContext,
   TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
@@ -195,9 +194,9 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
-    let Some(used_name) = ExportsInfoGetter::get_used_name(
-      GetUsedNameParam::WithNames(&exports_info),
+      .get_exports_info(&module.identifier());
+    let Some(used_name) = exports_info.get_used_name(
+      &compilation.exports_info_artifact,
       *runtime,
       std::slice::from_ref(&dep.name),
     ) else {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -341,7 +341,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       return None;
     }
     let imported_module_identifier = imported_module.identifier();
-    let exports_info = exports_info_artifact.get_exports_info(&imported_module_identifier);
+    let exports_info = exports_info_artifact.get_exports_info_data(&imported_module_identifier);
     if (!matches!(exports_type, ExportsType::DefaultWithNamed) || ids[0] != "default")
       && matches!(
         exports_info.is_export_provided(exports_info_artifact, ids),
@@ -369,7 +369,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         && ids.len() == 1
         && matches!(
           exports_info_artifact
-            .get_exports_info(parent_module_identifier)
+            .get_exports_info_data(parent_module_identifier)
             .is_export_provided(exports_info_artifact, std::slice::from_ref(name)),
           Some(ExportProvided::Provided)
         )
@@ -391,15 +391,15 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       }
       let mut pos = 0;
       let mut maybe_exports_info =
-        Some(exports_info_artifact.get_exports_info(&imported_module_identifier));
+        Some(exports_info_artifact.get_exports_info_data(&imported_module_identifier));
       while pos < ids.len()
         && let Some(exports_info) = &maybe_exports_info
       {
         let id = &ids[pos];
         pos += 1;
-        let export_info = exports_info.get_read_only_export_info(exports_info_artifact, id);
+        let export_info = exports_info.get_read_only_export_info(id);
         if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
-          let provided_exports = exports_info.get_provided_exports(exports_info_artifact);
+          let provided_exports = exports_info.get_provided_exports();
           let more_info = if let ProvidedExports::ProvidedNames(exports) = &provided_exports {
             if exports.is_empty() {
               " (module has no exports)".to_string()
@@ -433,7 +433,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
           maybe_exports_info = None;
           continue;
         };
-        maybe_exports_info = Some(nested_exports_info);
+        maybe_exports_info = Some(nested_exports_info.as_data(exports_info_artifact));
       }
       let msg = format!(
         "export {} {} was not found in '{}'",

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -8,9 +8,8 @@ use rspack_core::{
   ExportProvided, ExportsInfoArtifact, ExportsType, ExtendedReferencedExport, FactorizeInfo,
   ForwardId, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage,
   LazyUntil, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  PrefetchExportsInfoMode, ProvidedExports, ResourceIdentifier, RuntimeCondition, RuntimeSpec,
-  SideEffectsStateArtifact, SourceType, TemplateContext, TemplateReplaceSource,
-  TypeReexportPresenceMode, filter_runtime,
+  ProvidedExports, ResourceIdentifier, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact,
+  SourceType, TemplateContext, TemplateReplaceSource, TypeReexportPresenceMode, filter_runtime,
 };
 use rspack_error::{Diagnostic, Error, Severity};
 use swc_core::ecma::atoms::Atom;
@@ -342,13 +341,10 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       return None;
     }
     let imported_module_identifier = imported_module.identifier();
-    let exports_info = exports_info_artifact.get_prefetched_exports_info(
-      &imported_module_identifier,
-      PrefetchExportsInfoMode::Nested(ids),
-    );
+    let exports_info = exports_info_artifact.get_exports_info(&imported_module_identifier);
     if (!matches!(exports_type, ExportsType::DefaultWithNamed) || ids[0] != "default")
       && matches!(
-        exports_info.is_export_provided(ids),
+        exports_info.is_export_provided(exports_info_artifact, ids),
         Some(ExportProvided::NotProvided)
       )
     {
@@ -372,11 +368,9 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         .is_some()
         && ids.len() == 1
         && matches!(
-          exports_info_artifact.get_prefetched_exports_info(
-            parent_module_identifier,
-            PrefetchExportsInfoMode::Default,
-          )
-            .is_export_provided(std::slice::from_ref(name)),
+          exports_info_artifact
+            .get_exports_info(parent_module_identifier)
+            .is_export_provided(exports_info_artifact, std::slice::from_ref(name)),
           Some(ExportProvided::Provided)
         )
       {
@@ -396,18 +390,16 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         }
       }
       let mut pos = 0;
-      let mut maybe_exports_info = Some(exports_info_artifact.get_prefetched_exports_info(
-        &imported_module_identifier,
-        PrefetchExportsInfoMode::Nested(ids),
-      ));
+      let mut maybe_exports_info =
+        Some(exports_info_artifact.get_exports_info(&imported_module_identifier));
       while pos < ids.len()
         && let Some(exports_info) = &maybe_exports_info
       {
         let id = &ids[pos];
         pos += 1;
-        let export_info = exports_info.get_read_only_export_info(id);
+        let export_info = exports_info.get_read_only_export_info(exports_info_artifact, id);
         if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
-          let provided_exports = exports_info.get_provided_exports();
+          let provided_exports = exports_info.get_provided_exports(exports_info_artifact);
           let more_info = if let ProvidedExports::ProvidedNames(exports) = &provided_exports {
             if exports.is_empty() {
               " (module has no exports)".to_string()
@@ -441,7 +433,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
           maybe_exports_info = None;
           continue;
         };
-        maybe_exports_info = Some(exports_info.redirect(nested_exports_info, true));
+        maybe_exports_info = Some(nested_exports_info);
       }
       let msg = format!(
         "export {} {} was not found in '{}'",

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -7,13 +7,12 @@ use rspack_core::{
   AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyCondition, DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ExportPresenceMode, ExportProvided,
-  ExportsInfoArtifact, ExportsInfoGetter, ExportsType, ExtendedReferencedExport, FactorizeInfo,
-  ForwardId, GetUsedNameParam, ImportAttributes, ImportPhase, JavascriptParserOptions,
-  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleReferenceOptions, PrefetchExportsInfoMode, ReferencedExport, ResourceIdentifier,
-  RuntimeSpec, SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedByExports,
-  UsedByExportsCondition, UsedName, create_exports_object_referenced, property_access,
-  to_normal_comment,
+  ExportsInfoArtifact, ExportsType, ExtendedReferencedExport, FactorizeInfo, ForwardId,
+  ImportAttributes, ImportPhase, JavascriptParserOptions, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport,
+  ResourceIdentifier, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
+  TemplateReplaceSource, UsedByExports, UsedByExportsCondition, UsedName,
+  create_exports_object_referenced, property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
 use rspack_util::json_stringify_str;
@@ -399,18 +398,11 @@ impl ESMImportSpecifierDependencyTemplate {
           },
         )
       } else if dep.namespace_object_as_context {
-        match ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(
-            &compilation
-              .exports_info_artifact
-              .get_prefetched_exports_info(
-                con.module_identifier(),
-                PrefetchExportsInfoMode::Nested(ids),
-              ),
-          ),
-          *runtime,
-          ids,
-        ) {
+        match compilation
+          .exports_info_artifact
+          .get_exports_info(con.module_identifier())
+          .get_used_name(&compilation.exports_info_artifact, *runtime, ids)
+        {
           Some(UsedName::Normal(used_name)) => {
             scope.create_module_reference(
               con.module_identifier(),
@@ -505,10 +497,7 @@ impl ESMImportSpecifierDependencyTemplate {
     };
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(
-        con.module_identifier(),
-        PrefetchExportsInfoMode::Nested(ids),
-      );
+      .get_exports_info(con.module_identifier());
     let exports_type = module.get_exports_type(
       mg,
       &compilation.module_graph_cache_artifact,
@@ -524,10 +513,10 @@ impl ESMImportSpecifierDependencyTemplate {
           if ids.len() == 1 {
             Some(ExportProvided::Provided)
           } else {
-            exports_info.is_export_provided(&ids[1..])
+            exports_info.is_export_provided(&compilation.exports_info_artifact, &ids[1..])
           }
         } else {
-          exports_info.is_export_provided(ids)
+          exports_info.is_export_provided(&compilation.exports_info_artifact, ids)
         }
       }
       ExportsType::Namespace => {
@@ -538,12 +527,12 @@ impl ESMImportSpecifierDependencyTemplate {
             None
           }
         } else {
-          exports_info.is_export_provided(ids)
+          exports_info.is_export_provided(&compilation.exports_info_artifact, ids)
         }
       }
       ExportsType::Dynamic => {
         if first != "default" {
-          exports_info.is_export_provided(ids)
+          exports_info.is_export_provided(&compilation.exports_info_artifact, ids)
         } else {
           None
         }
@@ -566,15 +555,13 @@ impl ESMImportSpecifierDependencyTemplate {
         } else {
           ids
         };
-        let Some(used_name) = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
-          *runtime,
-          used_name_ids,
-        )
-        .and_then(|used_name| match used_name {
-          UsedName::Normal(names) => names.last().cloned(),
-          UsedName::Inlined(_) => unreachable!("Inlined must be provided"),
-        }) else {
+        let Some(used_name) = exports_info
+          .get_used_name(&compilation.exports_info_artifact, *runtime, used_name_ids)
+          .and_then(|used_name| match used_name {
+            UsedName::Normal(names) => names.last().cloned(),
+            UsedName::Inlined(_) => unreachable!("Inlined must be provided"),
+          })
+        else {
           return;
         };
         let code = self.get_code_for_ids(
@@ -685,25 +672,22 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         let prop = stack.last().expect("should have last");
         let mut concated_ids = prefixed_ids.clone();
         concated_ids.extend(stack.iter().map(|p| p.id.clone()));
-        let Some(new_name) = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(
-            &code_generatable_context
-              .compilation
-              .exports_info_artifact
-              .get_prefetched_exports_info(
-                &module.identifier(),
-                PrefetchExportsInfoMode::Nested(&concated_ids),
-              ),
-          ),
-          code_generatable_context.runtime,
-          &concated_ids,
-        )
-        .and_then(|used| match used {
-          UsedName::Normal(names) => names.last().cloned(),
-          UsedName::Inlined(inlined) => {
-            unreachable!("should not inline for destructuring {:#?}", inlined)
-          }
-        }) else {
+        let Some(new_name) = code_generatable_context
+          .compilation
+          .exports_info_artifact
+          .get_exports_info(&module.identifier())
+          .get_used_name(
+            &code_generatable_context.compilation.exports_info_artifact,
+            code_generatable_context.runtime,
+            &concated_ids,
+          )
+          .and_then(|used| match used {
+            UsedName::Normal(names) => names.last().cloned(),
+            UsedName::Inlined(inlined) => {
+              unreachable!("should not inline for destructuring {:#?}", inlined)
+            }
+          })
+        else {
           return;
         };
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -400,7 +400,7 @@ impl ESMImportSpecifierDependencyTemplate {
       } else if dep.namespace_object_as_context {
         match compilation
           .exports_info_artifact
-          .get_exports_info(con.module_identifier())
+          .get_exports_info_data(con.module_identifier())
           .get_used_name(&compilation.exports_info_artifact, *runtime, ids)
         {
           Some(UsedName::Normal(used_name)) => {
@@ -497,7 +497,7 @@ impl ESMImportSpecifierDependencyTemplate {
     };
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(con.module_identifier());
+      .get_exports_info_data(con.module_identifier());
     let exports_type = module.get_exports_type(
       mg,
       &compilation.module_graph_cache_artifact,
@@ -675,7 +675,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
         let Some(new_name) = code_generatable_context
           .compilation
           .exports_info_artifact
-          .get_exports_info(&module.identifier())
+          .get_exports_info_data(&module.identifier())
           .get_used_name(
             &code_generatable_context.compilation.exports_info_artifact,
             code_generatable_context.runtime,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -6,10 +6,9 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, ExportsInfoArtifact, ExportsInfoGetter, ExtendedReferencedExport, FactorizeInfo,
-  GetUsedNameParam, InitFragmentKey, InitFragmentStage, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, NormalInitFragment, PrefetchExportsInfoMode, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource, UsedName, create_exports_object_referenced,
+  DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, InitFragmentKey,
+  InitFragmentStage, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, create_exports_object_referenced,
 };
 use rspack_util::ext::DynHash;
 use swc_core::atoms::Atom;
@@ -171,28 +170,11 @@ impl DependencyTemplate for ProvideDependencyTemplate {
       return;
     };
 
-    let used_name = if dep.ids.is_empty() {
-      let exports_info_used = compilation
-        .exports_info_artifact
-        .get_prefetched_exports_info_used(con.module_identifier(), *runtime);
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithoutNames(&exports_info_used),
-        *runtime,
-        &dep.ids,
-      )
-    } else {
-      let exports_info = compilation
-        .exports_info_artifact
-        .get_prefetched_exports_info(
-          con.module_identifier(),
-          PrefetchExportsInfoMode::Nested(&dep.ids),
-        );
-      ExportsInfoGetter::get_used_name(
-        GetUsedNameParam::WithNames(&exports_info),
-        *runtime,
-        &dep.ids,
-      )
-    };
+    let exports_info = compilation
+      .exports_info_artifact
+      .get_exports_info(con.module_identifier());
+    let used_name =
+      exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.ids);
 
     init_fragments.push(Box::new(
       NormalInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -172,7 +172,7 @@ impl DependencyTemplate for ProvideDependencyTemplate {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(con.module_identifier());
+      .get_exports_info_data(con.module_identifier());
     let used_name =
       exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.ids);
 

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -53,9 +53,8 @@ impl ExportInfoDependency {
     if export_name.is_empty() && prop == "usedExports" {
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(&module_identifier);
-      let used_exports =
-        exports_info.get_used_exports(&compilation.exports_info_artifact, *runtime);
+        .get_exports_info_data(&module_identifier);
+      let used_exports = exports_info.get_used_exports(*runtime);
       return Some(match used_exports {
         UsedExports::Unknown => "null".to_owned(),
         UsedExports::UsedNamespace(value) => value.to_string(),
@@ -74,7 +73,7 @@ impl ExportInfoDependency {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&module_identifier);
+      .get_exports_info_data(&module_identifier);
 
     match prop.to_string().as_str() {
       "canMangle" => {
@@ -83,9 +82,7 @@ impl ExportInfoDependency {
         {
           export_info.can_mangle()
         } else {
-          exports_info
-            .other_exports_info(&compilation.exports_info_artifact)
-            .can_mangle()
+          exports_info.other_exports_info().can_mangle()
         };
         can_mangle.map(|v| v.to_string())
       }

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -5,8 +5,7 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided,
-  ExportsInfoGetter, GetUsedNameParam, PrefetchExportsInfoMode, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedExports, UsedName,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedExports, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -54,8 +53,9 @@ impl ExportInfoDependency {
     if export_name.is_empty() && prop == "usedExports" {
       let exports_info = compilation
         .exports_info_artifact
-        .get_prefetched_exports_info(&module_identifier, PrefetchExportsInfoMode::Default);
-      let used_exports = exports_info.get_used_exports(*runtime);
+        .get_exports_info(&module_identifier);
+      let used_exports =
+        exports_info.get_used_exports(&compilation.exports_info_artifact, *runtime);
       return Some(match used_exports {
         UsedExports::Unknown => "null".to_owned(),
         UsedExports::UsedNamespace(value) => value.to_string(),
@@ -74,36 +74,33 @@ impl ExportInfoDependency {
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(
-        &module_identifier,
-        PrefetchExportsInfoMode::Nested(export_name),
-      );
+      .get_exports_info(&module_identifier);
 
     match prop.to_string().as_str() {
       "canMangle" => {
-        let can_mangle = if let Some(export_info) =
-          exports_info.get_read_only_export_info_recursive(export_name)
+        let can_mangle = if let Some(export_info) = exports_info
+          .get_read_only_export_info_recursive(&compilation.exports_info_artifact, export_name)
         {
           export_info.can_mangle()
         } else {
-          exports_info.other_exports_info().can_mangle()
+          exports_info
+            .other_exports_info(&compilation.exports_info_artifact)
+            .can_mangle()
         };
         can_mangle.map(|v| v.to_string())
       }
       "canInline" => {
-        let used_name = ExportsInfoGetter::get_used_name(
-          GetUsedNameParam::WithNames(&exports_info),
-          *runtime,
-          export_name,
-        );
+        let used_name =
+          exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, export_name);
         Some(matches!(used_name, Some(UsedName::Inlined(_))).to_string())
       }
       "used" => {
-        let used = exports_info.get_used(export_name, *runtime);
+        let used = exports_info.get_used(&compilation.exports_info_artifact, export_name, *runtime);
         Some((!matches!(used, UsageState::Unused)).to_string())
       }
       "useInfo" => {
-        let used_state = exports_info.get_used(export_name, *runtime);
+        let used_state =
+          exports_info.get_used(&compilation.exports_info_artifact, export_name, *runtime);
         Some(
           (match used_state {
             UsageState::Used => "true",
@@ -116,7 +113,7 @@ impl ExportInfoDependency {
         )
       }
       "provideInfo" => exports_info
-        .is_export_provided(export_name)
+        .is_export_provided(&compilation.exports_info_artifact, export_name)
         .map(|provided| {
           (match provided {
             ExportProvided::Provided => "true",

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -22,9 +22,9 @@ pub(crate) fn has_impure_deferred_pure_checks(
         return true;
       };
 
-      let target_exports_info = exports_info_artifact.get_exports_info(ref_module);
-      let target_export_info = target_exports_info
-        .get_export_info_without_mut_module_graph(exports_info_artifact, &deferred_check.atom);
+      let target_exports_info = exports_info_artifact.get_exports_info_data(ref_module);
+      let target_export_info =
+        target_exports_info.get_export_info_without_mut_module_graph(&deferred_check.atom);
       let resolve_filter = |_: &ResolvedExportInfoTarget| true;
 
       let (ref_module_id, atom) = if let Some(GetTargetResult::Target(target)) = get_target(
@@ -82,7 +82,7 @@ pub(crate) fn runtime_condition_used_by_exports(
     UsedByExportsCondition::Set(used_by_exports) => {
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(module_identifier);
+        .get_exports_info_data(module_identifier);
       filter_runtime(runtime, |cur_runtime| {
         used_by_exports.iter().any(|name| {
           exports_info.get_used(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   Compilation, ExportsInfoArtifact, GetTargetResult, ModuleGraph, ModuleGraphConnection,
-  ModuleIdentifier, PrefetchExportsInfoMode, ResolvedExportInfoTarget, RuntimeCondition,
-  RuntimeSpec, UsageState, UsedByExports, UsedByExportsCondition, filter_runtime, get_target,
+  ModuleIdentifier, ResolvedExportInfoTarget, RuntimeCondition, RuntimeSpec, UsageState,
+  UsedByExports, UsedByExportsCondition, filter_runtime, get_target,
 };
 
 pub mod plugin;
@@ -22,10 +22,9 @@ pub(crate) fn has_impure_deferred_pure_checks(
         return true;
       };
 
-      let target_exports_info = exports_info_artifact
-        .get_prefetched_exports_info(ref_module, PrefetchExportsInfoMode::Default);
-      let target_export_info =
-        target_exports_info.get_export_info_without_mut_module_graph(&deferred_check.atom);
+      let target_exports_info = exports_info_artifact.get_exports_info(ref_module);
+      let target_export_info = target_exports_info
+        .get_export_info_without_mut_module_graph(exports_info_artifact, &deferred_check.atom);
       let resolve_filter = |_: &ResolvedExportInfoTarget| true;
 
       let (ref_module_id, atom) = if let Some(GetTargetResult::Target(target)) = get_target(
@@ -83,10 +82,14 @@ pub(crate) fn runtime_condition_used_by_exports(
     UsedByExportsCondition::Set(used_by_exports) => {
       let exports_info = compilation
         .exports_info_artifact
-        .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::Default);
+        .get_exports_info(module_identifier);
       filter_runtime(runtime, |cur_runtime| {
         used_by_exports.iter().any(|name| {
-          exports_info.get_used(std::slice::from_ref(name), cur_runtime) != UsageState::Unused
+          exports_info.get_used(
+            &compilation.exports_info_artifact,
+            std::slice::from_ref(name),
+            cur_runtime,
+          ) != UsageState::Unused
         })
       })
     }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -731,7 +731,7 @@ fn find_target_exports_info(
   let mut target_exports_info = None;
   let mut target_module = None;
   if let Some(GetTargetResult::Target(target)) = target {
-    let target_module_exports_info = exports_info_artifact.get_exports_info(&target.module);
+    let target_module_exports_info = exports_info_artifact.get_exports_info_data(&target.module);
     target_exports_info = target_module_exports_info
       .get_nested_exports_info(exports_info_artifact, target.export.as_deref())
       .map(|data| data.id());

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,12 +1,11 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules,
-  DependenciesBlock, DependencyId, EvaluatedInlinableValue, ExportInfo, ExportInfoData,
-  ExportNameOrSpec, ExportProvided, ExportsInfo, ExportsInfoArtifact, ExportsInfoData,
-  ExportsOfExportsSpec, ExportsSpec, GetTargetResult, Logger, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, Nullable, Plugin,
-  SideEffectsStateArtifact, get_target,
+  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules, DependencyId,
+  EvaluatedInlinableValue, ExportInfo, ExportInfoData, ExportNameOrSpec, ExportProvided,
+  ExportsInfo, ExportsInfoArtifact, ExportsInfoData, ExportsOfExportsSpec, ExportsSpec,
+  GetTargetResult, Logger, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
+  ModuleIdentifier, Nullable, Plugin, SideEffectsStateArtifact, get_target,
   incremental::{self, IncrementalPasses},
 };
 use rspack_error::Result;

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,12 +1,12 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules, DependencyId,
-  EvaluatedInlinableValue, ExportInfo, ExportInfoData, ExportNameOrSpec, ExportProvided,
-  ExportsInfo, ExportsInfoArtifact, ExportsInfoData, ExportsOfExportsSpec, ExportsSpec,
-  GetTargetResult, Logger, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, Nullable, Plugin, PrefetchExportsInfoMode, SideEffectsStateArtifact,
-  get_target,
+  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules,
+  DependenciesBlock, DependencyId, EvaluatedInlinableValue, ExportInfo, ExportInfoData,
+  ExportNameOrSpec, ExportProvided, ExportsInfo, ExportsInfoArtifact, ExportsInfoData,
+  ExportsOfExportsSpec, ExportsSpec, GetTargetResult, Logger, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, Nullable, Plugin,
+  SideEffectsStateArtifact, get_target,
   incremental::{self, IncrementalPasses},
 };
 use rspack_error::Result;
@@ -731,16 +731,9 @@ fn find_target_exports_info(
   let mut target_exports_info = None;
   let mut target_module = None;
   if let Some(GetTargetResult::Target(target)) = target {
-    let target_module_exports_info = exports_info_artifact.get_prefetched_exports_info(
-      &target.module,
-      if let Some(names) = &target.export {
-        PrefetchExportsInfoMode::Nested(names)
-      } else {
-        PrefetchExportsInfoMode::Default
-      },
-    );
+    let target_module_exports_info = exports_info_artifact.get_exports_info(&target.module);
     target_exports_info = target_module_exports_info
-      .get_nested_exports_info(target.export.as_deref())
+      .get_nested_exports_info(exports_info_artifact, target.export.as_deref())
       .map(|data| data.id());
     target_module = Some(target.module);
   }

--- a/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
@@ -2,10 +2,9 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use rspack_core::{
   Compilation, CompilationOptimizeDependencies, Dependency, DependencyId, ExportMode,
-  ExportProvided, ExportsInfo, ExportsInfoArtifact, ExportsInfoGetter, GetUsedNameParam,
-  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, Plugin, PrefetchExportsInfoMode,
-  RuntimeSpec, SideEffectsOptimizeArtifact, UsageState, UsedName, UsedNameItem,
-  build_module_graph::BuildModuleGraphArtifact, incremental::IncrementalPasses,
+  ExportProvided, ExportsInfo, ExportsInfoArtifact, ModuleGraph, ModuleGraphConnection,
+  ModuleIdentifier, Plugin, RuntimeSpec, SideEffectsOptimizeArtifact, UsageState, UsedName,
+  UsedNameItem, build_module_graph::BuildModuleGraphArtifact, incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -43,10 +42,8 @@ pub fn is_export_inlined(
     );
   }
 
-  let exports_info =
-    exports_info_artifact.get_prefetched_exports_info(module, PrefetchExportsInfoMode::Nested(ids));
-  let used_name =
-    ExportsInfoGetter::get_used_name(GetUsedNameParam::WithNames(&exports_info), runtime, ids);
+  let exports_info = exports_info_artifact.get_exports_info(module);
+  let used_name = exports_info.get_used_name(exports_info_artifact, runtime, ids);
   matches!(used_name, Some(UsedName::Inlined(_)))
 }
 
@@ -138,19 +135,19 @@ async fn optimize_dependencies(
     let batch = items
       .par_iter()
       .filter_map(|exports_info| {
-        let exports_info_data = ExportsInfoGetter::prefetch(
-          exports_info,
-          exports_info_artifact,
-          PrefetchExportsInfoMode::Default,
-        );
+        let exports_info_data = *exports_info;
         let export_list = {
           // If there are other usage (e.g. `import { Kind } from './enum'; Kind;`) in any runtime,
           // then we cannot inline this export.
-          if exports_info_data.other_exports_info().get_used(None) != UsageState::Unused {
+          if exports_info_data
+            .other_exports_info(exports_info_artifact)
+            .get_used(None)
+            != UsageState::Unused
+          {
             return None;
           }
           exports_info_data
-            .exports()
+            .exports(exports_info_artifact)
             .map(|(_, export_info_data)| {
               let do_inline = !export_info_data.has_used_name()
                 && export_info_data.can_inline() == Some(true)

--- a/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
@@ -42,7 +42,7 @@ pub fn is_export_inlined(
     );
   }
 
-  let exports_info = exports_info_artifact.get_exports_info(module);
+  let exports_info = exports_info_artifact.get_exports_info_data(module);
   let used_name = exports_info.get_used_name(exports_info_artifact, runtime, ids);
   matches!(used_name, Some(UsedName::Inlined(_)))
 }
@@ -135,20 +135,17 @@ async fn optimize_dependencies(
     let batch = items
       .par_iter()
       .filter_map(|exports_info| {
-        let exports_info_data = *exports_info;
+        let exports_info_data = exports_info.as_data(exports_info_artifact);
         let export_list = {
           // If there are other usage (e.g. `import { Kind } from './enum'; Kind;`) in any runtime,
           // then we cannot inline this export.
-          if exports_info_data
-            .other_exports_info(exports_info_artifact)
-            .get_used(None)
-            != UsageState::Unused
-          {
+          if exports_info_data.other_exports_info().get_used(None) != UsageState::Unused {
             return None;
           }
           exports_info_data
-            .exports(exports_info_artifact)
-            .map(|(_, export_info_data)| {
+            .exports()
+            .values()
+            .map(|export_info_data| {
               let do_inline = !export_info_data.has_used_name()
                 && export_info_data.can_inline() == Some(true)
                 && matches!(export_info_data.provided(), Some(ExportProvided::Provided));

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -5,8 +5,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   BuildMetaExportsType, Compilation, CompilationOptimizeCodeGeneration, ExportInfo, ExportProvided,
-  ExportsInfo, ExportsInfoArtifact, ExportsInfoGetter, Plugin, PrefetchExportsInfoMode,
-  PrefetchedExportsInfoWrapper, UsageState, UsedNameItem,
+  ExportsInfo, ExportsInfoArtifact, Plugin, UsageState, UsedNameItem,
   build_module_graph::BuildModuleGraphArtifact, incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
@@ -19,12 +18,16 @@ use crate::utils::mangle_exports::{
   NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS, NUMBER_OF_IDENTIFIER_START_CHARS, number_to_identifier,
 };
 
-fn can_mangle(exports_info: &PrefetchedExportsInfoWrapper<'_>) -> bool {
-  if exports_info.other_exports_info().get_used(None) != UsageState::Unused {
+fn can_mangle(exports_info_artifact: &ExportsInfoArtifact, exports_info: &ExportsInfo) -> bool {
+  if exports_info
+    .other_exports_info(exports_info_artifact)
+    .get_used(None)
+    != UsageState::Unused
+  {
     return false;
   }
   let mut has_something_to_mangle = false;
-  for (_, export_info) in exports_info.exports() {
+  for (_, export_info) in exports_info.exports(exports_info_artifact) {
     if export_info.can_mangle() == Some(true) {
       has_something_to_mangle = true;
     }
@@ -142,17 +145,13 @@ async fn optimize_code_generation(
       .filter_map(|(exports_info, is_namespace)| {
         let mut avoid_mangle_non_provided = !is_namespace;
         let deterministic = self.deterministic;
-        let exports_info_data = ExportsInfoGetter::prefetch(
-          exports_info,
-          exports_info_artifact,
-          PrefetchExportsInfoMode::Default,
-        );
+        let exports_info_data = *exports_info;
         let export_list = {
-          if !can_mangle(&exports_info_data) {
+          if !can_mangle(exports_info_artifact, &exports_info_data) {
             return None;
           }
           if !avoid_mangle_non_provided && deterministic {
-            for (_, export_info) in exports_info_data.exports() {
+            for (_, export_info) in exports_info_data.exports(exports_info_artifact) {
               if !matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
                 avoid_mangle_non_provided = true;
                 break;
@@ -160,7 +159,7 @@ async fn optimize_code_generation(
             }
           }
           exports_info_data
-            .exports()
+            .exports(exports_info_artifact)
             .map(|(_, export_info)| export_info)
             .collect::<Vec<_>>()
         };

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   BuildMetaExportsType, Compilation, CompilationOptimizeCodeGeneration, ExportInfo, ExportProvided,
-  ExportsInfo, ExportsInfoArtifact, Plugin, UsageState, UsedNameItem,
+  ExportsInfo, ExportsInfoArtifact, ExportsInfoData, Plugin, UsageState, UsedNameItem,
   build_module_graph::BuildModuleGraphArtifact, incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
@@ -18,16 +18,12 @@ use crate::utils::mangle_exports::{
   NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS, NUMBER_OF_IDENTIFIER_START_CHARS, number_to_identifier,
 };
 
-fn can_mangle(exports_info_artifact: &ExportsInfoArtifact, exports_info: &ExportsInfo) -> bool {
-  if exports_info
-    .other_exports_info(exports_info_artifact)
-    .get_used(None)
-    != UsageState::Unused
-  {
+fn can_mangle(exports_info: &ExportsInfoData) -> bool {
+  if exports_info.other_exports_info().get_used(None) != UsageState::Unused {
     return false;
   }
   let mut has_something_to_mangle = false;
-  for (_, export_info) in exports_info.exports(exports_info_artifact) {
+  for export_info in exports_info.exports().values() {
     if export_info.can_mangle() == Some(true) {
       has_something_to_mangle = true;
     }
@@ -145,23 +141,20 @@ async fn optimize_code_generation(
       .filter_map(|(exports_info, is_namespace)| {
         let mut avoid_mangle_non_provided = !is_namespace;
         let deterministic = self.deterministic;
-        let exports_info_data = *exports_info;
+        let exports_info_data = exports_info.as_data(exports_info_artifact);
         let export_list = {
-          if !can_mangle(exports_info_artifact, &exports_info_data) {
+          if !can_mangle(exports_info_data) {
             return None;
           }
           if !avoid_mangle_non_provided && deterministic {
-            for (_, export_info) in exports_info_data.exports(exports_info_artifact) {
+            for export_info in exports_info_data.exports().values() {
               if !matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
                 avoid_mangle_non_provided = true;
                 break;
               }
             }
           }
-          exports_info_data
-            .exports(exports_info_artifact)
-            .map(|(_, export_info)| export_info)
-            .collect::<Vec<_>>()
+          exports_info_data.exports().values().collect::<Vec<_>>()
         };
 
         Some((

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -10,8 +10,7 @@ use rspack_core::{
   DependencyType, ExportProvided, ExportsInfoArtifact, ExtendedReferencedExport, GetTargetResult,
   ImportedByDeferModulesArtifact, LibIdentOptions, Logger, ModuleGraph, ModuleGraphCacheArtifact,
   ModuleGraphConnection, ModuleGraphModule, ModuleIdentifier, OptimizationBailoutItem, Plugin,
-  PrefetchExportsInfoMode, ProvidedExports, RuntimeCondition, RuntimeSpec,
-  SideEffectsStateArtifact, SourceType,
+  ProvidedExports, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, SourceType,
   concatenated_module::{
     ConcatenatedInnerModule, ConcatenatedModule, RootModuleContext, is_esm_dep_like,
   },
@@ -747,8 +746,9 @@ impl ModuleConcatenationPlugin {
 
         let exports_info = compilation
           .exports_info_artifact
-          .get_prefetched_exports_info(&module_id, PrefetchExportsInfoMode::Default);
-        let relevant_exports = exports_info.get_relevant_exports(None);
+          .get_exports_info(&module_id);
+        let relevant_exports =
+          exports_info.get_relevant_exports(&compilation.exports_info_artifact, None);
         let unknown_exports = relevant_exports
           .iter()
           .filter(|export_info| {
@@ -903,9 +903,9 @@ impl ModuleConcatenationPlugin {
       .map(|module_id| {
         let exports_info = compilation
           .exports_info_artifact
-          .get_prefetched_exports_info(&module_id, PrefetchExportsInfoMode::Default);
+          .get_exports_info(&module_id);
         let provided_names = matches!(
-          exports_info.get_provided_exports(),
+          exports_info.get_provided_exports(&compilation.exports_info_artifact),
           ProvidedExports::ProvidedNames(_)
         );
         let module = module_graph
@@ -1043,8 +1043,10 @@ impl ModuleConcatenationPlugin {
       let module_graph_cache = &compilation.module_graph_cache_artifact;
       let exports_info = compilation
         .exports_info_artifact
-        .get_prefetched_exports_info(current_root, PrefetchExportsInfoMode::Default);
-      let filtered_runtime = filter_runtime(Some(runtime), |r| exports_info.is_module_used(r));
+        .get_exports_info(current_root);
+      let filtered_runtime = filter_runtime(Some(runtime), |r| {
+        exports_info.is_module_used(&compilation.exports_info_artifact, r)
+      });
       let active_runtime = match filtered_runtime {
         RuntimeCondition::Boolean(true) => Some(runtime.clone()),
         RuntimeCondition::Boolean(false) => None,

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -746,9 +746,8 @@ impl ModuleConcatenationPlugin {
 
         let exports_info = compilation
           .exports_info_artifact
-          .get_exports_info(&module_id);
-        let relevant_exports =
-          exports_info.get_relevant_exports(&compilation.exports_info_artifact, None);
+          .get_exports_info_data(&module_id);
+        let relevant_exports = exports_info.get_relevant_exports(None);
         let unknown_exports = relevant_exports
           .iter()
           .filter(|export_info| {
@@ -903,9 +902,9 @@ impl ModuleConcatenationPlugin {
       .map(|module_id| {
         let exports_info = compilation
           .exports_info_artifact
-          .get_exports_info(&module_id);
+          .get_exports_info_data(&module_id);
         let provided_names = matches!(
-          exports_info.get_provided_exports(&compilation.exports_info_artifact),
+          exports_info.get_provided_exports(),
           ProvidedExports::ProvidedNames(_)
         );
         let module = module_graph
@@ -1043,10 +1042,8 @@ impl ModuleConcatenationPlugin {
       let module_graph_cache = &compilation.module_graph_cache_artifact;
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(current_root);
-      let filtered_runtime = filter_runtime(Some(runtime), |r| {
-        exports_info.is_module_used(&compilation.exports_info_artifact, r)
-      });
+        .get_exports_info_data(current_root);
+      let filtered_runtime = filter_runtime(Some(runtime), |r| exports_info.is_module_used(r));
       let active_runtime = match filtered_runtime {
         RuntimeCondition::Boolean(true) => Some(runtime.clone()),
         RuntimeCondition::Boolean(false) => None,

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -208,10 +208,9 @@ async fn finish_modules(
           };
 
           let target_exports_info = exports_info_artifact
-            .get_exports_info(ref_module);
+            .get_exports_info_data(ref_module);
           let target_export_info =
-            target_exports_info
-              .get_export_info_without_mut_module_graph(exports_info_artifact, &deferred_check.atom);
+            target_exports_info.get_export_info_without_mut_module_graph(&deferred_check.atom);
           let resolve_filter = |_: &ResolvedExportInfoTarget| true;
 
           let (ref_module_id, atom) = if let Some(GetTargetResult::Target(target)) = get_target(
@@ -513,9 +512,8 @@ fn can_optimize_connection(
   if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
     && let Some(name) = &dep.name
   {
-    let exports_info = exports_info_artifact.get_exports_info(&original_module);
-    let export_info =
-      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, name);
+    let exports_info = exports_info_artifact.get_exports_info_data(&original_module);
+    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
 
     let resolve_filter = |target: &ResolvedExportInfoTarget| {
       side_effects_state_map[&target.module] == ConnectionState::Active(false)
@@ -559,9 +557,8 @@ fn can_optimize_connection(
     && let ids = dep.get_ids(module_graph)
     && !ids.is_empty()
   {
-    let exports_info = exports_info_artifact.get_exports_info(connection.module_identifier());
-    let export_info =
-      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, &ids[0]);
+    let exports_info = exports_info_artifact.get_exports_info_data(connection.module_identifier());
+    let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
 
     let resolve_filter = |target: &ResolvedExportInfoTarget| {
       side_effects_state_map[&target.module] == ConnectionState::Active(false)

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -7,9 +7,9 @@ use rspack_core::{
   CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta, DependencyId,
   ExportsInfoArtifact, FactoryMeta, GetTargetResult, Logger, ModuleFactoryCreateData, ModuleGraph,
   ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData, NormalModuleFactoryModule,
-  OptimizationBailoutItem, Plugin, PrefetchExportsInfoMode, ResolvedExportInfoTarget,
-  SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact,
-  SideEffectsState, SideEffectsStateArtifact,
+  OptimizationBailoutItem, Plugin, ResolvedExportInfoTarget, SideEffectsDoOptimize,
+  SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact, SideEffectsState,
+  SideEffectsStateArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   can_move_target, get_target,
   incremental::{self, IncrementalPasses, Mutation},
@@ -208,9 +208,10 @@ async fn finish_modules(
           };
 
           let target_exports_info = exports_info_artifact
-            .get_prefetched_exports_info(ref_module, PrefetchExportsInfoMode::Default);
+            .get_exports_info(ref_module);
           let target_export_info =
-            target_exports_info.get_export_info_without_mut_module_graph(&deferred_check.atom);
+            target_exports_info
+              .get_export_info_without_mut_module_graph(exports_info_artifact, &deferred_check.atom);
           let resolve_filter = |_: &ResolvedExportInfoTarget| true;
 
           let (ref_module_id, atom) = if let Some(GetTargetResult::Target(target)) = get_target(
@@ -512,9 +513,9 @@ fn can_optimize_connection(
   if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
     && let Some(name) = &dep.name
   {
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(&original_module, PrefetchExportsInfoMode::Default);
-    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let exports_info = exports_info_artifact.get_exports_info(&original_module);
+    let export_info =
+      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, name);
 
     let resolve_filter = |target: &ResolvedExportInfoTarget| {
       side_effects_state_map[&target.module] == ConnectionState::Active(false)
@@ -558,11 +559,9 @@ fn can_optimize_connection(
     && let ids = dep.get_ids(module_graph)
     && !ids.is_empty()
   {
-    let exports_info = exports_info_artifact.get_prefetched_exports_info(
-      connection.module_identifier(),
-      PrefetchExportsInfoMode::Default,
-    );
-    let export_info = exports_info.get_export_info_without_mut_module_graph(&ids[0]);
+    let exports_info = exports_info_artifact.get_exports_info(connection.module_identifier());
+    let export_info =
+      exports_info.get_export_info_without_mut_module_graph(exports_info_artifact, &ids[0]);
 
     let resolve_filter = |target: &ResolvedExportInfoTarget| {
       side_effects_state_map[&target.module] == ConnectionState::Active(false)

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -12,7 +12,7 @@ use json::{
 };
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ExportsInfo, ExportsInfoArtifact,
+  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ExportsInfoArtifact, ExportsInfoData,
   GenerateContext, Module, ModuleArgument, ModuleGraph, NAMESPACE_OBJECT_EXPORT, ParseOption,
   ParserAndGenerator, Plugin, RuntimeSpec, SourceType, UsageState, UsedNameItem,
   diagnostics::ModuleParseError,
@@ -189,14 +189,12 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .expect("should have json data");
         let exports_info = compilation
           .exports_info_artifact
-          .get_exports_info(&module.identifier());
+          .get_exports_info_data(&module.identifier());
 
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
             if matches!(
-              exports_info
-                .other_exports_info(&compilation.exports_info_artifact)
-                .get_used(*runtime),
+              exports_info.other_exports_info().get_used(*runtime),
               UsageState::Unused
             ) =>
           {
@@ -287,15 +285,11 @@ impl Plugin for JsonPlugin {
 
 pub fn create_object_for_exports_info(
   data: JsonValue,
-  exports_info: &ExportsInfo,
+  exports_info: &ExportsInfoData,
   runtime: Option<&RuntimeSpec>,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> JsonValue {
-  if exports_info
-    .other_exports_info(exports_info_artifact)
-    .get_used(runtime)
-    != UsageState::Unused
-  {
+  if exports_info.other_exports_info().get_used(runtime) != UsageState::Unused {
     return data;
   }
 
@@ -308,8 +302,7 @@ pub fn create_object_for_exports_info(
     JsonValue::Object(mut obj) => {
       let mut used_pair = vec![];
       for (key, value) in obj.iter_mut() {
-        let export_info =
-          exports_info.get_read_only_export_info(exports_info_artifact, &key.into());
+        let export_info = exports_info.get_read_only_export_info(&key.into());
         let used = export_info.get_used(runtime);
         if used == UsageState::Unused {
           continue;
@@ -319,7 +312,7 @@ pub fn create_object_for_exports_info(
         {
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
-          let exports_info = exports_info;
+          let exports_info = exports_info.as_data(exports_info_artifact);
           create_object_for_exports_info(temp, &exports_info, runtime, exports_info_artifact)
         } else {
           std::mem::replace(value, JsonValue::Null)
@@ -347,8 +340,7 @@ pub fn create_object_for_exports_info(
         .map(|(i, item)| {
           let mut i_buffer = itoa::Buffer::new();
           let i_str = i_buffer.format(i);
-          let export_info =
-            exports_info.get_read_only_export_info(exports_info_artifact, &i_str.into());
+          let export_info = exports_info.get_read_only_export_info(&i_str.into());
           let used = export_info.get_used(runtime);
           if used == UsageState::Unused {
             return None;
@@ -357,7 +349,7 @@ pub fn create_object_for_exports_info(
           if used == UsageState::OnlyPropertiesUsed
             && let Some(exports_info) = export_info.exports_info()
           {
-            let exports_info = exports_info;
+            let exports_info = exports_info.as_data(exports_info_artifact);
             Some(create_object_for_exports_info(
               item,
               &exports_info,
@@ -370,7 +362,7 @@ pub fn create_object_for_exports_info(
         })
         .collect::<Vec<_>>();
       let arr_length_used = exports_info
-        .get_read_only_export_info(exports_info_artifact, &"length".into())
+        .get_read_only_export_info(&"length".into())
         .get_used(runtime);
       let array_length_when_used = match arr_length_used {
         UsageState::Unused => None,

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -200,7 +200,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           {
             create_object_for_exports_info(
               json_data.clone(),
-              &exports_info,
+              exports_info,
               *runtime,
               &compilation.exports_info_artifact,
             )
@@ -313,7 +313,7 @@ pub fn create_object_for_exports_info(
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
           let exports_info = exports_info.as_data(exports_info_artifact);
-          create_object_for_exports_info(temp, &exports_info, runtime, exports_info_artifact)
+          create_object_for_exports_info(temp, exports_info, runtime, exports_info_artifact)
         } else {
           std::mem::replace(value, JsonValue::Null)
         };
@@ -352,7 +352,7 @@ pub fn create_object_for_exports_info(
             let exports_info = exports_info.as_data(exports_info_artifact);
             Some(create_object_for_exports_info(
               item,
-              &exports_info,
+              exports_info,
               runtime,
               exports_info_artifact,
             ))

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -12,10 +12,9 @@ use json::{
 };
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ExportsInfoArtifact, ExportsInfoGetter,
+  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ExportsInfo, ExportsInfoArtifact,
   GenerateContext, Module, ModuleArgument, ModuleGraph, NAMESPACE_OBJECT_EXPORT, ParseOption,
-  ParserAndGenerator, Plugin, PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, RuntimeSpec,
-  SourceType, UsageState, UsedNameItem,
+  ParserAndGenerator, Plugin, RuntimeSpec, SourceType, UsageState, UsedNameItem,
   diagnostics::ModuleParseError,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source, SourceExt},
 };
@@ -190,12 +189,14 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .expect("should have json data");
         let exports_info = compilation
           .exports_info_artifact
-          .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
+          .get_exports_info(&module.identifier());
 
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
             if matches!(
-              exports_info.other_exports_info().get_used(*runtime),
+              exports_info
+                .other_exports_info(&compilation.exports_info_artifact)
+                .get_used(*runtime),
               UsageState::Unused
             ) =>
           {
@@ -286,11 +287,15 @@ impl Plugin for JsonPlugin {
 
 pub fn create_object_for_exports_info(
   data: JsonValue,
-  exports_info: &PrefetchedExportsInfoWrapper<'_>,
+  exports_info: &ExportsInfo,
   runtime: Option<&RuntimeSpec>,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> JsonValue {
-  if exports_info.other_exports_info().get_used(runtime) != UsageState::Unused {
+  if exports_info
+    .other_exports_info(exports_info_artifact)
+    .get_used(runtime)
+    != UsageState::Unused
+  {
     return data;
   }
 
@@ -303,7 +308,8 @@ pub fn create_object_for_exports_info(
     JsonValue::Object(mut obj) => {
       let mut used_pair = vec![];
       for (key, value) in obj.iter_mut() {
-        let export_info = exports_info.get_read_only_export_info(&key.into());
+        let export_info =
+          exports_info.get_read_only_export_info(exports_info_artifact, &key.into());
         let used = export_info.get_used(runtime);
         if used == UsageState::Unused {
           continue;
@@ -313,11 +319,7 @@ pub fn create_object_for_exports_info(
         {
           // avoid clone
           let temp = std::mem::replace(value, JsonValue::Null);
-          let exports_info = ExportsInfoGetter::prefetch(
-            &exports_info,
-            exports_info_artifact,
-            PrefetchExportsInfoMode::Default,
-          );
+          let exports_info = exports_info;
           create_object_for_exports_info(temp, &exports_info, runtime, exports_info_artifact)
         } else {
           std::mem::replace(value, JsonValue::Null)
@@ -345,7 +347,8 @@ pub fn create_object_for_exports_info(
         .map(|(i, item)| {
           let mut i_buffer = itoa::Buffer::new();
           let i_str = i_buffer.format(i);
-          let export_info = exports_info.get_read_only_export_info(&i_str.into());
+          let export_info =
+            exports_info.get_read_only_export_info(exports_info_artifact, &i_str.into());
           let used = export_info.get_used(runtime);
           if used == UsageState::Unused {
             return None;
@@ -354,11 +357,7 @@ pub fn create_object_for_exports_info(
           if used == UsageState::OnlyPropertiesUsed
             && let Some(exports_info) = export_info.exports_info()
           {
-            let exports_info = ExportsInfoGetter::prefetch(
-              &exports_info,
-              exports_info_artifact,
-              PrefetchExportsInfoMode::Default,
-            );
+            let exports_info = exports_info;
             Some(create_object_for_exports_info(
               item,
               &exports_info,
@@ -371,7 +370,7 @@ pub fn create_object_for_exports_info(
         })
         .collect::<Vec<_>>();
       let arr_length_used = exports_info
-        .get_read_only_export_info(&"length".into())
+        .get_read_only_export_info(exports_info_artifact, &"length".into())
         .get_used(runtime);
       let array_length_when_used = match arr_length_used {
         UsageState::Unused => None,

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -8,8 +8,8 @@ use rspack_core::{
   CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules, CompilationParams,
   CompilerCompilation, EntryData, ExportProvided, ExportsInfoArtifact, Filename, LibraryExport,
   LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData, Plugin,
-  PrefetchExportsInfoMode, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, RuntimeVariable,
-  SideEffectsStateArtifact, SourceType, UsageState, get_entry_runtime, property_access,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, RuntimeVariable, SideEffectsStateArtifact,
+  SourceType, UsageState, get_entry_runtime, property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -269,12 +269,10 @@ async fn render_startup(
   let exports_name = runtime_template.render_runtime_variable(&RuntimeVariable::Exports);
   if matches!(self.options.unnamed, Unnamed::Static) {
     let export_target = access_with_init(&full_name_resolved, self.options.prefix.len(), true);
-    let exports_info = compilation
-      .exports_info_artifact
-      .get_prefetched_exports_info(module, PrefetchExportsInfoMode::Default);
+    let exports_info = compilation.exports_info_artifact.get_exports_info(module);
     let mut provided = vec![];
     let exports_name = runtime_template.render_runtime_variable(&RuntimeVariable::Exports);
-    for (_, export_info) in exports_info.exports() {
+    for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
       }

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -269,10 +269,12 @@ async fn render_startup(
   let exports_name = runtime_template.render_runtime_variable(&RuntimeVariable::Exports);
   if matches!(self.options.unnamed, Unnamed::Static) {
     let export_target = access_with_init(&full_name_resolved, self.options.prefix.len(), true);
-    let exports_info = compilation.exports_info_artifact.get_exports_info(module);
+    let exports_info = compilation
+      .exports_info_artifact
+      .get_exports_info_data(module);
     let mut provided = vec![];
     let exports_name = runtime_template.render_runtime_variable(&RuntimeVariable::Exports);
-    for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
+    for export_info in exports_info.exports().values() {
       if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
         continue;
       }

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -2,8 +2,8 @@ use std::hash::Hash;
 
 use rspack_core::{
   ChunkUkey, Compilation, CompilationParams, CompilerCompilation, ExportProvided, ExportsType,
-  LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, PrefetchExportsInfoMode,
-  RuntimeCodeTemplate, RuntimeVariable, UsedNameItem, property_access,
+  LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, RuntimeCodeTemplate, RuntimeVariable,
+  UsedNameItem, property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier, to_module_export_name,
 };
@@ -79,9 +79,7 @@ async fn render_startup(
       "{exports_name} = await {exports_name};\n"
     )));
   }
-  let exports_info = compilation
-    .exports_info_artifact
-    .get_prefetched_exports_info(module, PrefetchExportsInfoMode::Default);
+  let exports_info = compilation.exports_info_artifact.get_exports_info(module);
   let boxed_module = module_graph
     .module_by_identifier(module)
     .expect("should have build meta");
@@ -91,7 +89,7 @@ async fn render_startup(
     &compilation.exports_info_artifact,
     boxed_module.build_info().strict,
   );
-  for (_, export_info) in exports_info.exports() {
+  for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
     if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
       continue;
     };

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -79,7 +79,9 @@ async fn render_startup(
       "{exports_name} = await {exports_name};\n"
     )));
   }
-  let exports_info = compilation.exports_info_artifact.get_exports_info(module);
+  let exports_info = compilation
+    .exports_info_artifact
+    .get_exports_info_data(module);
   let boxed_module = module_graph
     .module_by_identifier(module)
     .expect("should have build meta");
@@ -89,7 +91,7 @@ async fn render_startup(
     &compilation.exports_info_artifact,
     boxed_module.build_info().strict,
   );
-  for (_, export_info) in exports_info.exports(&compilation.exports_info_artifact) {
+  for export_info in exports_info.exports().values() {
     if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
       continue;
     };

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -3,10 +3,9 @@ use std::{borrow::Cow, hash::Hash};
 use rspack_cacheable::with::AsVecConverter;
 use rspack_core::{
   BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkUkey, Compilation, CompilationParams,
-  CompilerCompilation, ExportInfo, ExportProvided, ExportsInfoArtifact, ExportsInfoGetter,
+  CompilerCompilation, ExportInfo, ExportProvided, ExportsInfo, ExportsInfoArtifact,
   GetTargetResult, Module, ModuleGraph, ModuleIdentifier, OptimizationBailoutItem, Plugin,
-  PrefetchExportsInfoMode, PrefetchedExportsInfoWrapper, RuntimeCodeTemplate, UsageState,
-  get_target,
+  RuntimeCodeTemplate, UsageState, get_target,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_comment_with_nl,
 };
@@ -31,7 +30,7 @@ pub struct ModuleInfoHeaderPlugin {
 fn print_exports_info_to_source<F>(
   source: &mut ConcatSource,
   ident: &str,
-  exports_info: &PrefetchedExportsInfoWrapper<'_>,
+  exports_info: &ExportsInfo,
   request_shortener: &F,
   already_printed: &mut FxHashSet<ExportInfo>,
   module_graph: &ModuleGraph,
@@ -39,13 +38,13 @@ fn print_exports_info_to_source<F>(
 ) where
   F: Fn(&ModuleIdentifier) -> String,
 {
-  let other_exports_info = exports_info.other_exports_info();
+  let other_exports_info = exports_info.other_exports_info(exports_info_artifact);
 
   let mut already_printed_exports = 0;
 
   let mut printed_exports = vec![];
 
-  for (_, export_info) in exports_info.exports() {
+  for (_, export_info) in exports_info.exports(exports_info_artifact) {
     let export_info_id = export_info.id();
     if !already_printed.contains(&export_info_id) {
       already_printed.insert(export_info_id);
@@ -97,11 +96,7 @@ fn print_exports_info_to_source<F>(
     source.add(RawStringSource::from(to_comment_with_nl(&export_str)));
 
     if let Some(exports_info) = &export_info.exports_info() {
-      let exports_info = ExportsInfoGetter::prefetch(
-        exports_info,
-        exports_info_artifact,
-        PrefetchExportsInfoMode::Default,
-      );
+      let exports_info = *exports_info;
       print_exports_info_to_source(
         source,
         &format!("{ident}  "),
@@ -263,7 +258,7 @@ async fn render_js_module_package(
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
+      .get_exports_info(&module.identifier());
 
     if !matches!(export_type, BuildMetaExportsType::Unset) {
       let request_shortener = |id: &ModuleIdentifier| {

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, hash::Hash};
 use rspack_cacheable::with::AsVecConverter;
 use rspack_core::{
   BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkUkey, Compilation, CompilationParams,
-  CompilerCompilation, ExportInfo, ExportProvided, ExportsInfo, ExportsInfoArtifact,
+  CompilerCompilation, ExportInfo, ExportProvided, ExportsInfoArtifact, ExportsInfoData,
   GetTargetResult, Module, ModuleGraph, ModuleIdentifier, OptimizationBailoutItem, Plugin,
   RuntimeCodeTemplate, UsageState, get_target,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
@@ -30,7 +30,7 @@ pub struct ModuleInfoHeaderPlugin {
 fn print_exports_info_to_source<F>(
   source: &mut ConcatSource,
   ident: &str,
-  exports_info: &ExportsInfo,
+  exports_info: &ExportsInfoData,
   request_shortener: &F,
   already_printed: &mut FxHashSet<ExportInfo>,
   module_graph: &ModuleGraph,
@@ -38,13 +38,13 @@ fn print_exports_info_to_source<F>(
 ) where
   F: Fn(&ModuleIdentifier) -> String,
 {
-  let other_exports_info = exports_info.other_exports_info(exports_info_artifact);
+  let other_exports_info = exports_info.other_exports_info();
 
   let mut already_printed_exports = 0;
 
   let mut printed_exports = vec![];
 
-  for (_, export_info) in exports_info.exports(exports_info_artifact) {
+  for export_info in exports_info.exports().values() {
     let export_info_id = export_info.id();
     if !already_printed.contains(&export_info_id) {
       already_printed.insert(export_info_id);
@@ -95,12 +95,11 @@ fn print_exports_info_to_source<F>(
 
     source.add(RawStringSource::from(to_comment_with_nl(&export_str)));
 
-    if let Some(exports_info) = &export_info.exports_info() {
-      let exports_info = *exports_info;
+    if let Some(exports_info) = export_info.exports_info() {
       print_exports_info_to_source(
         source,
         &format!("{ident}  "),
-        &exports_info,
+        exports_info.as_data(exports_info_artifact),
         request_shortener,
         already_printed,
         module_graph,
@@ -258,7 +257,7 @@ async fn render_js_module_package(
 
     let exports_info = compilation
       .exports_info_artifact
-      .get_exports_info(&module.identifier());
+      .get_exports_info_data(&module.identifier());
 
     if !matches!(export_type, BuildMetaExportsType::Unset) {
       let request_shortener = |id: &ModuleIdentifier| {

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -271,7 +271,7 @@ async fn render_js_module_package(
       print_exports_info_to_source(
         &mut new_source,
         "",
-        &exports_info,
+        exports_info,
         &request_shortener,
         &mut FxHashSet::default(),
         module_graph,

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -157,8 +157,8 @@ fn filter_client_components(
     if side_effect_free {
       let exports_info = compilation
         .exports_info_artifact
-        .get_exports_info(&module.identifier());
-      let unused = !exports_info.is_module_used(&compilation.exports_info_artifact, Some(runtime));
+        .get_exports_info_data(&module.identifier());
+      let unused = !exports_info.is_module_used(Some(runtime));
       if unused {
         return;
       }

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -1,7 +1,7 @@
 use derive_more::Debug;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  Compilation, DependencyId, Module, PrefetchExportsInfoMode, RscMeta, RscModuleType, RuntimeSpec,
+  Compilation, DependencyId, Module, RscMeta, RscModuleType, RuntimeSpec,
   module_declared_side_effect_free,
 };
 use rspack_plugin_javascript::dependency::{
@@ -155,10 +155,10 @@ fn filter_client_components(
     let side_effect_free = module_declared_side_effect_free(module).unwrap_or(false);
 
     if side_effect_free {
-      let prefetched_exports_info = compilation
+      let exports_info = compilation
         .exports_info_artifact
-        .get_prefetched_exports_info(&module.identifier(), PrefetchExportsInfoMode::Default);
-      let unused = !prefetched_exports_info.is_module_used(Some(runtime));
+        .get_exports_info(&module.identifier());
+      let unused = !exports_info.is_module_used(&compilation.exports_info_artifact, Some(runtime));
       if unused {
         return;
       }

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -34,25 +34,21 @@ pub fn collect_json_module_sizes(
       continue;
     };
 
-    let exports_info = exports_info_artifact.get_exports_info(module_id);
+    let exports_info = exports_info_artifact.get_exports_info_data(module_id);
 
     let final_json = match json_data {
       json::JsonValue::Object(_) | json::JsonValue::Array(_) => {
-        let needs_tree_shaking = exports_info
-          .other_exports_info(exports_info_artifact)
-          .get_used(None)
+        let needs_tree_shaking = exports_info.other_exports_info().get_used(None)
           == UsageState::Unused
-          || exports_info
-            .exports(exports_info_artifact)
-            .any(|(_, info)| {
-              let used = info.get_used(None);
-              used == UsageState::Unused || used == UsageState::OnlyPropertiesUsed
-            });
+          || exports_info.exports().values().any(|info| {
+            let used = info.get_used(None);
+            used == UsageState::Unused || used == UsageState::OnlyPropertiesUsed
+          });
 
         if needs_tree_shaking {
           create_object_for_exports_info(
             json_data.clone(),
-            &exports_info,
+            exports_info,
             None,
             exports_info_artifact,
           )

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -5,7 +5,7 @@ use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_core::{
   BoxModule, ChunkGraph, Compilation, Context, DependencyId, DependencyType, ExportsInfoArtifact,
   Module, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdsArtifact, ModuleType,
-  OptimizationBailoutItem, PrefetchExportsInfoMode, SideEffectsStateArtifact, UsageState,
+  OptimizationBailoutItem, SideEffectsStateArtifact, UsageState,
   rspack_sources::{MapOptions, ObjectPool},
 };
 use rspack_paths::Utf8PathBuf;
@@ -34,17 +34,20 @@ pub fn collect_json_module_sizes(
       continue;
     };
 
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(module_id, PrefetchExportsInfoMode::Default);
+    let exports_info = exports_info_artifact.get_exports_info(module_id);
 
     let final_json = match json_data {
       json::JsonValue::Object(_) | json::JsonValue::Array(_) => {
-        let needs_tree_shaking = exports_info.other_exports_info().get_used(None)
+        let needs_tree_shaking = exports_info
+          .other_exports_info(exports_info_artifact)
+          .get_used(None)
           == UsageState::Unused
-          || exports_info.exports().any(|(_, info)| {
-            let used = info.get_used(None);
-            used == UsageState::Unused || used == UsageState::OnlyPropertiesUsed
-          });
+          || exports_info
+            .exports(exports_info_artifact)
+            .any(|(_, info)| {
+              let used = info.get_used(None);
+              used == UsageState::Unused || used == UsageState::OnlyPropertiesUsed
+            });
 
         if needs_tree_shaking {
           create_object_for_exports_info(

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -128,7 +128,7 @@ impl Combinator {
     chunk_by_ukey: &ChunkByUkey,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Vec<ChunkCombination> {
-    let exports_info = exports_info_artifact.get_exports_info(module_identifier);
+    let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, FxHashSet<ChunkUkey>> = Default::default();
     let mut runtime_key_map = RuntimeKeyMap::default();
     for chunk_ukey in module_chunks {
@@ -136,7 +136,7 @@ impl Combinator {
       let runtime = chunk.runtime();
       let usage_key = runtime_key_map
         .entry(get_runtime_key(runtime).clone())
-        .or_insert_with(|| exports_info.get_usage_key(exports_info_artifact, Some(runtime)))
+        .or_insert_with(|| exports_info.get_usage_key(Some(runtime)))
         .clone();
 
       grouped_by_used_exports

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module, ModuleIdentifier,
-  PrefetchExportsInfoMode, RuntimeKeyMap, UsageKey, get_runtime_key,
+  RuntimeKeyMap, UsageKey, get_runtime_key,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_util::{
@@ -128,8 +128,7 @@ impl Combinator {
     chunk_by_ukey: &ChunkByUkey,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Vec<ChunkCombination> {
-    let exports_info = exports_info_artifact
-      .get_prefetched_exports_info(module_identifier, PrefetchExportsInfoMode::Default);
+    let exports_info = exports_info_artifact.get_exports_info(module_identifier);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, FxHashSet<ChunkUkey>> = Default::default();
     let mut runtime_key_map = RuntimeKeyMap::default();
     for chunk_ukey in module_chunks {
@@ -137,7 +136,7 @@ impl Combinator {
       let runtime = chunk.runtime();
       let usage_key = runtime_key_map
         .entry(get_runtime_key(runtime).clone())
-        .or_insert_with(|| exports_info.get_usage_key(Some(runtime)))
+        .or_insert_with(|| exports_info.get_usage_key(exports_info_artifact, Some(runtime)))
         .clone();
 
       grouped_by_used_exports


### PR DESCRIPTION
## Summary

prefetch functions is not necessary anymore, prefetch functions is used to avoid calling `&ModuleGraph` and `&mut ModuleGraph` at same time to enable parallel, since we move the exports info store from `module_graph` to `exports_info_artifact`, the `&mg / &mut mg` problem doesn't exists anymore, so the prefetch functions is also not needed anymore

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
