### PR TITLE
[WIP] perf(build): reduce binding size with size-optimized tracing, dll and browserslist crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,6 +373,29 @@ opt-level = "s"
 [profile.release.package.swc_ecma_ext_transforms]
 opt-level = "s"
 
+[profile.release.package.prost]
+opt-level = "s"
+
+[profile.release.package.prost-derive]
+opt-level = "s"
+
+[profile.release.package.rspack_plugin_dll]
+opt-level = "s"
+
+[profile.release.package.rspack_tracing]
+opt-level = "s"
+
+[profile.release.package.rspack_tracing_perfetto]
+opt-level = "s"
+
+[profile.release.package.tracing]
+opt-level = "s"
+
+[profile.release.package.browserslist-rs]
+opt-level = "s"
+
+[profile.release.package.tracing-subscriber]
+opt-level = "s"
 
 [profile.release.package.icu_normalizer]
 opt-level = "s"


### PR DESCRIPTION
## Summary

* modify tracing crates to size-optimized
* dll plugin is deprecated, move to size-optimized
* browserslist is only executed on initialization, then translated into lightningcss internal data structures. swc has its own browserslist parser

## Related links

https://github.com/web-infra-dev/rspack/issues/13908

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
