### PR TITLE
chore: enable Rslint for more packages and fix lint issues

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -100,12 +100,17 @@ export class RspackCLI {
     options: CommonOptionsForBuildAndServe,
     rspackCommand: Command,
   ) {
-    let { config, pathMap } = await this.loadConfig(options);
-    config = await this.buildConfig(config, pathMap, options, rspackCommand);
+    const { config: rawConfig, pathMap } = await this.loadConfig(options);
+    const config = await this.buildConfig(
+      rawConfig,
+      pathMap,
+      options,
+      rspackCommand,
+    );
     return config;
   }
 
-  async createCompiler(
+  createCompiler(
     config: RspackOptions | MultiRspackOptions,
     callback?: (e: Error | null, res?: Stats | MultiStats) => void,
   ) {

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -117,7 +117,7 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
 }
 
 export class BuildCommand implements RspackCommand {
-  async apply(cli: RspackCLI): Promise<void> {
+  apply(cli: RspackCLI): void {
     const command = cli.program
       .command('', 'run the Rspack build')
       .alias('build')

--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -27,7 +27,7 @@ type PreviewOptions = CommonOptions & {
 };
 
 export class PreviewCommand implements RspackCommand {
-  async apply(cli: RspackCLI): Promise<void> {
+  apply(cli: RspackCLI): void {
     const command = cli.program
       .command('preview [dir]', 'run the Rspack server for build output')
       .alias('p');
@@ -115,7 +115,7 @@ async function getPreviewConfig(
 ): Promise<RspackOptions | MultiRspackOptions> {
   const DEFAULT_ROOT = 'dist';
 
-  const internalPreviewConfig = async (item: RspackOptions) => {
+  const internalPreviewConfig = (item: RspackOptions) => {
     // all of the options that a preview static server needs(maybe not all)
     const devServer = item.devServer === false ? undefined : item.devServer;
     item.devServer = {

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -38,7 +38,7 @@ function normalizeHotOption(
 }
 
 export class ServeCommand implements RspackCommand {
-  async apply(cli: RspackCLI): Promise<void> {
+  apply(cli: RspackCLI): void {
     const command = cli.program
       .command('serve', 'run the rspack dev server.')
       .alias('server')

--- a/packages/rspack-cli/src/types.ts
+++ b/packages/rspack-cli/src/types.ts
@@ -22,5 +22,5 @@ export interface RspackCLILogger {
 }
 
 export interface RspackCommand {
-  apply(cli: RspackCLI): Promise<void>;
+  apply(cli: RspackCLI): void | Promise<void>;
 }

--- a/packages/rspack-test-tools/src/case/builtin.ts
+++ b/packages/rspack-test-tools/src/case/builtin.ts
@@ -18,7 +18,7 @@ const creator = new BasicCaseCreator({
     const filter = FILTERS[cat];
     return [
       {
-        config: async (context: ITestContext) => {
+        config: (context: ITestContext) => {
           const compiler = context.getCompiler();
           compiler.setOptions(defaultOptions(context));
         },

--- a/packages/rspack-test-tools/src/case/cache.ts
+++ b/packages/rspack-test-tools/src/case/cache.ts
@@ -69,7 +69,7 @@ function createCacheProcessor(
     after: async (context: ITestContext) => {
       await afterExecute(context, name);
     },
-    afterAll: async (context: ITestContext) => {
+    afterAll: (context: ITestContext) => {
       const updateIndex = updatePlugin.getUpdateIndex();
       const totalUpdates = updatePlugin.getTotalUpdates();
       if (updateIndex + 1 !== totalUpdates) {

--- a/packages/rspack-test-tools/src/case/common.ts
+++ b/packages/rspack-test-tools/src/case/common.ts
@@ -8,12 +8,12 @@ import checkArrayExpectation from '../helper/legacy/checkArrayExpectation';
 import { DEBUG_SCOPES } from '../test/debug';
 import type { ITestContext, ITestEnv } from '../type';
 
-export async function config(
+export function config(
   context: ITestContext,
   name: string,
   configFiles: string[],
   defaultOptions: RspackOptions = {},
-): Promise<RspackOptions> {
+): RspackOptions {
   const compiler = context.getCompiler();
   compiler.setOptions(defaultOptions);
   if (Array.isArray(configFiles)) {
@@ -27,10 +27,7 @@ export async function config(
   return compiler.getOptions() as RspackOptions;
 }
 
-export async function compiler(
-  context: ITestContext,
-  name: string,
-): Promise<Compiler> {
+export function compiler(context: ITestContext, name: string): Compiler {
   const compiler = context.getCompiler();
   compiler.createCompiler();
   return compiler.getCompiler()! as Compiler;
@@ -203,7 +200,7 @@ export async function check(
   }
 }
 
-export async function checkSnapshot(
+export function checkSnapshot(
   env: ITestEnv,
   context: ITestContext,
   name: string,
@@ -281,7 +278,7 @@ export async function checkSnapshot(
   }
 }
 
-export async function afterExecute(context: ITestContext, name: string) {
+export function afterExecute(context: ITestContext, name: string) {
   const compiler = context.getCompiler();
   const testConfig = context.getTestConfig();
   if (typeof testConfig.afterExecute === 'function') {

--- a/packages/rspack-test-tools/src/case/compiler.ts
+++ b/packages/rspack-test-tools/src/case/compiler.ts
@@ -7,7 +7,12 @@ import type {
   StatsCompilation,
 } from '@rspack/core';
 import { BasicCaseCreator } from '../test/creator';
-import type { ITestContext, ITestEnv, ITestProcessor } from '../type';
+import type {
+  ITestContext,
+  ITestEnv,
+  ITestProcessor,
+  MaybePromise,
+} from '../type';
 
 function createCompilerProcessor(
   name: string,
@@ -19,7 +24,7 @@ function createCompilerProcessor(
   };
   const files = {} as Record<string, string>;
   return {
-    config: async (context: ITestContext) => {
+    config: (context: ITestContext) => {
       const compiler = context.getCompiler();
       const options = caseConfig.options?.(context) || {};
       options.mode ??= 'production';
@@ -189,8 +194,8 @@ export type TCompilerCaseConfig = {
   error?: boolean;
   skip?: boolean;
   options?: (context: ITestContext) => RspackOptions;
-  compiler?: (context: ITestContext, compiler: Compiler) => Promise<void>;
-  build?: (context: ITestContext, compiler: Compiler) => Promise<void>;
+  compiler?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
+  build?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
   check?: ({
     context,
     stats,
@@ -203,6 +208,6 @@ export type TCompilerCaseConfig = {
     files?: Record<string, string>;
     compiler: Compiler;
     compilation?: Compilation;
-  }) => Promise<void>;
+  }) => MaybePromise<void>;
   compilerCallback?: (error: Error | null, stats: Stats | null) => void;
 };

--- a/packages/rspack-test-tools/src/case/config.ts
+++ b/packages/rspack-test-tools/src/case/config.ts
@@ -24,7 +24,7 @@ export type TConfigCaseConfig = Omit<TTestConfig, 'validate'>;
 
 export function createConfigProcessor(name: string): ITestProcessor {
   return {
-    config: async (context: ITestContext) => {
+    config: (context: ITestContext) => {
       configMultiCompiler(
         context,
         name,

--- a/packages/rspack-test-tools/src/case/defaults.ts
+++ b/packages/rspack-test-tools/src/case/defaults.ts
@@ -11,11 +11,11 @@ export function createDefaultsCase(name: string, src: string) {
   const caseConfig = require(src) as TDefaultsCaseConfig;
   it(`should generate the correct defaults from ${caseConfig.description}`, async () => {
     await run(name, {
-      config: async (context: ITestContext) => {
+      config: (context: ITestContext) => {
         const compiler = context.getCompiler();
         compiler.setOptions(options(context, caseConfig.options));
       },
-      compiler: async (context: ITestContext) => {
+      compiler: (context: ITestContext) => {
         const compiler = context.getCompiler();
         compiler.createCompiler();
       },

--- a/packages/rspack-test-tools/src/case/diagnostic.ts
+++ b/packages/rspack-test-tools/src/case/diagnostic.ts
@@ -12,7 +12,7 @@ const creator = new BasicCaseCreator({
   describe: false,
   steps: ({ name }) => [
     {
-      config: async (context: ITestContext) => {
+      config: (context: ITestContext) => {
         const compiler = context.getCompiler();
         let options = defaultOptions(context);
         const custom = readConfigFile(
@@ -32,7 +32,7 @@ const creator = new BasicCaseCreator({
         }
         compiler.setOptions(options);
       },
-      compiler: async (context: ITestContext) => {
+      compiler: (context: ITestContext) => {
         const compiler = context.getCompiler();
         compiler.createCompiler();
       },
@@ -102,7 +102,7 @@ function defaultOptions(context: ITestContext): RspackOptions {
   } as RspackOptions;
 }
 
-async function check(
+function check(
   env: ITestEnv,
   context: ITestContext,
   name: string,

--- a/packages/rspack-test-tools/src/case/error.ts
+++ b/packages/rspack-test-tools/src/case/error.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { Compiler, RspackOptions, StatsError } from '@rspack/core';
 import merge from 'rspack-merge';
 import { BasicCaseCreator } from '../test/creator';
-import type { ITestContext, ITestEnv } from '../type';
+import type { ITestContext, ITestEnv, MaybePromise } from '../type';
 
 let addedSerializer = false;
 
@@ -14,14 +14,18 @@ const creator = new BasicCaseCreator({
     const config = caseConfig as TErrorCaseConfig;
     return [
       {
-        config: async (context: ITestContext) => {
+        config: (context: ITestContext) => {
           const compiler = context.getCompiler();
           compiler.setOptions(options(context, config.options));
         },
         compiler: async (context: ITestContext) => {
           const compilerManager = context.getCompiler();
           compilerManager.createCompiler();
-          compiler(context, compilerManager.getCompiler()!, config.compiler);
+          await compiler(
+            context,
+            compilerManager.getCompiler()!,
+            config.compiler,
+          );
         },
         build: async (context: ITestContext) => {
           const compiler = context.getCompiler();
@@ -112,7 +116,7 @@ function options(
 async function compiler(
   context: ITestContext,
   compiler: Compiler,
-  custom?: (context: ITestContext, compiler: Compiler) => Promise<void>,
+  custom?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>,
 ) {
   if (compiler) {
     compiler.outputFileSystem = {
@@ -152,7 +156,7 @@ async function check(
   env: ITestEnv,
   context: ITestContext,
   name: string,
-  check?: (stats: RspackStatsDiagnostics) => Promise<void>,
+  check?: (stats: RspackStatsDiagnostics) => MaybePromise<void>,
 ) {
   if (context.getError().length > 0) {
     await check?.(
@@ -183,7 +187,7 @@ export type TErrorCaseConfig = {
   description: string;
   skip?: boolean;
   options?: (context: ITestContext) => RspackOptions;
-  compiler?: (context: ITestContext, compiler: Compiler) => Promise<void>;
-  build?: (context: ITestContext, compiler: Compiler) => Promise<void>;
-  check?: (stats: RspackStatsDiagnostics) => Promise<void>;
+  compiler?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
+  build?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
+  check?: (stats: RspackStatsDiagnostics) => MaybePromise<void>;
 };

--- a/packages/rspack-test-tools/src/case/esm-output.ts
+++ b/packages/rspack-test-tools/src/case/esm-output.ts
@@ -29,7 +29,7 @@ const creator = new BasicCaseCreator({
   },
   steps: ({ name }) => [
     {
-      config: async (context: ITestContext) => {
+      config: (context: ITestContext) => {
         configMultiCompiler(
           context,
           name,

--- a/packages/rspack-test-tools/src/case/example.ts
+++ b/packages/rspack-test-tools/src/case/example.ts
@@ -20,7 +20,7 @@ function overrideOptions(
 
 function createExampleProcessor(name: string): ITestProcessor {
   return {
-    config: async (context: ITestContext) => {
+    config: (context: ITestContext) => {
       configMultiCompiler(
         context,
         name,
@@ -38,7 +38,7 @@ function createExampleProcessor(name: string): ITestProcessor {
     run: async (env: ITestEnv, context: ITestContext) => {
       // no need to run, just check the building
     },
-    check: async (env: ITestEnv, context: ITestContext) => {
+    check: (env: ITestEnv, context: ITestContext) => {
       const compiler = context.getCompiler();
       const stats = compiler.getStats();
       if (stats?.hasErrors()) {

--- a/packages/rspack-test-tools/src/case/hash.ts
+++ b/packages/rspack-test-tools/src/case/hash.ts
@@ -31,7 +31,7 @@ const creator = new HashCaseCreator({
   describe: false,
   steps: ({ name }) => [
     {
-      config: async (context: ITestContext) => {
+      config: (context: ITestContext) => {
         configMultiCompiler(
           context,
           name,
@@ -96,7 +96,7 @@ function overrideOptions(
   }
 }
 
-async function check(env: ITestEnv, context: ITestContext, name: string) {
+function check(env: ITestEnv, context: ITestContext, name: string) {
   const compiler = context.getCompiler();
   const stats = compiler.getStats();
   const testConfig = context.getTestConfig();

--- a/packages/rspack-test-tools/src/case/hot-step.ts
+++ b/packages/rspack-test-tools/src/case/hot-step.ts
@@ -361,7 +361,7 @@ ${runtime.javascript.disposedModules.map((i) => `- ${i}`).join('\n')}
     await originRun(env, context);
   };
 
-  processor.check = async function (env, context) {
+  processor.check = function (env, context) {
     const compiler = context.getCompiler();
     const stats = compiler.getStats() as Stats;
     if (!stats || !stats.hash) {

--- a/packages/rspack-test-tools/src/case/hot.ts
+++ b/packages/rspack-test-tools/src/case/hot.ts
@@ -70,7 +70,7 @@ export function createHotProcessor(
     after: async (context: ITestContext) => {
       await afterExecute(context, name);
     },
-    afterAll: async (context: ITestContext) => {
+    afterAll: (context: ITestContext) => {
       if (context.getTestConfig().checkSteps === false) {
         return;
       }

--- a/packages/rspack-test-tools/src/case/multi-compiler.ts
+++ b/packages/rspack-test-tools/src/case/multi-compiler.ts
@@ -10,14 +10,19 @@ import type {
 } from '@rspack/core';
 import { createFsFromVolume, Volume } from 'memfs';
 import { BasicCaseCreator } from '../test/creator';
-import type { ITestContext, ITestEnv, ITestProcessor } from '../type';
+import type {
+  ITestContext,
+  ITestEnv,
+  ITestProcessor,
+  MaybePromise,
+} from '../type';
 
 function createMultiCompilerProcessor(
   name: string,
   caseConfig: TMultiCompilerCaseConfig,
 ) {
   return {
-    config: async (context: ITestContext) => {
+    config: (context: ITestContext) => {
       const compiler = context.getCompiler();
       const options = Object.assign(
         [
@@ -122,8 +127,8 @@ export type TMultiCompilerCaseConfig = {
   error?: boolean;
   skip?: boolean;
   options?: (context: ITestContext) => RspackOptions;
-  compiler?: (context: ITestContext, compiler: Compiler) => Promise<void>;
-  build?: (context: ITestContext, compiler: Compiler) => Promise<void>;
+  compiler?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
+  build?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
   check?: ({
     context,
     stats,
@@ -136,6 +141,6 @@ export type TMultiCompilerCaseConfig = {
     files?: Record<string, string>;
     compiler: Compiler;
     compilation?: Compilation;
-  }) => Promise<void>;
+  }) => MaybePromise<void>;
   compilerCallback?: (error: Error | null, stats: Stats | null) => void;
 };

--- a/packages/rspack-test-tools/src/case/stats-api.ts
+++ b/packages/rspack-test-tools/src/case/stats-api.ts
@@ -2,7 +2,7 @@ import type fs from 'node:fs';
 import type { Compiler, RspackOptions, Stats } from '@rspack/core';
 import { createFsFromVolume, Volume } from 'memfs';
 import { BasicCaseCreator } from '../test/creator';
-import type { ITestContext, ITestEnv } from '../type';
+import type { ITestContext, ITestEnv, MaybePromise } from '../type';
 
 let addedSerializer = false;
 
@@ -10,9 +10,9 @@ export type TStatsAPICaseConfig = {
   description: string;
   options?: (context: ITestContext) => RspackOptions;
   snapshotName?: string;
-  compiler?: (context: ITestContext, compiler: Compiler) => Promise<void>;
-  build?: (context: ITestContext, compiler: Compiler) => Promise<void>;
-  check?: (stats: Stats, compiler: Compiler) => Promise<void>;
+  compiler?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
+  build?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>;
+  check?: (stats: Stats, compiler: Compiler) => MaybePromise<void>;
 };
 
 const creator = new BasicCaseCreator({
@@ -22,14 +22,18 @@ const creator = new BasicCaseCreator({
     const config = caseConfig as TStatsAPICaseConfig;
     return [
       {
-        config: async (context: ITestContext) => {
+        config: (context: ITestContext) => {
           const compiler = context.getCompiler();
           compiler.setOptions(options(context, config.options));
         },
         compiler: async (context: ITestContext) => {
           const compilerManager = context.getCompiler();
           compilerManager.createCompiler();
-          compiler(context, compilerManager.getCompiler()!, config.compiler);
+          await compiler(
+            context,
+            compilerManager.getCompiler()!,
+            config.compiler,
+          );
         },
         build: async (context: ITestContext) => {
           const compiler = context.getCompiler();
@@ -92,7 +96,7 @@ function options(
 async function compiler(
   context: ITestContext,
   compiler: Compiler,
-  custom?: (context: ITestContext, compiler: Compiler) => Promise<void>,
+  custom?: (context: ITestContext, compiler: Compiler) => MaybePromise<void>,
 ) {
   if (custom) {
     await custom(context, compiler);
@@ -108,7 +112,7 @@ async function check(
   env: ITestEnv,
   context: ITestContext,
   name: string,
-  custom?: (stats: Stats, compiler: Compiler) => Promise<void>,
+  custom?: (stats: Stats, compiler: Compiler) => MaybePromise<void>,
 ) {
   const manager = context.getCompiler();
   const stats = manager.getStats()! as Stats;

--- a/packages/rspack-test-tools/src/case/stats-output.ts
+++ b/packages/rspack-test-tools/src/case/stats-output.ts
@@ -22,10 +22,10 @@ export function createStatsProcessor(
   const snapshotName = 'stats.txt';
   let stderr: any = null;
   return {
-    before: async (context: ITestContext) => {
+    before: (context: ITestContext) => {
       stderr = captureStdio(process.stderr, true);
     },
-    config: async (context: ITestContext) => {
+    config: (context: ITestContext) => {
       configMultiCompiler(
         context,
         name,
@@ -47,7 +47,7 @@ export function createStatsProcessor(
     check: async (env: ITestEnv, context: ITestContext) => {
       await check(env, context, name, writeStatsOuptut, snapshotName, stderr);
     },
-    after: async (context: ITestContext) => {
+    after: (context: ITestContext) => {
       stderr.restore();
     },
   };
@@ -137,7 +137,7 @@ class RspackStats {
   constructor(public value: string) {}
 }
 
-async function check(
+function check(
   env: ITestEnv,
   context: ITestContext,
   name: string,
@@ -236,7 +236,7 @@ async function check(
   }
 }
 
-async function statsCompiler(context: ITestContext, compiler: Compiler) {
+function statsCompiler(context: ITestContext, compiler: Compiler) {
   const compilers: Compiler[] = (compiler as any).compilers
     ? (compiler as any).compilers
     : [compiler as any];

--- a/packages/rspack-test-tools/src/case/treeshaking.ts
+++ b/packages/rspack-test-tools/src/case/treeshaking.ts
@@ -12,7 +12,7 @@ const creator = new BasicCaseCreator({
   },
   steps: ({ name }) => [
     {
-      config: async (context: ITestContext) => {
+      config: (context: ITestContext) => {
         const compiler = context.getCompiler();
         const options = defaultOptions(context);
         overrideOptions(context, options);

--- a/packages/rspack-test-tools/src/case/watch.ts
+++ b/packages/rspack-test-tools/src/case/watch.ts
@@ -12,6 +12,7 @@ import type {
   IModuleScope,
   ITestContext,
   ITestEnv,
+  ITestProcessor,
   ITestRunner,
 } from '../type';
 import { afterExecute, compiler, findMultiCompilerBundle, run } from './common';
@@ -31,7 +32,7 @@ export function createWatchInitialProcessor(
   step: string,
   watchState: Record<string, any>,
   { incremental = false, nativeWatcher = false } = {},
-) {
+): ITestProcessor {
   const watchContext: TWatchContext = {
     currentTriggerFilename: null,
     lastHash: null,
@@ -42,10 +43,10 @@ export function createWatchInitialProcessor(
   };
 
   return {
-    before: async (context: ITestContext) => {
+    before: (context: ITestContext) => {
       context.setValue('watchContext', watchContext);
     },
-    config: async (context: ITestContext) => {
+    config: (context: ITestContext) => {
       const testConfig = context.getTestConfig();
       const multiCompilerOptions = [];
       const caseOptions: RspackOptions[] = readConfigFile(
@@ -281,7 +282,7 @@ export function createWatchStepProcessor(
     watchState,
     { incremental },
   );
-  processor.compiler = async (context: ITestContext) => {
+  processor.compiler = (context: ITestContext) => {
     // do nothing
   };
   processor.build = async (context: ITestContext) => {

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -114,7 +114,7 @@ export class HotUpdatePlugin {
     this.updateIndex++;
     await this.updateFiles();
   }
-  async moveTempDir() {
+  moveTempDir() {
     // generate next temp dir path.
     const nextTempDir =
       this.tempDir.replace(/(___[0-9]+)?[/\\]*$/, '') +

--- a/packages/rspack-test-tools/src/runner/node/index.ts
+++ b/packages/rspack-test-tools/src/runner/node/index.ts
@@ -515,7 +515,7 @@ export class NodeRunner implements ITestRunner {
             const result = await _require(path.dirname(file!.path), specifier, {
               esmMode: EEsmMode.Evaluated,
             });
-            return await asModule(result, module.context);
+            return asModule(result, module.context);
           },
         } as any);
         esmCache.set(file.path, esm);
@@ -524,7 +524,7 @@ export class NodeRunner implements ITestRunner {
       return (async () => {
         if (esm.status === 'unlinked') {
           await esm.link(async (specifier, referencingModule) => {
-            return await asModule(
+            return asModule(
               await _require(
                 path.dirname(
                   referencingModule.identifier

--- a/packages/rspack-test-tools/src/runner/web/index.ts
+++ b/packages/rspack-test-tools/src/runner/web/index.ts
@@ -190,7 +190,8 @@ export class WebRunner extends NodeRunner {
         return {
           status: 200,
           ok: true,
-          json: async () => JSON.parse(buffer.toString('utf-8')),
+          json: () =>
+            Promise.resolve().then(() => JSON.parse(buffer.toString('utf-8'))),
         };
       } catch (err) {
         if ((err as { code: string }).code === 'ENOENT') {

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -51,6 +51,8 @@ export interface ITestLoader {
 
 export type TTestRunResult = Record<string, any>;
 
+export type MaybePromise<T> = T | Promise<T>;
+
 export interface ITesterConfig {
   name: string;
   src: string;
@@ -76,16 +78,16 @@ export interface ITester {
 }
 
 export interface ITestProcessor {
-  beforeAll?(context: ITestContext): Promise<void>;
-  afterAll?(context: ITestContext): Promise<void>;
-  before?(context: ITestContext): Promise<void>;
-  after?(context: ITestContext): Promise<void>;
+  beforeAll?(context: ITestContext): MaybePromise<void>;
+  afterAll?(context: ITestContext): MaybePromise<void>;
+  before?(context: ITestContext): MaybePromise<void>;
+  after?(context: ITestContext): MaybePromise<void>;
 
-  config(context: ITestContext): Promise<void>;
-  compiler(context: ITestContext): Promise<void>;
-  build(context: ITestContext): Promise<void>;
-  run(env: ITestEnv, context: ITestContext): Promise<void>;
-  check(env: ITestEnv, context: ITestContext): Promise<unknown>;
+  config(context: ITestContext): MaybePromise<void>;
+  compiler(context: ITestContext): MaybePromise<void>;
+  build(context: ITestContext): MaybePromise<void>;
+  run(env: ITestEnv, context: ITestContext): MaybePromise<void>;
+  check(env: ITestEnv, context: ITestContext): MaybePromise<unknown>;
 }
 
 export interface ITestReporter {

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -13,7 +13,7 @@ export default defineConfig([
   {
     languageOptions: {
       parserOptions: {
-        project: ['./packages/rspack/tsconfig.json'],
+        project: ['./packages/*/tsconfig.json'],
       },
     },
     rules: {


### PR DESCRIPTION
## Summary

This PR fixes the JavaScript lint failures caused by type-aware linting across workspace packages. It removes unnecessary async markers from synchronous CLI and test-tool hooks, allows test processors to return either synchronous values or promises, and keeps Promise semantics where mocked fetch JSON parsing can reject asynchronously.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).