### PR TITLE
feat(rstest): inject source-module origin into dynamic imports

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2921,6 +2921,7 @@ export interface RawRstestPluginOptions {
   manualMockRoot: string
   preserveNewUrl?: Array<string>
   globals?: boolean
+  injectDynamicImportOrigin?: boolean
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_api/src/rstest.rs
+++ b/crates/rspack_binding_api/src/rstest.rs
@@ -20,6 +20,13 @@ pub struct RawRstestPluginOptions {
   // Whether to handle global `rs` and `rstest` variables.
   // When false, only ESM imported variables are processed. Default is true.
   pub globals: Option<bool>,
+  // When `module.parser.javascript.importDynamic` is `false`, rewrite
+  // non-string-literal `import()` calls (template literals, variables) to the
+  // configured `output.importFunctionName` and append the source module's
+  // absolute path as an extra argument. The runtime uses it as the base for
+  // relative specifier resolution so paths inside bundled deps resolve to the
+  // source file's directory rather than the test entry's.
+  pub inject_dynamic_import_origin: Option<bool>,
 }
 
 impl From<RawRstestPluginOptions> for RstestPluginOptions {
@@ -31,6 +38,7 @@ impl From<RawRstestPluginOptions> for RstestPluginOptions {
       manual_mock_root: value.manual_mock_root,
       preserve_new_url: value.preserve_new_url.unwrap_or_default(),
       globals: value.globals.unwrap_or(true),
+      inject_dynamic_import_origin: value.inject_dynamic_import_origin.unwrap_or(false),
     }
   }
 }

