### PR TITLE
perf: reduce code splitter allocation and lookup overhead

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -733,7 +733,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     compilation: &mut Compilation,
   ) -> Result<FxIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
     let mut input_entrypoints_and_modules: FxIndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
-      FxIndexMap::default();
+      FxIndexMap::with_capacity_and_hasher(compilation.entries.len(), Default::default());
 
     let entries = compilation.entries.keys().cloned().collect::<Vec<_>>();
 
@@ -742,12 +742,16 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       all_modules
         .par_iter()
         .map(|m| {
-          (
-            *m,
-            mg.get_outgoing_connections(m)
-              .map(|con| *con.module_identifier())
-              .collect::<Vec<_>>(),
-          )
+          let mut outgoing = mg
+            .module_graph_module_by_identifier(m)
+            .map(|mgm| Vec::with_capacity(mgm.outgoing_connections().len()))
+            .unwrap_or_default();
+
+          for con in mg.get_outgoing_connections(m) {
+            outgoing.push(*con.module_identifier());
+          }
+
+          (*m, outgoing)
         })
         .collect::<IdentifierMap<_>>()
     };
@@ -756,12 +760,23 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       .iter()
       .map(|name| self.prepare_entry_input(name, compilation))
       .collect::<Result<Vec<_>>>()?;
+    let initial_depth_capacity = all_modules
+      .len()
+      .checked_div(entries.len())
+      .unwrap_or_default();
 
     let assign_depths_maps = assign_tasks
       .par_iter()
       .map(|(_, modules)| {
-        let mut assign_depths_map = IdentifierMap::default();
-        assign_depths(&mut assign_depths_map, modules.iter(), &outgoings);
+        let initial_depth_capacity = initial_depth_capacity.max(modules.len());
+        let mut assign_depths_map =
+          IdentifierMap::with_capacity_and_hasher(initial_depth_capacity, Default::default());
+        assign_depths(
+          &mut assign_depths_map,
+          modules.iter(),
+          &outgoings,
+          initial_depth_capacity,
+        );
         assign_depths_map
       })
       .collect::<Vec<_>>();

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -51,17 +51,11 @@ struct PreparedBlockConnectionBuilder {
   dependency: DependencyId,
 }
 
