### PR TITLE
test(benchmark): disable spawn blocking for codspeed

### DIFF
--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -7,7 +7,8 @@ repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
 
 [features]
-full = ["loaders"]
+codspeed = ["rspack_core/codspeed", "rspack_plugin_schemes/codspeed"]
+full     = ["loaders"]
 
 loader_lightningcss   = ["rspack_loader_lightningcss"]
 loader_preact_refresh = ["rspack_loader_preact_refresh"]

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -8,6 +8,9 @@ version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+codspeed = []
+
 [dependencies]
 anyhow       = { workspace = true }
 async-trait  = { workspace = true }

--- a/crates/rspack_plugin_schemes/src/file_uri.rs
+++ b/crates/rspack_plugin_schemes/src/file_uri.rs
@@ -8,7 +8,7 @@ use rspack_error::{Result, ToStringResultToRspackResultExt, error};
 use rspack_fs::ReadableFileSystem;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::AssertUtf8;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), not(feature = "codspeed")))]
 use tokio::task::spawn_blocking;
 use url::Url;
 
@@ -56,13 +56,17 @@ async fn read_resource(
   {
     let resource_path_owned = resource_path.to_owned();
     let fs = fs.clone();
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), not(feature = "codspeed")))]
     let result = {
       // Avoid blocking the Tokio worker thread on native targets.
       spawn_blocking(move || fs.read_sync(resource_path_owned.as_path()))
         .await
         .map_err(|e| error!("{e}, spawn task failed"))?
     };
+    #[cfg(all(not(target_family = "wasm"), feature = "codspeed"))]
+    // Keep CodSpeed benchmark file reads on the current runtime thread to avoid
+    // Tokio blocking-pool scheduling noise in simulation measurements.
+    let result = fs.read_sync(resource_path_owned.as_path());
     #[cfg(target_family = "wasm")]
     // Keep WASI filesystem access on the current thread. Under node:wasi,
     // blocking workers may observe a different host-side WASI environment.

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -14,7 +14,7 @@ tokio     = { workspace = true }
 [dev-dependencies]
 # Make rust analyzer happy
 async-trait                = { workspace = true }
-rspack                     = { workspace = true, features = ["full"] }
+rspack                     = { workspace = true, features = ["codspeed", "full"] }
 rspack_cacheable           = { workspace = true }
 rspack_collections         = { workspace = true }
 rspack_core                = { workspace = true, features = ["codspeed"] }


### PR DESCRIPTION
## Summary

- Add a `codspeed` feature to `rspack_plugin_schemes` and route `rspack/codspeed` through it.
- Keep `FileUriPlugin` resource reads on the current runtime thread under CodSpeed instead of using `tokio::task::spawn_blocking`.
- Enable the `rspack/codspeed` feature for the Rust benchmark crate.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo fmt --package rspack_plugin_schemes --check`
- `git diff --check`
- `cargo check -p rspack_plugin_schemes --features codspeed`
- `cargo check --benches -p rspack_benchmark`
- `cargo tree -p rspack_benchmark --edges features -i rspack_plugin_schemes`
- `cargo codspeed build -m simulation --profile codspeed -p rspack_benchmark`
- `CODSPEED_RUNNER_MODE=simulation pnpm run bench:rust`