### PR TITLE
docs(v1): add algolia site verification meta

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -52,7 +52,9 @@ export default defineConfig({
         },
       ],
     }),
-    pluginAlgolia(),
+    pluginAlgolia({
+      verificationContent: '6D9207CF5E163D9F',
+    }),
     pluginLlms(),
     pluginSitemap({
       siteUrl: PUBLISH_URL,


### PR DESCRIPTION
## Summary

- Build searchIndex for V1
- Add Algolia site verification meta first through `pluginAlgolia` configuration in `website/rspress.config.ts`:

- set `verificationContent: '6D9207CF5E163D9F'`
- keep existing HTML meta injection unchanged except removing manual Algolia tag insertion

## Related links

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
