### PR TITLE
fix: Remove runtime when generating chunk output paths in ESM library plugin

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1405,8 +1405,7 @@ var {} = {{}};
               &compilation.chunk_hashes_artifact,
               &SourceType::JavaScript,
               compilation.options.output.hash_digest_length,
-            ))
-            .runtime(chunk.runtime().as_str()),
+            )),
           &mut Default::default(),
         )
         .await

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -178,8 +178,7 @@ impl EsmLibraryPlugin {
             &compilation.chunk_hashes_artifact,
             &SourceType::JavaScript,
             compilation.options.output.hash_digest_length,
-          ))
-          .runtime(chunk.runtime().as_str()),
+          )),
         asset_info,
       )
       .await?;


### PR DESCRIPTION
### Motivation
- Avoid including the chunk runtime in the `PathData` passed to `get_path_with_info` for the ESM library plugin to prevent incorrect or unnecessary path interpolation when computing chunk output filenames.

### Description
- Remove the `.runtime(chunk.runtime().as_str())` call from the `PathData` builder in `crates/rspack_plugin_esm_library/src/link.rs` and `crates/rspack_plugin_esm_library/src/render.rs`, and adjust parentheses to keep the `get_path_with_info` calls valid.

### Testing
- Ran `cargo test -p rspack_plugin_esm_library` and the package test suite completed successfully.
