### PR TITLE
fix(deps): revert mimalloc update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,11 +2369,12 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2588,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.0", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
 miette              = { version = "7.6.0", default-features = false }
-mimalloc            = { version = "0.1.50", default-features = false }
+mimalloc            = { version = "0.1.48", default-features = false }
 mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
 notify              = { version = "8.2.0", default-features = false }
 num-bigint          = { version = "0.4.6", default-features = false }

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -12,13 +12,13 @@ tracy-client  = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
-mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
+mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true }
+mimalloc = { workspace = true, features = ["v3"] }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true }
+mimalloc = { workspace = true, features = ["v3"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

This PR reverts the mimalloc-related part of #13827 by pinning `mimalloc` back to `0.1.48`, restoring `libmimalloc-sys` `0.1.44`, and enabling the `v3` feature again. The benchmark comment on `120fea54` reported broad RSS memory regressions after that dependency update, so this should recover the allocator behavior. It may also fix the win32-arm64-msvc clean-exit segfault reported in #13925.

## Related links

- https://github.com/web-infra-dev/rspack/commit/120fea54dec501420d599ed1d94d59c2217acb61#commitcomment-183535535
- May fix https://github.com/web-infra-dev/rspack/issues/13925

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
