### PR TITLE
docs: clarify splitChunks name function

### DIFF
--- a/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -34,6 +34,42 @@ export default {
 };
 ```
 
+### Split extracted CSS with splitChunks
+
+`CssExtractRspackPlugin` adds extracted CSS modules with the `css/mini-extract` module type. You can use [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/webpack/split-chunks-plugin#splitchunkscachegroupscachegrouptype) to create a cache group that only matches CSS extracted by `CssExtractRspackPlugin`, without matching JavaScript modules or native CSS modules.
+
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  plugins: [new rspack.CssExtractRspackPlugin({})],
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        type: 'javascript/auto',
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        extractedCss: {
+          type: 'css/mini-extract',
+          name: 'styles',
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+```
+
+In this example, `extractedCss` only selects modules whose module type is `css/mini-extract`. `enforce: true` makes the CSS chunk be created even when the normal `minSize` or request-limit heuristics would skip it; remove `enforce` if you want the cache group to follow the normal splitChunks heuristics.
+
 ## Plugin options
 
 Options for `CssExtractRspackPlugin`.

--- a/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
@@ -396,7 +396,18 @@ This option lets you specify the delimiter to use for the generated names.
 
 #### splitChunks.cacheGroups.\{cacheGroup\}.name
 
-- **Type:** `string | function`
+- **Type:**
+
+```ts
+type SplitChunksName = false | string | SplitChunksNameFunction;
+
+type SplitChunksNameFunction = (
+  module: Module,
+  chunks: Chunk[],
+  cacheGroupKey: string,
+) => string | undefined;
+```
+
 - **Default:** `false`
 
 > where the version of the function type is `>=0.4.1`.
@@ -406,6 +417,68 @@ Also available for each cacheGroup: `splitChunks.cacheGroups.{cacheGroup}.name`.
 The name of the split chunk. Providing `false` will keep the same name of the chunks so it doesn't change names unnecessarily. It is the recommended value for production builds.
 
 Providing a string allows you to use a custom name. Specifying a string will merge all common modules and vendors into a single chunk. This might lead to bigger initial downloads and slow down page loads.
+
+When `name` is a function, Rspack calls it with these parameters:
+
+- `module`: the module that is being considered for the split chunk. You can use methods such as `module.identifier()` to derive a stable name from its request or resource path.
+- `chunks`: the chunks that currently contain this module and were selected by the cache group. Each item is a `Chunk` object, so common properties such as `chunk.name` are available.
+- `cacheGroupKey`: the key of the cache group that matched the module, for example `vendors` for `cacheGroups.vendors`.
+
+The function should return the split chunk name. Return `undefined` to let Rspack fall back to automatic naming for that module group.
+
+For example, you can name vendor chunks by the cache group key and by the selected chunk names:
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name(module, chunks, cacheGroupKey) {
+            const chunkNames = chunks
+              .map((chunk) => chunk.name)
+              .filter(Boolean)
+              .sort()
+              .join('~');
+
+            return `${cacheGroupKey}-${chunkNames || 'shared'}`;
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+You can also derive a chunk name from the package that provided the matched module:
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        npmPackage: {
+          test: /[\\/]node_modules[\\/]/,
+          name(module, chunks, cacheGroupKey) {
+            const identifier = module.identifier();
+            const match = identifier.match(
+              /[\\/]node_modules[\\/]((?:@[^\\/]+[\\/])?[^\\/]+)/,
+            );
+            const packageName = match
+              ? match[1].replace(/[\\/]/g, '-')
+              : 'misc';
+
+            return `${cacheGroupKey}-${packageName}`;
+          },
+        },
+      },
+    },
+  },
+};
+```
 
 `name` is not only a filename customization. It also changes grouping behavior: when different chunk combinations hit the same cache group and resolve to the same name, Rspack will merge them into the same named split chunk candidate. This can improve cache hit rate, but it can also force a page to fetch modules from unrelated dependency chains.
 

--- a/website/docs/zh/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -34,6 +34,42 @@ export default {
 };
 ```
 
