### PR TITLE
fix: handle weak dynamic imports without async chunks

### DIFF
--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -25,6 +25,8 @@ pub enum DependencyType {
   DynamicImport,
   // import() eager
   DynamicImportEager,
+  // import() weak
+  DynamicImportWeak,
   // cjs require
   CjsRequire,
   // cjs full require
@@ -150,6 +152,8 @@ impl DependencyType {
       DependencyType::EsmExportExpression => "esm export expression",
       DependencyType::EsmExportHeader => "esm export header",
       DependencyType::DynamicImport => "import()",
+      DependencyType::DynamicImportEager => "import() eager",
+      DependencyType::DynamicImportWeak => "import() weak",
       DependencyType::CjsRequire => "cjs require",
       DependencyType::CjsFullRequire => "cjs full require",
       DependencyType::CjsExports => "cjs exports",
@@ -180,7 +184,6 @@ impl DependencyType {
       },
       // TODO: mode
       DependencyType::ImportContext => "import context",
-      DependencyType::DynamicImportEager => "import() eager",
       DependencyType::CommonJSRequireContext => "commonjs require context",
       DependencyType::RequireContext => "require.context",
       DependencyType::RequireResolve => "require.resolve",

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -846,7 +846,7 @@ impl ModuleCodeTemplate {
         self.module_id_expr(request, module_id)
       )
     } else if weak {
-      self.weak_error(request)
+      self.weak_error_expression(request)
     } else {
       self.missing_module(request)
     }
@@ -866,6 +866,27 @@ impl ModuleCodeTemplate {
   pub fn weak_error(&self, request: &str) -> String {
     format!(
       "var e = new Error('Module is not available (weak dependency), request is {request}'); e.code = 'MODULE_NOT_FOUND'; throw e;"
+    )
+  }
+
+  // Weak errors are embedded as statements, expressions, or promises depending on the
+  // runtime template position, aligned with webpack RuntimeTemplate.weakError:
+  // https://github.com/webpack/webpack/blob/2944286213cf1b3697a1c8dd41ffd3f8ada99448/lib/RuntimeTemplate.js#L461-L486
+  pub fn weak_error_expression(&self, request: &str) -> String {
+    format!("Object({}())", self.weak_error_function(request))
+  }
+
+  pub fn weak_error_promise(&self, request: &str) -> String {
+    format!(
+      "Promise.resolve().then({})",
+      self.weak_error_function(request)
+    )
+  }
+
+  pub fn weak_error_function(&self, request: &str) -> String {
+    format!(
+      "function __rspack_weak_module_error__() {{ {} }}",
+      self.weak_error(request)
     )
   }
 
@@ -1214,6 +1235,14 @@ impl ModuleCodeTemplate {
     let Some(target_module) = mg.get_module_by_dependency_id(dep_id) else {
       return self.missing_module_promise(request);
     };
+    // Match webpack's weak module without-id path in moduleNamespacePromise:
+    // https://github.com/webpack/webpack/blob/2944286213cf1b3697a1c8dd41ffd3f8ada99448/lib/RuntimeTemplate.js#L682-L692
+    if weak
+      && ChunkGraph::get_module_id(&compilation.module_ids_artifact, target_module.identifier())
+        .is_none()
+    {
+      return self.weak_error_promise(request);
+    }
 
     let promise = self.block_promise(block, compilation, message);
     let exports_type = get_exports_type(

--- a/crates/rspack_plugin_circular_dependencies/src/lib.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/lib.rs
@@ -105,6 +105,7 @@ impl AggregatedDependency {
         // the context of circular detection.
         DependencyType::DynamicImport
           | DependencyType::DynamicImportEager
+          | DependencyType::DynamicImportWeak
           | DependencyType::LazyImport
           | DependencyType::ImportMetaHotAccept
           | DependencyType::ImportMetaHotDecline

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
@@ -1,0 +1,210 @@
+use rspack_cacheable::{
+  cacheable, cacheable_dyn,
+  with::{AsCacheable, AsOption, AsPreset, AsVec},
+};
+use rspack_core::{
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
+  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
+  FactorizeInfo, ImportAttributes, ImportPhase, ModuleDependency, ModuleGraphCacheArtifact,
+  ReferencedSpecifier, ResourceIdentifier, TemplateContext, TemplateReplaceSource,
+  create_exports_object_referenced, create_referenced_exports_by_referenced_specifiers,
+};
+use swc_core::ecma::atoms::Atom;
+
+use super::create_resource_identifier_for_esm_dependency;
+
+// Align with webpack's ImportWeakDependency:
+// https://github.com/webpack/webpack/blob/2944286213cf1b3697a1c8dd41ffd3f8ada99448/lib/dependencies/ImportWeakDependency.js
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct ImportWeakDependency {
+  id: DependencyId,
+  #[cacheable(with=AsPreset)]
+  request: Atom,
+  range: DependencyRange,
+  #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
+  referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
+  attributes: Option<ImportAttributes>,
+  phase: ImportPhase,
+  resource_identifier: ResourceIdentifier,
+  factorize_info: FactorizeInfo,
+  optional: bool,
+}
+
+impl ImportWeakDependency {
+  pub fn new(
+    request: Atom,
+    range: DependencyRange,
+    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
+    attributes: Option<ImportAttributes>,
+    phase: ImportPhase,
+    optional: bool,
+  ) -> Self {
+    let resource_identifier =
+      create_resource_identifier_for_esm_dependency(request.as_str(), attributes.as_ref());
+    Self {
+      request,
+      range,
+      id: DependencyId::new(),
+      referenced_specifiers,
+      attributes,
+      phase,
+      resource_identifier,
+      factorize_info: Default::default(),
+      optional,
+    }
+  }
+
+  pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+    self.referenced_specifiers = Some(referenced_specifiers);
+  }
+}
+
+#[cacheable_dyn]
+impl Dependency for ImportWeakDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
+  }
+
+  fn category(&self) -> &DependencyCategory {
+    &DependencyCategory::Esm
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    &DependencyType::DynamicImportWeak
+  }
+
+  fn get_attributes(&self) -> Option<&ImportAttributes> {
+    self.attributes.as_ref()
+  }
+
+  fn get_phase(&self) -> ImportPhase {
+    self.phase
+  }
+
+  fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
+  fn get_referenced_exports(
+    &self,
+    module_graph: &rspack_core::ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
+    _runtime: Option<&rspack_core::RuntimeSpec>,
+  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+    if let Some(referenced_specifiers) = &self.referenced_specifiers {
+      let module = module_graph
+        .get_module_by_dependency_id(&self.id)
+        .expect("should have module");
+      let parent_module = module_graph
+        .get_parent_module(&self.id)
+        .expect("should have parent module");
+      let strict = module_graph
+        .module_by_identifier(parent_module)
+        .expect("should have parent module")
+        .get_strict_esm_module();
+      let exports_type = module.get_exports_type(
+        module_graph,
+        module_graph_cache,
+        exports_info_artifact,
+        strict,
+      );
+      create_referenced_exports_by_referenced_specifiers(
+        referenced_specifiers,
+        exports_type,
+        module.build_info().json_data.is_some(),
+      )
+    } else {
+      create_exports_object_referenced()
+    }
+  }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
+}
+
+#[cacheable_dyn]
+impl ModuleDependency for ImportWeakDependency {
+  fn request(&self) -> &str {
+    &self.request
+  }
+
+  fn user_request(&self) -> &str {
+    &self.request
+  }
+
+  fn factorize_info(&self) -> &FactorizeInfo {
+    &self.factorize_info
+  }
+
+  fn factorize_info_mut(&mut self) -> &mut FactorizeInfo {
+    &mut self.factorize_info
+  }
+
+  fn get_optional(&self) -> bool {
+    self.optional
+  }
+
+  fn weak(&self) -> bool {
+    true
+  }
+}
+
+#[cacheable_dyn]
+impl DependencyCodeGeneration for ImportWeakDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
+    Some(ImportWeakDependencyTemplate::template_type())
+  }
+}
+
+impl AsContextDependency for ImportWeakDependency {}
+
+#[cacheable]
+#[derive(Debug, Clone, Default)]
+pub struct ImportWeakDependencyTemplate;
+
+impl ImportWeakDependencyTemplate {
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("ImportWeakDependency")
+  }
+}
+
+impl DependencyTemplate for ImportWeakDependencyTemplate {
+  fn render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ImportWeakDependency>()
+      .expect("ImportWeakDependencyTemplate should only be used for ImportWeakDependency");
+
+    let module_graph = code_generatable_context.compilation.get_module_graph();
+    let block = module_graph.get_parent_block(&dep.id);
+    source.replace(
+      dep.range.start,
+      dep.range.end,
+      code_generatable_context
+        .runtime_template
+        .module_namespace_promise(
+          code_generatable_context.compilation,
+          code_generatable_context.module.identifier(),
+          &dep.id,
+          block,
+          &dep.request,
+          dep.dependency_type().as_str(),
+          true,
+          dep.get_phase(),
+        ),
+      None,
+    );
+  }
+}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
@@ -10,6 +10,7 @@ mod import_dependency;
 mod import_eager_dependency;
 mod import_meta_resolve_dependency;
 mod import_meta_resolve_header_dependency;
