### PR TITLE
fix: use index maps for concatenated export rendering

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -20,8 +20,12 @@ use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
 };
 use rspack_util::{
-  SpanExt, ext::DynHash, fx_hash::FxIndexMap, itoa, json_stringify, json_stringify_str,
-  source_map::SourceMapKind, swc::join_atom,
+  SpanExt,
+  ext::DynHash,
+  fx_hash::{FxIndexMap, FxIndexSet},
+  itoa, json_stringify, json_stringify_str,
+  source_map::SourceMapKind,
+  swc::join_atom,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::{
@@ -1517,9 +1521,9 @@ impl Module for ConcatenatedModule {
     // Move it off the critical path once all replacements are applied.
     fast_set(&mut changes, Vec::new());
 
-    let mut exports_map: HashMap<Atom, String> = HashMap::default();
-    let mut unused_exports: HashSet<Atom> = HashSet::default();
-    let mut inlined_exports: HashSet<Atom> = HashSet::default();
+    let mut exports_map: FxIndexMap<Atom, String> = FxIndexMap::default();
+    let mut unused_exports: FxIndexSet<Atom> = FxIndexSet::default();
+    let mut inlined_exports: FxIndexSet<Atom> = FxIndexSet::default();
 
     let root_info = module_to_info_map
       .get(&self.root_module_ctxt.id)
@@ -1621,21 +1625,16 @@ impl Module for ConcatenatedModule {
 
     // Define exports
     if !exports_map.is_empty() {
-      let mut definitions: Vec<_> = exports_map
+      let definitions: Vec<_> = exports_map
         .iter()
         .map(|(key, value)| {
-          (
-            key.clone(),
-            format!(
-              "\n  {}: {}",
-              property_name(key).expect("should convert to property_name"),
-              runtime_template.returning_function(value, "")
-            ),
+          format!(
+            "\n  {}: {}",
+            property_name(key).expect("should convert to property_name"),
+            runtime_template.returning_function(value, "")
           )
         })
         .collect();
-      definitions.sort_by(|a, b| a.0.cmp(&b.0));
-      let definitions: Vec<_> = definitions.into_iter().map(|(_, s)| s).collect();
 
       let exports_argument = self.get_exports_argument();
 

--- a/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/dep.js
+++ b/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/dep.js
@@ -1,0 +1,3 @@
+export function marker() {
+	return "marker";
+}

--- a/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/index.js
+++ b/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/index.js
@@ -1,0 +1,16 @@
+const { usedA, usedB } = require("./root");
+const { expectSourceToContain } = require("@rspack/test-tools/helper/legacy/expectSource");
+
+it("should render concatenated export comments in deterministic order", () => {
+	expect(usedA()).toBe("marker-a");
+	expect(usedB()).toBe("marker-b");
+
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename, "utf-8");
+
+	/*********** DO NOT MATCH BELOW THIS LINE ***********/
+
+	expectSourceToContain(source, "usedA: () => (/* binding */ usedA)");
+	expectSourceToContain(source, "usedB: () => (/* binding */ usedB)");
+	expectSourceToContain(source, "// UNUSED EXPORTS: unusedA, unusedB");
+});

--- a/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/root.js
+++ b/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/root.js
@@ -1,0 +1,12 @@
+import { marker } from "./dep";
+
+export const unusedA = "unused-a";
+export const unusedB = "unused-b";
+
+export function usedA() {
+	return `${marker()}-a`;
+}
+
+export function usedB() {
+	return `${marker()}-b`;
+}

--- a/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/rspack.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    concatenateModules: true,
+    inlineExports: true,
+    mangleExports: false,
+    minimize: false,
+    providedExports: true,
+    usedExports: true,
+  },
+};


### PR DESCRIPTION
## Summary

- use FxIndexMap/FxIndexSet for ConcatenatedModule export rendering so definitions, unused exports, and inlined exports keep deterministic insertion order without sorting
- add a concatenate-modules regression case for deterministic export definitions and unused export comments

## Related links

- Follow-up to https://github.com/web-infra-dev/rspack/pull/13425#issuecomment-4132057246

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).