### PR TITLE
fix(rsc): group client chunks by server-entry ownership

### DIFF
--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -96,7 +96,7 @@ fn record_module(
     return;
   }
 
-  if is_css_mod(module.as_ref()) {
+  if is_css_mod(module.as_ref(), resource.as_ref()) {
     return;
   }
 

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -191,7 +191,12 @@ fn collect_server_entry_css_files(
     // Only server CSS blocks should populate `entryCssFiles` for loadCss().
     // Client component blocks use the client module request here; their CSS is
     // recorded on `clientManifest[*].cssFiles` when recording the client module.
-    // This lookup keeps those client component CSS files out of server entries.
+    //
+    // It is expected for a grouped client owner to have no `server_entries`
+    // record when that server entry only owns client components and imports no
+    // server CSS directly. Seeding `server_entries` for that case would make
+    // client component CSS look like server-entry CSS, which would duplicate
+    // the client manifest data and change the meaning of `entryCssFiles`.
     if entry_state
       .server_entries
       .get(server_entry)

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -188,9 +188,10 @@ fn collect_server_entry_css_files(
       continue;
     };
 
-    // Server-entry CSS blocks use the server entry resource as their request.
-    // Client component blocks use the client module request, so this lookup
-    // also filters out non-CSS blocks without walking dependencies again.
+    // Only server CSS blocks should populate `entryCssFiles` for loadCss().
+    // Client component blocks use the client module request here; their CSS is
+    // recorded on `clientManifest[*].cssFiles` when recording the client module.
+    // This lookup keeps those client component CSS files out of server entries.
     if entry_state
       .server_entries
       .get(server_entry)

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -658,7 +658,7 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
     if !client_modules.is_empty() || entry_state.has_css_imports_by_server_entry() {
       let dependency = Box::new(RscEntryDependency::new(
         entry_name.clone(),
-        entry_state.isolated_client_entries.clone(),
+        entry_state.ungrouped_client_entries.clone(),
         entry_state.root_client_entries.clone(),
         entry_state.client_entries_by_server_entry.clone(),
         entry_state.css_imports_by_server_entry(),

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -658,7 +658,9 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
     if !client_modules.is_empty() || entry_state.has_css_imports_by_server_entry() {
       let dependency = Box::new(RscEntryDependency::new(
         entry_name.clone(),
-        client_modules.clone(),
+        entry_state.isolated_client_entries.clone(),
+        entry_state.root_client_entries.clone(),
+        entry_state.client_entries_by_server_entry.clone(),
         entry_state.css_imports_by_server_entry(),
         false,
       ));

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -107,7 +107,7 @@ fn traverse_module(
       .insert(resource.to_string());
   }
 
-  if is_css_mod(module) {
+  if is_css_mod(module, resource.as_ref()) {
     record_css_import(
       compilation,
       module,

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -219,7 +219,7 @@ fn record_client_component_import(
       .client_component_imports
       .contains_key(resource)
   {
-    add_client_import_for_owner(
+    add_client_import_for_server_entry(
       module,
       resource,
       imported_identifiers,
@@ -274,14 +274,14 @@ fn get_imported_ids(module_graph: &ModuleGraph, dependency_id: &DependencyId) ->
   }
 }
 
-fn add_client_import_for_owner(
+fn add_client_import_for_server_entry(
   module: &dyn Module,
   resource: &str,
   imported_identifiers: &[Atom],
   current_server_entry: Option<&str>,
   component_info: &mut ComponentInfo,
 ) {
-  add_client_import_to_map(
+  add_client_import_to_scope(
     module,
     resource,
     imported_identifiers,
@@ -289,7 +289,7 @@ fn add_client_import_for_owner(
   );
 
   let Some(server_entry) = current_server_entry else {
-    add_client_import_to_map(
+    add_client_import_to_scope(
       module,
       resource,
       imported_identifiers,
@@ -302,7 +302,7 @@ fn add_client_import_for_owner(
     .client_component_imports_by_server_entry
     .entry(server_entry.to_string())
     .or_default();
-  add_client_import_to_map(
+  add_client_import_to_scope(
     module,
     resource,
     imported_identifiers,
@@ -310,7 +310,7 @@ fn add_client_import_for_owner(
   );
 }
 
-fn add_client_import_to_map(
+fn add_client_import_to_scope(
   module: &dyn Module,
   mod_request: &str,
   imported_identifiers: &[Atom],

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -1,8 +1,8 @@
 use derive_more::Debug;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  Compilation, DependencyId, Module, ModuleGraph, RscMeta, RscModuleType, RuntimeSpec,
-  module_declared_side_effect_free,
+  Compilation, DependencyId, Module, ModuleGraph, ModuleIdentifier, RscMeta, RscModuleType,
+  RuntimeSpec, module_declared_side_effect_free,
 };
 use rspack_plugin_javascript::dependency::{
   CommonJsExportRequireDependency, ESMExportImportedSpecifierDependency,
@@ -25,10 +25,11 @@ pub type ClientComponentImportsByServerEntry = FxIndexMap<String, ClientComponen
 // Used only to let `loadCss()` importers inherit their nearest server entry CSS files.
 pub type ImportMetaRscImporters = FxHashMap<String, FxIndexSet<String>>;
 
-// Tracks server component traversal per current `use server-entry` owner.
-// This lets a shared server component be visited once for each server entry
-// that needs to collect CSS from it, while still preventing recursive loops.
-type VisitedServerComponents = FxHashSet<(rspack_core::ModuleIdentifier, Option<String>)>;
+// Tracks server component traversal per current `use server-entry` owner and
+// dynamic import context. This lets a shared server component be visited once
+// for each server entry and sync/dynamic path that needs to collect client
+// imports, while still preventing recursive loops.
+type VisitedServerComponents = FxHashSet<(ModuleIdentifier, Option<String>, bool)>;
 
 #[derive(Debug, Default)]
 pub struct ComponentInfo {
@@ -145,6 +146,7 @@ fn traverse_module(
   let is_first_visit_server_component = visited_server_components.insert((
     module.identifier(),
     current_server_entry.map(ToOwned::to_owned),
+    is_under_server_dynamic_import,
   ));
   if !is_first_visit_server_component {
     return;

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -35,6 +35,13 @@ pub struct ComponentInfo {
   pub should_inject_ssr_modules: bool,
   /// All client component imports reached from this RSC entry.
   pub client_component_imports: ClientComponentImports,
+  /// Client component imports reached through a server-side dynamic import.
+  ///
+  /// These imports mark modules that must be emitted as independent async
+  /// blocks in the client compiler, so `import("./Client")` from a server
+  /// component does not get merged into the synchronous root/server-entry
+  /// client owner group.
+  pub async_client_component_imports: ClientComponentImports,
   /// Client component imports reached without a `use server-entry` owner.
   pub root_client_component_imports: ClientComponentImports,
   /// Client component imports reached under each `use server-entry` owner.
@@ -68,6 +75,7 @@ pub fn collect_component_info_from_entry_dependency(
     resolved_module.as_ref(),
     &[],
     None,
+    false,
     &mut visited_client_modules,
     &mut visited_server_components,
     &mut component_info,
@@ -83,6 +91,7 @@ fn traverse_module(
   module: &dyn Module,
   imported_identifiers: &[Atom],
   current_server_entry: Option<&str>,
+  is_under_server_dynamic_import: bool,
   visited_client_modules: &mut IdentifierSet,
   visited_server_components: &mut VisitedServerComponents,
   component_info: &mut ComponentInfo,
@@ -126,6 +135,7 @@ fn traverse_module(
       resource.as_ref(),
       imported_identifiers,
       current_server_entry,
+      is_under_server_dynamic_import,
       is_first_visit_client_module,
       component_info,
     );
@@ -150,6 +160,11 @@ fn traverse_module(
       continue;
     };
     let imported_ids = get_imported_ids(module_graph, &connection.dependency_id);
+    // A dependency with a parent block is inside a server-side dynamic import.
+    // Propagate the flag so client components reached that way keep a matching
+    // independent async chunk in the client compiler.
+    let is_under_server_dynamic_import =
+      is_under_server_dynamic_import || module_graph.get_parent_block(dependency_id).is_some();
 
     let Some(resolved_module) = module_graph.module_by_identifier(&connection.resolved_module)
     else {
@@ -161,6 +176,7 @@ fn traverse_module(
       resolved_module.as_ref(),
       &imported_ids,
       current_server_entry,
+      is_under_server_dynamic_import,
       visited_client_modules,
       visited_server_components,
       component_info,
@@ -211,6 +227,7 @@ fn record_client_component_import(
   resource: &str,
   imported_identifiers: &[Atom],
   current_server_entry: Option<&str>,
+  is_under_server_dynamic_import: bool,
   is_first_visit_client_module: bool,
   component_info: &mut ComponentInfo,
 ) {
@@ -219,6 +236,22 @@ fn record_client_component_import(
       .client_component_imports
       .contains_key(resource)
   {
+    if is_under_server_dynamic_import {
+      add_client_import_to_scope(
+        module,
+        resource,
+        imported_identifiers,
+        &mut component_info.client_component_imports,
+      );
+      add_client_import_to_scope(
+        module,
+        resource,
+        imported_identifiers,
+        &mut component_info.async_client_component_imports,
+      );
+      return;
+    }
+
     add_client_import_for_server_entry(
       module,
       resource,

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -20,6 +20,7 @@ use crate::{
 
 // { [request to inject into client compilation]: [exported names] }
 pub type ClientComponentImports = FxIndexMap<String, FxIndexSet<Atom>>;
+pub type ClientComponentImportsByServerEntry = FxIndexMap<String, ClientComponentImports>;
 // { [server entry path]: [`import.meta.rspackRsc` importer paths] }
 // Used only to let `loadCss()` importers inherit their nearest server entry CSS files.
 pub type ImportMetaRscImporters = FxHashMap<String, FxIndexSet<String>>;
@@ -32,7 +33,12 @@ type VisitedServerComponents = FxHashSet<(rspack_core::ModuleIdentifier, Option<
 #[derive(Debug, Default)]
 pub struct ComponentInfo {
   pub should_inject_ssr_modules: bool,
+  /// All client component imports reached from this RSC entry.
   pub client_component_imports: ClientComponentImports,
+  /// Client component imports reached without a `use server-entry` owner.
+  pub root_client_component_imports: ClientComponentImports,
+  /// Client component imports reached under each `use server-entry` owner.
+  pub client_component_imports_by_server_entry: ClientComponentImportsByServerEntry,
   pub css_imports_by_server_entry: CssImportsByServerEntry,
   pub root_css_imports: RootCssImports,
   pub import_meta_rsc_importers: ImportMetaRscImporters,
@@ -119,6 +125,7 @@ fn traverse_module(
       module,
       resource.as_ref(),
       imported_identifiers,
+      current_server_entry,
       is_first_visit_client_module,
       component_info,
     );
@@ -203,31 +210,21 @@ fn record_client_component_import(
   module: &dyn Module,
   resource: &str,
   imported_identifiers: &[Atom],
+  current_server_entry: Option<&str>,
   is_first_visit_client_module: bool,
   component_info: &mut ComponentInfo,
 ) {
-  if is_first_visit_client_module {
-    component_info
+  if is_first_visit_client_module
+    || component_info
       .client_component_imports
-      .entry(resource.to_string())
-      .or_default();
-    add_client_import(
-      module,
-      resource,
-      imported_identifiers,
-      true,
-      &mut component_info.client_component_imports,
-    );
-  } else if component_info
-    .client_component_imports
-    .contains_key(resource)
+      .contains_key(resource)
   {
-    add_client_import(
+    add_client_import_for_owner(
       module,
       resource,
       imported_identifiers,
-      false,
-      &mut component_info.client_component_imports,
+      current_server_entry,
+      component_info,
     );
   }
 }
@@ -275,6 +272,61 @@ fn get_imported_ids(module_graph: &ModuleGraph, dependency_id: &DependencyId) ->
   } else {
     vec!["*".into()]
   }
+}
+
+fn add_client_import_for_owner(
+  module: &dyn Module,
+  resource: &str,
+  imported_identifiers: &[Atom],
+  current_server_entry: Option<&str>,
+  component_info: &mut ComponentInfo,
+) {
+  add_client_import_to_map(
+    module,
+    resource,
+    imported_identifiers,
+    &mut component_info.client_component_imports,
+  );
+
+  let Some(server_entry) = current_server_entry else {
+    add_client_import_to_map(
+      module,
+      resource,
+      imported_identifiers,
+      &mut component_info.root_client_component_imports,
+    );
+    return;
+  };
+
+  let client_component_imports = component_info
+    .client_component_imports_by_server_entry
+    .entry(server_entry.to_string())
+    .or_default();
+  add_client_import_to_map(
+    module,
+    resource,
+    imported_identifiers,
+    client_component_imports,
+  );
+}
+
+fn add_client_import_to_map(
+  module: &dyn Module,
+  mod_request: &str,
+  imported_identifiers: &[Atom],
+  client_component_imports: &mut ClientComponentImports,
+) {
+  let is_first_visit_module = !client_component_imports.contains_key(mod_request);
+  if is_first_visit_module {
+    client_component_imports.insert(mod_request.to_string(), Default::default());
+  }
+  add_client_import(
+    module,
+    mod_request,
+    imported_identifiers,
+    is_first_visit_module,
+    client_component_imports,
+  );
 }
 
 fn add_client_import(

--- a/crates/rspack_plugin_rsc/src/plugin_state.rs
+++ b/crates/rspack_plugin_rsc/src/plugin_state.rs
@@ -44,8 +44,8 @@ pub struct EntryState {
   pub server_entries: FxHashMap<String, ServerEntryState>,
   /// All client modules discovered from the RSC graph for this entry.
   pub injected_client_entries: Vec<ClientModuleImport>,
-  /// Client modules used by multiple owners and kept as individual async chunks.
-  pub isolated_client_entries: Vec<ClientModuleImport>,
+  /// Client modules that cannot be assigned to exactly one owner and stay as standalone async chunks.
+  pub ungrouped_client_entries: Vec<ClientModuleImport>,
   /// Client modules used only by the root RSC tree.
   pub root_client_entries: Vec<ClientModuleImport>,
   /// Client modules used only by one `use server-entry` subtree.

--- a/crates/rspack_plugin_rsc/src/plugin_state.rs
+++ b/crates/rspack_plugin_rsc/src/plugin_state.rs
@@ -16,6 +16,7 @@ use crate::reference_manifest::{
 
 pub type ActionIdNamePair = (Atom, Atom);
 pub type CssImportsByServerEntry = FxHashMap<String, FxIndexSet<String>>;
+pub type ClientModulesByServerEntry = FxHashMap<String, Vec<ClientModuleImport>>;
 pub type RootCssImports = FxIndexSet<String>;
 
 /// Structured info about a client module to inject into the client compiler.
@@ -41,7 +42,14 @@ pub struct ServerEntryState {
 #[derive(Debug, Default)]
 pub struct EntryState {
   pub server_entries: FxHashMap<String, ServerEntryState>,
+  /// All client modules discovered from the RSC graph for this entry.
   pub injected_client_entries: Vec<ClientModuleImport>,
+  /// Client modules used by multiple owners and kept as individual async chunks.
+  pub isolated_client_entries: Vec<ClientModuleImport>,
+  /// Client modules used only by the root RSC tree.
+  pub root_client_entries: Vec<ClientModuleImport>,
+  /// Client modules used only by one `use server-entry` subtree.
+  pub client_entries_by_server_entry: ClientModulesByServerEntry,
   pub client_modules: FxHashMap<String, ManifestExport>,
   /// Root CSS import paths reached through a parent chain without `use server-entry`.
   /// These are attached directly to the matching client compiler entry.

--- a/crates/rspack_plugin_rsc/src/rsc_entry_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_dependency.rs
@@ -9,14 +9,21 @@ use rspack_core::{
   DependencyType, FactorizeInfo, ModuleDependency, ResourceIdentifier,
 };
 
-use crate::plugin_state::{ClientModuleImport, CssImportsByServerEntry};
+use crate::plugin_state::{
+  ClientModuleImport, ClientModulesByServerEntry, CssImportsByServerEntry,
+};
 
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct RscEntryDependency {
   id: DependencyId,
   pub name: Arc<str>,
+  /// Client modules that should keep the existing one-module-per-async-block behavior.
   pub client_modules: Vec<ClientModuleImport>,
+  /// Client modules owned by the root RSC entry.
+  pub root_client_modules: Vec<ClientModuleImport>,
+  #[cacheable(with=AsMap<AsCacheable, AsVec>)]
+  pub client_modules_by_server_entry: ClientModulesByServerEntry,
   #[cacheable(with=AsMap<AsCacheable, AsVec>)]
   pub css_imports_by_server_entry: CssImportsByServerEntry,
   /// When true, client modules are loaded eagerly (not as code-split points).
@@ -30,6 +37,8 @@ impl RscEntryDependency {
   pub fn new(
     name: Arc<str>,
     client_modules: Vec<ClientModuleImport>,
+    root_client_modules: Vec<ClientModuleImport>,
+    client_modules_by_server_entry: ClientModulesByServerEntry,
     css_imports_by_server_entry: CssImportsByServerEntry,
     is_server_side_rendering: bool,
   ) -> Self {
@@ -38,6 +47,8 @@ impl RscEntryDependency {
       id: DependencyId::new(),
       name,
       client_modules,
+      root_client_modules,
+      client_modules_by_server_entry,
       css_imports_by_server_entry,
       is_server_side_rendering,
       resource_identifier,

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -26,7 +26,7 @@ use swc_core::ecma::atoms::Atom;
 use crate::{
   client_reference_dependency::ClientReferenceDependency,
   constants::LAYERS_NAMES,
-  plugin_state::{ClientModuleImport, CssImportsByServerEntry},
+  plugin_state::{ClientModuleImport, ClientModulesByServerEntry, CssImportsByServerEntry},
 };
 
 #[impl_source_map_config]
@@ -38,6 +38,9 @@ pub struct RscEntryModule {
   identifier: ModuleIdentifier,
   lib_ident: String,
   client_modules: Vec<ClientModuleImport>,
+  root_client_modules: Vec<ClientModuleImport>,
+  #[cacheable(with=AsMap<AsCacheable, AsVec>)]
+  client_modules_by_server_entry: ClientModulesByServerEntry,
   #[cacheable(with=AsMap<AsCacheable, AsVec>)]
   css_imports_by_server_entry: CssImportsByServerEntry,
   name: Arc<str>,
@@ -53,6 +56,8 @@ impl RscEntryModule {
   pub fn new(
     name: Arc<str>,
     client_modules: Vec<ClientModuleImport>,
+    root_client_modules: Vec<ClientModuleImport>,
+    client_modules_by_server_entry: ClientModulesByServerEntry,
     css_imports_by_server_entry: CssImportsByServerEntry,
     is_server_side_rendering: bool,
   ) -> Self {
@@ -60,6 +65,8 @@ impl RscEntryModule {
     let identifier = create_identifier(
       name.as_ref(),
       &client_modules,
+      &root_client_modules,
+      &client_modules_by_server_entry,
       &css_imports_by_server_entry,
       is_server_side_rendering,
     );
@@ -75,6 +82,8 @@ impl RscEntryModule {
       identifier,
       lib_ident,
       client_modules,
+      root_client_modules,
+      client_modules_by_server_entry,
       css_imports_by_server_entry,
       name,
       is_server_side_rendering,
@@ -95,7 +104,9 @@ impl RscEntryModule {
 
   fn render_debug_comments(&self, compilation: &Compilation) -> String {
     let module_graph = compilation.get_module_graph();
-    let referenced_exports_by_request = create_referenced_exports_by_request(&self.client_modules);
+    let all_client_modules = self.all_client_modules();
+    let referenced_exports_by_request =
+      create_referenced_exports_by_request(all_client_modules.into_iter());
     let mut source = String::new();
 
     if self.is_server_side_rendering {
@@ -157,6 +168,16 @@ impl RscEntryModule {
     }
 
     source
+  }
+
+  fn all_client_modules(&self) -> Vec<&ClientModuleImport> {
+    let mut client_modules = Vec::new();
+    client_modules.extend(self.client_modules.iter());
+    client_modules.extend(self.root_client_modules.iter());
+    for modules in self.client_modules_by_server_entry.values() {
+      client_modules.extend(modules.iter());
+    }
+    client_modules
   }
 }
 
@@ -228,8 +249,9 @@ impl Module for RscEntryModule {
   ) -> Result<BuildResult> {
     if self.is_server_side_rendering {
       // Eager: no code-split points; use ImportEagerDependency (CSS filtering done at call site).
-      let mut dependencies: Vec<BoxDependency> = Vec::with_capacity(self.client_modules.len());
-      for client_module in &self.client_modules {
+      let all_client_modules = self.all_client_modules();
+      let mut dependencies: Vec<BoxDependency> = Vec::with_capacity(all_client_modules.len());
+      for client_module in all_client_modules {
         let referenced_specifiers = create_referenced_specifiers(&client_module.ids);
         let dep = ImportEagerDependency::new(
           Atom::from(client_module.request.as_str()),
@@ -248,21 +270,71 @@ impl Module for RscEntryModule {
       })
     } else {
       // Non-eager: code-split points; use AsyncDependenciesBlock + ClientReferenceDependency.
-      let mut blocks =
-        Vec::with_capacity(self.client_modules.len() + self.css_imports_by_server_entry.len());
+      let mut blocks = Vec::with_capacity(
+        self.client_modules.len()
+          + self.css_imports_by_server_entry.len()
+          + self.client_modules_by_server_entry.len()
+          + usize::from(!self.root_client_modules.is_empty()),
+      );
       let dependencies: Vec<BoxDependency> = vec![];
 
-      for (server_entry, css_imports) in &self.css_imports_by_server_entry {
-        if css_imports.is_empty() {
-          continue;
+      let mut server_entries = self
+        .css_imports_by_server_entry
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+      for server_entry in self.client_modules_by_server_entry.keys() {
+        if !server_entries.contains(server_entry) {
+          server_entries.push(server_entry.clone());
         }
+      }
+      server_entries.sort_unstable();
 
-        let dependencies = css_imports
-          .iter()
-          .map(|request| {
+      for server_entry in server_entries {
+        let mut block_dependencies: Vec<BoxDependency> = Vec::new();
+
+        if let Some(css_imports) = self.css_imports_by_server_entry.get(&server_entry) {
+          block_dependencies.extend(css_imports.iter().map(|request| {
             Box::new(ClientReferenceDependency::new(
               request.clone(),
               Default::default(),
+              self.is_server_side_rendering,
+            )) as Box<dyn Dependency>
+          }));
+        }
+
+        if let Some(client_modules) = self.client_modules_by_server_entry.get(&server_entry) {
+          block_dependencies.extend(client_modules.iter().map(|client_module| {
+            Box::new(ClientReferenceDependency::new(
+              client_module.request.clone(),
+              client_module.ids.clone(),
+              self.is_server_side_rendering,
+            )) as Box<dyn Dependency>
+          }));
+        }
+
+        if block_dependencies.is_empty() {
+          continue;
+        }
+
+        let block = AsyncDependenciesBlock::new(
+          self.identifier,
+          None,
+          None,
+          block_dependencies,
+          Some(server_entry.clone()),
+        );
+        blocks.push(Box::new(block));
+      }
+
+      if !self.root_client_modules.is_empty() {
+        let dependencies = self
+          .root_client_modules
+          .iter()
+          .map(|client_module| {
+            Box::new(ClientReferenceDependency::new(
+              client_module.request.clone(),
+              client_module.ids.clone(),
               self.is_server_side_rendering,
             )) as Box<dyn Dependency>
           })
@@ -271,9 +343,9 @@ impl Module for RscEntryModule {
         let block = AsyncDependenciesBlock::new(
           self.identifier,
           None,
-          Some(server_entry.as_str()),
+          None,
           dependencies,
-          Some(server_entry.clone()),
+          Some(format!("{}#root-client", self.name)),
         );
         blocks.push(Box::new(block));
       }
@@ -333,6 +405,8 @@ impl_empty_diagnosable_trait!(RscEntryModule);
 fn create_identifier(
   name: &str,
   client_modules: &[ClientModuleImport],
+  root_client_modules: &[ClientModuleImport],
+  client_modules_by_server_entry: &ClientModulesByServerEntry,
   css_imports_by_server_entry: &CssImportsByServerEntry,
   is_server_side_rendering: bool,
 ) -> ModuleIdentifier {
@@ -342,18 +416,21 @@ fn create_identifier(
   identifier.push(if is_server_side_rendering { '1' } else { '0' });
   identifier.push('|');
 
-  let mut client_modules = client_modules.iter().collect::<Vec<_>>();
-  client_modules.sort_unstable_by(|a, b| a.request.cmp(&b.request));
-  for client_module in client_modules {
-    push_value(&mut identifier, &client_module.request);
+  identifier.push_str("isolated[");
+  push_client_modules(&mut identifier, client_modules);
+  identifier.push_str("]|root[");
+  push_client_modules(&mut identifier, root_client_modules);
+  identifier.push_str("]|server[");
+  let mut client_modules_by_server_entry =
+    client_modules_by_server_entry.iter().collect::<Vec<_>>();
+  client_modules_by_server_entry.sort_unstable_by_key(|(server_entry, _)| *server_entry);
+  for (server_entry, client_modules) in client_modules_by_server_entry {
+    push_value(&mut identifier, server_entry);
     identifier.push('[');
-
-    let ids = sorted_strs(client_module.ids.iter().map(|id| id.as_str()));
-    for id in ids {
-      push_value(&mut identifier, id);
-    }
+    push_client_modules(&mut identifier, client_modules);
     identifier.push(']');
   }
+  identifier.push(']');
 
   identifier.push('|');
   let mut css_imports_by_server_entry = css_imports_by_server_entry.iter().collect::<Vec<_>>();
@@ -370,6 +447,21 @@ fn create_identifier(
   }
 
   ModuleIdentifier::from(identifier)
+}
+
+fn push_client_modules(identifier: &mut String, client_modules: &[ClientModuleImport]) {
+  let mut client_modules = client_modules.iter().collect::<Vec<_>>();
+  client_modules.sort_unstable_by(|a, b| a.request.cmp(&b.request));
+  for client_module in client_modules {
+    push_value(identifier, &client_module.request);
+    identifier.push('[');
+
+    let ids = sorted_strs(client_module.ids.iter().map(|id| id.as_str()));
+    for id in ids {
+      push_value(identifier, id);
+    }
+    identifier.push(']');
+  }
 }
 
 fn sorted_strs<'a>(values: impl Iterator<Item = &'a str>) -> Vec<&'a str> {
@@ -397,11 +489,10 @@ fn create_referenced_specifiers(ids: &FxIndexSet<Atom>) -> Option<Vec<Referenced
   )
 }
 
-fn create_referenced_exports_by_request(
-  client_modules: &[ClientModuleImport],
-) -> FxHashMap<&str, String> {
+fn create_referenced_exports_by_request<'a>(
+  client_modules: impl Iterator<Item = &'a ClientModuleImport>,
+) -> FxHashMap<&'a str, String> {
   client_modules
-    .iter()
     .map(|client_module| {
       let exports = format_referenced_exports(client_module);
       (client_module.request.as_str(), exports)

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -416,7 +416,7 @@ fn create_identifier(
   identifier.push(if is_server_side_rendering { '1' } else { '0' });
   identifier.push('|');
 
-  identifier.push_str("isolated[");
+  identifier.push_str("ungrouped[");
   push_client_modules(&mut identifier, client_modules);
   identifier.push_str("]|root[");
   push_client_modules(&mut identifier, root_client_modules);

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -11,16 +11,16 @@ use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
   BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, CodeGenerationResult, Compilation,
   Context, DependenciesBlock, Dependency, DependencyId, DependencyRange, FactoryMeta, ImportPhase,
-  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleDependency, ModuleGraph,
-  ModuleIdentifier, ModuleLayer, ModuleType, ReferencedSpecifier, RuntimeSpec, SourceType,
-  contextify, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleLayer,
+  ModuleType, ReferencedSpecifier, RuntimeSpec, SourceType, contextify, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_plugin_javascript::dependency::ImportEagerDependency;
 use rspack_util::{fx_hash::FxIndexSet, source_map::SourceMapKind};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use swc_core::ecma::atoms::Atom;
 
 use crate::{
@@ -103,71 +103,79 @@ impl RscEntryModule {
   }
 
   fn render_debug_comments(&self, compilation: &Compilation) -> String {
-    let module_graph = compilation.get_module_graph();
-    let all_client_modules = self.all_client_modules();
-    let referenced_exports_by_request =
-      create_referenced_exports_by_request(all_client_modules.into_iter());
     let mut source = String::new();
+    let root_chunking = self.debug_chunking("single async block");
+    let ungrouped_chunking = self.debug_chunking("one async block per module");
+    let server_entry_chunking = self.debug_chunking("one async block per server-entry");
 
-    if self.is_server_side_rendering {
-      for dep_id in self.get_dependencies() {
-        let dependency = module_graph.dependency_by_id(dep_id);
-        let dep = dependency
-          .downcast_ref::<ImportEagerDependency>()
-          .unwrap_or_else(|| {
-            panic!(
-              "Expected dependency of eager RscEntryModule to be ImportEagerDependency, got {:?}",
-              dependency.dependency_type()
-            )
-          });
-        append_debug_comment_for_request(
-          &mut source,
-          referenced_exports_by_request
-            .get(dep.request())
-            .map(String::as_str),
-          compilation,
-          dep.request(),
-        );
-      }
-
+    if self.is_server_side_rendering
+      && self.root_client_modules.is_empty()
+      && self.client_modules_by_server_entry.is_empty()
+      && self.css_imports_by_server_entry.is_empty()
+    {
+      append_client_modules_debug_section(
+        &mut source,
+        compilation,
+        "ssr-eager",
+        "eager import for SSR",
+        None,
+        &self.client_modules,
+      );
       return source;
     }
 
-    for block_id in self.get_blocks() {
-      let block = module_graph
-        .block_by_id(block_id)
-        .expect("should have block");
+    append_client_modules_debug_section(
+      &mut source,
+      compilation,
+      "root",
+      root_chunking,
+      None,
+      &self.root_client_modules,
+    );
+    append_client_modules_debug_section(
+      &mut source,
+      compilation,
+      "ungrouped",
+      ungrouped_chunking,
+      None,
+      &self.client_modules,
+    );
 
-      for dependency_id in block.get_dependencies() {
-        let dependency = module_graph.dependency_by_id(dependency_id);
-        let dep = dependency
-          .downcast_ref::<ClientReferenceDependency>()
-          .unwrap_or_else(|| {
-            panic!(
-              "Expected dependency of RscEntryModule to be ClientReferenceDependency, got {:?}",
-              dependency.dependency_type()
-            )
-          });
-
-        append_debug_comment_for_request(
-          &mut source,
-          referenced_exports_by_request
-            .get(dep.user_request())
-            .map(String::as_str)
-            .or_else(|| {
-              self
-                .css_imports_by_server_entry
-                .values()
-                .any(|imports| imports.contains(dep.user_request()))
-                .then_some("side-effect")
-            }),
-          compilation,
-          dep.user_request(),
-        );
-      }
+    for server_entry in self.debug_server_entries() {
+      append_server_entry_debug_section(
+        &mut source,
+        compilation,
+        server_entry.as_str(),
+        server_entry_chunking,
+        self.css_imports_by_server_entry.get(&server_entry),
+        self.client_modules_by_server_entry.get(&server_entry),
+      );
     }
 
     source
+  }
+
+  fn debug_chunking(&self, async_chunking: &'static str) -> &'static str {
+    if self.is_server_side_rendering {
+      "eager import for SSR"
+    } else {
+      async_chunking
+    }
+  }
+
+  fn debug_server_entries(&self) -> Vec<String> {
+    let mut server_entries = self
+      .css_imports_by_server_entry
+      .keys()
+      .cloned()
+      .collect::<Vec<_>>();
+    for server_entry in self.client_modules_by_server_entry.keys() {
+      if !server_entries.contains(server_entry) {
+        server_entries.push(server_entry.clone());
+      }
+    }
+    server_entries.sort_unstable();
+    server_entries
   }
 
   fn all_client_modules(&self) -> Vec<&ClientModuleImport> {
@@ -489,25 +497,119 @@ fn create_referenced_specifiers(ids: &FxIndexSet<Atom>) -> Option<Vec<Referenced
   )
 }
 
-fn create_referenced_exports_by_request<'a>(
-  client_modules: impl Iterator<Item = &'a ClientModuleImport>,
-) -> FxHashMap<&'a str, String> {
-  client_modules
-    .map(|client_module| {
-      let exports = format_referenced_exports(client_module);
-      (client_module.request.as_str(), exports)
-    })
-    .collect()
+fn append_client_modules_debug_section(
+  source: &mut String,
+  compilation: &Compilation,
+  chunk_group: &str,
+  chunking: &str,
+  server_entry: Option<&str>,
+  client_modules: &[ClientModuleImport],
+) {
+  if client_modules.is_empty() {
+    return;
+  }
+
+  let mut client_modules = client_modules.iter().collect::<Vec<_>>();
+  client_modules.sort_unstable_by(|a, b| a.request.cmp(&b.request));
+  append_debug_section_header(
+    source,
+    chunk_group,
+    chunking,
+    server_entry
+      .map(|server_entry| contextify(compilation.options.context.as_path(), server_entry)),
+  );
+  for client_module in client_modules {
+    let request = contextify(
+      compilation.options.context.as_path(),
+      client_module.request.as_str(),
+    );
+    append_debug_module_line(source, &request, &format_referenced_exports(client_module));
+  }
+  append_debug_section_end(source);
 }
 
-fn append_debug_comment_for_request(
+fn append_server_entry_debug_section(
   source: &mut String,
-  exports: Option<&str>,
   compilation: &Compilation,
-  request: &str,
+  server_entry: &str,
+  chunking: &str,
+  css_imports: Option<&FxIndexSet<String>>,
+  client_modules: Option<&Vec<ClientModuleImport>>,
 ) {
-  let request = contextify(compilation.options.context.as_path(), request);
-  append_debug_comment(source, &request, exports.unwrap_or("unknown"));
+  if css_imports.is_none_or(|css_imports| css_imports.is_empty())
+    && client_modules.is_none_or(|client_modules| client_modules.is_empty())
+  {
+    return;
+  }
+
+  append_debug_section_header(
+    source,
+    "server-entry",
+    chunking,
+    Some(contextify(
+      compilation.options.context.as_path(),
+      server_entry,
+    )),
+  );
+
+  if let Some(css_imports) = css_imports {
+    for css_import in sorted_strs(css_imports.iter().map(String::as_str)) {
+      let request = contextify(compilation.options.context.as_path(), css_import);
+      append_debug_module_line(source, &request, "side-effect");
+    }
+  }
+
+  if let Some(client_modules) = client_modules {
+    let mut client_modules = client_modules.iter().collect::<Vec<_>>();
+    client_modules.sort_unstable_by(|a, b| a.request.cmp(&b.request));
+    for client_module in client_modules {
+      let request = contextify(
+        compilation.options.context.as_path(),
+        client_module.request.as_str(),
+      );
+      append_debug_module_line(source, &request, &format_referenced_exports(client_module));
+    }
+  }
+
+  append_debug_section_end(source);
+}
+
+fn append_debug_section_header(
+  source: &mut String,
+  chunk_group: &str,
+  chunking: &str,
+  server_entry: Option<String>,
+) {
+  if !source.is_empty() {
+    source.push('\n');
+  }
+
+  let chunk_group = sanitize_comment_part(chunk_group);
+  let chunking = sanitize_comment_part(chunking);
+  write!(
+    source,
+    "/*!\n * chunk group: {chunk_group}\n * chunking: {chunking}\n"
+  )
+  .expect("writing debug comments to String should not fail");
+
+  if let Some(server_entry) = server_entry {
+    let server_entry = sanitize_comment_part(&server_entry);
+    writeln!(source, " * server-entry: {server_entry}")
+      .expect("writing debug comments to String should not fail");
+  }
+
+  source.push_str(" * modules:\n");
+}
+
+fn append_debug_module_line(source: &mut String, request: &str, exports: &str) {
+  let request = sanitize_comment_part(request);
+  let exports = sanitize_comment_part(exports);
+  writeln!(source, " * - {request} (exports: {exports})")
+    .expect("writing debug comments to String should not fail");
+}
+
+fn append_debug_section_end(source: &mut String) {
+  source.push_str(" */");
 }
 
 fn sanitize_comment_part(value: &str) -> Cow<'_, str> {
@@ -516,20 +618,6 @@ fn sanitize_comment_part(value: &str) -> Cow<'_, str> {
   } else {
     Cow::Borrowed(value)
   }
-}
-
-fn append_debug_comment(source: &mut String, request: &str, exports: &str) {
-  if !source.is_empty() {
-    source.push('\n');
-  }
-
-  let request = sanitize_comment_part(request);
-  let exports = sanitize_comment_part(exports);
-  write!(
-    source,
-    "/*!\n * module: {request}\n * exports: {exports}\n */"
-  )
-  .expect("writing debug comments to String should not fail");
 }
 
 fn format_referenced_exports(client_module: &ClientModuleImport) -> String {

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -325,10 +325,11 @@ impl Module for RscEntryModule {
           continue;
         }
 
+        let block_modifier = format!("server-entry={server_entry}");
         let block = AsyncDependenciesBlock::new(
           self.identifier,
           None,
-          None,
+          Some(&block_modifier),
           block_dependencies,
           Some(server_entry.clone()),
         );

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module_factory.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module_factory.rs
@@ -17,6 +17,8 @@ impl ModuleFactory for RscEntryModuleFactory {
       RscEntryModule::new(
         dependency.name.clone(),
         dependency.client_modules.clone(),
+        dependency.root_client_modules.clone(),
+        dependency.client_modules_by_server_entry.clone(),
         dependency.css_imports_by_server_entry.clone(),
         dependency.is_server_side_rendering,
       )

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -92,7 +92,7 @@ fn client_imports_to_modules(client_imports: &ClientComponentImports) -> Vec<Cli
     .collect()
 }
 
-fn classify_client_entries(
+fn group_client_entries_by_owner(
   client_imports: &ClientComponentImports,
   root_client_imports: &ClientComponentImports,
   client_imports_by_server_entry: &ClientComponentImportsByServerEntry,
@@ -555,7 +555,7 @@ impl RscServerPlugin {
 
     let client_entries = client_imports_to_modules(&client_imports);
     let (ungrouped_client_entries, root_client_entries, client_entries_by_server_entry) =
-      classify_client_entries(
+      group_client_entries_by_owner(
         &client_imports,
         &root_client_imports,
         &client_imports_by_server_entry,

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -44,6 +44,7 @@ struct ClientEntry {
   entry_name: Arc<str>,
   runtime: RuntimeSpec,
   client_imports: ClientComponentImports,
+  async_client_component_imports: ClientComponentImports,
   root_client_imports: ClientComponentImports,
   client_imports_by_server_entry: ClientComponentImportsByServerEntry,
   css_imports_by_server_entry: CssImportsByServerEntry,
@@ -94,6 +95,7 @@ fn client_imports_to_modules(client_imports: &ClientComponentImports) -> Vec<Cli
 
 fn group_client_entries_by_owner(
   client_imports: &ClientComponentImports,
+  async_client_component_imports: &ClientComponentImports,
   root_client_imports: &ClientComponentImports,
   client_imports_by_server_entry: &ClientComponentImportsByServerEntry,
 ) -> (
@@ -106,6 +108,22 @@ fn group_client_entries_by_owner(
   let mut client_entries_by_server_entry: ClientModulesByServerEntry = Default::default();
 
   for (request, ids) in client_imports {
+    let client_module = ClientModuleImport {
+      request: request.clone(),
+      ids: ids.iter().cloned().collect(),
+    };
+
+    // Preserve server-side dynamic import boundaries in the client compiler:
+    // `RscEntryModule` emits ungrouped modules as one async block per module,
+    // so a server `import("./Client")` keeps a matching client chunk instead
+    // of being merged into the synchronous root/server-entry owner group.
+    // The `client_module` above uses ids from `client_imports`, which keeps
+    // the merged export set when the same module is reached by multiple paths.
+    if async_client_component_imports.contains_key(request.as_str()) {
+      ungrouped_client_entries.push(client_module);
+      continue;
+    }
+
     let mut owner_count = 0usize;
     let is_root_owned = root_client_imports.contains_key(request.as_str());
     let mut owned_server_entry = None;
@@ -122,11 +140,6 @@ fn group_client_entries_by_owner(
         }
       }
     }
-
-    let client_module = ClientModuleImport {
-      request: request.clone(),
-      ids: ids.iter().cloned().collect(),
-    };
 
     if owner_count == 1 {
       if is_root_owned {
@@ -348,6 +361,7 @@ impl RscServerPlugin {
           entry_name: entry_name.clone(),
           runtime: runtime.clone(),
           client_imports: component_info.client_component_imports,
+          async_client_component_imports: component_info.async_client_component_imports,
           root_client_imports: component_info.root_client_component_imports,
           client_imports_by_server_entry: component_info.client_component_imports_by_server_entry,
           css_imports_by_server_entry: component_info.css_imports_by_server_entry,
@@ -546,6 +560,7 @@ impl RscServerPlugin {
       entry_name,
       runtime,
       client_imports,
+      async_client_component_imports,
       root_client_imports,
       client_imports_by_server_entry,
       css_imports_by_server_entry,
@@ -557,6 +572,7 @@ impl RscServerPlugin {
     let (ungrouped_client_entries, root_client_entries, client_entries_by_server_entry) =
       group_client_entries_by_owner(
         &client_imports,
+        &async_client_component_imports,
         &root_client_imports,
         &client_imports_by_server_entry,
       );

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -19,7 +19,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   component_info::{
-    ClientComponentImports, ImportMetaRscImporters, collect_component_info_from_entry_dependency,
+    ClientComponentImports, ClientComponentImportsByServerEntry, ImportMetaRscImporters,
+    collect_component_info_from_entry_dependency,
   },
   constants::{CSS_REGEX, LAYERS_NAMES},
   coordinator::Coordinator,
@@ -27,8 +28,8 @@ use crate::{
   loaders::action_entry_loader::ACTION_ENTRY_LOADER_IDENTIFIER,
   manifest_runtime_module::RscManifestRuntimeModule,
   plugin_state::{
-    ActionIdNamePair, ClientModuleImport, CssImportsByServerEntry, PLUGIN_STATES, PluginState,
-    RootCssImports,
+    ActionIdNamePair, ClientModuleImport, ClientModulesByServerEntry, CssImportsByServerEntry,
+    PLUGIN_STATES, PluginState, RootCssImports,
   },
   reference_manifest::{
     RscCssLinkProps, RscEntryManifest, RscManifest, build_server_consumer_module_map,
@@ -43,6 +44,8 @@ struct ClientEntry {
   entry_name: Arc<str>,
   runtime: RuntimeSpec,
   client_imports: ClientComponentImports,
+  root_client_imports: ClientComponentImports,
+  client_imports_by_server_entry: ClientComponentImportsByServerEntry,
   css_imports_by_server_entry: CssImportsByServerEntry,
   root_css_imports: RootCssImports,
   import_meta_rsc_importers: ImportMetaRscImporters,
@@ -77,6 +80,75 @@ pub struct RscServerPluginOptions {
   pub css_link_props: RscCssLinkProps,
   pub on_server_component_changes: Option<OnServerComponentChanges>,
   pub on_manifest: Option<OnManifest>,
+}
+
+fn client_imports_to_modules(client_imports: &ClientComponentImports) -> Vec<ClientModuleImport> {
+  client_imports
+    .iter()
+    .map(|(request, ids)| ClientModuleImport {
+      request: request.clone(),
+      ids: ids.iter().cloned().collect(),
+    })
+    .collect()
+}
+
+fn classify_client_entries(
+  client_imports: &ClientComponentImports,
+  root_client_imports: &ClientComponentImports,
+  client_imports_by_server_entry: &ClientComponentImportsByServerEntry,
+) -> (
+  Vec<ClientModuleImport>,
+  Vec<ClientModuleImport>,
+  ClientModulesByServerEntry,
+) {
+  let mut isolated_client_entries = Vec::new();
+  let mut root_client_entries = Vec::new();
+  let mut client_entries_by_server_entry: ClientModulesByServerEntry = Default::default();
+
+  for (request, ids) in client_imports {
+    let mut owner_count = 0usize;
+    let is_root_owned = root_client_imports.contains_key(request.as_str());
+    let mut owned_server_entry = None;
+
+    if is_root_owned {
+      owner_count += 1;
+    }
+
+    for (server_entry, client_imports) in client_imports_by_server_entry {
+      if client_imports.contains_key(request.as_str()) {
+        owner_count += 1;
+        if owned_server_entry.is_none() {
+          owned_server_entry = Some(server_entry);
+        }
+      }
+    }
+
+    let client_module = ClientModuleImport {
+      request: request.clone(),
+      ids: ids.iter().cloned().collect(),
+    };
+
+    if owner_count == 1 {
+      if is_root_owned {
+        root_client_entries.push(client_module);
+      } else if let Some(server_entry) = owned_server_entry {
+        client_entries_by_server_entry
+          .entry(server_entry.clone())
+          .or_default()
+          .push(client_module);
+      } else {
+        isolated_client_entries.push(client_module);
+      }
+    } else {
+      isolated_client_entries.push(client_module);
+    }
+  }
+
+  (
+    isolated_client_entries,
+    root_client_entries,
+    client_entries_by_server_entry,
+  )
 }
 
 #[plugin]
@@ -276,6 +348,8 @@ impl RscServerPlugin {
           entry_name: entry_name.clone(),
           runtime: runtime.clone(),
           client_imports: component_info.client_component_imports,
+          root_client_imports: component_info.root_client_component_imports,
+          client_imports_by_server_entry: component_info.client_component_imports_by_server_entry,
           css_imports_by_server_entry: component_info.css_imports_by_server_entry,
           root_css_imports: component_info.root_css_imports,
           import_meta_rsc_importers: component_info.import_meta_rsc_importers,
@@ -472,13 +546,22 @@ impl RscServerPlugin {
       entry_name,
       runtime,
       client_imports,
+      root_client_imports,
+      client_imports_by_server_entry,
       css_imports_by_server_entry,
       root_css_imports,
       import_meta_rsc_importers,
     } = client_entry;
 
-    let client_entries = {
-      let mut modules = Vec::new();
+    let client_entries = client_imports_to_modules(&client_imports);
+    let (isolated_client_entries, root_client_entries, client_entries_by_server_entry) =
+      classify_client_entries(
+        &client_imports,
+        &root_client_imports,
+        &client_imports_by_server_entry,
+      );
+
+    {
       let entry_state = plugin_state.entries.entry(entry_name.clone()).or_default();
       for (server_entry, css_imports) in css_imports_by_server_entry {
         entry_state
@@ -497,24 +580,14 @@ impl RscServerPlugin {
           .extend(importers);
       }
       entry_state.root_css_imports.extend(root_css_imports);
-
-      for (request, ids) in &client_imports {
-        modules.push(ClientModuleImport {
-          request: request.clone(),
-          ids: ids.iter().cloned().collect(),
-        });
-      }
-      modules
-    };
+      entry_state.injected_client_entries = client_entries.clone();
+      entry_state.isolated_client_entries = isolated_client_entries.clone();
+      entry_state.root_client_entries = root_client_entries.clone();
+      entry_state.client_entries_by_server_entry = client_entries_by_server_entry.clone();
+    }
 
     // Add for the client compilation
     // Inject the entry to the client compiler.
-    plugin_state
-      .entries
-      .entry(entry_name.clone())
-      .or_default()
-      .injected_client_entries = client_entries.clone();
-
     if !should_inject_ssr_modules {
       return None;
     }
@@ -531,6 +604,8 @@ impl RscServerPlugin {
     let ssr_entry_dependency = RscEntryDependency::new(
       entry_name.clone(),
       client_entries_for_ssr,
+      Default::default(),
+      Default::default(),
       Default::default(),
       true,
     );

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -101,7 +101,7 @@ fn classify_client_entries(
   Vec<ClientModuleImport>,
   ClientModulesByServerEntry,
 ) {
-  let mut isolated_client_entries = Vec::new();
+  let mut ungrouped_client_entries = Vec::new();
   let mut root_client_entries = Vec::new();
   let mut client_entries_by_server_entry: ClientModulesByServerEntry = Default::default();
 
@@ -137,15 +137,15 @@ fn classify_client_entries(
           .or_default()
           .push(client_module);
       } else {
-        isolated_client_entries.push(client_module);
+        ungrouped_client_entries.push(client_module);
       }
     } else {
-      isolated_client_entries.push(client_module);
+      ungrouped_client_entries.push(client_module);
     }
   }
 
   (
-    isolated_client_entries,
+    ungrouped_client_entries,
     root_client_entries,
     client_entries_by_server_entry,
   )
@@ -554,7 +554,7 @@ impl RscServerPlugin {
     } = client_entry;
 
     let client_entries = client_imports_to_modules(&client_imports);
-    let (isolated_client_entries, root_client_entries, client_entries_by_server_entry) =
+    let (ungrouped_client_entries, root_client_entries, client_entries_by_server_entry) =
       classify_client_entries(
         &client_imports,
         &root_client_imports,
@@ -581,7 +581,7 @@ impl RscServerPlugin {
       }
       entry_state.root_css_imports.extend(root_css_imports);
       entry_state.injected_client_entries = client_entries.clone();
-      entry_state.isolated_client_entries = isolated_client_entries;
+      entry_state.ungrouped_client_entries = ungrouped_client_entries;
       entry_state.root_client_entries = root_client_entries;
       entry_state.client_entries_by_server_entry = client_entries_by_server_entry;
     }

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -598,10 +598,15 @@ impl RscServerPlugin {
       entry_state.root_css_imports.extend(root_css_imports);
 
       // These grouped client entries are only used to shape client compiler
-      // async blocks. They intentionally do not seed `server_entries`: CSS
-      // imported by client components is collected from client chunks into
-      // `clientManifest[*].cssFiles`, while `server_entries` tracks server CSS
-      // imports and `import.meta.rspackRsc.loadCss()` data.
+      // async blocks. Do not create a `server_entries[server_entry]` record
+      // from `client_entries_by_server_entry` alone: a server entry that only
+      // owns client components has no server CSS block to record here.
+      //
+      // Client component CSS is collected from the client module chunks and
+      // stored on `clientManifest[*].cssFiles` when that client module is
+      // recorded. `server_entries` is intentionally reserved for server CSS
+      // imports and `import.meta.rspackRsc.loadCss()` data, which are the only
+      // sources that should populate `entryCssFiles`.
       entry_state.injected_client_entries = client_entries.clone();
       entry_state.ungrouped_client_entries = ungrouped_client_entries;
       entry_state.root_client_entries = root_client_entries;

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -580,6 +580,12 @@ impl RscServerPlugin {
           .extend(importers);
       }
       entry_state.root_css_imports.extend(root_css_imports);
+
+      // These grouped client entries are only used to shape client compiler
+      // async blocks. They intentionally do not seed `server_entries`: CSS
+      // imported by client components is collected from client chunks into
+      // `clientManifest[*].cssFiles`, while `server_entries` tracks server CSS
+      // imports and `import.meta.rspackRsc.loadCss()` data.
       entry_state.injected_client_entries = client_entries.clone();
       entry_state.ungrouped_client_entries = ungrouped_client_entries;
       entry_state.root_client_entries = root_client_entries;

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -581,9 +581,9 @@ impl RscServerPlugin {
       }
       entry_state.root_css_imports.extend(root_css_imports);
       entry_state.injected_client_entries = client_entries.clone();
-      entry_state.isolated_client_entries = isolated_client_entries.clone();
-      entry_state.root_client_entries = root_client_entries.clone();
-      entry_state.client_entries_by_server_entry = client_entries_by_server_entry.clone();
+      entry_state.isolated_client_entries = isolated_client_entries;
+      entry_state.root_client_entries = root_client_entries;
+      entry_state.client_entries_by_server_entry = client_entries_by_server_entry;
     }
 
     // Add for the client compilation

--- a/crates/rspack_plugin_rsc/src/utils.rs
+++ b/crates/rspack_plugin_rsc/src/utils.rs
@@ -29,15 +29,14 @@ pub fn get_module_resource<'a>(module: &'a dyn Module) -> Cow<'a, str> {
   }
 }
 
-pub fn is_css_mod(module: &dyn Module) -> bool {
+pub fn is_css_mod(module: &dyn Module, resource: &str) -> bool {
   if matches!(
     module.module_type(),
     ModuleType::Css | ModuleType::CssModule | ModuleType::CssAuto
   ) {
     return true;
   }
-  let resource = get_module_resource(module);
-  CSS_REGEX.is_match(resource.as_ref())
+  CSS_REGEX.is_match(resource)
 }
 
 pub struct ChunkModules<'a> {

--- a/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
@@ -61,11 +61,6 @@ export class RscServerPlugin extends RspackBuiltinPlugin {
     this.#options.coordinator.applyServerCompiler(compiler);
 
     const { coordinator, onServerComponentChanges } = this.#options;
-    let normalizedOnServerComponentChanges: (() => Promise<void>) | undefined;
-    if (onServerComponentChanges) {
-      normalizedOnServerComponentChanges = () =>
-        Promise.resolve(onServerComponentChanges());
-    }
     let onManifest: ((json: string) => void | Promise<void>) | undefined;
     if (this.#options.onManifest) {
       onManifest = (json: string) =>
@@ -76,7 +71,7 @@ export class RscServerPlugin extends RspackBuiltinPlugin {
       // @ts-expect-error we use a special API to get the underlying binding instance.
       coordinator: coordinator[GET_OR_INIT_BINDING](),
       cssLink: this.#options.cssLink,
-      onServerComponentChanges: normalizedOnServerComponentChanges,
+      onServerComponentChanges,
       onManifest,
     });
   }

--- a/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
@@ -61,6 +61,11 @@ export class RscServerPlugin extends RspackBuiltinPlugin {
     this.#options.coordinator.applyServerCompiler(compiler);
 
     const { coordinator, onServerComponentChanges } = this.#options;
+    let normalizedOnServerComponentChanges: (() => Promise<void>) | undefined;
+    if (onServerComponentChanges) {
+      normalizedOnServerComponentChanges = () =>
+        Promise.resolve(onServerComponentChanges());
+    }
     let onManifest: ((json: string) => void | Promise<void>) | undefined;
     if (this.#options.onManifest) {
       onManifest = (json: string) =>
@@ -71,7 +76,7 @@ export class RscServerPlugin extends RspackBuiltinPlugin {
       // @ts-expect-error we use a special API to get the underlying binding instance.
       coordinator: coordinator[GET_OR_INIT_BINDING](),
       cssLink: this.#options.cssLink,
-      onServerComponentChanges,
+      onServerComponentChanges: normalizedOnServerComponentChanges,
       onManifest,
     });
   }

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/rspack.config.js
@@ -1,0 +1,238 @@
+const path = require('node:path');
+const { experiments } = require('@rspack/core');
+
+const { createPlugins, Layers } = experiments.rsc;
+const { ServerPlugin, ClientPlugin } = createPlugins();
+
+const ssrEntry = path.join(__dirname, 'src/framework/entry.ssr.js');
+const rscEntry = path.join(__dirname, 'src/framework/entry.rsc.js');
+
+const pageOnePath = path.join(__dirname, 'src/pages/PageOne.js');
+const pageTwoPath = path.join(__dirname, 'src/pages/PageTwo.js');
+const clientPaths = {
+  pageOneA: path.join(__dirname, 'src/clients/PageOneClientA.js'),
+  pageOneB: path.join(__dirname, 'src/clients/PageOneClientB.js'),
+  pageTwo: path.join(__dirname, 'src/clients/PageTwoClient.js'),
+  rootA: path.join(__dirname, 'src/clients/RootOnlyA.js'),
+  rootB: path.join(__dirname, 'src/clients/RootOnlyB.js'),
+  sharedAcrossPages: path.join(__dirname, 'src/clients/SharedAcrossPages.js'),
+  sharedRootAndPage: path.join(__dirname, 'src/clients/SharedRootAndPage.js'),
+};
+
+const swcLoaderRule = {
+  test: /\.jsx?$/,
+  use: [
+    {
+      loader: 'builtin:swc-loader',
+      options: {
+        detectSyntax: 'auto',
+        jsc: {
+          transform: {
+            react: {
+              runtime: 'automatic',
+            },
+          },
+        },
+        rspackExperiments: {
+          reactServerComponents: true,
+        },
+      },
+    },
+  ],
+};
+
+const cssRule = {
+  test: /\.css$/,
+  type: 'css/auto',
+};
+
+function readAsset(compilation, file) {
+  return compilation.getAsset(file).source.source().toString();
+}
+
+function findCssAsset(compilation, marker) {
+  const cssAsset = compilation
+    .getAssets()
+    .filter(({ name }) => name.endsWith('.css'))
+    .find(({ source }) => source.source().toString().includes(marker));
+  expect(cssAsset).toBeDefined();
+  return cssAsset.name;
+}
+
+function expectSameChunks(a, b) {
+  expect(a.chunks).toEqual(b.chunks);
+}
+
+function expectDifferentChunks(a, b) {
+  expect(a.chunks).not.toEqual(b.chunks);
+}
+
+module.exports = [
+  {
+    mode: 'development',
+    target: 'node',
+    entry: {
+      main: {
+        import: ssrEntry,
+      },
+    },
+    resolve: {
+      extensions: ['...', '.ts', '.tsx', '.jsx'],
+    },
+    module: {
+      rules: [
+        cssRule,
+        swcLoaderRule,
+        {
+          resource: ssrEntry,
+          layer: Layers.ssr,
+        },
+        {
+          resource: rscEntry,
+          layer: Layers.rsc,
+          resolve: {
+            conditionNames: ['react-server', '...'],
+          },
+        },
+        {
+          issuerLayer: Layers.rsc,
+          resolve: {
+            conditionNames: ['react-server', '...'],
+          },
+        },
+      ],
+    },
+    plugins: [
+      new ServerPlugin({
+        onManifest(manifest) {
+          const mainEntry = manifest.main;
+          expect(mainEntry).toBeDefined();
+
+          const getClient = (request) => {
+            const client = mainEntry.clientManifest[request];
+            expect(client).toBeDefined();
+            return client;
+          };
+
+          const pageOneA = getClient(clientPaths.pageOneA);
+          const pageOneB = getClient(clientPaths.pageOneB);
+          const pageTwo = getClient(clientPaths.pageTwo);
+          const rootA = getClient(clientPaths.rootA);
+          const rootB = getClient(clientPaths.rootB);
+          const sharedAcrossPages = getClient(clientPaths.sharedAcrossPages);
+          const sharedRootAndPage = getClient(clientPaths.sharedRootAndPage);
+
+          expectSameChunks(pageOneA, pageOneB);
+          expectDifferentChunks(pageOneA, pageTwo);
+
+          expectSameChunks(rootA, rootB);
+          expectDifferentChunks(rootA, pageOneA);
+
+          expectDifferentChunks(sharedAcrossPages, pageOneA);
+          expectDifferentChunks(sharedAcrossPages, pageTwo);
+          expectDifferentChunks(sharedRootAndPage, rootA);
+          expectDifferentChunks(sharedRootAndPage, pageOneA);
+
+          expect(
+            Object.keys(mainEntry.clientManifest).filter(
+              (request) => request === clientPaths.sharedAcrossPages,
+            ),
+          ).toHaveLength(1);
+          expect(
+            Object.keys(mainEntry.clientManifest).filter(
+              (request) => request === clientPaths.sharedRootAndPage,
+            ),
+          ).toHaveLength(1);
+
+          expect(pageOneA.cssFiles).toBeDefined();
+          expect(pageOneB.cssFiles).toBeDefined();
+          expect(pageTwo.cssFiles).toBeDefined();
+          expect(mainEntry.entryCssFiles[pageOnePath]).toBeDefined();
+          expect(mainEntry.entryCssFiles[pageTwoPath]).toBeDefined();
+
+          expect(mainEntry.entryCssFiles[pageOnePath]).toEqual(
+            pageOneA.cssFiles,
+          );
+          expect(mainEntry.entryCssFiles[pageOnePath]).toEqual(
+            pageOneB.cssFiles,
+          );
+          expect(mainEntry.entryCssFiles[pageTwoPath]).toEqual(
+            pageTwo.cssFiles,
+          );
+        },
+      }),
+    ],
+    optimization: {
+      moduleIds: 'named',
+      chunkIds: 'named',
+    },
+  },
+  {
+    mode: 'development',
+    target: 'web',
+    entry: {
+      main: {
+        import: './src/framework/entry.client.js',
+      },
+    },
+    resolve: {
+      extensions: ['...', '.ts', '.tsx', '.jsx'],
+    },
+    module: {
+      rules: [cssRule, swcLoaderRule],
+    },
+    plugins: [
+      new ClientPlugin(),
+      (compiler) => {
+        compiler.hooks.done.tap('AssertRscClientChunkGrouping', (stats) => {
+          const { compilation } = stats;
+
+          const pageOneCssFile = findCssAsset(
+            compilation,
+            'page-one-server-css',
+          );
+          const pageOneCss = readAsset(compilation, pageOneCssFile);
+          expect(pageOneCss).toContain('page-one-client-a-css');
+          expect(pageOneCss).toContain('page-one-client-b-css');
+          expect(pageOneCss).not.toContain('page-two-client-css');
+          expect(pageOneCss).not.toContain('shared-across-pages-client-css');
+
+          const pageTwoCssFile = findCssAsset(
+            compilation,
+            'page-two-server-css',
+          );
+          const pageTwoCss = readAsset(compilation, pageTwoCssFile);
+          expect(pageTwoCssFile).not.toBe(pageOneCssFile);
+          expect(pageTwoCss).toContain('page-two-client-css');
+          expect(pageTwoCss).not.toContain('page-one-client-a-css');
+          expect(pageTwoCss).not.toContain('shared-across-pages-client-css');
+
+          const rootCssFile = findCssAsset(compilation, 'root-client-a-css');
+          const rootCss = readAsset(compilation, rootCssFile);
+          expect(rootCssFile).not.toBe(pageOneCssFile);
+          expect(rootCssFile).not.toBe(pageTwoCssFile);
+          expect(rootCss).toContain('root-client-b-css');
+          expect(rootCss).not.toContain('page-one-server-css');
+
+          const sharedAcrossPagesCssFile = findCssAsset(
+            compilation,
+            'shared-across-pages-client-css',
+          );
+          expect(sharedAcrossPagesCssFile).not.toBe(pageOneCssFile);
+          expect(sharedAcrossPagesCssFile).not.toBe(pageTwoCssFile);
+
+          const sharedRootAndPageCssFile = findCssAsset(
+            compilation,
+            'shared-root-page-client-css',
+          );
+          expect(sharedRootAndPageCssFile).not.toBe(rootCssFile);
+          expect(sharedRootAndPageCssFile).not.toBe(pageOneCssFile);
+        });
+      },
+    ],
+    optimization: {
+      moduleIds: 'named',
+      chunkIds: 'named',
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/rspack.config.js
@@ -18,6 +18,10 @@ const clientPaths = {
   rootB: path.join(__dirname, 'src/clients/RootOnlyB.js'),
   sharedAcrossPages: path.join(__dirname, 'src/clients/SharedAcrossPages.js'),
   sharedRootAndPage: path.join(__dirname, 'src/clients/SharedRootAndPage.js'),
+  sharedServerChild: path.join(
+    __dirname,
+    'src/clients/SharedServerChildClient.js',
+  ),
 };
 
 const swcLoaderRule = {
@@ -123,9 +127,11 @@ module.exports = [
           const rootB = getClient(clientPaths.rootB);
           const sharedAcrossPages = getClient(clientPaths.sharedAcrossPages);
           const sharedRootAndPage = getClient(clientPaths.sharedRootAndPage);
+          const sharedServerChild = getClient(clientPaths.sharedServerChild);
 
           expectSameChunks(pageOneA, pageOneB);
           expectDifferentChunks(pageOneA, pageOneDynamic);
+          expectDifferentChunks(pageOneA, sharedServerChild);
           expectDifferentChunks(pageOneA, pageTwo);
 
           expectSameChunks(rootA, rootB);
@@ -150,6 +156,7 @@ module.exports = [
           expect(pageOneA.cssFiles).toBeDefined();
           expect(pageOneB.cssFiles).toBeDefined();
           expect(pageOneDynamic.cssFiles).toBeDefined();
+          expect(sharedServerChild.cssFiles).toBeDefined();
           expect(pageTwo.cssFiles).toBeDefined();
           expect(mainEntry.entryCssFiles[pageOnePath]).toBeDefined();
           expect(mainEntry.entryCssFiles[pageTwoPath]).toBeDefined();
@@ -162,6 +169,9 @@ module.exports = [
           );
           expect(mainEntry.entryCssFiles[pageOnePath]).not.toEqual(
             pageOneDynamic.cssFiles,
+          );
+          expect(mainEntry.entryCssFiles[pageOnePath]).not.toEqual(
+            sharedServerChild.cssFiles,
           );
           expect(mainEntry.entryCssFiles[pageTwoPath]).toEqual(
             pageTwo.cssFiles,
@@ -202,6 +212,7 @@ module.exports = [
           expect(pageOneCss).toContain('page-one-client-a-css');
           expect(pageOneCss).toContain('page-one-client-b-css');
           expect(pageOneCss).not.toContain('page-one-dynamic-client-css');
+          expect(pageOneCss).not.toContain('shared-server-child-client-css');
           expect(pageOneCss).not.toContain('page-two-client-css');
           expect(pageOneCss).not.toContain('shared-across-pages-client-css');
 
@@ -210,6 +221,12 @@ module.exports = [
             'page-one-dynamic-client-css',
           );
           expect(pageOneDynamicCssFile).not.toBe(pageOneCssFile);
+
+          const sharedServerChildCssFile = findCssAsset(
+            compilation,
+            'shared-server-child-client-css',
+          );
+          expect(sharedServerChildCssFile).not.toBe(pageOneCssFile);
 
           const pageTwoCssFile = findCssAsset(
             compilation,

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/rspack.config.js
@@ -12,6 +12,7 @@ const pageTwoPath = path.join(__dirname, 'src/pages/PageTwo.js');
 const clientPaths = {
   pageOneA: path.join(__dirname, 'src/clients/PageOneClientA.js'),
   pageOneB: path.join(__dirname, 'src/clients/PageOneClientB.js'),
+  pageOneDynamic: path.join(__dirname, 'src/clients/PageOneDynamicClient.js'),
   pageTwo: path.join(__dirname, 'src/clients/PageTwoClient.js'),
   rootA: path.join(__dirname, 'src/clients/RootOnlyA.js'),
   rootB: path.join(__dirname, 'src/clients/RootOnlyB.js'),
@@ -116,6 +117,7 @@ module.exports = [
 
           const pageOneA = getClient(clientPaths.pageOneA);
           const pageOneB = getClient(clientPaths.pageOneB);
+          const pageOneDynamic = getClient(clientPaths.pageOneDynamic);
           const pageTwo = getClient(clientPaths.pageTwo);
           const rootA = getClient(clientPaths.rootA);
           const rootB = getClient(clientPaths.rootB);
@@ -123,6 +125,7 @@ module.exports = [
           const sharedRootAndPage = getClient(clientPaths.sharedRootAndPage);
 
           expectSameChunks(pageOneA, pageOneB);
+          expectDifferentChunks(pageOneA, pageOneDynamic);
           expectDifferentChunks(pageOneA, pageTwo);
 
           expectSameChunks(rootA, rootB);
@@ -146,6 +149,7 @@ module.exports = [
 
           expect(pageOneA.cssFiles).toBeDefined();
           expect(pageOneB.cssFiles).toBeDefined();
+          expect(pageOneDynamic.cssFiles).toBeDefined();
           expect(pageTwo.cssFiles).toBeDefined();
           expect(mainEntry.entryCssFiles[pageOnePath]).toBeDefined();
           expect(mainEntry.entryCssFiles[pageTwoPath]).toBeDefined();
@@ -155,6 +159,9 @@ module.exports = [
           );
           expect(mainEntry.entryCssFiles[pageOnePath]).toEqual(
             pageOneB.cssFiles,
+          );
+          expect(mainEntry.entryCssFiles[pageOnePath]).not.toEqual(
+            pageOneDynamic.cssFiles,
           );
           expect(mainEntry.entryCssFiles[pageTwoPath]).toEqual(
             pageTwo.cssFiles,
@@ -194,8 +201,15 @@ module.exports = [
           const pageOneCss = readAsset(compilation, pageOneCssFile);
           expect(pageOneCss).toContain('page-one-client-a-css');
           expect(pageOneCss).toContain('page-one-client-b-css');
+          expect(pageOneCss).not.toContain('page-one-dynamic-client-css');
           expect(pageOneCss).not.toContain('page-two-client-css');
           expect(pageOneCss).not.toContain('shared-across-pages-client-css');
+
+          const pageOneDynamicCssFile = findCssAsset(
+            compilation,
+            'page-one-dynamic-client-css',
+          );
+          expect(pageOneDynamicCssFile).not.toBe(pageOneCssFile);
 
           const pageTwoCssFile = findCssAsset(
             compilation,

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/Root.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/Root.js
@@ -1,0 +1,17 @@
+import { RootOnlyA } from './clients/RootOnlyA';
+import { RootOnlyB } from './clients/RootOnlyB';
+import { SharedRootAndPage } from './clients/SharedRootAndPage';
+import { PageOne } from './pages/PageOne';
+import { PageTwo } from './pages/PageTwo';
+
+export const Root = async () => {
+  return (
+    <main>
+      <RootOnlyA />
+      <RootOnlyB />
+      <SharedRootAndPage />
+      <PageOne />
+      <PageTwo />
+    </main>
+  );
+};

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientA.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientA.css
@@ -1,0 +1,3 @@
+.page-one-client-a-css {
+  color: dodgerblue;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientA.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientA.js
@@ -1,0 +1,7 @@
+"use client";
+
+import './PageOneClientA.css';
+
+export function PageOneClientA() {
+  return <button className="page-one-client-a-css">Page one A</button>;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientB.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientB.css
@@ -1,0 +1,3 @@
+.page-one-client-b-css {
+  color: royalblue;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientB.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneClientB.js
@@ -1,0 +1,7 @@
+"use client";
+
+import './PageOneClientB.css';
+
+export function PageOneClientB() {
+  return <button className="page-one-client-b-css">Page one B</button>;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneDynamicClient.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneDynamicClient.css
@@ -1,0 +1,3 @@
+.page-one-dynamic-client-css {
+  color: rgb(247, 190, 87);
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneDynamicClient.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageOneDynamicClient.js
@@ -1,0 +1,9 @@
+"use client";
+
+import './PageOneDynamicClient.css';
+
+export function PageOneDynamicClient() {
+  return (
+    <button className="page-one-dynamic-client-css">Page one dynamic</button>
+  );
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageTwoClient.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageTwoClient.css
@@ -1,0 +1,3 @@
+.page-two-client-css {
+  color: darkorange;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageTwoClient.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/PageTwoClient.js
@@ -1,0 +1,7 @@
+"use client";
+
+import './PageTwoClient.css';
+
+export function PageTwoClient() {
+  return <button className="page-two-client-css">Page two</button>;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyA.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyA.css
@@ -1,0 +1,3 @@
+.root-client-a-css {
+  color: seagreen;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyA.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyA.js
@@ -1,0 +1,7 @@
+"use client";
+
+import './RootOnlyA.css';
+
+export function RootOnlyA() {
+  return <button className="root-client-a-css">Root A</button>;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyB.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyB.css
@@ -1,0 +1,3 @@
+.root-client-b-css {
+  color: mediumseagreen;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyB.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/RootOnlyB.js
@@ -1,0 +1,7 @@
+"use client";
+
+import './RootOnlyB.css';
+
+export function RootOnlyB() {
+  return <button className="root-client-b-css">Root B</button>;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedAcrossPages.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedAcrossPages.css
@@ -1,0 +1,3 @@
+.shared-across-pages-client-css {
+  color: purple;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedAcrossPages.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedAcrossPages.js
@@ -1,0 +1,9 @@
+"use client";
+
+import './SharedAcrossPages.css';
+
+export function SharedAcrossPages() {
+  return (
+    <button className="shared-across-pages-client-css">Shared pages</button>
+  );
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedRootAndPage.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedRootAndPage.css
@@ -1,0 +1,3 @@
+.shared-root-page-client-css {
+  color: teal;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedRootAndPage.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedRootAndPage.js
@@ -1,0 +1,9 @@
+"use client";
+
+import './SharedRootAndPage.css';
+
+export function SharedRootAndPage() {
+  return (
+    <button className="shared-root-page-client-css">Shared root page</button>
+  );
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedServerChildClient.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedServerChildClient.css
@@ -1,0 +1,3 @@
+.shared-server-child-client-css {
+  color: rgb(108, 196, 161);
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedServerChildClient.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/clients/SharedServerChildClient.js
@@ -1,0 +1,11 @@
+"use client";
+
+import './SharedServerChildClient.css';
+
+export function SharedServerChildClient() {
+  return (
+    <button className="shared-server-child-client-css">
+      Shared server child
+    </button>
+  );
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/framework/entry.client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/framework/entry.client.js
@@ -1,0 +1,1 @@
+// This entry mirrors the client compiler half of an RSC app.

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/framework/entry.rsc.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/framework/entry.rsc.js
@@ -1,0 +1,10 @@
+import { renderToReadableStream } from 'react-server-dom-rspack/server';
+import { Root } from '../Root';
+
+export const renderRscStream = () => {
+  return renderToReadableStream(<Root />);
+};
+
+it('should build the RSC client chunk grouping fixture', () => {
+  expect(typeof renderRscStream).toBe('function');
+});

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/framework/entry.ssr.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/framework/entry.ssr.js
@@ -1,0 +1,7 @@
+import { createFromReadableStream } from 'react-server-dom-rspack/client';
+import { renderRscStream } from './entry.rsc';
+
+export const renderHTML = async () => {
+  const rscStream = await renderRscStream();
+  return createFromReadableStream(rscStream);
+};

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.css
@@ -1,0 +1,3 @@
+.page-one-server-css {
+  color: steelblue;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.js
@@ -1,0 +1,18 @@
+"use server-entry";
+
+import { PageOneClientA } from '../clients/PageOneClientA';
+import { PageOneClientB } from '../clients/PageOneClientB';
+import { SharedAcrossPages } from '../clients/SharedAcrossPages';
+import { SharedRootAndPage } from '../clients/SharedRootAndPage';
+import './PageOne.css';
+
+export const PageOne = async () => {
+  return (
+    <section className="page-one-server-css">
+      <PageOneClientA />
+      <PageOneClientB />
+      <SharedAcrossPages />
+      <SharedRootAndPage />
+    </section>
+  );
+};

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.js
@@ -7,10 +7,13 @@ import { SharedRootAndPage } from '../clients/SharedRootAndPage';
 import './PageOne.css';
 
 export const PageOne = async () => {
+  const { PageOneDynamicClient } = await import('../clients/PageOneDynamicClient');
+
   return (
     <section className="page-one-server-css">
       <PageOneClientA />
       <PageOneClientB />
+      <PageOneDynamicClient />
       <SharedAcrossPages />
       <SharedRootAndPage />
     </section>

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageOne.js
@@ -4,16 +4,22 @@ import { PageOneClientA } from '../clients/PageOneClientA';
 import { PageOneClientB } from '../clients/PageOneClientB';
 import { SharedAcrossPages } from '../clients/SharedAcrossPages';
 import { SharedRootAndPage } from '../clients/SharedRootAndPage';
+import { SharedServerChild } from '../server/SharedServerChild';
 import './PageOne.css';
 
 export const PageOne = async () => {
   const { PageOneDynamicClient } = await import('../clients/PageOneDynamicClient');
+  const { SharedServerChild: DynamicSharedServerChild } = await import(
+    '../server/SharedServerChild'
+  );
 
   return (
     <section className="page-one-server-css">
       <PageOneClientA />
       <PageOneClientB />
       <PageOneDynamicClient />
+      <SharedServerChild />
+      <DynamicSharedServerChild />
       <SharedAcrossPages />
       <SharedRootAndPage />
     </section>

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageTwo.css
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageTwo.css
@@ -1,0 +1,3 @@
+.page-two-server-css {
+  color: crimson;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageTwo.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/pages/PageTwo.js
@@ -1,0 +1,14 @@
+"use server-entry";
+
+import { PageTwoClient } from '../clients/PageTwoClient';
+import { SharedAcrossPages } from '../clients/SharedAcrossPages';
+import './PageTwo.css';
+
+export const PageTwo = async () => {
+  return (
+    <section className="page-two-server-css">
+      <PageTwoClient />
+      <SharedAcrossPages />
+    </section>
+  );
+};

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/server/SharedServerChild.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/src/server/SharedServerChild.js
@@ -1,0 +1,5 @@
+import { SharedServerChildClient } from '../clients/SharedServerChildClient';
+
+export function SharedServerChild() {
+  return <SharedServerChildClient />;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/test.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/client-chunk-grouping/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+  findBundle: function () {
+    return ['bundle0.js'];
+  },
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/__snapshot__/rsc-entry-debug-comments.txt
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/__snapshot__/rsc-entry-debug-comments.txt
@@ -7,8 +7,8 @@ server
  * - ./src/clients/PageOneClient.js (exports: PageOneClient)
  * - ./src/clients/PageTwoClient.js (exports: PageTwoClient)
  * - ./src/clients/RootClient.js (exports: RootClient)
- * - ./src/clients/SharedAcrossPages.js (exports: SharedAcrossPages)
- * - ./src/clients/SharedRootAndPage.js (exports: SharedRootAndPage)
+ * - ./src/clients/SharedAcrossPages.js (exports: *)
+ * - ./src/clients/SharedRootAndPage.js (exports: *)
  */
 
 client
@@ -23,8 +23,8 @@ client
  * chunk group: ungrouped
  * chunking: one async block per module
  * modules:
- * - ./src/clients/SharedAcrossPages.js (exports: SharedAcrossPages)
- * - ./src/clients/SharedRootAndPage.js (exports: SharedRootAndPage)
+ * - ./src/clients/SharedAcrossPages.js (exports: *)
+ * - ./src/clients/SharedRootAndPage.js (exports: *)
  */
 /*!
  * chunk group: server-entry

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/__snapshot__/rsc-entry-debug-comments.txt
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/__snapshot__/rsc-entry-debug-comments.txt
@@ -1,17 +1,44 @@
 server
 "use strict";
 /*!
- * module: ./src/Client.js
- * exports: Client
+ * chunk group: ssr-eager
+ * chunking: eager import for SSR
+ * modules:
+ * - ./src/clients/PageOneClient.js (exports: PageOneClient)
+ * - ./src/clients/PageTwoClient.js (exports: PageTwoClient)
+ * - ./src/clients/RootClient.js (exports: RootClient)
+ * - ./src/clients/SharedAcrossPages.js (exports: SharedAcrossPages)
+ * - ./src/clients/SharedRootAndPage.js (exports: SharedRootAndPage)
  */
 
 client
 "use strict";
 /*!
- * module: ./src/App.css
- * exports: side-effect
+ * chunk group: root
+ * chunking: single async block
+ * modules:
+ * - ./src/clients/RootClient.js (exports: RootClient)
  */
 /*!
- * module: ./src/Client.js
- * exports: Client
+ * chunk group: ungrouped
+ * chunking: one async block per module
+ * modules:
+ * - ./src/clients/SharedAcrossPages.js (exports: SharedAcrossPages)
+ * - ./src/clients/SharedRootAndPage.js (exports: SharedRootAndPage)
+ */
+/*!
+ * chunk group: server-entry
+ * chunking: one async block per server-entry
+ * server-entry: ./src/pages/PageOne.js
+ * modules:
+ * - ./src/pages/PageOne.css (exports: side-effect)
+ * - ./src/clients/PageOneClient.js (exports: PageOneClient)
+ */
+/*!
+ * chunk group: server-entry
+ * chunking: one async block per server-entry
+ * server-entry: ./src/pages/PageTwo.js
+ * modules:
+ * - ./src/pages/PageTwo.css (exports: side-effect)
+ * - ./src/clients/PageTwoClient.js (exports: PageTwoClient)
  */

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/App.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/App.js
@@ -1,8 +1,15 @@
-'use server-entry';
-
-import './App.css';
-import { Client } from './Client';
+import { RootClient } from './clients/RootClient';
+import { SharedRootAndPage } from './clients/SharedRootAndPage';
+import { PageOne } from './pages/PageOne';
+import { PageTwo } from './pages/PageTwo';
 
 export const App = () => {
-  return <Client />;
+  return (
+    <>
+      <RootClient />
+      <SharedRootAndPage />
+      <PageOne />
+      <PageTwo />
+    </>
+  );
 };

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/Client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/Client.js
@@ -1,5 +1,0 @@
-'use client';
-
-export const Client = () => {
-  return <button className="app">Client</button>;
-};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/PageOneClient.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/PageOneClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export const PageOneClient = () => {
+  return <button>Page one client</button>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/PageTwoClient.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/PageTwoClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export const PageTwoClient = () => {
+  return <button>Page two client</button>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/RootClient.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/RootClient.js
@@ -1,0 +1,5 @@
+'use client';
+
+export const RootClient = () => {
+  return <button>Root client</button>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/SharedAcrossPages.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/SharedAcrossPages.js
@@ -1,0 +1,5 @@
+'use client';
+
+export const SharedAcrossPages = () => {
+  return <button>Shared across pages</button>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/SharedRootAndPage.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/clients/SharedRootAndPage.js
@@ -1,0 +1,5 @@
+'use client';
+
+export const SharedRootAndPage = () => {
+  return <button>Shared root and page</button>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageOne.css
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageOne.css
@@ -1,3 +1,3 @@
-.app {
+.page-one {
   color: seagreen;
 }

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageOne.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageOne.js
@@ -1,0 +1,16 @@
+'use server-entry';
+
+import { PageOneClient } from '../clients/PageOneClient';
+import { SharedAcrossPages } from '../clients/SharedAcrossPages';
+import { SharedRootAndPage } from '../clients/SharedRootAndPage';
+import './PageOne.css';
+
+export const PageOne = () => {
+  return (
+    <section className="page-one">
+      <PageOneClient />
+      <SharedAcrossPages />
+      <SharedRootAndPage />
+    </section>
+  );
+};

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageTwo.css
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageTwo.css
@@ -1,0 +1,3 @@
+.page-two {
+  color: rebeccapurple;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageTwo.js
+++ b/tests/rspack-test/configCases/rsc-plugin/rsc-entry-debug-comments/src/pages/PageTwo.js
@@ -1,0 +1,14 @@
+'use server-entry';
+
+import { PageTwoClient } from '../clients/PageTwoClient';
+import { SharedAcrossPages } from '../clients/SharedAcrossPages';
+import './PageTwo.css';
+
+export const PageTwo = () => {
+  return (
+    <section className="page-two">
+      <PageTwoClient />
+      <SharedAcrossPages />
+    </section>
+  );
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Group `use client` modules by RSC ownership instead of always creating one async chunk per client boundary.
- Put client modules owned by a single `use server-entry` subtree into the same chunk group as that server-entry's CSS.
- Keep client modules shared by multiple server-entry/root owners isolated so each client manifest entry still maps to one emitted client asset.
- Group root-only client modules into one root client chunk for the RSC entry.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
