### PR TITLE
perf(split-chunks): lazily precompute sorted modules for compare

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,7 +1,6 @@
 use std::{cmp::Ordering, fmt};
 
 use derive_more::Debug;
-use itertools::Itertools;
 use rspack_collections::IdentifierSet;
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -27,6 +26,42 @@ impl<'a> IndexedCacheGroup<'a> {
 
   pub fn compare_by_index(&self, other: &Self) -> Ordering {
     self.cache_group_index.cmp(&other.cache_group_index)
+  }
+}
+
+#[derive(Debug)]
+enum ModulesForCompare {
+  Unsorted(Vec<ModuleIdentifier>),
+  Sorted(Vec<ModuleIdentifier>),
+}
+
+impl Default for ModulesForCompare {
+  fn default() -> Self {
+    Self::Unsorted(Default::default())
+  }
+}
+
+impl ModulesForCompare {
+  fn prepare(&mut self, modules: Vec<ModuleIdentifier>) {
+    if modules.is_empty() {
+      return;
+    }
+
+    if matches!(self, Self::Unsorted(modules_for_compare) if modules_for_compare.is_empty()) {
+      *self = Self::Unsorted(modules);
+    }
+  }
+
+  fn sorted(&mut self) -> &[ModuleIdentifier] {
+    if let Self::Unsorted(modules) = self {
+      modules.sort_unstable_by_key(|module| module.precomputed_hash());
+      *self = Self::Sorted(std::mem::take(modules));
+    }
+
+    let Self::Sorted(modules) = self else {
+      unreachable!("modules for compare should be sorted");
+    };
+    modules
   }
 }
 
@@ -86,6 +121,7 @@ pub(crate) struct ModuleGroup {
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: FxHashSet<ChunkUkey>,
+  modules_for_compare: ModulesForCompare,
   added: Vec<ModuleIdentifier>,
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,
@@ -101,6 +137,7 @@ impl ModuleGroup {
       sizes: Default::default(),
       source_types_modules: Default::default(),
       chunks: Default::default(),
+      modules_for_compare: Default::default(),
       chunk_name,
       added: Default::default(),
       removed: Default::default(),
@@ -138,15 +175,24 @@ impl ModuleGroup {
   }
 
   pub fn add_module(&mut self, module: ModuleIdentifier) {
-    if self.modules.insert(module) {
-      self.added.push(module);
-    }
+    self.modules.insert(module);
   }
 
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
     if self.modules.remove(&module) {
       self.removed.push(module);
     }
+  }
+
+  pub fn prepare_modules_for_sizes_and_compare(&mut self) {
+    let modules = self.modules.iter().copied().collect::<Vec<_>>();
+    self.added = modules.clone();
+    self.modules_for_compare.prepare(modules);
+    self.removed.reserve(self.modules.len());
+  }
+
+  pub fn sorted_modules_for_compare(&mut self) -> &[ModuleIdentifier] {
+    self.modules_for_compare.sorted()
   }
 
   pub fn get_cache_group<'a>(&self, cache_groups: &'a [CacheGroup]) -> &'a CacheGroup {
@@ -200,8 +246,8 @@ impl ModuleGroup {
 }
 
 pub(crate) fn compare_entries(
-  (a_key, a): (&ModuleGroupKey, &ModuleGroup),
-  (b_key, b): (&ModuleGroupKey, &ModuleGroup),
+  (a_key, a): (&ModuleGroupKey, &mut ModuleGroup),
+  (b_key, b): (&ModuleGroupKey, &mut ModuleGroup),
 ) -> f64 {
   // 1. by priority
   // no need to compare priority anymore because we already pick all cache groups with same priority
@@ -239,14 +285,8 @@ pub(crate) fn compare_entries(
     return diff;
   }
 
-  let mut modules_a = a
-    .modules
-    .iter()
-    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
-  let mut modules_b = b
-    .modules
-    .iter()
-    .sorted_unstable_by(|a, b| a.precomputed_hash().cmp(&b.precomputed_hash()));
+  let mut modules_a = a.sorted_modules_for_compare().iter();
+  let mut modules_b = b.sorted_modules_for_compare().iter();
 
   loop {
     match (modules_a.next(), modules_b.next()) {
@@ -257,7 +297,8 @@ pub(crate) fn compare_entries(
           return res as i32 as f64;
         }
       }
-      _ => unreachable!(),
+      (None, Some(_)) => return -1.0,
+      (Some(_), None) => return 1.0,
     }
   }
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -7,7 +7,7 @@ mod module_group;
 use std::{borrow::Cow, cmp::Ordering, fmt::Debug};
 
 use itertools::Itertools;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
 use rspack_collections::IdentifierMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
@@ -170,6 +170,9 @@ impl SplitChunksPlugin {
         .await?;
       tracing::trace!("prepared module_group_map {:#?}", module_group_map);
 
+      module_group_map
+        .par_iter_mut()
+        .for_each(|(_, module_group)| module_group.prepare_modules_for_sizes_and_compare());
       self.ensure_min_size_fit(&mut module_group_map, &module_sizes);
 
       while !module_group_map.is_empty() {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -1,5 +1,4 @@
 use std::{
-  cmp::Ordering,
   hash::{Hash, Hasher},
   ops::Deref,
   sync::Arc,
@@ -402,26 +401,20 @@ impl SplitChunksPlugin {
   ) -> (ModuleGroupKey, ModuleGroup) {
     debug_assert!(!module_group_map.is_empty());
 
-    let best_entry_key = module_group_map
-      .keys()
-      .map(|key| (key, module_group_map.get(key).expect("should have item")))
-      .min_by(|a, b| {
-        let result = compare_entries((a.0, a.1), (b.0, b.1));
-        if result < 0f64 {
-          Ordering::Greater
-        } else if result > 0f64 {
-          Ordering::Less
-        } else {
-          Ordering::Equal
-        }
-      })
-      .map(|(key, _)| key.clone())
-      .expect("at least have one item");
+    let mut best_entry_index = 0;
+    for entry_index in 1..module_group_map.len() {
+      let [(entry_key, entry), (best_entry_key, best_entry)] = module_group_map
+        .get_disjoint_indices_mut([entry_index, best_entry_index])
+        .expect("entry indices should be valid and unique");
+      let result = compare_entries((entry_key, entry), (best_entry_key, best_entry));
+      if result > 0f64 {
+        best_entry_index = entry_index;
+      }
+    }
 
-    let best_module_group = module_group_map
-      .swap_remove(&best_entry_key)
-      .expect("This should never happen, please file an issue");
-    (best_entry_key, best_module_group)
+    module_group_map
+      .swap_remove_index(best_entry_index)
+      .expect("This should never happen, please file an issue")
   }
 
   #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary

Avoid repeatedly sorting module identifiers inside `compare_entries`, while only paying the sorting cost when the modules tie-break is actually reached.

This PR:
- makes `add_module` only update the module set during module-group preparation
- prepares `added` and the compare snapshot from the complete module set before min-size filtering and best-group selection
- reserves `removed` capacity based on the module count to avoid repeated growth during removals
- represents the compare snapshot as an enum state: unsorted before the first modules tie-break, sorted after it has been prepared
- fills the sorted state lazily only when `compare_entries` needs to compare modules
- keeps `remove_module` from maintaining the compare snapshot, since it is only used as a deterministic tie-break key
- changes `find_best_module_group` to compare entries by index so both candidate groups can be lazily prepared during comparison

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
