### PR TITLE
docs: replace webpack-merge references with rspack-merge

### DIFF
--- a/website/docs/en/config/extends.mdx
+++ b/website/docs/en/config/extends.mdx
@@ -18,7 +18,7 @@ Used to extend configurations from other files or packages. This allows you to c
 :::info
 This option is only supported in [`@rspack/cli`](/api/cli).
 
-If you are using the JavaScript API or other Rspack-based tools, `extends` will not take effect, use [webpack-merge](/config#webpack-merge) instead.
+If you are using the JavaScript API or other Rspack-based tools, `extends` will not take effect, use [rspack-merge](/config#rspack-merge) instead.
 :::
 
 ## Basic usage

--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -224,7 +224,7 @@ export default function (env, argv) {
 
 ## Merge configurations
 
-Use Rspack's [extends](/config/extends) option or [webpack-merge](https://npmjs.com/package/webpack-merge) package to merge multiple Rspack configurations.
+Use Rspack's [extends](/config/extends) option or [rspack-merge](https://github.com/rstackjs/rspack-merge) package to merge multiple Rspack configurations.
 
 ### extends option
 
@@ -241,18 +241,18 @@ export default {
 
 > This option is only supported in `@rspack/cli`, see [extends](/config/extends) for more usage.
 
-### webpack-merge
+### rspack-merge
 
-`webpack-merge` is a community library for merging multiple webpack configurations, and it can also be used to merge Rspack configurations.
+`rspack-merge` is a community library for merging multiple Rspack configurations.
 
-First install `webpack-merge`:
+First install `rspack-merge`:
 
-<PackageManagerTabs command="add webpack-merge -D" />
+<PackageManagerTabs command="add rspack-merge -D" />
 
 Then you can use its `merge` function to merge configurations:
 
 ```js title="rspack.config.mjs"
-import { merge } from 'webpack-merge';
+import { merge } from 'rspack-merge';
 
 const isDev = process.env.NODE_ENV === 'development';
 const base = {};
@@ -263,4 +263,4 @@ const dev = {
 export default isDev ? merge(base, dev) : base;
 ```
 
-> See [webpack-merge documentation](https://npmjs.com/package/webpack-merge) for more details.
+> See [rspack-merge documentation](https://github.com/rstackjs/rspack-merge) for more details.

--- a/website/docs/en/config/index.mdx
+++ b/website/docs/en/config/index.mdx
@@ -243,7 +243,7 @@ export default {
 
 ### rspack-merge
 
-`rspack-merge` is a community library for merging multiple Rspack configurations.
+`rspack-merge` is a library for merging multiple Rspack configurations.
 
 First install `rspack-merge`:
 

--- a/website/docs/zh/config/extends.mdx
+++ b/website/docs/zh/config/extends.mdx
@@ -1,5 +1,5 @@
 ---
-description: '如果你在使用 JavaScript API，或是其他基于 Rspack 的工具，extends 将不会生效，请使用 webpack-merge 代替。'
+description: '如果你在使用 JavaScript API，或是其他基于 Rspack 的工具，extends 将不会生效，请使用 rspack-merge 代替。'
 ---
 
 import WebpackLicense from '@components/WebpackLicense';
@@ -18,7 +18,7 @@ import { Tabs, Tab } from '@theme';
 :::info
 该选项仅在 [@rspack/cli](/api/cli) 中有效。
 
-如果你在使用 JavaScript API，或是其他基于 Rspack 的工具，`extends` 将不会生效，请使用 [webpack-merge](/config#webpack-merge) 代替。
+如果你在使用 JavaScript API，或是其他基于 Rspack 的工具，`extends` 将不会生效，请使用 [rspack-merge](/config#rspack-merge) 代替。
 :::
 
 ## 基本用法

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -243,7 +243,7 @@ export default {
 
 ### rspack-merge
 
-`rspack-merge` 是一个社区库，用于合并多个 Rspack 配置。
+`rspack-merge` 是一个库，用于合并多个 Rspack 配置。
 
 首先安装 `rspack-merge`：
 

--- a/website/docs/zh/config/index.mdx
+++ b/website/docs/zh/config/index.mdx
@@ -224,7 +224,7 @@ export default function (env, argv) {
 
 ## 合并配置
 
-使用 Rspack 的 [extends](/config/extends) 选项或者 [webpack-merge](https://npmjs.com/package/webpack-merge) 包来合并多个 Rspack 配置。
+使用 Rspack 的 [extends](/config/extends) 选项或者 [rspack-merge](https://github.com/rstackjs/rspack-merge) 包来合并多个 Rspack 配置。
 
 ### extends 选项
 
@@ -241,18 +241,18 @@ export default {
 
 > 该选项仅在 `@rspack/cli` 中有效，查看 [extends](/config/extends) 了解更多用法。
 
-### webpack-merge
+### rspack-merge
 
-`webpack-merge` 是一个社区库，用于合并多个 webpack 配置，也能用于合并 Rspack 配置。
+`rspack-merge` 是一个社区库，用于合并多个 Rspack 配置。
 
-首先安装 `webpack-merge`：
+首先安装 `rspack-merge`：
 
-<PackageManagerTabs command="add webpack-merge -D" />
+<PackageManagerTabs command="add rspack-merge -D" />
 
 然后你就可以使用它的 `merge` 函数来合并配置：
 
 ```js title="rspack.config.mjs"
-import { merge } from 'webpack-merge';
+import { merge } from 'rspack-merge';
 
 const isDev = process.env.NODE_ENV === 'development';
 const base = {};
@@ -263,4 +263,4 @@ const dev = {
 export default isDev ? merge(base, dev) : base;
 ```
 
-> 查看 [webpack-merge 文档](https://npmjs.com/package/webpack-merge) 了解更多。
+> 查看 [rspack-merge 文档](https://github.com/rstackjs/rspack-merge) 了解更多。


### PR DESCRIPTION
Update documentation to reflect the change from webpack-merge to rspack-merge for configuration merging. This includes both English and Chinese versions of the docs.

## Summary

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
