### PR TITLE
test: split compilation stage benchmarks

### DIFF
--- a/xtask/benchmark/benches/benches.rs
+++ b/xtask/benchmark/benches/benches.rs
@@ -2,13 +2,16 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use groups::{
-  build_chunk_graph::chunk_graph, bundle::bundle, compilation_stages::compilation_stages,
-  module_graph_api::module_graph_api, persistent_cache::persistent_cache,
-  scan_dependencies::scan_dependencies,
+  build_chunk_graph::chunk_graph, bundle::bundle, module_graph_api::module_graph_api,
+  persistent_cache::persistent_cache, scan_dependencies::scan_dependencies,
 };
 use rspack_core::configure_rayon_current_thread_for_codspeed;
 
 mod groups;
+// Keep these registered stage entrypoints in a dedicated short source path:
+// CodSpeed embeds file!() into callgrind profile-part names shown by KCachegrind.
+#[path = "../stages/mod.rs"]
+mod stages;
 
 fn configure_rayon_for_codspeed(_: &mut Criterion) {
   configure_rayon_current_thread_for_codspeed();
@@ -22,6 +25,20 @@ criterion_main!(
   module_graph_api,
   scan_dependencies,
   bundle,
-  compilation_stages,
+  stages::flag_dependency_exports::stage,
+  stages::flag_dependency_usage::stage,
+  stages::create_module_ids::stage,
+  stages::split_chunks::stage,
+  stages::create_chunk_ids::stage,
+  stages::mangle_exports::stage,
+  stages::create_module_hashes::stage,
+  stages::runtime_requirements::stage,
+  stages::create_chunk_hashes::stage,
+  stages::create_full_hash::stage,
+  stages::create_module_assets::stage,
+  stages::create_chunk_assets::stage,
+  stages::real_content_hash::stage,
+  stages::create_concatenate_module::stage,
+  stages::concatenate_module_code_generation::stage,
   persistent_cache
 );

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -7,7 +7,7 @@ use std::{
   sync::Arc,
 };
 
-use criterion::{BatchSize, black_box, criterion_group};
+use criterion::{BatchSize, black_box};
 use rspack::builder::Builder as _;
 use rspack_benchmark::Criterion;
 use rspack_collections::IdentifierSet;
@@ -33,8 +33,8 @@ use rspack_plugin_split_chunks::{
   SplitChunksPlugin, create_all_chunk_filter, create_default_module_layer_filter,
   create_default_module_type_filter,
 };
-use rspack_tasks::within_compiler_context_for_testing_sync;
 use rustc_hash::FxHashMap;
+use tokio::runtime::Runtime;
 
 use crate::groups::build_chunk_graph::prepare_large_code_splitting_case;
 
@@ -47,34 +47,7 @@ const SPLIT_CHUNKS_WINDOW: usize = 20;
 const SPLIT_CHUNKS_COMMON_MODULES: usize = 16;
 const MODULE_ASSET_SEED_COUNT: usize = 256;
 
-pub fn compilation_stages_benchmark(c: &mut Criterion) {
-  within_compiler_context_for_testing_sync(|| {
-    compilation_stages_benchmark_inner(c);
-  })
-}
-
-fn compilation_stages_benchmark_inner(c: &mut Criterion) {
-  let rt = rspack_benchmark::build_tokio_rt();
-  let _guard = rt.enter();
-
-  flag_dependency_exports_benchmark(c, &rt);
-  flag_dependency_usage_benchmark(c, &rt);
-  create_module_ids_benchmark(c, &rt);
-  split_chunks_benchmark(c, &rt);
-  create_chunk_ids_benchmark(c, &rt);
-  mangle_exports_benchmark(c, &rt);
-  create_module_hashes_benchmark(c, &rt);
-  runtime_requirements_benchmark(c, &rt);
-  create_chunk_hashes_benchmark(c, &rt);
-  create_full_hash_benchmark(c, &rt);
-  create_module_assets_benchmark(c, &rt);
-  create_chunk_assets_benchmark(c, &rt);
-  real_content_hash_benchmark(c, &rt);
-  create_concatenate_module_benchmark(c, &rt);
-  concatenate_module_code_generation_benchmark(c, &rt);
-}
-
-fn flag_dependency_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn flag_dependency_exports_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -117,7 +90,7 @@ fn flag_dependency_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Run
   });
 }
 
-fn flag_dependency_usage_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn flag_dependency_usage_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -174,7 +147,7 @@ fn flag_dependency_usage_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runti
   });
 }
 
-fn create_module_ids_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_module_ids_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -210,7 +183,7 @@ fn create_module_ids_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) 
   });
 }
 
-fn split_chunks_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn split_chunks_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let mut compiler = create_split_chunks_stage_compiler(fs.clone());
 
@@ -318,7 +291,7 @@ fn split_chunks_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   });
 }
 
-fn create_chunk_ids_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_chunk_ids_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -365,7 +338,7 @@ fn create_chunk_ids_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   });
 }
 
-fn mangle_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn mangle_exports_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_mangle_exports_stage_compiler(fs.clone());
@@ -442,7 +415,7 @@ fn mangle_exports_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   });
 }
 
