### PR TITLE
docs: add TanStack Router to ecosystem

### DIFF
--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -136,6 +136,13 @@ Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow y
 
 [Storybook Rsbuild](https://storybook.rsbuild.rs/) allows you to use Rsbuild as the build tool for Storybook, and provides UI framework integrations like React and Vue.
 
+### TanStack Router
+
+<Tag color="geekblue">Router</Tag>
+<Tag color="purple">React</Tag>
+
+[TanStack Router](https://tanstack.com/router/latest/docs/installation/with-rspack) is a type-safe router for building React applications with features like nested routes, route-level data loading, and search params APIs.
+
 ## More
 
 Visit [awesome-rstack](https://github.com/rstackjs/awesome-rstack) to discover more projects within the Rspack ecosystem.

--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -141,7 +141,9 @@ Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow y
 <Tag color="geekblue">Router</Tag>
 <Tag color="purple">React</Tag>
 
-[TanStack Router](https://tanstack.com/router/latest/docs/installation/with-rspack) is a type-safe router for building React applications with features like nested routes, route-level data loading, and search params APIs.
+[TanStack Router](https://tanstack.com/router/latest) is a type-safe router for building React applications with features like nested routes, route-level data loading, and search params APIs.
+
+You can integrate TanStack Router with Rspack through the [Rspack plugin](https://tanstack.com/router/latest/docs/installation/with-rspack).
 
 ## More
 

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -126,6 +126,12 @@ Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你
 
 [Storybook Rsbuild](https://storybook.rsbuild.rs/) 允许你使用 Rsbuild 作为 Storybook 的构建工具，并提供了 React 和 Vue 等 UI 框架的集成。
 
+### TanStack Router
+
+<Tag color="geekblue">路由</Tag> <Tag color="purple">React</Tag>
+
+[TanStack Router](https://tanstack.com/router/latest/docs/installation/with-rspack) 是一个用于构建 React 应用的类型安全路由库，提供嵌套路由、路由级数据加载和 search params API 等能力。
+
 ## 更多
 
 访问 [awesome-rstack](https://github.com/rstackjs/awesome-rstack) 来发现更多 Rspack 生态中的项目。

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -130,7 +130,9 @@ Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你
 
 <Tag color="geekblue">路由</Tag> <Tag color="purple">React</Tag>
 
-[TanStack Router](https://tanstack.com/router/latest/docs/installation/with-rspack) 是一个用于构建 React 应用的类型安全路由库，提供嵌套路由、路由级数据加载和 search params API 等能力。
+[TanStack Router](https://tanstack.com/router/latest) 是一个用于构建 React 应用的类型安全路由库，提供嵌套路由、路由级数据加载和 search params API 等能力。
+
+TanStack Router 可以通过 [Rspack 插件](https://tanstack.com/router/latest/docs/installation/with-rspack) 与 Rspack 集成。
 
 ## 更多
 


### PR DESCRIPTION
## Summary

This PR adds TanStack Router to the ecosystem docs so users can find its official Rspack installation guide from the Rspack ecosystem page.

## Related links

https://tanstack.com/router/latest/docs/installation/with-rspack

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).