### PR TITLE
chore: use mimalloc for codspeed benchmark allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ version = "0.100.2"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
+ "mimalloc",
  "rspack",
  "rspack_cacheable",
  "rspack_collections",

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -11,6 +11,16 @@ version.workspace = true
 criterion = { workspace = true }
 tokio     = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Keep benchmark allocator features aligned with rspack_allocator.
+mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mimalloc = { workspace = true, features = ["v3"] }
+
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
+mimalloc = { workspace = true, features = ["v3"] }
+
 [dev-dependencies]
 # Make rust analyzer happy
 async-trait                = { workspace = true }

--- a/xtask/benchmark/src/lib.rs
+++ b/xtask/benchmark/src/lib.rs
@@ -1,22 +1,31 @@
 #![allow(clippy::unwrap_used)]
 
-use std::alloc::{GlobalAlloc, Layout, System};
+#[cfg(target_family = "wasm")]
+use std::alloc::System;
+use std::alloc::{GlobalAlloc, Layout};
 
 pub use criterion::*;
 use tokio::runtime::{Builder, Runtime};
 
 #[global_allocator]
-static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
+#[cfg(not(target_family = "wasm"))]
+static GLOBAL: NeverGrowInPlaceAllocator<mimalloc::MiMalloc> =
+  NeverGrowInPlaceAllocator::new(mimalloc::MiMalloc);
+
+#[global_allocator]
+#[cfg(target_family = "wasm")]
+static GLOBAL: NeverGrowInPlaceAllocator<System> = NeverGrowInPlaceAllocator::new(System);
 
 /// From Oxc: https://github.com/oxc-project/oxc/blob/main/tasks/benchmark/src/lib.rs
 /// Global allocator for use in benchmarks.
 ///
-/// A thin wrapper around Rust's default [`System`] allocator. It passes through `alloc`
-/// and `dealloc` methods to [`System`], but does not implement [`GlobalAlloc::realloc`].
+/// A thin wrapper around [`mimalloc::MiMalloc`] allocator. It passes through `alloc`
+/// and `dealloc` methods to [`mimalloc::MiMalloc`], but does not implement
+/// [`GlobalAlloc::realloc`].
 ///
 /// Rationale for this is:
 ///
-/// `realloc` for default [`System`] allocator calls `libc::realloc`, which may either:
+/// `realloc` for default system allocators may either:
 /// 1. allow the allocation to grow in place. or
 /// 2. create a new allocation, and copy memory from old allocation to the new one.
 ///
@@ -25,20 +34,29 @@ static GLOBAL: NeverGrowInPlaceAllocator = NeverGrowInPlaceAllocator;
 /// therefore produces large and unpredictable variance in benchmarks.
 ///
 /// By not providing a `realloc` method, this custom allocator delegates to the default
-/// [`GlobalAlloc::realloc`] implementation which *never* grows in place.
+/// [`GlobalAlloc::realloc`] implementation which *never* grows in place, while keeping
+/// `alloc` and `dealloc` visible to CodSpeed's mimalloc white-box allocator tracking.
 /// It therefore represents the "worse case scenario" for memory allocation performance.
 /// This behavior is consistent and predictable, and therefore stabilizes benchmark results.
-struct NeverGrowInPlaceAllocator;
+struct NeverGrowInPlaceAllocator<A> {
+  allocator: A,
+}
 
-// SAFETY: Methods simply delegate to `System` allocator
+impl<A> NeverGrowInPlaceAllocator<A> {
+  const fn new(allocator: A) -> Self {
+    Self { allocator }
+  }
+}
+
+// SAFETY: Methods simply delegate to the wrapped allocator.
 #[expect(unsafe_code, clippy::undocumented_unsafe_blocks)]
-unsafe impl GlobalAlloc for NeverGrowInPlaceAllocator {
+unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-    unsafe { System.alloc(layout) }
+    unsafe { self.allocator.alloc(layout) }
   }
 
   unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-    unsafe { System.dealloc(ptr, layout) }
+    unsafe { self.allocator.dealloc(ptr, layout) }
   }
 }
 


### PR DESCRIPTION
## Summary

- Route `NeverGrowInPlaceAllocator` alloc/dealloc through `mimalloc::MiMalloc` on non-wasm targets so CodSpeed can white-box allocator activity.
- Keep the allocator wrapper without a `realloc` override to preserve never-grow-in-place benchmark behavior.
- Keep wasm on `System` and align mimalloc feature flags with `rspack_allocator`.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo fmt -p rspack_benchmark`
- `cargo check -p rspack_benchmark --lib`
- `cargo check -p rspack_benchmark --benches`
- `RUSTFLAGS="--cfg codspeed" cargo check -p rspack_benchmark --lib`
- `pnpm exec taplo fmt --check xtask/benchmark/Cargo.toml`
- `git diff --check`