### PR TITLE
chore(benchmark): remove swc loader from threejs case

### DIFF
--- a/xtask/benchmark/benches/groups/bundle/basic_react.rs
+++ b/xtask/benchmark/benches/groups/bundle/basic_react.rs
@@ -6,5 +6,6 @@ pub fn compiler() -> CompilerBuilder {
   basic_compiler_builder(BuilderOptions {
     project: "basic-react",
     entry: "./src/index.jsx",
+    swc_loader: true,
   })
 }

--- a/xtask/benchmark/benches/groups/bundle/threejs.rs
+++ b/xtask/benchmark/benches/groups/bundle/threejs.rs
@@ -6,5 +6,6 @@ pub fn compiler() -> CompilerBuilder {
   basic_compiler_builder(BuilderOptions {
     project: "threejs",
     entry: "./src/Three.js",
+    swc_loader: false,
   })
 }

--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -15,6 +15,7 @@ pub type CompilerBuilderGenerator = Arc<dyn Fn() -> CompilerBuilder + Send + Syn
 pub struct BuilderOptions {
   pub project: &'static str,
   pub entry: &'static str,
+  pub swc_loader: bool,
 }
 
 pub fn basic_compiler_builder(options: BuilderOptions) -> CompilerBuilder {
@@ -30,31 +31,6 @@ pub fn basic_compiler_builder(options: BuilderOptions) -> CompilerBuilder {
   builder
     .context(dir.to_string_lossy().to_string())
     .entry("main", options.entry)
-    .module(ModuleOptions::builder().rule(ModuleRule {
-      test: Some(RuleSetCondition::Regexp(
-        RspackRegex::new("\\.(j|t)s(x)?$").unwrap(),
-      )),
-      effect: ModuleRuleEffect {
-        r#use: ModuleRuleUse::Array(vec![ModuleRuleUseLoader {
-        loader: "builtin:swc-loader".to_string(),
-        options: Some(json!({
-            "jsc": {
-                "parser": {
-                    "syntax": "typescript",
-                    "tsx": true,
-                },
-                "transform": {
-                    "react": {
-                        "runtime": "automatic",
-                    },
-                }
-            },
-        }).to_string()),
-      }]),
-        ..Default::default()
-      },
-      ..Default::default()
-    }))
     .cache(rspack_core::CacheOptions::Disabled)
     .optimization(Optimization::builder().minimize(false))
     .resolve(Resolve {
@@ -63,8 +39,40 @@ pub fn basic_compiler_builder(options: BuilderOptions) -> CompilerBuilder {
     })
     .experiments(Experiments::builder().css(true))
     .input_filesystem(Arc::new(NativeFileSystem::new(false)))
-    .output_filesystem(Arc::new(MemoryFileSystem::default()))
-    .enable_loader_swc();
+    .output_filesystem(Arc::new(MemoryFileSystem::default()));
+
+  if options.swc_loader {
+    builder
+      .module(ModuleOptions::builder().rule(ModuleRule {
+        test: Some(RuleSetCondition::Regexp(
+          RspackRegex::new("\\.(j|t)s(x)?$").unwrap(),
+        )),
+        effect: ModuleRuleEffect {
+          r#use: ModuleRuleUse::Array(vec![ModuleRuleUseLoader {
+            loader: "builtin:swc-loader".to_string(),
+            options: Some(
+              json!({
+                  "jsc": {
+                      "parser": {
+                          "syntax": "typescript",
+                          "tsx": true,
+                      },
+                      "transform": {
+                          "react": {
+                              "runtime": "automatic",
+                          },
+                      }
+                  },
+              })
+              .to_string(),
+            ),
+          }]),
+          ..Default::default()
+        },
+        ..Default::default()
+      }))
+      .enable_loader_swc();
+  }
 
   builder
 }


### PR DESCRIPTION
## Summary

- add a per-bundle benchmark switch for the SWC loader
- disable the SWC loader for the threejs benchmark case
- keep the SWC loader enabled for the basic-react benchmark case

## Testing

- cargo fmt --manifest-path xtask/benchmark/Cargo.toml
- cargo check -p rspack_benchmark --benches