### PR TITLE
docs: use rspack-v1 algolia index on v1 site

### DIFF
--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -71,7 +71,7 @@ const Search = () => {
       docSearchProps={{
         appId: 'TQOGCXPBUD', // cspell:disable-line
         apiKey: '8c30f9d1f12e786a132af15ea30cf997', // cspell:disable-line
-        indexName: 'rspack',
+        indexName: 'rspack-v1',
         searchParameters: {
           facetFilters: [`lang:${lang}`],
         },


### PR DESCRIPTION
<!-- Describe what this PR does and why. -->

Use the v1 Algolia index for the v1 website search configuration.

## Related links

- Base branch: `v1.x`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