-fn create_module_hashes_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_module_hashes_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -474,7 +447,7 @@ fn create_module_hashes_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtim
   });
 }
 
-fn create_chunk_hashes_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_chunk_hashes_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -500,7 +473,7 @@ fn create_chunk_hashes_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime
   });
 }
 
-fn runtime_requirements_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn runtime_requirements_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -556,7 +529,7 @@ fn runtime_requirements_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtim
   });
 }
 
-fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_full_hash_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -629,7 +602,7 @@ fn create_full_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
   });
 }
 
-fn create_chunk_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_chunk_assets_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -679,7 +652,7 @@ fn create_chunk_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime
   });
 }
 
-fn create_module_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_module_assets_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_general_stage_compiler(fs.clone());
@@ -743,7 +716,7 @@ fn create_module_assets_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtim
   });
 }
 
-fn real_content_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn real_content_hash_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let random_table = load_random_table();
   let mut compiler = create_real_content_hash_stage_compiler(fs.clone());
@@ -797,7 +770,7 @@ fn real_content_hash_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) 
   });
 }
 
-fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let mut compiler = create_concatenate_stage_compiler(fs.clone());
 
@@ -886,7 +859,7 @@ fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &tokio::runtime::R
   });
 }
 
-fn concatenate_module_code_generation_benchmark(c: &mut Criterion, rt: &tokio::runtime::Runtime) {
+pub(crate) fn concatenate_module_code_generation_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());
   let mut compiler = create_concatenate_stage_compiler(fs.clone());
 
@@ -1913,5 +1886,3 @@ fn create_split_chunks_plugin() -> SplitChunksPlugin {
     hide_path_info: Some(true),
   })
 }
-
-criterion_group!(compilation_stages, compilation_stages_benchmark);

--- a/xtask/benchmark/stages/concatenate_module_code_generation.rs
+++ b/xtask/benchmark/stages/concatenate_module_code_generation.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::concatenate_module_code_generation_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_chunk_assets.rs
+++ b/xtask/benchmark/stages/create_chunk_assets.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_chunk_assets_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_chunk_hashes.rs
+++ b/xtask/benchmark/stages/create_chunk_hashes.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_chunk_hashes_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_chunk_ids.rs
+++ b/xtask/benchmark/stages/create_chunk_ids.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_chunk_ids_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_concatenate_module.rs
+++ b/xtask/benchmark/stages/create_concatenate_module.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_concatenate_module_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_full_hash.rs
+++ b/xtask/benchmark/stages/create_full_hash.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_full_hash_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_module_assets.rs
+++ b/xtask/benchmark/stages/create_module_assets.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_module_assets_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_module_hashes.rs
+++ b/xtask/benchmark/stages/create_module_hashes.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_module_hashes_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/create_module_ids.rs
+++ b/xtask/benchmark/stages/create_module_ids.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::create_module_ids_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/flag_dependency_exports.rs
+++ b/xtask/benchmark/stages/flag_dependency_exports.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::flag_dependency_exports_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/flag_dependency_usage.rs
+++ b/xtask/benchmark/stages/flag_dependency_usage.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::flag_dependency_usage_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/mangle_exports.rs
+++ b/xtask/benchmark/stages/mangle_exports.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::mangle_exports_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/mod.rs
+++ b/xtask/benchmark/stages/mod.rs
@@ -1,0 +1,29 @@
+use rspack_benchmark::Criterion;
+use rspack_tasks::within_compiler_context_for_testing_sync;
+use tokio::runtime::Runtime;
+
+pub mod concatenate_module_code_generation;
+pub mod create_chunk_assets;
+pub mod create_chunk_hashes;
+pub mod create_chunk_ids;
+pub mod create_concatenate_module;
+pub mod create_full_hash;
+pub mod create_module_assets;
+pub mod create_module_hashes;
+pub mod create_module_ids;
+pub mod flag_dependency_exports;
+pub mod flag_dependency_usage;
+pub mod mangle_exports;
+pub mod real_content_hash;
+pub mod runtime_requirements;
+pub mod split_chunks;
+
+pub(crate) type StageBenchmark = fn(&mut Criterion, &Runtime);
+
+pub(crate) fn run(c: &mut Criterion, benchmark: StageBenchmark) {
+  within_compiler_context_for_testing_sync(|| {
+    let rt = rspack_benchmark::build_tokio_rt();
+    let _guard = rt.enter();
+    benchmark(c, &rt);
+  });
+}

--- a/xtask/benchmark/stages/real_content_hash.rs
+++ b/xtask/benchmark/stages/real_content_hash.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::real_content_hash_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/runtime_requirements.rs
+++ b/xtask/benchmark/stages/runtime_requirements.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::runtime_requirements_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/split_chunks.rs
+++ b/xtask/benchmark/stages/split_chunks.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(c, crate::groups::compilation_stages::split_chunks_benchmark);
+}
+
+criterion_group!(stage, bench);


### PR DESCRIPTION
## Summary

- Split compilation stage benchmark registration into per-stage entrypoint files under `xtask/benchmark/stages`.
- Keep the heavy benchmark implementations in `compilation_stages.rs` while shortening CodSpeed callgrind profile-part paths for KCachegrind readability.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).