--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -133,6 +133,7 @@ pub enum DependencyType {
   RstestModulePath,
   RstestMockModuleId,
   RstestHoistMock,
+  RstestDynamicImportOrigin,
   /// RSC entry that aggregates all "use client" and CSS modules for one Rspack entry
   RscEntry,
   /// RSC client reference to an individual "use client" or CSS module, not subject to lazy compilation
@@ -220,6 +221,7 @@ impl DependencyType {
       DependencyType::RstestModulePath => "rstest module path",
       DependencyType::RstestMockModuleId => "rstest mock module id",
       DependencyType::RstestHoistMock => "rstest hoist mock",
+      DependencyType::RstestDynamicImportOrigin => "rstest dynamic import origin",
       DependencyType::RscEntry => "rsc entry",
       DependencyType::RscClientReference => "rsc client reference",
     }

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate self as rspack_plugin_javascript;
 
 pub mod dependency;
-mod magic_comment;
+pub mod magic_comment;
 pub mod parser_and_generator;
 mod parser_plugin;
 mod plugin;

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -3,13 +3,14 @@
 extern crate self as rspack_plugin_javascript;
 
 pub mod dependency;
-pub mod magic_comment;
+mod magic_comment;
 pub mod parser_and_generator;
 mod parser_plugin;
 mod plugin;
 pub mod runtime;
 pub mod utils;
 pub mod visitors;
+pub use magic_comment::{RspackCommentMap, try_extract_magic_comment};
 pub use parser_plugin::*;
 use rspack_core::rspack_sources::SourceMap;
 pub use rspack_macros::implemented_javascript_parser_hooks;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1346,6 +1346,21 @@ impl<'parser> JavascriptParser<'parser> {
 }
 
 impl JavascriptParser<'_> {
+  pub fn import_dynamic(&self) -> Option<bool> {
+    self.javascript_options.import_dynamic
+  }
+
+  pub fn import_function_name(&self) -> &str {
+    &self.compiler_options.output.import_function_name
+  }
+
+  /// Mirrors `ImportParserPlugin.import_call`'s first bailout: an `import()`
+  /// call sitting after a terminating statement (e.g. `return` / `throw`) in
+  /// non-top-level scope is unreachable and should not produce dependencies.
+  pub fn is_unreachable_dynamic_import(&self) -> bool {
+    self.terminated.is_some() && !self.is_top_level_scope()
+  }
+
   pub fn evaluate_expression<'a>(&mut self, expr: &'a Expr) -> BasicEvaluatedExpression<'a> {
     match self.evaluating(expr) {
       Some(evaluated) => evaluated.with_expression(Some(expr)),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1346,21 +1346,6 @@ impl<'parser> JavascriptParser<'parser> {
 }
 
 impl JavascriptParser<'_> {
-  pub fn import_dynamic(&self) -> Option<bool> {
-    self.javascript_options.import_dynamic
-  }
-
-  pub fn import_function_name(&self) -> &str {
-    &self.compiler_options.output.import_function_name
-  }
-
-  /// Mirrors `ImportParserPlugin.import_call`'s first bailout: an `import()`
-  /// call sitting after a terminating statement (e.g. `return` / `throw`) in
-  /// non-top-level scope is unreachable and should not produce dependencies.
-  pub fn is_unreachable_dynamic_import(&self) -> bool {
-    self.terminated.is_some() && !self.is_top_level_scope()
-  }
-
   pub fn evaluate_expression<'a>(&mut self, expr: &'a Expr) -> BasicEvaluatedExpression<'a> {
     match self.evaluating(expr) {
       Some(evaluated) => evaluated.with_expression(Some(expr)),

--- a/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
@@ -1,0 +1,101 @@
+use rspack_cacheable::{cacheable, cacheable_dyn};
+use rspack_core::{
+  AsContextDependency, AsModuleDependency, DependencyCodeGeneration, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, TemplateContext,
+  TemplateReplaceSource,
+};
+use rspack_util::json_stringify_str;
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct RstestDynamicImportOriginDependency {
+  callee_range: DependencyRange,
+  args_end: u32,
+  /// Whether the original `import()` call had a 2nd argument (importAttributes).
+  /// When false, an `undefined` placeholder is emitted so `origin` always lands
+  /// at the 3rd argument position the runtime expects.
+  has_attributes: bool,
+  origin_path: String,
+}
+
+impl RstestDynamicImportOriginDependency {
+  pub fn new(
+    callee_range: DependencyRange,
+    args_end: u32,
+    has_attributes: bool,
+    origin_path: String,
+  ) -> Self {
+    Self {
+      callee_range,
+      args_end,
+      has_attributes,
+      origin_path,
+    }
+  }
+}
+
+#[cacheable_dyn]
+impl DependencyCodeGeneration for RstestDynamicImportOriginDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
+    Some(RstestDynamicImportOriginDependencyTemplate::template_type())
+  }
+}
+
+impl AsModuleDependency for RstestDynamicImportOriginDependency {}
+impl AsContextDependency for RstestDynamicImportOriginDependency {}
+
+#[cacheable]
+#[derive(Debug, Clone, Default)]
+pub struct RstestDynamicImportOriginDependencyTemplate;
+
+impl RstestDynamicImportOriginDependencyTemplate {
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::RstestDynamicImportOrigin)
+  }
+}
+
+impl DependencyTemplate for RstestDynamicImportOriginDependencyTemplate {
+  fn render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<RstestDynamicImportOriginDependency>()
+      .expect(
+        "RstestDynamicImportOriginDependencyTemplate can only be applied to \
+         RstestDynamicImportOriginDependency",
+      );
+
+    let import_fn = code_generatable_context
+      .compilation
+      .options
+      .output
+      .import_function_name
+      .clone();
+
+    // Replace `import` callee with the configured importFunctionName.
+    source.replace(
+      dep.callee_range.start,
+      dep.callee_range.end,
+      import_fn,
+      None,
+    );
+
+    // Append the origin so the runtime can resolve relative specifiers against
+    // the source module that produced the dynamic import, instead of the test
+    // entry. Always emit it at the third-argument position — fill the
+    // attributes slot with `void 0` when the call had only a specifier. We
+    // use `void 0` rather than the identifier `undefined` because the latter
+    // can be shadowed (e.g. `function f(undefined) { import(spec) }`), which
+    // would silently feed the runtime a bogus `importAttributes` value.
+    let tail = if dep.has_attributes {
+      format!(", {}", json_stringify_str(&dep.origin_path))
+    } else {
+      format!(", void 0, {}", json_stringify_str(&dep.origin_path))
+    };
+    source.replace(dep.args_end, dep.args_end, tail, None);
+  }
+}

