### PR TITLE
docs: clarify externalsType defaults

### DIFF
--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -53,7 +53,7 @@ console.log(dayjs().format('YYYY-MM-DD'));
 
 In the configuration above, the key `dayjs` under `externals` matches the module specifier in `import dayjs from 'dayjs'`, meaning that module should not be bundled.
 
-The value `dayjs` is then used to access the global variable at runtime. By default, [externalsType](#externalstype) is `var`, which means Rspack reads it from the global scope. In a browser, this usually means accessing `window.dayjs`.
+The value `dayjs` is then used to access the global variable at runtime. In this basic configuration, the default [externalsType](#externalstype) is `var`, which means Rspack reads it from the global scope. In a browser, this usually means accessing `window.dayjs`.
 
 ### String
 
@@ -308,9 +308,17 @@ export default {
 ## externalsType
 
 - **Type:** `string`
-- **Default:** `'var'`
+- **Default:** Depends on [`output.library.type`](/config/output#outputlibrarytype) and [`output.module`](/config/output#outputmodule)
+
+The default value is inferred as follows:
+
+- When [`output.library`](/config/output#outputlibrary) is configured, it matches [`output.library.type`](/config/output#outputlibrarytype).
+- Otherwise, when [`output.module`](/config/output#outputmodule) is `true`, it is `'module-import'`.
+- Otherwise, it is `'var'`.
 
 Specify the default type of externals. `amd`, `umd`, `system` and `jsonp` externals **depend on the [`output.library.type`](/config/output#outputlibrarytype)** being set to the same value e.g. you can only consume `amd` externals within an `amd` library.
+
+Set `externalsType` explicitly when the external dependency should use a different loading format from the inferred default.
 
 Supported types:
 

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -53,7 +53,7 @@ console.log(dayjs().format('YYYY-MM-DD'));
 
 在上述配置中，`externals` 的键名 `dayjs` 对应 `import dayjs from 'dayjs'` 中的模块标识符，表示该模块不会被打包。
 
-对应的值 `dayjs` 则用于在运行时访问全局变量。默认情况下，[externalsType](#externalstype) 为 `var`，即从全局作用域中读取该变量。在浏览器环境下，这通常等价于访问 `window.dayjs`。
+对应的值 `dayjs` 则用于在运行时访问全局变量。在这个基础配置中，[externalsType](#externalstype) 的默认值为 `var`，即从全局作用域中读取该变量。在浏览器环境下，这通常等价于访问 `window.dayjs`。
 
 ### 字符串
 
@@ -308,9 +308,17 @@ export default {
 ## externalsType
 
 - **类型：** `string`
-- **默认值：** `'var'`
+- **默认值：** 取决于 [`output.library.type`](/config/output#outputlibrarytype) 和 [`output.module`](/config/output#outputmodule)
+
+默认值的推导规则如下：
+
+- 配置了 [`output.library`](/config/output#outputlibrary) 时，与 [`output.library.type`](/config/output#outputlibrarytype) 保持一致。
+- 否则，如果 [`output.module`](/config/output#outputmodule) 为 `true`，则为 `'module-import'`。
+- 否则为 `'var'`。
 
 指定 externals 的默认类型。当 external 被设置为 `amd`，`umd`，`system` 以及 `jsonp` 时，[`output.library.type`](/config/output#outputlibrarytype) 的值也应相同。例如，你只能在 `amd` 库中使用 `amd` 的 externals。
+
+如果 external 依赖需要使用不同于推导结果的加载格式，请显式设置 `externalsType`。
 
 支持的类型如下：
 


### PR DESCRIPTION
## Summary

- Document how `externalsType` defaults are inferred from `output.library.type` and `output.module`.
- Clarify that the basic externals example still defaults to `var`.
- Keep the English and Chinese config docs aligned.

## Validation

- `git diff --cached --check`
- `git diff --check -- website/docs/en/config/externals.mdx website/docs/zh/config/externals.mdx`
