### PR TITLE
fix(cli): use rspack-merge for config extends

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -47,7 +47,8 @@
     "exit-hook": "^4.0.0",
     "jiti": "^2.6.1",
     "prebundle": "^1.6.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "webpack-merge": "6.0.1"
   },
   "peerDependencies": {
     "@rspack/core": "^2.0.0-0",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -47,8 +47,8 @@
     "exit-hook": "^4.0.0",
     "jiti": "^2.6.1",
     "prebundle": "^1.6.4",
-    "typescript": "^6.0.3",
-    "webpack-merge": "6.0.1"
+    "rspack-merge": "0.1.1",
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@rspack/core": "^2.0.0-0",

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { MultiRspackOptions, RspackOptions } from '@rspack/core';
-import merge from 'webpack-merge';
+import merge from 'rspack-merge';
 import findConfig from './findConfig';
 import type { CommonOptions } from './options';
 
@@ -199,6 +199,7 @@ export async function loadExtendedConfig(
   configPath: string,
   cwd: string,
   options: CommonOptions,
+  visitedPaths?: Set<string>,
 ): Promise<{
   config: RspackOptions;
   pathMap: WeakMap<RspackOptions, string[]>;
@@ -208,6 +209,7 @@ export async function loadExtendedConfig(
   configPath: string,
   cwd: string,
   options: CommonOptions,
+  visitedPaths?: Set<string>,
 ): Promise<{
   config: MultiRspackOptions;
   pathMap: WeakMap<RspackOptions, string[]>;
@@ -217,6 +219,7 @@ export async function loadExtendedConfig(
   configPath: string,
   cwd: string,
   options: CommonOptions,
+  visitedPaths?: Set<string>,
 ): Promise<{
   config: RspackOptions | MultiRspackOptions;
   pathMap: WeakMap<RspackOptions, string[]>;
@@ -226,20 +229,24 @@ export async function loadExtendedConfig(
   configPath: string,
   cwd: string,
   options: CommonOptions,
+  visitedPaths?: Set<string>,
 ): Promise<{
   config: RspackOptions | MultiRspackOptions;
   pathMap: WeakMap<RspackOptions, string[]>;
 }> {
+  const currentVisitedPaths = visitedPaths ?? new Set<string>();
+
   if (checkIsMultiRspackOptions(config)) {
-    // If the config is an array, we need to handle each item separately
     const resultPathMap = new WeakMap();
     const extendedConfigs = (await Promise.all(
       config.map(async (item) => {
+        const itemVisitedPaths = new Set(currentVisitedPaths);
         const { config, pathMap } = await loadExtendedConfig(
           item,
           configPath,
           cwd,
           options,
+          itemVisitedPaths,
         );
         resultPathMap.set(config, pathMap.get(config));
         return config;
@@ -248,6 +255,13 @@ export async function loadExtendedConfig(
     extendedConfigs.parallelism = config.parallelism;
     return { config: extendedConfigs, pathMap: resultPathMap };
   }
+
+  if (currentVisitedPaths.has(configPath)) {
+    throw new Error(
+      `Recursive configuration detected. Config file "${configPath}" extends itself.`,
+    );
+  }
+  currentVisitedPaths.add(configPath);
   // set config path
   const pathMap: WeakMap<RspackOptions, string[]> = new WeakMap();
   pathMap.set(config, [configPath]);
@@ -274,16 +288,21 @@ export async function loadExtendedConfig(
   for (const extendPath of extendsList) {
     let resolvedPath: string;
 
-    // Check if it's a node module or a relative path
-    if (
+    if (extendPath.startsWith('file://')) {
+      try {
+        resolvedPath = fileURLToPath(extendPath);
+      } catch {
+        throw new Error(
+          `Invalid file URL '${extendPath}' in extends configuration.`,
+        );
+      }
+    } else if (
       extendPath.startsWith('.') ||
       extendPath.startsWith('/') ||
       extendPath.includes(':\\')
     ) {
-      // It's a relative or absolute path
       resolvedPath = path.resolve(baseDir, extendPath);
 
-      // If the path doesn't have an extension, try to find a matching config file
       if (!path.extname(resolvedPath)) {
         const foundConfig = findConfig(resolvedPath);
         if (foundConfig) {
@@ -295,7 +314,6 @@ export async function loadExtendedConfig(
         }
       }
     } else {
-      // It's a node module
       try {
         resolvedPath = require.resolve(extendPath, { paths: [baseDir, cwd] });
       } catch {
@@ -320,13 +338,13 @@ export async function loadExtendedConfig(
       options,
     );
 
-    // Recursively load extended configurations from the extended config
     const { config: extendedConfig, pathMap: extendedPathMap } =
       (await loadExtendedConfig(
         resolvedConfig,
         resolvedPath,
         cwd,
         options,
+        currentVisitedPaths,
       )) as {
         config: RspackOptions;
         pathMap: WeakMap<RspackOptions, string[]>;

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -237,6 +237,7 @@ export async function loadExtendedConfig(
   const currentVisitedPaths = visitedPaths ?? new Set<string>();
 
   if (checkIsMultiRspackOptions(config)) {
+    // If the config is an array, we need to handle each item separately
     const resultPathMap = new WeakMap();
     const extendedConfigs = (await Promise.all(
       config.map(async (item) => {
@@ -296,7 +297,9 @@ export async function loadExtendedConfig(
           `Invalid file URL '${extendPath}' in extends configuration.`,
         );
       }
-    } else if (
+    }
+    // Check if it's a node module or a relative path
+    else if (
       extendPath.startsWith('.') ||
       extendPath.startsWith('/') ||
       extendPath.includes(':\\')
@@ -338,6 +341,7 @@ export async function loadExtendedConfig(
       options,
     );
 
+    // Recursively load extended configurations from the extended config
     const { config: extendedConfig, pathMap: extendedPathMap } =
       (await loadExtendedConfig(
         resolvedConfig,

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -304,8 +304,10 @@ export async function loadExtendedConfig(
       extendPath.startsWith('/') ||
       extendPath.includes(':\\')
     ) {
+      // It's a relative or absolute path
       resolvedPath = path.resolve(baseDir, extendPath);
 
+      // If the path doesn't have an extension, try to find a matching config file
       if (!path.extname(resolvedPath)) {
         const foundConfig = findConfig(resolvedPath);
         if (foundConfig) {
@@ -317,6 +319,7 @@ export async function loadExtendedConfig(
         }
       }
     } else {
+      // It's a node module
       try {
         resolvedPath = require.resolve(extendPath, { paths: [baseDir, cwd] });
       } catch {

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { MultiRspackOptions, RspackOptions } from '@rspack/core';
-import { rspack } from '@rspack/core';
+import merge from 'webpack-merge';
 import findConfig from './findConfig';
 import type { CommonOptions } from './options';
 
@@ -337,7 +337,7 @@ export async function loadExtendedConfig(
       ...(extendedPathMap.get(extendedConfig) || []),
     ];
     // Merge the configurations
-    resultConfig = rspack.util.cleverMerge(extendedConfig, resultConfig);
+    resultConfig = merge(extendedConfig, resultConfig);
     // Set config paths
     pathMap.set(resultConfig, configPaths);
   }

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { MultiRspackOptions, RspackOptions } from '@rspack/core';
-import merge from 'rspack-merge';
+import { merge } from 'rspack-merge';
 import findConfig from './findConfig';
 import type { CommonOptions } from './options';
 

--- a/packages/rspack-cli/tests/build/config/extends/extends.test.ts
+++ b/packages/rspack-cli/tests/build/config/extends/extends.test.ts
@@ -116,6 +116,134 @@ describe('rspack extends feature', () => {
     });
   });
 
+  describe('file protocol extends', () => {
+    const cwd = resolve(__dirname, './file-protocol');
+
+    it('should extend from a config using file protocol (import.meta.resolve)', async () => {
+      const { exitCode, stderr, stdout } = await run(cwd, []);
+
+      expect(stderr).toBeFalsy();
+      expect(stdout).toBeTruthy();
+      expect(exitCode).toBe(0);
+
+      const outputContent = await readFile(
+        resolve(cwd, './dist/base.bundle.js'),
+        {
+          encoding: 'utf-8',
+        },
+      );
+
+      expect(outputContent).toMatch(/File protocol extends test/);
+    });
+  });
+
+  describe('require.resolve extends', () => {
+    const cwd = resolve(__dirname, './require-resolve');
+
+    it('should extend from a config using require.resolve', async () => {
+      const { exitCode, stderr, stdout } = await run(cwd, []);
+
+      expect(stderr).toBeFalsy();
+      expect(stdout).toBeTruthy();
+      expect(exitCode).toBe(0);
+
+      const outputContent = await readFile(
+        resolve(cwd, './dist/base.bundle.js'),
+        {
+          encoding: 'utf-8',
+        },
+      );
+
+      expect(outputContent).toMatch(/Require resolve extends test/);
+    });
+  });
+
+  describe('json config extends', () => {
+    const cwd = resolve(__dirname, './json');
+
+    it('should extend from a JSON config file', async () => {
+      const { exitCode, stderr, stdout } = await run(cwd, []);
+
+      expect(stderr).toBeFalsy();
+      expect(stdout).toBeTruthy();
+      expect(exitCode).toBe(0);
+
+      const outputContent = await readFile(
+        resolve(cwd, './dist/base.bundle.js'),
+        {
+          encoding: 'utf-8',
+        },
+      );
+
+      expect(outputContent).toMatch(/JSON extends test/);
+    });
+  });
+
+  describe('multiple configs with extends', () => {
+    const cwd = resolve(__dirname, './multiple-configs');
+
+    it('should extend base config for each config in a multi-config array', async () => {
+      const { exitCode, stderr, stdout } = await run(cwd, []);
+
+      expect(stderr).toBeFalsy();
+      expect(stdout).toBeTruthy();
+      expect(exitCode).toBe(0);
+
+      const output1 = await readFile(resolve(cwd, './dist/bundle1.js'), {
+        encoding: 'utf-8',
+      });
+      const output2 = await readFile(resolve(cwd, './dist/bundle2.js'), {
+        encoding: 'utf-8',
+      });
+
+      expect(output1).toMatch(/i am index1/);
+      expect(output2).toMatch(/i am index2/);
+    });
+  });
+
+  describe('multiple configs with partial extends', () => {
+    const cwd = resolve(__dirname, './multiple-configs2');
+
+    it('should extend base config only for configs that have extends property', async () => {
+      const { exitCode, stderr, stdout } = await run(cwd, []);
+
+      expect(stderr).toBeFalsy();
+      expect(stdout).toBeTruthy();
+      expect(exitCode).toBe(0);
+
+      const output1 = await readFile(resolve(cwd, './dist/bundle1.js'), {
+        encoding: 'utf-8',
+      });
+      const output2 = await readFile(resolve(cwd, './dist/bundle2.js'), {
+        encoding: 'utf-8',
+      });
+
+      expect(output1).toMatch(/i am index1/);
+      expect(output2).toMatch(/i am index2/);
+    });
+  });
+
+  describe('recursive extends', () => {
+    const cwd = resolve(__dirname, './recursive-extends');
+
+    it('should throw an error on recursive extends', async () => {
+      const { exitCode, stderr } = await run(cwd, []);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toBeTruthy();
+    });
+
+    it('should throw an error on recursive extends #2', async () => {
+      const { exitCode, stderr } = await run(cwd, [
+        '--config',
+        'other.config.js',
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toBeTruthy();
+    });
+  });
+
   describe('backward compatibility', () => {
     // Use an existing test directory that doesn't use the extends feature
     const cwd = resolve(__dirname, '../../basic');

--- a/packages/rspack-cli/tests/build/config/extends/file-protocol/base.rspack.config.mjs
+++ b/packages/rspack-cli/tests/build/config/extends/file-protocol/base.rspack.config.mjs
@@ -1,0 +1,9 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+export default {
+  output: {
+    filename: 'base.bundle.js',
+  },
+  mode: 'development',
+};

--- a/packages/rspack-cli/tests/build/config/extends/file-protocol/override.config.mjs
+++ b/packages/rspack-cli/tests/build/config/extends/file-protocol/override.config.mjs
@@ -1,0 +1,10 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+export default {
+  output: {
+    filename: 'override.bundle.js',
+  },
+  name: 'override_config',
+  mode: 'development',
+};

--- a/packages/rspack-cli/tests/build/config/extends/file-protocol/package.json
+++ b/packages/rspack-cli/tests/build/config/extends/file-protocol/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/rspack-cli/tests/build/config/extends/file-protocol/rspack.config.mjs
+++ b/packages/rspack-cli/tests/build/config/extends/file-protocol/rspack.config.mjs
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+export default () => {
+  return {
+    extends: [import.meta.resolve('./base.rspack.config.mjs')],
+    entry: './src/index.js',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+    },
+  };
+};

--- a/packages/rspack-cli/tests/build/config/extends/file-protocol/src/index.js
+++ b/packages/rspack-cli/tests/build/config/extends/file-protocol/src/index.js
@@ -1,0 +1,1 @@
+console.log('File protocol extends test');

--- a/packages/rspack-cli/tests/build/config/extends/json/base.rspack.config.json
+++ b/packages/rspack-cli/tests/build/config/extends/json/base.rspack.config.json
@@ -1,0 +1,6 @@
+{
+  "output": {
+    "filename": "base.bundle.js"
+  },
+  "mode": "development"
+}

--- a/packages/rspack-cli/tests/build/config/extends/json/override.config.mjs
+++ b/packages/rspack-cli/tests/build/config/extends/json/override.config.mjs
@@ -1,0 +1,10 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+export default {
+  output: {
+    filename: 'override.bundle.js',
+  },
+  name: 'override_config',
+  mode: 'development',
+};

--- a/packages/rspack-cli/tests/build/config/extends/json/package.json
+++ b/packages/rspack-cli/tests/build/config/extends/json/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/packages/rspack-cli/tests/build/config/extends/json/rspack.config.mjs
+++ b/packages/rspack-cli/tests/build/config/extends/json/rspack.config.mjs
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+export default () => {
+  return {
+    extends: [import.meta.resolve('./base.rspack.config.json')],
+    entry: './src/index.js',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+    },
+  };
+};

--- a/packages/rspack-cli/tests/build/config/extends/json/src/index.js
+++ b/packages/rspack-cli/tests/build/config/extends/json/src/index.js
@@ -1,0 +1,1 @@
+console.log('JSON extends test');

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs/base.rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs/base.rspack.config.js
@@ -1,0 +1,7 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  name: 'base_config',
+  mode: 'development',
+};

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs/rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs/rspack.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/core').MultiRspackOptions}
+ */
+module.exports = [
+  {
+    name: 'derived_config1',
+    extends: path.resolve(__dirname, 'base.rspack.config.js'),
+    entry: './src/index1.js',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'bundle1.js',
+    },
+  },
+  {
+    name: 'derived_config2',
+    extends: path.resolve(__dirname, 'base.rspack.config.js'),
+    entry: './src/index2.js',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'bundle2.js',
+    },
+  },
+];

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs/src/index1.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs/src/index1.js
@@ -1,0 +1,1 @@
+console.log('i am index1.js');

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs/src/index2.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs/src/index2.js
@@ -1,0 +1,1 @@
+console.log('i am index2.js');

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs2/base.rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs2/base.rspack.config.js
@@ -1,0 +1,14 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  entry: './src/index1.js',
+  name: 'base_config',
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle1.js',
+  },
+};

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs2/rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs2/rspack.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/core').MultiRspackOptions}
+ */
+module.exports = [
+  {
+    extends: path.resolve(__dirname, 'base.rspack.config.js'),
+  },
+  {
+    name: 'derived_config2',
+    mode: 'development',
+    entry: './src/index2.js',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'bundle2.js',
+    },
+  },
+];

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs2/src/index1.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs2/src/index1.js
@@ -1,0 +1,1 @@
+console.log('i am index1.js');

--- a/packages/rspack-cli/tests/build/config/extends/multiple-configs2/src/index2.js
+++ b/packages/rspack-cli/tests/build/config/extends/multiple-configs2/src/index2.js
@@ -1,0 +1,1 @@
+console.log('i am index2.js');

--- a/packages/rspack-cli/tests/build/config/extends/recursive-extends/other.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/recursive-extends/other.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  extends: path.resolve(__dirname, 'rspack.config.js'),
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+  },
+};

--- a/packages/rspack-cli/tests/build/config/extends/recursive-extends/rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/recursive-extends/rspack.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  extends: path.resolve(__dirname, 'rspack.config.js'),
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+  },
+};

--- a/packages/rspack-cli/tests/build/config/extends/recursive-extends/src/index.js
+++ b/packages/rspack-cli/tests/build/config/extends/recursive-extends/src/index.js
@@ -1,0 +1,1 @@
+console.log('Recursive extends test');

--- a/packages/rspack-cli/tests/build/config/extends/require-resolve/base.rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/require-resolve/base.rspack.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  output: {
+    filename: 'base.bundle.js',
+  },
+  mode: 'development',
+};

--- a/packages/rspack-cli/tests/build/config/extends/require-resolve/override.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/require-resolve/override.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  output: {
+    filename: 'override.bundle.js',
+  },
+  name: 'override_config',
+  mode: 'development',
+};

--- a/packages/rspack-cli/tests/build/config/extends/require-resolve/rspack.config.js
+++ b/packages/rspack-cli/tests/build/config/extends/require-resolve/rspack.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+  extends: [require.resolve('./base.rspack.config.js')],
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+  },
+};

--- a/packages/rspack-cli/tests/build/config/extends/require-resolve/src/index.js
+++ b/packages/rspack-cli/tests/build/config/extends/require-resolve/src/index.js
@@ -1,0 +1,1 @@
+console.log('Require resolve extends test');

--- a/packages/rspack-cli/tests/build/issue-13732/base.config.js
+++ b/packages/rspack-cli/tests/build/issue-13732/base.config.js
@@ -1,0 +1,13 @@
+const PLUGIN_NAME = 'MyBasePlugin';
+
+export class MyBasePlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, () => {
+      console.log('MyBasePlugin: The Rspack build process is starting!');
+    });
+  }
+}
+
+module.exports = {
+  plugins: [new MyBasePlugin()],
+};

--- a/packages/rspack-cli/tests/build/issue-13732/entry.js
+++ b/packages/rspack-cli/tests/build/issue-13732/entry.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/packages/rspack-cli/tests/build/issue-13732/index.test.ts
+++ b/packages/rspack-cli/tests/build/issue-13732/index.test.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'path';
+import { readFile, run } from '../../utils/test-utils';
+
+describe('issue-11009 build', () => {
+  it.concurrent(
+    'should set config path to persistent cache build dependencies',
+    async () => {
+      if (process.env.WASM) {
+        // skip when test wasm
+        return;
+      }
+      const { stdout, stderr } = await run(__dirname, []);
+      expect(stdout).toContain(
+        'MyBasePlugin: The Rspack build process is starting!',
+      );
+      expect(stdout).toContain(
+        'MyPlugin: The Rspack build process is starting!',
+      );
+    },
+  );
+});

--- a/packages/rspack-cli/tests/build/issue-13732/rspack.config.js
+++ b/packages/rspack-cli/tests/build/issue-13732/rspack.config.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const PLUGIN_NAME = 'MyPlugin';
+
+class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, () => {
+      console.log('MyPlugin: The Rspack build process is starting!');
+    });
+  }
+}
+
+module.exports = {
+  mode: 'development',
+  entry: './entry.js',
+  output: {
+    clean: true,
+    path: path.resolve(__dirname, 'dist'),
+  },
+  extends: './base.config.js',
+  // Override or add to the base configuration
+  output: {
+    filename: '[name].bundle.js',
+  },
+  plugins: [
+    // "...", // uncomment this to inherit plugins, but it's also a type error
+    new MyPlugin(),
+  ],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      webpack-merge:
+        specifier: 6.0.1
+        version: 6.0.1
 
   packages/rspack-test-tools:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,12 +381,12 @@ importers:
       prebundle:
         specifier: ^1.6.4
         version: 1.6.4(typescript@6.0.3)
+      rspack-merge:
+        specifier: 0.1.1
+        version: 0.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
-      webpack-merge:
-        specifier: 6.0.1
-        version: 6.0.1
 
   packages/rspack-test-tools:
     dependencies:
@@ -6814,6 +6814,9 @@ packages:
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
+
+  rspack-merge@0.1.1:
+    resolution: {integrity: sha512-RHKi8nECjP0lM1V7RnM+8G8dRvWgrsnntzfogJQz7oSHo104ca4jsL3KN/0gru233n/lVGrqDPDNlCA4x0UNlg==}
 
   rspack-vue-loader@17.5.0:
     resolution: {integrity: sha512-hJrL2+jytfTs6ORHBOKTh5lU7BVZvmv7afELuQfyEpGC1ll7MKj1BxlgAIbhd6pZwoEwfdH79Lewtwe4VOlfCQ==}
@@ -14505,6 +14508,8 @@ snapshots:
   rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-rc.1):
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@module-federation/runtime-tools@2.3.3)(core-js@3.49.0)
+
+  rspack-merge@0.1.1: {}
 
   rspack-vue-loader@17.5.0(@rspack/core@packages+rspack)(vue@3.5.33):
     dependencies:

--- a/website/docs/en/config/extends.mdx
+++ b/website/docs/en/config/extends.mdx
@@ -76,7 +76,7 @@ export default {
 ```
 
 :::info Merge Behavior
-Rspack uses [webpack-merge](https://github.com/survivejs/webpack-merge) internally to merge configurations. The default merge rules are:
+`@rspack/cli` uses [webpack-merge](https://github.com/survivejs/webpack-merge) internally to merge configurations. The default merge rules are:
 
 - Simple values are overwritten
 - Arrays are concatenated

--- a/website/docs/en/config/extends.mdx
+++ b/website/docs/en/config/extends.mdx
@@ -76,7 +76,7 @@ export default {
 ```
 
 :::info Merge Behavior
-`@rspack/cli` uses [webpack-merge](https://github.com/survivejs/webpack-merge) internally to merge configurations. The default merge rules are:
+`@rspack/cli` uses [rspack-merge](https://github.com/rstackjs/rspack-merge) internally to merge configurations. The default merge rules are:
 
 - Simple values are overwritten
 - Arrays are concatenated

--- a/website/docs/en/config/extends.mdx
+++ b/website/docs/en/config/extends.mdx
@@ -76,8 +76,7 @@ export default {
 ```
 
 :::info Merge Behavior
-
-When merging configurations:
+Rspack uses [webpack-merge](https://github.com/survivejs/webpack-merge) internally to merge configurations. The default merge rules are:
 
 - Simple values are overwritten
 - Arrays are concatenated

--- a/website/docs/zh/config/extends.mdx
+++ b/website/docs/zh/config/extends.mdx
@@ -76,7 +76,7 @@ export default {
 ```
 
 :::info 合并行为
-Rspack 内部使用 [webpack-merge](https://github.com/survivejs/webpack-merge) 来合并配置，其默认合并规则如下：
+`@rspack/cli` 内部使用 [webpack-merge](https://github.com/survivejs/webpack-merge) 来合并配置，其默认合并规则如下：
 
 - 简单值会被覆盖
 - 数组会被连接

--- a/website/docs/zh/config/extends.mdx
+++ b/website/docs/zh/config/extends.mdx
@@ -76,7 +76,7 @@ export default {
 ```
 
 :::info 合并行为
-`@rspack/cli` 内部使用 [webpack-merge](https://github.com/survivejs/webpack-merge) 来合并配置，其默认合并规则如下：
+`@rspack/cli` 内部使用 [rspack-merge](https://github.com/rstackjs/rspack-merge) 来合并配置，其默认合并规则如下：
 
 - 简单值会被覆盖
 - 数组会被连接

--- a/website/docs/zh/config/extends.mdx
+++ b/website/docs/zh/config/extends.mdx
@@ -76,7 +76,7 @@ export default {
 ```
 
 :::info 合并行为
-当合并配置时：
+Rspack 内部使用 [webpack-merge](https://github.com/survivejs/webpack-merge) 来合并配置，其默认合并规则如下：
 
 - 简单值会被覆盖
 - 数组会被连接


### PR DESCRIPTION
## Summary

fix https://github.com/web-infra-dev/rspack/issues/13732

`webpack-cli` use `webpack-merge` for resolving config extends.

`rspack-merge` implements special handling for Rspack semantics, such as deduplicating loaders by their `test` rules. `cleverMerge` is a generic utility function.For the CLI extends scenario, `rspack-merge` is indeed the more suitable option.

## Related links

https://github.com/web-infra-dev/rspack/issues/13732

https://webpack.js.org/configuration/extending-configurations/

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
