### PR TITLE
feat(rslib): support emit isolated declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,6 +4083,7 @@ dependencies = [
  "swc_core",
  "swc_ecma_minifier",
  "swc_error_reporters",
+ "swc_typescript",
  "url",
 ]
 
@@ -4952,6 +4953,8 @@ name = "rspack_plugin_rslib"
 version = "0.100.1"
 dependencies = [
  "async-trait",
+ "cow-utils",
+ "pathdiff",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4959,6 +4962,7 @@ dependencies = [
  "rspack_fs",
  "rspack_hash",
  "rspack_hook",
+ "rspack_paths",
  "rspack_plugin_asset",
  "rspack_plugin_externals",
  "rspack_plugin_javascript",
@@ -7020,6 +7024,22 @@ dependencies = [
  "rustc-hash",
  "serde",
  "swc_common",
+]
+
+[[package]]
+name = "swc_typescript"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cea40da0e283592ce48623bd52032565c13fcb5362410b1919414830214450"
+dependencies = [
+ "bitflags 2.11.1",
+ "petgraph",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ swc_error_reporters = { version = "23.0.0", default-features = false }
 swc_html            = { version = "33.0.0", default-features = false }
 swc_html_minifier   = { version = "52.0.0", default-features = false }
 swc_plugin_runner   = { version = "27.0.0", default-features = false }
+swc_typescript      = { version = "28.0.0", default-features = false }
 
 swc_experimental_ecma_ast      = { version = "0.6.5", default-features = false }
 swc_experimental_ecma_parser   = { version = "0.6.5", default-features = false }

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2910,6 +2910,8 @@ export interface RawRslibPluginOptions {
    * @default `false`
    */
   autoCjsNodeBuiltin?: boolean
+  /** Emit isolated declaration files for modules transformed by `builtin:swc-loader` */
+  emitDts?: RawSwcEmitDtsOptions
 }
 
 export interface RawRstestPluginOptions {
@@ -3027,6 +3029,11 @@ export interface RawSubresourceIntegrityPluginOptions {
   integrityCallback?: (data: RawIntegrityData) => void
   hashFuncNames: Array<string>
   htmlPlugin: "JavaScript" | "Native" | "Disabled"
+}
+
+export interface RawSwcEmitDtsOptions {
+  rootDir: string
+  declarationDir: string
 }
 
 export interface RawSwcJsMinimizerOptions {

--- a/crates/rspack_binding_api/src/rslib.rs
+++ b/crates/rspack_binding_api/src/rslib.rs
@@ -1,5 +1,12 @@
 use derive_more::Debug;
-use rspack_plugin_rslib::RslibPluginOptions;
+use rspack_plugin_rslib::{RslibPluginOptions, SwcEmitDtsPluginOptions};
+
+#[derive(Debug)]
+#[napi(object, object_to_js = false)]
+pub struct RawSwcEmitDtsOptions {
+  pub root_dir: String,
+  pub declaration_dir: String,
+}
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -13,6 +20,8 @@ pub struct RawRslibPluginOptions {
   /// Auto downgrade module external type to node-commonjs for CJS require of node builtins
   /// @default `false`
   pub auto_cjs_node_builtin: Option<bool>,
+  /// Emit isolated declaration files for modules transformed by `builtin:swc-loader`
+  pub emit_dts: Option<RawSwcEmitDtsOptions>,
 }
 
 impl From<RawRslibPluginOptions> for RslibPluginOptions {
@@ -21,6 +30,16 @@ impl From<RawRslibPluginOptions> for RslibPluginOptions {
       intercept_api_plugin: value.intercept_api_plugin.unwrap_or_default(),
       force_node_shims: value.force_node_shims.unwrap_or_default(),
       auto_cjs_node_builtin: value.auto_cjs_node_builtin.unwrap_or_default(),
+      emit_dts: value.emit_dts.map(Into::into),
+    }
+  }
+}
+
+impl From<RawSwcEmitDtsOptions> for SwcEmitDtsPluginOptions {
+  fn from(value: RawSwcEmitDtsOptions) -> Self {
+    Self {
+      root_dir: value.root_dir,
+      declaration_dir: value.declaration_dir,
     }
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -122,6 +122,13 @@ pub type CssExports = FxIndexMap<String, FxIndexSet<CssExport>>;
 
 #[cacheable]
 #[derive(Debug, Clone)]
+pub struct IsolatedDts {
+  pub resource_path: String,
+  pub code: String,
+}
+
+#[cacheable]
+#[derive(Debug, Clone)]
 pub struct BuildInfo {
   /// Whether the result is cacheable, i.e shared between builds.
   pub cacheable: bool,
@@ -154,6 +161,7 @@ pub struct BuildInfo {
   pub inline_exports: bool,
   pub collected_typescript_info: Option<CollectedTypeScriptInfo>,
   pub rsc: Option<RscMeta>,
+  pub isolated_dts: Option<IsolatedDts>,
   /// Stores external fields from the JS side (Record<string, any>),
   /// while other properties are stored in KnownBuildInfo.
   #[cacheable(with=AsPreset)]
@@ -190,6 +198,7 @@ impl Default for BuildInfo {
       inline_exports: false,
       collected_typescript_info: None,
       rsc: None,
+      isolated_dts: None,
       extras: Default::default(),
       deferred_pure_checks: HashSet::default(),
     }

--- a/crates/rspack_javascript_compiler/Cargo.toml
+++ b/crates/rspack_javascript_compiler/Cargo.toml
@@ -20,6 +20,7 @@ swc_config          = { workspace = true }
 swc_core            = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "__parser", "ecma_ast", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "ecma_parser_unstable", "swc_ecma_codegen", "swc_ecma_visit"] }
 swc_ecma_minifier   = { workspace = true, features = ["concurrent"] }
 swc_error_reporters = { workspace = true }
+swc_typescript      = { workspace = true }
 url                 = { workspace = true }
 
 rspack_error     = { workspace = true }

--- a/crates/rspack_javascript_compiler/src/compiler/mod.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/mod.rs
@@ -52,12 +52,5 @@ impl TransformOutput {
 #[derive(Debug, Clone)]
 pub struct IsolatedDtsTransformOutput {
   pub code: String,
-  pub diagnostics: Vec<IsolatedDtsDiagnostic>,
-}
-
-#[derive(Debug, Clone)]
-pub struct IsolatedDtsDiagnostic {
-  pub message: String,
-  pub start: u32,
-  pub end: u32,
+  pub diagnostics: Vec<String>,
 }

--- a/crates/rspack_javascript_compiler/src/compiler/mod.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/mod.rs
@@ -48,3 +48,16 @@ impl TransformOutput {
     self
   }
 }
+
+#[derive(Debug, Clone)]
+pub struct IsolatedDtsTransformOutput {
+  pub code: String,
+  pub diagnostics: Vec<IsolatedDtsDiagnostic>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IsolatedDtsDiagnostic {
+  pub message: String,
+  pub start: u32,
+  pub end: u32,
+}

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, bail};
 use base64::prelude::*;
 use indoc::formatdoc;
 use rspack_error::Result;
-use rspack_util::{SpanExt, source_map::SourceMapKind, swc::minify_file_comments};
+use rspack_util::{source_map::SourceMapKind, swc::minify_file_comments};
 use swc_config::{is_module::IsModule, merge::Merge};
 pub use swc_core::base::config::Options as SwcOptions;
 use swc_core::{
@@ -29,6 +29,10 @@ use swc_core::{
   },
   ecma::{
     ast::{EsVersion, Pass, Program},
+    codegen::{
+      self, Emitter, Node,
+      text_writer::{self, WriteJs},
+    },
     parser::{
       Syntax, TsSyntax, parse_file_as_commonjs, parse_file_as_module, parse_file_as_program,
       parse_file_as_script,
@@ -41,7 +45,7 @@ use swc_typescript::fast_dts::FastDts;
 use url::Url;
 
 use super::{
-  IsolatedDtsDiagnostic, IsolatedDtsTransformOutput, JavaScriptCompiler, TransformOutput,
+  IsolatedDtsTransformOutput, JavaScriptCompiler, TransformOutput,
   stringify::{PrintOptions, SourceMapConfig},
 };
 
@@ -77,7 +81,6 @@ impl JavaScriptCompiler {
     program: &Program,
     filename: Arc<FileName>,
     unresolved_mark: Mark,
-    source_len: u32,
     target: EsVersion,
     comments: &SingleThreadedComments,
   ) -> Result<IsolatedDtsTransformOutput> {
@@ -92,33 +95,46 @@ impl JavaScriptCompiler {
       // declaration-safe codegen settings instead of reusing the JS output pipeline.
       let mut program = program.clone();
       let mut checker = FastDts::new(filename, unresolved_mark, Default::default());
-      let diagnostics = checker
-        .transform(&mut program)
-        .into_iter()
-        .map(|issue| IsolatedDtsDiagnostic {
-          message: issue.message.to_string(),
-          start: issue.range.span.real_lo(),
-          end: issue.range.span.real_hi(),
-        })
-        .collect();
+      let diagnostics = match checker.transform(&mut program) {
+        issues if issues.is_empty() => Vec::new(),
+        issues => {
+          let result = try_with_handler(self.cm.clone(), Default::default(), |handler| {
+            for issue in issues {
+              handler
+                .struct_span_err(issue.range.span, &issue.message)
+                .emit();
+            }
 
-      let code = self
-        .print(
-          &program,
-          PrintOptions {
-            source_len,
-            source_map: self.cm.clone(),
-            target,
-            source_map_config: SourceMapConfig::default(),
-            input_source_map: None,
-            minify: false,
+            Ok(())
+          });
+
+          match result {
+            Ok(()) => Vec::new(),
+            Err(error) => vec![error.to_pretty_string()],
+          }
+        }
+      };
+
+      let code = {
+        let mut buf = Vec::new();
+        {
+          let wr = Box::new(text_writer::JsWriter::new(
+            self.cm.clone(),
+            "\n",
+            &mut buf,
+            None,
+          )) as Box<dyn WriteJs>;
+          let mut emitter = Emitter {
+            cfg: codegen::Config::default().with_target(target),
             comments: Some(&comments as &dyn Comments),
-            preamble: "",
-            ascii_only: false,
-            inline_script: false,
-          },
-        )?
-        .code;
+            cm: self.cm.clone(),
+            wr,
+          };
+          program.emit_with(&mut emitter)?;
+        }
+        // SAFETY: SWC will emit valid utf8 for sure
+        unsafe { String::from_utf8_unchecked(buf) }
+      };
 
       Ok(IsolatedDtsTransformOutput { code, diagnostics })
     })

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -5,13 +5,13 @@
  * Author Donny/강동윤
  * Copyright (c)
  */
-use std::{fs::File, path::PathBuf, sync::Arc};
+use std::{cell::RefCell, fs::File, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::{Context, bail};
 use base64::prelude::*;
 use indoc::formatdoc;
 use rspack_error::Result;
-use rspack_util::{source_map::SourceMapKind, swc::minify_file_comments};
+use rspack_util::{SpanExt, source_map::SourceMapKind, swc::minify_file_comments};
 use swc_config::{is_module::IsModule, merge::Merge};
 pub use swc_core::base::config::Options as SwcOptions;
 use swc_core::{
@@ -37,10 +37,11 @@ use swc_core::{
   },
 };
 use swc_error_reporters::handler::try_with_handler;
+use swc_typescript::fast_dts::FastDts;
 use url::Url;
 
 use super::{
-  JavaScriptCompiler, TransformOutput,
+  IsolatedDtsDiagnostic, IsolatedDtsTransformOutput, JavaScriptCompiler, TransformOutput,
   stringify::{PrintOptions, SourceMapConfig},
 };
 
@@ -69,6 +70,58 @@ impl JavaScriptCompiler {
       JavaScriptTransformer::new(self.cm.clone(), fm, comments, self, options)?;
 
     javascript_transformer.transform(inspect_parsed_ast, before_pass, module_source_map_kind)
+  }
+
+  pub fn emit_isolated_dts(
+    &self,
+    program: &Program,
+    filename: Arc<FileName>,
+    unresolved_mark: Mark,
+    source_len: u32,
+    target: EsVersion,
+    comments: &SingleThreadedComments,
+  ) -> Result<IsolatedDtsTransformOutput> {
+    self.run(|| {
+      let (leading, trailing) = comments.borrow_all();
+      let comments = SingleThreadedComments::from_leading_and_trailing(
+        Rc::new(RefCell::new(leading.clone())),
+        Rc::new(RefCell::new(trailing.clone())),
+      );
+
+      // FastDts mutates the cloned program into declaration form. Re-print it with
+      // declaration-safe codegen settings instead of reusing the JS output pipeline.
+      let mut program = program.clone();
+      let mut checker = FastDts::new(filename, unresolved_mark, Default::default());
+      let diagnostics = checker
+        .transform(&mut program)
+        .into_iter()
+        .map(|issue| IsolatedDtsDiagnostic {
+          message: issue.message.to_string(),
+          start: issue.range.span.real_lo(),
+          end: issue.range.span.real_hi(),
+        })
+        .collect();
+
+      let code = self
+        .print(
+          &program,
+          PrintOptions {
+            source_len,
+            source_map: self.cm.clone(),
+            target,
+            source_map_config: SourceMapConfig::default(),
+            input_source_map: None,
+            minify: false,
+            comments: Some(&comments as &dyn Comments),
+            preamble: "",
+            ascii_only: false,
+            inline_script: false,
+          },
+        )?
+        .code;
+
+      Ok(IsolatedDtsTransformOutput { code, diagnostics })
+    })
   }
 }
 

--- a/crates/rspack_javascript_compiler/src/error.rs
+++ b/crates/rspack_javascript_compiler/src/error.rs
@@ -1,20 +1,14 @@
 use std::{
   fmt::Debug,
-  path::Path,
   sync::{Arc, mpsc},
 };
 
-use rspack_error::{BatchErrors, Error, Severity, error};
+use rspack_error::{BatchErrors, Error, error};
 use rspack_util::SpanExt;
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::common::{
-  BytePos, FileName, SourceMap, Span, Spanned,
-  errors::{ColorConfig, Emitter, HANDLER, Handler},
-  sync::Lrc,
-};
-use swc_error_reporters::{
-  ErrorEmitter,
-  handler::{HandlerOpts, ThreadSafetyDiagnostics},
+  SourceMap, Span, Spanned,
+  errors::{Emitter, HANDLER, Handler},
 };
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -67,46 +61,6 @@ pub fn ecma_parse_error_deduped_to_rspack_error(
     "JavaScript parse error".into(),
     message,
   )
-}
-
-pub fn render_pretty_span_diagnostic(
-  source_code: &str,
-  file_path: &Path,
-  start: u32,
-  end: u32,
-  message: &str,
-  severity: Severity,
-) -> String {
-  let cm: Lrc<SourceMap> = Default::default();
-  let file = cm.new_source_file(
-    Arc::new(FileName::Real(file_path.to_path_buf())),
-    source_code.to_string(),
-  );
-
-  let span = Span::new(
-    file.start_pos + BytePos(start),
-    file.start_pos + BytePos(end.max(start.saturating_add(1))),
-  );
-
-  let diagnostics = ThreadSafetyDiagnostics::default();
-  let emitter = Box::new(ErrorEmitter {
-    diagnostics: diagnostics.clone(),
-    cm: cm.clone(),
-    opts: HandlerOpts {
-      color: ColorConfig::Auto,
-      skip_filename: false,
-    },
-  });
-  let handler = Handler::with_emitter(true, false, emitter);
-
-  HANDLER.set(&handler, || match severity {
-    Severity::Error => handler.struct_span_err(span, message).emit(),
-    Severity::Warning => handler.struct_span_warn(span, message).emit(),
-  });
-
-  diagnostics
-    .to_pretty_string(&cm, false, ColorConfig::Auto)
-    .join("")
 }
 
 // keep this private to make sure with_rspack_error_handler is safety

--- a/crates/rspack_javascript_compiler/src/error.rs
+++ b/crates/rspack_javascript_compiler/src/error.rs
@@ -1,14 +1,20 @@
 use std::{
   fmt::Debug,
+  path::Path,
   sync::{Arc, mpsc},
 };
 
-use rspack_error::{BatchErrors, Error, error};
+use rspack_error::{BatchErrors, Error, Severity, error};
 use rspack_util::SpanExt;
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::common::{
-  SourceMap, Span, Spanned,
-  errors::{Emitter, HANDLER, Handler},
+  BytePos, FileName, SourceMap, Span, Spanned,
+  errors::{ColorConfig, Emitter, HANDLER, Handler},
+  sync::Lrc,
+};
+use swc_error_reporters::{
+  ErrorEmitter,
+  handler::{HandlerOpts, ThreadSafetyDiagnostics},
 };
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -61,6 +67,46 @@ pub fn ecma_parse_error_deduped_to_rspack_error(
     "JavaScript parse error".into(),
     message,
   )
+}
+
+pub fn render_pretty_span_diagnostic(
+  source_code: &str,
+  file_path: &Path,
+  start: u32,
+  end: u32,
+  message: &str,
+  severity: Severity,
+) -> String {
+  let cm: Lrc<SourceMap> = Default::default();
+  let file = cm.new_source_file(
+    Arc::new(FileName::Real(file_path.to_path_buf())),
+    source_code.to_string(),
+  );
+
+  let span = Span::new(
+    file.start_pos + BytePos(start),
+    file.start_pos + BytePos(end.max(start.saturating_add(1))),
+  );
+
+  let diagnostics = ThreadSafetyDiagnostics::default();
+  let emitter = Box::new(ErrorEmitter {
+    diagnostics: diagnostics.clone(),
+    cm: cm.clone(),
+    opts: HandlerOpts {
+      color: ColorConfig::Auto,
+      skip_filename: false,
+    },
+  });
+  let handler = Handler::with_emitter(true, false, emitter);
+
+  HANDLER.set(&handler, || match severity {
+    Severity::Error => handler.struct_span_err(span, message).emit(),
+    Severity::Warning => handler.struct_span_warn(span, message).emit(),
+  });
+
+  diagnostics
+    .to_pretty_string(&cm, false, ColorConfig::Auto)
+    .join("")
 }
 
 // keep this private to make sure with_rspack_error_handler is safety

--- a/crates/rspack_javascript_compiler/src/lib.rs
+++ b/crates/rspack_javascript_compiler/src/lib.rs
@@ -2,4 +2,8 @@ pub mod ast;
 mod compiler;
 mod error;
 
-pub use compiler::{JavaScriptCompiler, TransformOutput, minify, parse, transform};
+pub use compiler::{
+  IsolatedDtsDiagnostic, IsolatedDtsTransformOutput, JavaScriptCompiler, TransformOutput, minify,
+  parse, transform,
+};
+pub use error::render_pretty_span_diagnostic;

--- a/crates/rspack_javascript_compiler/src/lib.rs
+++ b/crates/rspack_javascript_compiler/src/lib.rs
@@ -3,7 +3,5 @@ mod compiler;
 mod error;
 
 pub use compiler::{
-  IsolatedDtsDiagnostic, IsolatedDtsTransformOutput, JavaScriptCompiler, TransformOutput, minify,
-  parse, transform,
+  IsolatedDtsTransformOutput, JavaScriptCompiler, TransformOutput, minify, parse, transform,
 };
-pub use error::render_pretty_span_diagnostic;

--- a/crates/rspack_loader_swc/src/isolated_dts.rs
+++ b/crates/rspack_loader_swc/src/isolated_dts.rs
@@ -1,0 +1,106 @@
+use rspack_core::RunnerContext;
+use rspack_error::{Diagnostic, Error, Result, Severity};
+use rspack_javascript_compiler::{IsolatedDtsDiagnostic, render_pretty_span_diagnostic};
+use rspack_loader_runner::LoaderContext;
+use rspack_paths::Utf8Path;
+use serde_json::{Map, Value};
+
+use crate::SWC_LOADER_IDENTIFIER;
+
+pub(crate) fn set_build_info(
+  build_info: &mut rspack_core::BuildInfo,
+  resource_path: String,
+  code: String,
+) {
+  build_info.extras.insert(
+    "rspack-swc-isolated-dts-emit".to_string(),
+    Value::Object(Map::from_iter([
+      ("resource_path".to_string(), Value::String(resource_path)),
+      ("code".to_string(), Value::String(code)),
+    ])),
+  );
+}
+
+pub(crate) fn handle_isolated_dts_diagnostics(
+  loader_context: &mut LoaderContext<RunnerContext>,
+  resource_path: &Utf8Path,
+  source_code: &str,
+  diagnostics: Vec<IsolatedDtsDiagnostic>,
+) -> Result<()> {
+  if !diagnostics.is_empty() {
+    return Err(create_isolated_dts_abort_error(
+      diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+          create_isolated_dts_traceable_error(
+            resource_path,
+            source_code,
+            &diagnostic,
+            Severity::Error,
+          )
+        })
+        .collect(),
+    ));
+  }
+
+  for diagnostic in diagnostics {
+    let error = create_isolated_dts_traceable_error(
+      resource_path,
+      source_code,
+      &diagnostic,
+      Severity::Warning,
+    );
+    loader_context.emit_diagnostic(Diagnostic::from(error));
+  }
+
+  Ok(())
+}
+
+fn create_isolated_dts_traceable_error(
+  resource_path: &Utf8Path,
+  source_code: &str,
+  diagnostic: &IsolatedDtsDiagnostic,
+  severity: Severity,
+) -> Error {
+  let mut error = match severity {
+    Severity::Error => Error::error(render_pretty_span_diagnostic(
+      source_code,
+      resource_path.as_std_path(),
+      diagnostic.start,
+      diagnostic.end,
+      &diagnostic.message,
+      Severity::Error,
+    )),
+    Severity::Warning => Error::warning(render_pretty_span_diagnostic(
+      source_code,
+      resource_path.as_std_path(),
+      diagnostic.start,
+      diagnostic.end,
+      &diagnostic.message,
+      Severity::Warning,
+    )),
+  };
+  error.code = Some(SWC_LOADER_IDENTIFIER.to_string());
+  error
+}
+
+fn create_isolated_dts_abort_error(mut errors: Vec<Error>) -> Error {
+  let mut error = Error::error("Failed to generate declaration files.".to_string());
+  error.code = Some(SWC_LOADER_IDENTIFIER.to_string());
+
+  if let Some(first_error) = errors.drain(..1).next() {
+    error.source_error = Some(Box::new(first_error));
+  }
+
+  if !errors.is_empty() {
+    error.help = Some(
+      errors
+        .into_iter()
+        .map(|error| error.message.clone())
+        .collect::<Vec<_>>()
+        .join("\n"),
+    );
+  }
+
+  error
+}

--- a/crates/rspack_loader_swc/src/isolated_dts.rs
+++ b/crates/rspack_loader_swc/src/isolated_dts.rs
@@ -1,106 +1,34 @@
-use rspack_core::RunnerContext;
-use rspack_error::{Diagnostic, Error, Result, Severity};
-use rspack_javascript_compiler::{IsolatedDtsDiagnostic, render_pretty_span_diagnostic};
-use rspack_loader_runner::LoaderContext;
-use rspack_paths::Utf8Path;
-use serde_json::{Map, Value};
+use rspack_core::{BuildInfo, IsolatedDts};
+use rspack_error::{Error, Result};
 
 use crate::SWC_LOADER_IDENTIFIER;
 
-pub(crate) fn set_build_info(
-  build_info: &mut rspack_core::BuildInfo,
-  resource_path: String,
-  code: String,
-) {
-  build_info.extras.insert(
-    "rspack-swc-isolated-dts-emit".to_string(),
-    Value::Object(Map::from_iter([
-      ("resource_path".to_string(), Value::String(resource_path)),
-      ("code".to_string(), Value::String(code)),
-    ])),
-  );
+pub(crate) fn set_build_info(build_info: &mut BuildInfo, resource_path: String, code: String) {
+  build_info.isolated_dts = Some(IsolatedDts {
+    resource_path,
+    code,
+  });
 }
 
-pub(crate) fn handle_isolated_dts_diagnostics(
-  loader_context: &mut LoaderContext<RunnerContext>,
-  resource_path: &Utf8Path,
-  source_code: &str,
-  diagnostics: Vec<IsolatedDtsDiagnostic>,
-) -> Result<()> {
-  if !diagnostics.is_empty() {
-    return Err(create_isolated_dts_abort_error(
-      diagnostics
-        .into_iter()
-        .map(|diagnostic| {
-          create_isolated_dts_traceable_error(
-            resource_path,
-            source_code,
-            &diagnostic,
-            Severity::Error,
-          )
-        })
-        .collect(),
-    ));
-  }
-
-  for diagnostic in diagnostics {
-    let error = create_isolated_dts_traceable_error(
-      resource_path,
-      source_code,
-      &diagnostic,
-      Severity::Warning,
-    );
-    loader_context.emit_diagnostic(Diagnostic::from(error));
-  }
-
-  Ok(())
-}
-
-fn create_isolated_dts_traceable_error(
-  resource_path: &Utf8Path,
-  source_code: &str,
-  diagnostic: &IsolatedDtsDiagnostic,
-  severity: Severity,
-) -> Error {
-  let mut error = match severity {
-    Severity::Error => Error::error(render_pretty_span_diagnostic(
-      source_code,
-      resource_path.as_std_path(),
-      diagnostic.start,
-      diagnostic.end,
-      &diagnostic.message,
-      Severity::Error,
-    )),
-    Severity::Warning => Error::warning(render_pretty_span_diagnostic(
-      source_code,
-      resource_path.as_std_path(),
-      diagnostic.start,
-      diagnostic.end,
-      &diagnostic.message,
-      Severity::Warning,
-    )),
+pub(crate) fn handle_isolated_dts_diagnostics(diagnostics: Vec<String>) -> Result<()> {
+  let mut diagnostics = diagnostics.into_iter();
+  let Some(first) = diagnostics.next() else {
+    return Ok(());
   };
-  error.code = Some(SWC_LOADER_IDENTIFIER.to_string());
-  error
-}
 
-fn create_isolated_dts_abort_error(mut errors: Vec<Error>) -> Error {
   let mut error = Error::error("Failed to generate declaration files.".to_string());
   error.code = Some(SWC_LOADER_IDENTIFIER.to_string());
-
-  if let Some(first_error) = errors.drain(..1).next() {
-    error.source_error = Some(Box::new(first_error));
+  error.source_error = Some(Box::new(create_isolated_dts_error(first)));
+  let remaining = diagnostics.collect::<Vec<_>>();
+  if !remaining.is_empty() {
+    error.help = Some(remaining.join("\n"));
   }
 
-  if !errors.is_empty() {
-    error.help = Some(
-      errors
-        .into_iter()
-        .map(|error| error.message.clone())
-        .collect::<Vec<_>>()
-        .join("\n"),
-    );
-  }
+  Err(error)
+}
 
+fn create_isolated_dts_error(diagnostic: String) -> Error {
+  let mut error = Error::error(diagnostic);
+  error.code = Some(SWC_LOADER_IDENTIFIER.to_string());
   error
 }

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -126,19 +126,22 @@ impl SwcLoader {
     let comments = Rc::new(SingleThreadedComments::default());
 
     let source = content.into_string_lossy();
-    let source_code = source.clone();
     let is_typescript =
       matches!(swc_options.config.jsc.syntax, Some(syntax) if syntax.typescript());
-    let should_emit_isolated_dts = swc_options
-      .config
-      .jsc
-      .experimental
-      .emit_isolated_dts
-      .into_bool();
-    let isolated_dts_target = swc_options.config.jsc.target.unwrap_or(EsVersion::EsNext);
-    let source_len = source.len() as u32;
-    let dts_filename = filename.clone();
-    let dts_comments = comments.clone();
+    let isolated_dts_context = (is_typescript
+      && swc_options
+        .config
+        .jsc
+        .experimental
+        .emit_isolated_dts
+        .into_bool())
+    .then(|| {
+      (
+        swc_options.config.jsc.target.unwrap_or(EsVersion::EsNext),
+        filename.clone(),
+        comments.clone(),
+      )
+    });
     let mut isolated_dts = Ok(None);
     let mut collected_ts_info = None;
     let rsc_meta: RefCell<Option<RscMeta>> = Default::default();
@@ -158,15 +161,14 @@ impl SwcLoader {
           return;
         }
 
-        if should_emit_isolated_dts {
+        if let Some((target, dts_filename, dts_comments)) = &isolated_dts_context {
           isolated_dts = javascript_compiler
             .emit_isolated_dts(
               program,
               dts_filename.clone(),
               unresolved_mark,
-              source_len,
-              isolated_dts_target,
-              &dts_comments,
+              *target,
+              dts_comments,
             )
             .map(Some);
         }
@@ -216,12 +218,7 @@ impl SwcLoader {
     }
 
     if let Some(isolated_dts) = isolated_dts? {
-      handle_isolated_dts_diagnostics(
-        loader_context,
-        &resource_path,
-        &source_code,
-        isolated_dts.diagnostics,
-      )?;
+      handle_isolated_dts_diagnostics(isolated_dts.diagnostics)?;
 
       set_build_info(
         loader_context.context.module.build_info_mut(),

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(box_patterns)]
 
 mod collect_ts_info;
+mod isolated_dts;
 mod options;
 mod plugin;
 mod rsc_transforms;
@@ -8,6 +9,7 @@ mod transformer;
 
 use std::{cell::RefCell, default::Default, path::Path, rc::Rc, sync::Arc};
 
+use isolated_dts::{handle_isolated_dts_diagnostics, set_build_info};
 use options::SwcCompilerOptionsWithAdditional;
 pub use options::SwcLoaderJsOptions;
 pub use plugin::SwcLoaderPlugin;
@@ -24,7 +26,7 @@ use swc_config::{merge::Merge, types::MergingOption};
 use swc_core::{
   base::config::{InputSourceMap, TransformConfig},
   common::{FileName, SyntaxContext, comments::SingleThreadedComments},
-  ecma::ast::noop_pass,
+  ecma::ast::{EsVersion, noop_pass},
 };
 
 use crate::{
@@ -65,7 +67,6 @@ impl SwcLoader {
     let Some(content) = loader_context.take_content() else {
       return Ok(());
     };
-
     let swc_options = {
       let mut swc_options = self.options_with_additional.swc_options.clone();
       if let Some(resource_specific_jsc) = self
@@ -125,8 +126,20 @@ impl SwcLoader {
     let comments = Rc::new(SingleThreadedComments::default());
 
     let source = content.into_string_lossy();
+    let source_code = source.clone();
     let is_typescript =
       matches!(swc_options.config.jsc.syntax, Some(syntax) if syntax.typescript());
+    let should_emit_isolated_dts = swc_options
+      .config
+      .jsc
+      .experimental
+      .emit_isolated_dts
+      .into_bool();
+    let isolated_dts_target = swc_options.config.jsc.target.unwrap_or(EsVersion::EsNext);
+    let source_len = source.len() as u32;
+    let dts_filename = filename.clone();
+    let dts_comments = comments.clone();
+    let mut isolated_dts = Ok(None);
     let mut collected_ts_info = None;
     let rsc_meta: RefCell<Option<RscMeta>> = Default::default();
 
@@ -144,6 +157,20 @@ impl SwcLoader {
         if !is_typescript {
           return;
         }
+
+        if should_emit_isolated_dts {
+          isolated_dts = javascript_compiler
+            .emit_isolated_dts(
+              program,
+              dts_filename.clone(),
+              unresolved_mark,
+              source_len,
+              isolated_dts_target,
+              &dts_comments,
+            )
+            .map(Some);
+        }
+
         let Some(options) = &self.options_with_additional.collect_typescript_info else {
           return;
         };
@@ -186,6 +213,21 @@ impl SwcLoader {
 
     for diagnostic in diagnostics {
       loader_context.emit_diagnostic(Error::warning(diagnostic).into());
+    }
+
+    if let Some(isolated_dts) = isolated_dts? {
+      handle_isolated_dts_diagnostics(
+        loader_context,
+        &resource_path,
+        &source_code,
+        isolated_dts.diagnostics,
+      )?;
+
+      set_build_info(
+        loader_context.context.module.build_info_mut(),
+        resource_path.as_str().to_string(),
+        isolated_dts.code,
+      );
     }
 
     if let Some(rsc) = rsc_meta.borrow_mut().take() {

--- a/crates/rspack_plugin_rslib/Cargo.toml
+++ b/crates/rspack_plugin_rslib/Cargo.toml
@@ -8,6 +8,8 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cow-utils                = { workspace = true }
+pathdiff                 = { workspace = true }
 rspack_cacheable         = { workspace = true }
 rspack_collections       = { workspace = true }
 rspack_core              = { workspace = true }
@@ -15,6 +17,7 @@ rspack_error             = { workspace = true }
 rspack_fs                = { workspace = true }
 rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
+rspack_paths             = { workspace = true }
 rspack_plugin_asset      = { workspace = true }
 rspack_plugin_externals  = { workspace = true }
 rspack_plugin_javascript = { workspace = true }

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -1,18 +1,22 @@
 use std::{
+  path::{Component, PathBuf},
   sync::Arc,
   time::{Duration, Instant},
 };
 
+use cow_utils::CowUtils;
+use pathdiff::diff_paths;
 use rspack_core::{
-  AssetEmittedInfo, BuildModuleGraphArtifact, ChunkUkey, Compilation,
-  CompilationOptimizeDependencies, CompilationParams, CompilerAssetEmitted, CompilerCompilation,
-  DependencyType, ExportsInfoArtifact, ModuleType, NormalModuleFactoryParser, ParserAndGenerator,
-  ParserOptions, Plugin, RuntimeCodeTemplate, SideEffectsOptimizeArtifact, get_module_directives,
-  get_module_hashbang,
+  AssetEmittedInfo, AssetInfo, BuildInfo, BuildModuleGraphArtifact, ChunkUkey, Compilation,
+  CompilationAsset, CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
+  CompilerAssetEmitted, CompilerCompilation, DependencyType, ExportsInfoArtifact, ModuleType,
+  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, RuntimeCodeTemplate,
+  SideEffectsOptimizeArtifact, get_module_directives, get_module_hashbang,
   rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
 };
-use rspack_error::{Diagnostic, Result};
+use rspack_error::{Diagnostic, Result, error};
 use rspack_hook::{plugin, plugin_hook};
+use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_plugin_asset::AssetParserAndGenerator;
 use rspack_plugin_externals::EsmNodeTargetPlugin;
 use rspack_plugin_javascript::{
@@ -31,11 +35,118 @@ use crate::{
   react_directives_parser_plugin::ReactDirectivesParserPlugin,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RslibPluginOptions {
   pub intercept_api_plugin: bool,
   pub force_node_shims: bool,
   pub auto_cjs_node_builtin: bool,
+  pub emit_dts: Option<SwcEmitDtsPluginOptions>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SwcEmitDtsPluginOptions {
+  pub root_dir: String,
+  pub declaration_dir: String,
+}
+
+#[derive(Debug, Clone)]
+struct SwcEmitDtsBuildInfo {
+  resource_path: String,
+  code: String,
+}
+
+fn get_build_info(build_info: &BuildInfo) -> Option<SwcEmitDtsBuildInfo> {
+  let value = build_info.extras.get("rspack-swc-isolated-dts-emit")?;
+  let value = value.as_object()?;
+  Some(SwcEmitDtsBuildInfo {
+    resource_path: value.get("resource_path")?.as_str()?.to_string(),
+    code: value.get("code")?.as_str()?.to_string(),
+  })
+}
+
+fn emit_isolated_dts_asset(
+  compilation: &mut Compilation,
+  emit_dts_options: &SwcEmitDtsPluginOptions,
+  dts: SwcEmitDtsBuildInfo,
+) -> Result<()> {
+  let SwcEmitDtsBuildInfo {
+    resource_path,
+    code,
+  } = dts;
+  let resource_path = Utf8PathBuf::from(resource_path);
+  let compiler_root = compilation.options.context.as_path();
+  let resolved_root_dir = resolve_emit_dts_path(compiler_root, &emit_dts_options.root_dir);
+  let resolved_declaration_dir =
+    resolve_emit_dts_path(compiler_root, &emit_dts_options.declaration_dir);
+  let output_path = compilation.options.output.path.clone();
+  let output_relative_path = resource_path
+    .strip_prefix(&resolved_root_dir)
+    .map_err(|_| {
+      error!(
+        "Failed to emit declaration files for {} because it is outside rootDir {}",
+        resource_path, resolved_root_dir
+      )
+    })?;
+  let declaration_file_path = resolved_declaration_dir
+    .join(output_relative_path)
+    .with_extension("d.ts");
+  let filename = if let Ok(relative_path) = declaration_file_path.strip_prefix(&output_path) {
+    relative_path.to_string()
+  } else {
+    diff_paths(&declaration_file_path, &output_path)
+      .ok_or_else(|| {
+        error!(
+          "Failed to emit declaration files for {} because declarationDir {} can not be relativized against output.path {}",
+          resource_path, resolved_declaration_dir, output_path
+        )
+      })?
+      .to_string_lossy()
+      .cow_replace('\\', "/")
+      .into_owned()
+  };
+
+  compilation.emit_asset(
+    filename,
+    CompilationAsset::new(
+      Some(RawStringSource::from(code).boxed()),
+      AssetInfo {
+        source_filename: Some(resource_path.as_str().to_string()),
+        ..Default::default()
+      },
+    ),
+  );
+
+  Ok(())
+}
+
+fn resolve_emit_dts_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {
+  let path = Utf8Path::new(value);
+  if path.is_absolute() {
+    path.to_path_buf()
+  } else {
+    normalize_joined_path(base.as_std_path().join(path.as_std_path()))
+      .to_string_lossy()
+      .to_string()
+      .into()
+  }
+}
+
+fn normalize_joined_path(path: PathBuf) -> PathBuf {
+  let mut normalized = PathBuf::new();
+
+  for component in path.components() {
+    match component {
+      Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+      Component::RootDir => normalized.push(component.as_os_str()),
+      Component::CurDir => {}
+      Component::ParentDir => {
+        normalized.pop();
+      }
+      Component::Normal(part) => normalized.push(part),
+    }
+  }
+
+  normalized
 }
 
 #[derive(Debug)]
@@ -230,6 +341,24 @@ async fn asset_emitted(
   Ok(())
 }
 
+#[plugin_hook(CompilationProcessAssets for RslibPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
+async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
+  let Some(options) = &self.options.emit_dts else {
+    return Ok(());
+  };
+  let dts_outputs = compilation
+    .get_module_graph()
+    .modules()
+    .filter_map(|(_, module)| get_build_info(module.build_info()))
+    .collect::<Vec<_>>();
+
+  for dts in dts_outputs {
+    emit_isolated_dts_asset(compilation, options, dts)?;
+  }
+
+  Ok(())
+}
+
 impl Plugin for RslibPlugin {
   fn name(&self) -> &'static str {
     "rslib"
@@ -251,6 +380,10 @@ impl Plugin for RslibPlugin {
       .compiler_hooks
       .asset_emitted
       .tap(asset_emitted::new(self));
+    ctx
+      .compilation_hooks
+      .process_assets
+      .tap(process_assets::new(self));
 
     if self.options.auto_cjs_node_builtin {
       EsmNodeTargetPlugin::new().apply(ctx)?;

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -1,5 +1,4 @@
 use std::{
-  path::{Component, PathBuf},
   sync::Arc,
   time::{Duration, Instant},
 };
@@ -7,11 +6,11 @@ use std::{
 use cow_utils::CowUtils;
 use pathdiff::diff_paths;
 use rspack_core::{
-  AssetEmittedInfo, AssetInfo, BuildInfo, BuildModuleGraphArtifact, ChunkUkey, Compilation,
-  CompilationAsset, CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
-  CompilerAssetEmitted, CompilerCompilation, DependencyType, ExportsInfoArtifact, ModuleType,
-  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, RuntimeCodeTemplate,
-  SideEffectsOptimizeArtifact, get_module_directives, get_module_hashbang,
+  AssetEmittedInfo, AssetInfo, BuildModuleGraphArtifact, ChunkUkey, Compilation, CompilationAsset,
+  CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
+  CompilerAssetEmitted, CompilerCompilation, DependencyType, ExportsInfoArtifact, IsolatedDts,
+  ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin,
+  RuntimeCodeTemplate, SideEffectsOptimizeArtifact, get_module_directives, get_module_hashbang,
   rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, error};
@@ -49,27 +48,12 @@ pub struct SwcEmitDtsPluginOptions {
   pub declaration_dir: String,
 }
 
-#[derive(Debug, Clone)]
-struct SwcEmitDtsBuildInfo {
-  resource_path: String,
-  code: String,
-}
-
-fn get_build_info(build_info: &BuildInfo) -> Option<SwcEmitDtsBuildInfo> {
-  let value = build_info.extras.get("rspack-swc-isolated-dts-emit")?;
-  let value = value.as_object()?;
-  Some(SwcEmitDtsBuildInfo {
-    resource_path: value.get("resource_path")?.as_str()?.to_string(),
-    code: value.get("code")?.as_str()?.to_string(),
-  })
-}
-
 fn emit_isolated_dts_asset(
   compilation: &mut Compilation,
   emit_dts_options: &SwcEmitDtsPluginOptions,
-  dts: SwcEmitDtsBuildInfo,
+  dts: IsolatedDts,
 ) -> Result<()> {
-  let SwcEmitDtsBuildInfo {
+  let IsolatedDts {
     resource_path,
     code,
   } = dts;
@@ -90,20 +74,19 @@ fn emit_isolated_dts_asset(
   let declaration_file_path = resolved_declaration_dir
     .join(output_relative_path)
     .with_extension("d.ts");
-  let filename = if let Ok(relative_path) = declaration_file_path.strip_prefix(&output_path) {
-    relative_path.to_string()
-  } else {
-    diff_paths(&declaration_file_path, &output_path)
-      .ok_or_else(|| {
-        error!(
-          "Failed to emit declaration files for {} because declarationDir {} can not be relativized against output.path {}",
-          resource_path, resolved_declaration_dir, output_path
-        )
-      })?
-      .to_string_lossy()
-      .cow_replace('\\', "/")
-      .into_owned()
-  };
+  let filename = diff_paths(
+    declaration_file_path.as_std_path(),
+    output_path.as_std_path(),
+  )
+    .ok_or_else(|| {
+      error!(
+        "Failed to emit declaration files for {} because declarationDir {} can not be relativized against output.path {}",
+        resource_path, resolved_declaration_dir, output_path
+      )
+    })?
+    .to_string_lossy()
+    .cow_replace('\\', "/")
+    .into_owned();
 
   compilation.emit_asset(
     filename,
@@ -124,29 +107,8 @@ fn resolve_emit_dts_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {
   if path.is_absolute() {
     path.to_path_buf()
   } else {
-    normalize_joined_path(base.as_std_path().join(path.as_std_path()))
-      .to_string_lossy()
-      .to_string()
-      .into()
+    base.join(path)
   }
-}
-
-fn normalize_joined_path(path: PathBuf) -> PathBuf {
-  let mut normalized = PathBuf::new();
-
-  for component in path.components() {
-    match component {
-      Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-      Component::RootDir => normalized.push(component.as_os_str()),
-      Component::CurDir => {}
-      Component::ParentDir => {
-        normalized.pop();
-      }
-      Component::Normal(part) => normalized.push(part),
-    }
-  }
-
-  normalized
 }
 
 #[derive(Debug)]
@@ -349,7 +311,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let dts_outputs = compilation
     .get_module_graph()
     .modules()
-    .filter_map(|(_, module)| get_build_info(module.build_info()))
+    .filter_map(|(_, module)| module.build_info().isolated_dts.clone())
     .collect::<Vec<_>>();
 
   for dts in dts_outputs {

--- a/tests/rspack-test/compilerCases/persistent-isolated-dts.js
+++ b/tests/rspack-test/compilerCases/persistent-isolated-dts.js
@@ -1,0 +1,112 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  experiments: { RslibPlugin }
+} = require("@rspack/core");
+
+const CASE_DIR = "persistent-isolated-dts";
+const CACHE_DIR = ".cache";
+const OUTPUT_DIR = "output";
+const WORK_DIR = "workdir";
+
+function getDtsPath(context) {
+  return context.getDist(path.join(WORK_DIR, "dist/types/index.d.ts"));
+}
+
+function readDts(context) {
+  return fs.readFileSync(getDtsPath(context), "utf-8");
+}
+
+async function recreateCompiler(context) {
+  const compilerManager = context.getCompiler();
+  await compilerManager.close();
+  const compiler = compilerManager.createCompiler();
+  compiler.outputFileSystem = fs;
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+  description:
+    "should re-emit declaration files assets after persistent cache recovery",
+  options(context) {
+    const sourceDir = path.resolve(__dirname, "../fixtures", CASE_DIR);
+    const workDir = context.getDist(WORK_DIR);
+    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.cpSync(sourceDir, workDir, { recursive: true });
+
+    return {
+      context: workDir,
+      entry: "./index.ts",
+      target: "node",
+      output: {
+        path: workDir,
+        filename: `${OUTPUT_DIR}/main.js`,
+        library: {
+          type: "commonjs"
+        }
+      },
+      experiments: {
+        cache: {
+          type: "persistent",
+          buildDependencies: [__filename],
+          storage: {
+            type: "filesystem",
+            directory: context.getDist(CACHE_DIR)
+          }
+        }
+      },
+      module: {
+        rules: [
+          {
+            test: /\.ts$/,
+            type: "javascript/auto",
+            use: {
+              loader: "builtin:swc-loader",
+              options: {
+                jsc: {
+                  parser: {
+                    syntax: "typescript"
+                  },
+                  experimental: {
+                    emitIsolatedDts: true
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      plugins: [
+        new RslibPlugin({
+          emitDts: {
+            rootDir: workDir,
+            declarationDir: "./dist/types"
+          }
+        })
+      ]
+    };
+  },
+  async compiler(_, compiler) {
+    compiler.outputFileSystem = fs;
+  },
+  async build(context) {
+    const compilerManager = context.getCompiler();
+    await compilerManager.build();
+    context.setValue("firstOutput", readDts(context));
+
+    fs.rmSync(getDtsPath(context), { force: true });
+
+    await recreateCompiler(context);
+    await compilerManager.build();
+    context.setValue("secondOutput", readDts(context));
+  },
+  async check({ context }) {
+    const firstOutput = context.getValue("firstOutput");
+    const secondOutput = context.getValue("secondOutput");
+
+    expect(firstOutput).toContain("export interface Foo");
+    expect(firstOutput).toContain("export declare const foo: Foo;");
+    expect(secondOutput).toContain("export interface Foo");
+    expect(secondOutput).toContain("export declare const foo: Foo;");
+  }
+};

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
@@ -1,0 +1,22 @@
+export interface Foo {
+  value: string;
+}
+
+export const foo: Foo = { value: "bar" };
+
+const fs = __non_webpack_require__("node:fs");
+const path = __non_webpack_require__("node:path");
+
+it("should emit declaration assets only through RslibPlugin", () => {
+  const dts = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../configCases/rslib/emit-isolated-dts/dist/types/index.d.ts",
+    ),
+    "utf-8",
+  );
+
+  expect(foo).toEqual({ value: "bar" });
+  expect(dts).toContain("export interface Foo");
+  expect(dts).toContain("export declare const foo: Foo;");
+});

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/rspack.config.js
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/rspack.config.js
@@ -1,0 +1,42 @@
+const {
+  experiments: { RslibPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  entry: './index.ts',
+  target: 'node',
+  output: {
+    library: {
+      type: 'commonjs',
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        type: 'javascript/auto',
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              experimental: {
+                emitIsolatedDts: true,
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  plugins: [
+    new RslibPlugin({
+      emitDts: {
+        rootDir: __dirname,
+        declarationDir: './dist/types',
+      },
+    }),
+  ],
+};

--- a/tests/rspack-test/fixtures/persistent-isolated-dts/index.ts
+++ b/tests/rspack-test/fixtures/persistent-isolated-dts/index.ts
@@ -1,0 +1,7 @@
+export interface Foo {
+  value: string;
+}
+
+export const foo: Foo = {
+  value: "bar"
+};

--- a/tests/rspack-test/statsOutputCases/rslib-emit-isolated-dts-error/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/rslib-emit-isolated-dts-error/__snapshots__/stats.txt
@@ -1,0 +1,13 @@
+ERROR in ./index.ts
+  × Module build failed (from builtin:swc-loader):
+  ├─▶   × Failed to generate declaration files.
+  │   
+  ╰─▶   ×   x TS9016: Objects that contain shorthand properties can't be inferred with --isolatedDeclarations.
+        │    ,-[<TEST_ROOT>/statsOutputCases/rslib-emit-isolated-dts-error/index.ts<LINE_COL>]
+        │  1 | const shorthand = "baz";
+        │  2 | export const shorthandObject = { shorthand };
+        │    :                                ^^^^^^^^^^^^^
+        │    `----
+        │
+
+Rspack compiled with 1 error

--- a/tests/rspack-test/statsOutputCases/rslib-emit-isolated-dts-error/index.ts
+++ b/tests/rspack-test/statsOutputCases/rslib-emit-isolated-dts-error/index.ts
@@ -1,0 +1,2 @@
+const shorthand = "baz";
+export const shorthandObject = { shorthand };

--- a/tests/rspack-test/statsOutputCases/rslib-emit-isolated-dts-error/rspack.config.js
+++ b/tests/rspack-test/statsOutputCases/rslib-emit-isolated-dts-error/rspack.config.js
@@ -1,0 +1,36 @@
+const {
+  experiments: { RslibPlugin },
+} = require('@rspack/core');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  entry: './index',
+  stats: 'errors-warnings',
+  resolve: {
+    extensions: ['...', '.ts', '.tsx', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          detectSyntax: 'auto',
+          jsc: {
+            experimental: {
+              emitIsolatedDts: true,
+            },
+          },
+        },
+      },
+    ],
+  },
+  plugins: [
+    new RslibPlugin({
+      emitDts: {
+        rootDir: __dirname,
+        declarationDir: './dist/types',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

This PR adds Rslib support for emitting isolated declaration assets from modules transformed by `builtin:swc-loader`, so declaration output can be generated through the compilation asset pipeline and restored after persistent cache recovery.

- Adds `emitDts` options to `RslibPlugin` and emits `.d.ts` assets relative to `rootDir` and `declarationDir`.
- Uses SWC FastDts during loader transform, stores declaration output in module build info, and renders isolated declaration diagnostics through rspack errors.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