--- a/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
@@ -12,7 +12,7 @@ pub struct RstestDynamicImportOriginDependency {
   callee_range: DependencyRange,
   args_end: u32,
   /// Whether the original `import()` call had a 2nd argument (importAttributes).
-  /// When false, an `undefined` placeholder is emitted so `origin` always lands
+  /// When false, a `void 0` placeholder is emitted so `origin` always lands
   /// at the 3rd argument position the runtime expects.
   has_attributes: bool,
   origin_path: String,

--- a/crates/rspack_plugin_rstest/src/lib.rs
+++ b/crates/rspack_plugin_rstest/src/lib.rs
@@ -1,3 +1,4 @@
+mod dynamic_import_origin_dependency;
 mod esm_import_dependency;
 mod import_dependency;
 mod mock_method_dependency;

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -54,6 +54,13 @@ pub struct RstestParserPluginOptions {
   /// absolute path as an extra argument so the runtime can resolve relative
   /// specifiers against it.
   pub inject_dynamic_import_origin: bool,
+  /// Snapshot of `module.parser.javascript*.importDynamic` for this module
+  /// type. Used by the dynamic-import-origin rewrite to gate behavior on
+  /// `Some(false)`.
+  pub import_dynamic: Option<bool>,
+  /// Snapshot of `output.importFunctionName`. Used by the
+  /// dynamic-import-origin rewrite to substitute the `import` callee.
+  pub import_function_name: String,
 }
 
 impl Default for RstestParserPluginOptions {
@@ -65,6 +72,8 @@ impl Default for RstestParserPluginOptions {
       manual_mock_root: String::new(),
       globals: true,
       inject_dynamic_import_origin: false,
+      import_dynamic: None,
+      import_function_name: String::new(),
     }
   }
 }
@@ -730,7 +739,9 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       }
     }
 
