### PR TITLE
chore(deps): remove http-proxy-middleware dts patch

### DIFF
--- a/packages/rspack/prebundle.config.js
+++ b/packages/rspack/prebundle.config.js
@@ -29,22 +29,6 @@ export default {
     {
       name: 'http-proxy-middleware',
       dtsOnly: true,
-      afterBundle(task) {
-        // Suppress missing-module errors for optional Hono peer type imports in generated d.ts files.
-        replaceFileContent(join(task.distPath, 'index.d.ts'), (content) => {
-          return content
-            .replace(
-              `import { HttpBindings } from '@hono/node-server';`,
-              `// @ts-ignore
-import { HttpBindings } from '@hono/node-server';`,
-            )
-            .replace(
-              `import { MiddlewareHandler } from 'hono';`,
-              `// @ts-ignore
-import { MiddlewareHandler } from 'hono';`,
-            );
-        });
-      },
     },
     {
       name: 'open',


### PR DESCRIPTION
## Summary

`http-proxy-middleware` was updated in #13909, and the declaration patch added for older Hono peer type imports is no longer needed. This PR removes that post-bundle rewrite from the prebundle config so the generated d.ts output is used directly.

## Related links

- https://github.com/web-infra-dev/rspack/pull/13909#issuecomment-4365961659

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).