### PR TITLE
chore(deps): upgrade pnpm to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,1 @@
 registry=https://registry.npmjs.org/
-
-# The package of the same name conflicts with node:buffer and it will affect our ci results. https://www.npmjs.com/package/buffer 
-hoist-pattern[]=!buffer
-
-# Use symlinked executables instead of command shims with `NODE_PATH` to achieve better DX in debugging with LLDB, etc.
-# See: https://pnpm.io/npmrc#prefer-symlinked-executables
-prefer-symlinked-executables=true

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bench:prepare": "node ./scripts/bench/setup.mjs"
   },
   "engines": {
-    "pnpm": "10.33.2"
+    "pnpm": ">=11.0.0"
   },
   "devDependencies": {
     "@rslint/core": "0.5.1",
@@ -69,5 +69,5 @@
     "typescript": "^6.0.3",
     "zx": "8.8.5"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.0.6"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  webpack-sources@3.3.4:
-    hash: 0d62122aa5f9ac77d9ad3b4959c3c0492778a5948c0b00b45a673f3facfca327
-    path: patches/webpack-sources@3.3.4.patch
+  webpack-sources@3.3.4: 0d62122aa5f9ac77d9ad3b4959c3c0492778a5948c0b00b45a673f3facfca327
 
 importers:
 
@@ -14464,8 +14462,6 @@ snapshots:
   rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.3):
     optionalDependencies:
       '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)(core-js@3.49.0)
-
-  rspack-merge@0.1.1: {}
 
   rspack-merge@0.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,12 +17,26 @@ packages:
 
 dedupePeers: true
 
+hoistPattern:
+  - '!buffer'
+
+preferSymlinkedExecutables: true
+
 patchedDependencies:
   webpack-sources@3.3.4: patches/webpack-sources@3.3.4.patch
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - 'core-js'
-  - 'es5-ext'
-  - 'esbuild'
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  core-js: false
+  es5-ext: false
+  esbuild: true
+
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'


### PR DESCRIPTION
## Summary

This PR upgrades the repository package manager declaration to pnpm 11 and migrates pnpm settings that are no longer read from `.npmrc` into `pnpm-workspace.yaml`. It replaces `onlyBuiltDependencies` with pnpm 11 `allowBuilds`, keeps release-age exclusions for Rstack packages, and normalizes the lockfile entries required by pnpm 11.

## Related links

https://github.com/web-infra-dev/rsbuild/pull/7607
https://github.com/pnpm/pnpm/releases/tag/v11.0.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).