### PR TITLE
perf(split-chunks): batch split chunk runtime updates

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -7,6 +7,7 @@ use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use ustr::Ustr;
 
 use crate::{
   ChunkGraph, ChunkGroupByUkey, ChunkGroupOrderKey, ChunkGroupUkey, ChunkHashesArtifact, ChunkUkey,
@@ -47,6 +48,45 @@ impl ChunkHashesResult {
 pub struct ChunkRenderResult {
   pub manifests: Vec<RenderManifestEntry>,
   pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Default)]
+pub struct ChunkSplitData {
+  groups: HashSet<ChunkGroupUkey>,
+  id_name_hints: HashSet<String>,
+  runtimes: Vec<Ustr>,
+}
+
+impl ChunkSplitData {
+  pub fn with_capacity(groups: usize, id_name_hints: usize) -> Self {
+    Self {
+      groups: HashSet::with_capacity_and_hasher(groups, Default::default()),
+      id_name_hints: HashSet::with_capacity_and_hasher(id_name_hints, Default::default()),
+      runtimes: Vec::new(),
+    }
+  }
+
+  fn add_runtime(&mut self, runtime: &RuntimeSpec) {
+    self.runtimes.extend(runtime.iter().copied());
+  }
+
+  pub fn apply_to(self, chunk: &mut Chunk) {
+    chunk.groups.extend(self.groups);
+    chunk.id_name_hints.extend(self.id_name_hints);
+    if !self.runtimes.is_empty() {
+      let runtime = if chunk.runtime.is_empty() {
+        self.runtimes.into_iter().collect::<RuntimeSpec>()
+      } else {
+        chunk
+          .runtime
+          .iter()
+          .copied()
+          .chain(self.runtimes)
+          .collect::<RuntimeSpec>()
+      };
+      chunk.runtime = runtime;
+    }
+  }
 }
 
 #[derive(Debug, Clone)]
@@ -311,21 +351,35 @@ impl Chunk {
     None
   }
 
-  pub fn split(&mut self, new_chunk: &mut Chunk, chunk_group_by_ukey: &mut ChunkGroupByUkey) {
+  pub fn split_collect_new_chunk_data(
+    &mut self,
+    new_chunk_ukey: ChunkUkey,
+    chunk_group_by_ukey: &mut ChunkGroupByUkey,
+    split_data: &mut ChunkSplitData,
+  ) {
     let group_keys: Vec<_> = {
       let temp_ref = chunk_group_by_ukey as &ChunkGroupByUkey;
       self.get_sorted_groups_iter(temp_ref).copied().collect()
     };
 
+    split_data.groups.reserve(group_keys.len());
     for group_key in group_keys {
       let group = chunk_group_by_ukey.expect_get_mut(&group_key);
-      group.insert_chunk(new_chunk.ukey, self.ukey);
-      new_chunk.add_group(group.ukey);
+      group.insert_chunk(new_chunk_ukey, self.ukey);
+      split_data.groups.insert(group.ukey);
     }
-    new_chunk
+
+    split_data.id_name_hints.reserve(self.id_name_hints.len());
+    split_data
       .id_name_hints
       .extend(self.id_name_hints.iter().cloned());
-    new_chunk.runtime.extend(&self.runtime);
+    split_data.add_runtime(&self.runtime);
+  }
+
+  pub fn split(&mut self, new_chunk: &mut Chunk, chunk_group_by_ukey: &mut ChunkGroupByUkey) {
+    let mut split_data = ChunkSplitData::with_capacity(self.groups.len(), self.id_name_hints.len());
+    self.split_collect_new_chunk_data(new_chunk.ukey, chunk_group_by_ukey, &mut split_data);
+    split_data.apply_to(new_chunk);
   }
 
   pub fn can_be_initial(&self, chunk_group_by_ukey: &ChunkGroupByUkey) -> bool {

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -352,7 +352,7 @@ impl Chunk {
   }
 
   pub fn split_collect_new_chunk_data(
-    &mut self,
+    &self,
     new_chunk_ukey: ChunkUkey,
     chunk_group_by_ukey: &mut ChunkGroupByUkey,
     split_data: &mut ChunkSplitData,

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -253,7 +253,7 @@ impl SplitChunksPlugin {
       for original_chunk_ukey in original_chunks {
         debug_assert!(&new_chunk_ukey != original_chunk_ukey);
         let original_chunk = chunk_by_ukey
-          .get_mut(original_chunk_ukey)
+          .get(original_chunk_ukey)
           .expect("split_from_original_chunks failed");
         original_chunk.split_collect_new_chunk_data(
           new_chunk_ukey,

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -1,6 +1,8 @@
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
-use rspack_core::{Chunk, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation};
+use rspack_core::{
+  Chunk, ChunkSplitData, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation,
+};
 use rustc_hash::FxHashSet;
 
 use crate::{SplitChunksPlugin, common::ModuleChunks, module_group::ModuleGroup};
@@ -240,20 +242,34 @@ impl SplitChunksPlugin {
     compilation: &mut Compilation,
   ) {
     let new_chunk_ukey = new_chunk;
-    for original_chunk_ukey in original_chunks {
-      debug_assert!(&new_chunk_ukey != original_chunk_ukey);
-      let [Some(new_chunk), Some(original_chunk)] = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .get_many_mut([&new_chunk_ukey, original_chunk_ukey])
-      else {
-        panic!("split_from_original_chunks failed")
-      };
-      original_chunk.split(
-        new_chunk,
-        &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
-      );
-      if let Some(mut mutations) = compilation.incremental.mutations_write() {
+    if original_chunks.is_empty() {
+      return;
+    }
+
+    {
+      let chunk_by_ukey = &mut compilation.build_chunk_graph_artifact.chunk_by_ukey;
+      let chunk_group_by_ukey = &mut compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
+      let mut split_data = ChunkSplitData::default();
+      for original_chunk_ukey in original_chunks {
+        debug_assert!(&new_chunk_ukey != original_chunk_ukey);
+        let original_chunk = chunk_by_ukey
+          .get_mut(original_chunk_ukey)
+          .expect("split_from_original_chunks failed");
+        original_chunk.split_collect_new_chunk_data(
+          new_chunk_ukey,
+          chunk_group_by_ukey,
+          &mut split_data,
+        );
+      }
+
+      let new_chunk = chunk_by_ukey
+        .get_mut(&new_chunk_ukey)
+        .expect("split_from_original_chunks failed");
+      split_data.apply_to(new_chunk);
+    }
+
+    if let Some(mut mutations) = compilation.incremental.mutations_write() {
+      for original_chunk_ukey in original_chunks {
         mutations.add(Mutation::ChunkSplit {
           from: *original_chunk_ukey,
           to: new_chunk_ukey,


### PR DESCRIPTION
## Summary

- batch the data written to the new split chunk while iterating original chunks
- collect runtime names as `Ustr` values and build the new chunk `RuntimeSpec` once at the end
- avoid repeated runtime key updates during split chunk creation

## Related links

Stacked on #13854.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).