### PR TITLE
docs: sync zh FAQ with RSC update

### DIFF
--- a/website/docs/zh/misc/faq.mdx
+++ b/website/docs/zh/misc/faq.mdx
@@ -32,7 +32,3 @@ Rspack 内部使用 SWC 进行代码的降级编译（通过 [builtin:swc-loader
 ## 自定义插件和自定义 Loader 需要使用 Rust 进行开发吗？
 
 不需要。你可以像开发 webpack 插件和 loader 一样，使用 JavaScript 来开发插件和 loader。你也可以选择使用 Rust 来开发插件和 loader，参考 [rspack-binding-template](https://github.com/rstackjs/rspack-binding-template)。
-
-## Rspack 计划支持 React Server Components 吗？
-
-Rspack 团队正在支持 React Server Components，相关 PR：[#12012](https://github.com/web-infra-dev/rspack/pull/12012)。


### PR DESCRIPTION
## Summary

Syncs the Chinese FAQ with https://github.com/web-infra-dev/rspack/pull/13898 by removing the outdated React Server Components support plan section.

## Related links

https://github.com/web-infra-dev/rspack/pull/13898

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