-    if self.options.inject_dynamic_import_origin && matches!(parser.import_dynamic(), Some(false)) {
+    if self.options.inject_dynamic_import_origin
+      && matches!(self.options.import_dynamic, Some(false))
+    {
       // Only handle the regular evaluation phase. `import.defer(...)` and
       // `import.source(...)` carry phase semantics that rstest's runtime
       // does not implement, and the default `ImportParserPlugin` enforces
@@ -747,21 +758,12 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       // would produce a SyntaxError at parse time. Skip injection when no
       // custom `importFunctionName` is configured and let the default
       // `ImportParserPlugin` handle the call as before.
-      if parser.import_function_name() == "import" {
+      if self.options.import_function_name == "import" {
         return None;
       }
 
-      // Mirror `ImportParserPlugin.import_call`'s bailouts so we don't
-      // change behavior for cases the default plugin already handles
-      // specially:
-      //   - dead code after `return`/`throw` in non-top-level scope
-      //   - `/* webpackIgnore: true */` magic comment
-      // In both cases we yield to the default plugin (return None) instead
-      // of rewriting the call.
-      if parser.is_unreachable_dynamic_import() {
-        return None;
-      }
-
+      // Mirror `ImportParserPlugin.import_call`'s `/* webpackIgnore: true */`
+      // bailout so authors can opt out of rewriting on a per-call basis.
       let arg = call_expr.args.first()?;
       if arg.spread.is_some() {
         return None;

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -5,6 +5,7 @@ use rspack_core::{
 use rspack_plugin_javascript::{
   JavascriptParserPlugin,
   dependency::{CommonJsRequireDependency, ImportDependency, RequireHeaderDependency},
+  magic_comment::try_extract_magic_comment,
   utils::{
     self,
     eval::{self},
@@ -20,6 +21,7 @@ use swc_core::{
 static RSTEST_MOCK_FIRST_ARG_TAG: &str = "strip the import call from the first arg of mock series";
 
 use crate::{
+  dynamic_import_origin_dependency::RstestDynamicImportOriginDependency,
   mock_method_dependency::{MockMethod, MockMethodDependency},
   mock_module_id_dependency::MockModuleIdDependency,
   module_path_name_dependency::{ModulePathNameDependency, NameType},
@@ -46,6 +48,12 @@ pub struct RstestParserPluginOptions {
   /// Whether to handle global `rs` and `rstest` variables.
   /// When false, only ESM imported variables are processed.
   pub globals: bool,
+  /// When `module.parser.javascript.importDynamic` is `false` and the dynamic
+  /// import specifier is not a plain string literal, rewrite the callee to the
+  /// configured `output.importFunctionName` and append the source module's
+  /// absolute path as an extra argument so the runtime can resolve relative
+  /// specifiers against it.
+  pub inject_dynamic_import_origin: bool,
 }
 
 impl Default for RstestParserPluginOptions {
@@ -56,6 +64,7 @@ impl Default for RstestParserPluginOptions {
       import_meta_path_name: false,
       manual_mock_root: String::new(),
       globals: true,
+      inject_dynamic_import_origin: false,
     }
   }
 }
@@ -706,7 +715,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     call_expr: &CallExpr,
-    _import_then: Option<&CallExpr>,
+    import_then: Option<&CallExpr>,
     _members: Option<(&[Atom], bool)>,
   ) -> Option<bool> {
     let first_arg = self.handle_mock_first_arg(parser, call_expr);
@@ -719,6 +728,83 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       if tag_data.is_some() {
         return Some(true);
       }
+    }
+
+    if self.options.inject_dynamic_import_origin && matches!(parser.import_dynamic(), Some(false)) {
+      // Only handle the regular evaluation phase. `import.defer(...)` and
+      // `import.source(...)` carry phase semantics that rstest's runtime
+      // does not implement, and the default `ImportParserPlugin` enforces
+      // the `experiments.deferImport` gate which we must not bypass.
+      let import_node = call_expr.callee.as_import()?;
+      if !matches!(
+        import_node.phase,
+        swc_core::ecma::ast::ImportPhase::Evaluation
+      ) {
+        return None;
+      }
+
+      // Native `import()` only accepts 1-2 args; appending a third argument
+      // would produce a SyntaxError at parse time. Skip injection when no
+      // custom `importFunctionName` is configured and let the default
+      // `ImportParserPlugin` handle the call as before.
+      if parser.import_function_name() == "import" {
+        return None;
+      }
+
+      // Mirror `ImportParserPlugin.import_call`'s bailouts so we don't
+      // change behavior for cases the default plugin already handles
+      // specially:
+      //   - dead code after `return`/`throw` in non-top-level scope
+      //   - `/* webpackIgnore: true */` magic comment
+      // In both cases we yield to the default plugin (return None) instead
+      // of rewriting the call.
+      if parser.is_unreachable_dynamic_import() {
+        return None;
+      }
+
+      let arg = call_expr.args.first()?;
+      if arg.spread.is_some() {
+        return None;
+      }
+
+      let magic = try_extract_magic_comment(parser, call_expr.span, arg.span());
+      if magic.get_ignore().unwrap_or_default() {
+        return None;
+      }
+
+      let param = parser.evaluate_expression(arg.expr.as_ref());
+      if param.is_string() {
+        return None;
+      }
+
+      let resource_path = parser.resource_data.path()?;
+      let origin_path = resource_path.as_str().to_string();
+
+      let last_arg = call_expr
+        .args
+        .last()
+        .expect("call_expr.args has at least one element");
+      let args_end = last_arg.span().real_hi();
+      let has_attributes = call_expr.args.len() >= 2;
+
+      parser.add_presentational_dependency(Box::new(RstestDynamicImportOriginDependency::new(
+        call_expr.callee.span().into(),
+        args_end,
+        has_attributes,
+        origin_path,
+      )));
+
+      // Returning `Some(true)` short-circuits the parser's walk of this
+      // `import()` node (see `walk.rs` `Callee::Import` branch), so we must
+      // walk nested expressions ourselves — otherwise `require(...)` or
+      // `import()` calls inside the specifier or the `.then` callback get
+      // dropped from the dependency graph.
+      parser.walk_expr_or_spread(&call_expr.args);
+      if let Some(import_then) = import_then {
+        parser.walk_expr_or_spread(&import_then.args);
+      }
+
+      return Some(true);
     }
 
     None

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
 use rspack_plugin_javascript::{
   JavascriptParserPlugin,
   dependency::{CommonJsRequireDependency, ImportDependency, RequireHeaderDependency},
-  magic_comment::try_extract_magic_comment,
+  try_extract_magic_comment,
   utils::{
     self,
     eval::{self},

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -1,5 +1,5 @@
 use std::{
-  sync::{Arc, LazyLock},
+  sync::{Arc, LazyLock, OnceLock},
   time::{Duration, Instant},
 };
 
@@ -63,11 +63,15 @@ pub struct ProgressPluginStateInfo {
 #[derive(Debug)]
 pub struct RstestPlugin {
   options: RstestPluginOptions,
+  /// Captured from `compilation.options.output.import_function_name` in the
+  /// `compilation` hook so the parser plugin (constructed later in
+  /// `nmf_parser`) can read it without reaching into `JavascriptParser`.
+  import_function_name: OnceLock<String>,
 }
 
 impl RstestPlugin {
   pub fn new(options: RstestPluginOptions) -> Self {
-    Self::new_inner(options)
+    Self::new_inner(options, OnceLock::new())
   }
 
   fn calc_default_mocked_target(&self, value: &str) -> Utf8PathBuf {
@@ -230,11 +234,24 @@ async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut Box<dyn ParserAndGenerator>,
-  _parser_options: Option<&ParserOptions>,
+  parser_options: Option<&ParserOptions>,
 ) -> Result<()> {
   if module_type.is_js_like()
     && let Some(parser) = parser.downcast_mut::<JavaScriptParserAndGenerator>()
   {
+    // Read the merged `module.parser.javascript*.importDynamic` for this
+    // module type so the parser plugin can short-circuit when dynamic imports
+    // are disabled, without reaching into `JavascriptParser`.
+    let import_dynamic = parser_options
+      .and_then(|opts| {
+        opts
+          .get_javascript()
+          .or_else(|| opts.get_javascript_auto())
+          .or_else(|| opts.get_javascript_esm())
+          .or_else(|| opts.get_javascript_dynamic())
+      })
+      .and_then(|js| js.import_dynamic);
+
     parser.add_parser_plugin(Box::new(RstestParserPlugin::new(
       crate::parser_plugin::RstestParserPluginOptions {
         module_path_name: self.options.module_path_name,
@@ -243,6 +260,8 @@ async fn nmf_parser(
         manual_mock_root: self.options.manual_mock_root.clone(),
         globals: self.options.globals,
         inject_dynamic_import_origin: self.options.inject_dynamic_import_origin,
+        import_dynamic,
+        import_function_name: self.import_function_name.get().cloned().unwrap_or_default(),
       },
     )) as BoxJavascriptParserPlugin);
   }
@@ -256,6 +275,13 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
+  // Capture the configured `output.importFunctionName` so the parser plugin
+  // can read it without reaching into `JavascriptParser`. Set runs before
+  // `nmf_parser` so the value is observable when the parser plugin is built.
+  let _ = self
+    .import_function_name
+    .set(compilation.options.output.import_function_name.clone());
+
   compilation.set_dependency_template(
     ModulePathNameDependencyTemplate::template_type(),
     Arc::new(ModulePathNameDependencyTemplate::default()),

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -29,6 +29,7 @@ static RSTEST_FLAG_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 use crate::{
+  dynamic_import_origin_dependency::RstestDynamicImportOriginDependencyTemplate,
   esm_import_dependency::{
     RstestESMImportSideEffectDependencyTemplate, RstestESMImportSpecifierDependencyTemplate,
   },
@@ -48,6 +49,7 @@ pub struct RstestPluginOptions {
   pub manual_mock_root: String,
   pub preserve_new_url: Vec<String>,
   pub globals: bool,
+  pub inject_dynamic_import_origin: bool,
 }
 
 #[derive(Debug)]
@@ -240,6 +242,7 @@ async fn nmf_parser(
         import_meta_path_name: self.options.import_meta_path_name,
         manual_mock_root: self.options.manual_mock_root.clone(),
         globals: self.options.globals,
+        inject_dynamic_import_origin: self.options.inject_dynamic_import_origin,
       },
     )) as BoxJavascriptParserPlugin);
   }
@@ -266,6 +269,11 @@ async fn compilation(
   compilation.set_dependency_template(
     MockModuleIdDependencyTemplate::template_type(),
     Arc::new(MockModuleIdDependencyTemplate::default()),
+  );
+
+  compilation.set_dependency_template(
+    RstestDynamicImportOriginDependencyTemplate::template_type(),
+    Arc::new(RstestDynamicImportOriginDependencyTemplate::default()),
   );
 
   Ok(())
@@ -436,7 +444,7 @@ impl Plugin for RstestPlugin {
       .compilation
       .tap(compilation_stage_9999::new(self));
 
-    if self.options.module_path_name {
+    if self.options.module_path_name || self.options.inject_dynamic_import_origin {
       ctx
         .normal_module_factory_hooks
         .parser

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin/index.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin/index.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+const sourceFile = path.resolve(
+	__dirname,
+	'../../../../configCases/rstest/dynamic-import-origin/src/index.js',
+);
+
+it('rewrites template-literal dynamic imports with importFunctionName + origin', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'dynamicImportOrigin.mjs'),
+		'utf-8',
+	);
+
+	const importFn = 'import.meta.__rstest_dynamic_import__';
+	const originLiteral = JSON.stringify(sourceFile);
+
+	// Template literal call (1 arg) must be rewritten and end with
+	// `, void 0, "<origin>")` so origin always lands at the third-argument
+	// position the runtime expects. We use `void 0` rather than the
+	// identifier `undefined` because the latter can be shadowed.
+	expect(content).toContain(`${importFn}(\`./translations/`);
+	expect(content).toContain(
+		`/strings.json\`, void 0, ${originLiteral})`,
+	);
+
+	// The shadow-resistant placeholder must be `void 0`, not `undefined`.
+	expect(content).not.toMatch(
+		/__rstest_dynamic_import__\(`\.\/translations[^)]*,\s*undefined,/,
+	);
+
+	// Variable specifier with attributes — origin is the third argument,
+	// inserted *after* `{ with: ... }` (no `undefined` placeholder needed).
+	expect(content).toContain(
+		`${importFn}(name, { with: { type: 'json' } }, ${originLiteral})`,
+	);
+
+	// No doubled importFunctionName (the rspack#13673 regression).
+	expect(content).not.toContain(`${importFn}${importFn}`);
+
+	// Static literal `import('./literal.js')` must NOT be rewritten by us — it
+	// goes through rspack's default ImportDependency path and ends up as a
+	// `__webpack_require__.e(...).then(...)` chain.
+	expect(content).not.toContain(`${importFn}('./literal.js'`);
+	expect(content).not.toContain(`${importFn}("./literal.js"`);
+
+	// `require('./nested.js')` nested inside the dynamic import argument
+	// must still be collected as a dependency. Otherwise `nested.js` would
+	// not be in the bundle and accessing `.name` would throw at runtime.
+	expect(content).toContain(`module.exports = { name: './literal.js' }`);
+
+	// `/* webpackIgnore: true */ import(...)` must be left as a native
+	// dynamic import. We must not rewrite the callee or append origin.
+	expect(content).toContain('`./ignored/${');
+	expect(content).not.toMatch(
+		/__rstest_dynamic_import__\(`\.\/ignored\//,
+	);
+});

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin/rspack.config.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+  {
+    entry: './src/index.js',
+    target: 'node',
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: 'dynamicImportOrigin.mjs',
+      module: true,
+      importFunctionName: 'import.meta.__rstest_dynamic_import__',
+      chunkFormat: 'module',
+    },
+    module: {
+      parser: {
+        javascript: {
+          importDynamic: false,
+        },
+      },
+    },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: false,
+        hoistMockModule: false,
+        importMetaPathName: true,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+        injectDynamicImportOrigin: true,
+      }),
+    ],
+  },
+  {
+    entry: {
+      main: './index.js',
+    },
+    output: {
+      filename: '[name].js',
+    },
+    externalsPresets: {
+      node: true,
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin/src/index.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin/src/index.js
@@ -1,0 +1,34 @@
+// `import.meta.url` must continue to work alongside dynamic-import rewriting.
+const here = import.meta.url;
+
+const dir = process.env.x;
+
+// Template literal — should be rewritten with origin appended.
+const a = import(`./translations/${dir}/strings.json`);
+
+// Variable specifier with attributes — origin must be inserted *after* the
+// attributes object as the third argument.
+const name = process.env.name;
+const b = import(name, { with: { type: 'json' } });
+
+// Literal specifier — should fall through to rspack's default static path
+// (no origin injection).
+const c = import('./literal.js');
+
+// Nested require inside the import() arg — must still be collected as a
+// dependency by the parser even though we short-circuit ImportParserPlugin.
+const d = import(require('./nested.js').name);
+
+// `webpackIgnore: true` — must NOT be rewritten; the user wants the native
+// runtime to load it.
+const e = import(/* webpackIgnore: true */ `./ignored/${dir}.mjs`);
+
+// Shadow-resistance: even when `undefined` is shadowed in the enclosing
+// scope, the missing-attributes placeholder must still resolve to the
+// real `undefined` value (`void 0`).
+function shadowSafe(undefined) {
+  return import(`./translations/${dir}/strings.json`);
+}
+const f = shadowSafe(42);
+
+console.log(here, a, b, c, d, e, f);

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin/src/literal.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin/src/literal.js
@@ -1,0 +1,1 @@
+export const literal = 'literal-target';

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin/src/nested.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin/src/nested.js
@@ -1,0 +1,1 @@
+module.exports = { name: './literal.js' };

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin/test.config.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: function () {
+		return ['main.js'];
+	},
+};


### PR DESCRIPTION
## Summary

Add a `RstestPlugin` option `injectDynamicImportOrigin`. When `module.parser.javascript.importDynamic: false`, non-string-evaluatable `import()` calls are rewritten to `<importFunctionName>(specifier, importAttributes, "<originPath>")` so the rstest runtime can resolve relative specifiers against the source module that produced the call instead of the test entry.

Closes web-infra-dev/rstest#1207, web-infra-dev/rstest#358 once the matching rstest runtime change lands.

## Prior art

- #13673 attempted the same direction in rspack core via a `ConstDependency` callee rewrite. It was reverted in #13699 because the `ConstDependency` overlapped with `ImportMetaPlugin`'s rewrites for `importFunctionName: "import.meta.X"`, producing a doubled string.
- This PR scopes the rewrite to `rspack_plugin_rstest` and does both source replacements (callee + origin arg) inside a single dedicated dependency template, so no span is shared with any other plugin.

## Test plan

- [x] new `configCases/rstest/dynamic-import-origin/` covers template literal / variable specifier / `with: {...}` attributes / static literal / nested `require()` / `webpackIgnore` / `undefined` shadowing
- [x] reporter's failing e2e (`externals/dynamicImportRelative.test.ts`) passes with this rspack + the companion rstest runtime patch
- [ ] CI green