### PR TITLE
chore: upgrade swc_core from 64 to 65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
  "rspack_tasks",
  "rustc-hash",
  "serde_json",
- "swc_core",
+ "swc_core 65.0.1",
  "tokio",
 ]
 
@@ -3796,7 +3796,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sftrace-setup",
- "swc_core",
+ "swc_core 65.0.1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3873,7 +3873,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "sugar_path",
- "swc_core",
+ "swc_core 65.0.1",
  "ustr-fxhash",
  "xxhash-rust",
 ]
@@ -3900,7 +3900,7 @@ dependencies = [
  "rspack_sources",
  "rustc-hash",
  "serde_json",
- "swc_core",
+ "swc_core 65.0.1",
  "ustr-fxhash",
  "xxhash-rust",
 ]
@@ -3974,7 +3974,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "swc_core",
+ "swc_core 65.0.1",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",
  "swc_experimental_ecma_semantic",
@@ -4080,7 +4080,7 @@ dependencies = [
  "serde",
  "stacker",
  "swc_config",
- "swc_core",
+ "swc_core 65.0.1",
  "swc_ecma_minifier",
  "swc_error_reporters",
  "url",
@@ -4184,7 +4184,7 @@ dependencies = [
  "sugar_path",
  "swc",
  "swc_config",
- "swc_core",
+ "swc_core 65.0.1",
  "tokio",
  "tracing",
 ]
@@ -4520,7 +4520,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "swc_core",
+ "swc_core 65.0.1",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",
  "swc_experimental_ecma_semantic",
@@ -4609,7 +4609,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "swc_core",
+ "swc_core 65.0.1",
  "swc_html",
  "swc_html_minifier",
  "tracing",
@@ -4665,7 +4665,7 @@ dependencies = [
  "slotmap",
  "smallvec",
  "sugar_path",
- "swc_core",
+ "swc_core 65.0.1",
  "tokio",
  "tracing",
  "url",
@@ -4722,7 +4722,7 @@ dependencies = [
  "rspack_plugin_split_chunks",
  "rspack_util",
  "serde_json",
- "swc_core",
+ "swc_core 65.0.1",
  "tracing",
 ]
 
@@ -4918,7 +4918,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simd-json",
- "swc_core",
+ "swc_core 65.0.1",
  "tokio",
  "tracing",
  "urlencoding",
@@ -4964,7 +4964,7 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
- "swc_core",
+ "swc_core 65.0.1",
  "tracing",
 ]
 
@@ -4982,7 +4982,7 @@ dependencies = [
  "rspack_plugin_javascript",
  "rspack_util",
  "rustc-hash",
- "swc_core",
+ "swc_core 65.0.1",
  "tracing",
 ]
 
@@ -5132,7 +5132,7 @@ dependencies = [
  "rspack_util",
  "serde_json",
  "swc_config",
- "swc_core",
+ "swc_core 65.0.1",
  "swc_ecma_minifier",
  "thread_local",
  "tracing",
@@ -5151,7 +5151,7 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_util",
- "swc_core",
+ "swc_core 65.0.1",
  "tokio",
  "tracing",
  "wasmparser 0.222.0",
@@ -5178,7 +5178,7 @@ dependencies = [
  "regress",
  "rspack_cacheable",
  "rspack_error",
- "swc_core",
+ "swc_core 65.0.1",
 ]
 
 [[package]]
@@ -5245,7 +5245,7 @@ dependencies = [
  "heck",
  "rustc-hash",
  "serde",
- "swc_core",
+ "swc_core 65.0.1",
 ]
 
 [[package]]
@@ -5256,7 +5256,7 @@ dependencies = [
  "insta",
  "rspack_javascript_compiler",
  "rustc-hash",
- "swc_core",
+ "swc_core 65.0.1",
 ]
 
 [[package]]
@@ -5333,7 +5333,7 @@ dependencies = [
  "signal-hook",
  "sugar_path",
  "swc_config",
- "swc_core",
+ "swc_core 65.0.1",
  "swc_plugin_runner",
  "unicase",
  "wasi-common",
@@ -5828,9 +5828,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "62.0.0"
+version = "63.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d37dafd7bf211a8e8fcbf4c457c0aa6beab54b1b64b73d6d7f5ff361b57d3dc"
+checksum = "ed538506e7f012866133821341c7eb55b08adb445d230f1caf894db730f32418"
 dependencies = [
  "anyhow",
  "base64",
@@ -6000,6 +6000,22 @@ name = "swc_core"
 version = "64.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e469652a94edc37bf70f0a8274ffe1996ba0ab36042d306c5af6a7431e2559bc"
+dependencies = [
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_visit",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
+version = "65.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d31c34dbae14e61ab4236f32dffc29632f5a8324c1a38d3ad52236b5eeadf5"
 dependencies = [
  "par-core",
  "swc",
@@ -6303,9 +6319,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "52.0.0"
+version = "52.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022cf97e5c6947281df1fde76e2217e03a18d5cbf2e50904be99a62c105a91fa"
+checksum = "993e8c98b61b4018d9502a50a6a9ab20212696bf8cb2f3588fa7e7a2b8260407"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -6339,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "39.0.0"
+version = "39.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcab483dcb857e39ffadd080da9c7644228bb5459f03d0f7b73a43b25acb0e1a"
+checksum = "c94d9deb6d91ade011685df51fdbb345f33de17e0b70ea7b2028051a8b76da36"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6659,9 +6675,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "46.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c2fba9629eb1b240564e01ca2eabd6476823758287334a0ba80974d69ad672"
+checksum = "9ca42ecf63797d54a536888d01859bc6dfdf6104ca9664cb99410945d63ea6b1"
 dependencies = [
  "bytes-str",
  "rustc-hash",
@@ -6753,7 +6769,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "num-bigint",
  "oxc_index",
- "swc_core",
+ "swc_core 64.0.0",
  "swc_experimental_ast_macros",
  "unicode-id-start",
 ]
@@ -6770,7 +6786,7 @@ dependencies = [
  "rustc-hash",
  "seq-macro",
  "smartstring",
- "swc_core",
+ "swc_core 64.0.0",
  "swc_experimental_ecma_ast",
  "tracing",
 ]
@@ -6783,7 +6799,7 @@ checksum = "5f208a43d5f1cf1f75709f8fa0d18b8faa29c52aeef391be6d6f2f4e88d174e5"
 dependencies = [
  "oxc_index",
  "rustc-hash",
- "swc_core",
+ "swc_core 64.0.0",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_visit",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
  "rspack_tasks",
  "rustc-hash",
  "serde_json",
- "swc_core 65.0.1",
+ "swc_core",
  "tokio",
 ]
 
@@ -3796,7 +3796,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sftrace-setup",
- "swc_core 65.0.1",
+ "swc_core",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3873,7 +3873,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "sugar_path",
- "swc_core 65.0.1",
+ "swc_core",
  "ustr-fxhash",
  "xxhash-rust",
 ]
@@ -3900,7 +3900,7 @@ dependencies = [
  "rspack_sources",
  "rustc-hash",
  "serde_json",
- "swc_core 65.0.1",
+ "swc_core",
  "ustr-fxhash",
  "xxhash-rust",
 ]
@@ -3974,7 +3974,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "swc_core 65.0.1",
+ "swc_core",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",
  "swc_experimental_ecma_semantic",
@@ -4080,7 +4080,7 @@ dependencies = [
  "serde",
  "stacker",
  "swc_config",
- "swc_core 65.0.1",
+ "swc_core",
  "swc_ecma_minifier",
  "swc_error_reporters",
  "url",
@@ -4184,7 +4184,7 @@ dependencies = [
  "sugar_path",
  "swc",
  "swc_config",
- "swc_core 65.0.1",
+ "swc_core",
  "tokio",
  "tracing",
 ]
@@ -4520,7 +4520,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "swc_core 65.0.1",
+ "swc_core",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",
  "swc_experimental_ecma_semantic",
@@ -4609,7 +4609,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar_path",
- "swc_core 65.0.1",
+ "swc_core",
  "swc_html",
  "swc_html_minifier",
  "tracing",
@@ -4665,7 +4665,7 @@ dependencies = [
  "slotmap",
  "smallvec",
  "sugar_path",
- "swc_core 65.0.1",
+ "swc_core",
  "tokio",
  "tracing",
  "url",
@@ -4722,7 +4722,7 @@ dependencies = [
  "rspack_plugin_split_chunks",
  "rspack_util",
  "serde_json",
- "swc_core 65.0.1",
+ "swc_core",
  "tracing",
 ]
 
@@ -4918,7 +4918,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simd-json",
- "swc_core 65.0.1",
+ "swc_core",
  "tokio",
  "tracing",
  "urlencoding",
@@ -4964,7 +4964,7 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
- "swc_core 65.0.1",
+ "swc_core",
  "tracing",
 ]
 
@@ -4982,7 +4982,7 @@ dependencies = [
  "rspack_plugin_javascript",
  "rspack_util",
  "rustc-hash",
- "swc_core 65.0.1",
+ "swc_core",
  "tracing",
 ]
 
@@ -5132,7 +5132,7 @@ dependencies = [
  "rspack_util",
  "serde_json",
  "swc_config",
- "swc_core 65.0.1",
+ "swc_core",
  "swc_ecma_minifier",
  "thread_local",
  "tracing",
@@ -5151,7 +5151,7 @@ dependencies = [
  "rspack_hash",
  "rspack_hook",
  "rspack_util",
- "swc_core 65.0.1",
+ "swc_core",
  "tokio",
  "tracing",
  "wasmparser 0.222.0",
@@ -5178,7 +5178,7 @@ dependencies = [
  "regress",
  "rspack_cacheable",
  "rspack_error",
- "swc_core 65.0.1",
+ "swc_core",
 ]
 
 [[package]]
@@ -5245,7 +5245,7 @@ dependencies = [
  "heck",
  "rustc-hash",
  "serde",
- "swc_core 65.0.1",
+ "swc_core",
 ]
 
 [[package]]
@@ -5256,7 +5256,7 @@ dependencies = [
  "insta",
  "rspack_javascript_compiler",
  "rustc-hash",
- "swc_core 65.0.1",
+ "swc_core",
 ]
 
 [[package]]
@@ -5333,7 +5333,7 @@ dependencies = [
  "signal-hook",
  "sugar_path",
  "swc_config",
- "swc_core 65.0.1",
+ "swc_core",
  "swc_plugin_runner",
  "unicase",
  "wasi-common",
@@ -5993,22 +5993,6 @@ dependencies = [
  "quote",
  "swc_macros_common",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "swc_core"
-version = "64.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e469652a94edc37bf70f0a8274ffe1996ba0ab36042d306c5af6a7431e2559bc"
-dependencies = [
- "swc_allocator",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_visit",
- "vergen",
 ]
 
 [[package]]
@@ -6762,23 +6746,23 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_ast"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792dd470b0c73c95007e8419770af9d1d705d954bf45f1b09e837ef0c8a7408"
+checksum = "e989e5521df651db50467a9a87f3ec8ea2750e77baa1f598bfec452ccaff8860"
 dependencies = [
  "hashbrown 0.16.1",
  "num-bigint",
  "oxc_index",
- "swc_core 64.0.0",
+ "swc_core",
  "swc_experimental_ast_macros",
  "unicode-id-start",
 ]
 
 [[package]]
 name = "swc_experimental_ecma_parser"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610afe364e0b605baf1d323573b5e82af372e330113ee804e880051ba30c9b35"
+checksum = "d135d7979c1d780a2cc0eda478d3009a65dc082821421759cdbf871c4148cbfe"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6786,20 +6770,20 @@ dependencies = [
  "rustc-hash",
  "seq-macro",
  "smartstring",
- "swc_core 64.0.0",
+ "swc_core",
  "swc_experimental_ecma_ast",
  "tracing",
 ]
 
 [[package]]
 name = "swc_experimental_ecma_semantic"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f208a43d5f1cf1f75709f8fa0d18b8faa29c52aeef391be6d6f2f4e88d174e5"
+checksum = "9db20f10f09a5d81a41ea26d4ab83873cc63e55add9740ceb3377511c43073f5"
 dependencies = [
  "oxc_index",
  "rustc-hash",
- "swc_core 64.0.0",
+ "swc_core",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_visit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,9 @@ swc_html            = { version = "33.0.0", default-features = false }
 swc_html_minifier   = { version = "52.0.0", default-features = false }
 swc_plugin_runner   = { version = "27.0.0", default-features = false }
 
-swc_experimental_ecma_ast      = { version = "0.6.4", default-features = false }
-swc_experimental_ecma_parser   = { version = "0.6.4", default-features = false }
-swc_experimental_ecma_semantic = { version = "0.6.4", default-features = false }
+swc_experimental_ecma_ast      = { version = "0.6.5", default-features = false }
+swc_experimental_ecma_parser   = { version = "0.6.5", default-features = false }
+swc_experimental_ecma_semantic = { version = "0.6.5", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,10 +131,10 @@ rkyv      = { version = "=0.8.8", default-features = false, features = ["std", "
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.8", default-features = false }
-swc                 = { version = "62.0.0", default-features = false }
-swc_config          = { version = "4.0.0", default-features = false }
-swc_core            = { version = "64.0.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "52.0.0", default-features = false }
+swc                 = { version = "63.0.0", default-features = false }
+swc_config          = { version = "4.0.1", default-features = false }
+swc_core            = { version = "65.0.1", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "52.0.2", default-features = false }
 swc_error_reporters = { version = "23.0.0", default-features = false }
 swc_html            = { version = "33.0.0", default-features = false }
 swc_html_minifier   = { version = "52.0.0", default-features = false }

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -223,16 +223,14 @@ impl<'a> JavaScriptTransformer<'a> {
           &self.cm.clone(),
           &self.fm.name,
           move |syntax, target, is_module| {
-            self
-              .parse_js(
-                self.fm.clone(),
-                handler,
-                target,
-                syntax,
-                is_module,
-                Some(&self.comments).map(|c| c as &dyn Comments),
-              )
-              .map(|program| (program, false))
+            self.parse_js(
+              self.fm.clone(),
+              handler,
+              target,
+              syntax,
+              is_module,
+              Some(&self.comments).map(|c| c as &dyn Comments),
+            )
           },
           self.options.output_path.as_deref(),
           self.options.source_root.clone(),

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -223,14 +223,16 @@ impl<'a> JavaScriptTransformer<'a> {
           &self.cm.clone(),
           &self.fm.name,
           move |syntax, target, is_module| {
-            self.parse_js(
-              self.fm.clone(),
-              handler,
-              target,
-              syntax,
-              is_module,
-              Some(&self.comments).map(|c| c as &dyn Comments),
-            )
+            self
+              .parse_js(
+                self.fm.clone(),
+                handler,
+                target,
+                syntax,
+                is_module,
+                Some(&self.comments).map(|c| c as &dyn Comments),
+              )
+              .map(|program| (program, false))
           },
           self.options.output_path.as_deref(),
           self.options.source_root.clone(),

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "64.0.0"
+  "65.0.1"
 }
 
 /// The version of the JavaScript `@rspack/core` package.

--- a/deny.toml
+++ b/deny.toml
@@ -242,6 +242,7 @@ skip = [
     { crate = "windows-sys", reason = "external dependency"},
     { crate = "bitflags", reason = "external dependency"},
     { crate = "foldhash", reason = "external dependency" },
+    { crate = "swc_core@64.0.0", reason = "swc_experimental_ecma_* 0.6.4 has not upgraded to swc_core 65 yet" },
     { crate = "wasmparser", reason = "external dependency"},
     { crate = "windows_i686_gnullvm", reason = "external dependency"},
     { crate = "hermit-abi", reason = "external dependency"},

--- a/deny.toml
+++ b/deny.toml
@@ -242,7 +242,6 @@ skip = [
     { crate = "windows-sys", reason = "external dependency"},
     { crate = "bitflags", reason = "external dependency"},
     { crate = "foldhash", reason = "external dependency" },
-    { crate = "swc_core@64.0.0", reason = "swc_experimental_ecma_* 0.6.4 has not upgraded to swc_core 65 yet" },
     { crate = "wasmparser", reason = "external dependency"},
     { crate = "windows_i686_gnullvm", reason = "external dependency"},
     { crate = "hermit-abi", reason = "external dependency"},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,8 +660,8 @@ importers:
         specifier: 0.5.21
         version: 0.5.21
       '@swc/plugin-remove-console':
-        specifier: ^12.7.0
-        version: 12.7.0
+        specifier: ^12.9.0
+        version: 12.9.0
       '@types/babel__generator':
         specifier: 7.27.0
         version: 7.27.0
@@ -3358,8 +3358,8 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
-  '@swc/plugin-remove-console@12.7.0':
-    resolution: {integrity: sha512-gdzoBtQSKvIoZDT/FJN9vmqC2ip+/ehmFcwNr/MVENXmk29eHjeWVTvhPJX5yOp87NBzpnkuOyR53SOt7vfzmA==}
+  '@swc/plugin-remove-console@12.9.0':
+    resolution: {integrity: sha512-Ve64fWHghdhMHMYAmKlIdyV0aIbj8PX6mlUwXyf1dJXsBirkDm3HYtGw+XIpyNtIUfg1Rojyqc+TXATrqgRdhg==}
 
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
@@ -10334,7 +10334,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/plugin-remove-console@12.7.0':
+  '@swc/plugin-remove-console@12.9.0':
     dependencies:
       '@swc/counter': 0.1.3
 

--- a/tests/rspack-test/package.json
+++ b/tests/rspack-test/package.json
@@ -24,7 +24,7 @@
     "@rspack/test-tools": "workspace:*",
     "@rstest/core": "^0.9.9",
     "@swc/helpers": "0.5.21",
-    "@swc/plugin-remove-console": "^12.7.0",
+    "@swc/plugin-remove-console": "^12.9.0",
     "@types/babel__generator": "7.27.0",
     "@types/babel__traverse": "7.28.0",
     "@types/fs-extra": "11.0.4",


### PR DESCRIPTION
## Summary

- Upgrade SWC Rust crates to the latest published compatible versions (`swc`, `swc_core`, `swc_config`, `swc_ecma_minifier`).
- Upgrade `@swc/plugin-remove-console` to `^12.9.0`.
- Adapt `Options::build_as_input` call site for the new SWC parse callback return shape.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo check --workspace --all-targets --locked`
- `cargo fmt --all --check`
- `pnpm run check-dependency-version`