### PR TITLE
chore: enable Rslint JS recommended rules 

### DIFF
--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig, ts } from '@rslint/core';
+import { defineConfig, js, ts } from '@rslint/core';
 
 export default defineConfig([
+  js.configs.recommended,
+  ts.configs.recommended,
   {
     // Global ignores — entry with only `ignores` excludes matching files from all rules
     ignores: [
       'packages/rspack/src/runtime/moduleFederationDefaultRuntime.js',
-      'packages/rspack/compiled/**',
       '**/tests/**',
     ],
   },
-  ts.configs.recommended,
   {
     languageOptions: {
       parserOptions: {

--- a/scripts/build-npm.cjs
+++ b/scripts/build-npm.cjs
@@ -44,9 +44,12 @@ function parseTriple(rawTriple) {
   let sys;
   let abi = null;
   if (triples.length === 4) {
-    [cpu, , sys, abi = null] = triples;
+    cpu = triples[0];
+    sys = triples[2];
+    abi = triples[3] ?? null;
   } else if (triples.length === 3) {
-    [cpu, , sys] = triples;
+    cpu = triples[0];
+    sys = triples[2];
   } else {
     [cpu, sys] = triples;
   }


### PR DESCRIPTION
## Summary

This PR updates the lint configuration to include the JavaScript recommended rules and fixes the reported sparse array destructuring in the npm build script while preserving target triple parsing behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).