### PR TITLE
perf: reduce binary size by unifying glob implementation with fast-glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ dependencies = [
  "derive_more",
  "dyn-clone",
  "either",
+ "fast-glob",
  "futures",
  "hashlink",
  "heck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,7 +3693,6 @@ dependencies = [
  "cow-utils",
  "derive_more",
  "futures",
- "glob",
  "heck",
  "napi",
  "napi-derive",
@@ -4341,8 +4340,8 @@ name = "rspack_plugin_copy"
 version = "0.100.2"
 dependencies = [
  "derive_more",
+ "fast-glob",
  "futures",
- "glob",
  "pathdiff",
  "regex",
  "rspack_core",
@@ -5240,7 +5239,6 @@ dependencies = [
 name = "rspack_swc_plugin_ts_collector"
 version = "0.100.2"
 dependencies = [
- "glob",
  "insta",
  "rspack_javascript_compiler",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ enum-tag            = { version = "0.3.0", default-features = false }
 fast-glob           = { version = "1.0.1", default-features = false }
 form_urlencoded     = { version = "1.2.2", default-features = false }
 futures             = { version = "0.3.32", default-features = false, features = ["std"] }
-glob                = { version = "0.3.3", default-features = false }
 hashlink            = { version = "0.11.0", default-features = false }
 heck                = { version = "0.5.0", default-features = false }
 hex                 = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -57,7 +57,6 @@ napi-derive = { workspace = true, features = ["compat-mode"] }
 
 derive_more                            = { workspace = true, features = ["debug"] }
 futures                                = { workspace = true }
-glob                                   = { workspace = true }
 heck                                   = { workspace = true }
 once_cell                              = { workspace = true }
 rayon                                  = { workspace = true }

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_copy.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_copy.rs
@@ -192,12 +192,7 @@ impl From<RawCopyPattern> for CopyPattern {
       glob_options: CopyGlobOptions {
         case_sensitive_match: glob_options.case_sensitive_match,
         dot: glob_options.dot,
-        ignore: glob_options.ignore.map(|ignore| {
-          ignore
-            .into_iter()
-            .map(|filter| glob::Pattern::new(filter.as_ref()).expect("Invalid pattern option"))
-            .collect()
-        }),
+        ignore: glob_options.ignore,
       },
       copy_permissions,
       transform_fn: transform.map(|transformer| -> TransformerFn {

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -16,6 +16,7 @@ dashmap                    = { workspace = true, features = ["rayon"] }
 derive_more                = { workspace = true, features = ["debug"] }
 dyn-clone                  = { workspace = true }
 either                     = { workspace = true }
+fast-glob                  = { workspace = true }
 futures                    = { workspace = true }
 hashlink                   = { workspace = true }
 heck                       = { workspace = true }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -426,6 +426,11 @@ async fn visit_dirs(
     fs,
     options.context_options.recursive,
     true, // always skip dotfiles
+    &mut |path| {
+      exclude
+        .as_ref()
+        .is_none_or(|exclude| !exclude.test(path.as_str()))
+    },
     &mut |path, _filename| {
       let path_str = path.as_str();
 

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, sync::Arc};
 
-use async_recursion::async_recursion;
 use cow_utils::CowUtils;
 use derive_more::Debug;
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
@@ -17,7 +16,7 @@ use crate::{
   DependencyCategory, DependencyId, DependencyType, ModuleExt, ModuleFactory,
   ModuleFactoryCreateData, ModuleFactoryResult, ResolveArgs, ResolveContextModuleDependencies,
   ResolveInnerOptions, ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory,
-  SharedPluginDriver, resolve,
+  SharedPluginDriver, resolve, walk_dir,
 };
 
 #[derive(Debug)]
@@ -411,7 +410,6 @@ impl ContextModuleFactory {
   }
 }
 
-#[async_recursion]
 async fn visit_dirs(
   ctx: &str,
   dir: &Utf8Path,
@@ -420,42 +418,27 @@ async fn visit_dirs(
   resolve_options: &ResolveInnerOptions<'_>,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> Result<()> {
-  if !fs.metadata(dir).await.is_ok_and(|m| m.is_directory) {
-    return Ok(());
-  }
   let include = &options.context_options.include;
   let exclude = &options.context_options.exclude;
-  for filename in fs.read_dir(dir).await? {
-    let path = dir.join(&filename);
-    let path_str = path.as_str();
 
-    if let Some(exclude) = exclude
-      && exclude.test(path_str)
-    {
-      // ignore excluded files
-      continue;
-    }
+  walk_dir(
+    dir,
+    fs,
+    options.context_options.recursive,
+    true, // always skip dotfiles
+    &mut |path, _filename| {
+      let path_str = path.as_str();
 
-    if fs.metadata(&path).await.is_ok_and(|m| m.is_directory) {
-      if options.context_options.recursive {
-        visit_dirs(
-          ctx,
-          &path,
-          dependencies,
-          options,
-          resolve_options,
-          fs.clone(),
-        )
-        .await?;
+      if let Some(exclude) = exclude
+        && exclude.test(path_str)
+      {
+        return;
       }
-    } else if filename.starts_with('.') {
-      // ignore hidden files
-    } else {
+
       if let Some(include) = include
         && !include.test(path_str)
       {
-        // ignore not included files
-        continue;
+        return;
       }
 
       // FIXME: nodejs resolver return path of context, sometimes is '/a/b', sometimes is '/a/b/'
@@ -475,7 +458,7 @@ async fn visit_dirs(
       );
 
       let Some(reg_exp) = &options.context_options.reg_exp else {
-        return Ok(());
+        return;
       };
 
       requests.iter().for_each(|r| {
@@ -509,10 +492,10 @@ async fn visit_dirs(
           dependency_type: DependencyType::ContextElement(options.type_prefix),
           factorize_info: Default::default(),
         });
-      })
-    }
-  }
-  Ok(())
+      });
+    },
+  )
+  .await
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_core/src/glob_utils.rs
+++ b/crates/rspack_core/src/glob_utils.rs
@@ -78,6 +78,38 @@ fn normalize_path_separators(s: &str) -> String {
   s.cow_replace('\\', "/").into_owned()
 }
 
+/// Walk a directory tree recursively, calling `on_file` for each file found.
+///
+/// - `root`: starting directory
+/// - `recursive`: whether to descend into subdirectories
+/// - `skip_dotfiles`: whether to skip files whose name starts with `.`
+/// - `on_file`: called with (full_path, filename) for each file
+#[async_recursion]
+pub(crate) async fn walk_dir(
+  root: &Utf8Path,
+  fs: Arc<dyn ReadableFileSystem>,
+  recursive: bool,
+  skip_dotfiles: bool,
+  on_file: &mut (impl FnMut(Utf8PathBuf, String) + Send),
+) -> Result<()> {
+  if !fs.metadata(root).await.is_ok_and(|m| m.is_directory) {
+    return Ok(());
+  }
+  for filename in fs.read_dir(root).await? {
+    let path = root.join(&filename);
+    if fs.metadata(&path).await.is_ok_and(|m| m.is_directory) {
+      if recursive {
+        walk_dir(&path, fs.clone(), recursive, skip_dotfiles, on_file).await?;
+      }
+    } else if skip_dotfiles && filename.starts_with('.') {
+      // skip dotfiles
+    } else {
+      on_file(path, filename);
+    }
+  }
+  Ok(())
+}
+
 /// Find files matching a glob pattern by traversing the filesystem.
 /// Replaces `glob::glob_with`.
 pub async fn find_files_by_glob(
@@ -90,53 +122,26 @@ pub async fn find_files_by_glob(
   let base_dir_path = Utf8Path::new(base_dir);
 
   let mut results = Vec::new();
-  visit_glob_dirs(
+  walk_dir(
     base_dir_path,
-    base_dir_path,
-    &normalized_pattern,
-    options,
-    &*fs,
-    &mut results,
+    fs,
+    true,  // always recursive for glob
+    false, // dotfile filtering handled in callback below
+    &mut |path, _filename| {
+      if options.require_literal_leading_dot
+        && path_has_dot_component(&path, base_dir_path)
+        && !pattern_has_explicit_dot_for(&normalized_pattern, base_dir_path, &path)
+      {
+        return;
+      }
+      let normalized_path = normalize_path_separators(path.as_str());
+      if glob_match_with_options(&normalized_pattern, &normalized_path, options) {
+        results.push(path);
+      }
+    },
   )
   .await?;
   Ok(results)
-}
-
-#[async_recursion]
-async fn visit_glob_dirs(
-  base_dir: &Utf8Path,
-  current_dir: &Utf8Path,
-  pattern: &str,
-  options: &GlobMatchOptions,
-  fs: &dyn ReadableFileSystem,
-  results: &mut Vec<Utf8PathBuf>,
-) -> Result<()> {
-  if !fs.metadata(current_dir).await.is_ok_and(|m| m.is_directory) {
-    return Ok(());
-  }
-
-  for filename in fs.read_dir(current_dir).await? {
-    let path = current_dir.join(&filename);
-
-    if fs.metadata(&path).await.is_ok_and(|m| m.is_directory) {
-      // Always traverse into subdirectories, including dot-directories.
-      // This matches glob crate behavior — `**` traverses all directories.
-      visit_glob_dirs(base_dir, &path, pattern, options, fs, results).await?;
-    } else {
-      if options.require_literal_leading_dot
-        && path_has_dot_component(&path, base_dir)
-        && !pattern_has_explicit_dot_for(pattern, base_dir, &path)
-      {
-        continue;
-      }
-
-      let normalized_path = normalize_path_separators(path.as_str());
-      if glob_match_with_options(pattern, &normalized_path, options) {
-        results.push(path);
-      }
-    }
-  }
-  Ok(())
 }
 
 fn path_has_dot_component(path: &Utf8Path, base_dir: &Utf8Path) -> bool {
@@ -150,8 +155,6 @@ fn path_has_dot_component(path: &Utf8Path, base_dir: &Utf8Path) -> bool {
 }
 
 /// Check whether the glob pattern has an explicit `.` for a given dot-file path.
-/// This is an approximation: we check if the path component that starts with `.`
-/// appears in the pattern with a literal `.` prefix.
 fn pattern_has_explicit_dot_for(pattern: &str, base_dir: &Utf8Path, path: &Utf8Path) -> bool {
   let path_str = normalize_path_separators(path.as_str());
   let base_str = normalize_path_separators(base_dir.as_str());
@@ -162,12 +165,8 @@ fn pattern_has_explicit_dot_for(pattern: &str, base_dir: &Utf8Path, path: &Utf8P
     &path_str
   };
 
-  // For each path component that starts with '.', check if the pattern
-  // explicitly contains it with a literal dot at that position.
   for component in relative.split('/') {
     if component.starts_with('.') {
-      // Check if the pattern contains `/.` followed by this component name
-      // (or starts with `.` for the first component)
       let dot_component = format!(".{}", &component[1..]);
       if pattern.contains(&format!("/{}", dot_component)) || pattern.starts_with(&dot_component) {
         return true;

--- a/crates/rspack_core/src/glob_utils.rs
+++ b/crates/rspack_core/src/glob_utils.rs
@@ -63,9 +63,25 @@ pub fn glob_match_with_options(pattern: &str, path: &str, options: &GlobMatchOpt
 /// Extract the base directory from a glob pattern.
 /// Returns everything before the first glob metacharacter, up to and including the last `/`.
 fn extract_glob_base_dir(pattern: &str) -> &str {
-  let idx = pattern
-    .find(|c: char| ['*', '?', '[', '{'].contains(&c))
-    .unwrap_or(pattern.len());
+  let mut escaped = false;
+  let mut idx = pattern.len();
+  for (byte_idx, c) in pattern.char_indices() {
+    if escaped {
+      escaped = false;
+      continue;
+    }
+
+    if c == '\\' {
+      escaped = true;
+      continue;
+    }
+
+    if ['*', '?', '[', '{'].contains(&c) {
+      idx = byte_idx;
+      break;
+    }
+  }
+
   let before = &pattern[..idx];
   match before.rfind('/') {
     Some(slash_idx) => &pattern[..=slash_idx],
@@ -90,6 +106,7 @@ pub(crate) async fn walk_dir(
   fs: Arc<dyn ReadableFileSystem>,
   recursive: bool,
   skip_dotfiles: bool,
+  should_enter_dir: &mut (impl FnMut(&Utf8Path) -> bool + Send),
   on_file: &mut (impl FnMut(Utf8PathBuf, String) + Send),
 ) -> Result<()> {
   if !fs.metadata(root).await.is_ok_and(|m| m.is_directory) {
@@ -98,8 +115,16 @@ pub(crate) async fn walk_dir(
   for filename in fs.read_dir(root).await? {
     let path = root.join(&filename);
     if fs.metadata(&path).await.is_ok_and(|m| m.is_directory) {
-      if recursive {
-        walk_dir(&path, fs.clone(), recursive, skip_dotfiles, on_file).await?;
+      if recursive && should_enter_dir(&path) {
+        walk_dir(
+          &path,
+          fs.clone(),
+          recursive,
+          skip_dotfiles,
+          should_enter_dir,
+          on_file,
+        )
+        .await?;
       }
     } else if skip_dotfiles && filename.starts_with('.') {
       // skip dotfiles
@@ -127,6 +152,7 @@ pub async fn find_files_by_glob(
     fs,
     true,  // always recursive for glob
     false, // dotfile filtering handled in callback below
+    &mut |_path| true,
     &mut |path, _filename| {
       if options.require_literal_leading_dot
         && path_has_dot_component(&path, base_dir_path)
@@ -156,22 +182,80 @@ fn path_has_dot_component(path: &Utf8Path, base_dir: &Utf8Path) -> bool {
 
 /// Check whether the glob pattern has an explicit `.` for a given dot-file path.
 fn pattern_has_explicit_dot_for(pattern: &str, base_dir: &Utf8Path, path: &Utf8Path) -> bool {
-  let path_str = normalize_path_separators(path.as_str());
   let base_str = normalize_path_separators(base_dir.as_str());
+  let path_str = normalize_path_separators(path.as_str());
+  let pattern_suffix = pattern.strip_prefix(&base_str).unwrap_or(pattern);
 
-  let relative = if let Some(stripped) = path_str.strip_prefix(&base_str) {
-    stripped
-  } else {
-    &path_str
-  };
+  let relative = path_str.strip_prefix(&base_str).unwrap_or(&path_str);
+  let pattern_segments = pattern_suffix
+    .split('/')
+    .filter(|segment| !segment.is_empty())
+    .collect::<Vec<_>>();
+  let path_segments = relative
+    .split('/')
+    .filter(|segment| !segment.is_empty())
+    .collect::<Vec<_>>();
 
-  for component in relative.split('/') {
-    if let Some(stripped) = component.strip_prefix('.') {
-      let dot_component = format!(".{stripped}");
-      if pattern.contains(&format!("/{dot_component}")) || pattern.starts_with(&dot_component) {
-        return true;
+  fn matches_explicit_dot_segments(patterns: &[&str], paths: &[&str]) -> bool {
+    match (patterns.split_first(), paths.split_first()) {
+      (None, None) => true,
+      (None, Some(_)) => false,
+      (Some((&"**", pattern_rest)), _) => {
+        matches_explicit_dot_segments(pattern_rest, paths)
+          || matches!(
+            paths.split_first(),
+            Some((&path_head, path_rest))
+              if !path_head.starts_with('.') && matches_explicit_dot_segments(patterns, path_rest)
+          )
       }
+      (Some((&pattern_head, pattern_rest)), Some((&path_head, path_rest))) => {
+        if path_head.starts_with('.') && !pattern_head.starts_with('.') {
+          return false;
+        }
+        glob_match(pattern_head.as_bytes(), path_head.as_bytes())
+          && matches_explicit_dot_segments(pattern_rest, path_rest)
+      }
+      (Some(_), None) => false,
     }
   }
-  false
+
+  matches_explicit_dot_segments(&pattern_segments, &path_segments)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn extract_glob_base_dir_skips_escaped_metacharacters() {
+    assert_eq!(
+      extract_glob_base_dir("./fixtures/a\\[b\\]/file"),
+      "./fixtures/a\\[b\\]/"
+    );
+    assert_eq!(
+      extract_glob_base_dir("./fixtures/a\\[b\\]/**/*.js"),
+      "./fixtures/a\\[b\\]/"
+    );
+  }
+
+  #[test]
+  fn explicit_dot_patterns_allow_wildcard_dot_segments() {
+    let base_dir = Utf8Path::new("./fixtures/");
+
+    assert!(pattern_has_explicit_dot_for(
+      "./fixtures/**/.*",
+      base_dir,
+      Utf8Path::new("./fixtures/.env")
+    ));
+    assert!(pattern_has_explicit_dot_for(
+      "./fixtures/**/.*/index.js",
+      base_dir,
+      Utf8Path::new("./fixtures/.cache/index.js")
+    ));
+    assert!(!pattern_has_explicit_dot_for(
+      "./fixtures/**/index.js",
+      base_dir,
+      Utf8Path::new("./fixtures/.cache/index.js")
+    ));
+  }
 }

--- a/crates/rspack_core/src/glob_utils.rs
+++ b/crates/rspack_core/src/glob_utils.rs
@@ -1,0 +1,178 @@
+use core::fmt;
+use std::sync::Arc;
+
+use async_recursion::async_recursion;
+use cow_utils::CowUtils;
+use fast_glob::glob_match;
+use rspack_error::Result;
+use rspack_fs::ReadableFileSystem;
+use rspack_paths::{Utf8Path, Utf8PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct GlobMatchOptions {
+  pub case_sensitive: bool,
+  pub require_literal_leading_dot: bool,
+}
+
+impl Default for GlobMatchOptions {
+  fn default() -> Self {
+    Self {
+      case_sensitive: true,
+      require_literal_leading_dot: true,
+    }
+  }
+}
+
+impl fmt::Display for GlobMatchOptions {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "GlobMatchOptions {{ case_sensitive: {}, require_literal_leading_dot: {} }}",
+      self.case_sensitive, self.require_literal_leading_dot
+    )
+  }
+}
+
+/// Escape special glob characters in a literal path string.
+/// Replaces `glob::Pattern::escape`.
+pub fn escape_glob_pattern(s: &str) -> String {
+  let mut result = String::with_capacity(s.len());
+  for c in s.chars() {
+    match c {
+      '*' | '?' | '[' | ']' | '{' | '}' => {
+        result.push('\\');
+        result.push(c);
+      }
+      _ => result.push(c),
+    }
+  }
+  result
+}
+
+/// Match a path against a glob pattern with options.
+pub fn glob_match_with_options(pattern: &str, path: &str, options: &GlobMatchOptions) -> bool {
+  if options.case_sensitive {
+    glob_match(pattern.as_bytes(), path.as_bytes())
+  } else {
+    let pattern = pattern.to_lowercase();
+    let path = path.to_lowercase();
+    glob_match(pattern.as_bytes(), path.as_bytes())
+  }
+}
+
+/// Extract the base directory from a glob pattern.
+/// Returns everything before the first glob metacharacter, up to and including the last `/`.
+fn extract_glob_base_dir(pattern: &str) -> &str {
+  let idx = pattern
+    .find(|c: char| ['*', '?', '[', '{'].contains(&c))
+    .unwrap_or(pattern.len());
+  let before = &pattern[..idx];
+  match before.rfind('/') {
+    Some(slash_idx) => &pattern[..=slash_idx],
+    None => "./",
+  }
+}
+
+/// Normalize backslashes to forward slashes in a path string.
+fn normalize_path_separators(s: &str) -> String {
+  s.cow_replace('\\', "/").into_owned()
+}
+
+/// Find files matching a glob pattern by traversing the filesystem.
+/// Replaces `glob::glob_with`.
+pub async fn find_files_by_glob(
+  pattern: &str,
+  options: &GlobMatchOptions,
+  fs: Arc<dyn ReadableFileSystem>,
+) -> Result<Vec<Utf8PathBuf>> {
+  let normalized_pattern = normalize_path_separators(pattern);
+  let base_dir = extract_glob_base_dir(&normalized_pattern);
+  let base_dir_path = Utf8Path::new(base_dir);
+
+  let mut results = Vec::new();
+  visit_glob_dirs(
+    base_dir_path,
+    base_dir_path,
+    &normalized_pattern,
+    options,
+    &*fs,
+    &mut results,
+  )
+  .await?;
+  Ok(results)
+}
+
+#[async_recursion]
+async fn visit_glob_dirs(
+  base_dir: &Utf8Path,
+  current_dir: &Utf8Path,
+  pattern: &str,
+  options: &GlobMatchOptions,
+  fs: &dyn ReadableFileSystem,
+  results: &mut Vec<Utf8PathBuf>,
+) -> Result<()> {
+  if !fs.metadata(current_dir).await.is_ok_and(|m| m.is_directory) {
+    return Ok(());
+  }
+
+  for filename in fs.read_dir(current_dir).await? {
+    let path = current_dir.join(&filename);
+
+    if fs.metadata(&path).await.is_ok_and(|m| m.is_directory) {
+      // Always traverse into subdirectories, including dot-directories.
+      // This matches glob crate behavior — `**` traverses all directories.
+      visit_glob_dirs(base_dir, &path, pattern, options, fs, results).await?;
+    } else {
+      if options.require_literal_leading_dot
+        && path_has_dot_component(&path, base_dir)
+        && !pattern_has_explicit_dot_for(pattern, base_dir, &path)
+      {
+        continue;
+      }
+
+      let normalized_path = normalize_path_separators(path.as_str());
+      if glob_match_with_options(pattern, &normalized_path, options) {
+        results.push(path);
+      }
+    }
+  }
+  Ok(())
+}
+
+fn path_has_dot_component(path: &Utf8Path, base_dir: &Utf8Path) -> bool {
+  let relative = path.strip_prefix(base_dir).unwrap_or(path);
+  for component in relative.components() {
+    if component.as_str().starts_with('.') {
+      return true;
+    }
+  }
+  false
+}
+
+/// Check whether the glob pattern has an explicit `.` for a given dot-file path.
+/// This is an approximation: we check if the path component that starts with `.`
+/// appears in the pattern with a literal `.` prefix.
+fn pattern_has_explicit_dot_for(pattern: &str, base_dir: &Utf8Path, path: &Utf8Path) -> bool {
+  let path_str = normalize_path_separators(path.as_str());
+  let base_str = normalize_path_separators(base_dir.as_str());
+
+  let relative = if let Some(stripped) = path_str.strip_prefix(&base_str) {
+    stripped
+  } else {
+    &path_str
+  };
+
+  // For each path component that starts with '.', check if the pattern
+  // explicitly contains it with a literal dot at that position.
+  for component in relative.split('/') {
+    if component.starts_with('.') {
+      // Check if the pattern contains `/.` followed by this component name
+      // (or starts with `.` for the first component)
+      let dot_component = format!(".{}", &component[1..]);
+      if pattern.contains(&format!("/{}", dot_component)) || pattern.starts_with(&dot_component) {
+        return true;
+      }
+    }
+  }
+  false
+}

--- a/crates/rspack_core/src/glob_utils.rs
+++ b/crates/rspack_core/src/glob_utils.rs
@@ -54,8 +54,8 @@ pub fn glob_match_with_options(pattern: &str, path: &str, options: &GlobMatchOpt
   if options.case_sensitive {
     glob_match(pattern.as_bytes(), path.as_bytes())
   } else {
-    let pattern = pattern.to_lowercase();
-    let path = path.to_lowercase();
+    let pattern = pattern.cow_to_lowercase();
+    let path = path.cow_to_lowercase();
     glob_match(pattern.as_bytes(), path.as_bytes())
   }
 }
@@ -166,9 +166,9 @@ fn pattern_has_explicit_dot_for(pattern: &str, base_dir: &Utf8Path, path: &Utf8P
   };
 
   for component in relative.split('/') {
-    if component.starts_with('.') {
-      let dot_component = format!(".{}", &component[1..]);
-      if pattern.contains(&format!("/{}", dot_component)) || pattern.starts_with(&dot_component) {
+    if let Some(stripped) = component.strip_prefix('.') {
+      let dot_component = format!(".{stripped}");
+      if pattern.contains(&format!("/{dot_component}")) || pattern.starts_with(&dot_component) {
         return true;
       }
     }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -50,6 +50,7 @@ pub use context_module::*;
 mod context_module_factory;
 pub use context_module_factory::*;
 mod glob_utils;
+pub(crate) use glob_utils::walk_dir;
 pub use glob_utils::*;
 mod init_fragment;
 pub use init_fragment::*;

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -49,6 +49,8 @@ mod context_module;
 pub use context_module::*;
 mod context_module_factory;
 pub use context_module_factory::*;
+mod glob_utils;
+pub use glob_utils::*;
 mod init_fragment;
 pub use init_fragment::*;
 mod module_factory;

--- a/crates/rspack_plugin_copy/Cargo.toml
+++ b/crates/rspack_plugin_copy/Cargo.toml
@@ -8,8 +8,8 @@ version.workspace = true
 
 [dependencies]
 derive_more  = { workspace = true, features = ["debug"] }
+fast-glob    = { workspace = true }
 futures      = { workspace = true }
-glob         = { workspace = true }
 pathdiff     = { workspace = true, features = ["camino"] }
 regex        = { workspace = true }
 rspack_core  = { workspace = true }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -8,18 +8,19 @@ use std::{
 };
 
 use derive_more::Debug;
+use fast_glob::glob_match;
 use futures::future::{BoxFuture, join_all};
-use glob::{MatchOptions, Pattern as GlobPattern};
 use regex::Regex;
 use rspack_core::{
   AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
-  CompilationProcessAssets, Filename, Logger, PathData, Plugin,
+  CompilationProcessAssets, Filename, GlobMatchOptions, Logger, PathData, Plugin,
+  escape_glob_pattern, find_files_by_glob,
   rspack_sources::{BoxSource, RawBufferSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
 use rspack_hook::{plugin, plugin_hook};
-use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
+use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
 use sugar_path::SugarPath;
 
@@ -106,7 +107,7 @@ pub struct CopyPattern {
 pub struct CopyGlobOptions {
   pub case_sensitive_match: Option<bool>,
   pub dot: Option<bool>,
-  pub ignore: Option<Vec<GlobPattern>>,
+  pub ignore: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -164,7 +165,9 @@ impl CopyRspackPlugin {
       return Ok(None);
     }
     if let Some(ignore) = &pattern.glob_options.ignore
-      && ignore.iter().any(|ignore| ignore.matches(entry.as_str()))
+      && ignore
+        .iter()
+        .any(|ignore| glob_match(ignore.as_bytes(), entry.as_str().as_bytes()))
     {
       return Ok(None);
     }
@@ -415,7 +418,7 @@ impl CopyRspackPlugin {
         if dot_enable.is_none() {
           dot_enable = Some(true);
         }
-        let mut escaped = Utf8PathBuf::from(GlobPattern::escape(abs_from.as_str()));
+        let mut escaped = Utf8PathBuf::from(escape_glob_pattern(abs_from.as_str()));
         escaped.push("**/*");
 
         escaped.as_str().to_string()
@@ -435,7 +438,7 @@ impl CopyRspackPlugin {
           dot_enable = Some(true);
         }
 
-        GlobPattern::escape(abs_from.as_str())
+        escape_glob_pattern(abs_from.as_str())
       }
       FromType::Glob => {
         need_add_context_to_dependency = true;
@@ -456,29 +459,30 @@ impl CopyRspackPlugin {
 
     logger.log(format!("begin globbing '{glob_query}'..."));
 
-    let glob_entries = glob::glob_with(
+    let glob_match_options = GlobMatchOptions {
+      case_sensitive: pattern.glob_options.case_sensitive_match.unwrap_or(true),
+      require_literal_leading_dot: !dot_enable.unwrap_or(false),
+    };
+
+    let glob_entries = find_files_by_glob(
       &glob_query,
-      MatchOptions {
-        case_sensitive: pattern.glob_options.case_sensitive_match.unwrap_or(true),
-        require_literal_separator: Default::default(),
-        require_literal_leading_dot: !dot_enable.unwrap_or(false),
-      },
-    );
+      &glob_match_options,
+      compilation.input_filesystem.clone(),
+    )
+    .await;
 
     match glob_entries {
       Ok(entries) => {
         let entries: Vec<_> = entries
-          .filter_map(|entry| {
-            let entry = entry.ok()?.assert_utf8();
-
-            let filters = pattern.glob_options.ignore.as_ref();
-
-            if let Some(filters) = filters {
+          .into_iter()
+          .filter(|entry| {
+            if let Some(filters) = &pattern.glob_options.ignore {
               // If filters length is 0, exist is true by default
-              let exist = filters.iter().all(|filter| !filter.matches(entry.as_str()));
-              exist.then_some(entry)
+              filters
+                .iter()
+                .all(|filter| !glob_match(filter.as_bytes(), entry.as_str().as_bytes()))
             } else {
-              Some(entry)
+              true
             }
           })
           .collect();
@@ -571,7 +575,7 @@ impl CopyRspackPlugin {
         diagnostics
           .lock()
           .expect("failed to obtain lock of `diagnostics`")
-          .push(Diagnostic::error("Glob Error".into(), e.msg.to_string()));
+          .push(Diagnostic::error("Glob Error".into(), e.to_string()));
 
         Ok(None)
       }

--- a/crates/swc_plugin_ts_collector/Cargo.toml
+++ b/crates/swc_plugin_ts_collector/Cargo.toml
@@ -11,7 +11,6 @@ rustc-hash = { workspace = true }
 swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit", "ecma_parser"] }
 
 [dev-dependencies]
-glob                       = { workspace = true }
 insta                      = { workspace = true }
 rspack_javascript_compiler = { workspace = true }
 

--- a/crates/swc_plugin_ts_collector/tests/fixture.rs
+++ b/crates/swc_plugin_ts_collector/tests/fixture.rs
@@ -5,7 +5,6 @@ use std::{
   sync::Arc,
 };
 
-use glob::glob;
 use rspack_javascript_compiler::{JavaScriptCompiler, transform::SwcOptions};
 use rspack_swc_plugin_ts_collector::{ExportedEnumCollector, TypeExportsCollector};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -17,6 +16,21 @@ use swc_core::{
     visit::VisitWith,
   },
 };
+
+fn find_ts_files(dir: &Path) -> Vec<PathBuf> {
+  let mut results = Vec::new();
+  if let Ok(entries) = std::fs::read_dir(dir) {
+    for entry in entries.flatten() {
+      let path = entry.path();
+      if path.is_dir() {
+        results.extend(find_ts_files(&path));
+      } else if path.extension().map_or(false, |e| e == "ts") {
+        results.push(path);
+      }
+    }
+  }
+  results
+}
 
 fn snapshot_name(root: &Path, input: &Path) -> String {
   #[allow(clippy::disallowed_methods)]
@@ -31,10 +45,7 @@ fn snapshot_name(root: &Path, input: &Path) -> String {
 #[test]
 fn type_exports() {
   let tests_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR").to_string()).join("tests");
-  let cases = glob(&format!("{}/type-exports/**/*.ts", tests_dir.display()))
-    .expect("glob failed")
-    .collect::<Result<Vec<_>, _>>()
-    .expect("glob error");
+  let cases = find_ts_files(&tests_dir.join("type-exports"));
   assert!(!cases.is_empty(), "no test cases found");
   for input in cases {
     let snapshot_name = snapshot_name(&tests_dir, &input);
@@ -64,10 +75,7 @@ fn type_exports() {
 #[test]
 fn enums() {
   let tests_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR").to_string()).join("tests");
-  let cases = glob(&format!("{}/enums/**/*.ts", tests_dir.display()))
-    .expect("glob failed")
-    .collect::<Result<Vec<_>, _>>()
-    .expect("glob error");
+  let cases = find_ts_files(&tests_dir.join("enums"));
   assert!(!cases.is_empty(), "no test cases found");
   for input in cases {
     let snapshot_name = snapshot_name(&tests_dir, &input);

--- a/crates/swc_plugin_ts_collector/tests/fixture.rs
+++ b/crates/swc_plugin_ts_collector/tests/fixture.rs
@@ -24,7 +24,7 @@ fn find_ts_files(dir: &Path) -> Vec<PathBuf> {
       let path = entry.path();
       if path.is_dir() {
         results.extend(find_ts_files(&path));
-      } else if path.extension().map_or(false, |e| e == "ts") {
+      } else if path.extension().is_some_and(|e| e == "ts") {
         results.push(path);
       }
     }


### PR DESCRIPTION
## Summary

replace glob in copy plugin with fast-glob

## Related links

following https://github.com/web-infra-dev/rspack/pull/13946


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
