### PR TITLE
test: configure rayon for codspeed benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ unused_lifetimes                       = "warn"
 unused_macro_rules                     = "warn"
 
 [workspace.lints.rust.unexpected_cfgs]
-check-cfg = ['cfg(allocative)', 'cfg(dylint_lib, values("rspack_collection_hasher"))']
+check-cfg = ['cfg(allocative)', 'cfg(codspeed)', 'cfg(dylint_lib, values("rspack_collection_hasher"))']
 level     = "warn"
 
 [workspace.lints.clippy]

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -76,7 +76,7 @@ pretty_assertions = { workspace = true }
 workspace = true
 
 [features]
-codspeed   = []
+codspeed   = ["rspack_parallel/codspeed"]
 debug_tool = ["rspack_util/debug_tool"]
 default    = []
 napi       = ["dep:napi", "dep:rspack_napi", "dep:rkyv"]

--- a/crates/rspack_core/src/utils/codspeed.rs
+++ b/crates/rspack_core/src/utils/codspeed.rs
@@ -1,0 +1,14 @@
+use std::sync::Once;
+
+static RAYON_FOR_CODSPEED: Once = Once::new();
+
+/// Make Rayon use the benchmark thread as worker 0 so CodSpeed attributes
+/// rayon work to the measured parent function.
+pub fn configure_rayon_current_thread_for_codspeed() {
+  RAYON_FOR_CODSPEED.call_once(|| {
+    rayon::ThreadPoolBuilder::new()
+      .use_current_thread()
+      .build_global()
+      .expect("rayon global thread pool should be configured before rayon is used");
+  });
+}

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -8,6 +8,8 @@ use crate::{
   ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, ConcatenatedModule,
   ModuleGraph, ModuleIdentifier,
 };
+#[cfg(feature = "codspeed")]
+mod codspeed;
 mod comment;
 mod compile_boolean_matcher;
 mod concatenated_module_visitor;
@@ -41,6 +43,8 @@ pub use memory_gc::MemoryGCStorage;
 pub use rspack_parallel::{FutureConsumer, RayonConsumer};
 pub use steal_cell::StealCell;
 
+#[cfg(feature = "codspeed")]
+pub use self::codspeed::*;
 pub use self::{
   comment::*,
   extract_source_map::*,

--- a/crates/rspack_parallel/Cargo.toml
+++ b/crates/rspack_parallel/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true
+
+[features]
+codspeed = []

--- a/crates/rspack_parallel/src/iterator_consumer/rayon.rs
+++ b/crates/rspack_parallel/src/iterator_consumer/rayon.rs
@@ -1,3 +1,4 @@
+#[cfg(all(not(target_family = "wasm"), not(feature = "codspeed")))]
 use std::sync::mpsc::channel;
 
 use rayon::iter::ParallelIterator;
@@ -18,7 +19,7 @@ where
 {
   type Item = I;
 
-  #[cfg(not(target_family = "wasm"))]
+  #[cfg(all(not(target_family = "wasm"), not(feature = "codspeed")))]
   fn consume(self, mut func: impl FnMut(Self::Item)) {
     let (tx, rx) = channel::<Self::Item>();
     std::thread::scope(|s| {
@@ -32,7 +33,7 @@ where
     });
   }
 
-  #[cfg(target_family = "wasm")]
+  #[cfg(any(target_family = "wasm", feature = "codspeed"))]
   fn consume(self, mut func: impl FnMut(Self::Item)) {
     let items: Vec<Self::Item> = self.collect();
     for item in items {

--- a/xtask/benchmark/benches/benches.rs
+++ b/xtask/benchmark/benches/benches.rs
@@ -1,15 +1,23 @@
 #![allow(clippy::unwrap_used)]
 
-use criterion::criterion_main;
+use criterion::{Criterion, criterion_group, criterion_main};
 use groups::{
   build_chunk_graph::chunk_graph, bundle::bundle, compilation_stages::compilation_stages,
   module_graph_api::module_graph_api, persistent_cache::persistent_cache,
   scan_dependencies::scan_dependencies,
 };
+use rspack_core::configure_rayon_current_thread_for_codspeed;
 
 mod groups;
 
+fn configure_rayon_for_codspeed(_: &mut Criterion) {
+  configure_rayon_current_thread_for_codspeed();
+}
+
+criterion_group!(codspeed_setup, configure_rayon_for_codspeed);
+
 criterion_main!(
+  codspeed_setup,
   chunk_graph,
   module_graph_api,
   scan_dependencies,

--- a/xtask/benchmark/src/lib.rs
+++ b/xtask/benchmark/src/lib.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
-use std::{
-  alloc::{GlobalAlloc, Layout, System},
-  thread,
-};
+use std::alloc::{GlobalAlloc, Layout, System};
 
 pub use criterion::*;
 use tokio::runtime::{Builder, Runtime};
@@ -46,12 +43,24 @@ unsafe impl GlobalAlloc for NeverGrowInPlaceAllocator {
 }
 
 pub fn build_tokio_rt() -> Runtime {
-  let cpu_num = thread::available_parallelism()
+  #[cfg(codspeed)]
+  {
+    return Builder::new_current_thread()
+      .max_blocking_threads(8)
+      .build()
+      .expect("should not fail to build tokio runtime");
+  }
+
+  #[cfg(not(codspeed))]
+  let cpu_num = std::thread::available_parallelism()
     .expect("failed to get cpu num")
     .get();
-  Builder::new_multi_thread()
-    .worker_threads(cpu_num.min(4))
-    .max_blocking_threads(8)
-    .build()
-    .expect("should not fail to build tokio runtime")
+  #[cfg(not(codspeed))]
+  {
+    Builder::new_multi_thread()
+      .worker_threads(cpu_num.min(4))
+      .max_blocking_threads(8)
+      .build()
+      .expect("should not fail to build tokio runtime")
+  }
 }


### PR DESCRIPTION
## Summary
* before
<img width="1596" height="710" alt="image" src="https://github.com/user-attachments/assets/a9d0365d-8503-4573-bafa-a87a7ca4e4fb" />

* after
<img width="1736" height="912" alt="image" src="https://github.com/user-attachments/assets/803ed266-84f6-4838-8265-dcab7a370798" />

Configure Rayon before the Rust benchmark groups run when `rspack_core` is built with the `codspeed` feature. The benchmark entrypoint now runs a small setup group first, and that setup uses `ThreadPoolBuilder::use_current_thread()` so Rayon worker 0 is the benchmark thread. This helps CodSpeed attribute Rayon work to the measured parent function.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `cargo fmt --all`
- `cargo check --benches -p rspack_benchmark`
- `RUSTFLAGS="--cfg codspeed --check-cfg=cfg(codspeed)" cargo check --benches -p rspack_benchmark`