### PR TITLE
refactor: reduce unnecessary clone overhead in JSON and ESM codegen

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -280,8 +280,8 @@ pub fn to_static(
   stylesheet: StyleSheet,
   options: ParserOptions<'static, 'static>,
 ) -> StyleSheet<'static, 'static> {
-  let sources = stylesheet.sources.clone();
-  let rules = stylesheet.rules.clone().into_owned();
+  let StyleSheet { sources, rules, .. } = stylesheet;
+  let rules = rules.into_owned();
 
   StyleSheet::new(sources, rules, options)
 }

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1500,12 +1500,16 @@ var {} = {{}};
                     runtime_template,
                   )
                   .await?;
-                *concate_info = codegen_res
+                let current_module = &codegen_res
                   .concatenation_scope
                   .as_ref()
                   .expect("should have concatenation scope")
-                  .current_module
-                  .clone();
+                  .current_module;
+                concate_info.namespace_export_symbol =
+                  current_module.namespace_export_symbol.clone();
+                concate_info.export_map = current_module.export_map.clone();
+                concate_info.raw_export_map = current_module.raw_export_map.clone();
+                concate_info.import_map = current_module.import_map.clone();
 
                 let m = module_graph
                   .module_by_identifier(&id)

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -8,7 +8,6 @@ use json::{
   JsonValue,
   number::Number,
   object::Object,
-  stringify,
 };
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
@@ -45,7 +44,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
       .build_info()
       .json_data
       .as_ref()
-      .map_or(0.0, |data| stringify(data.clone()).len() as f64)
+      .map_or(0.0, |data| data.dump().len() as f64)
   }
 
   async fn parse<'a>(
@@ -191,24 +190,29 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .exports_info_artifact
           .get_exports_info_data(&module.identifier());
 
-        let final_json = match json_data {
+        let (is_js_object, final_json_string) = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
             if matches!(
               exports_info.other_exports_info().get_used(*runtime),
               UsageState::Unused
             ) =>
           {
-            create_object_for_exports_info(
+            let final_json = create_object_for_exports_info(
               json_data.clone(),
               exports_info,
               *runtime,
               &compilation.exports_info_artifact,
+            );
+            (
+              final_json.is_object() || final_json.is_array(),
+              final_json.dump(),
             )
           }
-          _ => json_data.clone(),
+          _ => (
+            json_data.is_object() || json_data.is_array(),
+            json_data.dump(),
+          ),
         };
-        let is_js_object = final_json.is_object() || final_json.is_array();
-        let final_json_string = stringify(final_json);
         let json_str = utils::escape_json(&final_json_string);
         let json_expr = if self.json_parse && is_js_object && json_str.len() > 20 {
           Cow::Owned(format!(

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -36,7 +36,7 @@ pub fn collect_json_module_sizes(
 
     let exports_info = exports_info_artifact.get_exports_info_data(module_id);
 
-    let final_json = match json_data {
+    let json_str = match json_data {
       json::JsonValue::Object(_) | json::JsonValue::Array(_) => {
         let needs_tree_shaking = exports_info.other_exports_info().get_used(None)
           == UsageState::Unused
@@ -52,14 +52,14 @@ pub fn collect_json_module_sizes(
             None,
             exports_info_artifact,
           )
+          .dump()
         } else {
-          json_data.clone()
+          json_data.dump()
         }
       }
-      _ => json_data.clone(),
+      _ => json_data.dump(),
     };
 
-    let json_str = json::stringify(final_json);
     let size = ("module.exports = ".len() + json_str.len()) as i32;
     json_sizes.insert(module_id.to_string(), size);
   }


### PR DESCRIPTION
## Summary

Reduce avoidable clone overhead in a few hot paths:
- move owned `StyleSheet` fields in `to_static` instead of cloning them
- serialize borrowed `JsonValue` data with `dump()` when tree-shaking is not rebuilding the JSON AST
- avoid cloning the full `ConcatenatedModuleInfo` in ESM link code when only a few codegen-mutated fields are needed
- apply the same borrowed JSON serialization optimization in rsdoctor's JSON size collection

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation:
- `cargo check -p rspack_plugin_esm_library -p rspack_plugin_json -p rspack_loader_lightningcss -p rspack_plugin_rsdoctor`
- `cargo fmt --all --check`