### PR TITLE
docs: fix Modern.js links

### DIFF
--- a/website/docs/en/blog/announcing-0-2.mdx
+++ b/website/docs/en/blog/announcing-0-2.mdx
@@ -167,17 +167,15 @@ Rspack has additional adaptation of webpack's plugins. We have tracked the adapt
 
 ### Modern.js Framework
 
-Thanks to the close collaboration and parallel iteration of the [Modern.js framework](https://modernjs.dev/en/) and Rspack, **Modern.js Rspack mode has covered 85% of the framework's capabilities**, supporting SSR, BFF, micro front-end scenarios, and aligning with TypeScript type checking, code compatibility detection and other features.
+Thanks to the close collaboration and parallel iteration of the [Modern.js framework](https://modernjs.dev/) and Rspack, **Modern.js Rspack mode has covered 85% of the framework's capabilities**, supporting SSR, BFF, micro front-end scenarios, and aligning with TypeScript type checking, code compatibility detection and other features.
 
 At ByteDance, more than 80 projects are using the Modern.js Rspack mode. Some of the projects have been deployed into production and have seen a 10x improvement in build performance.
 
 ### Modern.js Doc
 
-In addition to the Modern.js framework, the document site solution under the Modern.js system - [Modern.js Doc](https://modernjs.dev/doc-tools/) - has also switched the bundler from webpack to Rspack, and rewritten the MDX compilation process based on Rust.
+In addition to the Modern.js framework, the document site solution under the Modern.js system - Modern.js Doc - has also switched the bundler from webpack to Rspack, and rewritten the MDX compilation process based on Rust.
 
 Compared to previous versions using webpack, the current version's build speed can be reduced to seconds. Using the Modern.js official website documentation as an example, the project's startup and build time has been reduced from 30 seconds to less than 2 seconds. In the future, we plan to rename Modern.js Doc to **Rspress** as the official documentation site solution for Rspack and maintain it through a separate repository.
-
-> Welcome to visit the [Modern.js code repository](https://github.com/web-infra-dev/modern.js) and experience the above content.
 
 ### Vue
 

--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -70,7 +70,7 @@ Docusaurus supports Rspack as the bundler since v3.6, see [Docusaurus Faster](ht
 <Tag color="geekblue">Web framework</Tag>
 <Tag color="purple">React</Tag>
 
-[Modern.js](https://modernjs.dev/en/) is a Rsbuild-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
+[Modern.js](https://modernjs.dev/) is a Rsbuild-based progressive React framework that supports nested routes, SSR, and provides out-of-the-box CSS solutions such as styled components and Tailwind CSS.
 
 ### Meteor
 

--- a/website/docs/zh/blog/announcing-0-2.mdx
+++ b/website/docs/zh/blog/announcing-0-2.mdx
@@ -164,17 +164,15 @@ Rspack 适配的 webpack 的 plugin 和 loader 远不仅此，我们在 [loader-
 
 ### Modern.js 框架
 
-得益于 [Modern.js 框架](https://modernjs.dev) 与 Rspack 的紧密合作与并行迭代，**Modern.js Rspack 模式已经覆盖了 85% 的框架能力**，支持 SSR、BFF、微前端等场景，并对齐了 TypeScript 类型检查、代码兼容性检测等功能。
+得益于 [Modern.js 框架](https://modernjs.dev/zh/) 与 Rspack 的紧密合作与并行迭代，**Modern.js Rspack 模式已经覆盖了 85% 的框架能力**，支持 SSR、BFF、微前端等场景，并对齐了 TypeScript 类型检查、代码兼容性检测等功能。
 
 在字节跳动内部，已有 80+ 个业务项目在使用 Modern.js Rspack 模式。其中一部分项目已经上线至生产环境，获得 10 倍左右的构建性能提升。
 
 ### Modern.js Doc
 
-除了 Modern.js 框架，Modern.js 体系下的文档站开发方案 —— [Modern.js Doc](https://modernjs.dev/doc-tools/zh/) 也将构建工具从 webpack 切换到了 Rspack，并将 MDX 编译流程基于 Rust 重写。
+除了 Modern.js 框架，Modern.js 体系下的文档站开发方案 —— Modern.js Doc 也将构建工具从 webpack 切换到了 Rspack，并将 MDX 编译流程基于 Rust 重写。
 
 相较于早期使用 webpack 的版本，当前版本的文档构建速度可以缩短至秒级。以 Modern.js 官网文档为例，项目的启动和构建时间从 30s 缩短到 2s 以内。未来，我们计划将 Modern.js Doc 更名为 **Rspress**，作为 Rspack 官方的文档站方案，并通过单独的仓库进行维护。
-
-> 欢迎访问 [Modern.js 代码仓库](https://github.com/web-infra-dev/modern.js) 并体验上述内容。
 
 ### Vue
 

--- a/website/docs/zh/blog/announcing-2-0.mdx
+++ b/website/docs/zh/blog/announcing-2-0.mdx
@@ -295,7 +295,7 @@ export default {
 - **使用 Rsbuild**：我们通过 [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) 提供了开箱即用的 RSC 支持。
 - **手动配置 Rspack**：参考 [React Server Components 文档](/guide/tech/rsc) 以手动添加相关配置。
 
-在生态支持方面，Modern.js 已基于 Rspack 提供 RSC 支持，详见 [Modern.js RSC 文档](https://modernjs.dev/guides/basic-features/render/rsc.html)。同时，Rspack 已支持 React Router 的 Data Mode，相关示例见 [React Router 示例](https://github.com/rstackjs/rsbuild-plugin-rsc/tree/main/examples/react-router)。
+在生态支持方面，Modern.js 已基于 Rspack 提供 RSC 支持，详见 [Modern.js RSC 文档](https://modernjs.dev/zh/guides/basic-features/render/rsc.html)。同时，Rspack 已支持 React Router 的 Data Mode，相关示例见 [React Router 示例](https://github.com/rstackjs/rsbuild-plugin-rsc/tree/main/examples/react-router)。
 
 另外，我们也在与 [TanStack](https://tanstack.com/) 团队展开合作，计划在后续版本中提供对 [TanStack Start](https://tanstack.com/start) 和 [TanStack 的 RSC](https://tanstack.com/blog/react-server-components) 的支持。TanStack Start 是一个基于 TanStack Router 构建的全栈框架，我们非常期待结合双方的能力，共同探索 RSC 在不同场景下的更多可能性。
 

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -66,7 +66,7 @@ Docusaurus 从 v3.6 开始支持使用 Rspack 作为打包工具，详见 [Docus
 
 <Tag color="geekblue">Web 框架</Tag> <Tag color="purple">React</Tag>
 
-[Modern.js](https://modernjs.dev/) 是一个基于 Rsbuild 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
+[Modern.js](https://modernjs.dev/zh/) 是一个基于 Rsbuild 实现的渐进式 React 框架，支持嵌套路由、服务器端渲染（SSR）和模块联邦，并提供开箱即用的 CSS 解决方案。
 
 ### Meteor
 


### PR DESCRIPTION
## Summary

This PR fixes Modern.js documentation links so English docs use the default Modern.js site and Chinese docs include the /zh/ language path. It also removes outdated Modern.js Doc link references from the 0.2 announcement.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).