### PR TITLE
fix(rslib): make isolated dts metadata relative

### DIFF
--- a/crates/rspack_binding_api/src/rslib.rs
+++ b/crates/rspack_binding_api/src/rslib.rs
@@ -1,5 +1,5 @@
 use derive_more::Debug;
-use rspack_plugin_rslib::{RslibPluginOptions, SwcEmitDtsPluginOptions};
+use rspack_plugin_rslib::{RslibPluginOptions, SwcEmitDtsOptions};
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -35,7 +35,7 @@ impl From<RawRslibPluginOptions> for RslibPluginOptions {
   }
 }
 
-impl From<RawSwcEmitDtsOptions> for SwcEmitDtsPluginOptions {
+impl From<RawSwcEmitDtsOptions> for SwcEmitDtsOptions {
   fn from(value: RawSwcEmitDtsOptions) -> Self {
     Self {
       root_dir: value.root_dir,

--- a/crates/rspack_loader_swc/src/isolated_dts.rs
+++ b/crates/rspack_loader_swc/src/isolated_dts.rs
@@ -1,9 +1,27 @@
 use rspack_core::{BuildInfo, IsolatedDts};
 use rspack_error::{Error, Result};
+use rspack_paths::Utf8Path;
+use sugar_path::SugarPath;
 
 use crate::SWC_LOADER_IDENTIFIER;
 
-pub(crate) fn set_build_info(build_info: &mut BuildInfo, resource_path: String, code: String) {
+pub(crate) fn set_build_info(
+  build_info: &mut BuildInfo,
+  resource_path: &Utf8Path,
+  compiler_context: &Utf8Path,
+  code: String,
+) {
+  // BuildInfo is persisted in cache, so avoid storing checkout-specific absolute paths.
+  let relative_resource_path = resource_path
+    .as_std_path()
+    .relative(compiler_context.as_std_path());
+  let resource_path = if relative_resource_path.is_relative() {
+    relative_resource_path
+  } else {
+    resource_path.as_std_path().normalize().into_owned()
+  }
+  .to_slash_lossy()
+  .into_owned();
   build_info.isolated_dts = Some(IsolatedDts {
     resource_path,
     code,

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -64,6 +64,7 @@ impl SwcLoader {
       .resource_path()
       .map(|p| p.to_path_buf())
       .unwrap_or_default();
+    loader_context.context.module.build_info_mut().isolated_dts = None;
     let Some(content) = loader_context.take_content() else {
       return Ok(());
     };
@@ -222,7 +223,8 @@ impl SwcLoader {
 
       set_build_info(
         loader_context.context.module.build_info_mut(),
-        resource_path.as_str().to_string(),
+        resource_path.as_path(),
+        loader_context.context.options.context.as_path(),
         isolated_dts.code,
       );
     }

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -22,6 +22,7 @@ use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin, JavascriptModulesRender, JsPlugin, RenderSource,
   parser_and_generator::JavaScriptParserAndGenerator,
 };
+use rspack_util::node_path::NodePath;
 
 use crate::{
   asset::RslibAssetParserAndGenerator,
@@ -39,26 +40,40 @@ pub struct RslibPluginOptions {
   pub intercept_api_plugin: bool,
   pub force_node_shims: bool,
   pub auto_cjs_node_builtin: bool,
-  pub emit_dts: Option<SwcEmitDtsPluginOptions>,
+  pub emit_dts: Option<SwcEmitDtsOptions>,
 }
 
 #[derive(Debug, Clone)]
-pub struct SwcEmitDtsPluginOptions {
+pub struct SwcEmitDtsOptions {
   pub root_dir: String,
   pub declaration_dir: String,
 }
 
 fn emit_isolated_dts_asset(
   compilation: &mut Compilation,
-  emit_dts_options: &SwcEmitDtsPluginOptions,
+  emit_dts_options: &SwcEmitDtsOptions,
   dts: IsolatedDts,
 ) -> Result<()> {
   let IsolatedDts {
     resource_path,
     code,
   } = dts;
-  let resource_path = Utf8PathBuf::from(resource_path);
   let compiler_root = compilation.options.context.as_path();
+  let raw_resource_path = Utf8PathBuf::from(&resource_path);
+  // Cached isolated dts metadata stores resource paths relative to the compiler context.
+  let resource_path = resolve_emit_dts_path(compiler_root, &resource_path);
+  // AssetInfo.source_filename is expected to be relative to the compilation context.
+  let source_filename = if raw_resource_path.is_relative() {
+    Some(
+      raw_resource_path
+        .as_str()
+        .cow_replace('\\', "/")
+        .into_owned(),
+    )
+  } else {
+    diff_paths(resource_path.as_std_path(), compiler_root.as_std_path())
+      .map(|path| path.to_string_lossy().cow_replace('\\', "/").into_owned())
+  };
   let resolved_root_dir = resolve_emit_dts_path(compiler_root, &emit_dts_options.root_dir);
   let resolved_declaration_dir =
     resolve_emit_dts_path(compiler_root, &emit_dts_options.declaration_dir);
@@ -93,7 +108,7 @@ fn emit_isolated_dts_asset(
     CompilationAsset::new(
       Some(RawStringSource::from(code).boxed()),
       AssetInfo {
-        source_filename: Some(resource_path.as_str().to_string()),
+        source_filename,
         ..Default::default()
       },
     ),
@@ -105,9 +120,9 @@ fn emit_isolated_dts_asset(
 fn resolve_emit_dts_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {
   let path = Utf8Path::new(value);
   if path.is_absolute() {
-    path.to_path_buf()
+    path.to_path_buf().node_normalize()
   } else {
-    base.join(path)
+    base.node_join(path).node_normalize()
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes isolated declaration emission metadata so persistent cache entries do not store checkout-specific absolute module paths. The swc loader now stores isolated dts resource paths relative to the compiler context and clears stale metadata before each load, while Rslib resolves cached paths against the current context and keeps `AssetInfo.source_filename` relative.

## Related links

https://github.com/web-infra-dev/rspack/pull/13872

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
