### PR TITLE
feat(rsc): support configurable CSS link props

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1055,10 +1055,16 @@ export interface JsRscClientPluginOptions {
   coordinator: JsCoordinator
 }
 
+export interface JsRscCssLinkOptions {
+  precedence?: string | false
+  props?: Record<string, string>
+}
+
 export interface JsRscServerPluginOptions {
   coordinator: JsCoordinator
   onServerComponentChanges?: (() => void | Promise<void>) | undefined | null
   onManifest?: ((arg: string) => Promise<undefined>) | undefined | null
+  cssLink?: false | JsRscCssLinkOptions
 }
 
 export interface JsRsdoctorAsset {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1056,7 +1056,7 @@ export interface JsRscClientPluginOptions {
 }
 
 export interface JsRscCssLinkOptions {
-  precedence?: string | false
+  precedence?: string | boolean
   props?: Record<string, string>
 }
 

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1064,7 +1064,7 @@ export interface JsRscServerPluginOptions {
   coordinator: JsCoordinator
   onServerComponentChanges?: (() => void | Promise<void>) | undefined | null
   onManifest?: ((arg: string) => Promise<undefined>) | undefined | null
-cssLink?: false | { precedence?: string | false; props?: Record<string, string> }
+  cssLink?: JsRscCssLinkOptions
 }
 
 export interface JsRsdoctorAsset {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1064,7 +1064,7 @@ export interface JsRscServerPluginOptions {
   coordinator: JsCoordinator
   onServerComponentChanges?: (() => void | Promise<void>) | undefined | null
   onManifest?: ((arg: string) => Promise<undefined>) | undefined | null
-  cssLink?: false | JsRscCssLinkOptions
+cssLink?: false | { precedence?: string | false; props?: Record<string, string> }
 }
 
 export interface JsRsdoctorAsset {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1062,9 +1062,9 @@ export interface JsRscCssLinkOptions {
 
 export interface JsRscServerPluginOptions {
   coordinator: JsCoordinator
+  cssLink?: JsRscCssLinkOptions | undefined | null
   onServerComponentChanges?: (() => void | Promise<void>) | undefined | null
   onManifest?: ((arg: string) => Promise<undefined>) | undefined | null
-  cssLink?: JsRscCssLinkOptions
 }
 
 export interface JsRsdoctorAsset {

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -88,12 +88,11 @@ pub struct JsRscCssLinkOptions<'a> {
 #[napi(object, object_to_js = false)]
 pub struct JsRscServerPluginOptions<'a> {
   pub coordinator: ClassInstance<'a, JsCoordinator>,
+  pub css_link: Option<Either3<JsRscCssLinkOptions<'a>, Undefined, Null>>,
   #[napi(ts_type = "(() => void | Promise<void>) | undefined | null")]
   pub on_server_component_changes:
     Option<Either3<Function<'static, (), OnServerComponentChangesReturn>, Undefined, Null>>,
   pub on_manifest: Option<Either3<Function<'static, String, Promise<()>>, Undefined, Null>>,
-  #[napi(ts_type = "{ precedence?: string | false; props?: Record<string, string> }")]
-  pub css_link: Option<JsRscCssLinkOptions<'a>>,
 }
 
 fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps> {
@@ -111,15 +110,15 @@ fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps>
 }
 
 fn normalize_css_link_props(
-  css_link_props: Option<JsRscCssLinkOptions<'_>>,
+  css_link_props: Option<Either3<JsRscCssLinkOptions<'_>, Undefined, Null>>,
 ) -> napi::Result<RscCssLinkProps> {
   match css_link_props {
-    None => {
+    None | Some(Either3::B(_)) | Some(Either3::C(_)) => {
       let mut props = RscCssLinkProps::default();
       props.insert("precedence".to_string(), "default".to_string());
       Ok(props)
     }
-    Some(css_link_options) => {
+    Some(Either3::A(css_link_options)) => {
       let mut props = css_link_options
         .props
         .map(object_to_css_link_props)

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -92,11 +92,8 @@ pub struct JsRscServerPluginOptions<'a> {
   pub on_server_component_changes:
     Option<Either3<Function<'static, (), OnServerComponentChangesReturn>, Undefined, Null>>,
   pub on_manifest: Option<Either3<Function<'static, String, Promise<()>>, Undefined, Null>>,
-  #[napi(
-    js_name = "cssLink",
-    ts_type = "false | { precedence?: string | false; props?: Record<string, string> }"
-  )]
-  pub css_link_props: Option<Either<JsRscCssLinkOptions<'a>, bool>>,
+  #[napi(ts_type = "false | { precedence?: string | false; props?: Record<string, string> }")]
+  pub css_link: Option<Either<JsRscCssLinkOptions<'a>, bool>>,
 }
 
 fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps> {
@@ -212,7 +209,7 @@ impl TryFrom<JsRscServerPluginOptions<'_>> for RscServerPluginOptions {
       coordinator: value.coordinator.i.clone(),
       on_server_component_changes,
       on_manifest,
-      css_link_props: normalize_css_link_props(value.css_link_props)?,
+      css_link_props: normalize_css_link_props(value.css_link)?,
     })
   }
 }

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -113,7 +113,7 @@ fn normalize_css_link_props(
   css_link_props: Option<Either3<JsRscCssLinkOptions<'_>, Undefined, Null>>,
 ) -> napi::Result<RscCssLinkProps> {
   match css_link_props {
-    None | Some(Either3::B(_)) | Some(Either3::C(_)) => {
+    None | Some(Either3::B(_) | Either3::C(_)) => {
       let mut props = RscCssLinkProps::default();
       props.insert("precedence".to_string(), "default".to_string());
       Ok(props)

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -5,7 +5,7 @@ use napi::{
   Env, Status,
   bindgen_prelude::{
     ClassInstance, Either, Either3, External, ExternalRef, FromNapiValue, Function, JsObjectValue,
-    Null, Object, Promise, Reference, Undefined, WeakReference,
+    Null, Object, Promise, Reference, Undefined, ValidateNapiValue, WeakReference, sys,
   },
   threadsafe_function::ThreadsafeFunction,
 };
@@ -15,6 +15,7 @@ use rspack_error::ToStringResultToRspackResultExt;
 use rspack_plugin_rsc::{
   Coordinator, OnManifest, RscClientPluginOptions, RscCssLinkProps, RscServerPluginOptions,
 };
+use rspack_util::fx_hash::FxIndexMap;
 
 use crate::JsCompiler;
 
@@ -77,31 +78,50 @@ impl From<&JsRscClientPluginOptions<'_>> for RscClientPluginOptions {
   }
 }
 
-#[napi(object, object_to_js = false)]
-pub struct JsRscCssLinkOptions<'a> {
-  #[napi(ts_type = "string | false")]
+#[napi(object, object_from_js = false, object_to_js = false)]
+pub struct JsRscCssLinkOptions {
   pub precedence: Option<Either<String, bool>>,
   #[napi(ts_type = "Record<string, string>")]
-  pub props: Option<Object<'a>>,
+  pub props: Option<FxIndexMap<String, String>>,
+}
+
+impl FromNapiValue for JsRscCssLinkOptions {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    let object = unsafe { Object::from_napi_value(env, napi_val)? };
+    Ok(Self {
+      precedence: object.get::<Either<String, bool>>("precedence")?,
+      props: object
+        .get::<Object>("props")?
+        .map(object_to_css_link_props)
+        .transpose()?,
+    })
+  }
+}
+
+impl ValidateNapiValue for JsRscCssLinkOptions {
+  unsafe fn validate(
+    env: sys::napi_env,
+    napi_val: sys::napi_value,
+  ) -> napi::Result<sys::napi_value> {
+    unsafe { Object::validate(env, napi_val) }
+  }
 }
 
 #[napi(object, object_to_js = false)]
 pub struct JsRscServerPluginOptions<'a> {
   pub coordinator: ClassInstance<'a, JsCoordinator>,
-  pub css_link: Option<Either3<JsRscCssLinkOptions<'a>, Undefined, Null>>,
+  #[napi(ts_type = "JsRscCssLinkOptions | undefined | null")]
+  pub css_link: Option<Either3<JsRscCssLinkOptions, Undefined, Null>>,
   #[napi(ts_type = "(() => void | Promise<void>) | undefined | null")]
   pub on_server_component_changes:
     Option<Either3<Function<'static, (), OnServerComponentChangesReturn>, Undefined, Null>>,
   pub on_manifest: Option<Either3<Function<'static, String, Promise<()>>, Undefined, Null>>,
 }
 
-fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps> {
-  let mut props = RscCssLinkProps::default();
+fn object_to_css_link_props(object: Object<'_>) -> napi::Result<FxIndexMap<String, String>> {
+  let mut props = FxIndexMap::default();
   let keys = Object::keys(&object)?;
   for key in keys {
-    if key == "precedence" {
-      continue;
-    }
     if let Some(value) = object.get::<String>(&key)? {
       props.insert(key, value);
     }
@@ -110,21 +130,16 @@ fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps>
 }
 
 fn normalize_css_link_props(
-  css_link_props: Option<Either3<JsRscCssLinkOptions<'_>, Undefined, Null>>,
-) -> napi::Result<RscCssLinkProps> {
+  css_link_props: Option<Either3<JsRscCssLinkOptions, Undefined, Null>>,
+) -> RscCssLinkProps {
   match css_link_props {
     None | Some(Either3::B(_) | Either3::C(_)) => {
       let mut props = RscCssLinkProps::default();
       props.insert("precedence".to_string(), "default".to_string());
-      Ok(props)
+      props
     }
     Some(Either3::A(css_link_options)) => {
-      let mut props = css_link_options
-        .props
-        .map(object_to_css_link_props)
-        .transpose()?
-        .unwrap_or_default();
-
+      let mut props = css_link_options.props.unwrap_or_default();
       match css_link_options.precedence {
         Some(Either::A(precedence)) => {
           props.insert("precedence".to_string(), precedence);
@@ -136,8 +151,7 @@ fn normalize_css_link_props(
           props.insert("precedence".to_string(), "default".to_string());
         }
       }
-
-      Ok(props)
+      props
     }
   }
 }
@@ -202,7 +216,7 @@ impl TryFrom<JsRscServerPluginOptions<'_>> for RscServerPluginOptions {
       coordinator: value.coordinator.i.clone(),
       on_server_component_changes,
       on_manifest,
-      css_link_props: normalize_css_link_props(value.css_link)?,
+      css_link_props: normalize_css_link_props(value.css_link),
     })
   }
 }

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -4,15 +4,17 @@ use futures::future::BoxFuture;
 use napi::{
   Env, Status,
   bindgen_prelude::{
-    ClassInstance, Either3, External, ExternalRef, FromNapiValue, Function, JsObjectValue, Null,
-    Object, Promise, Reference, Undefined, WeakReference,
+    ClassInstance, Either, Either3, External, ExternalRef, FromNapiValue, Function, JsObjectValue,
+    Null, Object, Promise, Reference, Undefined, WeakReference,
   },
   threadsafe_function::ThreadsafeFunction,
 };
 use once_cell::unsync::OnceCell;
 use rspack_core::{Compiler, CompilerId};
 use rspack_error::ToStringResultToRspackResultExt;
-use rspack_plugin_rsc::{Coordinator, OnManifest, RscClientPluginOptions, RscServerPluginOptions};
+use rspack_plugin_rsc::{
+  Coordinator, OnManifest, RscClientPluginOptions, RscCssLinkProps, RscServerPluginOptions,
+};
 
 use crate::JsCompiler;
 
@@ -76,18 +78,84 @@ impl From<&JsRscClientPluginOptions<'_>> for RscClientPluginOptions {
 }
 
 #[napi(object, object_to_js = false)]
+pub struct JsRscCssLinkOptions<'a> {
+  #[napi(ts_type = "string | false")]
+  pub precedence: Option<Either<String, bool>>,
+  #[napi(ts_type = "Record<string, string>")]
+  pub props: Option<Object<'a>>,
+}
+
+#[napi(object, object_to_js = false)]
 pub struct JsRscServerPluginOptions<'a> {
   pub coordinator: ClassInstance<'a, JsCoordinator>,
   #[napi(ts_type = "(() => void | Promise<void>) | undefined | null")]
   pub on_server_component_changes:
     Option<Either3<Function<'static, (), OnServerComponentChangesReturn>, Undefined, Null>>,
   pub on_manifest: Option<Either3<Function<'static, String, Promise<()>>, Undefined, Null>>,
