### PR TITLE
perf: reduce normal module creation and rule matching overhead

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -32,7 +32,6 @@ macro_rules! expect {
 
 use std::{
   borrow::Cow,
-  future::ready,
   sync::{Arc, LazyLock},
 };
 
@@ -1833,6 +1832,13 @@ impl ModuleOptionsBuilder {
   }
 }
 
+fn extension_rule(extension: &str) -> RuleSetCondition {
+  RuleSetCondition::Regexp(
+    RspackRegex::new(&format!("{}$", regex::escape(extension)))
+      .expect("should initialize default extension regex"),
+  )
+}
+
 fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
   let mut rules = vec![
     // application/node
@@ -1846,14 +1852,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
     },
     // .json
     ModuleRule {
-      test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-        Box::pin(ready(Ok(
-          ctx
-            .as_str()
-            .map(|data| data.ends_with(".json"))
-            .unwrap_or_default(),
-        )))
-      }))),
+      test: Some(extension_rule(".json")),
       effect: ModuleRuleEffect {
         r#type: Some(ModuleType::Json),
         ..Default::default()
@@ -1871,14 +1870,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
     },
     // .mjs
     ModuleRule {
-      test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-        Box::pin(ready(Ok(
-          ctx
-            .as_str()
-            .map(|data| data.ends_with(".mjs"))
-            .unwrap_or_default(),
-        )))
-      }))),
+      test: Some(extension_rule(".mjs")),
       effect: ModuleRuleEffect {
         r#type: Some(ModuleType::JsEsm),
         resolve: Some(Resolve {
@@ -1897,14 +1889,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
     },
     // .js with type:module
     ModuleRule {
-      test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-        Box::pin(ready(Ok(
-          ctx
-            .as_str()
-            .map(|data| data.ends_with(".js"))
-            .unwrap_or_default(),
-        )))
-      }))),
+      test: Some(extension_rule(".js")),
       description_data: Some(HashMap::from_iter([(
         "type".into(),
         RuleSetCondition::String("module".into()).into(),
@@ -1927,14 +1912,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
     },
     // .cjs
     ModuleRule {
-      test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-        Box::pin(ready(Ok(
-          ctx
-            .as_str()
-            .map(|data| data.ends_with(".cjs"))
-            .unwrap_or_default(),
-        )))
-      }))),
+      test: Some(extension_rule(".cjs")),
       effect: ModuleRuleEffect {
         r#type: Some(ModuleType::JsDynamic),
         ..Default::default()
@@ -1943,14 +1921,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
     },
     // .js with type:commonjs
     ModuleRule {
-      test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-        Box::pin(ready(Ok(
-          ctx
-            .as_str()
-            .map(|data| data.ends_with(".js"))
-            .unwrap_or_default(),
-        )))
-      }))),
+      test: Some(extension_rule(".js")),
       description_data: Some(HashMap::from_iter([(
         "type".into(),
         RuleSetCondition::String("commonjs".into()).into(),
@@ -1995,14 +1966,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
   if async_web_assembly {
     rules.extend(vec![
       ModuleRule {
-        test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-          Box::pin(ready(Ok(
-            ctx
-              .as_str()
-              .map(|data| data.ends_with(".wasm"))
-              .unwrap_or_default(),
-          )))
-        }))),
+        test: Some(extension_rule(".wasm")),
         effect: ModuleRuleEffect {
           r#type: Some(ModuleType::WasmAsync),
           ..Default::default()
@@ -2058,14 +2022,7 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
 
     rules.extend(vec![
       ModuleRule {
-        test: Some(RuleSetCondition::Func(Box::new(|ctx| {
-          Box::pin(ready(Ok(
-            ctx
-              .as_str()
-              .map(|data| data.ends_with(".css"))
-              .unwrap_or_default(),
-          )))
-        }))),
+        test: Some(extension_rule(".css")),
         effect: ModuleRuleEffect {
           r#type: Some(ModuleType::CssAuto),
           resolve: Some(resolve.clone()),

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1935,13 +1935,14 @@ fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {
     // text/javascript or application/javascript
     ModuleRule {
       mimetype: Some(
-        RuleSetCondition::Logical(Box::new(RuleSetLogicalConditions {
-          or: Some(vec![
+        RuleSetCondition::Logical(Box::new(RuleSetLogicalConditions::new(
+          None,
+          Some(vec![
             RuleSetCondition::String("text/javascript".into()),
             RuleSetCondition::String("application/javascript".into()),
           ]),
-          ..Default::default()
-        }))
+          None,
+        )))
         .into(),
       ),
       effect: ModuleRuleEffect {

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -707,7 +707,10 @@ CompilerOptions {
                         ModuleRule {
                             rspack_resource: None,
                             test: Some(
-                                "Func(...)",
+                                RspackRegex {
+                                    flags: "",
+                                    source: "\\.json$",
+                                },
                             ),
                             include: None,
                             exclude: None,
@@ -780,7 +783,10 @@ CompilerOptions {
                         ModuleRule {
                             rspack_resource: None,
                             test: Some(
-                                "Func(...)",
+                                RspackRegex {
+                                    flags: "",
+                                    source: "\\.mjs$",
+                                },
                             ),
                             include: None,
                             exclude: None,
@@ -872,7 +878,10 @@ CompilerOptions {
                         ModuleRule {
                             rspack_resource: None,
                             test: Some(
-                                "Func(...)",
+                                RspackRegex {
+                                    flags: "",
+                                    source: "\\.js$",
+                                },
                             ),
                             include: None,
                             exclude: None,
@@ -973,7 +982,10 @@ CompilerOptions {
                         ModuleRule {
                             rspack_resource: None,
                             test: Some(
-                                "Func(...)",
+                                RspackRegex {
+                                    flags: "",
+                                    source: "\\.cjs$",
+                                },
                             ),
                             include: None,
                             exclude: None,
@@ -1007,7 +1019,10 @@ CompilerOptions {
                         ModuleRule {
                             rspack_resource: None,
                             test: Some(
-                                "Func(...)",
+                                RspackRegex {
+                                    flags: "",
+                                    source: "\\.js$",
+                                },
                             ),
                             include: None,
                             exclude: None,
@@ -1156,7 +1171,10 @@ CompilerOptions {
                         ModuleRule {
                             rspack_resource: None,
                             test: Some(
-                                "Func(...)",
+                                RspackRegex {
+                                    flags: "",
+                                    source: "\\.wasm$",
+                                },
                             ),
                             include: None,
                             exclude: None,

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1714,7 +1714,7 @@ impl NormalModuleFactoryCreateModule for NormalModuleFactoryCreateModuleTap {
       .call_with_promise(JsNormalModuleFactoryCreateModuleArgs {
         dependency_type: data.dependencies[0].dependency_type().to_string(),
         raw_request: create_data.raw_request.clone(),
-        resource_resolve_data: (&create_data.resource_resolve_data).into(),
+        resource_resolve_data: create_data.resource_resolve_data.as_ref().into(),
         context: data.context.to_string(),
         match_resource: create_data.match_resource.clone(),
       })

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -82,25 +82,24 @@ impl TryFrom<RawRuleSetLogicalConditions> for rspack_core::RuleSetLogicalConditi
   type Error = rspack_error::Error;
 
   fn try_from(value: RawRuleSetLogicalConditions) -> rspack_error::Result<Self> {
-    Ok(Self {
-      and: value
-        .and
-        .map(|i| {
-          i.into_iter()
-            .map(TryFrom::try_from)
-            .collect::<rspack_error::Result<Vec<_>>>()
-        })
-        .transpose()?,
-      or: value
-        .or
-        .map(|i| {
-          i.into_iter()
-            .map(TryFrom::try_from)
-            .collect::<rspack_error::Result<Vec<_>>>()
-        })
-        .transpose()?,
-      not: value.not.map(TryFrom::try_from).transpose()?,
-    })
+    let and = value
+      .and
+      .map(|i| {
+        i.into_iter()
+          .map(TryFrom::try_from)
+          .collect::<rspack_error::Result<Vec<_>>>()
+      })
+      .transpose()?;
+    let or = value
+      .or
+      .map(|i| {
+        i.into_iter()
+          .map(TryFrom::try_from)
+          .collect::<rspack_error::Result<Vec<_>>>()
+      })
+      .transpose()?;
+    let not = value.not.map(TryFrom::try_from).transpose()?;
+    Ok(Self::new(and, or, not))
   }
 }
 
@@ -120,7 +119,7 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
           l,
         )?))
       }
-      RawRuleSetCondition::array(a) => Self::Array(
+      RawRuleSetCondition::array(a) => Self::array(
         a.into_iter()
           .map(|i| i.try_into())
           .collect::<rspack_error::Result<Vec<_>>>()?,

--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -5,7 +5,7 @@ use napi::{
   bindgen_prelude::{Function, block_on},
 };
 use napi_derive::napi;
-use rspack_core::{ResolveContext, Resolver};
+use rspack_core::Resolver;
 use serde::Serialize;
 
 use crate::{error::ErrorCode, utils::callbackify};
@@ -76,19 +76,18 @@ impl JsResolver {
     callbackify(
       f,
       async move {
-        let mut resolve_context = ResolveContext::default();
-        match resolver
-          .resolve_with_context(Path::new(&path), &request, &mut resolve_context)
-          .await
-        {
+        let (resolve_result, mut resolve_dependencies) = resolver
+          .resolve_with_context(Path::new(&path), &request)
+          .await;
+        match resolve_result {
           Ok(rspack_core::ResolveResult::Resource(resource)) => {
             let mut resolve_request = ResolveRequest::from(resource);
-            resolve_request.file_dependencies = resolve_context
+            resolve_request.file_dependencies = resolve_dependencies
               .file_dependencies
               .drain()
               .map(|path| path.to_string_lossy().into_owned())
               .collect();
-            resolve_request.missing_dependencies = resolve_context
+            resolve_request.missing_dependencies = resolve_dependencies
               .missing_dependencies
               .drain()
               .map(|path| path.to_string_lossy().into_owned())

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -218,8 +218,6 @@ impl ContextModuleFactory {
     let dependency = data.dependencies[0]
       .as_context_dependency()
       .expect("should be context dependency");
-    let mut file_dependencies = Default::default();
-    let mut missing_dependencies = Default::default();
 
     let request = before_resolve_data.request;
     let (loader_request, specifier) = match request.rfind('!') {
@@ -290,11 +288,11 @@ impl ContextModuleFactory {
       resolve_options: data.resolve_options.clone(),
       resolve_to_context: true,
       optional: dependency.get_optional(),
-      file_dependencies: &mut file_dependencies,
-      missing_dependencies: &mut missing_dependencies,
     };
 
-    let resource_data = resolve(resolve_args, plugin_driver).await;
+    let (resource_data, resolve_dependencies) = resolve(resolve_args, plugin_driver).await;
+    let file_dependencies = resolve_dependencies.file_dependencies;
+    let missing_dependencies = resolve_dependencies.missing_dependencies;
 
     let (module, context_module_options) = match resource_data {
       Ok(ResolveResult::Resource(resource)) => {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -131,7 +131,7 @@ pub struct NormalModule {
   /// Resolve options derived from [Rule.resolve]
   resolve_options: Option<Arc<Resolve>>,
   /// Parser options derived from [Rule.parser]
-  parser_options: Option<ParserOptions>,
+  parser_options: Option<Arc<ParserOptions>>,
   /// Generator options derived from [Rule.generator]
   generator_options: Option<GeneratorOptions>,
   /// enable/disable extracting source map
@@ -179,7 +179,7 @@ impl NormalModule {
     module_type: impl Into<ModuleType>,
     layer: Option<ModuleLayer>,
     parser_and_generator: Box<dyn ParserAndGenerator>,
-    parser_options: Option<ParserOptions>,
+    parser_options: Option<Arc<ParserOptions>>,
     generator_options: Option<GeneratorOptions>,
     match_resource: Option<ResourceData>,
     resource_data: Arc<ResourceData>,
@@ -298,7 +298,7 @@ impl NormalModule {
   }
 
   pub fn get_parser_options(&self) -> Option<&ParserOptions> {
-    self.parser_options.as_ref()
+    self.parser_options.as_deref()
   }
 
   pub fn get_generator_options(&self) -> Option<&GeneratorOptions> {
@@ -560,7 +560,7 @@ impl Module for NormalModule {
         source: source.clone(),
         module_context: &self.context,
         module_identifier: self.id,
-        module_parser_options: self.parser_options.as_ref(),
+        module_parser_options: self.parser_options.as_deref(),
         module_type: &self.module_type,
         module_layer: self.layer.as_ref(),
         module_user_request: &self.user_request,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -122,7 +122,7 @@ pub struct NormalModule {
   resource_data: Arc<ResourceData>,
   /// Loaders for the module
   #[debug(skip)]
-  loaders: Vec<BoxLoader>,
+  loaders: Arc<[BoxLoader]>,
 
   /// Built source of this module (passed with loaders)
   #[cacheable(with=AsOption<AsPreset>)]
@@ -206,7 +206,7 @@ impl NormalModule {
       match_resource,
       resource_data,
       resolve_options,
-      loaders,
+      loaders: loaders.into(),
       source: None,
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -122,7 +122,7 @@ pub struct NormalModule {
   resource_data: Arc<ResourceData>,
   /// Loaders for the module
   #[debug(skip)]
-  loaders: Arc<[BoxLoader]>,
+  loaders: Vec<BoxLoader>,
 
   /// Built source of this module (passed with loaders)
   #[cacheable(with=AsOption<AsPreset>)]
@@ -206,7 +206,7 @@ impl NormalModule {
       match_resource,
       resource_data,
       resolve_options,
-      loaders: loaders.into(),
+      loaders,
       source: None,
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
 
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
@@ -28,7 +28,7 @@ define_hook!(NormalModuleFactoryResolveForScheme: SeriesBail(data: &mut ModuleFa
 define_hook!(NormalModuleFactoryResolveInScheme: SeriesBail(data: &mut ModuleFactoryCreateData, resource_data: &mut ResourceData, for_name: &Scheme) -> bool,tracing=false);
 define_hook!(NormalModuleFactoryAfterResolve: SeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> bool,tracing=false);
 define_hook!(NormalModuleFactoryCreateModule: SeriesBail(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData) -> BoxModule,tracing=false);
-define_hook!(NormalModuleFactoryModule: Series(data: &mut ModuleFactoryCreateData, create_data: &mut NormalModuleCreateData, module: &mut BoxModule),tracing=false);
+define_hook!(NormalModuleFactoryModule: Series(data: &mut ModuleFactoryCreateData, create_data: &NormalModuleCreateData, module: &mut BoxModule),tracing=false);
 define_hook!(NormalModuleFactoryParser: Series(module_type: &ModuleType, parser: &mut Box<dyn ParserAndGenerator>, parser_options: Option<&ParserOptions>),tracing=false);
 define_hook!(NormalModuleFactoryResolveLoader: SeriesBail(context: &Context, resolver: &Resolver, l: &ModuleRuleUseLoader) -> BoxLoader,tracing=false);
 define_hook!(NormalModuleFactoryAfterFactorize: Series(data: &mut ModuleFactoryCreateData, module: &mut BoxModule),tracing=false);
@@ -36,6 +36,57 @@ define_hook!(NormalModuleFactoryAfterFactorize: Series(data: &mut ModuleFactoryC
 pub enum NormalModuleFactoryResolveResult {
   Module(BoxModule),
   Ignored,
+}
+
+#[derive(Debug)]
+pub enum NormalModuleCreateDataResource {
+  Owned(ResourceData),
+  Shared(Arc<ResourceData>),
+}
+
+impl NormalModuleCreateDataResource {
+  fn into_shared(self) -> Arc<ResourceData> {
+    match self {
+      Self::Owned(resource_data) => Arc::new(resource_data),
+      Self::Shared(resource_data) => resource_data,
+    }
+  }
+
+  fn take_shared(&mut self) -> Arc<ResourceData> {
+    let shared = std::mem::replace(
+      self,
+      Self::Owned(ResourceData::new_with_resource(String::new())),
+    )
+    .into_shared();
+    *self = Self::Shared(Arc::clone(&shared));
+    shared
+  }
+
+  pub fn update_resource_data(&mut self, new_resource: String) {
+    match self {
+      Self::Owned(resource_data) => resource_data.update_resource_data(new_resource),
+      Self::Shared(_) => {
+        panic!("shared resource resolve data cannot be mutated after module creation")
+      }
+    }
+  }
+}
+
+impl Deref for NormalModuleCreateDataResource {
+  type Target = ResourceData;
+
+  fn deref(&self) -> &Self::Target {
+    match self {
+      Self::Owned(resource_data) => resource_data,
+      Self::Shared(resource_data) => resource_data,
+    }
+  }
+}
+
+impl AsRef<ResourceData> for NormalModuleCreateDataResource {
+  fn as_ref(&self) -> &ResourceData {
+    self
+  }
 }
 
 fn create_global_parser_options_cache(
@@ -223,6 +274,24 @@ mod tests {
       .expect("javascript parser options should be resolved");
     assert_eq!(options.jsx, Some(false));
     assert_eq!(options.require_dynamic, Some(true));
+  }
+
+  #[test]
+  fn reuse_create_data_resource_resolve_data_for_normal_module() {
+    let resource_data = ResourceData::new_with_resource("/a.js".to_string());
+    let mut create_data = NormalModuleCreateData {
+      raw_request: "./a".to_string(),
+      request: "/a.js".to_string(),
+      user_request: "./a".to_string(),
+      resource_resolve_data: NormalModuleCreateDataResource::Owned(resource_data),
+      match_resource: None,
+      side_effects: None,
+      context: None,
+    };
+
+    let resource_data = create_data.resource_resolve_data.take_shared();
+
+    assert_eq!(resource_data.resource(), "/a.js");
   }
 }
 
@@ -700,7 +769,7 @@ module.exports = "data:,";
           .map(|d| d.resource().to_owned()),
         side_effects: resolved_side_effects,
         context: resource_data.context().map(|c| c.to_owned()),
-        resource_resolve_data: resource_data,
+        resource_resolve_data: NormalModuleCreateDataResource::Owned(resource_data),
       };
       if let Some(plugin_result) = self
         .plugin_driver
@@ -727,6 +796,7 @@ module.exports = "data:,";
     {
       module
     } else {
+      let resource_resolve_data = create_data.resource_resolve_data.take_shared();
       NormalModule::new(
         create_data.request.clone(),
         create_data.user_request.clone(),
@@ -737,7 +807,7 @@ module.exports = "data:,";
         resolved_parser_options,
         resolved_generator_options,
         match_resource_data,
-        Arc::new(create_data.resource_resolve_data.clone()),
+        resource_resolve_data.clone(),
         resolved_resolve_options,
         loaders,
         create_data.context.clone().map(|x| x.into()),
@@ -750,7 +820,7 @@ module.exports = "data:,";
       .plugin_driver
       .normal_module_factory_hooks
       .module
-      .call(data, &mut create_data, &mut module)
+      .call(data, &create_data, &mut module)
       .await?;
 
     data.add_file_dependencies(file_dependencies);
@@ -1007,7 +1077,7 @@ pub struct NormalModuleCreateData {
   pub raw_request: String,
   pub request: String,
   pub user_request: String,
-  pub resource_resolve_data: ResourceData,
+  pub resource_resolve_data: NormalModuleCreateDataResource,
   pub match_resource: Option<String>,
   pub side_effects: Option<bool>,
   pub context: Option<String>,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
@@ -14,7 +14,7 @@ use crate::{
   DependencyType, FactoryMeta, FuncUseCtx, GeneratorOptions, ModuleExt, ModuleFactory,
   ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleRuleEffect,
   ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, ModuleType, NormalModule,
-  ParserAndGenerator, ParserOptions, RawModule, Resolve, ResolveArgs,
+  ParserAndGenerator, ParserOptions, ParserOptionsMap, RawModule, Resolve, ResolveArgs,
   ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory, ResourceData,
   ResourceParsedData, RunnerContext, RuntimeGlobals, SharedPluginDriver,
   diagnostics::EmptyDependency, module_rules_matcher, parse_resource, resolve,
@@ -36,6 +36,105 @@ define_hook!(NormalModuleFactoryAfterFactorize: Series(data: &mut ModuleFactoryC
 pub enum NormalModuleFactoryResolveResult {
   Module(BoxModule),
   Ignored,
+}
+
+fn create_global_parser_options_cache(
+  parser_options: Option<&ParserOptionsMap>,
+) -> HashMap<String, Arc<ParserOptions>> {
+  let mut cache = HashMap::new();
+  let Some(parser_options) = parser_options else {
+    return cache;
+  };
+
+  for (key, options) in parser_options.iter() {
+    cache.insert(key.clone(), Arc::new(options.clone()));
+  }
+
+  for module_type in [
+    ModuleType::JsAuto,
+    ModuleType::JsDynamic,
+    ModuleType::JsEsm,
+    ModuleType::CssAuto,
+    ModuleType::CssModule,
+  ] {
+    if let Some(options) = resolve_global_parser_options(parser_options, &module_type) {
+      cache.insert(module_type.as_str().to_owned(), Arc::new(options));
+    }
+  }
+
+  cache
+}
+
+fn resolve_global_parser_options(
+  parser_options: &ParserOptionsMap,
+  module_type: &ModuleType,
+) -> Option<ParserOptions> {
+  let options = parser_options.get(module_type.as_str());
+  match module_type {
+    ModuleType::JsAuto | ModuleType::JsDynamic | ModuleType::JsEsm => {
+      // Merge `module.parser.["javascript/xxx"]` with `module.parser.["javascript"]` first.
+      rspack_util::merge_from_optional_with(
+        parser_options.get("javascript").cloned(),
+        options,
+        |javascript_options, options| match (javascript_options, options) {
+          (
+            ParserOptions::Javascript(a),
+            ParserOptions::JavascriptAuto(b)
+            | ParserOptions::JavascriptDynamic(b)
+            | ParserOptions::JavascriptEsm(b),
+          ) => ParserOptions::Javascript(a.merge_from(b)),
+          _ => unreachable!(),
+        },
+      )
+    }
+    ModuleType::CssAuto | ModuleType::CssModule => rspack_util::merge_from_optional_with(
+      parser_options.get("css").cloned(),
+      options,
+      |css_options, options| match (css_options, options) {
+        (ParserOptions::Css(a), ParserOptions::CssAuto(b)) => {
+          ParserOptions::CssAuto(Into::<CssAutoParserOptions>::into(a).merge_from(b))
+        }
+        (ParserOptions::Css(a), ParserOptions::CssModule(b)) => {
+          ParserOptions::CssModule(Into::<CssModuleParserOptions>::into(a).merge_from(b))
+        }
+        _ => unreachable!(),
+      },
+    ),
+    _ => options.cloned(),
+  }
+}
+
+fn merge_parser_options_with_local(
+  global_parser: Option<Arc<ParserOptions>>,
+  local_parser: Option<&ParserOptions>,
+) -> Option<Arc<ParserOptions>> {
+  match (global_parser, local_parser) {
+    (None, None) => None,
+    (None, Some(local)) => Some(Arc::new(local.clone())),
+    (Some(global), None) => Some(global),
+    (Some(global), Some(local)) => Some(Arc::new(match (&*global, local) {
+      (ParserOptions::Asset(a), ParserOptions::Asset(b)) => {
+        ParserOptions::Asset(a.clone().merge_from(b))
+      }
+      (ParserOptions::Css(a), ParserOptions::Css(b)) => ParserOptions::Css(a.clone().merge_from(b)),
+      (ParserOptions::CssAuto(a), ParserOptions::CssAuto(b)) => {
+        ParserOptions::CssAuto(a.clone().merge_from(b))
+      }
+      (ParserOptions::CssModule(a), ParserOptions::CssModule(b)) => {
+        ParserOptions::CssModule(a.clone().merge_from(b))
+      }
+      (
+        ParserOptions::Javascript(a),
+        ParserOptions::JavascriptAuto(b)
+        | ParserOptions::JavascriptDynamic(b)
+        | ParserOptions::JavascriptEsm(b),
+      ) => ParserOptions::Javascript(a.clone().merge_from(b)),
+      (ParserOptions::Json(a), ParserOptions::Json(b)) => {
+        ParserOptions::Json(a.clone().merge_from(b))
+      }
+      (global, _) => global.clone(),
+    })),
+  }
 }
 
 #[derive(Debug, Default)]
@@ -60,6 +159,7 @@ pub struct NormalModuleFactoryHooks {
 #[derive(Debug)]
 pub struct NormalModuleFactory {
   options: Arc<CompilerOptions>,
+  global_parser_options: HashMap<String, Arc<ParserOptions>>,
   loader_resolver_factory: Arc<ResolverFactory>,
   plugin_driver: SharedPluginDriver,
 }
@@ -85,6 +185,47 @@ impl ModuleFactory for NormalModuleFactory {
   }
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::JavascriptParserOptions;
+
+  #[test]
+  fn reuse_global_parser_options_when_local_options_are_empty() {
+    let global = Arc::new(ParserOptions::Javascript(JavascriptParserOptions {
+      jsx: Some(true),
+      ..Default::default()
+    }));
+
+    let resolved = merge_parser_options_with_local(Some(Arc::clone(&global)), None)
+      .expect("global parser options should be reused");
+
+    assert!(Arc::ptr_eq(&resolved, &global));
+  }
+
+  #[test]
+  fn merge_local_parser_options_into_global_parser_options() {
+    let global = Arc::new(ParserOptions::Javascript(JavascriptParserOptions {
+      jsx: Some(true),
+      require_dynamic: Some(true),
+      ..Default::default()
+    }));
+    let local = ParserOptions::JavascriptAuto(JavascriptParserOptions {
+      jsx: Some(false),
+      ..Default::default()
+    });
+
+    let resolved = merge_parser_options_with_local(Some(global), Some(&local))
+      .expect("merged parser options should exist");
+
+    let options = resolved
+      .get_javascript()
+      .expect("javascript parser options should be resolved");
+    assert_eq!(options.jsx, Some(false));
+    assert_eq!(options.require_dynamic, Some(true));
+  }
+}
+
 const HYPHEN: char = '-';
 const EXCLAMATION: char = '!';
 const DOT: char = '.';
@@ -97,8 +238,10 @@ impl NormalModuleFactory {
     loader_resolver_factory: Arc<ResolverFactory>,
     plugin_driver: SharedPluginDriver,
   ) -> Self {
+    let global_parser_options = create_global_parser_options_cache(options.module.parser.as_ref());
     Self {
       options,
+      global_parser_options,
       loader_resolver_factory,
       plugin_driver,
     }
@@ -533,7 +676,7 @@ module.exports = "data:,";
           resolved_module_type.as_str()
         )
       })?(
-      resolved_parser_options.as_ref(),
+      resolved_parser_options.as_deref(),
       resolved_generator_options.as_ref(),
     );
     self
@@ -543,7 +686,7 @@ module.exports = "data:,";
       .call(
         &resolved_module_type,
         &mut resolved_parser_and_generator,
-        resolved_parser_options.as_ref(),
+        resolved_parser_options.as_deref(),
       )
       .await?;
 
@@ -693,42 +836,11 @@ module.exports = "data:,";
     module_type: &ModuleType,
     parser: Option<ParserOptions>,
     generator: Option<GeneratorOptions>,
-  ) -> (Option<ParserOptions>, Option<GeneratorOptions>) {
-    let global_parser = self.options.module.parser.as_ref().and_then(|p| {
-      let options = p.get(module_type.as_str());
-      match module_type {
-        ModuleType::JsAuto | ModuleType::JsDynamic | ModuleType::JsEsm => {
-          // Merge `module.parser.["javascript/xxx"]` with `module.parser.["javascript"]` first
-          rspack_util::merge_from_optional_with(
-            p.get("javascript").cloned(),
-            options,
-            |javascript_options, options| match (javascript_options, options) {
-              (
-                ParserOptions::Javascript(a),
-                ParserOptions::JavascriptAuto(b)
-                | ParserOptions::JavascriptDynamic(b)
-                | ParserOptions::JavascriptEsm(b),
-              ) => ParserOptions::Javascript(a.merge_from(b)),
-              _ => unreachable!(),
-            },
-          )
-        }
-        ModuleType::CssAuto | ModuleType::CssModule => rspack_util::merge_from_optional_with(
-          p.get("css").cloned(),
-          options,
-          |css_options, options| match (css_options, options) {
-            (ParserOptions::Css(a), ParserOptions::CssAuto(b)) => {
-              ParserOptions::CssAuto(Into::<CssAutoParserOptions>::into(a).merge_from(b))
-            }
-            (ParserOptions::Css(a), ParserOptions::CssModule(b)) => {
-              ParserOptions::CssModule(Into::<CssModuleParserOptions>::into(a).merge_from(b))
-            }
-            _ => unreachable!(),
-          },
-        ),
-        _ => options.cloned(),
-      }
-    });
+  ) -> (Option<Arc<ParserOptions>>, Option<GeneratorOptions>) {
+    let global_parser = self
+      .global_parser_options
+      .get(module_type.as_str())
+      .map(Arc::clone);
     let global_generator = self.options.module.generator.as_ref().and_then(|g| {
       let options = g.get(module_type.as_str());
 
@@ -778,28 +890,7 @@ module.exports = "data:,";
         _ => options.cloned(),
       }
     });
-    let parser = rspack_util::merge_from_optional_with(
-      global_parser,
-      parser.as_ref(),
-      |global, local| match (global, local) {
-        (ParserOptions::Asset(a), ParserOptions::Asset(b)) => ParserOptions::Asset(a.merge_from(b)),
-        (ParserOptions::Css(a), ParserOptions::Css(b)) => ParserOptions::Css(a.merge_from(b)),
-        (ParserOptions::CssAuto(a), ParserOptions::CssAuto(b)) => {
-          ParserOptions::CssAuto(a.merge_from(b))
-        }
-        (ParserOptions::CssModule(a), ParserOptions::CssModule(b)) => {
-          ParserOptions::CssModule(a.merge_from(b))
-        }
-        (
-          ParserOptions::Javascript(a),
-          ParserOptions::JavascriptAuto(b)
-          | ParserOptions::JavascriptDynamic(b)
-          | ParserOptions::JavascriptEsm(b),
-        ) => ParserOptions::Javascript(a.merge_from(b)),
-        (ParserOptions::Json(a), ParserOptions::Json(b)) => ParserOptions::Json(a.merge_from(b)),
-        (global, _) => global,
-      },
-    );
+    let parser = merge_parser_options_with_local(global_parser, parser.as_ref());
     let generator = rspack_util::merge_from_optional_with(
       global_generator,
       generator.as_ref(),

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -541,11 +541,11 @@ impl NormalModuleFactory {
           resolve_options: data.resolve_options.clone(),
           resolve_to_context: false,
           optional: dependency_optional,
-          file_dependencies: &mut file_dependencies,
-          missing_dependencies: &mut missing_dependencies,
         };
 
-        let resource_data = resolve(resolve_args, plugin_driver).await;
+        let (resource_data, resolve_dependencies) = resolve(resolve_args, plugin_driver).await;
+        file_dependencies = resolve_dependencies.file_dependencies;
+        missing_dependencies = resolve_dependencies.missing_dependencies;
 
         match resource_data {
           Ok(ResolveResult::Resource(resource)) => resource.into(),
@@ -585,8 +585,8 @@ module.exports = "data:,";
             return Ok(Some(ModuleFactoryResult::new_with_module(raw_module)));
           }
           Err(err) => {
-            data.add_file_dependencies(file_dependencies);
-            data.add_missing_dependencies(missing_dependencies);
+            data.file_dependencies = file_dependencies;
+            data.missing_dependencies = missing_dependencies;
             return Err(err);
           }
         }
@@ -826,8 +826,8 @@ module.exports = "data:,";
       .call(data, &create_data, &mut module)
       .await?;
 
-    data.add_file_dependencies(file_dependencies);
-    data.add_missing_dependencies(missing_dependencies);
+    data.file_dependencies = file_dependencies;
+    data.missing_dependencies = missing_dependencies;
 
     Ok(Some(ModuleFactoryResult::new_with_module(module)))
   }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -39,6 +39,7 @@ pub enum NormalModuleFactoryResolveResult {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum NormalModuleCreateDataResource {
   Owned(ResourceData),
   Shared(Arc<ResourceData>),
@@ -53,12 +54,8 @@ impl NormalModuleCreateDataResource {
   }
 
   fn take_shared(&mut self) -> Arc<ResourceData> {
-    let shared = std::mem::replace(
-      self,
-      Self::Owned(ResourceData::new_with_resource(String::new())),
-    )
-    .into_shared();
-    *self = Self::Shared(Arc::clone(&shared));
+    let shared = std::mem::take(self).into_shared();
+    *self = Self::Shared(shared.clone());
     shared
   }
 
@@ -69,6 +66,12 @@ impl NormalModuleCreateDataResource {
         panic!("shared resource resolve data cannot be mutated after module creation")
       }
     }
+  }
+}
+
+impl Default for NormalModuleCreateDataResource {
+  fn default() -> Self {
+    Self::Owned(ResourceData::default())
   }
 }
 
@@ -807,7 +810,7 @@ module.exports = "data:,";
         resolved_parser_options,
         resolved_generator_options,
         match_resource_data,
-        resource_resolve_data.clone(),
+        resource_resolve_data,
         resolved_resolve_options,
         loaders,
         create_data.context.clone().map(|x| x.into()),

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -891,7 +891,10 @@ pub enum RuleSetCondition {
   String(String),
   Regexp(RspackRegex),
   Logical(Box<RuleSetLogicalConditions>),
-  Array(Vec<RuleSetCondition>),
+  Array {
+    items: Vec<RuleSetCondition>,
+    can_sync: bool,
+  },
   Func(RuleSetConditionFnMatcher),
 }
 
@@ -901,7 +904,7 @@ impl fmt::Debug for RuleSetCondition {
       Self::String(i) => i.fmt(f),
       Self::Regexp(i) => i.fmt(f),
       Self::Logical(i) => i.fmt(f),
-      Self::Array(i) => i.fmt(f),
+      Self::Array { items, .. } => items.fmt(f),
       Self::Func(_) => "Func(...)".fmt(f),
     }
   }
@@ -942,6 +945,20 @@ impl DataRef<'_> {
 }
 
 impl RuleSetCondition {
+  pub fn array(items: Vec<RuleSetCondition>) -> Self {
+    let can_sync = items.iter().all(Self::can_sync);
+    Self::Array { items, can_sync }
+  }
+
+  fn can_sync(&self) -> bool {
+    match self {
+      Self::String(_) | Self::Regexp(_) => true,
+      Self::Logical(logical) => logical.can_sync,
+      Self::Array { can_sync, .. } => *can_sync,
+      Self::Func(_) => false,
+    }
+  }
+
   pub fn try_match_sync(&self, data: DataRef<'_>) -> Option<Result<bool>> {
     match self {
       Self::String(s) => Some(Ok(
@@ -953,9 +970,17 @@ impl RuleSetCondition {
       Self::Regexp(r) => Some(Ok(
         data.as_str().map(|data| r.test(data)).unwrap_or_default(),
       )),
-      Self::Logical(g) => g.try_match_sync(data),
-      Self::Array(l) => {
-        for item in l {
+      Self::Logical(g) => {
+        if !g.can_sync {
+          return None;
+        }
+        g.try_match_sync(data)
+      }
+      Self::Array { items, can_sync } => {
+        if !can_sync {
+          return None;
+        }
+        for item in items {
           match item.try_match_sync(data) {
             Some(Ok(true)) => return Some(Ok(true)),
             Some(Ok(false)) => {}
@@ -983,7 +1008,7 @@ impl RuleSetCondition {
           .try_match_sync(data)
           .expect("non-function condition should match synchronously"),
         Self::Logical(g) => g.try_match_async(data).await,
-        Self::Array(l) => try_any(l, |i| i.try_match(data)).await,
+        Self::Array { items, .. } => try_any(items, |i| i.try_match(data)).await,
         Self::Func(f) => f(data).await,
       }
     })
@@ -994,11 +1019,11 @@ impl RuleSetCondition {
       RuleSetCondition::String(s) => Some(Ok(s.is_empty())),
       RuleSetCondition::Regexp(rspack_regex) => Some(Ok(rspack_regex.test(""))),
       RuleSetCondition::Logical(logical) => logical.match_when_empty_sync(),
-      RuleSetCondition::Array(arr) => {
-        if !arr.is_empty() {
+      RuleSetCondition::Array { items, .. } => {
+        if !items.is_empty() {
           return Some(Ok(false));
         }
-        for item in arr {
+        for item in items {
           match item.match_when_empty_sync() {
             Some(Ok(true)) => return Some(Ok(true)),
             Some(Ok(false)) => {}
@@ -1022,11 +1047,11 @@ impl RuleSetCondition {
   fn match_when_empty_async(&self) -> BoxFuture<'_, Result<bool>> {
     Box::pin(async move {
       let res = match self {
-        RuleSetCondition::String(_) | RuleSetCondition::Regexp(_) | RuleSetCondition::Array(_) => {
-          self
-            .match_when_empty_sync()
-            .expect("non-function condition should match synchronously")?
-        }
+        RuleSetCondition::String(_)
+        | RuleSetCondition::Regexp(_)
+        | RuleSetCondition::Array { .. } => self
+          .match_when_empty_sync()
+          .expect("non-function condition should match synchronously")?,
         RuleSetCondition::Logical(logical) => logical.match_when_empty_async().await?,
         RuleSetCondition::Func(func) => func("".into()).await?,
       };
@@ -1079,15 +1104,53 @@ impl From<RuleSetCondition> for RuleSetConditionWithEmpty {
   }
 }
 
-#[derive(Debug, Default)]
 pub struct RuleSetLogicalConditions {
   pub and: Option<Vec<RuleSetCondition>>,
   pub or: Option<Vec<RuleSetCondition>>,
   pub not: Option<RuleSetCondition>,
+  can_sync: bool,
+}
+
+impl Default for RuleSetLogicalConditions {
+  fn default() -> Self {
+    Self::new(None, None, None)
+  }
+}
+
+impl fmt::Debug for RuleSetLogicalConditions {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("RuleSetLogicalConditions")
+      .field("and", &self.and)
+      .field("or", &self.or)
+      .field("not", &self.not)
+      .finish()
+  }
 }
 
 impl RuleSetLogicalConditions {
+  pub fn new(
+    and: Option<Vec<RuleSetCondition>>,
+    or: Option<Vec<RuleSetCondition>>,
+    not: Option<RuleSetCondition>,
+  ) -> Self {
+    let can_sync = and
+      .iter()
+      .flatten()
+      .chain(or.iter().flatten())
+      .all(RuleSetCondition::can_sync)
+      && not.as_ref().is_none_or(RuleSetCondition::can_sync);
+    Self {
+      and,
+      or,
+      not,
+      can_sync,
+    }
+  }
+
   fn try_match_sync(&self, data: DataRef<'_>) -> Option<Result<bool>> {
+    if !self.can_sync {
+      return None;
+    }
     if let Some(and) = &self.and {
       for item in and {
         match item.try_match_sync(data) {
@@ -1156,6 +1219,9 @@ impl RuleSetLogicalConditions {
   }
 
   fn match_when_empty_sync(&self) -> Option<Result<bool>> {
+    if !self.can_sync {
+      return None;
+    }
     let mut has_condition = false;
     let mut match_when_empty = true;
     if let Some(and) = &self.and {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -942,34 +942,96 @@ impl DataRef<'_> {
 }
 
 impl RuleSetCondition {
-  #[async_recursion]
-  pub async fn try_match(&self, data: DataRef<'async_recursion>) -> Result<bool> {
+  pub fn try_match_sync(&self, data: DataRef<'_>) -> Option<Result<bool>> {
     match self {
-      Self::String(s) => Ok(
+      Self::String(s) => Some(Ok(
         data
           .as_str()
           .map(|data| data.starts_with(s))
           .unwrap_or_default(),
-      ),
-      Self::Regexp(r) => Ok(data.as_str().map(|data| r.test(data)).unwrap_or_default()),
-      Self::Logical(g) => g.try_match(data).await,
-      Self::Array(l) => try_any(l, |i| async { i.try_match(data).await }).await,
-      Self::Func(f) => f(data).await,
+      )),
+      Self::Regexp(r) => Some(Ok(
+        data.as_str().map(|data| r.test(data)).unwrap_or_default(),
+      )),
+      Self::Logical(g) => g.try_match_sync(data),
+      Self::Array(l) => {
+        for item in l {
+          match item.try_match_sync(data) {
+            Some(Ok(true)) => return Some(Ok(true)),
+            Some(Ok(false)) => {}
+            Some(Err(err)) => return Some(Err(err)),
+            None => return None,
+          }
+        }
+        Some(Ok(false))
+      }
+      Self::Func(_) => None,
     }
   }
 
-  #[async_recursion]
-  async fn match_when_empty(&self) -> Result<bool> {
-    let res = match self {
-      RuleSetCondition::String(s) => s.is_empty(),
-      RuleSetCondition::Regexp(rspack_regex) => rspack_regex.test(""),
-      RuleSetCondition::Logical(logical) => logical.match_when_empty().await?,
-      RuleSetCondition::Array(arr) => {
-        arr.is_empty() && try_any(arr, |c| async move { c.match_when_empty().await }).await?
+  pub async fn try_match(&self, data: DataRef<'_>) -> Result<bool> {
+    if let Some(result) = self.try_match_sync(data) {
+      return result;
+    }
+    self.try_match_async(data).await
+  }
+
+  fn try_match_async<'a>(&'a self, data: DataRef<'a>) -> BoxFuture<'a, Result<bool>> {
+    Box::pin(async move {
+      match self {
+        Self::String(_) | Self::Regexp(_) => self
+          .try_match_sync(data)
+          .expect("non-function condition should match synchronously"),
+        Self::Logical(g) => g.try_match_async(data).await,
+        Self::Array(l) => try_any(l, |i| i.try_match(data)).await,
+        Self::Func(f) => f(data).await,
       }
-      RuleSetCondition::Func(func) => func("".into()).await?,
-    };
-    Ok(res)
+    })
+  }
+
+  fn match_when_empty_sync(&self) -> Option<Result<bool>> {
+    match self {
+      RuleSetCondition::String(s) => Some(Ok(s.is_empty())),
+      RuleSetCondition::Regexp(rspack_regex) => Some(Ok(rspack_regex.test(""))),
+      RuleSetCondition::Logical(logical) => logical.match_when_empty_sync(),
+      RuleSetCondition::Array(arr) => {
+        if !arr.is_empty() {
+          return Some(Ok(false));
+        }
+        for item in arr {
+          match item.match_when_empty_sync() {
+            Some(Ok(true)) => return Some(Ok(true)),
+            Some(Ok(false)) => {}
+            Some(Err(err)) => return Some(Err(err)),
+            None => return None,
+          }
+        }
+        Some(Ok(false))
+      }
+      RuleSetCondition::Func(_) => None,
+    }
+  }
+
+  async fn match_when_empty(&self) -> Result<bool> {
+    if let Some(result) = self.match_when_empty_sync() {
+      return result;
+    }
+    self.match_when_empty_async().await
+  }
+
+  fn match_when_empty_async(&self) -> BoxFuture<'_, Result<bool>> {
+    Box::pin(async move {
+      let res = match self {
+        RuleSetCondition::String(_) | RuleSetCondition::Regexp(_) | RuleSetCondition::Array(_) => {
+          self
+            .match_when_empty_sync()
+            .expect("non-function condition should match synchronously")?
+        }
+        RuleSetCondition::Logical(logical) => logical.match_when_empty_async().await?,
+        RuleSetCondition::Func(func) => func("".into()).await?,
+      };
+      Ok(res)
+    })
   }
 }
 
@@ -987,11 +1049,22 @@ impl RuleSetConditionWithEmpty {
     }
   }
 
+  pub fn try_match_sync(&self, data: DataRef<'_>) -> Option<Result<bool>> {
+    self.condition.try_match_sync(data)
+  }
+
   pub async fn try_match(&self, data: DataRef<'_>) -> Result<bool> {
     self.condition.try_match(data).await
   }
 
+  pub fn match_when_empty_sync(&self) -> Option<Result<bool>> {
+    self.condition.match_when_empty_sync()
+  }
+
   pub async fn match_when_empty(&self) -> Result<bool> {
+    if let Some(result) = self.match_when_empty_sync() {
+      return result;
+    }
     self
       .match_when_empty
       .get_or_try_init(|| async { self.condition.match_when_empty().await })
@@ -1014,43 +1087,160 @@ pub struct RuleSetLogicalConditions {
 }
 
 impl RuleSetLogicalConditions {
-  #[async_recursion]
-  pub async fn try_match(&self, data: DataRef<'async_recursion>) -> Result<bool> {
-    if let Some(and) = &self.and
-      && try_any(and, |i| async { i.try_match(data).await.map(|i| !i) }).await?
-    {
-      return Ok(false);
+  fn try_match_sync(&self, data: DataRef<'_>) -> Option<Result<bool>> {
+    if let Some(and) = &self.and {
+      for item in and {
+        match item.try_match_sync(data) {
+          Some(Ok(true)) => {}
+          Some(Ok(false)) => return Some(Ok(false)),
+          Some(Err(err)) => return Some(Err(err)),
+          None => return None,
+        }
+      }
     }
-    if let Some(or) = &self.or
-      && try_all(or, |i| async { i.try_match(data).await.map(|i| !i) }).await?
-    {
-      return Ok(false);
+    if let Some(or) = &self.or {
+      let mut matched = false;
+      for item in or {
+        match item.try_match_sync(data) {
+          Some(Ok(true)) => {
+            matched = true;
+            break;
+          }
+          Some(Ok(false)) => {}
+          Some(Err(err)) => return Some(Err(err)),
+          None => return None,
+        }
+      }
+      if !matched {
+        return Some(Ok(false));
+      }
     }
     if let Some(not) = &self.not
-      && not.try_match(data).await?
+      && match not.try_match_sync(data) {
+        Some(Ok(value)) => value,
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+      }
     {
-      return Ok(false);
+      return Some(Ok(false));
     }
-    Ok(true)
+    Some(Ok(true))
   }
 
-  pub async fn match_when_empty(&self) -> Result<bool> {
+  pub async fn try_match(&self, data: DataRef<'_>) -> Result<bool> {
+    if let Some(result) = self.try_match_sync(data) {
+      return result;
+    }
+    self.try_match_async(data).await
+  }
+
+  fn try_match_async<'a>(&'a self, data: DataRef<'a>) -> BoxFuture<'a, Result<bool>> {
+    Box::pin(async move {
+      if let Some(and) = &self.and
+        && try_any(and, |i| async { i.try_match(data).await.map(|i| !i) }).await?
+      {
+        return Ok(false);
+      }
+      if let Some(or) = &self.or
+        && try_all(or, |i| async { i.try_match(data).await.map(|i| !i) }).await?
+      {
+        return Ok(false);
+      }
+      if let Some(not) = &self.not
+        && not.try_match(data).await?
+      {
+        return Ok(false);
+      }
+      Ok(true)
+    })
+  }
+
+  fn match_when_empty_sync(&self) -> Option<Result<bool>> {
     let mut has_condition = false;
     let mut match_when_empty = true;
     if let Some(and) = &self.and {
       has_condition = true;
-      match_when_empty &= try_all(and, |i| async { i.match_when_empty().await }).await?;
+      match try_all_sync(and, |i| i.match_when_empty_sync()) {
+        Some(Ok(value)) => match_when_empty &= value,
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+      }
     }
     if let Some(or) = &self.or {
       has_condition = true;
-      match_when_empty &= try_any(or, |i| async { i.match_when_empty().await }).await?;
+      match try_any_sync(or, |i| i.match_when_empty_sync()) {
+        Some(Ok(value)) => match_when_empty &= value,
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+      }
     }
     if let Some(not) = &self.not {
       has_condition = true;
-      match_when_empty &= !not.match_when_empty().await?;
+      match not.match_when_empty_sync() {
+        Some(Ok(value)) => match_when_empty &= !value,
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+      }
     }
-    Ok(has_condition && match_when_empty)
+    Some(Ok(has_condition && match_when_empty))
   }
+
+  pub async fn match_when_empty(&self) -> Result<bool> {
+    if let Some(result) = self.match_when_empty_sync() {
+      return result;
+    }
+    self.match_when_empty_async().await
+  }
+
+  fn match_when_empty_async(&self) -> BoxFuture<'_, Result<bool>> {
+    Box::pin(async move {
+      let mut has_condition = false;
+      let mut match_when_empty = true;
+      if let Some(and) = &self.and {
+        has_condition = true;
+        match_when_empty &= try_all(and, |i| async { i.match_when_empty().await }).await?;
+      }
+      if let Some(or) = &self.or {
+        has_condition = true;
+        match_when_empty &= try_any(or, |i| async { i.match_when_empty().await }).await?;
+      }
+      if let Some(not) = &self.not {
+        has_condition = true;
+        match_when_empty &= !not.match_when_empty().await?;
+      }
+      Ok(has_condition && match_when_empty)
+    })
+  }
+}
+
+fn try_any_sync<T, F, E>(items: &[T], f: F) -> Option<Result<bool, E>>
+where
+  F: Fn(&T) -> Option<Result<bool, E>>,
+{
+  for item in items {
+    match f(item) {
+      Some(Ok(true)) => return Some(Ok(true)),
+      Some(Ok(false)) => {}
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+  Some(Ok(false))
+}
+
+fn try_all_sync<T, F, E>(items: &[T], f: F) -> Option<Result<bool, E>>
+where
+  F: Fn(&T) -> Option<Result<bool, E>>,
+{
+  for item in items {
+    match f(item) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+  Some(Ok(true))
 }
 
 pub struct FuncUseCtx {

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -11,13 +11,15 @@ use regex::Regex;
 use rspack_error::Error;
 use rspack_fs::ReadableFileSystem;
 use rspack_loader_runner::{DescriptionData, ResourceData};
-use rspack_paths::{ArcPathSet, AssertUtf8, Utf8PathBuf};
+use rspack_paths::{AssertUtf8, Utf8PathBuf};
 use rspack_util::identifier::insert_zero_width_space_for_fragment;
 use sugar_path::SugarPath;
 
 pub use self::{
   factory::{ResolveOptionsWithDependencyType, ResolverFactory},
-  resolver_impl::{ResolveContext, ResolveInnerError, ResolveInnerOptions, Resolver},
+  resolver_impl::{
+    ResolveContext, ResolveDependencies, ResolveInnerError, ResolveInnerOptions, Resolver,
+  },
 };
 use crate::{
   Context, DependencyCategory, DependencyRange, DependencyType, ModuleIdentifier, Resolve,
@@ -42,8 +44,6 @@ pub struct ResolveArgs<'a> {
   pub resolve_options: Option<Arc<Resolve>>,
   pub resolve_to_context: bool,
   pub optional: bool,
-  pub file_dependencies: &'a mut ArcPathSet,
-  pub missing_dependencies: &'a mut ArcPathSet,
 }
 
 /// A successful path resolution or an ignored path.
@@ -309,7 +309,7 @@ if its extension was not listed in the `resolve.extensions`. Here're some possib
 pub async fn resolve(
   args: ResolveArgs<'_>,
   plugin_driver: &SharedPluginDriver,
-) -> Result<ResolveResult, Error> {
+) -> (Result<ResolveResult, Error>, ResolveDependencies) {
   let dep = ResolveOptionsWithDependencyType {
     resolve_options: args
       .resolve_options
@@ -319,12 +319,11 @@ pub async fn resolve(
     dependency_category: *args.dependency_category,
   };
 
-  let mut context = Default::default();
   let resolver = plugin_driver.resolver_factory.get(dep);
-  let mut result = resolver
-    .resolve_with_context(args.context.as_ref(), args.specifier, &mut context)
-    .await
-    .map_err(|error| error.into_resolve_error(&args));
+  let (result, dependencies) = resolver
+    .resolve_with_context(args.context.as_ref(), args.specifier)
+    .await;
+  let mut result = result.map_err(|error| error.into_resolve_error(&args));
 
   if let Err(ref err) = result {
     tracing::error!(
@@ -338,11 +337,6 @@ pub async fn resolve(
     );
   }
 
-  args.file_dependencies.extend(context.file_dependencies);
-  args
-    .missing_dependencies
-    .extend(context.missing_dependencies);
-
   if result.is_err()
     && let Some(hint) = resolve_for_error_hints(args, plugin_driver, resolver.inner_fs()).await
   {
@@ -352,5 +346,5 @@ pub async fn resolve(
     })
   };
 
-  result
+  (result, dependencies)
 }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -16,12 +16,14 @@ use crate::{
 };
 
 #[derive(Debug, Default, Clone)]
-pub struct ResolveContext {
+pub struct ResolveDependencies {
   /// Files that was found on file system
   pub file_dependencies: ArcPathSet,
   /// Dependencies that was not found on file system
   pub missing_dependencies: ArcPathSet,
 }
+
+pub type ResolveContext = ResolveDependencies;
 
 /// Proxy to [nodejs_resolver::Error] or [rspack_resolver::ResolveError]
 #[derive(Debug)]
@@ -160,20 +162,28 @@ impl Resolver {
     &self,
     path: &Path,
     request: &str,
-    resolve_context: &mut ResolveContext,
-  ) -> Result<ResolveResult, ResolveInnerError> {
+  ) -> (
+    Result<ResolveResult, ResolveInnerError>,
+    ResolveDependencies,
+  ) {
     let resolver = &self.resolver;
     let mut context = Default::default();
     let result = resolver
       .resolve_with_context(path, request, &mut context)
       .await;
-    resolve_context
-      .file_dependencies
-      .extend(context.file_dependencies.into_iter().map(Into::into));
-    resolve_context
-      .missing_dependencies
-      .extend(context.missing_dependencies.into_iter().map(Into::into));
-    match result {
+    let dependencies = ResolveDependencies {
+      file_dependencies: context
+        .file_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect(),
+      missing_dependencies: context
+        .missing_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect(),
+    };
+    let result = match result {
       Ok(r) => Ok(ResolveResult::Resource(Resource {
         path: r.path().to_path_buf().assert_utf8(),
         query: r.query().unwrap_or_default().to_string(),
@@ -184,7 +194,8 @@ impl Resolver {
       })),
       Err(rspack_resolver::ResolveError::Ignored(_)) => Ok(ResolveResult::Ignored),
       Err(error) => Err(ResolveInnerError::RspackResolver(error)),
-    }
+    };
+    (result, dependencies)
   }
 
   pub fn inner_fs(&self) -> Arc<dyn ReadableFileSystem> {

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -3,7 +3,10 @@ use rspack_error::Result;
 use rspack_loader_runner::ResourceData;
 use rspack_paths::Utf8Path;
 
-use crate::{DependencyCategory, ImportAttributes, ModuleRule, ModuleRuleEffect};
+use crate::{
+  DataRef, DependencyCategory, ImportAttributes, ModuleRule, ModuleRuleEffect,
+  RuleSetConditionWithEmpty,
+};
 
 pub async fn module_rules_matcher<'a>(
   rules: &'a [ModuleRule],
@@ -90,6 +93,48 @@ async fn module_rules_matcher_async<'a>(
   Ok(())
 }
 
+macro_rules! ensure_sync_matched {
+  ($result:expr) => {
+    match $result {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  };
+}
+
+macro_rules! ensure_sync_not_matched {
+  ($result:expr) => {
+    match $result {
+      Some(Ok(true)) => return Some(Ok(false)),
+      Some(Ok(false)) => {}
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  };
+}
+
+fn check_optional_sync(
+  condition: &RuleSetConditionWithEmpty,
+  data: Option<DataRef<'_>>,
+) -> Option<Result<bool>> {
+  match data {
+    Some(data) => condition.try_match_sync(data),
+    None => condition.match_when_empty_sync(),
+  }
+}
+
+async fn check_optional_async(
+  condition: &RuleSetConditionWithEmpty,
+  data: Option<DataRef<'_>>,
+) -> Result<bool> {
+  match data {
+    Some(data) => condition.try_match(data).await,
+    None => condition.match_when_empty().await,
+  }
+}
+
 /// Match the `ModuleRule` against the given `ResourceData`, and return the matching `ModuleRule` if matched.
 pub async fn module_rule_matcher<'a>(
   module_rule: &'a ModuleRule,
@@ -135,12 +180,7 @@ fn module_rule_matcher_sync<'a>(
   matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Option<Result<bool>> {
   if let Some(test_rule) = &module_rule.rspack_resource {
-    match test_rule.try_match_sync(resource_data.resource().into()) {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(test_rule.try_match_sync(resource_data.resource().into()));
   }
 
   let resource_path = resource_data
@@ -149,162 +189,76 @@ fn module_rule_matcher_sync<'a>(
     .as_str();
 
   if let Some(test_rule) = &module_rule.test {
-    match test_rule.try_match_sync(resource_path.into()) {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(test_rule.try_match_sync(resource_path.into()));
   } else if let Some(resource_rule) = &module_rule.resource {
-    match resource_rule.try_match_sync(resource_path.into()) {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(resource_rule.try_match_sync(resource_path.into()));
   }
 
   if let Some(include_rule) = &module_rule.include {
-    match include_rule.try_match_sync(resource_path.into()) {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(include_rule.try_match_sync(resource_path.into()));
   }
 
   if let Some(exclude_rule) = &module_rule.exclude {
-    match exclude_rule.try_match_sync(resource_path.into()) {
-      Some(Ok(true)) => return Some(Ok(false)),
-      Some(Ok(false)) => {}
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_not_matched!(exclude_rule.try_match_sync(resource_path.into()));
   }
 
   if let Some(resource_query_rule) = &module_rule.resource_query {
-    let result = if let Some(resource_query) = resource_data.query() {
-      resource_query_rule.try_match_sync(resource_query.into())
-    } else {
-      resource_query_rule.match_when_empty_sync()
-    };
-    match result {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(check_optional_sync(
+      resource_query_rule,
+      resource_data.query().map(Into::into),
+    ));
   }
 
   if let Some(resource_fragment_condition) = &module_rule.resource_fragment {
-    let result = if let Some(resource_fragment) = resource_data.fragment() {
-      resource_fragment_condition.try_match_sync(resource_fragment.into())
-    } else {
-      resource_fragment_condition.match_when_empty_sync()
-    };
-    match result {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(check_optional_sync(
+      resource_fragment_condition,
+      resource_data.fragment().map(Into::into),
+    ));
   }
 
   if let Some(mimetype_condition) = &module_rule.mimetype {
-    let result = if let Some(mimetype) = resource_data.mimetype() {
-      mimetype_condition.try_match_sync(mimetype.into())
-    } else {
-      mimetype_condition.match_when_empty_sync()
-    };
-    match result {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(check_optional_sync(
+      mimetype_condition,
+      resource_data.mimetype().map(Into::into),
+    ));
   }
 
   if let Some(scheme_condition) = &module_rule.scheme {
     let scheme = resource_data.get_scheme();
     if scheme.is_none() {
-      match scheme_condition.match_when_empty_sync() {
-        Some(Ok(true)) => {}
-        Some(Ok(false)) => return Some(Ok(false)),
-        Some(Err(err)) => return Some(Err(err)),
-        None => return None,
-      }
+      ensure_sync_matched!(scheme_condition.match_when_empty_sync());
     }
-    match scheme_condition.try_match_sync(scheme.as_str().into()) {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(scheme_condition.try_match_sync(scheme.as_str().into()));
   }
 
   if let Some(issuer_rule) = &module_rule.issuer {
-    let result = if let Some(issuer) = issuer {
-      issuer_rule.try_match_sync((*issuer).into())
-    } else {
-      issuer_rule.match_when_empty_sync()
-    };
-    match result {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(check_optional_sync(issuer_rule, issuer.map(Into::into)));
   }
 
   if let Some(issuer_layer_rule) = &module_rule.issuer_layer {
-    let result = if let Some(issuer_layer) = issuer_layer {
-      issuer_layer_rule.try_match_sync((*issuer_layer).into())
-    } else {
-      issuer_layer_rule.match_when_empty_sync()
-    };
-    match result {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(check_optional_sync(
+      issuer_layer_rule,
+      issuer_layer.map(Into::into),
+    ));
   }
 
   if let Some(dependency_rule) = &module_rule.dependency {
-    match dependency_rule.try_match_sync(dependency.as_str().into()) {
-      Some(Ok(true)) => {}
-      Some(Ok(false)) => return Some(Ok(false)),
-      Some(Err(err)) => return Some(Err(err)),
-      None => return None,
-    }
+    ensure_sync_matched!(dependency_rule.try_match_sync(dependency.as_str().into()));
   }
 
   if let Some(description_data) = &module_rule.description_data {
     if let Some(resource_description) = resource_data.description() {
       for (k, matcher) in description_data {
-        let result = if let Some(v) = k
-          .split('.')
-          .try_fold(resource_description.json(), |acc, key| acc.get(key))
-        {
-          matcher.try_match_sync(v.into())
-        } else {
-          matcher.match_when_empty_sync()
-        };
-        match result {
-          Some(Ok(true)) => {}
-          Some(Ok(false)) => return Some(Ok(false)),
-          Some(Err(err)) => return Some(Err(err)),
-          None => return None,
-        }
+        ensure_sync_matched!(check_optional_sync(
+          matcher,
+          k.split('.')
+            .try_fold(resource_description.json(), |acc, key| acc.get(key))
+            .map(Into::into),
+        ));
       }
     } else {
       for matcher in description_data.values() {
-        match matcher.match_when_empty_sync() {
-          Some(Ok(true)) => {}
-          Some(Ok(false)) => return Some(Ok(false)),
-          Some(Err(err)) => return Some(Err(err)),
-          None => return None,
-        }
+        ensure_sync_matched!(matcher.match_when_empty_sync());
       }
     }
   }
@@ -312,26 +266,14 @@ fn module_rule_matcher_sync<'a>(
   if let Some(with) = &module_rule.with {
     if let Some(attributes) = attributes {
       for (k, matcher) in with {
-        let result = if let Some(v) = attributes.get(k) {
-          matcher.try_match_sync(v.into())
-        } else {
-          matcher.match_when_empty_sync()
-        };
-        match result {
-          Some(Ok(true)) => {}
-          Some(Ok(false)) => return Some(Ok(false)),
-          Some(Err(err)) => return Some(Err(err)),
-          None => return None,
-        }
+        ensure_sync_matched!(check_optional_sync(
+          matcher,
+          attributes.get(k).map(Into::into),
+        ));
       }
     } else {
       for matcher in with.values() {
-        match matcher.match_when_empty_sync() {
-          Some(Ok(true)) => {}
-          Some(Ok(false)) => return Some(Ok(false)),
-          Some(Err(err)) => return Some(Err(err)),
-          None => return None,
-        }
+        ensure_sync_matched!(matcher.match_when_empty_sync());
       }
     }
   }
@@ -428,37 +370,26 @@ async fn module_rule_matcher_async<'a>(
     return Ok(false);
   }
 
-  if let Some(resource_query_rule) = &module_rule.resource_query {
-    if let Some(resource_query) = resource_data.query() {
-      if !resource_query_rule.try_match(resource_query.into()).await? {
-        return Ok(false);
-      }
-    } else if !resource_query_rule.match_when_empty().await? {
-      return Ok(false);
-    }
+  if let Some(resource_query_rule) = &module_rule.resource_query
+    && !check_optional_async(resource_query_rule, resource_data.query().map(Into::into)).await?
+  {
+    return Ok(false);
   }
 
-  if let Some(resource_fragment_condition) = &module_rule.resource_fragment {
-    if let Some(resource_fragment) = resource_data.fragment() {
-      if !resource_fragment_condition
-        .try_match(resource_fragment.into())
-        .await?
-      {
-        return Ok(false);
-      }
-    } else if !resource_fragment_condition.match_when_empty().await? {
-      return Ok(false);
-    }
+  if let Some(resource_fragment_condition) = &module_rule.resource_fragment
+    && !check_optional_async(
+      resource_fragment_condition,
+      resource_data.fragment().map(Into::into),
+    )
+    .await?
+  {
+    return Ok(false);
   }
 
-  if let Some(mimetype_condition) = &module_rule.mimetype {
-    if let Some(mimetype) = resource_data.mimetype() {
-      if !mimetype_condition.try_match(mimetype.into()).await? {
-        return Ok(false);
-      }
-    } else if !mimetype_condition.match_when_empty().await? {
-      return Ok(false);
-    }
+  if let Some(mimetype_condition) = &module_rule.mimetype
+    && !check_optional_async(mimetype_condition, resource_data.mimetype().map(Into::into)).await?
+  {
+    return Ok(false);
   }
 
   if let Some(scheme_condition) = &module_rule.scheme {
@@ -471,34 +402,16 @@ async fn module_rule_matcher_async<'a>(
     }
   }
 
-  if let Some(issuer_rule) = &module_rule.issuer {
-    match issuer {
-      Some(issuer) => {
-        if !issuer_rule.try_match(issuer.into()).await? {
-          return Ok(false);
-        }
-      }
-      None => {
-        if !issuer_rule.match_when_empty().await? {
-          return Ok(false);
-        }
-      }
-    }
+  if let Some(issuer_rule) = &module_rule.issuer
+    && !check_optional_async(issuer_rule, issuer.map(Into::into)).await?
+  {
+    return Ok(false);
   }
 
-  if let Some(issuer_layer_rule) = &module_rule.issuer_layer {
-    match issuer_layer {
-      Some(issuer_layer) => {
-        if !issuer_layer_rule.try_match(issuer_layer.into()).await? {
-          return Ok(false);
-        }
-      }
-      None => {
-        if !issuer_layer_rule.match_when_empty().await? {
-          return Ok(false);
-        }
-      }
-    };
+  if let Some(issuer_layer_rule) = &module_rule.issuer_layer
+    && !check_optional_async(issuer_layer_rule, issuer_layer.map(Into::into)).await?
+  {
+    return Ok(false);
   }
 
   if let Some(dependency_rule) = &module_rule.dependency
@@ -512,14 +425,14 @@ async fn module_rule_matcher_async<'a>(
   if let Some(description_data) = &module_rule.description_data {
     if let Some(resource_description) = resource_data.description() {
       for (k, matcher) in description_data {
-        if let Some(v) = k
-          .split('.')
-          .try_fold(resource_description.json(), |acc, key| acc.get(key))
+        if !check_optional_async(
+          matcher,
+          k.split('.')
+            .try_fold(resource_description.json(), |acc, key| acc.get(key))
+            .map(Into::into),
+        )
+        .await?
         {
-          if !matcher.try_match(v.into()).await? {
-            return Ok(false);
-          }
-        } else if !matcher.match_when_empty().await? {
           return Ok(false);
         }
       }
@@ -535,11 +448,7 @@ async fn module_rule_matcher_async<'a>(
   if let Some(with) = &module_rule.with {
     if let Some(attributes) = attributes {
       for (k, matcher) in with {
-        if let Some(v) = attributes.get(k) {
-          if !matcher.try_match(v.into()).await? {
-            return Ok(false);
-          }
-        } else if !matcher.match_when_empty().await? {
+        if !check_optional_async(matcher, attributes.get(k).map(Into::into)).await? {
           return Ok(false);
         }
       }

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -14,8 +14,69 @@ pub async fn module_rules_matcher<'a>(
   attributes: Option<&ImportAttributes>,
   matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Result<()> {
+  let matched_rules_len = matched_rules.len();
+  if let Some(result) = module_rules_matcher_sync(
+    rules,
+    resource_data,
+    issuer,
+    issuer_layer,
+    dependency,
+    attributes,
+    matched_rules,
+  ) {
+    return result;
+  }
+  matched_rules.truncate(matched_rules_len);
+  module_rules_matcher_async(
+    rules,
+    resource_data,
+    issuer,
+    issuer_layer,
+    dependency,
+    attributes,
+    matched_rules,
+  )
+  .await
+}
+
+fn module_rules_matcher_sync<'a>(
+  rules: &'a [ModuleRule],
+  resource_data: &ResourceData,
+  issuer: Option<&'a str>,
+  issuer_layer: Option<&'a str>,
+  dependency: &DependencyCategory,
+  attributes: Option<&ImportAttributes>,
+  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
+) -> Option<Result<()>> {
   for rule in rules {
-    module_rule_matcher(
+    match module_rule_matcher_sync(
+      rule,
+      resource_data,
+      issuer,
+      issuer_layer,
+      dependency,
+      attributes,
+      matched_rules,
+    ) {
+      Some(Ok(_)) => {}
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+  Some(Ok(()))
+}
+
+async fn module_rules_matcher_async<'a>(
+  rules: &'a [ModuleRule],
+  resource_data: &ResourceData,
+  issuer: Option<&'a str>,
+  issuer_layer: Option<&'a str>,
+  dependency: &DependencyCategory,
+  attributes: Option<&ImportAttributes>,
+  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
+) -> Result<()> {
+  for rule in rules {
+    module_rule_matcher_async(
       rule,
       resource_data,
       issuer,
@@ -30,8 +91,300 @@ pub async fn module_rules_matcher<'a>(
 }
 
 /// Match the `ModuleRule` against the given `ResourceData`, and return the matching `ModuleRule` if matched.
-#[async_recursion]
 pub async fn module_rule_matcher<'a>(
+  module_rule: &'a ModuleRule,
+  resource_data: &ResourceData,
+  issuer: Option<&'a str>,
+  issuer_layer: Option<&'a str>,
+  dependency: &DependencyCategory,
+  attributes: Option<&ImportAttributes>,
+  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
+) -> Result<bool> {
+  let matched_rules_len = matched_rules.len();
+  if let Some(result) = module_rule_matcher_sync(
+    module_rule,
+    resource_data,
+    issuer,
+    issuer_layer,
+    dependency,
+    attributes,
+    matched_rules,
+  ) {
+    return result;
+  }
+  matched_rules.truncate(matched_rules_len);
+  module_rule_matcher_async(
+    module_rule,
+    resource_data,
+    issuer,
+    issuer_layer,
+    dependency,
+    attributes,
+    matched_rules,
+  )
+  .await
+}
+
+fn module_rule_matcher_sync<'a>(
+  module_rule: &'a ModuleRule,
+  resource_data: &ResourceData,
+  issuer: Option<&'a str>,
+  issuer_layer: Option<&'a str>,
+  dependency: &DependencyCategory,
+  attributes: Option<&ImportAttributes>,
+  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
+) -> Option<Result<bool>> {
+  if let Some(test_rule) = &module_rule.rspack_resource {
+    match test_rule.try_match_sync(resource_data.resource().into()) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  let resource_path = resource_data
+    .path()
+    .unwrap_or_else(|| Utf8Path::new(""))
+    .as_str();
+
+  if let Some(test_rule) = &module_rule.test {
+    match test_rule.try_match_sync(resource_path.into()) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  } else if let Some(resource_rule) = &module_rule.resource {
+    match resource_rule.try_match_sync(resource_path.into()) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(include_rule) = &module_rule.include {
+    match include_rule.try_match_sync(resource_path.into()) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(exclude_rule) = &module_rule.exclude {
+    match exclude_rule.try_match_sync(resource_path.into()) {
+      Some(Ok(true)) => return Some(Ok(false)),
+      Some(Ok(false)) => {}
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(resource_query_rule) = &module_rule.resource_query {
+    let result = if let Some(resource_query) = resource_data.query() {
+      resource_query_rule.try_match_sync(resource_query.into())
+    } else {
+      resource_query_rule.match_when_empty_sync()
+    };
+    match result {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(resource_fragment_condition) = &module_rule.resource_fragment {
+    let result = if let Some(resource_fragment) = resource_data.fragment() {
+      resource_fragment_condition.try_match_sync(resource_fragment.into())
+    } else {
+      resource_fragment_condition.match_when_empty_sync()
+    };
+    match result {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(mimetype_condition) = &module_rule.mimetype {
+    let result = if let Some(mimetype) = resource_data.mimetype() {
+      mimetype_condition.try_match_sync(mimetype.into())
+    } else {
+      mimetype_condition.match_when_empty_sync()
+    };
+    match result {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(scheme_condition) = &module_rule.scheme {
+    let scheme = resource_data.get_scheme();
+    if scheme.is_none() {
+      match scheme_condition.match_when_empty_sync() {
+        Some(Ok(true)) => {}
+        Some(Ok(false)) => return Some(Ok(false)),
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+      }
+    }
+    match scheme_condition.try_match_sync(scheme.as_str().into()) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(issuer_rule) = &module_rule.issuer {
+    let result = if let Some(issuer) = issuer {
+      issuer_rule.try_match_sync((*issuer).into())
+    } else {
+      issuer_rule.match_when_empty_sync()
+    };
+    match result {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(issuer_layer_rule) = &module_rule.issuer_layer {
+    let result = if let Some(issuer_layer) = issuer_layer {
+      issuer_layer_rule.try_match_sync((*issuer_layer).into())
+    } else {
+      issuer_layer_rule.match_when_empty_sync()
+    };
+    match result {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(dependency_rule) = &module_rule.dependency {
+    match dependency_rule.try_match_sync(dependency.as_str().into()) {
+      Some(Ok(true)) => {}
+      Some(Ok(false)) => return Some(Ok(false)),
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(description_data) = &module_rule.description_data {
+    if let Some(resource_description) = resource_data.description() {
+      for (k, matcher) in description_data {
+        let result = if let Some(v) = k
+          .split('.')
+          .try_fold(resource_description.json(), |acc, key| acc.get(key))
+        {
+          matcher.try_match_sync(v.into())
+        } else {
+          matcher.match_when_empty_sync()
+        };
+        match result {
+          Some(Ok(true)) => {}
+          Some(Ok(false)) => return Some(Ok(false)),
+          Some(Err(err)) => return Some(Err(err)),
+          None => return None,
+        }
+      }
+    } else {
+      for matcher in description_data.values() {
+        match matcher.match_when_empty_sync() {
+          Some(Ok(true)) => {}
+          Some(Ok(false)) => return Some(Ok(false)),
+          Some(Err(err)) => return Some(Err(err)),
+          None => return None,
+        }
+      }
+    }
+  }
+
+  if let Some(with) = &module_rule.with {
+    if let Some(attributes) = attributes {
+      for (k, matcher) in with {
+        let result = if let Some(v) = attributes.get(k) {
+          matcher.try_match_sync(v.into())
+        } else {
+          matcher.match_when_empty_sync()
+        };
+        match result {
+          Some(Ok(true)) => {}
+          Some(Ok(false)) => return Some(Ok(false)),
+          Some(Err(err)) => return Some(Err(err)),
+          None => return None,
+        }
+      }
+    } else {
+      for matcher in with.values() {
+        match matcher.match_when_empty_sync() {
+          Some(Ok(true)) => {}
+          Some(Ok(false)) => return Some(Ok(false)),
+          Some(Err(err)) => return Some(Err(err)),
+          None => return None,
+        }
+      }
+    }
+  }
+
+  matched_rules.push(&module_rule.effect);
+
+  if let Some(rules) = &module_rule.rules {
+    match module_rules_matcher_sync(
+      rules,
+      resource_data,
+      issuer,
+      issuer_layer,
+      dependency,
+      attributes,
+      matched_rules,
+    ) {
+      Some(Ok(())) => {}
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  }
+
+  if let Some(one_of) = &module_rule.one_of {
+    let mut matched_once = false;
+    for rule in one_of {
+      match module_rule_matcher_sync(
+        rule,
+        resource_data,
+        issuer,
+        issuer_layer,
+        dependency,
+        attributes,
+        matched_rules,
+      ) {
+        Some(Ok(true)) => {
+          matched_once = true;
+          break;
+        }
+        Some(Ok(false)) => {}
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+      }
+    }
+    if !matched_once {
+      return Some(Ok(false));
+    }
+  }
+
+  Some(Ok(true))
+}
+
+#[async_recursion]
+async fn module_rule_matcher_async<'a>(
   module_rule: &'a ModuleRule,
   resource_data: &ResourceData,
   issuer: Option<&'a str>,

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -118,7 +118,7 @@ impl Debug for Content {
 }
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ResourceData {
   /// Resource with absolute path, query and fragment
   resource: String,
@@ -299,24 +299,6 @@ impl ResourceData {
       self.set_fragment_optional(parsed.fragment);
     }
     self.set_resource(new_resource);
-  }
-}
-
-impl Default for ResourceData {
-  fn default() -> Self {
-    Self {
-      resource: String::new(),
-      resource_path: None,
-      resource_query: None,
-      resource_fragment: None,
-      resource_description: None,
-      mimetype: None,
-      parameters: None,
-      encoding: None,
-      encoded_content: None,
-      context: None,
-      scheme: OnceCell::new(),
-    }
   }
 }
 

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -302,6 +302,24 @@ impl ResourceData {
   }
 }
 
+impl Default for ResourceData {
+  fn default() -> Self {
+    Self {
+      resource: String::new(),
+      resource_path: None,
+      resource_query: None,
+      resource_fragment: None,
+      resource_description: None,
+      mimetype: None,
+      parameters: None,
+      encoding: None,
+      encoded_content: None,
+      context: None,
+      scheme: OnceCell::new(),
+    }
+  }
+}
+
 /// Used for [Rule.descriptionData](https://rspack.rs/config/module.html#ruledescriptiondata) and
 /// package.json.sideEffects in tree shaking.
 #[cacheable]

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -97,16 +97,15 @@ fn create_loader_context<Context: Send>(
 
 #[tracing::instrument("LoaderRunner:run_loaders", skip_all, level = "trace")]
 pub async fn run_loaders<Context: Send>(
-  loaders: Arc<[Arc<dyn Loader<Context>>]>,
+  loaders: Vec<Arc<dyn Loader<Context>>>,
   resource_data: Arc<ResourceData>,
   plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
   context: Context,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> (LoaderResult<Context>, Option<Error>) {
   let loaders = loaders
-    .iter()
-    .cloned()
-    .map(LoaderItem::from)
+    .into_iter()
+    .map(|i| i.into())
     .collect::<Vec<LoaderItem<Context>>>();
   let mut cx = create_loader_context(loaders, resource_data, plugin, context);
   let result = run_loaders_impl(&mut cx, fs).await;
@@ -439,7 +438,7 @@ mod test {
     // Ignore error: Final loader didn't return a Buffer or String
     assert!(
       run_loaders(
-        vec![p1, p2, c1, c2].into(),
+        vec![p1, p2, c1, c2],
         rs.clone(),
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -459,7 +458,7 @@ mod test {
     // Ignore error: Final loader didn't return a Buffer or String
     assert!(
       run_loaders(
-        vec![p1, p2, p3].into(),
+        vec![p1, p2, p3],
         rs.clone(),
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -532,7 +531,7 @@ mod test {
 
     assert!(
       run_loaders(
-        vec![Arc::new(Normal) as Arc<dyn Loader>, Arc::new(Normal2)].into(),
+        vec![Arc::new(Normal) as Arc<dyn Loader>, Arc::new(Normal2)],
         rs,
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -589,7 +588,7 @@ mod test {
     // Ignore error: Final loader didn't return a Buffer or String
     assert!(
       run_loaders(
-        vec![Arc::new(Normal2) as Arc<dyn Loader>, Arc::new(Normal)].into(),
+        vec![Arc::new(Normal2), Arc::new(Normal)],
         rs,
         Some(Arc::new(TestContentPlugin)),
         (),

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -97,15 +97,16 @@ fn create_loader_context<Context: Send>(
 
 #[tracing::instrument("LoaderRunner:run_loaders", skip_all, level = "trace")]
 pub async fn run_loaders<Context: Send>(
-  loaders: Vec<Arc<dyn Loader<Context>>>,
+  loaders: Arc<[Arc<dyn Loader<Context>>]>,
   resource_data: Arc<ResourceData>,
   plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
   context: Context,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> (LoaderResult<Context>, Option<Error>) {
   let loaders = loaders
-    .into_iter()
-    .map(|i| i.into())
+    .iter()
+    .cloned()
+    .map(LoaderItem::from)
     .collect::<Vec<LoaderItem<Context>>>();
   let mut cx = create_loader_context(loaders, resource_data, plugin, context);
   let result = run_loaders_impl(&mut cx, fs).await;
@@ -438,7 +439,7 @@ mod test {
     // Ignore error: Final loader didn't return a Buffer or String
     assert!(
       run_loaders(
-        vec![p1, p2, c1, c2],
+        vec![p1, p2, c1, c2].into(),
         rs.clone(),
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -458,7 +459,7 @@ mod test {
     // Ignore error: Final loader didn't return a Buffer or String
     assert!(
       run_loaders(
-        vec![p1, p2, p3],
+        vec![p1, p2, p3].into(),
         rs.clone(),
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -531,7 +532,7 @@ mod test {
 
     assert!(
       run_loaders(
-        vec![Arc::new(Normal) as Arc<dyn Loader>, Arc::new(Normal2)],
+        vec![Arc::new(Normal) as Arc<dyn Loader>, Arc::new(Normal2)].into(),
         rs,
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -588,7 +589,7 @@ mod test {
     // Ignore error: Final loader didn't return a Buffer or String
     assert!(
       run_loaders(
-        vec![Arc::new(Normal2), Arc::new(Normal)],
+        vec![Arc::new(Normal2) as Arc<dyn Loader>, Arc::new(Normal)].into(),
         rs,
         Some(Arc::new(TestContentPlugin)),
         (),

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_plugin.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_plugin.rs
@@ -125,7 +125,7 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
 async fn nmf_module(
   &self,
   _data: &mut ModuleFactoryCreateData,
-  _create_data: &mut NormalModuleCreateData,
+  _create_data: &NormalModuleCreateData,
   module: &mut BoxModule,
 ) -> Result<()> {
   if self.options.scope.is_none()

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -133,7 +133,7 @@ impl SideEffectsFlagPlugin {
 async fn nmf_module(
   &self,
   _data: &mut ModuleFactoryCreateData,
-  create_data: &mut NormalModuleCreateData,
+  create_data: &NormalModuleCreateData,
   module: &mut BoxModule,
 ) -> Result<()> {
   if let Some(has_side_effects) = create_data.side_effects {
@@ -143,7 +143,7 @@ async fn nmf_module(
     return Ok(());
   }
 
-  let resource_data = &create_data.resource_resolve_data;
+  let resource_data = create_data.resource_resolve_data.as_ref();
   let Some(resource_path) = resource_data.path() else {
     return Ok(());
   };

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -128,7 +128,7 @@ async fn compilation(
 async fn normal_module_factory_module(
   &self,
   module_factory_create_data: &mut ModuleFactoryCreateData,
-  create_data: &mut NormalModuleCreateData,
+  create_data: &NormalModuleCreateData,
   module: &mut BoxModule,
 ) -> Result<()> {
   let dep_type = module_factory_create_data.dependencies[0].dependency_type();

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_plugin.rs
@@ -270,11 +270,11 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
 async fn normal_module_factory_module(
   &self,
   data: &mut ModuleFactoryCreateData,
-  create_data: &mut NormalModuleCreateData,
+  create_data: &NormalModuleCreateData,
   _module: &mut BoxModule,
 ) -> Result<()> {
   let resource = create_data.resource_resolve_data.resource();
-  let resource_data = &create_data.resource_resolve_data;
+  let resource_data = create_data.resource_resolve_data.as_ref();
   if self
     .resolved_provide_map
     .read()

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   Compilation, CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
   CompilerCompilation, DependencyType, ExportsInfoArtifact, FactoryMeta, ModuleFactoryCreateData,
   ModuleType, NormalModuleFactoryBeforeResolve, NormalModuleFactoryParser, ParserAndGenerator,
-  ParserOptions, Plugin, ResolveContext, ResolveOptionsWithDependencyType, ResolveResult,
+  ParserOptions, Plugin, ResolveOptionsWithDependencyType, ResolveResult,
   SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   module_declared_side_effect_free,
@@ -145,12 +145,11 @@ impl RstestPlugin {
       dependency_category,
     };
     let resolver = data.resolver_factory.get(dep);
-    let mut resolve_context = ResolveContext::default();
 
-    let resolved_directory_target = match resolver
-      .resolve_with_context(data.context.as_ref(), stripped, &mut resolve_context)
-      .await
-    {
+    let (resolve_result, resolve_dependencies) = resolver
+      .resolve_with_context(data.context.as_ref(), stripped)
+      .await;
+    let resolved_directory_target = match resolve_result {
       Ok(ResolveResult::Resource(resource)) => self.resolve_directory_mock_target(
         Utf8Path::new(stripped),
         data.context.as_ref(),
@@ -160,8 +159,8 @@ impl RstestPlugin {
       _ => None,
     };
 
-    data.add_file_dependencies(resolve_context.file_dependencies);
-    data.add_missing_dependencies(resolve_context.missing_dependencies);
+    data.add_file_dependencies(resolve_dependencies.file_dependencies);
+    data.add_missing_dependencies(resolve_dependencies.missing_dependencies);
     let resolved_request = resolved_directory_target
       .unwrap_or(default_target)
       .to_string();


### PR DESCRIPTION
## Summary

This PR reduces several hot-path costs around normal module creation, resolving, and module rule matching.

It reuses global parser options when rule-level parser options do not need merging, avoiding repeated cloning of `JavascriptParserOptions`. It also changes `NormalModuleCreateData` resource data handling so owned resource resolve data can be moved into `NormalModule` and wrapped in `Arc` only when needed, reducing extra clones during module creation.

Resolver dependency collection now returns resolved dependency sets directly for normal and context module resolving paths. Callers that can replace dependency sets do so directly instead of extending large `ArcPathSet`s after resolution.

Default module rules no longer use function conditions for simple extension checks. They now use regex conditions, which lets rule matching stay on the synchronous fast path for common default rules.

`module_rules_matcher` now has a synchronous fast path for string, regex, logical, and array conditions, and only falls back to async boxed futures when function conditions are actually present. Composite rule conditions also carry a `can_sync` marker so rules containing function conditions can skip the failed sync probe and go directly to async matching.
