### PR TITLE
fix: enable module static cache in development

### DIFF
--- a/crates/rspack_core/src/compilation/run_passes.rs
+++ b/crates/rspack_core/src/compilation/run_passes.rs
@@ -43,17 +43,13 @@ impl Compilation {
       Box::new(AfterProcessAssetsPass),
       Box::new(AfterSealPass),
     ];
-    if !self.options.mode.is_development() {
-      self.module_static_cache.enable_new_cache();
-    }
+    self.module_static_cache.enable_new_cache();
 
     for pass in &passes {
       pass.run(self, cache).await?;
     }
 
-    if !self.options.mode.is_development() {
-      self.module_static_cache.disable_cache();
-    }
+    self.module_static_cache.disable_cache();
 
     Ok(())
   }


### PR DESCRIPTION
## Summary

Enable module static cache for both development and production compilations by removing the `mode.is_development()` guards around cache enable/disable in `Compilation::run_passes`.

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo fmt --all --check`
- `cargo check -p rspack_core`

Note: commit was created with `--no-verify` because `pnpm`/`corepack` is not available in this shell, so the Husky pre-commit hook could not start.