+  #[napi(
+    js_name = "cssLink",
+    ts_type = "false | { precedence?: string | false; props?: Record<string, string> }"
+  )]
+  pub css_link_props: Option<Either<JsRscCssLinkOptions<'a>, bool>>,
 }
 
-impl TryFrom<&JsRscServerPluginOptions<'_>> for RscServerPluginOptions {
+fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps> {
+  let mut props = RscCssLinkProps::default();
+  let keys = Object::keys(&object)?;
+  for key in keys {
+    if key == "precedence" {
+      continue;
+    }
+    if let Some(value) = object.get::<String>(&key)? {
+      props.insert(key, value);
+    }
+  }
+  Ok(props)
+}
+
+fn normalize_css_link_props(
+  css_link_props: Option<Either<JsRscCssLinkOptions<'_>, bool>>,
+) -> napi::Result<RscCssLinkProps> {
+  match css_link_props {
+    Some(Either::B(false)) => Ok(RscCssLinkProps::default()),
+    Some(Either::B(true)) | None => {
+      let mut props = RscCssLinkProps::default();
+      props.insert("precedence".to_string(), "default".to_string());
+      Ok(props)
+    }
+    Some(Either::A(css_link_options)) => {
+      let mut props = css_link_options
+        .props
+        .map(object_to_css_link_props)
+        .transpose()?
+        .unwrap_or_default();
+
+      match css_link_options.precedence {
+        Some(Either::A(precedence)) => {
+          props.insert("precedence".to_string(), precedence);
+        }
+        Some(Either::B(false)) => {
+          props.shift_remove("precedence");
+        }
+        Some(Either::B(true)) => {
+          return Err(napi::Error::from_reason(
+            "RSC cssLink.precedence must be a string or false.",
+          ));
+        }
+        None => {
+          props.insert("precedence".to_string(), "default".to_string());
+        }
+      }
+
+      Ok(props)
+    }
+  }
+}
+
+impl TryFrom<JsRscServerPluginOptions<'_>> for RscServerPluginOptions {
   type Error = napi::Error;
 
