### PR TITLE
feat(create-rspack): support rslint template mapping

### DIFF
--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -24,7 +24,7 @@
     "dev": "rslib build -w"
   },
   "dependencies": {
-    "create-rstack": "2.0.1"
+    "create-rstack": "2.1.1"
   },
   "devDependencies": {
     "@rslib/core": "0.21.3",

--- a/packages/create-rspack/src/index.ts
+++ b/packages/create-rspack/src/index.ts
@@ -6,6 +6,7 @@ import {
   copyFolder,
   create,
   type ESLintTemplateName,
+  type RslintTemplateName,
   select,
 } from 'create-rstack';
 
@@ -68,6 +69,16 @@ function mapRstestTemplate(templateName: string): string {
   }
 }
 
+function mapRslintTemplate(templateName: string): RslintTemplateName {
+  switch (templateName) {
+    case 'react-js':
+    case 'react-ts':
+      return templateName;
+    default:
+      return `vanilla-${templateName.split('-')[1]}` as RslintTemplateName;
+  }
+}
+
 create({
   root,
   name: 'rspack',
@@ -82,6 +93,7 @@ create({
   skipFiles: ['.npmignore'],
   getTemplateName,
   mapESLintTemplate,
+  mapRslintTemplate,
   extraTools: [
     {
       value: 'rstest',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
   packages/create-rspack:
     dependencies:
       create-rstack:
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 2.1.1
+        version: 2.1.1
     devDependencies:
       '@rslib/core':
         specifier: 0.21.3
@@ -4304,8 +4304,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  create-rstack@2.0.1:
-    resolution: {integrity: sha512-J5YQviohaHIyCEID4fZa4dxurMRJDpGs2GJBHO82RM8URUbOhf9k9UkKbbwNOwVXFKlPRQgOtuQyiJwz1f0IvA==}
+  create-rstack@2.1.1:
+    resolution: {integrity: sha512-fYIgIQXml9HmgcqnIo2fqBsql4f1+6dGYzznwg5+fc8dXcdPvukdYgOg4wZsmXha6qvneAjLm9/1O/2CeXYvfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   cross-env@10.1.0:
@@ -11397,7 +11397,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  create-rstack@2.0.1: {}
+  create-rstack@2.1.1: {}
 
   cross-env@10.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

This PR updates `create-rspack` to use `create-rstack@2.1.1` so the generator can pass through the new Rslint template mapping support. It maps React templates to React-specific Rslint configs and all other framework templates to vanilla JS/TS configs.

## Related links

- https://github.com/rstackjs/create-rstack/releases/tag/v2.1.1
- https://github.com/rstackjs/create-rstack/pull/134

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).