### PR TITLE
fix(deps): upgrade mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,12 +2369,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -2589,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.0", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
 miette              = { version = "7.6.0", default-features = false }
-mimalloc            = { version = "0.1.48", default-features = false }
+mimalloc            = { version = "0.1.50", default-features = false }
 mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
 notify              = { version = "8.2.0", default-features = false }
 num-bigint          = { version = "0.4.6", default-features = false }

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -12,13 +12,13 @@ tracy-client  = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
-mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [lints]
 workspace = true

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -13,13 +13,13 @@ tokio     = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Keep benchmark allocator features aligned with rspack_allocator.
-mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 # Make rust analyzer happy


### PR DESCRIPTION
## Summary
related to https://github.com/web-infra-dev/rspack/pull/13942
Upgrade `mimalloc` from `0.1.48` to `0.1.50`.

This also removes the stale `v3` feature usage from `rspack_allocator` and `rspack_benchmark`. `mimalloc 0.1.50` no longer exposes that feature; it already vendors mimalloc v3.

This PR intentionally does **not** change mimalloc runtime defaults such as `allow_thp`, `arena_purge_mult`, `purge_delay`, or `disallow_arena_alloc`.

## Binding RSS Investigation

The observed regression is from the binding ecosystem benchmark, not the Rust benchmark. The benchmark samples the Node.js process RSS via `process.memoryUsage().rss` after the native `.node` binding runs a build.

The RSS increase is not caused by a `v3.3.1` arena purge behavior change relative to `v3.3.0`. The relevant arena purge defaults and main purge path are effectively the same between `v3.3.0` and `v3.3.1`:

- `purge_delay = 1000ms`
- `arena_purge_mult = 1`
- arena purge delay is still `purge_delay * arena_purge_mult`
- with THP enabled, arena purge still uses the large OS page size as the minimal purge granularity

The root cause is the larger allocator policy change from mimalloc `v3.1.5` to `v3.3.x`, combined with the binding benchmark's sampling point:

- `mimalloc 0.1.48` vendors mimalloc `v3.1.5`; `mimalloc 0.1.50` vendors mimalloc `v3.3.1`.
- `v3.3.x` enables mimalloc's large page size class by default (`MI_ENABLE_LARGE_PAGES=1`; `v3.1.5` defaulted to `0`).
- `v3.3.x` adds Linux THP-aware purge behavior. When THP is available and `allow_thp` is enabled, `_mi_os_minimal_purge_size()` returns the large OS page size, usually `2MiB`, so arena purge avoids fragmenting THP.
- The binding build workload has bursty allocation/free behavior. At the benchmark sampling point, some arena pages are already freeable but are still retained until the delayed purge window expires or until they can be purged at the larger THP-friendly granularity.
- RSS includes this allocator-retained committed memory, even though it is not live JS/Rust heap.

In short: the benchmark is observing retained arena memory from the newer mimalloc policy. This is an allocator tradeoff for less frequent decommit/recommit and less THP fragmentation, not a live-heap leak in Rspack.

## Evidence

Same-machine artifact reruns for `threejs_production-mode_10x_persistent-cold`:

| Artifact / mode | mimalloc | exec median | RSS median |
| --- | --- | ---: | ---: |
| old artifact | `0.1.48` / `v3.1.5` | `2.83s` | `744MiB` |
| upgraded artifact | `0.1.50` / `v3.3.1` | `2.86s` | `870MiB` |
| upgraded artifact + `MIMALLOC_PURGE_DELAY=10` | `0.1.50` / `v3.3.1` | `2.64s` | `759MiB` |
| upgraded artifact + `MIMALLOC_PURGE_DELAY=20` | `0.1.50` / `v3.3.1` | `2.67s` | `758MiB` |

`MIMALLOC_SHOW_STATS=1` also points in the same direction:

- `v3.1.5`: usually one arena, about `1GiB` reserved, current committed around `570-590MiB`, purged around `360-380MiB`.
- `v3.3.1`: usually two arenas, about `2GiB` reserved, current committed around `1.0GiB`, purged around `440-515MiB`.

Custom mimalloc instrumentation showed that the second arena is not caused by one huge allocation. It can be triggered by normal page allocations such as:

```text
arena_count=1 slice_count=1  alloc_size=65536
arena_count=1 slice_count=8  alloc_size=524288
arena_count=1 slice_count=64 alloc_size=4194304
```

Options that reduce RSS were tested but are not used in this PR:

- `MIMALLOC_DISALLOW_ARENA_ALLOC=1` lowers RSS but changes allocation strategy broadly and can slow binding builds.
- `arena_purge_mult=0` lowers RSS by making arena purge immediate, but it changes runtime allocator behavior and may increase decommit/recommit overhead.
- `allow_thp=0` or compile-time `MI_ENABLE_LARGE_PAGES=0` only explains part of the RSS difference and changes allocator/runtime tradeoffs.
- lowering `arena_max_object_size` to `16M/32M` did not materially recover RSS for this workload.

## Validation

- `cargo update -p mimalloc --precise 0.1.50`
- `cargo tree -p rspack_allocator --target x86_64-unknown-linux-gnu -i mimalloc -e features`
- `cargo tree -p rspack_benchmark --target x86_64-unknown-linux-gnu -i mimalloc -e features`
- `cargo check -p rspack_allocator --target x86_64-unknown-linux-gnu`
- `cargo check -p rspack_benchmark --target x86_64-unknown-linux-gnu`
- `cargo fmt --all --check`
- `pnpm dlx @taplo/cli@0.7.0 format --check Cargo.toml crates/rspack_allocator/Cargo.toml xtask/benchmark/Cargo.toml`
- `git diff --check`

## Related links

- microsoft/mimalloc commit `9199d54b`: enabled mimalloc large page size class by default again.
- microsoft/mimalloc issue `#1246`: previous arena purge scheduling issue; the relevant fixes are already in the v3.3 line.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
