### PR TITLE
refactor(rstest): expose injectDynamicImportOrigin.functionName and resolve callee once

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2925,7 +2925,7 @@ export interface RawRstestPluginOptions {
   manualMockRoot: string
   preserveNewUrl?: Array<string>
   globals?: boolean
-  injectDynamicImportOrigin?: boolean | { functionName?: string }
+injectDynamicImportOrigin?: boolean | { functionName?: string }
 }
 
 export interface RawRuleSetCondition {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2914,6 +2914,10 @@ export interface RawRslibPluginOptions {
   emitDts?: RawSwcEmitDtsOptions
 }
 
+export interface RawRstestDynamicImportOriginOptions {
+  functionName?: string
+}
+
 export interface RawRstestPluginOptions {
   injectModulePathName: boolean
   importMetaPathName: boolean
@@ -2921,7 +2925,7 @@ export interface RawRstestPluginOptions {
   manualMockRoot: string
   preserveNewUrl?: Array<string>
   globals?: boolean
-  injectDynamicImportOrigin?: boolean
+  injectDynamicImportOrigin?: boolean | { functionName?: string }
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_api/src/rstest.rs
+++ b/crates/rspack_binding_api/src/rstest.rs
@@ -1,5 +1,14 @@
 use derive_more::Debug;
-use rspack_plugin_rstest::RstestPluginOptions;
+use napi::Either;
+use rspack_plugin_rstest::{RstestDynamicImportOriginOptions, RstestPluginOptions};
+
+#[derive(Debug)]
+#[napi(object, object_to_js = false)]
+pub struct RawRstestDynamicImportOriginOptions {
+  // Override the callee that replaces `import` in the rewrite. When omitted,
+  // rstest falls back to `output.importFunctionName`.
+  pub function_name: Option<String>,
+}
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -20,17 +29,27 @@ pub struct RawRstestPluginOptions {
   // Whether to handle global `rs` and `rstest` variables.
   // When false, only ESM imported variables are processed. Default is true.
   pub globals: Option<bool>,
-  // When `module.parser.javascript.importDynamic` is `false`, rewrite
-  // non-string-literal `import()` calls (template literals, variables) to the
-  // configured `output.importFunctionName` and append the source module's
-  // absolute path as an extra argument. The runtime uses it as the base for
-  // relative specifier resolution so paths inside bundled deps resolve to the
-  // source file's directory rather than the test entry's.
-  pub inject_dynamic_import_origin: Option<bool>,
+  // When enabled, rewrite non-string-literal `import()` calls (template
+  // literals, variables) to the configured callee and append the source
+  // module's absolute path as an extra argument. The runtime uses it as the
+  // base for relative specifier resolution so paths inside bundled deps
+  // resolve to the source file's directory rather than the test entry's.
+  //
+  // Pass `true` to enable with the callee taken from `output.importFunctionName`,
+  // or pass an object with `functionName` to override the callee independently.
+  #[napi(ts_type = "boolean | { functionName?: string }")]
+  pub inject_dynamic_import_origin: Option<Either<bool, RawRstestDynamicImportOriginOptions>>,
 }
 
 impl From<RawRstestPluginOptions> for RstestPluginOptions {
   fn from(value: RawRstestPluginOptions) -> Self {
+    let inject_dynamic_import_origin = match value.inject_dynamic_import_origin {
+      None | Some(Either::A(false)) => None,
+      Some(Either::A(true)) => Some(RstestDynamicImportOriginOptions::default()),
+      Some(Either::B(opts)) => Some(RstestDynamicImportOriginOptions {
+        function_name: opts.function_name,
+      }),
+    };
     Self {
       module_path_name: value.inject_module_path_name,
       hoist_mock_module: value.hoist_mock_module,
@@ -38,7 +57,7 @@ impl From<RawRstestPluginOptions> for RstestPluginOptions {
       manual_mock_root: value.manual_mock_root,
       preserve_new_url: value.preserve_new_url.unwrap_or_default(),
       globals: value.globals.unwrap_or(true),
-      inject_dynamic_import_origin: value.inject_dynamic_import_origin.unwrap_or(false),
+      inject_dynamic_import_origin,
     }
   }
 }

--- a/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
@@ -45,10 +45,20 @@ impl AsModuleDependency for RstestDynamicImportOriginDependency {}
 impl AsContextDependency for RstestDynamicImportOriginDependency {}
 
 #[cacheable]
-#[derive(Debug, Clone, Default)]
-pub struct RstestDynamicImportOriginDependencyTemplate;
+#[derive(Debug, Clone)]
+pub struct RstestDynamicImportOriginDependencyTemplate {
+  /// Resolved callee for the rewrite — rstest's own `functionName` override
+  /// or the `output.importFunctionName` fallback. Held on the template (one
+  /// per compilation) rather than per-dep so identical bytes aren't cloned
+  /// for every `import()` call site.
+  function_name: String,
+}
 
 impl RstestDynamicImportOriginDependencyTemplate {
+  pub fn new(function_name: String) -> Self {
+    Self { function_name }
+  }
+
   pub fn template_type() -> DependencyTemplateType {
     DependencyTemplateType::Dependency(DependencyType::RstestDynamicImportOrigin)
   }
@@ -59,7 +69,7 @@ impl DependencyTemplate for RstestDynamicImportOriginDependencyTemplate {
     &self,
     dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
-    code_generatable_context: &mut TemplateContext,
+    _code_generatable_context: &mut TemplateContext,
   ) {
     let dep = dep
       .as_any()
@@ -69,28 +79,15 @@ impl DependencyTemplate for RstestDynamicImportOriginDependencyTemplate {
          RstestDynamicImportOriginDependency",
       );
 
-    let import_fn = code_generatable_context
-      .compilation
-      .options
-      .output
-      .import_function_name
-      .clone();
-
-    // Replace `import` callee with the configured importFunctionName.
     source.replace(
       dep.callee_range.start,
       dep.callee_range.end,
-      import_fn,
+      self.function_name.clone(),
       None,
     );
 
-    // Append the origin so the runtime can resolve relative specifiers against
-    // the source module that produced the dynamic import, instead of the test
-    // entry. Always emit it at the third-argument position — fill the
-    // attributes slot with `void 0` when the call had only a specifier. We
-    // use `void 0` rather than the identifier `undefined` because the latter
-    // can be shadowed (e.g. `function f(undefined) { import(spec) }`), which
-    // would silently feed the runtime a bogus `importAttributes` value.
+    // `void 0` (rather than the identifier `undefined`) for the missing
+    // attributes slot — `undefined` can be shadowed by a local binding.
     let tail = if dep.has_attributes {
       format!(", {}", json_stringify_str(&dep.origin_path))
     } else {

--- a/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
@@ -48,9 +48,11 @@ impl AsContextDependency for RstestDynamicImportOriginDependency {}
 #[derive(Debug, Clone)]
 pub struct RstestDynamicImportOriginDependencyTemplate {
   /// Resolved callee for the rewrite — rstest's own `functionName` override
-  /// or the `output.importFunctionName` fallback. Held on the template (one
-  /// per compilation) rather than per-dep so identical bytes aren't cloned
-  /// for every `import()` call site.
+  /// or the `output.importFunctionName` fallback. Resolved once at `apply`
+  /// time (with the default `import` normalized to "feature off" since
+  /// native `import()` only accepts 1-2 args) and held here so each
+  /// `import()` call site reuses the same string without repeating the
+  /// override + fallback + default-`import` check.
   function_name: String,
 }
 

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -48,19 +48,10 @@ pub struct RstestParserPluginOptions {
   /// Whether to handle global `rs` and `rstest` variables.
   /// When false, only ESM imported variables are processed.
   pub globals: bool,
-  /// When `module.parser.javascript.importDynamic` is `false` and the dynamic
-  /// import specifier is not a plain string literal, rewrite the callee to the
-  /// configured `output.importFunctionName` and append the source module's
-  /// absolute path as an extra argument so the runtime can resolve relative
-  /// specifiers against it.
+  /// Whether to rewrite non-string-literal `import()` calls with origin info.
+  /// Pre-resolved at plugin construction — false here covers both "feature
+  /// disabled" and "callee resolved to default `import`".
   pub inject_dynamic_import_origin: bool,
-  /// Snapshot of `module.parser.javascript*.importDynamic` for this module
-  /// type. Used by the dynamic-import-origin rewrite to gate behavior on
-  /// `Some(false)`.
-  pub import_dynamic: Option<bool>,
-  /// Snapshot of `output.importFunctionName`. Used by the
-  /// dynamic-import-origin rewrite to substitute the `import` callee.
-  pub import_function_name: String,
 }
 
 impl Default for RstestParserPluginOptions {
@@ -72,8 +63,6 @@ impl Default for RstestParserPluginOptions {
       manual_mock_root: String::new(),
       globals: true,
       inject_dynamic_import_origin: false,
-      import_dynamic: None,
-      import_function_name: String::new(),
     }
   }
 }
@@ -739,9 +728,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       }
     }
 
-    if self.options.inject_dynamic_import_origin
-      && matches!(self.options.import_dynamic, Some(false))
-    {
+    if self.options.inject_dynamic_import_origin {
       // Only handle the regular evaluation phase. `import.defer(...)` and
       // `import.source(...)` carry phase semantics that rstest's runtime
       // does not implement, and the default `ImportParserPlugin` enforces
@@ -751,14 +738,6 @@ impl JavascriptParserPlugin for RstestParserPlugin {
         import_node.phase,
         swc_core::ecma::ast::ImportPhase::Evaluation
       ) {
-        return None;
-      }
-
-      // Native `import()` only accepts 1-2 args; appending a third argument
-      // would produce a SyntaxError at parse time. Skip injection when no
-      // custom `importFunctionName` is configured and let the default
-      // `ImportParserPlugin` handle the call as before.
-      if self.options.import_function_name == "import" {
         return None;
       }
 

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -49,7 +49,14 @@ pub struct RstestPluginOptions {
   pub manual_mock_root: String,
   pub preserve_new_url: Vec<String>,
   pub globals: bool,
-  pub inject_dynamic_import_origin: bool,
+  pub inject_dynamic_import_origin: Option<RstestDynamicImportOriginOptions>,
+}
+
+#[derive(Debug, Default)]
+pub struct RstestDynamicImportOriginOptions {
+  /// Overrides the rewrite callee. When `None`, falls back to
+  /// `output.importFunctionName`.
+  pub function_name: Option<String>,
 }
 
 #[derive(Debug)]
@@ -63,10 +70,10 @@ pub struct ProgressPluginStateInfo {
 #[derive(Debug)]
 pub struct RstestPlugin {
   options: RstestPluginOptions,
-  /// Captured from `compilation.options.output.import_function_name` in the
-  /// `compilation` hook so the parser plugin (constructed later in
-  /// `nmf_parser`) can read it without reaching into `JavascriptParser`.
-  import_function_name: OnceLock<String>,
+  /// Resolved at `apply` time. `Some(callee)` enables the rewrite; `None`
+  /// covers both "feature disabled" and "callee resolved to default `import`"
+  /// (incompatible with native syntax — rewriting would yield a SyntaxError).
+  dynamic_import_origin_callee: OnceLock<Option<Arc<str>>>,
 }
 
 impl RstestPlugin {
@@ -234,23 +241,15 @@ async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut Box<dyn ParserAndGenerator>,
-  parser_options: Option<&ParserOptions>,
+  _parser_options: Option<&ParserOptions>,
 ) -> Result<()> {
   if module_type.is_js_like()
     && let Some(parser) = parser.downcast_mut::<JavaScriptParserAndGenerator>()
   {
-    // Read the merged `module.parser.javascript*.importDynamic` for this
-    // module type so the parser plugin can short-circuit when dynamic imports
-    // are disabled, without reaching into `JavascriptParser`.
-    let import_dynamic = parser_options
-      .and_then(|opts| {
-        opts
-          .get_javascript()
-          .or_else(|| opts.get_javascript_auto())
-          .or_else(|| opts.get_javascript_esm())
-          .or_else(|| opts.get_javascript_dynamic())
-      })
-      .and_then(|js| js.import_dynamic);
+    let inject_dynamic_import_origin = self
+      .dynamic_import_origin_callee
+      .get()
+      .is_some_and(|c| c.is_some());
 
     parser.add_parser_plugin(Box::new(RstestParserPlugin::new(
       crate::parser_plugin::RstestParserPluginOptions {
@@ -259,9 +258,7 @@ async fn nmf_parser(
         import_meta_path_name: self.options.import_meta_path_name,
         manual_mock_root: self.options.manual_mock_root.clone(),
         globals: self.options.globals,
-        inject_dynamic_import_origin: self.options.inject_dynamic_import_origin,
-        import_dynamic,
-        import_function_name: self.import_function_name.get().cloned().unwrap_or_default(),
+        inject_dynamic_import_origin,
       },
     )) as BoxJavascriptParserPlugin);
   }
@@ -275,13 +272,6 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  // Capture the configured `output.importFunctionName` so the parser plugin
-  // can read it without reaching into `JavascriptParser`. Set runs before
-  // `nmf_parser` so the value is observable when the parser plugin is built.
-  let _ = self
-    .import_function_name
-    .set(compilation.options.output.import_function_name.clone());
-
   compilation.set_dependency_template(
     ModulePathNameDependencyTemplate::template_type(),
     Arc::new(ModulePathNameDependencyTemplate::default()),
@@ -297,10 +287,14 @@ async fn compilation(
     Arc::new(MockModuleIdDependencyTemplate::default()),
   );
 
-  compilation.set_dependency_template(
-    RstestDynamicImportOriginDependencyTemplate::template_type(),
-    Arc::new(RstestDynamicImportOriginDependencyTemplate::default()),
-  );
+  if let Some(Some(callee)) = self.dynamic_import_origin_callee.get() {
+    compilation.set_dependency_template(
+      RstestDynamicImportOriginDependencyTemplate::template_type(),
+      Arc::new(RstestDynamicImportOriginDependencyTemplate::new(
+        callee.to_string(),
+      )),
+    );
+  }
 
   Ok(())
 }
@@ -458,6 +452,23 @@ impl Plugin for RstestPlugin {
   }
 
   fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    // Resolve the rewrite callee once: rstest's own `functionName` override
+    // takes precedence; otherwise fall back to `output.importFunctionName`.
+    // Normalize the default `"import"` to `None` since native `import()` only
+    // accepts 1-2 args — appending origin would yield a SyntaxError.
+    let resolved_callee = self
+      .options
+      .inject_dynamic_import_origin
+      .as_ref()
+      .and_then(|cfg| {
+        let name = cfg
+          .function_name
+          .as_deref()
+          .unwrap_or(&ctx.compiler_options.output.import_function_name);
+        (name != "import").then(|| Arc::<str>::from(name))
+      });
+    let _ = self.dynamic_import_origin_callee.set(resolved_callee);
+
     ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
@@ -470,7 +481,7 @@ impl Plugin for RstestPlugin {
       .compilation
       .tap(compilation_stage_9999::new(self));
 
-    if self.options.module_path_name || self.options.inject_dynamic_import_origin {
+    if self.options.module_path_name || self.options.inject_dynamic_import_origin.is_some() {
       ctx
         .normal_module_factory_hooks
         .parser

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/index.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/index.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const sourceFile = path.resolve(
+	__dirname,
+	'../../../../configCases/rstest/dynamic-import-origin-function-name/src/index.js',
+);
+
+it('rewrites dynamic imports with `injectDynamicImportOrigin.functionName` override', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'dynamicImportOrigin.mjs'),
+		'utf-8',
+	);
+
+	const importFn = 'globalThis.__custom_import__';
+	const originLiteral = JSON.stringify(sourceFile);
+
+	// Override callee from `injectDynamicImportOrigin: { functionName }` must
+	// be used. `output.importFunctionName` is left at its default `'import'`
+	// in this fixture — that default is normalized to "feature off", so a
+	// successful rewrite here can only have come from the override path.
+	expect(content).toContain(`${importFn}(\`./translations/`);
+	expect(content).toContain(
+		`/strings.json\`, void 0, ${originLiteral})`,
+	);
+
+	// Native `import(\`./translations/...\`, ...)` must not survive — would
+	// indicate the override didn't reach the rewrite (regression guard for
+	// the N-API conversion + apply-time normalization path).
+	expect(content).not.toMatch(
+		/\bimport\(`\.\/translations[^)]*,\s*void 0,/,
+	);
+});

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/rspack.config.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+  {
+    entry: './src/index.js',
+    target: 'node',
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: 'dynamicImportOrigin.mjs',
+      module: true,
+      // Intentionally NOT setting `importFunctionName` — its default is
+      // `'import'`, which the rewrite normalizes to "feature off". A
+      // successful rewrite in this fixture therefore proves the
+      // `{ functionName }` override flowed through the N-API conversion
+      // and apply-time normalization.
+      chunkFormat: 'module',
+    },
+    module: {
+      parser: {
+        javascript: {
+          importDynamic: false,
+        },
+      },
+    },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: false,
+        hoistMockModule: false,
+        importMetaPathName: true,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+        injectDynamicImportOrigin: {
+          functionName: 'globalThis.__custom_import__',
+        },
+      }),
+    ],
+  },
+  {
+    entry: {
+      main: './index.js',
+    },
+    output: {
+      filename: '[name].js',
+    },
+    externalsPresets: {
+      node: true,
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/src/index.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/src/index.js
@@ -1,0 +1,8 @@
+const dir = process.env.x;
+
+// Template literal — exercises the dynamic-import rewrite path. The callee
+// must come from `injectDynamicImportOrigin: { functionName }`, NOT from
+// `output.importFunctionName` (left at its `'import'` default in this fixture).
+const a = import(`./translations/${dir}/strings.json`);
+
+console.log(a);

--- a/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/test.config.js
+++ b/tests/rspack-test/configCases/rstest/dynamic-import-origin-function-name/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: function () {
+		return ['main.js'];
+	},
+};


### PR DESCRIPTION
## Background

Follow-up to #13849. rstest's dynamic-import-origin rewrite hard-coupled its rewrite callee to `output.importFunctionName` and gated itself on `module.parser.javascript.importDynamic === false`.

## Why change

- `output.importFunctionName` is a generic rspack output knob (chunk loading uses it too). Conflating it with rstest's runtime entry point forces users to repurpose one config for two unrelated concerns.
- The `importDynamic` gate is redundant: `RstestParserPlugin` registers ahead of `ImportParserPlugin`, so plugin ordering alone already satisfies the original "don't collide with default `import()` handling" intent.

## How

- Accept `injectDynamicImportOrigin: { functionName?: string }` as an alternative to `boolean`, so rstest can pick its callee independently. Boolean callers are unaffected (subtype of the new union).
- Resolve the callee once in `Plugin::apply`, drop the `importDynamic` gate, and normalize the default `'import'` to "feature off" at apply time (native `import()` won't accept the extra origin arg).

Public API stays fully compatible. One edge case shifts: `injectDynamicImportOrigin: true` + custom `output.importFunctionName` without `importDynamic: false` previously silently no-op'd and now applies — closer to a fix than a break.

## Test plan

- [x] Existing `dynamic-import-origin` fixture (boolean form) passes
- [x] New `dynamic-import-origin-function-name` fixture (object form) passes