### PR TITLE
perf(build): reduce binding size with size-optimized Wasmtime crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,6 +385,15 @@ opt-level = "s"
 [profile.release.package.oneshot]
 opt-level = "s"
 
+[profile.release.package."cranelift-codegen"]
+opt-level = "s"
+
+[profile.release.package.wasmtime]
+opt-level = "s"
+
+[profile.release.package."wasi-common"]
+opt-level = "s"
+
 # This is for CI build based on release but with faster build time
 [profile.ci]
 codegen-units = 256


### PR DESCRIPTION
## Summary

This PR reduces the native binding binary size by compiling the Wasmtime/WASI runtime crates with size-oriented release optimization while keeping the rest of the release profile optimized for speed.

Dependency path:

```text
rspack_node
└─ rspack_binding_api/plugin
   └─ rspack_util/plugin
      ├─ wasmtime
      │  └─ cranelift-codegen
      └─ wasi-common
```

Optimized crates:

- `wasmtime`: wasm plugin runtime
- `wasi-common`: WASI environment for wasm plugins
- `cranelift-codegen`: Wasmtime's Cranelift backend

This keeps the optimization scoped to the wasm plugin runtime dependency chain. There are no public API or behavior changes.

## Size impact

Local darwin-arm64 release build:

- Before: 41,691,072 bytes
- After: 40,898,016 bytes
- Reduced: 793,056 bytes (about 774 KiB)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).