### PR TITLE
docs: correct terminology spelling

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -3303,7 +3303,7 @@ export interface TsconfigOptions {
    */
   configFile: string
   /**
-   * Support for Typescript Project References.
+   * Support for TypeScript Project References.
    *
    * * `'auto'`: use the `references` field from tsconfig of `config_file`.
    * * `string[]`: manually provided relative or absolute path.

--- a/crates/rspack_binding_api/src/rspack_resolver/options.rs
+++ b/crates/rspack_binding_api/src/rspack_resolver/options.rs
@@ -205,7 +205,7 @@ pub struct TsconfigOptions {
   /// * an absolute path to the configuration file.
   pub config_file: String,
 
-  /// Support for Typescript Project References.
+  /// Support for TypeScript Project References.
   ///
   /// * `'auto'`: use the `references` field from tsconfig of `config_file`.
   /// * `string[]`: manually provided relative or absolute path.

--- a/crates/rspack_core/src/options/resolve/mod.rs
+++ b/crates/rspack_core/src/options/resolve/mod.rs
@@ -155,7 +155,7 @@ pub struct TsconfigOptions {
   #[cacheable(with=AsPreset)]
   pub config_file: Utf8PathBuf,
 
-  /// Support for Typescript Project References.
+  /// Support for TypeScript Project References.
   pub references: TsconfigReferences,
 }
 

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -163,7 +163,7 @@ pub async fn resolve_for_error_hints(
       return Some(format!("Did you mean '{}'?
 
 The request '{}' failed to resolve only because it was resolved as fully specified,
-probably because the origin is strict EcmaScript Module,
+probably because the origin is strict ECMAScript Module,
 e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\"type\": \"module\"'.
 
 The extension in the request is mandatory for it to be fully specified.

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -47,7 +47,7 @@ fn resolve_relative_resource_path(
   source_map_path: Option<&Utf8Path>,
 ) -> Option<String> {
   if absolute_resource_path.starts_with("webpack/") {
-    // Webpack runtime modules are virtual
+    // webpack runtime modules are virtual
     return Some(absolute_resource_path.to_string());
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -32,7 +32,7 @@ impl JavascriptParser<'_> {
       self.build_meta.has_top_level_await = true;
     } else {
       self.throw_top_level_await_error(
-        "Top-level-await is only supported in EcmaScript Modules".into(),
+        "Top-level-await is only supported in ECMAScript Modules".into(),
         span,
       );
     }

--- a/packages/rspack/src/config/target.ts
+++ b/packages/rspack/src/config/target.ts
@@ -445,7 +445,7 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
   ],
   [
     'esX',
-    'EcmaScript in this version. Examples: es2020, es5.',
+    'ECMAScript in this version. Examples: es2020, es5.',
     /^es(\d+)$/,
     (version) => {
       let v = +version;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -304,7 +304,7 @@ export type OutputModule = boolean;
 /** Tell Rspack to remove a module from the module instance cache (require.cache) if it throws an exception when it is required. */
 export type StrictModuleExceptionHandling = boolean;
 
-/** Handle error in module loading as per EcmaScript Modules spec at a performance cost. */
+/** Handle error in module loading as per ECMAScript Modules spec at a performance cost. */
 export type StrictModuleErrorHandling = boolean;
 
 /** Indicates what global object will be used to mount the library. */
@@ -415,7 +415,7 @@ export type Environment = {
   /** The environment supports 'document' variable. */
   document?: boolean;
 
-  /** The environment supports an async import() function to import EcmaScript modules. */
+  /** The environment supports an async import() function to import ECMAScript modules. */
   dynamicImport?: boolean;
 
   /** The environment supports an async import() when creating a worker, only for web targets at the moment. */
@@ -545,7 +545,7 @@ export type Output = {
   strictModuleExceptionHandling?: StrictModuleExceptionHandling;
 
   /**
-   * Handle error in module loading as per EcmaScript Modules spec at a performance cost.
+   * Handle error in module loading as per ECMAScript Modules spec at a performance cost.
    * @default false
    * */
   strictModuleErrorHandling?: StrictModuleErrorHandling;

--- a/tests/rspack-test/configCases/resolver-factory/resolve/rspack.config.js
+++ b/tests/rspack-test/configCases/resolver-factory/resolve/rspack.config.js
@@ -22,7 +22,7 @@ class Plugin {
 
               expect(error).toBeNull();
               expect(res).toBe(path.join(__dirname, '/index.js'));
-              // Webpack does not have resource field
+              // webpack does not have resource field
               expect(req.resource).toBe(undefined);
               expect(req.path).toBe(path.join(__dirname, '/index.js'));
               callback();

--- a/tests/rspack-test/configCases/resolver-factory/with-fragment/rspack.config.js
+++ b/tests/rspack-test/configCases/resolver-factory/with-fragment/rspack.config.js
@@ -27,7 +27,7 @@ class Plugin {
 
               expect(error).toBeNull();
               expect(res).toBe(path.join(__dirname, '/index.js#fragment'));
-              // Webpack does not have resource field
+              // webpack does not have resource field
               expect(req.resource).toBe(undefined);
               expect(req.path).toBe(path.join(__dirname, '/index.js'));
               expect(req.fragment).toBe('#fragment');

--- a/tests/rspack-test/configCases/resolver-factory/with-query/rspack.config.js
+++ b/tests/rspack-test/configCases/resolver-factory/with-query/rspack.config.js
@@ -23,7 +23,7 @@ class Plugin {
 
               expect(error).toBeNull();
               expect(res).toBe(path.join(__dirname, '/index.js?query'));
-              // Webpack does not have resource field
+              // webpack does not have resource field
               expect(req.resource).toBe(undefined);
               expect(req.path).toBe(path.join(__dirname, '/index.js'));
               expect(req.query).toBe('?query');

--- a/tests/rspack-test/configCases/web/fetch-priority/index.js
+++ b/tests/rspack-test/configCases/web/fetch-priority/index.js
@@ -34,7 +34,7 @@ it("should set fetchPriority", () => {
 	const script7 = document.head.children[6];
 	expect(script7.getAttribute("fetchpriority")).toBeFalsy();
 
-	// Webpack context
+	// webpack context
 	const loader = import.meta.webpackContext("./dir", {
 		mode: "lazy",
 		fetchPriority: "high"

--- a/tests/rspack-test/diagnosticsCases/factorize/fully-specified-resolve-suggestions/stats.err
+++ b/tests/rspack-test/diagnosticsCases/factorize/fully-specified-resolve-suggestions/stats.err
@@ -7,7 +7,7 @@ ERROR in ./index.js 1:1-15
   help: Did you mean './foo.js'?
         
         The request './foo' failed to resolve only because it was resolved as fully specified,
-        probably because the origin is strict EcmaScript Module,
+        probably because the origin is strict ECMAScript Module,
         e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"'.
         
         The extension in the request is mandatory for it to be fully specified.

--- a/tests/rspack-test/diagnosticsCases/module-parse-failed/tla_esm_error/stats.err
+++ b/tests/rspack-test/diagnosticsCases/module-parse-failed/tla_esm_error/stats.err
@@ -1,6 +1,6 @@
 ERROR in ./index.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Top-level-await is only supported in EcmaScript Modules
+  ╰─▶   × JavaScript parse error: Top-level-await is only supported in ECMAScript Modules
          ╭─[3:4]
        1 │ await Promise.resolve("aaa");
        2 │
@@ -13,7 +13,7 @@ ERROR in ./index.js
 
 ERROR in ./index.js
   × Module parse failed:
-  ╰─▶   × JavaScript parse error: Top-level-await is only supported in EcmaScript Modules
+  ╰─▶   × JavaScript parse error: Top-level-await is only supported in ECMAScript Modules
          ╭─[1:0]
        1 │ await Promise.resolve("aaa");
          · ─────

--- a/tests/rspack-test/normalCases/parsing/typeof-api/index.js
+++ b/tests/rspack-test/normalCases/parsing/typeof-api/index.js
@@ -19,6 +19,6 @@ it("should not parse filtered stuff", function () {
 	if (typeof __webpack_init_sharing__ !== "function") require("fail");
 	if (typeof __webpack_nonce__ !== "string") require("fail");
 	if (typeof __webpack_chunkname__ !== "string") require("fail");
-	// if (typeof __webpack_is_included__ !== "function") require("fail"); // Webpack also can't eval `typeof __webpack_is_included !== "function"`
+	// if (typeof __webpack_is_included__ !== "function") require("fail"); // webpack also can't eval `typeof __webpack_is_included !== "function"`
 	if (typeof __webpack_require__ !== "function") require("fail");
 });

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -445,7 +445,7 @@ type Environment = {
   destructuring?: boolean;
   /** The environment supports 'document' variable. */
   document?: boolean;
-  /** The environment supports an async import() function to import EcmaScript modules. */
+  /** The environment supports an async import() function to import ECMAScript modules. */
   dynamicImport?: boolean;
   /** The environment supports an async import() when creating a worker, only for web targets at the moment. */
   dynamicImportInWorker?: boolean;

--- a/website/docs/zh/api/javascript-api/resolver.mdx
+++ b/website/docs/zh/api/javascript-api/resolver.mdx
@@ -1,10 +1,10 @@
 ---
-description: 'Rspack 使用 Rust 编写的更高性能的 rspack-resolver 来代替 Webpack 中的 enhanced-resolve，并通过 rspack.experiments.resolver 实验性地重导出了这些 API。'
+description: 'Rspack 使用 Rust 编写的更高性能的 rspack-resolver 来代替 webpack 中的 enhanced-resolve，并通过 rspack.experiments.resolver 实验性地重导出了这些 API。'
 ---
 
 # Resolver API
 
-Rspack 使用 Rust 编写的更高性能的 [rspack-resolver](https://github.com/rstackjs/rspack-resolver) 来代替 Webpack 中的 [enhanced-resolve](https://github.com/webpack/enhanced-resolve)，并通过 `rspack.experiments.resolver` 实验性地重导出了这些 API。这使你能够直接调用 rspack-resolver 的 `resolver.sync` 或 `resolver.async` 等功能。
+Rspack 使用 Rust 编写的更高性能的 [rspack-resolver](https://github.com/rstackjs/rspack-resolver) 来代替 webpack 中的 [enhanced-resolve](https://github.com/webpack/enhanced-resolve)，并通过 `rspack.experiments.resolver` 实验性地重导出了这些 API。这使你能够直接调用 rspack-resolver 的 `resolver.sync` 或 `resolver.async` 等功能。
 
 完整的用法以及选项参见 [rspack-resolver](https://github.com/rstackjs/rspack-resolver)，以下是一个简单的示例，演示如何使用 Rspack 解析模块的路径：
 

--- a/website/docs/zh/blog/announcing-1-5.mdx
+++ b/website/docs/zh/blog/announcing-1-5.mdx
@@ -230,7 +230,7 @@ export type MyType = {
 
 这是因为 Rspack 在解析模块时，采用独立的方式处理每个模块，导致类型的导出（例子中的 `MyType`）被错误识别为一个值而非类型，由于在 `./types.ts` 中找不到相应的值导出，因此触发了上述警告。
 
-Rspack 1.5 引入了 [experiments.typeReexportsPresence](/config/experiments#experimentstypereexportspresence) 配置，用于改进对 Typescript 类型导出的识别。开启此配置后，Rspack 能够正确识别跨模块分析类型重导出，从而避免误报警告。
+Rspack 1.5 引入了 [experiments.typeReexportsPresence](/config/experiments#experimentstypereexportspresence) 配置，用于改进对 TypeScript 类型导出的识别。开启此配置后，Rspack 能够正确识别跨模块分析类型重导出，从而避免误报警告。
 
 > 详见 [experiments.typeReexportsPresence](/config/experiments#experimentstypereexportspresence)。
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -441,7 +441,7 @@ type Environment = {
   destructuring?: boolean;
   /** The environment supports 'document' variable. */
   document?: boolean;
-  /** The environment supports an async import() function to import EcmaScript modules. */
+  /** The environment supports an async import() function to import ECMAScript modules. */
   dynamicImport?: boolean;
   /** The environment supports an async import() when creating a worker, only for web targets at the moment. */
   dynamicImportInWorker?: boolean;


### PR DESCRIPTION
## Summary

This PR corrects terminology spelling across comments, diagnostics, type descriptions, and documentation so terms like `ECMAScript`, `TypeScript`, and `webpack` are written consistently.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).