+### 通过 splitChunks 拆分提取出的 CSS
+
+`CssExtractRspackPlugin` 会为提取出的 CSS 模块添加 `css/mini-extract` 模块类型。你可以使用 [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/webpack/split-chunks-plugin#splitchunkscachegroupscachegrouptype) 创建一个只命中 `CssExtractRspackPlugin` 提取出的 CSS 的 cache group，而不会命中 JavaScript 模块或内置 CSS 模块。
+
+```ts title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  plugins: [new rspack.CssExtractRspackPlugin({})],
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        type: 'javascript/auto',
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        extractedCss: {
+          type: 'css/mini-extract',
+          name: 'styles',
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+```
+
+在这个例子中，`extractedCss` 只会选择模块类型为 `css/mini-extract` 的模块。`enforce: true` 会让 CSS chunk 即使在普通 `minSize` 或请求数限制启发式规则下会被跳过时也被创建；如果希望该 cache group 遵循普通 splitChunks 启发式规则，可以移除 `enforce`。
+
 ## Plugin 选项
 
 CssExtractRspackPlugin 插件的选项。

--- a/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
@@ -392,7 +392,18 @@ Rspack 在处理 `maxSize` 时会基于路径派生出的确定性 key 对模块
 
 #### splitChunks.cacheGroups.\{cacheGroup\}.name
 
-- **类型：** `string | function`
+- **类型：**
+
+```ts
+type SplitChunksName = false | string | SplitChunksNameFunction;
+
+type SplitChunksNameFunction = (
+  module: Module,
+  chunks: Chunk[],
+  cacheGroupKey: string,
+) => string | undefined;
+```
+
 - **默认值：** `false`
 
 > 其中函数类型的版本要求为 `>=0.4.1`
@@ -400,6 +411,68 @@ Rspack 在处理 `maxSize` 时会基于路径派生出的确定性 key 对模块
 每个 cacheGroup 也可以使用：`splitChunks.cacheGroups.{cacheGroup}.name`。
 
 拆分 chunk 的名称。设为 `false` 将保持 chunk 的相同名称，因此不会不必要地更改名称。这是生产环境下构建的建议值。
+
+当 `name` 为函数时，Rspack 会传入以下参数：
+
+- `module`：当前正在考虑拆分的模块。你可以使用 `module.identifier()` 等方法，根据模块请求或资源路径生成稳定的名称。
+- `chunks`：当前包含该模块并被 cache group 选中的 chunks。每一项都是 `Chunk` 对象，因此可以访问 `chunk.name` 等常用属性。
+- `cacheGroupKey`：命中该模块的 cache group 的 key，例如 `cacheGroups.vendors` 对应的值是 `vendors`。
+
+函数应返回拆分 chunk 的名称。返回 `undefined` 时，Rspack 会对该模块组回退到自动命名。
+
+例如，你可以根据 cache group key 和选中的 chunk 名称来命名 vendor chunk：
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name(module, chunks, cacheGroupKey) {
+            const chunkNames = chunks
+              .map((chunk) => chunk.name)
+              .filter(Boolean)
+              .sort()
+              .join('~');
+
+            return `${cacheGroupKey}-${chunkNames || 'shared'}`;
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+你也可以根据提供该模块的 npm 包名生成 chunk 名称：
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        npmPackage: {
+          test: /[\\/]node_modules[\\/]/,
+          name(module, chunks, cacheGroupKey) {
+            const identifier = module.identifier();
+            const match = identifier.match(
+              /[\\/]node_modules[\\/]((?:@[^\\/]+[\\/])?[^\\/]+)/,
+            );
+            const packageName = match
+              ? match[1].replace(/[\\/]/g, '-')
+              : 'misc';
+
+            return `${cacheGroupKey}-${packageName}`;
+          },
+        },
+      },
+    },
+  },
+};
+```
 
 `name` 不只是文件名定制选项，它还会改变分组行为：当不同的 chunk 组合命中了同一个 cacheGroup，并且最终解析到相同的 `name` 时，Rspack 会把它们合并成同一个命名后的拆分候选。这样虽然可能提高缓存命中率，但也可能让某些页面去请求本来不需要的模块依赖链。
 


### PR DESCRIPTION
### Motivation

- Make the `splitChunks.name` / `splitChunks.cacheGroups.{cacheGroup}.name` API clearer by documenting the exact function signature, parameters and return behaviour. 
- Provide concrete examples so users can implement custom naming strategies (vendor-by-chunk, npm-package-by-name) and understand how naming affects grouping.

### Description

- Updated English and Chinese SplitChunksPlugin docs (`website/docs/en/plugins/webpack/split-chunks-plugin.mdx`, `website/docs/zh/plugins/webpack/split-chunks-plugin.mdx`) to include an explicit TypeScript function signature for `name` and a short `SplitChunksNameFunction` type. 
- Added parameter descriptions for the function form: `module`, `chunks`, and `cacheGroupKey`, and documented that returning `undefined` falls back to automatic naming. 
- Added two concrete examples demonstrating (1) vendor chunk names derived from selected chunk names and (2) chunk names derived from the npm package that provided a matched module, in both English and Chinese docs. 
- Ran Prettier formatting on the modified files to ensure style consistency.
