### PR TITLE
chore(benchmark): disable minimize for bundle codspeed

### DIFF
--- a/xtask/benchmark/benches/groups/bundle.rs
+++ b/xtask/benchmark/benches/groups/bundle.rs
@@ -23,7 +23,7 @@ fn bundle_benchmark(c: &mut Criterion) {
   let rt = rspack_benchmark::build_tokio_rt();
   for (id, get_compiler) in derive_projects(projects) {
     group.bench_function(format!("bundle@{id}"), |b| {
-      b.to_async(&rt).iter_batched(
+      b.iter_batched(
         || {
           let compiler_context = Arc::new(CompilerContext::new());
           (
@@ -32,10 +32,10 @@ fn bundle_benchmark(c: &mut Criterion) {
           )
         },
         |(compiler_context, mut compiler)| {
-          within_compiler_context(compiler_context, async move {
+          rt.block_on(within_compiler_context(compiler_context, async move {
             compiler.run().await.unwrap();
             assert!(compiler.compilation.get_errors().next().is_none());
-          })
+          }))
         },
         criterion::BatchSize::PerIteration,
       );

--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use rspack::builder::{Builder, CompilerBuilder};
 use rspack_core::{
   Compiler, Experiments, Mode, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleUse,
-  ModuleRuleUseLoader, Resolve, RuleSetCondition,
+  ModuleRuleUseLoader, Optimization, Resolve, RuleSetCondition,
 };
 use rspack_fs::{MemoryFileSystem, NativeFileSystem};
 use rspack_regex::RspackRegex;
@@ -56,6 +56,7 @@ pub fn basic_compiler_builder(options: BuilderOptions) -> CompilerBuilder {
       ..Default::default()
     }))
     .cache(rspack_core::CacheOptions::Disabled)
+    .optimization(Optimization::builder().minimize(false))
     .resolve(Resolve {
       extensions: Some(vec!["...".to_string(), ".jsx".to_string()]),
       ..Default::default()


### PR DESCRIPTION
## Summary

- Disable minimization for all bundle CodSpeed benchmark cases through the shared bundle compiler builder.
- Keep development and production-sourcemap bundle cases comparable without SWC minimizer work in the measurement.

## Validation

- `cargo check -p rspack_benchmark --benches`
