### PR TITLE
refactor: cache logging to use atomic logger counters

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -296,7 +296,7 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
 
     create_module_hashes(&mut compilation, modules.clone()).await?;
 
-    code_generation_modules(&mut compilation, &mut None, modules.clone()).await?;
+    code_generation_modules(&mut compilation, None, modules.clone()).await?;
     let plugin_driver = compilation.plugin_driver.clone();
     process_modules_runtime_requirements(&mut compilation, modules.clone(), plugin_driver.clone())
       .await?;

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -85,7 +85,7 @@ async fn code_generation_pass_impl(compilation: &mut Compilation) -> Result<()> 
 #[instrument("Compilation:code_generation",target=TRACING_BENCH_TARGET, skip_all)]
 pub async fn code_generation(compilation: &mut Compilation, modules: IdentifierSet) -> Result<()> {
   let logger = compilation.get_logger("rspack.Compilation");
-  let mut codegen_cache_counter = match compilation.options.cache {
+  let codegen_cache_counter = match compilation.options.cache {
     CacheOptions::Disabled => None,
     _ => Some(logger.cache("module code generation cache")),
   };
@@ -106,13 +106,13 @@ pub async fn code_generation(compilation: &mut Compilation, modules: IdentifierS
 
   code_generation_modules(
     compilation,
-    &mut codegen_cache_counter,
+    codegen_cache_counter.as_ref(),
     no_codegen_dependencies_modules,
   )
   .await?;
   code_generation_modules(
     compilation,
-    &mut codegen_cache_counter,
+    codegen_cache_counter.as_ref(),
     has_codegen_dependencies_modules,
   )
   .await?;
@@ -126,7 +126,7 @@ pub async fn code_generation(compilation: &mut Compilation, modules: IdentifierS
 
 pub(crate) async fn code_generation_modules(
   compilation: &mut Compilation,
-  cache_counter: &mut Option<CacheCount>,
+  cache_counter: Option<&CacheCount>,
   modules: IdentifierSet,
 ) -> Result<()> {
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
@@ -168,15 +168,15 @@ pub(crate) async fn code_generation_modules(
   let results = rspack_parallel::scope::<_, _>(|token| {
     jobs.into_iter().for_each(|job| {
       // SAFETY: await immediately and trust caller to poll future entirely
-      let s = unsafe { token.used((compilation_ref, &module_graph, job)) };
+      let s = unsafe { token.used((compilation_ref, &module_graph, cache_counter, job)) };
 
-      s.spawn(|(this, module_graph, job)| async {
+      s.spawn(|(this, module_graph, cache_counter, job)| async move {
         let options = &this.options;
 
         let module = module_graph
           .module_by_identifier(&job.module)
           .expect("should have module");
-        let codegen_res = this
+        let (codegen_res, from_cache) = this
           .code_generate_cache_artifact
           .use_cache(&job, || async {
             let mut runtime_template = this.runtime_template.create_module_code_template();
@@ -215,6 +215,13 @@ pub(crate) async fn code_generation_modules(
               })
           })
           .await;
+        if let Some(counter) = cache_counter {
+          if from_cache {
+            counter.hit();
+          } else {
+            counter.miss();
+          }
+        }
 
         (job.module, job.runtimes, codegen_res)
       })
@@ -226,14 +233,7 @@ pub(crate) async fn code_generation_modules(
     .map(|res| res.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
-  for (module, runtimes, (codegen_res, from_cache)) in results {
-    if let Some(counter) = cache_counter {
-      if from_cache {
-        counter.hit();
-      } else {
-        counter.miss();
-      }
-    }
+  for (module, runtimes, codegen_res) in results {
     let codegen_res = match codegen_res {
       Ok(codegen_res) => codegen_res,
       Err(err) => {

--- a/crates/rspack_core/src/logger.rs
+++ b/crates/rspack_core/src/logger.rs
@@ -1,7 +1,10 @@
 use std::{
   backtrace::Backtrace,
   hash::BuildHasherDefault,
-  sync::Arc,
+  sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+  },
   time::{Duration, Instant},
 };
 
@@ -218,17 +221,18 @@ pub trait Logger {
   fn cache(&self, label: &'static str) -> CacheCount {
     CacheCount {
       label,
-      total: 0,
-      hit: 0,
+      total: AtomicU32::new(0),
+      hit: AtomicU32::new(0),
     }
   }
 
   fn cache_end(&self, count: CacheCount) {
-    if count.total != 0 {
+    let total = count.total.load(Ordering::Relaxed);
+    if total != 0 {
       self.raw(LogType::Cache {
         label: count.label,
-        hit: count.hit,
-        total: count.total,
+        hit: count.hit.load(Ordering::Relaxed),
+        total,
       })
     }
   }
@@ -273,18 +277,18 @@ impl StartTimeAggregate {
 #[derive(Debug)]
 pub struct CacheCount {
   label: &'static str,
-  hit: u32,
-  total: u32,
+  hit: AtomicU32,
+  total: AtomicU32,
 }
 
 impl CacheCount {
-  pub fn hit(&mut self) {
-    self.total += 1;
-    self.hit += 1;
+  pub fn hit(&self) {
+    self.total.fetch_add(1, Ordering::Relaxed);
+    self.hit.fetch_add(1, Ordering::Relaxed);
   }
 
-  pub fn miss(&mut self) {
-    self.total += 1;
+  pub fn miss(&self) {
+    self.total.fetch_add(1, Ordering::Relaxed);
   }
 }
 

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -1,11 +1,7 @@
 use std::{
   hash::{Hash, Hasher},
   path::Path,
-  sync::{
-    LazyLock, Mutex,
-    atomic::{AtomicU32, Ordering},
-    mpsc,
-  },
+  sync::{LazyLock, Mutex, mpsc},
 };
 
 use cow_utils::CowUtils;
@@ -182,8 +178,10 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let minimize_persistent_cache = compilation.minimize_persistent_cache_artifact.take();
   let new_persistent_cache_entries: Mutex<Vec<(MinimizeCacheKey, CachedMinimizeEntry)>> =
     Mutex::new(Vec::new());
-  let cache_hits = AtomicU32::new(0);
-  let cache_misses = AtomicU32::new(0);
+  let logger = compilation.get_logger(PLUGIN_NAME);
+  let minimize_cache_counter = minimize_persistent_cache
+    .as_ref()
+    .map(|_| logger.cache("minimize persistent cache"));
 
   let (tx, rx) = mpsc::channel::<Vec<Diagnostic>>();
   // collect all extracted comments info
@@ -245,7 +243,9 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
           // Check persistent cache
           if let Some(cached) = cache.get(key) {
-            cache_hits.fetch_add(1, Ordering::Relaxed);
+            if let Some(counter) = &minimize_cache_counter {
+              counter.hit();
+            }
             original.set_source(Some(cached.source.clone()));
             original.get_info_mut().minimized.replace(true);
             if let Some(ec) = &cached.extracted_comments {
@@ -263,7 +263,9 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             return Ok(());
           }
 
-          cache_misses.fetch_add(1, Ordering::Relaxed);
+          if let Some(counter) = &minimize_cache_counter {
+            counter.miss();
+          }
           Some(key)
         } else {
           None
@@ -494,13 +496,9 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     }
     compilation.minimize_persistent_cache_artifact = Some(cache);
 
-    // Log cache statistics
-    let hits = cache_hits.load(Ordering::Relaxed);
-    let misses = cache_misses.load(Ordering::Relaxed);
-    let logger = compilation.get_logger(PLUGIN_NAME);
-    logger.log(format!(
-      "minimize persistent cache: {hits} hit, {misses} miss"
-    ));
+    if let Some(counter) = minimize_cache_counter {
+      logger.cache_end(counter);
+    }
   }
 
   compilation.extend_diagnostics(rx.into_iter().flatten().collect::<Vec<_>>());

--- a/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/rspack.config.js
@@ -25,7 +25,7 @@ module.exports = {
           const s = stats.toJson({
             all: false,
             assets: true,
-            logging: 'log',
+            logging: 'verbose',
           });
 
           const jsAssets = s.assets.filter((a) => a.name?.endsWith('.js'));
@@ -36,7 +36,9 @@ module.exports = {
           const logEntries = s.logging[PLUGIN_NAME]?.entries ?? [];
           const cacheLogEntry = logEntries.find(
             (e) =>
-              e.message && e.message.includes('minimize persistent cache:'),
+              e.type === 'cache' &&
+              e.message &&
+              e.message.startsWith('minimize persistent cache:'),
           );
 
           if (updateIndex === 5) {
@@ -49,12 +51,13 @@ module.exports = {
           expect(cacheLogEntry).toBeTruthy();
 
           const match = cacheLogEntry.message.match(
-            /minimize persistent cache: (\d+) hit, (\d+) miss/,
+            /minimize persistent cache: [\d.]+% \((\d+)\/(\d+)\)/,
           );
           expect(match).toBeTruthy();
 
           const hits = parseInt(match[1], 10);
-          const misses = parseInt(match[2], 10);
+          const total = parseInt(match[2], 10);
+          const misses = total - hits;
 
           if (updateIndex === 0) {
             // Cold build, cache is empty → all misses


### PR DESCRIPTION
## Summary
- Switch `Logger::cache` / `CacheCount` to atomic counters so cache stats can be updated safely from parallel code (since most cacheable calculation are also parallel-able)
- Update code generation and SWC JS minimizer cache accounting to use the shared atomic counter directly
- Emit minimize persistent cache stats through the cache log channel and adjust the integration test to assert the cache log format

## Testing
- `cargo fmt -p rspack_core -p rspack_plugin_swc_js_minimizer`
- `cargo check -p rspack_core -p rspack_plugin_swc_js_minimizer`
- Updated the minimize-cache integration test to validate the `cache` log entry