-  fn try_from(value: &JsRscServerPluginOptions) -> napi::Result<Self> {
+  fn try_from(value: JsRscServerPluginOptions) -> napi::Result<Self> {
     let on_server_component_changes: Option<
       Box<dyn Fn() -> BoxFuture<'static, rspack_error::Result<()>> + Sync + Send>,
     > = match &value.on_server_component_changes {
@@ -144,6 +212,7 @@ impl TryFrom<&JsRscServerPluginOptions<'_>> for RscServerPluginOptions {
       coordinator: value.coordinator.i.clone(),
       on_server_component_changes,
       on_manifest,
+      css_link_props: normalize_css_link_props(value.css_link_props)?,
     })
   }
 }

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -92,8 +92,8 @@ pub struct JsRscServerPluginOptions<'a> {
   pub on_server_component_changes:
     Option<Either3<Function<'static, (), OnServerComponentChangesReturn>, Undefined, Null>>,
   pub on_manifest: Option<Either3<Function<'static, String, Promise<()>>, Undefined, Null>>,
-  #[napi(ts_type = "false | { precedence?: string | false; props?: Record<string, string> }")]
-  pub css_link: Option<Either<JsRscCssLinkOptions<'a>, bool>>,
+  #[napi(ts_type = "{ precedence?: string | false; props?: Record<string, string> }")]
+  pub css_link: Option<JsRscCssLinkOptions<'a>>,
 }
 
 fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps> {
@@ -111,16 +111,15 @@ fn object_to_css_link_props(object: Object<'_>) -> napi::Result<RscCssLinkProps>
 }
 
 fn normalize_css_link_props(
-  css_link_props: Option<Either<JsRscCssLinkOptions<'_>, bool>>,
+  css_link_props: Option<JsRscCssLinkOptions<'_>>,
 ) -> napi::Result<RscCssLinkProps> {
   match css_link_props {
-    Some(Either::B(false)) => Ok(RscCssLinkProps::default()),
-    Some(Either::B(true)) | None => {
+    None => {
       let mut props = RscCssLinkProps::default();
       props.insert("precedence".to_string(), "default".to_string());
       Ok(props)
     }
-    Some(Either::A(css_link_options)) => {
+    Some(css_link_options) => {
       let mut props = css_link_options
         .props
         .map(object_to_css_link_props)
@@ -134,12 +133,7 @@ fn normalize_css_link_props(
         Some(Either::B(false)) => {
           props.shift_remove("precedence");
         }
-        Some(Either::B(true)) => {
-          return Err(napi::Error::from_reason(
-            "RSC cssLink.precedence must be a string or false.",
-          ));
-        }
-        None => {
+        Some(Either::B(true)) | None => {
           props.insert("precedence".to_string(), "default".to_string());
         }
       }

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -903,7 +903,7 @@ impl<'a> BuiltinPlugin<'a> {
       BuiltinPluginName::RscServerPlugin => {
         #[cfg(not(feature = "browser"))]
         {
-          let options = &downcast_into::<JsRscServerPluginOptions>(self.options)
+          let options = downcast_into::<JsRscServerPluginOptions>(self.options)
             .map_err(|report| napi::Error::from_reason(report.to_string()))?;
           plugins.push(RscServerPlugin::new(options.try_into()?).boxed());
         }

--- a/crates/rspack_loader_swc/src/rsc_transforms/to_client_ref.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/to_client_ref.rs
@@ -27,12 +27,11 @@ const API_RSC_MANIFEST: &str = "__rspack_rsc_manifest__";
 /// import * as React from "react";
 ///
 /// const resources = (__rspack_rsc_manifest__.clientManifest?.[resource]?.cssFiles ?? [])
-///   .map(href => React.createElement("link", {
+///   .map(href => React.createElement("link", Object.assign({}, __rspack_rsc_manifest__.cssLinkProps, {
 ///     key: href,
 ///     rel: "stylesheet",
-///     href,
-///     precedence: "default"
-///   }));
+///     href
+///   })));
 ///
 /// const Ref1 = registerClientReference(function() { throw new Error(...); }, resource, "default");
 /// export default resources.length
@@ -53,12 +52,11 @@ const API_RSC_MANIFEST: &str = "__rspack_rsc_manifest__";
 /// const React = require("react");
 ///
 /// const resources = (__rspack_rsc_manifest__.clientManifest?.[resource]?.cssFiles ?? [])
-///   .map(href => React.createElement("link", {
+///   .map(href => React.createElement("link", Object.assign({}, __rspack_rsc_manifest__.cssLinkProps, {
 ///     key: href,
 ///     rel: "stylesheet",
-///     href,
-///     precedence: "default"
-///   }));
+///     href
+///   })));
 ///
 /// const Ref1 = registerClientReference(function() { throw new Error(...); }, resource, "default");
 /// module.exports = resources.length
@@ -398,30 +396,21 @@ fn react_fragment_with_resources(ref_name: &str, resources_name: &str, react_nam
 }
 
 fn react_link_element(react_name: &str) -> Expr {
-  react_create_element_call(
-    react_name,
-    str_expr("link"),
-    object_expr(vec![
-      key_value_prop("key", ident_expr("href")),
-      key_value_prop("rel", str_expr("stylesheet")),
-      key_value_prop("href", ident_expr("href")),
-      key_value_prop("precedence", str_expr("default")),
-    ]),
-    vec![],
-  )
+  react_create_element_call(react_name, str_expr("link"), link_props_expr(), vec![])
 }
 
-fn react_create_element_call(
-  react_name: &str,
-  element: Expr,
-  props: Expr,
-  children: Vec<Expr>,
-) -> Expr {
-  let mut args = vec![element, props];
-  args.extend(children);
+fn link_props_expr() -> Expr {
   call_expr(
-    member_expr(ident_expr(react_name), REACT_CREATE_ELEMENT),
-    args,
+    member_expr(ident_expr("Object"), "assign"),
+    vec![
+      object_expr(vec![]),
+      member_expr(ident_expr(API_RSC_MANIFEST), "cssLinkProps"),
+      object_expr(vec![
+        key_value_prop("key", ident_expr("href")),
+        key_value_prop("rel", str_expr("stylesheet")),
+        key_value_prop("href", ident_expr("href")),
+      ]),
+    ],
     DUMMY_SP,
   )
 }
@@ -438,6 +427,21 @@ fn key_value_prop(name: &str, value: Expr) -> PropOrSpread {
     key: PropName::Ident(ident_name(name)),
     value: Box::new(value),
   })))
+}
+
+fn react_create_element_call(
+  react_name: &str,
+  element: Expr,
+  props: Expr,
+  children: Vec<Expr>,
+) -> Expr {
+  let mut args = vec![element, props];
+  args.extend(children);
+  call_expr(
+    member_expr(ident_expr(react_name), REACT_CREATE_ELEMENT),
+    args,
+    DUMMY_SP,
+  )
 }
 
 fn null_expr() -> Expr {

--- a/crates/rspack_loader_swc/src/rsc_transforms/to_client_ref.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/to_client_ref.rs
@@ -27,11 +27,12 @@ const API_RSC_MANIFEST: &str = "__rspack_rsc_manifest__";
 /// import * as React from "react";
 ///
 /// const resources = (__rspack_rsc_manifest__.clientManifest?.[resource]?.cssFiles ?? [])
-///   .map(href => React.createElement("link", Object.assign({}, __rspack_rsc_manifest__.cssLinkProps, {
+///   .map(href => React.createElement("link", {
+///     ...__rspack_rsc_manifest__.cssLinkProps,
 ///     key: href,
 ///     rel: "stylesheet",
 ///     href
-///   })));
+///   }));
 ///
 /// const Ref1 = registerClientReference(function() { throw new Error(...); }, resource, "default");
 /// export default resources.length
@@ -52,11 +53,12 @@ const API_RSC_MANIFEST: &str = "__rspack_rsc_manifest__";
 /// const React = require("react");
 ///
 /// const resources = (__rspack_rsc_manifest__.clientManifest?.[resource]?.cssFiles ?? [])
-///   .map(href => React.createElement("link", Object.assign({}, __rspack_rsc_manifest__.cssLinkProps, {
+///   .map(href => React.createElement("link", {
+///     ...__rspack_rsc_manifest__.cssLinkProps,
 ///     key: href,
 ///     rel: "stylesheet",
 ///     href
-///   })));
+///   }));
 ///
 /// const Ref1 = registerClientReference(function() { throw new Error(...); }, resource, "default");
 /// module.exports = resources.length
@@ -400,19 +402,12 @@ fn react_link_element(react_name: &str) -> Expr {
 }
 
 fn link_props_expr() -> Expr {
-  call_expr(
-    member_expr(ident_expr("Object"), "assign"),
-    vec![
-      object_expr(vec![]),
-      member_expr(ident_expr(API_RSC_MANIFEST), "cssLinkProps"),
-      object_expr(vec![
-        key_value_prop("key", ident_expr("href")),
-        key_value_prop("rel", str_expr("stylesheet")),
-        key_value_prop("href", ident_expr("href")),
-      ]),
-    ],
-    DUMMY_SP,
-  )
+  object_expr(vec![
+    spread_prop(member_expr(ident_expr(API_RSC_MANIFEST), "cssLinkProps")),
+    key_value_prop("key", ident_expr("href")),
+    key_value_prop("rel", str_expr("stylesheet")),
+    key_value_prop("href", ident_expr("href")),
+  ])
 }
 
 fn object_expr(props: Vec<PropOrSpread>) -> Expr {
@@ -427,6 +422,13 @@ fn key_value_prop(name: &str, value: Expr) -> PropOrSpread {
     key: PropName::Ident(ident_name(name)),
     value: Box::new(value),
   })))
+}
+
+fn spread_prop(expr: Expr) -> PropOrSpread {
+  PropOrSpread::Spread(SpreadElement {
+    dot3_token: DUMMY_SP,
+    expr: Box::new(expr),
+  })
 }
 
 fn react_create_element_call(

--- a/crates/rspack_plugin_rsc/src/lib.rs
+++ b/crates/rspack_plugin_rsc/src/lib.rs
@@ -17,4 +17,5 @@ mod utils;
 pub use client_plugin::{RscClientPlugin, RscClientPluginOptions};
 pub use coordinator::Coordinator;
 pub use loaders::action_entry_loader_plugin::ActionEntryLoaderPlugin;
+pub use reference_manifest::RscCssLinkProps;
 pub use server_plugin::{OnManifest, RscServerPlugin, RscServerPluginOptions};

--- a/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
+++ b/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
@@ -82,6 +82,7 @@ impl RuntimeModule for RscManifestRuntimeModule {
       module_loading,
       server_entries: &entry_state.server_entries,
       bootstrap_scripts: &entry_state.bootstrap_scripts,
+      css_link_props: &plugin_state.css_link_props,
     };
 
     Ok(formatdoc! {

--- a/crates/rspack_plugin_rsc/src/plugin_state.rs
+++ b/crates/rspack_plugin_rsc/src/plugin_state.rs
@@ -11,7 +11,7 @@ use rspack_util::{
 use rustc_hash::FxHashMap;
 
 use crate::reference_manifest::{
-  ManifestExport, ManifestNode, ModuleLoading, ServerReferenceManifest,
+  ManifestExport, ManifestNode, ModuleLoading, RscCssLinkProps, ServerReferenceManifest,
 };
 
 pub type ActionIdNamePair = (Atom, Atom);
@@ -74,12 +74,14 @@ impl EntryState {
 #[derive(Debug, Default)]
 pub struct PluginState {
   pub module_loading: Option<ModuleLoading>,
+  pub css_link_props: RscCssLinkProps,
   pub entries: FxHashMap<Arc<str>, EntryState>,
 }
 
 impl PluginState {
   pub fn clear(&mut self) {
     self.module_loading = None;
+    self.css_link_props.clear();
     self.entries.clear();
   }
 }

--- a/crates/rspack_plugin_rsc/src/reference_manifest.rs
+++ b/crates/rspack_plugin_rsc/src/reference_manifest.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use rspack_core::{ChunkGraph, Compilation, Module, ModuleGraph, ModuleId, ModuleIdentifier};
 use rspack_error::Result;
-use rspack_util::fx_hash::FxIndexSet;
+use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeMap};
 
@@ -48,6 +48,8 @@ pub struct ModuleLoading {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub cross_origin: Option<CrossOriginMode>,
 }
+
+pub type RscCssLinkProps = FxIndexMap<String, String>;
 
 pub type ServerReferenceManifest = FxHashMap<String, ManifestExport>;
 
@@ -102,6 +104,7 @@ pub struct RscEntryManifest<'a> {
   pub server_entries: &'a FxHashMap<String, ServerEntryState>,
   #[serde(rename = "entryJsFiles")]
   pub bootstrap_scripts: &'a FxIndexSet<String>,
+  pub css_link_props: &'a RscCssLinkProps,
 }
 
 /// Full manifest (all entries) for the onManifest callback. Map from entry name to per-entry manifest.

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -29,7 +29,8 @@ use crate::{
     RootCssImports,
   },
   reference_manifest::{
-    RscEntryManifest, RscManifest, build_server_consumer_module_map, build_server_manifest,
+    RscCssLinkProps, RscEntryManifest, RscManifest, build_server_consumer_module_map,
+    build_server_manifest,
   },
   rsc_entry_dependency::RscEntryDependency,
   rsc_entry_module_factory::RscEntryModuleFactory,
@@ -70,6 +71,7 @@ pub type OnManifest = Box<dyn Fn(String) -> BoxFuture<'static, Result<()>> + Syn
 
 pub struct RscServerPluginOptions {
   pub coordinator: Arc<Coordinator>,
+  pub css_link_props: RscCssLinkProps,
   pub on_server_component_changes: Option<OnServerComponentChanges>,
   pub on_manifest: Option<OnManifest>,
 }
@@ -83,6 +85,7 @@ pub struct RscServerPlugin {
   on_server_component_changes: Option<OnServerComponentChanges>,
   #[debug(skip)]
   on_manifest: Option<OnManifest>,
+  css_link_props: RscCssLinkProps,
   prev_server_component_hashes: AtomicRefCell<IdentifierMap<u64>>,
 }
 
@@ -92,6 +95,7 @@ impl RscServerPlugin {
       options.coordinator,
       options.on_server_component_changes,
       options.on_manifest,
+      options.css_link_props,
       Default::default(),
     )
   }
@@ -113,6 +117,10 @@ async fn this_compilation(
       vacant_entry.insert(Default::default());
     }
   };
+  PLUGIN_STATES
+    .entry(compilation.compiler_id())
+    .or_default()
+    .css_link_props = self.css_link_props.clone();
 
   self.coordinator.start_server_entries_compilation().await?;
 
@@ -616,6 +624,7 @@ async fn done(&self, compilation: &Compilation) -> Result<()> {
             module_loading,
             server_entries: &state.server_entries,
             bootstrap_scripts: &state.bootstrap_scripts,
+            css_link_props: &plugin_state.css_link_props,
           },
         );
       }

--- a/packages/rspack/src/builtin-plugin/rsc/RscClientPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscClientPlugin.ts
@@ -19,7 +19,7 @@ export class RscClientPlugin extends RspackBuiltinPlugin {
     this.#options.coordinator.applyClientCompiler(compiler);
 
     return createBuiltinPlugin(this.name, {
-      // @ts-ignore
+      // @ts-expect-error we use a special API to get the underlying binding instance.
       coordinator: this.#options.coordinator[GET_OR_INIT_BINDING](),
     });
   }

--- a/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
@@ -43,7 +43,7 @@ export type RscCssLinkOptions = {
 
 export type RscServerPluginOptions = {
   coordinator: Coordinator;
-  cssLink?: RscCssLinkOptions;
+  cssLink?: RscCssLinkOptions | null;
   onServerComponentChanges?: () => void | Promise<void>;
   onManifest?: (manifest: RscManifest) => void | Promise<void>;
 };

--- a/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
@@ -28,13 +28,24 @@ export interface RscManifestPerEntry {
   moduleLoading: RscModuleLoading;
   entryCssFiles: Record<string, string[]>;
   entryJsFiles: string[];
+  cssLinkProps: RscCssLinkProps;
 }
 
 /** Full RSC manifest (all entries) passed to onManifest. Map from entry name to per-entry manifest. */
 export type RscManifest = Record<string, RscManifestPerEntry>;
 
+export type RscCssLinkProps = Record<string, string>;
+
+export type RscCssLinkOptions =
+  | false
+  | {
+      precedence?: string | false;
+      props?: RscCssLinkProps;
+    };
+
 export type RscServerPluginOptions = {
   coordinator: Coordinator;
+  cssLink?: RscCssLinkOptions;
   onServerComponentChanges?: () => void | Promise<void>;
   onManifest?: (manifest: RscManifest) => void | Promise<void>;
 };
@@ -59,8 +70,9 @@ export class RscServerPlugin extends RspackBuiltinPlugin {
     }
 
     return createBuiltinPlugin(this.name, {
-      // @ts-ignore
+      // @ts-expect-error we use a special API to get the underlying binding instance.
       coordinator: coordinator[GET_OR_INIT_BINDING](),
+      cssLink: this.#options.cssLink,
       onServerComponentChanges,
       onManifest,
     });

--- a/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/RscServerPlugin.ts
@@ -36,12 +36,10 @@ export type RscManifest = Record<string, RscManifestPerEntry>;
 
 export type RscCssLinkProps = Record<string, string>;
 
-export type RscCssLinkOptions =
-  | false
-  | {
-      precedence?: string | false;
-      props?: RscCssLinkProps;
-    };
+export type RscCssLinkOptions = {
+  precedence?: string | false;
+  props?: RscCssLinkProps;
+};
 
 export type RscServerPluginOptions = {
   coordinator: Coordinator;

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/rspack.config.js
@@ -1,0 +1,100 @@
+const path = require('node:path');
+const { experiments } = require('@rspack/core');
+
+const { createPlugins, Layers } = experiments.rsc;
+const { ServerPlugin, ClientPlugin } = createPlugins();
+
+const ssrEntry = path.join(__dirname, 'src/framework/entry.ssr.js');
+const rscEntry = path.join(__dirname, 'src/framework/entry.rsc.js');
+
+const swcLoaderRule = {
+  test: /\.jsx?$/,
+  use: [
+    {
+      loader: 'builtin:swc-loader',
+      options: {
+        detectSyntax: 'auto',
+        jsc: {
+          transform: {
+            react: {
+              runtime: 'automatic',
+            },
+          },
+        },
+        rspackExperiments: {
+          reactServerComponents: true,
+        },
+      },
+    },
+  ],
+};
+
+const cssRule = {
+  test: /\.css$/,
+  type: 'css/auto',
+};
+
+module.exports = [
+  {
+    mode: 'production',
+    target: 'node',
+    entry: {
+      main: {
+        import: ssrEntry,
+      },
+    },
+    resolve: {
+      extensions: ['...', '.ts', '.tsx', '.jsx'],
+    },
+    module: {
+      rules: [
+        cssRule,
+        swcLoaderRule,
+        {
+          resource: ssrEntry,
+          layer: Layers.ssr,
+        },
+        {
+          resource: rscEntry,
+          layer: Layers.rsc,
+          resolve: {
+            conditionNames: ['react-server', '...'],
+          },
+        },
+        {
+          issuerLayer: Layers.rsc,
+          resolve: {
+            conditionNames: ['react-server', '...'],
+          },
+        },
+      ],
+    },
+    plugins: [
+      new ServerPlugin({
+        cssLink: {
+          precedence: false,
+          props: {
+            as: 'style',
+            'data-rspack-rsc': 'enabled',
+          },
+        },
+      }),
+    ],
+  },
+  {
+    mode: 'production',
+    target: 'web',
+    entry: {
+      main: {
+        import: './src/framework/entry.client.js',
+      },
+    },
+    resolve: {
+      extensions: ['...', '.ts', '.tsx', '.jsx'],
+    },
+    module: {
+      rules: [cssRule, swcLoaderRule],
+    },
+    plugins: [new ClientPlugin()],
+  },
+];

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/App.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/App.js
@@ -1,0 +1,12 @@
+"use server-entry";
+
+import { Client } from './Client';
+
+export const App = () => {
+  return (
+    <>
+      <h1>RSC CSS link props</h1>
+      <Client />
+    </>
+  );
+};

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/Client.css
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/Client.css
@@ -1,0 +1,3 @@
+.client {
+  color: limegreen;
+}

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/Client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/Client.js
@@ -1,0 +1,11 @@
+"use client";
+
+import './Client.css';
+
+export const Client = () => {
+  return (
+    <button className="client" type="button">
+      Client
+    </button>
+  );
+};

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/framework/entry.client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/framework/entry.client.js
@@ -1,0 +1,1 @@
+// Client entry for the RSC CSS link props test.

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/framework/entry.rsc.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/framework/entry.rsc.js
@@ -1,0 +1,35 @@
+import { renderToReadableStream } from 'react-server-dom-rspack/server';
+import { App } from '../App';
+import { Client } from '../Client';
+
+export const renderRscStream = () => {
+  return renderToReadableStream(<App />);
+};
+
+it('should expose configured CSS link props in the RSC runtime manifest', () => {
+  const manifest = __rspack_rsc_manifest__;
+
+  expect(manifest.cssLinkProps).toEqual({
+    as: 'style',
+    'data-rspack-rsc': 'enabled',
+  });
+  expect(manifest.cssLinkProps).not.toHaveProperty('precedence');
+});
+
+it('should apply configured CSS link props to generated link elements', () => {
+  const clientElement = Client({});
+  const [resourceElements] = clientElement.props.children;
+  const [linkElement] = resourceElements;
+
+  expect(linkElement.type).toBe('link');
+  expect(linkElement.props).toEqual(
+    expect.objectContaining({
+      as: 'style',
+      'data-rspack-rsc': 'enabled',
+      rel: 'stylesheet',
+      href: expect.stringMatching(/\.css$/),
+    }),
+  );
+  expect(linkElement.key).toMatch(/\.css$/);
+  expect(linkElement.props).not.toHaveProperty('precedence');
+});

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/framework/entry.ssr.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/src/framework/entry.ssr.js
@@ -1,0 +1,7 @@
+import { createFromReadableStream } from 'react-server-dom-rspack/client';
+import { renderRscStream } from './entry.rsc';
+
+export const renderHTML = async () => {
+  const rscStream = await renderRscStream();
+  return createFromReadableStream(rscStream);
+};

--- a/tests/rspack-test/configCases/rsc-plugin/css-link-props/test.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/css-link-props/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+  findBundle: function () {
+    return ['bundle0.js'];
+  },
+};


### PR DESCRIPTION
## Summary

- add `cssLink` options to RSC `ServerPlugin` for configuring generated stylesheet `<link>` props
- expose normalized CSS link props on the RSC runtime manifest as `cssLinkProps`
- apply configured props when generating CSS resource link elements for client references
- add a config case covering custom CSS link props and disabling default `precedence`

```js
new ServerPlugin({
  cssLink: {
    precedence: false,
    props: {
      as: 'style',
      'data-rspack-rsc': 'enabled',
    },
  },
}),
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