+mod import_weak_dependency;
 mod provide_dependency;
 
 use rspack_core::{DependencyCategory, ImportAttributes, ResourceIdentifier};
@@ -44,6 +45,7 @@ pub use self::{
   import_meta_resolve_header_dependency::{
     ImportMetaResolveHeaderDependency, ImportMetaResolveHeaderDependencyTemplate,
   },
+  import_weak_dependency::{ImportWeakDependency, ImportWeakDependencyTemplate},
   provide_dependency::{ProvideDependency, ProvideDependencyTemplate},
 };
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -18,7 +18,9 @@ use swc_core::{
 
 use super::JavascriptParserPlugin;
 use crate::{
-  dependency::{ImportContextDependency, ImportDependency, ImportEagerDependency},
+  dependency::{
+    ImportContextDependency, ImportDependency, ImportEagerDependency, ImportWeakDependency,
+  },
   magic_comment::try_extract_magic_comment,
   utils::object_properties::{get_attributes, get_value_by_obj_prop},
   visitors::{
@@ -397,6 +399,22 @@ impl JavascriptParserPlugin for ImportParserPlugin {
           dep_idx,
           dep_type: DependencyType::DynamicImportEager,
         }
+      } else if matches!(mode, DynamicImportMode::Weak) {
+        let dep = ImportWeakDependency::new(
+          param.string().as_str().into(),
+          import_call_span.into(),
+          exports,
+          attributes,
+          phase,
+          parser.in_try,
+        );
+        let dep_idx = parser.next_dependency_idx();
+        parser.add_dependency(Box::new(dep));
+        ImportDependencyLocator {
+          block_idx: None,
+          dep_idx,
+          dep_type: DependencyType::DynamicImportWeak,
+        }
       } else {
         let dep = Box::new(ImportDependency::new(
           param.string().as_str().into(),
@@ -544,6 +562,12 @@ impl JavascriptParserPlugin for ImportParserPlugin {
           let dep = dep
             .downcast_mut::<ImportEagerDependency>()
             .expect("Failed to downcast to ImportEagerDependency");
+          dep.set_referenced_specifiers(references);
+        }
+        DependencyType::DynamicImportWeak => {
+          let dep = dep
+            .downcast_mut::<ImportWeakDependency>()
+            .expect("Failed to downcast to ImportWeakDependency");
           dep.set_referenced_specifiers(references);
         }
         DependencyType::ImportContext => {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -31,7 +31,7 @@ use crate::{
     ImportMetaContextDependencyTemplate, ImportMetaHotAcceptDependencyTemplate,
     ImportMetaHotDeclineDependencyTemplate, ImportMetaResolveContextDependencyTemplate,
     ImportMetaResolveDependencyTemplate, ImportMetaResolveHeaderDependencyTemplate,
-    IsIncludedDependencyTemplate, ModuleArgumentDependencyTemplate,
+    ImportWeakDependencyTemplate, IsIncludedDependencyTemplate, ModuleArgumentDependencyTemplate,
     ModuleDecoratorDependencyTemplate, ModuleHotAcceptDependencyTemplate,
     ModuleHotDeclineDependencyTemplate, ProvideDependencyTemplate,
     PureExpressionDependencyTemplate, RequireContextDependencyTemplate,
@@ -156,6 +156,10 @@ async fn compilation(
     params.normal_module_factory.clone(),
   );
   compilation.set_dependency_factory(
+    DependencyType::DynamicImportWeak,
+    params.normal_module_factory.clone(),
+  );
+  compilation.set_dependency_factory(
     DependencyType::ImportContext,
     params.context_module_factory.clone(),
   );
@@ -227,6 +231,10 @@ async fn compilation(
   compilation.set_dependency_template(
     ImportEagerDependencyTemplate::template_type(),
     Arc::new(ImportEagerDependencyTemplate::default()),
+  );
+  compilation.set_dependency_template(
+    ImportWeakDependencyTemplate::template_type(),
+    Arc::new(ImportWeakDependencyTemplate::default()),
   );
   compilation.set_dependency_template(
     ProvideDependencyTemplate::template_type(),

--- a/tests/rspack-test/configCases/parsing/import-weak/index.js
+++ b/tests/rspack-test/configCases/parsing/import-weak/index.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should reject weak import without loading an async chunk", async function () {
+	await expect(
+		import(/* webpackMode: "weak" */ "./weak-dependency")
+	).rejects.toMatchObject({
+		code: "MODULE_NOT_FOUND",
+		message: expect.stringMatching(/weak dependency/)
+	});
+
+	const jsFiles = fs
+		.readdirSync(__dirname)
+		.filter(file => file.endsWith(".js") || file.endsWith(".mjs"));
+	expect(jsFiles).toEqual(["bundle0.js"]);
+
+	const source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+	expect(source).not.toMatch(/__webpack_require__\.e\(\s*\/\* import\(\) \*\//);
+	expect(source).toContain("weak dependency");
+});

--- a/tests/rspack-test/configCases/parsing/import-weak/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/import-weak/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  node: {
+    __dirname: false,
+  },
+  optimization: {
+    minimize: false,
+  },
+};

--- a/tests/rspack-test/configCases/parsing/import-weak/weak-dependency.js
+++ b/tests/rspack-test/configCases/parsing/import-weak/weak-dependency.js
@@ -1,0 +1,1 @@
+export default "weak";

--- a/tests/rspack-test/statsOutputCases/import-weak-parser-option/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/import-weak-parser-option/__snapshots__/stats.txt
@@ -1,9 +1,8 @@
 asset entry.js xx KiB [emitted] (name: entry)
-asset 357.js xx bytes [emitted]
 asset 966.js xx bytes [emitted]
 runtime modules xx KiB 10 modules
+orphan modules xx bytes [orphan] 1 module
 cacheable modules xx bytes
   ./entry.js xx bytes [built] [code generated]
-  ./modules/a.js xx bytes [built] [code generated]
   ./modules/b.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s

--- a/tests/rspack-test/statsOutputCases/import-weak/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/import-weak/__snapshots__/stats.txt
@@ -1,9 +1,8 @@
 asset entry.js xx KiB [emitted] (name: entry)
-asset 357.js xx bytes [emitted]
 asset 966.js xx bytes [emitted]
 runtime modules xx KiB 10 modules
+orphan modules xx bytes [orphan] 1 module
 cacheable modules xx bytes
   ./entry.js xx bytes [built] [code generated]
-  ./modules/a.js xx bytes [built] [code generated]
   ./modules/b.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s


### PR DESCRIPTION
## Summary

- preserve `webpackMode: "weak"` on literal dynamic imports
- avoid creating async dependency blocks/chunks for weak imports
- add regression coverage and update weak import stats snapshots

## Related links

Closes #13814

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Documentation is not required for this bug fix.

Tested with:

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "configCases/parsing/import-weak"`
- `cd tests/rspack-test && pnpm run test -t "statsOutputCases/import-weak"`
- `cd tests/rspack-test && pnpm run test -t "normalCases/chunks/inline-options"`