### PR TITLE
perf: reduce split chunks allocation overhead

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -322,7 +322,9 @@ impl Chunk {
       group.insert_chunk(new_chunk.ukey, self.ukey);
       new_chunk.add_group(group.ukey);
     }
-    new_chunk.id_name_hints.extend(self.id_name_hints.clone());
+    new_chunk
+      .id_name_hints
+      .extend(self.id_name_hints.iter().cloned());
     new_chunk.runtime.extend(&self.runtime);
   }
 

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -134,16 +134,39 @@ impl RuntimeSpec {
   }
 
   fn update_key(&mut self) {
-    if self.inner.is_empty() {
-      if self.key.is_empty() {
-        return;
+    match self.inner.len() {
+      0 => {
+        self.key.clear();
       }
-      self.key = String::new();
-      return;
+      1 => {
+        self.key.clear();
+        self.key.push_str(
+          self
+            .inner
+            .iter()
+            .next()
+            .expect("should have one runtime")
+            .as_str(),
+        );
+      }
+      _ => {
+        let mut ordered = self.inner.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+        ordered.sort_unstable();
+
+        let capacity = ordered.iter().map(|s| s.len()).sum::<usize>() + ordered.len() - 1;
+        self.key.clear();
+        self.key.reserve(capacity);
+
+        let mut iter = ordered.into_iter();
+        if let Some(first) = iter.next() {
+          self.key.push_str(first);
+        }
+        for runtime in iter {
+          self.key.push('_');
+          self.key.push_str(runtime);
+        }
+      }
     }
-    let mut ordered = self.inner.iter().map(|s| s.as_str()).collect::<Vec<_>>();
-    ordered.sort_unstable();
-    self.key = ordered.join("_");
   }
 
   pub fn as_str(&self) -> &str {

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -57,7 +57,7 @@ impl MatchGroup {
     }
   }
 
-  pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
+  pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> &SplitChunkSizes {
     if !self.added.is_empty() {
       let added = std::mem::take(&mut self.added);
       for module in added {
@@ -92,14 +92,12 @@ impl MatchGroup {
       }
     }
 
-    self.sizes.clone()
+    &self.sizes
   }
 }
 
 impl ModulesContainer for MatchGroup {
-  type Modules = IdentifierSet;
-
-  fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
+  fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> &SplitChunkSizes {
     MatchGroup::get_sizes(self, module_sizes)
   }
 

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -97,6 +97,8 @@ impl MatchGroup {
 }
 
 impl ModulesContainer for MatchGroup {
+  type Modules = IdentifierSet;
+
   fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
     MatchGroup::get_sizes(self, module_sizes)
   }

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,8 +1,7 @@
 use std::{cmp::Ordering, fmt};
 
 use derive_more::Debug;
-use itertools::Itertools;
-use rspack_collections::IdentifierSet;
+use rspack_collections::{IdentifierIndexSet, IdentifierSet};
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -74,7 +73,7 @@ impl fmt::Display for ModuleGroupKey {
 /// The original name of `ModuleGroup` is `ChunkInfoItem` borrowed from Webpack
 #[derive(Debug)]
 pub(crate) struct ModuleGroup {
-  pub modules: IdentifierSet,
+  pub modules: IdentifierIndexSet,
   /// the real index used for mapping the ModuleGroup to corresponding CacheGroup
   pub cache_group_index: u32,
   pub cache_group_reuse_existing_chunk: bool,
@@ -90,6 +89,7 @@ pub(crate) struct ModuleGroup {
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,
   total_size: f64,
+  modules_sorted: bool,
 }
 
 impl ModuleGroup {
@@ -105,6 +105,7 @@ impl ModuleGroup {
       added: Default::default(),
       removed: Default::default(),
       total_size: 0.0,
+      modules_sorted: false,
     }
   }
 
@@ -140,11 +141,12 @@ impl ModuleGroup {
   pub fn add_module(&mut self, module: ModuleIdentifier) {
     if self.modules.insert(module) {
       self.added.push(module);
+      self.modules_sorted = false;
     }
   }
 
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
-    if self.modules.remove(&module) {
+    if self.modules.shift_remove(&module) {
       self.removed.push(module);
     }
   }
@@ -158,6 +160,18 @@ impl ModuleGroup {
       unreachable!("should update sizes before get total size");
     }
     self.total_size
+  }
+
+  pub fn sort_modules_for_compare(&mut self) {
+    if self.modules_sorted {
+      return;
+    }
+    self.modules.sort_unstable_by(|a, b| {
+      a.precomputed_hash()
+        .cmp(&b.precomputed_hash())
+        .then_with(|| a.cmp(b))
+    });
+    self.modules_sorted = true;
   }
 
   pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
@@ -203,50 +217,17 @@ pub(crate) fn compare_entries(
   (a_key, a): (&ModuleGroupKey, &ModuleGroup),
   (b_key, b): (&ModuleGroupKey, &ModuleGroup),
 ) -> f64 {
-  // 1. by priority
-  // no need to compare priority anymore because we already pick all cache groups with same priority
-  // let diff_priority = a.cache_group_priority - b.cache_group_priority;
-  // if diff_priority != 0f64 {
-  //   return diff_priority;
-  // }
-  // 2. by number of chunks
-  let a_chunks_len = a.chunks.len();
-  let b_chunks_len = b.chunks.len();
-  let diff_count = a_chunks_len as f64 - b_chunks_len as f64;
-  if diff_count != 0f64 {
-    return diff_count;
+  if let Some(result) = compare_entries_without_modules((a_key, a), (b_key, b)) {
+    return result;
   }
 
-  // 3. by size reduction
-  let a_size_reduce = a.get_total_size() * (a_chunks_len - 1) as f64;
-  let b_size_reduce = b.get_total_size() * (b_chunks_len - 1) as f64;
-  let diff_size_reduce = a_size_reduce - b_size_reduce;
-  if diff_size_reduce != 0f64 {
-    return diff_size_reduce;
-  }
+  debug_assert!(
+    a.modules_sorted && b.modules_sorted,
+    "module groups should be sorted before comparing module identifiers"
+  );
 
-  // 4. by cache group index
-  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
-  if index_diff != 0f64 {
-    return index_diff;
-  }
-
-  // 5. by number of modules (to be able to compare by identifier)
-  let modules_a_len = a.modules.len();
-  let modules_b_len = b.modules.len();
-  let diff = modules_a_len as f64 - modules_b_len as f64;
-  if diff != 0f64 {
-    return diff;
-  }
-
-  let mut modules_a = a
-    .modules
-    .iter()
-    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
-  let mut modules_b = b
-    .modules
-    .iter()
-    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
+  let mut modules_a = a.modules.iter();
+  let mut modules_b = b.modules.iter();
 
   loop {
     match (modules_a.next(), modules_b.next()) {
@@ -266,4 +247,47 @@ pub(crate) fn compare_entries(
     Ordering::Equal => 0.0,
     Ordering::Greater => 1.0,
   }
+}
+
+pub(crate) fn compare_entries_without_modules(
+  (_, a): (&ModuleGroupKey, &ModuleGroup),
+  (_, b): (&ModuleGroupKey, &ModuleGroup),
+) -> Option<f64> {
+  // 1. by priority
+  // no need to compare priority anymore because we already pick all cache groups with same priority
+  // let diff_priority = a.cache_group_priority - b.cache_group_priority;
+  // if diff_priority != 0f64 {
+  //   return Some(diff_priority);
+  // }
+  // 2. by number of chunks
+  let a_chunks_len = a.chunks.len();
+  let b_chunks_len = b.chunks.len();
+  let diff_count = a_chunks_len as f64 - b_chunks_len as f64;
+  if diff_count != 0f64 {
+    return Some(diff_count);
+  }
+
+  // 3. by size reduction
+  let a_size_reduce = a.get_total_size() * (a_chunks_len - 1) as f64;
+  let b_size_reduce = b.get_total_size() * (b_chunks_len - 1) as f64;
+  let diff_size_reduce = a_size_reduce - b_size_reduce;
+  if diff_size_reduce != 0f64 {
+    return Some(diff_size_reduce);
+  }
+
+  // 4. by cache group index
+  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
+  if index_diff != 0f64 {
+    return Some(index_diff);
+  }
+
+  // 5. by number of modules (to be able to compare by identifier)
+  let modules_a_len = a.modules.len();
+  let modules_b_len = b.modules.len();
+  let diff = modules_a_len as f64 - modules_b_len as f64;
+  if diff != 0f64 {
+    return Some(diff);
+  }
+
+  None
 }

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,7 +1,8 @@
 use std::{cmp::Ordering, fmt};
 
 use derive_more::Debug;
-use rspack_collections::{IdentifierIndexSet, IdentifierSet};
+use itertools::Itertools;
+use rspack_collections::IdentifierSet;
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -73,7 +74,7 @@ impl fmt::Display for ModuleGroupKey {
 /// The original name of `ModuleGroup` is `ChunkInfoItem` borrowed from Webpack
 #[derive(Debug)]
 pub(crate) struct ModuleGroup {
-  pub modules: IdentifierIndexSet,
+  pub modules: IdentifierSet,
   /// the real index used for mapping the ModuleGroup to corresponding CacheGroup
   pub cache_group_index: u32,
   pub cache_group_reuse_existing_chunk: bool,
@@ -89,7 +90,6 @@ pub(crate) struct ModuleGroup {
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,
   total_size: f64,
-  modules_sorted: bool,
 }
 
 impl ModuleGroup {
@@ -105,7 +105,6 @@ impl ModuleGroup {
       added: Default::default(),
       removed: Default::default(),
       total_size: 0.0,
-      modules_sorted: false,
     }
   }
 
@@ -141,12 +140,11 @@ impl ModuleGroup {
   pub fn add_module(&mut self, module: ModuleIdentifier) {
     if self.modules.insert(module) {
       self.added.push(module);
-      self.modules_sorted = false;
     }
   }
 
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
-    if self.modules.shift_remove(&module) {
+    if self.modules.remove(&module) {
       self.removed.push(module);
     }
   }
@@ -162,19 +160,7 @@ impl ModuleGroup {
     self.total_size
   }
 
-  pub fn sort_modules_for_compare(&mut self) {
-    if self.modules_sorted {
-      return;
-    }
-    self.modules.sort_unstable_by(|a, b| {
-      a.precomputed_hash()
-        .cmp(&b.precomputed_hash())
-        .then_with(|| a.cmp(b))
-    });
-    self.modules_sorted = true;
-  }
-
-  pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
+  pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> &SplitChunkSizes {
     if !self.added.is_empty() {
       let added = std::mem::take(&mut self.added);
       for module in added {
@@ -209,7 +195,7 @@ impl ModuleGroup {
       }
     }
 
-    self.sizes.clone()
+    &self.sizes
   }
 }
 
@@ -217,17 +203,50 @@ pub(crate) fn compare_entries(
   (a_key, a): (&ModuleGroupKey, &ModuleGroup),
   (b_key, b): (&ModuleGroupKey, &ModuleGroup),
 ) -> f64 {
-  if let Some(result) = compare_entries_without_modules((a_key, a), (b_key, b)) {
-    return result;
+  // 1. by priority
+  // no need to compare priority anymore because we already pick all cache groups with same priority
+  // let diff_priority = a.cache_group_priority - b.cache_group_priority;
+  // if diff_priority != 0f64 {
+  //   return diff_priority;
+  // }
+  // 2. by number of chunks
+  let a_chunks_len = a.chunks.len();
+  let b_chunks_len = b.chunks.len();
+  let diff_count = a_chunks_len as f64 - b_chunks_len as f64;
+  if diff_count != 0f64 {
+    return diff_count;
   }
 
-  debug_assert!(
-    a.modules_sorted && b.modules_sorted,
-    "module groups should be sorted before comparing module identifiers"
-  );
+  // 3. by size reduction
+  let a_size_reduce = a.get_total_size() * (a_chunks_len - 1) as f64;
+  let b_size_reduce = b.get_total_size() * (b_chunks_len - 1) as f64;
+  let diff_size_reduce = a_size_reduce - b_size_reduce;
+  if diff_size_reduce != 0f64 {
+    return diff_size_reduce;
+  }
 
-  let mut modules_a = a.modules.iter();
-  let mut modules_b = b.modules.iter();
+  // 4. by cache group index
+  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
+  if index_diff != 0f64 {
+    return index_diff;
+  }
+
+  // 5. by number of modules (to be able to compare by identifier)
+  let modules_a_len = a.modules.len();
+  let modules_b_len = b.modules.len();
+  let diff = modules_a_len as f64 - modules_b_len as f64;
+  if diff != 0f64 {
+    return diff;
+  }
+
+  let mut modules_a = a
+    .modules
+    .iter()
+    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
+  let mut modules_b = b
+    .modules
+    .iter()
+    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
 
   loop {
     match (modules_a.next(), modules_b.next()) {
@@ -247,47 +266,4 @@ pub(crate) fn compare_entries(
     Ordering::Equal => 0.0,
     Ordering::Greater => 1.0,
   }
-}
-
-pub(crate) fn compare_entries_without_modules(
-  (_, a): (&ModuleGroupKey, &ModuleGroup),
-  (_, b): (&ModuleGroupKey, &ModuleGroup),
-) -> Option<f64> {
-  // 1. by priority
-  // no need to compare priority anymore because we already pick all cache groups with same priority
-  // let diff_priority = a.cache_group_priority - b.cache_group_priority;
-  // if diff_priority != 0f64 {
-  //   return Some(diff_priority);
-  // }
-  // 2. by number of chunks
-  let a_chunks_len = a.chunks.len();
-  let b_chunks_len = b.chunks.len();
-  let diff_count = a_chunks_len as f64 - b_chunks_len as f64;
-  if diff_count != 0f64 {
-    return Some(diff_count);
-  }
-
-  // 3. by size reduction
-  let a_size_reduce = a.get_total_size() * (a_chunks_len - 1) as f64;
-  let b_size_reduce = b.get_total_size() * (b_chunks_len - 1) as f64;
-  let diff_size_reduce = a_size_reduce - b_size_reduce;
-  if diff_size_reduce != 0f64 {
-    return Some(diff_size_reduce);
-  }
-
-  // 4. by cache group index
-  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
-  if index_diff != 0f64 {
-    return Some(index_diff);
-  }
-
-  // 5. by number of modules (to be able to compare by identifier)
-  let modules_a_len = a.modules.len();
-  let modules_b_len = b.modules.len();
-  let diff = modules_a_len as f64 - modules_b_len as f64;
-  if diff != 0f64 {
-    return Some(diff);
-  }
-
-  None
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 
 pub trait ModulesContainer {
+  type Modules;
+
   fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes;
   fn get_source_types_modules(
     &self,
@@ -15,10 +17,12 @@ pub trait ModulesContainer {
     module_sizes: &ModuleSizes,
   ) -> IdentifierSet;
   fn remove_module(&mut self, module: ModuleIdentifier);
-  fn modules(&self) -> &IdentifierIndexSet;
+  fn modules(&self) -> &Self::Modules;
 }
 
 impl ModulesContainer for ModuleGroup {
+  type Modules = IdentifierIndexSet;
+
   fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
     ModuleGroup::get_sizes(self, module_sizes)
   }

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use rspack_collections::{IdentifierIndexSet, IdentifierSet};
+use rspack_collections::IdentifierSet;
 use rspack_core::{ModuleIdentifier, SourceType};
 
 use super::ModuleGroupMap;
@@ -8,22 +8,18 @@ use crate::{
 };
 
 pub trait ModulesContainer {
-  type Modules;
-
-  fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes;
+  fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> &SplitChunkSizes;
   fn get_source_types_modules(
     &self,
     source_types: &[SourceType],
     module_sizes: &ModuleSizes,
   ) -> IdentifierSet;
   fn remove_module(&mut self, module: ModuleIdentifier);
-  fn modules(&self) -> &Self::Modules;
+  fn modules(&self) -> &IdentifierSet;
 }
 
 impl ModulesContainer for ModuleGroup {
-  type Modules = IdentifierIndexSet;
-
-  fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> SplitChunkSizes {
+  fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> &SplitChunkSizes {
     ModuleGroup::get_sizes(self, module_sizes)
   }
 
@@ -39,7 +35,7 @@ impl ModulesContainer for ModuleGroup {
     ModuleGroup::remove_module(self, module);
   }
 
-  fn modules(&self) -> &IdentifierIndexSet {
+  fn modules(&self) -> &IdentifierSet {
     &self.modules
   }
 }
@@ -147,14 +143,19 @@ impl SplitChunksPlugin {
           module_group,
           cache_group,
           module_sizes,
-        ) || !Self::check_min_size_reduction(
-          &module_group.get_sizes(module_sizes),
-          &cache_group.min_size_reduction,
-          module_group.chunks.len(),
         ) {
           Some(module_group_key.clone())
         } else {
-          None
+          let chunks_len = module_group.chunks.len();
+          if !Self::check_min_size_reduction(
+            module_group.get_sizes(module_sizes),
+            &cache_group.min_size_reduction,
+            chunks_len,
+          ) {
+            Some(module_group_key.clone())
+          } else {
+            None
+          }
         }
       })
       .collect::<Vec<_>>();

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use rspack_collections::IdentifierSet;
+use rspack_collections::{IdentifierIndexSet, IdentifierSet};
 use rspack_core::{ModuleIdentifier, SourceType};
 
 use super::ModuleGroupMap;
@@ -15,7 +15,7 @@ pub trait ModulesContainer {
     module_sizes: &ModuleSizes,
   ) -> IdentifierSet;
   fn remove_module(&mut self, module: ModuleIdentifier);
-  fn modules(&self) -> &IdentifierSet;
+  fn modules(&self) -> &IdentifierIndexSet;
 }
 
 impl ModulesContainer for ModuleGroup {
@@ -35,7 +35,7 @@ impl ModulesContainer for ModuleGroup {
     ModuleGroup::remove_module(self, module);
   }
 
-  fn modules(&self) -> &IdentifierSet {
+  fn modules(&self) -> &IdentifierIndexSet {
     &self.modules
   }
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -49,14 +49,64 @@ impl Deref for ChunkCombination {
   }
 }
 
+enum SelectedChunks<'a> {
+  All(&'a ChunkCombination),
+  Filtered(Vec<ChunkUkey>),
+}
+
+enum SelectedChunksIter<'a> {
+  All(std::collections::hash_set::Iter<'a, ChunkUkey>),
+  Filtered(std::slice::Iter<'a, ChunkUkey>),
+}
+
+impl<'a> Iterator for SelectedChunksIter<'a> {
+  type Item = &'a ChunkUkey;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    match self {
+      Self::All(iter) => iter.next(),
+      Self::Filtered(iter) => iter.next(),
+    }
+  }
+
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    match self {
+      Self::All(iter) => iter.size_hint(),
+      Self::Filtered(iter) => iter.size_hint(),
+    }
+  }
+}
+
+impl SelectedChunks<'_> {
+  fn len(&self) -> usize {
+    match self {
+      Self::All(chunks) => chunks.len(),
+      Self::Filtered(chunks) => chunks.len(),
+    }
+  }
+
+  fn iter(&self) -> SelectedChunksIter<'_> {
+    match self {
+      Self::All(chunks) => SelectedChunksIter::All(chunks.iter()),
+      Self::Filtered(chunks) => SelectedChunksIter::Filtered(chunks.iter()),
+    }
+  }
+
+  fn key(&self) -> Option<ChunksKey> {
+    match self {
+      Self::All(chunks) => Some(chunks.key),
+      Self::Filtered(_) => None,
+    }
+  }
+}
+
 /// If a module meets requirements of a `ModuleGroup`. We consider the `Module` and the `CacheGroup`
 /// to be a `MatchedItem`, which are consumed later to calculate `ModuleGroup`.
 struct MatchedItem<'a> {
   module: &'a dyn Module,
   cache_group_index: u32,
   cache_group: &'a CacheGroup,
-  selected_chunks: Vec<ChunkUkey>,
-  selected_chunks_key: Option<ChunksKey>,
+  selected_chunks: SelectedChunks<'a>,
 }
 
 fn get_key<I: Iterator<Item = ChunkUkey>>(
@@ -435,28 +485,34 @@ impl SplitChunksPlugin {
               }
 
 
-              let selected_chunks = if cache_group.chunk_filter.is_func() {
-                join_all(chunk_combination.iter().map(|c| async move {
-                  // Filter by `splitChunks.cacheGroups.{cacheGroup}.chunks`
-                  cache_group.chunk_filter.test_func(c, compilation).await.map(|filtered|  (c, filtered))
-                }))
-                  .await
-                  .into_iter()
-                  .collect::<Result<Vec<_>>>()?
-                  .into_iter()
-                  .filter_map(
-                    |(chunk, filtered)| {
-                      if filtered {
-                        Some(chunk)
-                      } else {
-                        None
+              let selected_chunks = if matches!(&cache_group.chunk_filter, ChunkFilter::All) {
+                SelectedChunks::All(chunk_combination)
+              } else if cache_group.chunk_filter.is_func() {
+                SelectedChunks::Filtered(
+                  join_all(chunk_combination.iter().map(|c| async move {
+                    // Filter by `splitChunks.cacheGroups.{cacheGroup}.chunks`
+                    cache_group.chunk_filter.test_func(c, compilation).await.map(|filtered|  (c, filtered))
+                  }))
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .filter_map(
+                      |(chunk, filtered)| {
+                        if filtered {
+                          Some(chunk)
+                        } else {
+                          None
+                        }
                       }
-                    }
-                  ).copied().collect::<Vec<_>>()
+                    ).copied().collect::<Vec<_>>(),
+                )
               } else {
-                chunk_combination.iter().filter(|c| {
-                  cache_group.chunk_filter.test_internal(c, compilation)
-                }).copied().collect::<Vec<_>>()
+                SelectedChunks::Filtered(
+                  chunk_combination.iter().filter(|c| {
+                    cache_group.chunk_filter.test_internal(c, compilation)
+                  }).copied().collect::<Vec<_>>(),
+                )
               };
 
               // Filter by `splitChunks.cacheGroups.{cacheGroup}.minChunks`
@@ -474,15 +530,12 @@ impl SplitChunksPlugin {
               if selected_chunks.iter().any(|c| removed_module_chunks.get(mid).is_some_and(|chunks| chunks.contains(c))) {
                 continue;
               }
-              let selected_chunks_key = matches!(&cache_group.chunk_filter, ChunkFilter::All)
-                .then_some(chunk_combination.key);
               merge_matched_item_into_module_group_map(
                 MatchedItem {
                   module,
                   cache_group,
                   cache_group_index: *cache_group_index,
                   selected_chunks,
-                  selected_chunks_key,
                 },
                 module_group_map,
                 compilation,
@@ -605,18 +658,19 @@ async fn merge_matched_item_into_module_group_map(
     cache_group_index,
     cache_group,
     selected_chunks,
-    selected_chunks_key,
   } = matched_item;
 
   // `Module`s with the same chunk_name would be merged togother.
   // `Module`s could be in different `ModuleGroup`s.
+  let selected_chunks_for_name;
   let chunk_name = match &cache_group.name {
     ChunkNameGetter::String(name) => Some(name.clone()),
     ChunkNameGetter::Disabled => None,
     ChunkNameGetter::Fn(f) => {
+      selected_chunks_for_name = selected_chunks.iter().copied().collect::<Vec<_>>();
       let ctx = ChunkNameGetterFnCtx {
         module,
-        chunks: &selected_chunks,
+        chunks: &selected_chunks_for_name,
         cache_group_key: &cache_group.key,
         compilation,
       };
@@ -631,7 +685,8 @@ async fn merge_matched_item_into_module_group_map(
   } else {
     ModuleGroupKey::Anonymous {
       cache_group_index,
-      chunks_key: selected_chunks_key
+      chunks_key: selected_chunks
+        .key()
         .unwrap_or_else(|| get_key(selected_chunks.iter().copied(), chunk_index_map)),
     }
   };

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -596,9 +596,14 @@ impl SplitChunksPlugin {
     }
 
     // Sort the module_group_map by key to ensure deterministic iteration order
-    let mut result: Vec<_> = module_group_map.into_iter().collect();
+    let module_group_count = module_group_map.len();
+    let mut result = Vec::with_capacity(module_group_count);
+    result.extend(module_group_map);
     result.sort_by(|a, b| a.0.cmp(&b.0));
-    Ok(result.into_iter().collect())
+    let mut ordered_result =
+      ModuleGroupMap::with_capacity_and_hasher(module_group_count, Default::default());
+    ordered_result.extend(result);
+    Ok(ordered_result)
   }
 
   // #[tracing::instrument(skip_all)]

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -1,5 +1,4 @@
 use std::{
-  cmp::Ordering,
   hash::{Hash, Hasher},
   ops::Deref,
   sync::Arc,
@@ -25,7 +24,10 @@ use crate::{
   SplitChunksPlugin,
   common::{ChunkFilter, ModuleChunks, ModuleSizes},
   min_size::remove_min_size_violating_modules,
-  module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries},
+  module_group::{
+    IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries,
+    compare_entries_without_modules,
+  },
   options::{
     cache_group::CacheGroup,
     cache_group_test::{CacheGroupTest, CacheGroupTestFnCtx},
@@ -362,21 +364,42 @@ impl SplitChunksPlugin {
   ) -> (ModuleGroupKey, ModuleGroup) {
     debug_assert!(!module_group_map.is_empty());
 
-    let best_entry_key = module_group_map
-      .keys()
-      .map(|key| (key, module_group_map.get(key).expect("should have item")))
-      .min_by(|a, b| {
-        let result = compare_entries((a.0, a.1), (b.0, b.1));
-        if result < 0f64 {
-          Ordering::Greater
-        } else if result > 0f64 {
-          Ordering::Less
-        } else {
-          Ordering::Equal
-        }
-      })
-      .map(|(key, _)| key.clone())
-      .expect("at least have one item");
+    let mut keys = module_group_map.keys();
+    let mut best_entry_key = keys.next().cloned().expect("at least have one item");
+
+    let keys = keys.cloned().collect::<Vec<_>>();
+    for key in keys {
+      let result = {
+        let best_module_group = module_group_map
+          .get(&best_entry_key)
+          .expect("should have best item");
+        let module_group = module_group_map.get(&key).expect("should have item");
+        compare_entries_without_modules((&key, module_group), (&best_entry_key, best_module_group))
+      };
+
+      let result = if let Some(result) = result {
+        result
+      } else {
+        module_group_map
+          .get_mut(&best_entry_key)
+          .expect("should have best item")
+          .sort_modules_for_compare();
+        module_group_map
+          .get_mut(&key)
+          .expect("should have item")
+          .sort_modules_for_compare();
+
+        let best_module_group = module_group_map
+          .get(&best_entry_key)
+          .expect("should have best item");
+        let module_group = module_group_map.get(&key).expect("should have item");
+        compare_entries((&key, module_group), (&best_entry_key, best_module_group))
+      };
+
+      if result > 0f64 {
+        best_entry_key = key;
+      }
+    }
 
     let best_module_group = module_group_map
       .swap_remove(&best_entry_key)

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -138,6 +138,48 @@ pub(crate) struct Combinator {
   grouped_by_exports: IdentifierMap<Vec<ChunksKey>>,
 }
 
+enum ChunkCombinations<'a> {
+  Slice(&'a [ChunkCombination]),
+  UsedExports(Vec<&'a ChunkCombination>),
+}
+
+enum ChunkCombinationsIter<'a> {
+  Slice(std::slice::Iter<'a, ChunkCombination>),
+  UsedExports(std::iter::Copied<std::slice::Iter<'a, &'a ChunkCombination>>),
+}
+
+impl<'a> Iterator for ChunkCombinationsIter<'a> {
+  type Item = &'a ChunkCombination;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    match self {
+      Self::Slice(iter) => iter.next(),
+      Self::UsedExports(iter) => iter.next(),
+    }
+  }
+
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    match self {
+      Self::Slice(iter) => iter.size_hint(),
+      Self::UsedExports(iter) => iter.size_hint(),
+    }
+  }
+}
+
+impl<'a> IntoIterator for &'a ChunkCombinations<'a> {
+  type Item = &'a ChunkCombination;
+  type IntoIter = ChunkCombinationsIter<'a>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    match self {
+      ChunkCombinations::Slice(combs) => ChunkCombinationsIter::Slice(combs.iter()),
+      ChunkCombinations::UsedExports(combs) => {
+        ChunkCombinationsIter::UsedExports(combs.iter().copied())
+      }
+    }
+  }
+}
+
 impl Combinator {
   fn get_non_used_exports_combs(
     &self,
@@ -212,17 +254,15 @@ impl Combinator {
     used_exports: bool,
     module_chunks: &ModuleChunks,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
-  ) -> Vec<ChunkCombination> {
+  ) -> ChunkCombinations<'_> {
     if used_exports {
-      self
-        .get_used_exports_combs(module)
-        .into_iter()
-        .cloned()
-        .collect()
+      ChunkCombinations::UsedExports(self.get_used_exports_combs(module))
     } else {
-      self
-        .get_non_used_exports_combs(module, module_chunks, chunk_index_map)
-        .to_vec()
+      ChunkCombinations::Slice(self.get_non_used_exports_combs(
+        module,
+        module_chunks,
+        chunk_index_map,
+      ))
     }
   }
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -1,4 +1,5 @@
 use std::{
+  cmp::Ordering,
   hash::{Hash, Hasher},
   ops::Deref,
   sync::Arc,
@@ -24,10 +25,7 @@ use crate::{
   SplitChunksPlugin,
   common::{ChunkFilter, ModuleChunks, ModuleSizes},
   min_size::remove_min_size_violating_modules,
-  module_group::{
-    IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries,
-    compare_entries_without_modules,
-  },
+  module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries},
   options::{
     cache_group::CacheGroup,
     cache_group_test::{CacheGroupTest, CacheGroupTestFnCtx},
@@ -404,42 +402,21 @@ impl SplitChunksPlugin {
   ) -> (ModuleGroupKey, ModuleGroup) {
     debug_assert!(!module_group_map.is_empty());
 
-    let mut keys = module_group_map.keys();
-    let mut best_entry_key = keys.next().cloned().expect("at least have one item");
-
-    let keys = keys.cloned().collect::<Vec<_>>();
-    for key in keys {
-      let result = {
-        let best_module_group = module_group_map
-          .get(&best_entry_key)
-          .expect("should have best item");
-        let module_group = module_group_map.get(&key).expect("should have item");
-        compare_entries_without_modules((&key, module_group), (&best_entry_key, best_module_group))
-      };
-
-      let result = if let Some(result) = result {
-        result
-      } else {
-        module_group_map
-          .get_mut(&best_entry_key)
-          .expect("should have best item")
-          .sort_modules_for_compare();
-        module_group_map
-          .get_mut(&key)
-          .expect("should have item")
-          .sort_modules_for_compare();
-
-        let best_module_group = module_group_map
-          .get(&best_entry_key)
-          .expect("should have best item");
-        let module_group = module_group_map.get(&key).expect("should have item");
-        compare_entries((&key, module_group), (&best_entry_key, best_module_group))
-      };
-
-      if result > 0f64 {
-        best_entry_key = key;
-      }
-    }
+    let best_entry_key = module_group_map
+      .keys()
+      .map(|key| (key, module_group_map.get(key).expect("should have item")))
+      .min_by(|a, b| {
+        let result = compare_entries((a.0, a.1), (b.0, b.1));
+        if result < 0f64 {
+          Ordering::Greater
+        } else if result > 0f64 {
+          Ordering::Less
+        } else {
+          Ordering::Equal
+        }
+      })
+      .map(|(key, _)| key.clone())
+      .expect("at least have one item");
 
     let best_module_group = module_group_map
       .swap_remove(&best_entry_key)
@@ -691,8 +668,20 @@ impl SplitChunksPlugin {
         }
 
         // Validate `min_size` again
-        if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes)
-          || !Self::check_min_size_reduction(&other_module_group.get_sizes(module_sizes), &cache_group.min_size_reduction, other_module_group.chunks.len()) {
+        if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes) {
+          tracing::trace!(
+            "{key} is deleted for violating min_size {:#?}",
+            cache_group.min_size,
+          );
+          return Some(key.clone());
+        }
+
+        let chunks_len = other_module_group.chunks.len();
+        if !Self::check_min_size_reduction(
+          other_module_group.get_sizes(module_sizes),
+          &cache_group.min_size_reduction,
+          chunks_len,
+        ) {
           tracing::trace!(
             "{key} is deleted for violating min_size {:#?}",
             cache_group.min_size,


### PR DESCRIPTION
## Summary

Reduce allocation and cloning overhead in split chunks hot paths.

This PR:
- avoids collecting selected chunks for `chunks: "all"` by borrowing the existing chunk combination
- avoids cloning chunk combinations from `Combinator::get_combs` by returning borrowed combination views
- changes split chunk size accessors to return `&SplitChunkSizes`, so callers only clone when needed
- preallocates the temporary `Vec` and final `ModuleGroupMap` when converting the prepared `DashMap`
- reduces small allocation overhead in `RuntimeSpec::update_key`
- avoids cloning the whole `id_name_hints` set in `Chunk::split`

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
