### PR TITLE
chore: reduce binding release size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,30 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,8 +2538,6 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
  "owo-colors",
@@ -7278,7 +7252,6 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "tokio-macros",
- "tracing",
 ]
 
 [[package]]
@@ -7848,7 +7821,6 @@ dependencies = [
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "windows-sys 0.59.0",
 ]
 
@@ -7979,23 +7951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object",
- "target-lexicon",
- "wasmparser 0.235.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wast"
 version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8085,26 +8040,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.17",
- "wasmparser 0.235.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ libraries = [{ path = "linting/*" }]
 
 [workspace.dependencies]
 aho-corasick    = { version = "1.1.4", default-features = false }
-anyhow          = { version = "1.0.102", default-features = false, features = ["backtrace", "std"] }
+anyhow          = { version = "1.0.102", default-features = false, features = ["std"] }
 anymap          = { package = "anymap3", version = "1.0.1", default-features = false, features = ["std"] }
 async-recursion = { version = "1.1.1", default-features = false }
 async-trait     = { version = "0.1.89", default-features = false }
@@ -295,9 +295,6 @@ opt-level = "s"
 [profile.release.package.rspack_plugin_rsdoctor]
 opt-level = "s"
 
-[profile.release.package.backtrace]
-opt-level = "s"
-
 [profile.release.package.aho-corasick]
 opt-level = "s"
 
@@ -337,6 +334,8 @@ opt-level = "s"
 [profile.release.package.rspack_error]
 opt-level = "s"
 
+[profile.release.package.rspack_loader_testing]
+opt-level = "z"
 
 [profile.release.package.rspack_plugin_progress]
 opt-level = "s"
@@ -354,7 +353,7 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package.wasmparser]
-opt-level = "s"
+opt-level = "z"
 
 [profile.release.package.jsonc-parser]
 opt-level = "s"
@@ -387,13 +386,100 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package."cranelift-codegen"]
-opt-level = "s"
+opt-level = "z"
+
+[profile.release.package."cranelift-assembler-x64"]
+opt-level = "z"
+
+[profile.release.package."cranelift-bforest"]
+opt-level = "z"
+
+[profile.release.package."cranelift-bitset"]
+opt-level = "z"
+
+[profile.release.package."cranelift-codegen-shared"]
+opt-level = "z"
+
+[profile.release.package."cranelift-control"]
+opt-level = "z"
+
+[profile.release.package."cranelift-entity"]
+opt-level = "z"
+
+[profile.release.package."cranelift-frontend"]
+opt-level = "z"
+
+[profile.release.package."cranelift-native"]
+opt-level = "z"
+
+[profile.release.package.regalloc2]
+opt-level = "z"
+
+[profile.release.package."pulley-interpreter"]
+opt-level = "z"
+
+[profile.release.package."wasm-encoder"]
+opt-level = "z"
 
 [profile.release.package.wasmtime]
 opt-level = "s"
 
+[profile.release.package.wasmtime-environ]
+opt-level = "z"
+
+[profile.release.package."wasmtime-internal-asm-macros"]
+opt-level = "z"
+
+[profile.release.package."wasmtime-internal-cranelift"]
+opt-level = "z"
+
+[profile.release.package."wasmtime-internal-jit-icache-coherence"]
+opt-level = "z"
+
+[profile.release.package."wasmtime-internal-math"]
+opt-level = "z"
+
+[profile.release.package."wasmtime-internal-slab"]
+opt-level = "z"
+
+[profile.release.package."wasmtime-internal-unwinder"]
+opt-level = "z"
+
+[profile.release.package.wasmprinter]
+opt-level = "z"
+
+[profile.release.package.wast]
+opt-level = "z"
+
 [profile.release.package."wasi-common"]
-opt-level = "s"
+opt-level = "z"
+
+[profile.release.package."cap-fs-ext"]
+opt-level = "z"
+
+[profile.release.package."cap-primitives"]
+opt-level = "z"
+
+[profile.release.package."cap-rand"]
+opt-level = "z"
+
+[profile.release.package."cap-std"]
+opt-level = "z"
+
+[profile.release.package."cap-time-ext"]
+opt-level = "z"
+
+[profile.release.package."io-extras"]
+opt-level = "z"
+
+[profile.release.package."io-lifetimes"]
+opt-level = "z"
+
+[profile.release.package."system-interface"]
+opt-level = "z"
+
+[profile.release.package.wiggle]
+opt-level = "z"
 
 # This is for CI build based on release but with faster build time
 [profile.ci]

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -52,7 +52,7 @@ tracing                 = { workspace = true }
 tracing-subscriber      = { workspace = true }
 tracy-client            = { workspace = true, optional = true }
 
-napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9", "compat-mode"] }
+napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "napi9", "compat-mode"] }
 napi-derive = { workspace = true, features = ["compat-mode"] }
 
 derive_more                            = { workspace = true, features = ["debug"] }
@@ -116,7 +116,7 @@ rustc-hash                             = { workspace = true }
 serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "parking_lot"] }
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -569,9 +569,10 @@ fn register_global_trace(
   filter: String,
   #[napi(ts_arg_type = " \"logger\" | \"perfetto\" ")] layer: String,
   output: String,
-) -> anyhow::Result<()> {
+) -> napi::Result<()> {
   #[cfg(not(feature = "browser"))]
-  trace_event::register_global_trace(filter, layer, output)?;
+  trace_event::register_global_trace(filter, layer, output)
+    .map_err(|e| napi::Error::from_reason(e.to_string()))?;
   Ok(())
 }
 

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -59,7 +59,7 @@ serde                      = { workspace = true }
 serde_json                 = { workspace = true }
 sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }
-tokio                      = { workspace = true, features = ["rt", "macros"] }
+tokio                      = { workspace = true, features = ["rt", "sync", "time"] }
 tracing                    = { workspace = true }
 urlencoding                = { workspace = true }
 ustr                       = { workspace = true }
@@ -71,6 +71,7 @@ swc_experimental_ecma_semantic = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tokio             = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -8,8 +8,8 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow             = { workspace = true, features = ["backtrace"] }
-miette             = { workspace = true, features = ["fancy", "derive"] }
+anyhow             = { workspace = true }
+miette             = { workspace = true, features = ["fancy-no-backtrace", "derive"] }
 owo-colors         = { workspace = true }
 rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -14,11 +14,14 @@ pnp          = { workspace = true }
 rspack_error = { workspace = true }
 rspack_paths = { workspace = true }
 rspack_util  = { workspace = true }
-tokio        = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tokio        = { workspace = true, features = ["rt", "sync"] }
 tracing      = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "sync", "fs"] }
+tokio = { workspace = true, features = ["rt", "sync", "fs"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [lints]
 workspace = true

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -11,7 +11,6 @@ async-trait = { workspace = true }
 derive_more = { workspace = true, features = ["debug"] }
 memchr      = { workspace = true }
 rustc-hash  = { workspace = true }
-tokio       = { workspace = true, features = ["test-util"] }
 
 once_cell          = { workspace = true }
 rspack_cacheable   = { workspace = true }
@@ -24,6 +23,9 @@ rspack_util        = { workspace = true }
 serde_json         = { workspace = true }
 tracing            = { workspace = true }
 winnow             = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9", "compat-mode"] }
+napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "napi9", "compat-mode"] }
 oneshot      = { workspace = true }
 rspack_error = { workspace = true }
 serde_json   = { workspace = true }

--- a/crates/rspack_parallel/Cargo.toml
+++ b/crates/rspack_parallel/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 async-trait  = { workspace = true }
 rayon        = { workspace = true }
 rspack_tasks = { workspace = true }
-tokio        = { workspace = true, features = ["rt", "sync", "macros"] }
+tokio        = { workspace = true, features = ["rt", "sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -38,7 +38,7 @@ anyhow            = { workspace = true, optional = true }
 once_cell         = { workspace = true, optional = true }
 swc_plugin_runner = { workspace = true, optional = true }
 wasi-common       = { workspace = true, optional = true, features = ["sync", "wasmtime"] }
-wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift", "threads"] }
+wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift"] }
 
 rspack_regex = { workspace = true }
 signal-hook  = { workspace = true, optional = true }

--- a/crates/rspack_watcher/Cargo.toml
+++ b/crates/rspack_watcher/Cargo.toml
@@ -15,14 +15,15 @@ rspack_error = { workspace = true }
 rspack_paths = { workspace = true }
 rspack_regex = { workspace = true }
 rspack_util  = { workspace = true }
-tokio        = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tokio        = { workspace = true, features = ["rt", "sync", "time"] }
 tracing      = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "sync", "fs"] }
+tokio = { workspace = true, features = ["rt", "sync", "fs"] }
 
 [dev-dependencies]
 tempfile = "3.23.0"
+tokio    = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

This draft reduces the published `@rspack/binding` linux-x64-gnu release artifact size by combining a feature audit with constrained release-profile size optimization.

Feature-level changes:

- Drop the external `backtrace` chain by removing `anyhow/backtrace` and switching `rspack_error` from `miette/fancy` to `miette/fancy-no-backtrace`.
- Remove `napi/anyhow` from the binding crates and convert the exported trace registration API to return `napi::Result` directly.
- Remove release-path Tokio features that were only used for tests or not used by the crate code: `test-util`, `tracing`, and several crate-local `macros` uses moved to `dev-dependencies`.
- Drop `wasmtime/threads`, which removes the unused Winch codegen path from the release graph for the SWC wasm plugin runtime.

Release profile size optimization excludes all `rspack_plugin_*` crates. Existing `rspack_plugin_*` profile entries remain at their previous `s` level, and no `rspack_plugin_*` crate is changed to `opt-level = "z"`.

SWC wasm plugin execution is also treated conservatively: `swc_plugin_runner` is not size-optimized with `z`, and `wasmtime` stays at its previous `s` level. The remaining `z` coverage is limited to non-`rspack_plugin` paths such as selected loader/testing/tooling code plus Cranelift/WASI supporting crates where the direct wasm-plugin benchmark did not show a regression after keeping `wasmtime` out of `z`.

## Feature Audit Notes

Confirmed removed from the release feature graph:

- `backtrace`, `backtrace-ext`
- `napi/anyhow`
- `tokio/test-util`, `tokio/tracing`
- `wasmtime/threads`, `wasmtime-internal-winch`, `winch-codegen`

Checked and intentionally kept:

- `napi/serde-json`: required by many `serde_json::Value` N-API conversions.
- `napi/compat-mode`: required by existing compat API types such as `CallContext`, `JsObject`, `JsString`, `JsSymbol`, and `Ref`.
- `napi9`: required by symbol APIs.
- `tracing-subscriber/json` and `env-filter`: part of the exported trace registration behavior.
- `mime_guess/rev-mappings`: used by `get_mime_extensions_str`.
- All `rspack_plugin_*` crates: treated as hot paths per review feedback, so they are not size-optimized with `z`.

## SWC Wasm Plugin Performance

Measured with a temporary CodSpeed/Vitest benchmark that calls native `transformSync` directly with `@swc/plugin-remove-console` on a generated 600-function JS module. This isolates the SWC wasm plugin runtime better than a full bundle benchmark.

CodSpeed CPU simulation result:

- control runtime profile: `74.50 ms`
- all-size profile candidate: `77.83 ms`
- final profile in this PR: `74.46 ms`

CodSpeed reported `No impact detected`. The all-size candidate was dropped because it put `wasmtime` on `z` and looked slower in this direct wasm-plugin workload. Walltime mode could not run in this container because CodSpeed attempted to install Linux perf packages via sudo and sudo requires a password.

## Size

Measured on linux-x64-gnu with `RUST_TARGET=x86_64-unknown-linux-gnu` from a clean PR tree.

- no-LTO release-path baseline: `54,948,712` bytes
- no-LTO with this patch: `54,359,272` bytes
- no-LTO delta: `589,440` bytes smaller
- full release baseline: `48,439,848` bytes
- full release with this patch: `47,140,136` bytes
- full release delta: `1,299,712` bytes smaller

The no-LTO build is only fast feedback. The published release target remains over 1 MiB smaller after LTO while keeping all `rspack_plugin_*`, `swc_plugin_runner`, and `wasmtime` out of `z` size optimization.

## Validation

- `git diff --check`
- `cargo check -p rspack_node --target x86_64-unknown-linux-gnu --no-default-features --features plugin,info-level`
- `cargo test -p rspack_core -p rspack_fs -p rspack_parallel -p rspack_watcher -p rspack_loader_runner --no-run`
- `RUST_TARGET=x86_64-unknown-linux-gnu CARGO_PROFILE_RELEASE_LTO=false CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 pnpm build:binding:release`
- `RUST_TARGET=x86_64-unknown-linux-gnu pnpm build:binding:release`
- `node -e "require('./crates/node_binding/rspack.linux-x64-gnu.node'); console.log('ok')"`
- `codspeed run -m simulation -- pnpm --dir tests/bench exec vitest bench swc-wasm-plugin.codex.bench.ts --run` using a temporary local benchmark file