### PR TITLE
chore: document loader getOptions query string parsing

### DIFF
--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -399,7 +399,7 @@ module.exports = function myLoader(source) {
 :::tip
 When a loader is configured with a query string such as `loader: './my-loader?s=foo+bar'`, `this.getOptions()` parses that string with Node.js `querystring.parse()`. That means a literal `+` is decoded as a space, so the result is `{ s: 'foo bar' }`.
 
-If you need a literal plus sign, encode it as `%2B` (for example `./my-loader?s=foo%2Bbar`) or prefer an `options` object in the loader rule. Use [this.query](#thisquery) when you need the raw query string.
+If you need a literal plus sign, encode `+` as `%2B` or prefer an `options` object in the loader rule. Use [this.query](#thisquery) when you need the raw query string.
 :::
 
 In TypeScript, you can set the options type through the generic of `LoaderContext`.

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -396,6 +396,12 @@ module.exports = function myLoader(source) {
 };
 ```
 
+:::tip
+When a loader is configured with a query string such as `loader: './my-loader?s=foo+bar'`, `this.getOptions()` parses that string with Node.js `querystring.parse()`. That means a literal `+` is decoded as a space, so the result is `{ s: 'foo bar' }`.
+
+If you need a literal plus sign, encode it as `%2B` (for example `./my-loader?s=foo%2Bbar`) or prefer an `options` object in the loader rule. Use [this.query](#thisquery) when you need the raw query string.
+:::
+
 In TypeScript, you can set the options type through the generic of `LoaderContext`.
 
 ```ts title="my-loader.ts"
@@ -528,6 +534,8 @@ The value depends on the loader configuration:
 
 - If the current loader was configured with an options object, `this.query` will point to that object.
 - If the current loader has no options, but was invoked with a query string, this will be a string starting with `?`.
+
+Unlike [this.getOptions()](#thisgetoptions), the query-string form is not parsed. For example, `loader: './my-loader?s=foo+bar'` gives `this.query === '?s=foo+bar'`.
 
 ## this.request
 

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -390,7 +390,7 @@ module.exports = function myLoader(source) {
 :::tip
 当 loader 通过查询字符串配置时，例如 `loader: './my-loader?s=foo+bar'`，`this.getOptions()` 会使用 Node.js 的 `querystring.parse()` 解析该字符串。这意味着字面量 `+` 会被解码为空格，因此结果会是 `{ s: 'foo bar' }`。
 
-如果你需要字面量加号，请将其编码为 `%2B`（例如 `./my-loader?s=foo%2Bbar`），或者优先在规则里使用 `options` 对象。若你需要读取原始查询字符串，请使用 [this.query](#thisquery)。
+如果你需要字面量加号，请将 `+` 编码为 `%2B`，或者优先在规则里使用 `options` 对象。若你需要读取原始查询字符串，请使用 [this.query](#thisquery)。
 :::
 
 在 TypeScript 中，你可以通过 `LoaderContext` 的泛型来设置 options 的类型。

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -387,6 +387,12 @@ module.exports = function myLoader(source) {
 };
 ```
 
+:::tip
+当 loader 通过查询字符串配置时，例如 `loader: './my-loader?s=foo+bar'`，`this.getOptions()` 会使用 Node.js 的 `querystring.parse()` 解析该字符串。这意味着字面量 `+` 会被解码为空格，因此结果会是 `{ s: 'foo bar' }`。
+
+如果你需要字面量加号，请将其编码为 `%2B`（例如 `./my-loader?s=foo%2Bbar`），或者优先在规则里使用 `options` 对象。若你需要读取原始查询字符串，请使用 [this.query](#thisquery)。
+:::
+
 在 TypeScript 中，你可以通过 `LoaderContext` 的泛型来设置 options 的类型。
 
 ```ts title="my-loader.ts"
@@ -519,6 +525,8 @@ module.exports = function loader(source) {
 
 - 如果当前 loader 配置了一个选项对象，`this.query` 将指向这个对象。
 - 如果当前 loader 没有选项，但是通过查询字符串调用，这将是一个以 `?` 开头的字符串。
+
+与 [this.getOptions()](#thisgetoptions) 不同，查询字符串形式在这里不会被解析。例如，`loader: './my-loader?s=foo+bar'` 时，`this.query === '?s=foo+bar'`。
 
 ## this.request
 


### PR DESCRIPTION
## Summary

Clarify that `this.getOptions()` decodes `+` to a space when a loader is configured with a query string.
Document the `%2B` and `options` object workarounds, and note that `this.query` keeps the raw string in both the English and Chinese loader context docs.

## Related links

- Closes #10600

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).