### PR TITLE
fix(plugin-library): skip unused exports in ModuleLibraryPlugin

### DIFF
--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -101,9 +101,6 @@ async fn render_startup(
       .chunk_by_ukey
       .expect_get(chunk_ukey);
     let info_name = export_info.name().expect("should have name");
-    let used_name = export_info
-      .get_used_name(Some(info_name), Some(chunk.runtime()))
-      .expect("name can't be empty");
     let var_name = format!("{exports_name}{}", to_identifier(info_name));
 
     if info_name == "default"
@@ -116,6 +113,11 @@ async fn render_startup(
         "var {var_name} = {exports_name};\n",
       )));
     } else {
+      // Skip exports unused in this runtime (matches webpack's `if (!exportInfo.provided) continue;`).
+      let Some(used_name) = export_info.get_used_name(Some(info_name), Some(chunk.runtime()))
+      else {
+        continue;
+      };
       source.add(RawStringSource::from(format!(
         "var {var_name} = {};\n",
         match used_name {


### PR DESCRIPTION
## Summary

`ModuleLibraryPlugin::render_startup` calls `get_used_name(...).expect("name can't be empty")` for every export. `get_used_name` returns `None` when the export isn't used in the current chunk runtime (e.g. tree-shaken or `UsageState::Unused`), which panics rsbuild builds with:

```
thread 'tokio-N' panicked at crates/rspack_plugin_library/src/module_library_plugin.rs:106:8:
name can't be empty
```

Replace the `.expect(..)` with a `None`-skip, matching webpack's `ModuleLibraryPlugin` (`if (!exportInfo.provided) continue;`). The default-export branch never used `used_name`, so it's now only requested in the named-export branch where it's needed.

## Related links

Closes #13918

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).