### PR TITLE
fix(cli): respect devServer port in preview

### DIFF
--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -127,7 +127,7 @@ async function getPreviewConfig(
         publicPath: options.publicPath ?? '/',
       },
       hot: false,
-      port: options.port ?? 8080,
+      port: options.port ?? devServer?.port ?? 8080,
       proxy: devServer?.proxy,
       host: options.host ?? devServer?.host,
       open: options.open ?? devServer?.open,

--- a/packages/rspack-cli/tests/preview/dev-server-port/index.test.ts
+++ b/packages/rspack-cli/tests/preview/dev-server-port/index.test.ts
@@ -1,0 +1,43 @@
+import {
+  getRandomPort,
+  normalizeStdout,
+  runWatch,
+} from '../../utils/test-utils';
+
+describe('preview command devServer port', () => {
+  it('uses devServer.port when --port is not specified', async () => {
+    const port = await getRandomPort();
+    const { stdout } = await runWatch(
+      __dirname,
+      ['preview'],
+      {
+        killString: /localhost/,
+      },
+      {
+        RSPACK_PREVIEW_TEST_PORT: port.toString(),
+      },
+    );
+
+    expect(normalizeStdout(stdout)).toContain(`http://localhost:${port}/`);
+  });
+
+  it('uses --port before devServer.port', async () => {
+    const devServerPort = await getRandomPort();
+    const cliPort = await getRandomPort();
+    const { stdout } = await runWatch(
+      __dirname,
+      ['preview', '--port', cliPort.toString()],
+      {
+        killString: /localhost/,
+      },
+      {
+        RSPACK_PREVIEW_TEST_PORT: devServerPort.toString(),
+      },
+    );
+
+    const output = normalizeStdout(stdout);
+
+    expect(output).toContain(`http://localhost:${cliPort}/`);
+    expect(output).not.toContain(`http://localhost:${devServerPort}/`);
+  });
+});

--- a/packages/rspack-cli/tests/preview/dev-server-port/rspack.config.js
+++ b/packages/rspack-cli/tests/preview/dev-server-port/rspack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  mode: 'production',
+  devServer: {
+    port: Number(process.env.RSPACK_PREVIEW_TEST_PORT),
+  },
+};


### PR DESCRIPTION
## Summary

- make `rspack preview` reuse `devServer.port` when `--port` is not specified
- keep `--port` as the highest-precedence preview port override
- add preview regression tests for both port precedence cases

## Related links

Refs #13799

## Test Plan

- `pnpm --filter @rspack/cli build`
- `NAPI_RS_NATIVE_LIBRARY_PATH="$PWD/node_modules/.pnpm/@rspack+binding-darwin-arm64@2.0.0/node_modules/@rspack/binding-darwin-arm64/rspack.darwin-arm64.node" pnpm --filter @rspack/cli test -- tests/preview`
- `pnpm exec prettier --check packages/rspack-cli/src/commands/preview.ts packages/rspack-cli/tests/preview/dev-server-port/index.test.ts packages/rspack-cli/tests/preview/dev-server-port/rspack.config.js`
- `pnpm exec rslint packages/rspack-cli/src/commands/preview.ts`
- `git diff --check HEAD`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
