### PR TITLE
docs: replace storybook roadmap link with migration guide

### DIFF
--- a/website/docs/en/guide/migration/storybook.mdx
+++ b/website/docs/en/guide/migration/storybook.mdx
@@ -50,6 +50,6 @@ export default {
 
 The [rstackjs/storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes) repository provides examples of Storybook for React / Vue projects.
 
-## Limitations
+## More details
 
-Rspack is gradually improving full support for Storybook. Currently, there are some capabilities that are not supported, see [storybook-rsbuild - Roadmap](https://github.com/rstackjs/storybook-rsbuild#roadmap) for details.
+This page is a quick start. For the complete migration walkthrough — including handling webpack-dependent addons, mapping common webpack patterns to Rsbuild, and migrating from the Vite framework — see the [storybook-rsbuild migration guide](https://storybook.rsbuild.rs/guide/migration#from-storybook-webpack5-framework).

--- a/website/docs/en/guide/migration/storybook.mdx
+++ b/website/docs/en/guide/migration/storybook.mdx
@@ -52,4 +52,4 @@ The [rstackjs/storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild/t
 
 ## More details
 
-This page is a quick start. For the complete migration walkthrough — including handling webpack-dependent addons, mapping common webpack patterns to Rsbuild, and migrating from the Vite framework — see the [storybook-rsbuild migration guide](https://storybook.rsbuild.rs/guide/migration#from-storybook-webpack5-framework).
+This page is a quick start. For the complete migration walkthrough — including handling webpack-dependent addons, mapping common webpack patterns to Rsbuild, and migrating from Vite — see the [storybook-rsbuild migration guide](https://storybook.rsbuild.rs/guide/migration#from-storybook-webpack5-framework).

--- a/website/docs/zh/guide/migration/storybook.mdx
+++ b/website/docs/zh/guide/migration/storybook.mdx
@@ -52,4 +52,4 @@ export default {
 
 ## 更多详情
 
-本页是快速入门。完整的迁移步骤——包括处理依赖 webpack 的 addons、常见 webpack 配置到 Rsbuild 的对照、以及从 Vite 框架的迁移——见 [storybook-rsbuild 迁移指南](https://storybook.rsbuild.rs/guide/migration#from-storybook-webpack5-framework)。
+本页提供快速入门指引。完整的迁移步骤，包括如何处理依赖 webpack 的 addons、常见 webpack 配置与 Rsbuild 配置的对应关系，以及从 Vite 迁移的说明，请参考 [storybook-rsbuild 迁移指南](https://storybook.rsbuild.rs/guide/migration#from-storybook-webpack5-framework)。

--- a/website/docs/zh/guide/migration/storybook.mdx
+++ b/website/docs/zh/guide/migration/storybook.mdx
@@ -50,6 +50,6 @@ export default {
 
 在 [rstackjs/storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes) 仓库中提供了 React / Vue 项目的 Storybook 示例。
 
-## 局限
+## 更多详情
 
-Rspack 正在逐步完善对 Storybook 的完整支持，目前有部分能力不支持，具体见 [storybook-rsbuild - Roadmap](https://github.com/rstackjs/storybook-rsbuild#roadmap)。
+本页是快速入门。完整的迁移步骤——包括处理依赖 webpack 的 addons、常见 webpack 配置到 Rsbuild 的对照、以及从 Vite 框架的迁移——见 [storybook-rsbuild 迁移指南](https://storybook.rsbuild.rs/guide/migration#from-storybook-webpack5-framework)。


### PR DESCRIPTION
## Summary

The `Limitations` section in `migration/storybook` linked to a non-existent `#roadmap` anchor on the storybook-rsbuild repo (reported in [rstackjs/storybook-rsbuild#485](https://github.com/rstackjs/storybook-rsbuild/issues/485)).

This page is a quick start; the storybook-rsbuild docs site is the comprehensive reference. Renamed the section to `More details` and pointed it at the storybook-rsbuild migration guide so readers land somewhere useful.

## Related links

- Closes rstackjs/storybook-rsbuild#485

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).