### PR TITLE
docs: clarify dev server usage

### DIFF
--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'describes the options that affect the behavior of @rspack/dev-server (short: dev-server), based on webpack-dev-server@5, which facilitates rapid application...'
+description: 'Configure @rspack/dev-server for local development and preview.'
 ---
 
 import WebpackLicense from '@components/WebpackLicense';
@@ -9,15 +9,17 @@ import { Tabs, Tab } from '@theme';
 
 # DevServer
 
-This page describes the options that affect the behavior of [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server) (short: dev-server), based on `webpack-dev-server@5`, which facilitates rapid application development.
+This page describes the options used by [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server) to run a local development server for Rspack projects.
 
 - **Type:** `object`
 
-:::tip
-If the current application does not depend on `@rspack/dev-server`, then the devServer config will have no effect.
+## When to use
 
-For example, Rspack CLI depends on `@rspack/dev-server` by default, so the devServer config can be used in Rspack CLI projects. Rsbuild has implemented its own dev server and provides a separate "server" config, so the devServer config cannot be used in Rsbuild projects.
-:::
+The `devServer` config only takes effect when using `@rspack/dev-server`. If the current application does not start `@rspack/dev-server`, this config will have no effect.
+
+For example, with Rspack CLI, install `@rspack/dev-server` and use `rspack dev` or `rspack serve` to apply the `devServer` config. Rsbuild implements its own dev server and provides a separate `server` config, so Rsbuild projects should configure that instead.
+
+When using `rspack preview`, the Rspack CLI also loads `@rspack/dev-server` and respects a subset of `devServer` options: [`port`](#devserverport), [`host`](#devserverhost), [`open`](#devserveropen), [`server`](#devserverserver), [`proxy`](#devserverproxy), and [`historyApiFallback`](#devserverhistoryapifallback).
 
 ## devServer.allowedHosts
 
@@ -333,7 +335,7 @@ export default {
 - **Type:** `object`
 - **Default:** `{}`
 
-Provide options to [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) which handles Rspack assets.
+Provide options to [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware), which serves Rspack build assets from the dev server.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -550,7 +552,7 @@ export default {
 ```
 
 :::info
-When using `rspack dev` or `rspack serve`, you can override this option from the CLI with `--open`, `--open <value>`, or `--no-open`. The CLI flag takes precedence over `devServer.open` in the configuration.
+When using `rspack dev` or `rspack serve`, you can override this option from the CLI with `--open`, `--open <value>`, or `--no-open`. When using `rspack preview`, this option is also respected, and `--open` takes precedence over `devServer.open` in the configuration.
 :::
 
 To open a specified page in a browser:

--- a/website/docs/en/guide/features/dev-server.mdx
+++ b/website/docs/en/guide/features/dev-server.mdx
@@ -1,21 +1,22 @@
 ---
-description: 'Rspack CLI comes with a built-in @rspack/dev-server for development and debugging'
+description: '@rspack/dev-server provides local development server support for Rspack CLI, including HMR and proxying.'
 ---
+
+import { PackageManagerTabs } from '@theme';
 
 # Dev server
 
-Rspack CLI comes with a built-in `@rspack/dev-server` for development and debugging. Its capabilities are similar to `webpack-dev-server`, including features like hot module replacement (HMR), proxy server and more.
+The `rspack dev` and `rspack serve` commands run a local development server through [@rspack/dev-server](https://npmjs.com/package/@rspack/dev-server). It provides hot module replacement (HMR), static file serving, proxying, and related development features.
 
-:::tip
+## Install dev server
 
-`webpack-dev-server@5` is used in `@rspack/dev-server`, which has some differences from `webpack-dev-server@4`.
+`@rspack/dev-server` is an optional peer dependency of `@rspack/cli`.
 
-- The minimum supported Node.js version for webpack-dev-server v5 is 18.12.0.
-- Several configuration options have changed. Please refer to the [webpack-dev-server v5 migration guide](https://github.com/webpack/webpack-dev-server/blob/master/migration-v5.md).
+Install it before using `rspack dev`, `rspack serve`, or `rspack preview`:
 
-:::
+<PackageManagerTabs command="add @rspack/dev-server -D" />
 
-### HMR
+## HMR
 
 By default, Rspack enables HMR in dev mode. You can disable HMR by configuring the `devServer.hot` option in Rspack configuration.
 
@@ -31,9 +32,9 @@ export default {
 Do not include `[hash]` or `[contenthash]` in [output.cssFilename](/config/output#outputcssfilename), otherwise CSS HMR may not work.
 :::
 
-### Proxy
+## Proxy
 
-Rspack has a built-in simple proxy server. You can enable the proxy server by configuring the `devServer.proxy` option in Rspack configuration. The devServer internally uses [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) to implement the proxy function. For example, you can proxy `/api` to `http://localhost:3000` as follows:
+The dev server includes proxy support. Configure the `devServer.proxy` option to proxy matching requests. This feature is powered by [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware). For example, you can proxy `/api` to `http://localhost:3000` as follows:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -1,5 +1,5 @@
 ---
-description: '该选项用于配置 @rspack/dev-server 的行为，基于 webpack-dev-server@5，用于快速开发应用程序。'
+description: '配置 @rspack/dev-server 的本地开发和预览行为。'
 ---
 
 import WebpackLicense from '@components/WebpackLicense';
@@ -9,15 +9,17 @@ import { Tabs, Tab } from '@theme';
 
 # DevServer
 
-该选项用于配置 [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server) 的行为，基于 `webpack-dev-server@5`，用于快速开发应用程序。
+该选项用于配置 [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server) 的本地开发服务器行为。
 
 - **类型：** `object`
 
-:::tip
-如果你的应用未依赖 `@rspack/dev-server`，那么 devServer 配置将不起作用。
+## 何时使用
 
-例如，Rspack CLI 默认依赖 `@rspack/dev-server`，因此在使用 Rspack CLI 的项目里可以使用 devServer 配置。而 Rsbuild 自行实现了开发服务器，并提供了单独的 "server" 配置，所以 Rsbuild 项目不能使用 devServer 配置。
-:::
+`devServer` 配置只会在使用 `@rspack/dev-server` 时生效。如果当前应用没有启动 `@rspack/dev-server`，该配置不会生效。
+
+例如，使用 Rspack CLI 时，需要在项目中安装 `@rspack/dev-server`，并通过 `rspack dev` 或 `rspack serve` 启动开发服务器后，`devServer` 配置才会生效。而 Rsbuild 使用自己的开发服务器，并提供了单独的 `server` 配置，因此 Rsbuild 项目应通过 `server` 来配置开发服务器。
+
+当使用 `rspack preview` 时，Rspack CLI 也会加载 `@rspack/dev-server`，并读取部分 `devServer` 选项：[`port`](#devserverport)、[`host`](#devserverhost)、[`open`](#devserveropen)、[`server`](#devserverserver)、[`proxy`](#devserverproxy) 和 [`historyApiFallback`](#devserverhistoryapifallback)。
 
 ## devServer.allowedHosts
 
@@ -323,7 +325,7 @@ export default {
 - **类型：** `object`
 - **默认值：** `{}`
 
-提供选项给 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware)，它用于处理 Rspack 的静态资源。
+提供给 [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware) 的选项，用于在开发服务器中提供 Rspack 构建产物。
 
 ```ts title="rspack.config.mjs"
 export default {
@@ -540,7 +542,7 @@ export default {
 ```
 
 :::info 提示
-当你使用 `rspack dev` 或 `rspack serve` 时，可以通过 `--open`、`--open <value>` 或 `--no-open` 在命令行中覆盖此选项。命令行参数的优先级高于配置中的 `devServer.open`。
+当你使用 `rspack dev` 或 `rspack serve` 时，可以通过 `--open`、`--open <value>` 或 `--no-open` 在命令行中覆盖此选项。当你使用 `rspack preview` 时，此选项也会生效，且 `--open` 的优先级高于配置中的 `devServer.open`。
 :::
 
 在浏览器中打开指定页面：

--- a/website/docs/zh/guide/features/dev-server.mdx
+++ b/website/docs/zh/guide/features/dev-server.mdx
@@ -1,21 +1,22 @@
 ---
-description: 'Rspack CLI 内置了 @rspack/dev-server 用于开发调试，它的能力与 webpack-dev-server 相似，内置了 HMR、代理服务器等功能。'
+description: '@rspack/dev-server 为 Rspack CLI 提供本地开发服务器能力，包括 HMR 和代理等功能。'
 ---
+
+import { PackageManagerTabs } from '@theme';
 
 # 开发服务器
 
-Rspack CLI 内置了 `@rspack/dev-server` 用于开发调试，它的能力与 `webpack-dev-server` 相似，内置了 HMR、代理服务器等功能。
+`rspack dev` 和 `rspack serve` 命令会通过 [@rspack/dev-server](https://npmjs.com/package/@rspack/dev-server) 启动本地开发服务器。它提供热模块替换（HMR）、静态文件服务、代理等开发能力。
 
-:::tip
+## 安装 dev server
 
-`@rspack/dev-server` 中使用了 `webpack-dev-server@5` ，与 `webpack-dev-server@4` 有一些差异。
+`@rspack/dev-server` 是 `@rspack/cli` 的可选 peer dependency。
 
-- webpack-dev-server v5 最低支持的 Node.js 版本为 18.12.0。
-- 配置选项发生了若干变更，请参阅 [webpack-dev-server v5 的迁移指南](https://github.com/webpack/webpack-dev-server/blob/master/migration-v5.md)。
+使用 `rspack dev`、`rspack serve` 或 `rspack preview` 前，请先安装：
 
-:::
+<PackageManagerTabs command="add @rspack/dev-server -D" />
 
-### HMR
+## HMR
 
 Rspack 在 dev 模式下默认开启了 HMR，你也可以在 Rspack 配置中设置 `devServer.hot` 选项来关闭 HMR。
 
@@ -31,9 +32,9 @@ export default {
 不要在 [output.cssFilename](/config/output#outputcssfilename) 中包含 `[hash]` 或者 `[contenthash]`，否则 CSS 的 HMR 可能会不生效。
 :::
 
-### Proxy
+## Proxy
 
-Rspack 内置了一个简单的代理服务器，你可以在 Rspack 配置中添加 `devServer.proxy` 选项来开启代理服务器。devServer 内部使用了 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) 来实现代理功能。例如我们可以通过如下方式将 `/api` 代理到 `http://localhost:3000`。
+开发服务器内置代理能力。你可以在 Rspack 配置中添加 `devServer.proxy` 选项来代理匹配的请求。该功能基于 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) 实现。例如我们可以通过如下方式将 `/api` 代理到 `http://localhost:3000`。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR updates the dev server docs to clarify that `@rspack/dev-server` must be installed for Rspack CLI dev-server commands, explains when `devServer` config takes effect, and documents the subset of options respected by `rspack preview`.

## Related links

None

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).