### PR TITLE
perf: optimize build chunk graph traversal

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1189,14 +1189,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   fn add_and_enter_module(&mut self, item: &AddAndEnterModule, compilation: &mut Compilation) {
     tracing::trace!("add_and_enter_module {:?}", item);
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .is_module_in_chunk(&item.module, item.chunk)
-    {
-      return;
-    }
-
     // if this module in parent chunks
     let module_ordinal = *self.ordinal_by_module.get(&item.module).unwrap_or_else(|| {
       panic!(
@@ -1204,6 +1196,15 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         &item.module
       )
     });
+    if self
+      .mask_by_chunk
+      .get(&item.chunk)
+      .expect("chunk must in mask_by_chunk")
+      .bit(module_ordinal)
+    {
+      return;
+    }
+
     let cgi = self.chunk_group_info_mut(&item.chunk_group_info);
 
     if cgi.min_available_modules.bit(module_ordinal) {
@@ -1396,18 +1397,19 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     );
 
     for (module, active_state, connections) in block_modules.iter().rev() {
-      if compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .is_module_in_chunk(module, item.chunk)
+      let ordinal = *self.ordinal_by_module.get(module).unwrap_or_else(|| {
+        panic!("expected a module ordinal for identifier '{module}', but none was found.")
+      });
+      if self
+        .mask_by_chunk
+        .get(&item.chunk)
+        .expect("chunk must in mask_by_chunk")
+        .bit(ordinal)
       {
         // skip early if already connected
         continue;
       }
 
-      let ordinal = *self.ordinal_by_module.get(module).unwrap_or_else(|| {
-        panic!("expected a module ordinal for identifier '{module}', but none was found.")
-      });
       let chunk_group_info = self.chunk_group_info_mut(&item.chunk_group_info);
       if !active_state.is_true() {
         chunk_group_info

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -62,6 +62,8 @@ type PreparedBlockConnectionMap =
   FxIndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
+type ActiveConnectionStateCache =
+  HashMap<(Option<Arc<RuntimeSpec>>, ConnectionIdList), ConnectionState>;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ModuleSet {
@@ -314,6 +316,7 @@ pub(crate) struct CodeSplitter {
   pub(crate) named_chunk_groups: HashMap<String, CgiUkey>,
   pub(crate) named_async_entrypoints: HashMap<String, CgiUkey>,
   pub(crate) block_modules_runtime_map: BlockModulesRuntimeMap,
+  active_connection_state_cache: ActiveConnectionStateCache,
   pub(crate) ordinal_by_module: IdentifierMap<u64>,
   pub(crate) mask_by_chunk: HashMap<ChunkUkey, ModuleSet>,
   module_count: usize,
@@ -411,6 +414,32 @@ fn get_active_state_of_connections(
     }
   }
   merged
+}
+
+fn get_cached_active_state_of_connections(
+  cache: &mut ActiveConnectionStateCache,
+  connections: &ConnectionIdList,
+  runtime: Option<Arc<RuntimeSpec>>,
+  module_graph: &ModuleGraph,
+  module_graph_cache: &ModuleGraphCacheArtifact,
+  side_effects_state_artifact: &SideEffectsStateArtifact,
+  exports_info_artifact: &ExportsInfoArtifact,
+) -> ConnectionState {
+  let key = (runtime.clone(), connections.clone());
+  if let Some(state) = cache.get(&key) {
+    return *state;
+  }
+
+  let state = get_active_state_of_connections(
+    connections,
+    runtime.as_deref(),
+    module_graph,
+    module_graph_cache,
+    side_effects_state_artifact,
+    exports_info_artifact,
+  );
+  cache.insert(key, state);
+  state
 }
 
 impl CodeSplitter {
@@ -1897,6 +1926,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       &self.prepared_blocks_map,
       &self.prepared_connection_map,
       runtime_map,
+      &mut self.active_connection_state_cache,
     );
 
     runtime_map
@@ -2070,14 +2100,16 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         let side_effects_state_artifact = &compilation
           .build_module_graph_artifact
           .side_effects_state_artifact;
+        let active_connection_state_cache = &mut self.active_connection_state_cache;
 
         let mut queue_actions = Vec::new();
         let mut modules_to_skip = Vec::new();
 
         skipped_module_connections.retain(|(module, connections)| {
-          let active_state = get_active_state_of_connections(
+          let active_state = get_cached_active_state_of_connections(
+            active_connection_state_cache,
             connections,
-            Some(&runtime),
+            Some(runtime.clone()),
             module_graph,
             module_graph_cache,
             side_effects_state_artifact,
@@ -2338,6 +2370,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     compilation: &Compilation,
   ) -> Result<()> {
     self.module_count = all_modules.len();
+    self.active_connection_state_cache.clear();
     let mg = compilation.get_module_graph();
     self.prepared_connection_map = all_modules
       .par_iter()
@@ -2552,6 +2585,7 @@ fn extract_block_modules(
   prepared_blocks_map: &DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
   prepared_connection_map: &IdentifierMap<PreparedBlockConnectionMap>,
   map: &mut BlockConnectionMap,
+  active_connection_state_cache: &mut ActiveConnectionStateCache,
 ) {
   let block = module.into();
   let blocks = prepared_blocks_map.get(&block).cloned().unwrap_or_default();
@@ -2573,9 +2607,10 @@ fn extract_block_modules(
     let modules = module_map
       .get_mut(block_id)
       .expect("should have modules in block_modules_runtime_map");
-    let active_state = get_active_state_of_connections(
+    let active_state = get_cached_active_state_of_connections(
+      active_connection_state_cache,
       connections,
-      runtime.as_deref(),
+      runtime.clone(),
       compilation.get_module_graph(),
       &compilation.module_graph_cache_artifact,
       &compilation

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -33,7 +33,31 @@ pub(crate) type DependenciesBlockIdentifierMap<V> =
 pub(crate) type DependenciesBlockIdentifierSet =
   std::collections::HashSet<DependenciesBlockIdentifier, BuildHasherDefault<FxHasher>>;
 
-type ConnectionIdList = Arc<Vec<DependencyId>>;
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) enum ConnectionIdList {
+  One(DependencyId),
+  Many(Arc<[DependencyId]>),
+}
+
+impl ConnectionIdList {
+  fn from_vec(connections: Vec<DependencyId>) -> Self {
+    debug_assert!(!connections.is_empty());
+    if let [connection] = connections.as_slice() {
+      Self::One(*connection)
+    } else {
+      Self::Many(connections.into())
+    }
+  }
+
+  #[inline]
+  fn as_slice(&self) -> &[DependencyId] {
+    match self {
+      Self::One(connection) => std::slice::from_ref(connection),
+      Self::Many(connections) => connections.as_ref(),
+    }
+  }
+}
+
 type PreparedBlockConnectionMap =
   FxIndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
 type BlockConnectionMap =
@@ -348,14 +372,14 @@ fn add_chunk_in_group(
 }
 
 fn get_active_state_of_connections(
-  connections: &[DependencyId],
+  connections: &ConnectionIdList,
   runtime: Option<&RuntimeSpec>,
   module_graph: &ModuleGraph,
   module_graph_cache: &ModuleGraphCacheArtifact,
   side_effects_state_artifact: &SideEffectsStateArtifact,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> ConnectionState {
-  let mut iter = connections.iter();
+  let mut iter = connections.as_slice().iter();
   let id = iter.next().expect("should have connection");
   let mut merged = module_graph
     .connection_by_dependency_id(id)
@@ -2369,7 +2393,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           *module,
           connection_map
             .into_iter()
-            .map(|(key, connections)| (key, Arc::new(connections)))
+            .map(|(key, connections)| (key, ConnectionIdList::from_vec(connections)))
             .collect(),
         )
       })

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use itertools::Itertools;
-use num_bigint::BigUint;
 use rayon::prelude::*;
 use rspack_collections::{IdentifierIndexSet, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnostic, Error, Result, error};
@@ -40,6 +39,64 @@ type PreparedBlockConnectionMap =
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ModuleSet {
+  words: Vec<u64>,
+}
+
+impl ModuleSet {
+  const BITS: usize = u64::BITS as usize;
+
+  pub(crate) fn with_module_count(module_count: usize) -> Self {
+    Self {
+      words: vec![0; (module_count + 1).div_ceil(Self::BITS)],
+    }
+  }
+
+  #[inline]
+  pub(crate) fn bit(&self, ordinal: u64) -> bool {
+    let word_index = ordinal as usize / Self::BITS;
+    let bit_index = ordinal as usize % Self::BITS;
+    self
+      .words
+      .get(word_index)
+      .is_some_and(|word| word & (1u64 << bit_index) != 0)
+  }
+
+  #[inline]
+  pub(crate) fn set_bit(&mut self, ordinal: u64, value: bool) {
+    let word_index = ordinal as usize / Self::BITS;
+    let bit_index = ordinal as usize % Self::BITS;
+    if self.words.len() <= word_index {
+      self.words.resize(word_index + 1, 0);
+    }
+
+    let mask = 1u64 << bit_index;
+    if value {
+      self.words[word_index] |= mask;
+    } else {
+      self.words[word_index] &= !mask;
+    }
+  }
+
+  #[inline]
+  fn union_with(&mut self, other: &Self) {
+    if self.words.len() < other.words.len() {
+      self.words.resize(other.words.len(), 0);
+    }
+    for (left, right) in self.words.iter_mut().zip(&other.words) {
+      *left |= *right;
+    }
+  }
+
+  #[inline]
+  fn intersect_with(&mut self, other: &Self) {
+    for (index, word) in self.words.iter_mut().enumerate() {
+      *word &= other.words.get(index).copied().unwrap_or_default();
+    }
+  }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGroupInfo {
   pub initialized: bool,
@@ -48,9 +105,9 @@ pub struct ChunkGroupInfo {
   pub chunk_loading: bool,
   pub async_chunks: bool,
   pub runtime: Arc<RuntimeSpec>,
-  pub min_available_modules: Arc<BigUint>,
+  pub min_available_modules: Arc<ModuleSet>,
   pub min_available_modules_init: bool,
-  pub available_modules_to_be_merged: Vec<Arc<BigUint>>,
+  pub available_modules_to_be_merged: Vec<Arc<ModuleSet>>,
 
   pub skipped_items: IdentifierIndexSet,
   pub skipped_module_connections: FxIndexSet<(ModuleIdentifier, ConnectionIdList)>,
@@ -63,7 +120,7 @@ pub struct ChunkGroupInfo {
 
   // set of modules available including modules from this chunk group
   // A derived attribute, therefore utilizing interior mutability to manage updates
-  resulting_available_modules: Option<Arc<BigUint>>,
+  resulting_available_modules: Option<Arc<ModuleSet>>,
 
   pub outgoing_blocks: AsyncDependenciesBlockIdentifierSet,
 }
@@ -98,7 +155,7 @@ impl ChunkGroupInfo {
   fn calculate_resulting_available_modules(
     &mut self,
     chunk_group: &ChunkGroup,
-    mask_by_chunk: &HashMap<ChunkUkey, BigUint>,
+    mask_by_chunk: &HashMap<ChunkUkey, ModuleSet>,
   ) {
     if self.resulting_available_modules.is_some() {
       return;
@@ -111,7 +168,7 @@ impl ChunkGroupInfo {
       let mask = mask_by_chunk
         .get(chunk)
         .expect("chunk must in mask_by_chunk");
-      new_resulting_available_modules |= mask
+      new_resulting_available_modules.union_with(mask)
     }
 
     self.resulting_available_modules = Some(Arc::new(new_resulting_available_modules));
@@ -234,7 +291,8 @@ pub(crate) struct CodeSplitter {
   pub(crate) named_async_entrypoints: HashMap<String, CgiUkey>,
   pub(crate) block_modules_runtime_map: BlockModulesRuntimeMap,
   pub(crate) ordinal_by_module: IdentifierMap<u64>,
-  pub(crate) mask_by_chunk: HashMap<ChunkUkey, BigUint>,
+  pub(crate) mask_by_chunk: HashMap<ChunkUkey, ModuleSet>,
+  module_count: usize,
 
   stat_processed_queue_items: u32,
   stat_processed_blocks: u32,
@@ -404,7 +462,9 @@ impl CodeSplitter {
     if created && let Some(mut mutations) = compilation.incremental.mutations_write() {
       mutations.add(Mutation::ChunkAdd { chunk: chunk_ukey });
     }
-    self.mask_by_chunk.insert(chunk_ukey, BigUint::from(0u32));
+    self
+      .mask_by_chunk
+      .insert(chunk_ukey, ModuleSet::with_module_count(self.module_count));
     let runtime = get_entry_runtime(name, options, &compilation.entries);
     let chunk = compilation
       .build_chunk_graph_artifact
@@ -704,7 +764,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           if created && let Some(mut mutations) = compilation.incremental.mutations_write() {
             mutations.add(Mutation::ChunkAdd { chunk: chunk_ukey });
           }
-          self.mask_by_chunk.insert(chunk_ukey, BigUint::from(0u32));
+          self
+            .mask_by_chunk
+            .insert(chunk_ukey, ModuleSet::with_module_count(self.module_count));
           let chunk = compilation
             .build_chunk_graph_artifact
             .chunk_by_ukey
@@ -1555,7 +1617,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .build_chunk_graph_artifact
         .chunk_graph
         .add_chunk(chunk_ukey);
-      self.mask_by_chunk.insert(chunk_ukey, BigUint::from(0u32));
+      self
+        .mask_by_chunk
+        .insert(chunk_ukey, ModuleSet::with_module_count(self.module_count));
       let module_graph = compilation.get_module_graph();
       let block = module_graph
         .block_by_id(&block_id)
@@ -2056,7 +2120,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
   }
 
-  fn _debug_available_modules(&self, available_modules: &BigUint) -> IdentifierSet {
+  fn _debug_available_modules(&self, available_modules: &ModuleSet) -> IdentifierSet {
     let mut set: IdentifierSet = Default::default();
 
     for (module, ordinal) in &self.ordinal_by_module {
@@ -2095,7 +2159,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .unwrap_or_else(|| panic!("ChunkGroupInfo({info_ukey:?}) not found"))
         .available_sources
         .clone();
-      let mut available_modules = BigUint::from(0u32);
+      let mut available_modules = ModuleSet::with_module_count(self.module_count);
 
       // combine min_available_modules from all resulting_available_modules
       for source_ukey in source_ukeys {
@@ -2116,7 +2180,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           .resulting_available_modules
           .as_ref()
           .expect("should have resulting available modules");
-        available_modules |= resulting_available_modules.as_ref();
+        available_modules.union_with(resulting_available_modules);
       }
 
       self.outdated_chunk_group_info.insert(info_ukey);
@@ -2182,8 +2246,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
                 }
 
                 let orig = cgi.min_available_modules.clone();
-                cgi.min_available_modules =
-                  Arc::new(cgi.min_available_modules.as_ref() & modules_to_be_merged.as_ref());
+                let mut min_available_modules = cgi.min_available_modules.as_ref().clone();
+                min_available_modules.intersect_with(modules_to_be_merged.as_ref());
+                cgi.min_available_modules = Arc::new(min_available_modules);
                 changed |= orig != cgi.min_available_modules;
               }
             }
@@ -2248,6 +2313,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     all_modules: &Vec<ModuleIdentifier>,
     compilation: &Compilation,
   ) -> Result<()> {
+    self.module_count = all_modules.len();
     let mg = compilation.get_module_graph();
     self.prepared_connection_map = all_modules
       .par_iter()

--- a/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use num_bigint::BigUint;
 use rspack_collections::{IdentifierIndexSet, IdentifierMap, IdentifierSet};
 use rspack_error::Result;
 use rustc_hash::FxHashSet;
 use tracing::instrument;
 
-use super::code_splitter::{CgiUkey, CodeSplitter, DependenciesBlockIdentifier};
+use super::code_splitter::{CgiUkey, CodeSplitter, DependenciesBlockIdentifier, ModuleSet};
 use crate::{
   AsyncDependenciesBlockIdentifier, AsyncDependenciesBlockIdentifierSet, ChunkGroupKind,
   ChunkGroupUkey, ChunkUkey, Compilation, GroupOptions, ModuleIdentifier, RuntimeSpec,
@@ -510,13 +509,15 @@ impl CodeSplitter {
       }
     }
     for chunk in compilation.build_chunk_graph_artifact.chunk_by_ukey.keys() {
-      let mut mask = BigUint::from(0u32);
+      let mut mask = ModuleSet::with_module_count(ordinal_by_module.len());
       for module_id in compilation
         .build_chunk_graph_artifact
         .chunk_graph
         .get_chunk_modules_identifier(chunk)
       {
-        let module_ordinal = self.get_module_ordinal(*module_id);
+        let module_ordinal = *ordinal_by_module
+          .get(module_id)
+          .expect("module should have ordinal");
         mask.set_bit(module_ordinal, true);
       }
       self.mask_by_chunk.insert(*chunk, mask);
@@ -806,7 +807,7 @@ impl CodeSplitter {
     &self,
     cache: &ChunkCreateData,
     runtime: &RuntimeSpec,
-    new_available_modules: Arc<BigUint>,
+    new_available_modules: Arc<ModuleSet>,
     options: Option<&GroupOptions>,
   ) -> bool {
     cache.can_rebuild
@@ -818,17 +819,11 @@ impl CodeSplitter {
   pub fn available_modules_affected(
     &self,
     cache: &ChunkCreateData,
-    new_available_modules: Arc<BigUint>,
+    new_available_modules: Arc<ModuleSet>,
   ) -> bool {
     if new_available_modules == cache.available_modules {
       return false;
     }
-
-    // get changed modules
-    // 0010
-    // 0100
-    // diff: 0110
-    let diff = cache.available_modules.as_ref() ^ new_available_modules.as_ref();
 
     let cache_result = cache
       .cache_result
@@ -841,7 +836,7 @@ impl CodeSplitter {
       .chain(cache_result.skipped_modules.iter())
     {
       let m = self.get_module_ordinal(*m);
-      if diff.bit(m) {
+      if cache.available_modules.bit(m) != new_available_modules.bit(m) {
         return true;
       }
     }
@@ -862,7 +857,7 @@ struct CacheResult {
 #[derive(Debug, Clone)]
 pub struct ChunkCreateData {
   // input
-  available_modules: Arc<BigUint>,
+  available_modules: Arc<ModuleSet>,
   options: Option<GroupOptions>,
   runtime: RuntimeSpec,
   pub module: ModuleIdentifier,


### PR DESCRIPTION
## Summary

- Use per-chunk module masks for hot module-in-chunk checks during chunk graph traversal.
- Replace BigUint-backed available-module sets with a fixed-width local bitset to reduce allocation and arithmetic overhead.
- Store single dependency connection lists inline instead of allocating an Arc<Vec<_>> for every list.
- Cache computed connection active states by runtime and connection list so repeated checks can reuse the result.

## Why

The build_chunk_graph profile shows time in repeated module membership checks, available-module set merging, dependency connection list allocation, and active-state evaluation. These changes keep the same traversal semantics while reducing the amount of generic big-integer work, heap allocation, and repeated connection-state computation on the hot path.

## Validation

- cargo check -p rspack_core
