### PR TITLE
perf: optimize swc source map handling

### DIFF
--- a/crates/rspack_binding_api/src/swc.rs
+++ b/crates/rspack_binding_api/src/swc.rs
@@ -66,6 +66,7 @@ fn _transform(source: String, options: String) -> napi::Result<TransformOutput> 
       comments,
       options,
       Some(module_source_map_kind),
+      None,
       |_, _| {},
       |_| noop_pass(),
     )

--- a/crates/rspack_javascript_compiler/examples/transform.rs
+++ b/crates/rspack_javascript_compiler/examples/transform.rs
@@ -16,6 +16,7 @@ fn main() {
     comments,
     Default::default(),
     None,
+    None,
     |_, _| {},
     |_| noop_pass(),
   );

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -82,7 +82,7 @@ impl JavaScriptCompiler {
     } = options;
     let mut src_map_buf = vec![];
 
-    if source_map_config.enable {
+    if source_map_config.enable && source_map_config.emit_columns {
       let mut v = IdentCollector {
         names: Default::default(),
       };

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -20,7 +20,7 @@ use swc_core::{
     config::{
       BuiltInput, Config, InputSourceMap, JsMinifyCommentOption, OutputCharset, SourceMapsConfig,
     },
-    sourcemap,
+    sourcemap::{self, RawToken},
   },
   common::{
     FileName, GLOBALS, Mark, SourceFile, SourceMap,
@@ -54,6 +54,7 @@ impl JavaScriptCompiler {
     comments: std::rc::Rc<SingleThreadedComments>,
     options: SwcOptions,
     module_source_map_kind: Option<SourceMapKind>,
+    input_source_map: Option<sourcemap::SourceMap>,
     inspect_parsed_ast: impl FnOnce(&Program, Mark),
     before_pass: impl FnOnce(&Program) -> P + 'a,
   ) -> Result<TransformOutput>
@@ -68,8 +69,82 @@ impl JavaScriptCompiler {
     let javascript_transformer =
       JavaScriptTransformer::new(self.cm.clone(), fm, comments, self, options)?;
 
-    javascript_transformer.transform(inspect_parsed_ast, before_pass, module_source_map_kind)
+    javascript_transformer.transform(
+      inspect_parsed_ast,
+      before_pass,
+      module_source_map_kind,
+      input_source_map,
+    )
   }
+}
+
+pub fn rspack_source_map_to_swc_source_map(
+  source_map: &rspack_sources::SourceMap,
+) -> sourcemap::SourceMap {
+  let sources = source_map
+    .sources()
+    .iter()
+    .map(|source| source.clone().into())
+    .collect::<Vec<_>>();
+  let names = source_map
+    .names()
+    .iter()
+    .map(|name| name.clone().into())
+    .collect::<Vec<_>>();
+  let sources_content = source_map.sources().iter().enumerate().fold(
+    None,
+    |mut sources_content: Option<Vec<_>>, (source_index, _)| {
+      let source_content = source_map
+        .get_source_content(source_index)
+        .map(|source_content| source_content.to_string().into());
+      if source_content.is_some() || sources_content.is_some() {
+        sources_content
+          .get_or_insert_with(|| vec![None; source_index])
+          .push(source_content);
+      }
+      sources_content
+    },
+  );
+  let tokens = source_map
+    .decoded_mappings()
+    .map(|mapping| {
+      let (src_line, src_col, src_id, name_id) = if let Some(original) = mapping.original {
+        (
+          original.original_line.saturating_sub(1),
+          original.original_column,
+          original.source_index,
+          original.name_index.unwrap_or(!0),
+        )
+      } else {
+        (0, 0, !0, !0)
+      };
+      RawToken {
+        dst_line: mapping.generated_line.saturating_sub(1),
+        dst_col: mapping.generated_column,
+        src_line,
+        src_col,
+        src_id,
+        name_id,
+        is_range: false,
+      }
+    })
+    .collect();
+
+  let mut swc_source_map = sourcemap::SourceMap::new(
+    source_map.file().map(ToString::to_string).map(Into::into),
+    tokens,
+    names,
+    sources,
+    sources_content,
+  );
+  swc_source_map.set_source_root(source_map.source_root().map(ToString::to_string));
+  if let Some(ignore_list) = source_map.ignore_list() {
+    for &source_index in ignore_list {
+      swc_source_map.add_to_ignore_list(source_index);
+    }
+  }
+
+  swc_source_map
 }
 
 struct JavaScriptTransformer<'a> {
@@ -122,6 +197,7 @@ impl<'a> JavaScriptTransformer<'a> {
     inspect_parsed_ast: impl FnOnce(&Program, Mark),
     before_pass: impl FnOnce(&Program) -> P + 'a,
     module_source_map_kind: Option<SourceMapKind>,
+    prebuilt_input_source_map: Option<sourcemap::SourceMap>,
   ) -> Result<TransformOutput>
   where
     P: Pass + 'a,
@@ -141,7 +217,11 @@ impl<'a> JavaScriptTransformer<'a> {
       names: Default::default(),
     };
 
-    let input_source_map = self.input_source_map(&built_input.input_source_map)?;
+    let input_source_map = if let Some(input_source_map) = prebuilt_input_source_map {
+      Some(input_source_map)
+    } else {
+      self.input_source_map(&built_input.input_source_map)?
+    };
 
     let diagnostics = self.transform_with_built_input(&mut built_input, inspect_parsed_ast)?;
     let ascii_only = built_input

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -14,7 +14,9 @@ pub use plugin::SwcLoaderPlugin;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, Mode, Module, RscMeta, RunnerContext};
 use rspack_error::{Diagnostic, Error, Result, SerdeResultToRspackResultExt};
-use rspack_javascript_compiler::{JavaScriptCompiler, TransformOutput};
+use rspack_javascript_compiler::{
+  JavaScriptCompiler, TransformOutput, transform::rspack_source_map_to_swc_source_map,
+};
 use rspack_loader_runner::{Identifier, Loader, LoaderContext};
 #[cfg(allocative)]
 use rspack_util::allocative;
@@ -66,6 +68,7 @@ impl SwcLoader {
       return Ok(());
     };
 
+    let mut input_source_map = None;
     let swc_options = {
       let mut swc_options = self.options_with_additional.swc_options.clone();
       if let Some(resource_specific_jsc) = self
@@ -91,8 +94,9 @@ impl SwcLoader {
       }
 
       if loader_context.context.source_map_kind.enabled() {
-        if let Some(pre_source_map) = loader_context.source_map().cloned() {
-          swc_options.config.input_source_map = Some(InputSourceMap::Str(pre_source_map.to_json()))
+        if let Some(pre_source_map) = loader_context.source_map() {
+          input_source_map = Some(rspack_source_map_to_swc_source_map(pre_source_map));
+          swc_options.config.input_source_map = Some(InputSourceMap::Bool(false));
         }
       } else {
         swc_options.config.input_source_map = Some(InputSourceMap::Bool(false));
@@ -140,6 +144,7 @@ impl SwcLoader {
       comments.clone(),
       swc_options,
       Some(loader_context.context.source_map_kind),
+      input_source_map,
       |program, unresolved_mark| {
         if !is_typescript {
           return;

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -28,7 +28,7 @@ use rspack_plugin_javascript::{ExtractedCommentsInfo, JavascriptModulesChunkHash
 use rspack_regex::RspackRegex;
 use rspack_util::{
   asset_condition::AssetConditions,
-  fx_hash::{FxHashMap, FxHasher},
+  fx_hash::{FxHashMap, FxHashSet, FxHasher},
 };
 use swc_config::types::BoolOrDataConfig;
 use swc_core::{
@@ -308,6 +308,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         let comments_op = |comments: &SingleThreadedComments| {
           if let Some(ref extract_comments) = extract_comments_option {
             let mut extracted_comments = vec![];
+            let mut seen_comments = FxHashSet::default();
             // add all matched comments to source
 
             let (leading_trivial, trailing_trivial) = comments.borrow_all();
@@ -323,7 +324,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
                       format!("/*{}*/", c.text)
                     }
                   };
-                  if !extracted_comments.contains(&comment) {
+                  if seen_comments.insert(comment.clone()) {
                     extracted_comments.push(comment);
                   }
                 }
@@ -340,7 +341,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
                       format!("/*{}*/", c.text)
                     }
                   };
-                  if !extracted_comments.contains(&comment) {
+                  if seen_comments.insert(comment.clone()) {
                     extracted_comments.push(comment);
                   }
                 }


### PR DESCRIPTION
## Summary

- pass prebuilt SWC source maps through the JavaScript compiler for builtin swc-loader to avoid JSON serialize/parse roundtrips
- skip identifier name collection when printing cheap source maps without columns
- use a set for swc minimizer extracted comment dedupe while preserving output order

## Testing

- `cargo fmt --all --check`
- `cargo check -p rspack_javascript_compiler -p rspack_loader_swc -p rspack_plugin_swc_js_minimizer -p rspack_binding_api`
- `cargo test -p rspack_javascript_compiler -p rspack_loader_swc -p rspack_plugin_swc_js_minimizer --lib`
- `/opt/homebrew/bin/pnpm run build:binding:dev`
- `PATH=/opt/homebrew/bin:/usr/local/bin:$PATH /opt/homebrew/bin/pnpm run build:js`
- `PATH=/opt/homebrew/bin:/usr/local/bin:$PATH RSPACK_BINDING=/Users/bytedance/.codex/worktrees/b363/rspack/crates/node_binding/rspack.darwin-arm64.node /opt/homebrew/bin/pnpm --dir tests/rspack-test run test -- -t "configCases/builtin-swc-loader/input-source-map-cheap-module"`
- `PATH=/opt/homebrew/bin:/usr/local/bin:$PATH RSPACK_BINDING=/Users/bytedance/.codex/worktrees/b363/rspack/crates/node_binding/rspack.darwin-arm64.node /opt/homebrew/bin/pnpm --dir tests/rspack-test run test -- -t "configCases/optimization/minimizer-swc-extract-comments"`