### PR TITLE
test: reduce persistent cache bench output variance

### DIFF
--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -19,6 +19,9 @@ pub use native_fs::{NativeFileSystem, NativeReadStream, NativeWriteStream};
 mod memory_fs;
 pub use memory_fs::{MemoryFileSystem, MemoryReadStream, MemoryWriteStream};
 
+mod noop_fs;
+pub use noop_fs::NoopFileSystem;
+
 mod error;
 pub use error::{
   Error, FsResultToIoResultExt, IoResultToFsResultExt, Result, RspackResultToFsResultExt,

--- a/crates/rspack_fs/src/noop_fs.rs
+++ b/crates/rspack_fs/src/noop_fs.rs
@@ -1,0 +1,52 @@
+use rspack_paths::Utf8Path;
+
+use crate::{Error, FileMetadata, FilePermissions, Result, WritableFileSystem};
+
+#[derive(Debug, Default)]
+pub struct NoopFileSystem;
+
+#[async_trait::async_trait]
+impl WritableFileSystem for NoopFileSystem {
+  async fn create_dir(&self, _dir: &Utf8Path) -> Result<()> {
+    Ok(())
+  }
+
+  async fn create_dir_all(&self, _dir: &Utf8Path) -> Result<()> {
+    Ok(())
+  }
+
+  async fn write(&self, _file: &Utf8Path, _data: &[u8]) -> Result<()> {
+    Ok(())
+  }
+
+  async fn remove_file(&self, _file: &Utf8Path) -> Result<()> {
+    Ok(())
+  }
+
+  async fn remove_dir_all(&self, _dir: &Utf8Path) -> Result<()> {
+    Ok(())
+  }
+
+  async fn read_dir(&self, _dir: &Utf8Path) -> Result<Vec<String>> {
+    Ok(Vec::new())
+  }
+
+  async fn read_file(&self, _file: &Utf8Path) -> Result<Vec<u8>> {
+    Err(not_found())
+  }
+
+  async fn stat(&self, _file: &Utf8Path) -> Result<FileMetadata> {
+    Err(not_found())
+  }
+
+  async fn set_permissions(&self, _path: &Utf8Path, _perm: FilePermissions) -> Result<()> {
+    Ok(())
+  }
+}
+
+fn not_found() -> Error {
+  Error::Io(std::io::Error::new(
+    std::io::ErrorKind::NotFound,
+    "file not exist",
+  ))
+}

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   CacheOptions, Mode,
   cache::persistent::{PersistentCacheOptions, snapshot::SnapshotOptions, storage::StorageOptions},
 };
-use rspack_fs::{MemoryFileSystem, NativeFileSystem};
+use rspack_fs::{NativeFileSystem, NoopFileSystem};
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
 
 use super::bundle::basic_react;
@@ -188,7 +188,7 @@ fn persistent_compiler(project_dir: &Path, cache_dir: &Path) -> rspack::builder:
       readonly: false,
     }))
     .input_filesystem(Arc::new(NativeFileSystem::new(false)))
-    .output_filesystem(Arc::new(MemoryFileSystem::default()));
+    .output_filesystem(Arc::new(NoopFileSystem));
   builder
 }
 


### PR DESCRIPTION
## Summary

- add a `NoopFileSystem` implementation to `rspack_fs`
- use it as the output filesystem for the persistent cache benchmark to avoid MemoryFileSystem write variance

## Related links

- https://github.com/web-infra-dev/rspack/blob/599e09b0baa077fda13024f8908c51e9992e2c61/xtask/benchmark/benches/groups/persistent_cache.rs#L191

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Verified with:

```bash
cargo check -p rspack_benchmark --benches
```