### PR TITLE
docs: sync Shakapacker ecosystem docs to zh

### DIFF
--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -114,6 +114,12 @@ Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://nx.dev/nx-a
 
 Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
 
+### Shakapacker
+
+<Tag color="geekblue">构建工具</Tag> <Tag color="purple">Rails</Tag>
+
+[Shakapacker](https://shakapacker.com/) 用于编译 Rails 前端资源。参见 [Rspack 集成文档](https://github.com/shakacode/shakapacker/blob/main/docs/rspack.md)。
+
 ### Storybook
 
 <Tag color="geekblue">UI 开发</Tag>


### PR DESCRIPTION
## Summary

Syncs the Chinese ecosystem docs with the merged Shakapacker entry added in #13866, so the Rails/Shakapacker integration is listed consistently across locales.

## Related links

Closes https://github.com/web-infra-dev/rspack/issues/13820
Syncs https://github.com/web-infra-dev/rspack/pull/13866

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
