### PR TITLE
docs: add webpack package replacements

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -364,3 +364,18 @@ Migrate [raw-loader](https://github.com/webpack-contrib/raw-loader) to [Asset Mo
    },
  };
 ```
+
+## Common webpack package replacements
+
+When migrating webpack ecosystem packages, the following non-plugin packages usually need to be replaced.
+
+| webpack package          | Rspack replacement                                                                       | Notes                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------- | -------------------------------------- |
+| `webpack`                | [`@rspack/core`](https://www.npmjs.com/package/@rspack/core)                             | Core package.                          |
+| `webpack-cli`            | [`@rspack/cli`](https://www.npmjs.com/package/@rspack/cli)                               | CLI commands for Rspack.               |
+| `webpack-dev-server`     | [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server)                    | Development server for Rspack.         |
+| `webpack-dev-middleware` | [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware)            | Middleware for custom Node.js servers. |
+| `webpack-chain`          | [`rspack-chain`](https://github.com/rstackjs/rspack-chain)                               | Chainable Rspack configuration API.    |
+| `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge) or [extends](/config/extends) | Rspack configuration merging.          |
+
+> For plugin packages, see [Plugin compatibility](/guide/compatibility/plugin).

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -369,13 +369,13 @@ Migrate [raw-loader](https://github.com/webpack-contrib/raw-loader) to [Asset Mo
 
 When migrating webpack ecosystem packages, the following non-plugin packages usually need to be replaced.
 
-| webpack package          | Rspack replacement                                                                       | Notes                                  |
-| ------------------------ | ---------------------------------------------------------------------------------------- | -------------------------------------- |
-| `webpack`                | [`@rspack/core`](https://www.npmjs.com/package/@rspack/core)                             | Core package.                          |
-| `webpack-cli`            | [`@rspack/cli`](https://www.npmjs.com/package/@rspack/cli)                               | CLI commands for Rspack.               |
-| `webpack-dev-server`     | [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server)                    | Development server for Rspack.         |
-| `webpack-dev-middleware` | [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware)            | Middleware for custom Node.js servers. |
-| `webpack-chain`          | [`rspack-chain`](https://github.com/rstackjs/rspack-chain)                               | Chainable Rspack configuration API.    |
-| `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge) or [extends](/config/extends) | Rspack configuration merging.          |
+| webpack package          | Rspack replacement                                                            | Notes                                  |
+| ------------------------ | ----------------------------------------------------------------------------- | -------------------------------------- |
+| `webpack`                | [`@rspack/core`](https://www.npmjs.com/package/@rspack/core)                  | Core package.                          |
+| `webpack-cli`            | [`@rspack/cli`](https://www.npmjs.com/package/@rspack/cli)                    | CLI commands for Rspack.               |
+| `webpack-dev-server`     | [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server)         | Development server for Rspack.         |
+| `webpack-dev-middleware` | [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware) | Middleware for custom Node.js servers. |
+| `webpack-chain`          | [`rspack-chain`](https://github.com/rstackjs/rspack-chain)                    | Chainable Rspack configuration API.    |
+| `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge)                    | Rspack configuration merging.          |
 
 > For plugin packages, see [Plugin compatibility](/guide/compatibility/plugin).

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -367,13 +367,13 @@ module.exports = {
 
 迁移 webpack 生态中的配套库时，下面这些非插件类包通常需要替换：
 
-| webpack 库               | Rspack 替代方案                                                                          | 说明                            |
-| ------------------------ | ---------------------------------------------------------------------------------------- | ------------------------------- |
-| `webpack`                | [`@rspack/core`](https://www.npmjs.com/package/@rspack/core)                             | 核心包。                        |
-| `webpack-cli`            | [`@rspack/cli`](https://www.npmjs.com/package/@rspack/cli)                               | Rspack CLI 命令。               |
-| `webpack-dev-server`     | [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server)                    | Rspack 开发服务器。             |
-| `webpack-dev-middleware` | [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware)            | 自定义 Node.js 服务中的中间件。 |
-| `webpack-chain`          | [`rspack-chain`](https://github.com/rstackjs/rspack-chain)                               | 链式生成 Rspack 配置。          |
-| `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge) 或 [extends](/config/extends) | 合并 Rspack 配置。              |
+| webpack 库               | Rspack 替代方案                                                               | 说明                            |
+| ------------------------ | ----------------------------------------------------------------------------- | ------------------------------- |
+| `webpack`                | [`@rspack/core`](https://www.npmjs.com/package/@rspack/core)                  | 核心包。                        |
+| `webpack-cli`            | [`@rspack/cli`](https://www.npmjs.com/package/@rspack/cli)                    | Rspack CLI 命令。               |
+| `webpack-dev-server`     | [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server)         | Rspack 开发服务器。             |
+| `webpack-dev-middleware` | [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware) | 自定义 Node.js 服务中的中间件。 |
+| `webpack-chain`          | [`rspack-chain`](https://github.com/rstackjs/rspack-chain)                    | 链式生成 Rspack 配置。          |
+| `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge)                    | 合并 Rspack 配置。              |
 
 > 对于插件类包，请查看 [Plugin 兼容](/guide/compatibility/plugin)。

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -362,3 +362,18 @@ module.exports = {
    },
  };
 ```
+
+## 常见 webpack 库替换
+
+迁移 webpack 生态中的配套库时，下面这些非插件类包通常需要替换：
+
+| webpack 库               | Rspack 替代方案                                                                          | 说明                            |
+| ------------------------ | ---------------------------------------------------------------------------------------- | ------------------------------- |
+| `webpack`                | [`@rspack/core`](https://www.npmjs.com/package/@rspack/core)                             | 核心包。                        |
+| `webpack-cli`            | [`@rspack/cli`](https://www.npmjs.com/package/@rspack/cli)                               | Rspack CLI 命令。               |
+| `webpack-dev-server`     | [`@rspack/dev-server`](https://github.com/rstackjs/rspack-dev-server)                    | Rspack 开发服务器。             |
+| `webpack-dev-middleware` | [`@rspack/dev-middleware`](https://github.com/rstackjs/rspack-dev-middleware)            | 自定义 Node.js 服务中的中间件。 |
+| `webpack-chain`          | [`rspack-chain`](https://github.com/rstackjs/rspack-chain)                               | 链式生成 Rspack 配置。          |
+| `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge) 或 [extends](/config/extends) | 合并 Rspack 配置。              |
+
+> 对于插件类包，请查看 [Plugin 兼容](/guide/compatibility/plugin)。


### PR DESCRIPTION
## Summary

This PR updates the webpack migration guide to list common non-plugin package replacements in docs, helping users map webpack ecosystem packages to the corresponding Rspack packages during migration.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