-struct PreparedBlockConnectionGroupBuilder {
-  block: DependenciesBlockIdentifier,
-  module: ModuleIdentifier,
-  connections: Vec<DependencyId>,
-}
-
 fn finalize_prepared_connection_map(
   connections: impl IntoIterator<Item = PreparedBlockConnectionBuilder>,
   capacity: usize,
 ) -> PreparedBlockConnectionMap {
-  let mut groups = Vec::<PreparedBlockConnectionGroupBuilder>::with_capacity(capacity);
+  let mut groups = PreparedBlockConnectionMap::with_capacity(capacity);
   let mut group_index_by_block = Vec::<(DependenciesBlockIdentifier, IdentifierMap<usize>)>::new();
   for connection in connections {
     let index_by_module = if let Some((_, index_by_module)) = group_index_by_block
@@ -78,27 +72,22 @@ fn finalize_prepared_connection_map(
     };
 
     if let Some(index) = index_by_module.get(&connection.module) {
-      groups[*index].connections.push(connection.dependency);
+      Arc::get_mut(&mut groups[*index].connections)
+        .expect("prepared connections should not be shared during finalize")
+        .push(connection.dependency);
       continue;
     }
 
     let index = groups.len();
     index_by_module.insert(connection.module, index);
-    groups.push(PreparedBlockConnectionGroupBuilder {
+    groups.push(PreparedBlockConnection {
       block: connection.block,
       module: connection.module,
-      connections: vec![connection.dependency],
+      connections: Arc::new(vec![connection.dependency]),
     });
   }
 
   groups
-    .into_iter()
-    .map(|connection| PreparedBlockConnection {
-      block: connection.block,
-      module: connection.module,
-      connections: Arc::new(connection.connections),
-    })
-    .collect()
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2335,9 +2324,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         let mut ordered_deps = Vec::new();
         let mut unordered_deps = Vec::with_capacity(dependency_count);
         for dep_id in all_dependencies {
-          let Some(connection) = mg.connection_by_dependency_id(dep_id) else {
-            continue;
-          };
           let dep = mg.dependency_by_id(dep_id);
           let module_dep = dep.as_module_dependency();
           if module_dep.is_none() && dep.as_context_dependency().is_none() {
@@ -2346,6 +2332,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           if matches!(module_dep.map(|d| d.weak()), Some(true)) {
             continue;
           }
+          let Some(connection) = mg.connection_by_dependency_id(dep_id) else {
+            continue;
+          };
 
           let module_identifier = *connection.module_identifier();
           let block_id = if let Some(block) = mg.get_parent_block(dep_id) {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1981,12 +1981,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       let (
         cgi_ukey,
         chunk_group_ukey,
-        runtime,
         min_available_modules,
         mut skipped_items,
         mut skipped_module_connections,
-        children,
-        available_children,
       ) = {
         let cgi = self
           .chunk_group_infos
@@ -1995,12 +1992,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         (
           cgi.ukey,
           cgi.chunk_group,
-          cgi.runtime.clone(),
           cgi.min_available_modules.clone(),
           std::mem::take(&mut cgi.skipped_items),
           std::mem::take(&mut cgi.skipped_module_connections),
-          cgi.children.clone(),
-          cgi.available_children.clone(),
         )
       };
 
@@ -2014,33 +2008,33 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
       // 1. Reconsider skipped items
       // Use retain instead of collect + shift_remove to avoid O(n²)
-      let mut add_and_enter_modules = Vec::new();
-      skipped_items.retain(|module| {
-        let ordinal = self.ordinal_by_module.get(module).unwrap_or_else(|| {
-          panic!("expected a module ordinal for identifier '{module}', but none was found.")
+      let ordinal_by_module = &self.ordinal_by_module;
+      {
+        let queue = &mut self.queue;
+        skipped_items.retain(|module| {
+          let ordinal = ordinal_by_module.get(module).unwrap_or_else(|| {
+            panic!("expected a module ordinal for identifier '{module}', but none was found.")
+          });
+          if !min_available_modules.bit(*ordinal) {
+            queue.push(QueueAction::AddAndEnterModule(AddAndEnterModule {
+              module: *module,
+              chunk_group_info: cgi_ukey,
+              chunk,
+            }));
+            false
+          } else {
+            true
+          }
         });
-        if !min_available_modules.bit(*ordinal) {
-          add_and_enter_modules.push(*module);
-          false
-        } else {
-          true
-        }
-      });
-
-      for m in add_and_enter_modules {
-        self
-          .queue
-          .push(QueueAction::AddAndEnterModule(AddAndEnterModule {
-            module: m,
-            chunk_group_info: cgi_ukey,
-            chunk,
-          }))
       }
 
       // 2. Reconsider skipped connections
       // Use retain instead of collect indices + shift_remove_index to avoid O(n²)
       if !skipped_module_connections.is_empty() {
-        let ordinal_by_module = &self.ordinal_by_module;
+        let runtime = self
+          .chunk_group_info(&chunk_group_info_ukey)
+          .runtime
+          .clone();
         let module_graph = compilation.get_module_graph();
         let module_graph_cache = &compilation.module_graph_cache_artifact;
         let exports_info_artifact = &compilation.exports_info_artifact;
@@ -2048,62 +2042,75 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           .build_module_graph_artifact
           .side_effects_state_artifact;
 
-        let mut queue_actions = Vec::new();
-        let mut modules_to_skip = Vec::new();
-
-        skipped_module_connections.retain(|(module, connections)| {
-          let active_state = get_active_state_of_connections(
-            connections,
-            Some(&runtime),
-            module_graph,
-            module_graph_cache,
-            side_effects_state_artifact,
-            exports_info_artifact,
-          );
-          if active_state.is_false() {
-            return true;
-          }
-          if active_state.is_true() {
-            let module_ordinal = ordinal_by_module.get(module).unwrap_or_else(|| {
-              panic!("expected a module ordinal for identifier '{module}', but none was found.")
-            });
-            if min_available_modules.bit(*module_ordinal) {
-              modules_to_skip.push(*module);
+        {
+          let queue = &mut self.queue;
+          skipped_module_connections.retain(|(module, connections)| {
+            let active_state = get_active_state_of_connections(
+              connections,
+              Some(&runtime),
+              module_graph,
+              module_graph_cache,
+              side_effects_state_artifact,
+              exports_info_artifact,
+            );
+            if active_state.is_false() {
+              return true;
+            }
+            if active_state.is_true() {
+              let module_ordinal = ordinal_by_module.get(module).unwrap_or_else(|| {
+                panic!("expected a module ordinal for identifier '{module}', but none was found.")
+              });
+              if min_available_modules.bit(*module_ordinal) {
+                skipped_items.insert(*module);
+                return false;
+              }
+              queue.push(QueueAction::AddAndEnterModule(AddAndEnterModule {
+                module: *module,
+                chunk_group_info: chunk_group_info_ukey,
+                chunk,
+              }));
               return false;
             }
-            queue_actions.push(QueueAction::AddAndEnterModule(AddAndEnterModule {
+            queue.push(QueueAction::ProcessBlock(ProcessBlock {
+              block: (*module).into(),
               module: *module,
               chunk_group_info: chunk_group_info_ukey,
               chunk,
             }));
-            return false;
-          }
-          queue_actions.push(QueueAction::ProcessBlock(ProcessBlock {
-            block: (*module).into(),
-            module: *module,
-            chunk_group_info: chunk_group_info_ukey,
-            chunk,
-          }));
-          true
-        });
-
-        for m in modules_to_skip {
-          skipped_items.insert(m);
+            true
+          });
         }
-        self.queue.extend(queue_actions);
       }
+
+      let (children, available_children) = {
+        let cgi = self
+          .chunk_group_infos
+          .get(&chunk_group_info_ukey)
+          .unwrap_or_else(|| panic!("ChunkGroupInfo({chunk_group_info_ukey:?}) not found"));
+        let children = if cgi.children.is_empty() {
+          Vec::new()
+        } else {
+          cgi.children.iter().copied().collect_vec()
+        };
+        let available_children = if cgi.available_children.is_empty() {
+          Vec::new()
+        } else {
+          cgi.available_children.iter().copied().collect_vec()
+        };
+        (children, available_children)
+      };
 
       // 3. Reconsider children chunk groups
       if !children.is_empty() {
         self.stat_child_chunk_groups_reconnected += children.len() as u32;
 
         let connect_list = self.queue_connect.entry(chunk_group_info_ukey).or_default();
-        connect_list.extend(children.iter().map(|child| (*child, None)));
+        connect_list.extend(children.into_iter().map(|child| (child, None)));
       }
 
       // 4. Reconsider chunk groups for combining
-      for cgi in &available_children {
-        self.chunk_groups_for_combining.insert(*cgi);
+      for cgi in available_children {
+        self.chunk_groups_for_combining.insert(cgi);
       }
 
       {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2217,55 +2217,57 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
 
     for batch in chunk_groups_merging_batches {
-      let chunk_groups_merging_tasks = batch
-        .into_iter()
-        .map(|(info_ukey, process_block)| {
-          let cgi = std::mem::take(self.chunk_group_info_mut(&info_ukey));
-          (info_ukey, process_block, cgi)
+      let mut chunk_groups_merging_tasks = Vec::with_capacity(batch.len());
+      for (info_ukey, process_block) in batch {
+        let cgi = std::mem::take(self.chunk_group_info_mut(&info_ukey));
+        chunk_groups_merging_tasks.push((info_ukey, process_block, cgi));
+      }
+
+      let mut chunk_group_merging_results = chunk_groups_merging_tasks
+        .into_par_iter()
+        .map(|(info_ukey, process_block, mut cgi)| {
+          let mut changed = false;
+          let available_modules_length = cgi.available_modules_to_be_merged.len() as u32;
+
+          if !cgi.available_modules_to_be_merged.is_empty() {
+            let available_modules_to_be_merged =
+              std::mem::take(&mut cgi.available_modules_to_be_merged);
+
+            for modules_to_be_merged in available_modules_to_be_merged {
+              if !cgi.min_available_modules_init {
+                cgi.min_available_modules_init = true;
+                cgi.min_available_modules = modules_to_be_merged;
+                changed = true;
+                continue;
+              }
+
+              let merged = cgi.min_available_modules.as_ref() & modules_to_be_merged.as_ref();
+              if &merged != cgi.min_available_modules.as_ref() {
+                cgi.min_available_modules = Arc::new(merged);
+                changed = true;
+              }
+            }
+          }
+
+          if changed {
+            cgi.invalidate_resulting_available_modules();
+          }
+
+          (
+            info_ukey,
+            Some(cgi),
+            process_block,
+            changed,
+            available_modules_length,
+          )
         })
         .collect::<Vec<_>>();
 
-      let (chunk_group_infos, chunk_group_merging_results): (Vec<_>, Vec<_>) =
-        chunk_groups_merging_tasks
-          .into_par_iter()
-          .map(|(info_ukey, process_block, mut cgi)| {
-            let mut changed = false;
-            let available_modules_length = cgi.available_modules_to_be_merged.len() as u32;
-
-            if !cgi.available_modules_to_be_merged.is_empty() {
-              let available_modules_to_be_merged =
-                std::mem::take(&mut cgi.available_modules_to_be_merged);
-
-              for modules_to_be_merged in available_modules_to_be_merged {
-                if !cgi.min_available_modules_init {
-                  cgi.min_available_modules_init = true;
-                  cgi.min_available_modules = modules_to_be_merged;
-                  changed = true;
-                  continue;
-                }
-
-                let orig = cgi.min_available_modules.clone();
-                cgi.min_available_modules =
-                  Arc::new(cgi.min_available_modules.as_ref() & modules_to_be_merged.as_ref());
-                changed |= orig != cgi.min_available_modules;
-              }
-            }
-
-            if changed {
-              cgi.invalidate_resulting_available_modules();
-            }
-            (
-              (info_ukey, cgi),
-              (info_ukey, process_block, changed, available_modules_length),
-            )
-          })
-          .unzip();
-
-      for (info_ukey, cgi) in chunk_group_infos {
-        *self.chunk_group_info_mut(&info_ukey) = cgi;
+      for (info_ukey, cgi, _, _, _) in &mut chunk_group_merging_results {
+        *self.chunk_group_info_mut(info_ukey) = cgi.take().expect("should have chunk group info");
       }
 
-      for (info_ukey, process_block, changed, available_modules_length) in
+      for (info_ukey, _, process_block, changed, available_modules_length) in
         chunk_group_merging_results
       {
         self.stat_merged_available_module_sets += available_modules_length;

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -787,22 +787,25 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       let mg = compilation.get_module_graph();
       all_modules
         .par_iter()
-        .map(|m| {
-          let outgoing = mg
-            .module_graph_module_by_identifier(m)
-            .map(|mgm| {
-              let outgoing_connections = mgm.outgoing_connections();
-              let mut outgoing = Vec::with_capacity(outgoing_connections.len());
-              for id in outgoing_connections {
-                if let Some(con) = mg.connection_by_dependency_id(id) {
-                  outgoing.push(*con.module_identifier());
-                }
-              }
-              outgoing
-            })
-            .unwrap_or_default();
+        .filter_map(|m| {
+          let mgm = mg.module_graph_module_by_identifier(m)?;
+          let outgoing_connections = mgm.outgoing_connections();
+          if outgoing_connections.is_empty() {
+            return None;
+          }
 
-          (*m, outgoing)
+          let mut outgoing = Vec::with_capacity(outgoing_connections.len());
+          for id in outgoing_connections {
+            if let Some(con) = mg.connection_by_dependency_id(id) {
+              outgoing.push(*con.module_identifier());
+            }
+          }
+
+          if outgoing.is_empty() {
+            None
+          } else {
+            Some((*m, outgoing))
+          }
         })
         .collect::<IdentifierMap<_>>()
     };
@@ -2136,53 +2139,76 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   fn process_chunk_groups_for_combining(&mut self, compilation: &mut Compilation) {
     let chunk_group_infos = &self.chunk_group_infos;
-    self.chunk_groups_for_combining.retain(|info_ukey| {
-      let info = chunk_group_infos
-        .get(info_ukey)
-        .unwrap_or_else(|| panic!("ChunkGroupInfo({info_ukey:?}) not found"));
-      info.available_sources.iter().all(|source_ukey| {
-        let source = chunk_group_infos
-          .get(source_ukey)
-          .unwrap_or_else(|| panic!("ChunkGroupInfo({source_ukey:?}) not found"));
-        source.min_available_modules_init
-      })
-    });
-
     let chunk_groups_for_combining = self
       .chunk_groups_for_combining
       .iter()
-      .copied()
+      .filter_map(|info_ukey| {
+        let info = chunk_group_infos
+          .get(info_ukey)
+          .unwrap_or_else(|| panic!("ChunkGroupInfo({info_ukey:?}) not found"));
+        let mut source_ukeys = Vec::with_capacity(info.available_sources.len());
+        for source_ukey in &info.available_sources {
+          let source = chunk_group_infos
+            .get(source_ukey)
+            .unwrap_or_else(|| panic!("ChunkGroupInfo({source_ukey:?}) not found"));
+          if !source.min_available_modules_init {
+            return None;
+          }
+          source_ukeys.push(*source_ukey);
+        }
+        Some((*info_ukey, source_ukeys))
+      })
       .collect_vec();
     let chunk_group_by_ukey = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
-    for info_ukey in chunk_groups_for_combining {
-      let source_ukeys = self
-        .chunk_group_infos
-        .get(&info_ukey)
-        .unwrap_or_else(|| panic!("ChunkGroupInfo({info_ukey:?}) not found"))
-        .available_sources
-        .clone();
-      let mut available_modules = BigUint::from(0u32);
-
-      // combine min_available_modules from all resulting_available_modules
-      for source_ukey in source_ukeys {
-        let source_chunk_group = self
-          .chunk_group_infos
-          .get(&source_ukey)
-          .unwrap_or_else(|| panic!("ChunkGroupInfo({source_ukey:?}) not found"))
-          .chunk_group;
+    for (info_ukey, source_ukeys) in chunk_groups_for_combining {
+      let available_modules = if let [source_ukey] = source_ukeys.as_slice() {
         let source = self
           .chunk_group_infos
-          .get_mut(&source_ukey)
+          .get_mut(source_ukey)
           .unwrap_or_else(|| panic!("ChunkGroupInfo({source_ukey:?}) not found"));
+        let source_chunk_group = source.chunk_group;
         source.calculate_resulting_available_modules(
           chunk_group_by_ukey.expect_get(&source_chunk_group),
           &self.mask_by_chunk,
         );
-        let resulting_available_modules = source
+        source
           .resulting_available_modules
-          .as_ref()
-          .expect("should have resulting available modules");
-        available_modules |= resulting_available_modules.as_ref();
+          .clone()
+          .expect("should have resulting available modules")
+      } else {
+        let mut available_modules = BigUint::from(0u32);
+
+        // combine min_available_modules from all resulting_available_modules
+        for source_ukey in source_ukeys {
+          let source = self
+            .chunk_group_infos
+            .get_mut(&source_ukey)
+            .unwrap_or_else(|| panic!("ChunkGroupInfo({source_ukey:?}) not found"));
+          let source_chunk_group = source.chunk_group;
+          source.calculate_resulting_available_modules(
+            chunk_group_by_ukey.expect_get(&source_chunk_group),
+            &self.mask_by_chunk,
+          );
+          let resulting_available_modules = source
+            .resulting_available_modules
+            .as_ref()
+            .expect("should have resulting available modules");
+          available_modules |= resulting_available_modules.as_ref();
+        }
+        Arc::new(available_modules)
+      };
+
+      let should_update = {
+        let info = self
+          .chunk_group_infos
+          .get(&info_ukey)
+          .unwrap_or_else(|| panic!("ChunkGroupInfo({info_ukey:?}) not found"));
+        !info.min_available_modules_init
+          || info.min_available_modules.as_ref() != available_modules.as_ref()
+      };
+
+      if !should_update {
+        continue;
       }
 
       self.outdated_chunk_group_info.insert(info_ukey);
@@ -2191,7 +2217,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .get_mut(&info_ukey)
         .unwrap_or_else(|| panic!("ChunkGroupInfo({info_ukey:?}) not found"));
       info.invalidate_resulting_available_modules();
-      info.min_available_modules = Arc::new(available_modules);
+      info.min_available_modules = available_modules;
       info.min_available_modules_init = true;
     }
 

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -58,12 +58,25 @@ struct PreparedBlockConnectionGroupBuilder {
 }
 
 fn finalize_prepared_connection_map(
-  connections: Vec<PreparedBlockConnectionBuilder>,
+  connections: impl IntoIterator<Item = PreparedBlockConnectionBuilder>,
+  capacity: usize,
 ) -> PreparedBlockConnectionMap {
-  let mut groups = Vec::<PreparedBlockConnectionGroupBuilder>::new();
-  let mut group_index_by_block = DependenciesBlockIdentifierMap::<IdentifierMap<usize>>::default();
+  let mut groups = Vec::<PreparedBlockConnectionGroupBuilder>::with_capacity(capacity);
+  let mut group_index_by_block = Vec::<(DependenciesBlockIdentifier, IdentifierMap<usize>)>::new();
   for connection in connections {
-    let index_by_module = group_index_by_block.entry(connection.block).or_default();
+    let index_by_module = if let Some((_, index_by_module)) = group_index_by_block
+      .iter_mut()
+      .find(|(block, _)| *block == connection.block)
+    {
+      index_by_module
+    } else {
+      group_index_by_block.push((connection.block, IdentifierMap::default()));
+      &mut group_index_by_block
+        .last_mut()
+        .expect("should have block")
+        .1
+    };
+
     if let Some(index) = index_by_module.get(&connection.module) {
       groups[*index].connections.push(connection.dependency);
       continue;
@@ -2317,10 +2330,10 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           .module_graph_module_by_identifier(module)
           .map(|mgm| mgm.all_dependencies())
           .unwrap_or_default();
-        let mut connection_map = Vec::new();
+        let dependency_count = all_dependencies.len();
 
         let mut ordered_deps = Vec::new();
-        let mut unordered_deps = Vec::new();
+        let mut unordered_deps = Vec::with_capacity(dependency_count);
         for dep_id in all_dependencies {
           let Some(connection) = mg.connection_by_dependency_id(dep_id) else {
             continue;
@@ -2348,23 +2361,30 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         }
         ordered_deps.sort_by_key(|(source_order, _, _, _)| *source_order);
 
-        for (_, block, dependency, module) in ordered_deps {
-          connection_map.push(PreparedBlockConnectionBuilder {
-            block,
-            module,
-            dependency,
-          });
-        }
+        let connection_count = ordered_deps.len() + unordered_deps.len();
+        let ordered_deps = ordered_deps
+          .into_iter()
+          .map(
+            |(_, block, dependency, module)| PreparedBlockConnectionBuilder {
+              block,
+              module,
+              dependency,
+            },
+          );
+        let unordered_deps = unordered_deps
+          .into_iter()
+          .map(
+            |(block, dependency, module)| PreparedBlockConnectionBuilder {
+              block,
+              module,
+              dependency,
+            },
+          );
 
-        for (block, dependency, module) in unordered_deps {
-          connection_map.push(PreparedBlockConnectionBuilder {
-            block,
-            module,
-            dependency,
-          });
-        }
-
-        (*module, finalize_prepared_connection_map(connection_map))
+        (
+          *module,
+          finalize_prepared_connection_map(ordered_deps.chain(unordered_deps), connection_count),
+        )
       })
       .collect::<IdentifierMap<_>>();
 

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1,4 +1,5 @@
 use std::{
+  collections::hash_map,
   hash::BuildHasherDefault,
   sync::{Arc, atomic::AtomicU32},
 };
@@ -56,35 +57,29 @@ fn finalize_prepared_connection_map(
   capacity: usize,
 ) -> PreparedBlockConnectionMap {
   let mut groups = PreparedBlockConnectionMap::with_capacity(capacity);
-  let mut group_index_by_block = Vec::<(DependenciesBlockIdentifier, IdentifierMap<usize>)>::new();
+  let mut group_index_by_block = DependenciesBlockIdentifierMap::<IdentifierMap<usize>>::default();
   for connection in connections {
-    let index_by_module = if let Some((_, index_by_module)) = group_index_by_block
-      .iter_mut()
-      .find(|(block, _)| *block == connection.block)
-    {
-      index_by_module
-    } else {
-      group_index_by_block.push((connection.block, IdentifierMap::default()));
-      &mut group_index_by_block
-        .last_mut()
-        .expect("should have block")
-        .1
+    let index_by_module = match group_index_by_block.entry(connection.block) {
+      hash_map::Entry::Occupied(entry) => entry.into_mut(),
+      hash_map::Entry::Vacant(entry) => entry.insert(IdentifierMap::default()),
     };
 
-    if let Some(index) = index_by_module.get(&connection.module) {
-      Arc::get_mut(&mut groups[*index].connections)
-        .expect("prepared connections should not be shared during finalize")
-        .push(connection.dependency);
-      continue;
+    match index_by_module.entry(connection.module) {
+      hash_map::Entry::Occupied(entry) => {
+        Arc::get_mut(&mut groups[*entry.get()].connections)
+          .expect("prepared connections should not be shared during finalize")
+          .push(connection.dependency);
+      }
+      hash_map::Entry::Vacant(entry) => {
+        let index = groups.len();
+        entry.insert(index);
+        groups.push(PreparedBlockConnection {
+          block: connection.block,
+          module: connection.module,
+          connections: Arc::new(vec![connection.dependency]),
+        });
+      }
     }
-
-    let index = groups.len();
-    index_by_module.insert(connection.module, index);
-    groups.push(PreparedBlockConnection {
-      block: connection.block,
-      module: connection.module,
-      connections: Arc::new(vec![connection.dependency]),
-    });
   }
 
   groups
@@ -2387,11 +2382,10 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       })
       .collect::<IdentifierMap<_>>();
 
-    let block_map_capacity = all_modules.len() + mg.blocks().len();
     let mut prepared_blocks_map = DependenciesBlockIdentifierMap::<
       Vec<AsyncDependenciesBlockIdentifier>,
     >::with_capacity_and_hasher(
-      block_map_capacity, Default::default()
+      all_modules.len(), Default::default()
     );
 
     for module in all_modules {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1892,11 +1892,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
     let queue_connect = std::mem::take(&mut self.queue_connect);
     for (chunk_group_info_ukey, targets) in queue_connect {
-      let target_groups = targets
-        .iter()
-        .map(|(target_ukey, _)| self.chunk_group_info(target_ukey).chunk_group)
-        .collect_vec();
-
       let (chunk_group_ukey, resulting_available_modules, runtime) = {
         let chunk_group_info = self
           .chunk_group_infos
@@ -1923,27 +1918,22 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         )
       };
 
-      compilation
-        .build_chunk_graph_artifact
-        .chunk_group_by_ukey
-        .expect_get_mut(&chunk_group_ukey)
-        .children
-        .extend(target_groups);
-
       self.stat_connected_chunk_groups += targets.len() as u32;
 
       // 3. Update chunk group info
+      let mut target_groups = Vec::with_capacity(targets.len());
       for (target_ukey, process_block) in targets {
-        let updated = {
+        let (target_group, updated) = {
           let target_cgi = self
             .chunk_group_infos
             .get_mut(&target_ukey)
             .unwrap_or_else(|| panic!("ChunkGroupInfo({target_ukey:?}) not found"));
+          let target_group = target_cgi.chunk_group;
 
           compilation
             .build_chunk_graph_artifact
             .chunk_group_by_ukey
-            .expect_get_mut(&target_cgi.chunk_group)
+            .expect_get_mut(&target_group)
             .add_parent(chunk_group_ukey);
 
           target_cgi
@@ -1959,12 +1949,11 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             Arc::get_mut(&mut target_cgi.runtime).expect("should have runtime")
           };
 
-          let mut updated = false;
-          for &r in runtime.iter() {
-            updated |= target_runtime.insert(r);
-          }
-          updated
+          let runtime_len = target_runtime.len();
+          target_runtime.extend(&runtime);
+          (target_group, target_runtime.len() != runtime_len)
         };
+        target_groups.push(target_group);
 
         self
           .chunk_groups_for_merging
@@ -1973,6 +1962,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           self.outdated_chunk_group_info.insert(target_ukey);
         }
       }
+
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_group_by_ukey
+        .expect_get_mut(&chunk_group_ukey)
+        .children
+        .extend(target_groups);
     }
   }
 

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -38,7 +38,6 @@ type PreparedBlockConnectionMap =
   FxIndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
-type SkippedModuleConnection = (ModuleIdentifier, ConnectionIdList, ConnectionState);
 
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGroupInfo {
@@ -53,7 +52,7 @@ pub struct ChunkGroupInfo {
   pub available_modules_to_be_merged: Vec<Arc<BigUint>>,
 
   pub skipped_items: IdentifierIndexSet,
-  pub skipped_module_connections: FxIndexSet<SkippedModuleConnection>,
+  pub skipped_module_connections: FxIndexSet<(ModuleIdentifier, ConnectionIdList)>,
   // set of children chunk groups, that will be revisited when available_modules shrink
   pub children: FxIndexSet<CgiUkey>,
   // set of chunk groups that are the source for min_available_modules
@@ -1410,11 +1409,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       });
       let chunk_group_info = self.chunk_group_info_mut(&item.chunk_group_info);
       if !active_state.is_true() {
-        chunk_group_info.skipped_module_connections.insert((
-          *module,
-          connections.clone(),
-          *active_state,
-        ));
+        chunk_group_info
+          .skipped_module_connections
+          .insert((*module, connections.clone()));
         if active_state.is_false() {
           continue;
         }
@@ -1916,6 +1913,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       let (
         cgi_ukey,
         chunk_group_ukey,
+        runtime,
         min_available_modules,
         mut skipped_items,
         mut skipped_module_connections,
@@ -1929,6 +1927,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         (
           cgi.ukey,
           cgi.chunk_group,
+          cgi.runtime.clone(),
           cgi.min_available_modules.clone(),
           std::mem::take(&mut cgi.skipped_items),
           std::mem::take(&mut cgi.skipped_module_connections),
@@ -1974,11 +1973,25 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       // Use retain instead of collect indices + shift_remove_index to avoid O(n²)
       if !skipped_module_connections.is_empty() {
         let ordinal_by_module = &self.ordinal_by_module;
+        let module_graph = compilation.get_module_graph();
+        let module_graph_cache = &compilation.module_graph_cache_artifact;
+        let exports_info_artifact = &compilation.exports_info_artifact;
+        let side_effects_state_artifact = &compilation
+          .build_module_graph_artifact
+          .side_effects_state_artifact;
 
         let mut queue_actions = Vec::new();
         let mut modules_to_skip = Vec::new();
 
-        skipped_module_connections.retain(|(module, _, active_state)| {
+        skipped_module_connections.retain(|(module, connections)| {
+          let active_state = get_active_state_of_connections(
+            connections,
+            Some(&runtime),
+            module_graph,
+            module_graph_cache,
+            side_effects_state_artifact,
+            exports_info_artifact,
+          );
           if active_state.is_false() {
             return true;
           }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -33,7 +33,7 @@ pub(crate) type DependenciesBlockIdentifierMap<V> =
 pub(crate) type DependenciesBlockIdentifierSet =
   std::collections::HashSet<DependenciesBlockIdentifier, BuildHasherDefault<FxHasher>>;
 
-type ConnectionIdList = Arc<[DependencyId]>;
+type ConnectionIdList = Arc<Vec<DependencyId>>;
 type PreparedBlockConnectionMap = Vec<PreparedBlockConnection>;
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
@@ -96,7 +96,7 @@ fn finalize_prepared_connection_map(
     .map(|connection| PreparedBlockConnection {
       block: connection.block,
       module: connection.module,
-      connections: Arc::from(connection.connections.into_boxed_slice()),
+      connections: Arc::new(connection.connections),
     })
     .collect()
 }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -34,10 +34,59 @@ pub(crate) type DependenciesBlockIdentifierSet =
   std::collections::HashSet<DependenciesBlockIdentifier, BuildHasherDefault<FxHasher>>;
 
 type ConnectionIdList = Arc<[DependencyId]>;
-type PreparedBlockConnectionMap =
-  FxIndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
+type PreparedBlockConnectionMap = Vec<PreparedBlockConnection>;
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
+
+#[derive(Debug, Clone)]
+struct PreparedBlockConnection {
+  block: DependenciesBlockIdentifier,
+  module: ModuleIdentifier,
+  connections: ConnectionIdList,
+}
+
+struct PreparedBlockConnectionBuilder {
+  block: DependenciesBlockIdentifier,
+  module: ModuleIdentifier,
+  dependency: DependencyId,
+}
+
+struct PreparedBlockConnectionGroupBuilder {
+  block: DependenciesBlockIdentifier,
+  module: ModuleIdentifier,
+  connections: Vec<DependencyId>,
+}
+
+fn finalize_prepared_connection_map(
+  connections: Vec<PreparedBlockConnectionBuilder>,
+) -> PreparedBlockConnectionMap {
+  let mut groups = Vec::<PreparedBlockConnectionGroupBuilder>::new();
+  let mut group_index_by_block = DependenciesBlockIdentifierMap::<IdentifierMap<usize>>::default();
+  for connection in connections {
+    let index_by_module = group_index_by_block.entry(connection.block).or_default();
+    if let Some(index) = index_by_module.get(&connection.module) {
+      groups[*index].connections.push(connection.dependency);
+      continue;
+    }
+
+    let index = groups.len();
+    index_by_module.insert(connection.module, index);
+    groups.push(PreparedBlockConnectionGroupBuilder {
+      block: connection.block,
+      module: connection.module,
+      connections: vec![connection.dependency],
+    });
+  }
+
+  groups
+    .into_iter()
+    .map(|connection| PreparedBlockConnection {
+      block: connection.block,
+      module: connection.module,
+      connections: Arc::from(connection.connections.into_boxed_slice()),
+    })
+    .collect()
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGroupInfo {
@@ -2268,12 +2317,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           .module_graph_module_by_identifier(module)
           .map(|mgm| mgm.all_dependencies())
           .unwrap_or_default();
-        let mut connection_map = FxIndexMap::<
-          (DependenciesBlockIdentifier, ModuleIdentifier),
-          Vec<DependencyId>,
-        >::with_capacity_and_hasher(
-          all_dependencies.len(), Default::default()
-        );
+        let mut connection_map = Vec::new();
 
         let mut ordered_deps = Vec::new();
         let mut unordered_deps = Vec::new();
@@ -2304,27 +2348,23 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         }
         ordered_deps.sort_by_key(|(source_order, _, _, _)| *source_order);
 
-        for (_, block_id, dep_id, module_identifier) in ordered_deps {
-          connection_map
-            .entry((block_id, module_identifier))
-            .and_modify(|e| e.push(dep_id))
-            .or_insert_with(|| vec![dep_id]);
+        for (_, block, dependency, module) in ordered_deps {
+          connection_map.push(PreparedBlockConnectionBuilder {
+            block,
+            module,
+            dependency,
+          });
         }
 
-        for (block_id, dep_id, module_identifier) in unordered_deps {
-          connection_map
-            .entry((block_id, module_identifier))
-            .and_modify(|e| e.push(dep_id))
-            .or_insert_with(|| vec![dep_id]);
+        for (block, dependency, module) in unordered_deps {
+          connection_map.push(PreparedBlockConnectionBuilder {
+            block,
+            module,
+            dependency,
+          });
         }
 
-        (
-          *module,
-          connection_map
-            .into_iter()
-            .map(|(key, connections)| (key, Arc::from(connections.into_boxed_slice())))
-            .collect(),
-        )
+        (*module, finalize_prepared_connection_map(connection_map))
       })
       .collect::<IdentifierMap<_>>();
 
@@ -2476,15 +2516,15 @@ fn extract_block_modules(
     .get(&module)
     .expect("should have outgoing deps");
 
-  for ((block_id, module_identifier), connections) in connection_map {
-    if map.contains_key(block_id) {
+  for connection in connection_map {
+    if map.contains_key(&connection.block) {
       continue;
     }
     let modules = module_map
-      .get_mut(block_id)
+      .get_mut(&connection.block)
       .expect("should have modules in block_modules_runtime_map");
     let active_state = get_active_state_of_connections(
-      connections,
+      &connection.connections,
       runtime.as_deref(),
       compilation.get_module_graph(),
       &compilation.module_graph_cache_artifact,
@@ -2493,7 +2533,11 @@ fn extract_block_modules(
         .side_effects_state_artifact,
       &compilation.exports_info_artifact,
     );
-    modules.push((*module_identifier, active_state, connections.clone()));
+    modules.push((
+      connection.module,
+      active_state,
+      connection.connections.clone(),
+    ));
   }
   for (block, modules) in module_map {
     map.insert(block, Arc::new(modules));

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1,5 +1,4 @@
 use std::{
-  collections::VecDeque,
   hash::BuildHasherDefault,
   sync::{Arc, atomic::AtomicU32},
 };
@@ -34,11 +33,12 @@ pub(crate) type DependenciesBlockIdentifierMap<V> =
 pub(crate) type DependenciesBlockIdentifierSet =
   std::collections::HashSet<DependenciesBlockIdentifier, BuildHasherDefault<FxHasher>>;
 
-type ConnectionIdList = Arc<Vec<DependencyId>>;
+type ConnectionIdList = Arc<[DependencyId]>;
 type PreparedBlockConnectionMap =
   FxIndexMap<(DependenciesBlockIdentifier, ModuleIdentifier), ConnectionIdList>;
 type BlockConnectionMap =
   DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
+type SkippedModuleConnection = (ModuleIdentifier, ConnectionIdList, ConnectionState);
 
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGroupInfo {
@@ -53,7 +53,7 @@ pub struct ChunkGroupInfo {
   pub available_modules_to_be_merged: Vec<Arc<BigUint>>,
 
   pub skipped_items: IdentifierIndexSet,
-  pub skipped_module_connections: FxIndexSet<(ModuleIdentifier, ConnectionIdList)>,
+  pub skipped_module_connections: FxIndexSet<SkippedModuleConnection>,
   // set of children chunk groups, that will be revisited when available_modules shrink
   pub children: FxIndexSet<CgiUkey>,
   // set of chunk groups that are the source for min_available_modules
@@ -1410,9 +1410,11 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       });
       let chunk_group_info = self.chunk_group_info_mut(&item.chunk_group_info);
       if !active_state.is_true() {
-        chunk_group_info
-          .skipped_module_connections
-          .insert((*module, connections.clone()));
+        chunk_group_info.skipped_module_connections.insert((
+          *module,
+          connections.clone(),
+          *active_state,
+        ));
         if active_state.is_false() {
           continue;
         }
@@ -1914,7 +1916,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       let (
         cgi_ukey,
         chunk_group_ukey,
-        runtime,
         min_available_modules,
         mut skipped_items,
         mut skipped_module_connections,
@@ -1928,7 +1929,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         (
           cgi.ukey,
           cgi.chunk_group,
-          cgi.runtime.clone(),
           cgi.min_available_modules.clone(),
           std::mem::take(&mut cgi.skipped_items),
           std::mem::take(&mut cgi.skipped_module_connections),
@@ -1974,25 +1974,11 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       // Use retain instead of collect indices + shift_remove_index to avoid O(n²)
       if !skipped_module_connections.is_empty() {
         let ordinal_by_module = &self.ordinal_by_module;
-        let module_graph = compilation.get_module_graph();
-        let module_graph_cache = &compilation.module_graph_cache_artifact;
-        let exports_info_artifact = &compilation.exports_info_artifact;
-        let side_effects_state_artifact = &compilation
-          .build_module_graph_artifact
-          .side_effects_state_artifact;
 
         let mut queue_actions = Vec::new();
         let mut modules_to_skip = Vec::new();
 
-        skipped_module_connections.retain(|(module, connections)| {
-          let active_state = get_active_state_of_connections(
-            connections,
-            Some(&runtime),
-            module_graph,
-            module_graph_cache,
-            side_effects_state_artifact,
-            exports_info_artifact,
-          );
+        skipped_module_connections.retain(|(module, _, active_state)| {
           if active_state.is_false() {
             return true;
           }
@@ -2250,96 +2236,98 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     self.prepared_connection_map = all_modules
       .par_iter()
       .map(|module| {
+        let all_dependencies = mg
+          .module_graph_module_by_identifier(module)
+          .map(|mgm| mgm.all_dependencies())
+          .unwrap_or_default();
         let mut connection_map = FxIndexMap::<
           (DependenciesBlockIdentifier, ModuleIdentifier),
           Vec<DependencyId>,
-        >::default();
+        >::with_capacity_and_hasher(
+          all_dependencies.len(), Default::default()
+        );
 
         let mut ordered_deps = Vec::new();
         let mut unordered_deps = Vec::new();
-        for dep in mg
-          .get_outgoing_deps_in_order(module)
-          .map(|dep_id| mg.dependency_by_id(dep_id))
-          .filter(|dep| {
-            dep.as_module_dependency().is_some() || dep.as_context_dependency().is_some()
-          })
-          .filter(|dep| !matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)))
-        {
-          if let Some(source_order) = dep.source_order() {
-            ordered_deps.push((source_order, dep));
-          } else {
-            unordered_deps.push(dep);
-          }
-        }
-        ordered_deps.sort_by_key(|(source_order, _)| *source_order);
-
-        for dep in ordered_deps
-          .into_iter()
-          .map(|(_, dep)| dep)
-          .chain(unordered_deps)
-        {
-          let dep_id = dep.id();
-
-          // Dependency created but no module is available.
-          // This could happen when module factorization is failed, but `options.bail` set to `false`
-          let Some(module_identifier) = mg.module_identifier_by_dependency_id(dep_id) else {
+        for dep_id in all_dependencies {
+          let Some(connection) = mg.connection_by_dependency_id(dep_id) else {
             continue;
           };
+          let dep = mg.dependency_by_id(dep_id);
+          let module_dep = dep.as_module_dependency();
+          if module_dep.is_none() && dep.as_context_dependency().is_none() {
+            continue;
+          }
+          if matches!(module_dep.map(|d| d.weak()), Some(true)) {
+            continue;
+          }
+
+          let module_identifier = *connection.module_identifier();
           let block_id = if let Some(block) = mg.get_parent_block(dep_id) {
             (*block).into()
           } else {
             (*module).into()
           };
+          if let Some(source_order) = dep.source_order() {
+            ordered_deps.push((source_order, block_id, *dep_id, module_identifier));
+          } else {
+            unordered_deps.push((block_id, *dep_id, module_identifier));
+          }
+        }
+        ordered_deps.sort_by_key(|(source_order, _, _, _)| *source_order);
 
+        for (_, block_id, dep_id, module_identifier) in ordered_deps {
           connection_map
-            .entry((block_id, *module_identifier))
-            .and_modify(|e| e.push(*dep_id))
-            .or_insert_with(|| vec![*dep_id]);
+            .entry((block_id, module_identifier))
+            .and_modify(|e| e.push(dep_id))
+            .or_insert_with(|| vec![dep_id]);
+        }
+
+        for (block_id, dep_id, module_identifier) in unordered_deps {
+          connection_map
+            .entry((block_id, module_identifier))
+            .and_modify(|e| e.push(dep_id))
+            .or_insert_with(|| vec![dep_id]);
         }
 
         (
           *module,
           connection_map
             .into_iter()
-            .map(|(key, connections)| (key, Arc::new(connections)))
+            .map(|(key, connections)| (key, Arc::from(connections.into_boxed_slice())))
             .collect(),
         )
       })
       .collect::<IdentifierMap<_>>();
 
-    self.prepared_blocks_map = all_modules
-      .par_iter()
-      .map(|module| {
-        let mut map =
-          DependenciesBlockIdentifierMap::<Vec<AsyncDependenciesBlockIdentifier>>::default();
+    let block_map_capacity = all_modules.len() + mg.blocks().len();
+    let mut prepared_blocks_map = DependenciesBlockIdentifierMap::<
+      Vec<AsyncDependenciesBlockIdentifier>,
+    >::with_capacity_and_hasher(
+      block_map_capacity, Default::default()
+    );
 
-        let mut queue = VecDeque::<DependenciesBlockIdentifier>::new();
+    for module in all_modules {
+      let blocks = compilation
+        .get_module_graph()
+        .module_by_identifier(module)
+        .expect("should have module")
+        .get_blocks();
 
-        queue.push_back((*module).into());
+      if !blocks.is_empty() {
+        prepared_blocks_map.insert((*module).into(), blocks.to_vec());
+      }
+    }
 
-        while let Some(module) = queue.pop_front() {
-          let blocks = module.get_blocks(compilation);
+    for (block_id, block) in mg.blocks() {
+      let blocks = block.get_blocks();
 
-          if blocks.is_empty() {
-            continue;
-          }
+      if !blocks.is_empty() {
+        prepared_blocks_map.insert((*block_id).into(), blocks.to_vec());
+      }
+    }
 
-          for block in blocks.iter() {
-            queue.push_back((*block).into());
-          }
-
-          map.insert(module, blocks);
-        }
-
-        map
-      })
-      .reduce(
-        DependenciesBlockIdentifierMap::<Vec<AsyncDependenciesBlockIdentifier>>::default,
-        |mut a, b| {
-          a.extend(b);
-          a
-        },
-      );
+    self.prepared_blocks_map = prepared_blocks_map;
 
     Ok(())
   }
@@ -2409,23 +2397,6 @@ impl DependenciesBlockIdentifier {
     }
   }
 
-  pub fn get_blocks(&self, compilation: &Compilation) -> Vec<AsyncDependenciesBlockIdentifier> {
-    match self {
-      DependenciesBlockIdentifier::Module(m) => compilation
-        .get_module_graph()
-        .module_by_identifier(m)
-        .expect("should have module")
-        .get_blocks()
-        .to_vec(),
-      DependenciesBlockIdentifier::AsyncDependenciesBlock(a) => compilation
-        .get_module_graph()
-        .block_by_id(a)
-        .expect("should have block")
-        .get_blocks()
-        .to_vec(),
-    }
-  }
-
   pub fn as_async(self) -> Option<AsyncDependenciesBlockIdentifier> {
     if let DependenciesBlockIdentifier::AsyncDependenciesBlock(id) = self {
       Some(id)
@@ -2462,13 +2433,16 @@ fn extract_block_modules(
   map: &mut BlockConnectionMap,
 ) {
   let block = module.into();
-  let blocks = prepared_blocks_map.get(&block).cloned().unwrap_or_default();
+  let blocks = prepared_blocks_map
+    .get(&block)
+    .map(|blocks| blocks.as_slice())
+    .unwrap_or_default();
   let mut module_map: DependenciesBlockIdentifierMap<
     Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>,
   > =
     DependenciesBlockIdentifierMap::with_capacity_and_hasher(blocks.len() + 1, Default::default());
   module_map.insert(block, Vec::new());
-  module_map.extend(blocks.into_iter().map(|block| (block.into(), Vec::new())));
+  module_map.extend(blocks.iter().map(|block| ((*block).into(), Vec::new())));
 
   let connection_map = prepared_connection_map
     .get(&module)

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -793,14 +793,19 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       all_modules
         .par_iter()
         .map(|m| {
-          let mut outgoing = mg
+          let outgoing = mg
             .module_graph_module_by_identifier(m)
-            .map(|mgm| Vec::with_capacity(mgm.outgoing_connections().len()))
+            .map(|mgm| {
+              let outgoing_connections = mgm.outgoing_connections();
+              let mut outgoing = Vec::with_capacity(outgoing_connections.len());
+              for id in outgoing_connections {
+                if let Some(con) = mg.connection_by_dependency_id(id) {
+                  outgoing.push(*con.module_identifier());
+                }
+              }
+              outgoing
+            })
             .unwrap_or_default();
-
-          for con in mg.get_outgoing_connections(m) {
-            outgoing.push(*con.module_identifier());
-          }
 
           (*m, outgoing)
         })
@@ -837,9 +842,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
 
     // Using this defer insertion strategies to workaround rustc borrow rules
-    for assign_depths_map in assign_depths_maps {
-      for (k, v) in assign_depths_map {
-        compilation.get_module_graph_mut().set_depth_if_lower(&k, v);
+    {
+      let module_graph = compilation.get_module_graph_mut();
+      for assign_depths_map in assign_depths_maps {
+        for (k, v) in assign_depths_map {
+          module_graph.set_depth_if_lower(&k, v);
+        }
       }
     }
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1459,11 +1459,12 @@ impl AssetInfoRelated {
 /// the same time.
 pub fn assign_depths<'a>(
   assign_map: &mut IdentifierMap<usize>,
-  modules: impl Iterator<Item = &'a ModuleIdentifier>,
+  modules: impl ExactSizeIterator<Item = &'a ModuleIdentifier>,
   outgoings: &IdentifierMap<Vec<ModuleIdentifier>>,
+  initial_queue_capacity: usize,
 ) {
   // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/Compilation.js#L3720
-  let mut q = VecDeque::new();
+  let mut q = VecDeque::with_capacity(initial_queue_capacity.max(modules.len()));
   for item in modules {
     q.push_back((*item, 0));
   }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1479,8 +1479,10 @@ pub fn assign_depths<'a>(
         vac.insert(depth);
       }
     };
-    for con in outgoings.get(&id).expect("should have outgoings").iter() {
-      q.push_back((*con, depth + 1));
+    if let Some(outgoing_modules) = outgoings.get(&id) {
+      for con in outgoing_modules {
+        q.push_back((*con, depth + 1));
+      }
     }
   }
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1459,12 +1459,14 @@ impl AssetInfoRelated {
 /// the same time.
 pub fn assign_depths<'a>(
   assign_map: &mut IdentifierMap<usize>,
-  modules: impl ExactSizeIterator<Item = &'a ModuleIdentifier>,
+  modules: impl Iterator<Item = &'a ModuleIdentifier>,
   outgoings: &IdentifierMap<Vec<ModuleIdentifier>>,
   initial_queue_capacity: usize,
 ) {
   // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/Compilation.js#L3720
-  let mut q = VecDeque::with_capacity(initial_queue_capacity.max(modules.len()));
+  let (module_count_lower_bound, module_count_upper_bound) = modules.size_hint();
+  let module_count = module_count_upper_bound.unwrap_or(module_count_lower_bound);
+  let mut q = VecDeque::with_capacity(initial_queue_capacity.max(module_count));
   for item in modules {
     q.push_back((*item, 0));
   }

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -827,14 +827,18 @@ pub(crate) fn assign_dyn_import_chunk_short_names(compilation: &mut Compilation)
   let module_graph = compilation.get_module_graph();
 
   // Collect all existing named chunks
-  let mut used_names: FxHashMap<String, usize> = FxHashMap::default();
+  let mut used_names: FxHashMap<String, usize> = FxHashMap::with_capacity_and_hasher(
+    compilation.build_chunk_graph_artifact.named_chunks.len(),
+    Default::default(),
+  );
   for name in compilation.build_chunk_graph_artifact.named_chunks.keys() {
     used_names.insert(name.clone(), 1);
   }
 
   // Collect candidates: (chunk_ukey, root_module_identifier) for unnamed non-initial chunks
   // with exactly one root module
-  let mut candidates: Vec<(ChunkUkey, ModuleIdentifier)> = Vec::new();
+  let mut candidates: Vec<(ChunkUkey, ModuleIdentifier)> =
+    Vec::with_capacity(compilation.build_chunk_graph_artifact.chunk_by_ukey.len());
 
   for (chunk_ukey, chunk) in compilation.build_chunk_graph_artifact.chunk_by_ukey.iter() {
     // Skip chunks that already have a name
@@ -867,8 +871,10 @@ pub(crate) fn assign_dyn_import_chunk_short_names(compilation: &mut Compilation)
 
   // Compute short names and track duplicates
   // name_to_chunks: maps base_name → list of (chunk_ukey, module_identifier) in sorted order
-  let mut name_to_chunks: Vec<(String, Vec<(ChunkUkey, ModuleIdentifier)>)> = Vec::new();
-  let mut name_index_map: FxHashMap<String, usize> = FxHashMap::default();
+  let mut name_to_chunks: Vec<(String, Vec<(ChunkUkey, ModuleIdentifier)>)> =
+    Vec::with_capacity(candidates.len());
+  let mut name_index_map: FxHashMap<String, usize> =
+    FxHashMap::with_capacity_and_hasher(candidates.len(), Default::default());
 
   for (chunk_ukey, module_id) in &candidates {
     let Some(module_path) = module_graph
@@ -891,7 +897,7 @@ pub(crate) fn assign_dyn_import_chunk_short_names(compilation: &mut Compilation)
   }
 
   // Assign names, handling deduplication
-  let mut assignments: Vec<(ChunkUkey, String)> = Vec::new();
+  let mut assignments: Vec<(ChunkUkey, String)> = Vec::with_capacity(candidates.len());
 
   for (base_name, chunks) in &name_to_chunks {
     if chunks.len() == 1 && !used_names.contains_key(base_name) {


### PR DESCRIPTION
## Summary

- Optimize code splitter preparation by replacing the prepared connection `IndexMap` with vector-backed grouped connections and building the async block map directly from modules and module graph blocks.
- Reduce module graph lookups and allocation churn while preparing entrypoint depth data, including sparse outgoing maps, preallocated depth queues, and a single mutable module graph pass for depth writes.
- Streamline chunk group processing paths by avoiding temporary collections/clones in connect queue, outdated chunk group revisits, combining, and merging.
- Add capacity hints for dynamic import chunk short-name assignment in the ESM library chunk optimizer.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).