### PR TITLE
test: split benchmark case entrypoints

### DIFF
--- a/xtask/benchmark/benches/benches.rs
+++ b/xtask/benchmark/benches/benches.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::unwrap_used)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use groups::{
-  build_chunk_graph::chunk_graph, bundle::bundle, module_graph_api::module_graph_api,
-  persistent_cache::persistent_cache, scan_dependencies::scan_dependencies,
-};
 use rspack_core::configure_rayon_current_thread_for_codspeed;
 
 mod groups;
+// Keep these registered case entrypoints in a dedicated short source path:
+// CodSpeed embeds file!() into callgrind profile-part names shown by KCachegrind.
+#[path = "../cases/mod.rs"]
+mod cases;
 // Keep these registered stage entrypoints in a dedicated short source path:
 // CodSpeed embeds file!() into callgrind profile-part names shown by KCachegrind.
 #[path = "../stages/mod.rs"]
@@ -21,10 +21,14 @@ criterion_group!(codspeed_setup, configure_rayon_for_codspeed);
 
 criterion_main!(
   codspeed_setup,
-  chunk_graph,
-  module_graph_api,
-  scan_dependencies,
-  bundle,
+  cases::build_chunk_graph::case,
+  cases::build_module_graph::case,
+  cases::module_graph_api::case,
+  cases::scan_dependencies::case,
+  cases::bundle_basic_react_development::case,
+  cases::bundle_basic_react_production_sourcemap::case,
+  cases::bundle_threejs_development::case,
+  cases::bundle_threejs_production_sourcemap::case,
   stages::flag_dependency_exports::stage,
   stages::flag_dependency_usage::stage,
   stages::create_module_ids::stage,
@@ -40,5 +44,6 @@ criterion_main!(
   stages::real_content_hash::stage,
   stages::create_concatenate_module::stage,
   stages::concatenate_module_code_generation::stage,
-  persistent_cache
+  cases::persistent_cache_restore::case,
+  cases::persistent_cache_restore_after_single_file_change::case
 );

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 use std::{cell::RefCell, sync::Arc};
 
-use criterion::{BatchSize, criterion_group};
+use criterion::BatchSize;
 use rspack::builder::Builder as _;
 use rspack_benchmark::Criterion;
 use rspack_core::{
@@ -301,12 +301,6 @@ pub fn build_module_graph_benchmark_inner(c: &mut Criterion) {
     );
   });
 }
-
-criterion_group!(
-  chunk_graph,
-  build_chunk_graph_benchmark,
-  build_module_graph_benchmark
-);
 
 fn reset_chunk_graph_state(compilation: &mut Compilation) {
   compilation.build_chunk_graph_artifact.chunk_by_ukey = Default::default();

--- a/xtask/benchmark/benches/groups/bundle.rs
+++ b/xtask/benchmark/benches/groups/bundle.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use criterion::{Criterion, criterion_group};
+use criterion::Criterion;
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
 
 use crate::groups::bundle::util::{CompilerBuilderGenerator, derive_projects};
@@ -9,36 +9,38 @@ pub mod basic_react;
 pub mod threejs;
 pub mod util;
 
-criterion_group!(bundle, bundle_benchmark);
-
-fn bundle_benchmark(c: &mut Criterion) {
-  let mut group = c.benchmark_group("bundle");
-
+pub(crate) fn bundle_benchmark_case(c: &mut Criterion, target_id: &str) {
   let projects: Vec<(&'static str, CompilerBuilderGenerator)> = vec![
     ("basic-react", Arc::new(basic_react::compiler)),
     ("threejs", Arc::new(threejs::compiler)),
   ];
+  let (id, get_compiler) = derive_projects(projects)
+    .into_iter()
+    .find(|(id, _)| id == target_id)
+    .unwrap_or_else(|| panic!("unknown bundle benchmark case: {target_id}"));
 
   // Codspeed can only handle to up to 500 threads by default
   let rt = rspack_benchmark::build_tokio_rt();
-  for (id, get_compiler) in derive_projects(projects) {
-    group.bench_function(format!("bundle@{id}"), |b| {
-      b.iter_batched(
-        || {
-          let compiler_context = Arc::new(CompilerContext::new());
-          (
-            compiler_context.clone(),
-            within_compiler_context_sync(compiler_context, || get_compiler().build().unwrap()),
-          )
-        },
-        |(compiler_context, mut compiler)| {
-          rt.block_on(within_compiler_context(compiler_context, async move {
-            compiler.run().await.unwrap();
-            assert!(compiler.compilation.get_errors().next().is_none());
-          }))
-        },
-        criterion::BatchSize::PerIteration,
-      );
-    });
-  }
+  let mut group = c.benchmark_group("bundle");
+
+  group.bench_function(format!("bundle@{id}"), |b| {
+    b.iter_batched(
+      || {
+        let compiler_context = Arc::new(CompilerContext::new());
+        (
+          compiler_context.clone(),
+          within_compiler_context_sync(compiler_context, || get_compiler().build().unwrap()),
+        )
+      },
+      |(compiler_context, mut compiler)| {
+        rt.block_on(within_compiler_context(compiler_context, async move {
+          compiler.run().await.unwrap();
+          assert!(compiler.compilation.get_errors().next().is_none());
+        }))
+      },
+      criterion::BatchSize::PerIteration,
+    );
+  });
+
+  group.finish();
 }

--- a/xtask/benchmark/benches/groups/module_graph_api.rs
+++ b/xtask/benchmark/benches/groups/module_graph_api.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use criterion::criterion_group;
 use rspack::builder::Builder as _;
 use rspack_benchmark::Criterion;
 use rspack_core::{
@@ -106,5 +105,3 @@ pub fn module_graph_api_benchmark_inner(c: &mut Criterion) {
     });
   });
 }
-
-criterion_group!(module_graph_api, module_graph_api_benchmark);

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -8,7 +8,7 @@ use std::{
   },
 };
 
-use criterion::{BatchSize, Criterion, criterion_group};
+use criterion::{BatchSize, Criterion};
 use rspack_core::{
   CacheOptions, Mode,
   cache::persistent::{PersistentCacheOptions, snapshot::SnapshotOptions, storage::StorageOptions},
@@ -32,76 +32,67 @@ const UPDATED_TEXT: &str = "Hello from cache";
 // This benchmark intentionally keeps setup light and does not perform extra
 // correctness validation of cache state. Functional/cache-correctness behavior
 // is covered by dedicated test cases elsewhere.
-pub fn persistent_cache_benchmark(c: &mut Criterion) {
+pub fn persistent_cache_restore_benchmark(c: &mut Criterion) {
+  persistent_cache_benchmark_case(
+    c,
+    "rust@persistent_cache_restore@basic-react-development",
+    |_| {},
+  );
+}
+
+pub fn persistent_cache_restore_after_single_file_change_benchmark(c: &mut Criterion) {
+  persistent_cache_benchmark_case(
+    c,
+    "rust@persistent_cache_restore_after_single_file_change@basic-react-development",
+    |measured_case| {
+      mutate_leaf_module(&measured_case.project_dir);
+    },
+  );
+}
+
+fn persistent_cache_benchmark_case<F>(
+  c: &mut Criterion,
+  benchmark_id: &'static str,
+  prepare_restore_case: F,
+) where
+  F: Fn(&PreparedCase),
+{
   let mut group = c.benchmark_group("persistent_cache");
   let rt = rspack_benchmark::build_tokio_rt();
   let pending_cleanup = RefCell::new(Vec::new());
 
-  group.bench_function(
-    "rust@persistent_cache_restore@basic-react-development",
-    |b| {
-      b.iter_batched(
-        || {
-          // Clear the previous measured workspace outside the next sample's
-          // timed region so cleanup cost never lands in benchmark results.
-          cleanup_pending_workspaces(&pending_cleanup);
+  group.bench_function(benchmark_id, |b| {
+    b.iter_batched(
+      || {
+        // Clear the previous measured workspace outside the next sample's
+        // timed region so cleanup cost never lands in benchmark results.
+        cleanup_pending_workspaces(&pending_cleanup);
 
-          // The measured workspace is seeded once here and then left untouched
-          // until the timed restore build runs.
-          let measured_case = prepare_seeded_case();
-          rt.block_on(run_compiler(
-            &measured_case.project_dir,
-            &measured_case.cache_dir,
-          ));
-          pending_cleanup
-            .borrow_mut()
-            .push(measured_case.workspace_dir.clone());
-          measured_case
-        },
-        |case| {
-          // Criterion/CodSpeed reports the time for this restore build only.
-          rt.block_on(run_restore_build(&case));
-        },
-        BatchSize::PerIteration,
-      );
-    },
-  );
-
-  group.bench_function(
-    "rust@persistent_cache_restore_after_single_file_change@basic-react-development",
-    |b| {
-      b.iter_batched(
-        || {
-          cleanup_pending_workspaces(&pending_cleanup);
-
-          // Seed a fresh workspace first, then apply one deterministic source
-          // edit before entering the timed restore path.
-          let measured_case = prepare_seeded_case();
-          rt.block_on(run_compiler(
-            &measured_case.project_dir,
-            &measured_case.cache_dir,
-          ));
-          mutate_leaf_module(&measured_case.project_dir);
-          pending_cleanup
-            .borrow_mut()
-            .push(measured_case.workspace_dir.clone());
-          measured_case
-        },
-        |case| {
-          // Timed path for "persistent cache restore after a single-file edit".
-          rt.block_on(run_restore_build(&case));
-        },
-        BatchSize::PerIteration,
-      );
-    },
-  );
+        // The measured workspace is seeded once here and then prepared for the
+        // timed restore build.
+        let measured_case = prepare_seeded_case();
+        rt.block_on(run_compiler(
+          &measured_case.project_dir,
+          &measured_case.cache_dir,
+        ));
+        prepare_restore_case(&measured_case);
+        pending_cleanup
+          .borrow_mut()
+          .push(measured_case.workspace_dir.clone());
+        measured_case
+      },
+      |case| {
+        // Criterion/CodSpeed reports the time for this restore build only.
+        rt.block_on(run_restore_build(&case));
+      },
+      BatchSize::PerIteration,
+    );
+  });
 
   group.finish();
 
   cleanup_pending_workspaces(&pending_cleanup);
 }
-
-criterion_group!(persistent_cache, persistent_cache_benchmark);
 
 struct PreparedCase {
   workspace_dir: PathBuf,

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -52,7 +52,7 @@ pub fn persistent_cache_restore_after_single_file_change_benchmark(c: &mut Crite
 
 fn persistent_cache_benchmark_case<F>(
   c: &mut Criterion,
-  benchmark_id: &'static str,
+  benchmark_id: &str,
   prepare_restore_case: F,
 ) where
   F: Fn(&PreparedCase),
@@ -71,14 +71,13 @@ fn persistent_cache_benchmark_case<F>(
         // The measured workspace is seeded once here and then prepared for the
         // timed restore build.
         let measured_case = prepare_seeded_case();
+        let cleanup_guard = PreparedCaseCleanup::new(measured_case.workspace_dir.clone());
         rt.block_on(run_compiler(
           &measured_case.project_dir,
           &measured_case.cache_dir,
         ));
         prepare_restore_case(&measured_case);
-        pending_cleanup
-          .borrow_mut()
-          .push(measured_case.workspace_dir.clone());
+        cleanup_guard.defer_to(&pending_cleanup);
         measured_case
       },
       |case| {
@@ -98,6 +97,32 @@ struct PreparedCase {
   workspace_dir: PathBuf,
   project_dir: PathBuf,
   cache_dir: PathBuf,
+}
+
+struct PreparedCaseCleanup {
+  workspace_dir: Option<PathBuf>,
+}
+
+impl PreparedCaseCleanup {
+  fn new(workspace_dir: PathBuf) -> Self {
+    Self {
+      workspace_dir: Some(workspace_dir),
+    }
+  }
+
+  fn defer_to(mut self, pending_cleanup: &RefCell<Vec<PathBuf>>) {
+    if let Some(workspace_dir) = self.workspace_dir.take() {
+      pending_cleanup.borrow_mut().push(workspace_dir);
+    }
+  }
+}
+
+impl Drop for PreparedCaseCleanup {
+  fn drop(&mut self) {
+    if let Some(workspace_dir) = self.workspace_dir.take() {
+      let _ = fs::remove_dir_all(workspace_dir);
+    }
+  }
 }
 
 // Create an isolated copy of the shared benchmark fixture plus a sample-local

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -7,7 +7,7 @@ use std::{
   sync::Arc,
 };
 
-use criterion::{BatchSize, black_box, criterion_group};
+use criterion::{BatchSize, black_box};
 use rspack::builder::{Builder as _, NodeOptionBuilder};
 use rspack_benchmark::Criterion;
 use rspack_core::{
@@ -406,5 +406,3 @@ fn extract_tarball_entry_to_file(archive_path: &Path, tar_entry: &str, destinati
     )
   });
 }
-
-criterion_group!(scan_dependencies, benchmark_scan_dependencies);

--- a/xtask/benchmark/cases/build_chunk_graph.rs
+++ b/xtask/benchmark/cases/build_chunk_graph.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::build_chunk_graph::build_chunk_graph_benchmark(c);
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/build_chunk_graph.rs
+++ b/xtask/benchmark/cases/build_chunk_graph.rs
@@ -1,8 +1,1 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
-  crate::groups::build_chunk_graph::build_chunk_graph_benchmark(c);
-}
-
-criterion_group!(case, bench);
+case_entry!(crate::groups::build_chunk_graph::build_chunk_graph_benchmark);

--- a/xtask/benchmark/cases/build_module_graph.rs
+++ b/xtask/benchmark/cases/build_module_graph.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::build_chunk_graph::build_module_graph_benchmark(c);
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/build_module_graph.rs
+++ b/xtask/benchmark/cases/build_module_graph.rs
@@ -1,8 +1,1 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
-  crate::groups::build_chunk_graph::build_module_graph_benchmark(c);
-}
-
-criterion_group!(case, bench);
+case_entry!(crate::groups::build_chunk_graph::build_module_graph_benchmark);

--- a/xtask/benchmark/cases/bundle_basic_react_development.rs
+++ b/xtask/benchmark/cases/bundle_basic_react_development.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::bundle::bundle_benchmark_case(c, "basic-react-development");
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/bundle_basic_react_development.rs
+++ b/xtask/benchmark/cases/bundle_basic_react_development.rs
@@ -1,8 +1,3 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
+case_entry!(|c| {
   crate::groups::bundle::bundle_benchmark_case(c, "basic-react-development");
-}
-
-criterion_group!(case, bench);
+});

--- a/xtask/benchmark/cases/bundle_basic_react_production_sourcemap.rs
+++ b/xtask/benchmark/cases/bundle_basic_react_production_sourcemap.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::bundle::bundle_benchmark_case(c, "basic-react-production-sourcemap");
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/bundle_basic_react_production_sourcemap.rs
+++ b/xtask/benchmark/cases/bundle_basic_react_production_sourcemap.rs
@@ -1,8 +1,3 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
+case_entry!(|c| {
   crate::groups::bundle::bundle_benchmark_case(c, "basic-react-production-sourcemap");
-}
-
-criterion_group!(case, bench);
+});

--- a/xtask/benchmark/cases/bundle_threejs_development.rs
+++ b/xtask/benchmark/cases/bundle_threejs_development.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::bundle::bundle_benchmark_case(c, "threejs-development");
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/bundle_threejs_development.rs
+++ b/xtask/benchmark/cases/bundle_threejs_development.rs
@@ -1,8 +1,3 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
+case_entry!(|c| {
   crate::groups::bundle::bundle_benchmark_case(c, "threejs-development");
-}
-
-criterion_group!(case, bench);
+});

--- a/xtask/benchmark/cases/bundle_threejs_production_sourcemap.rs
+++ b/xtask/benchmark/cases/bundle_threejs_production_sourcemap.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::bundle::bundle_benchmark_case(c, "threejs-production-sourcemap");
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/bundle_threejs_production_sourcemap.rs
+++ b/xtask/benchmark/cases/bundle_threejs_production_sourcemap.rs
@@ -1,8 +1,3 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
+case_entry!(|c| {
   crate::groups::bundle::bundle_benchmark_case(c, "threejs-production-sourcemap");
-}
-
-criterion_group!(case, bench);
+});

--- a/xtask/benchmark/cases/mod.rs
+++ b/xtask/benchmark/cases/mod.rs
@@ -1,0 +1,10 @@
+pub mod build_chunk_graph;
+pub mod build_module_graph;
+pub mod bundle_basic_react_development;
+pub mod bundle_basic_react_production_sourcemap;
+pub mod bundle_threejs_development;
+pub mod bundle_threejs_production_sourcemap;
+pub mod module_graph_api;
+pub mod persistent_cache_restore;
+pub mod persistent_cache_restore_after_single_file_change;
+pub mod scan_dependencies;

--- a/xtask/benchmark/cases/mod.rs
+++ b/xtask/benchmark/cases/mod.rs
@@ -1,3 +1,16 @@
+macro_rules! case_entry {
+  ($register:expr) => {
+    use criterion::criterion_group;
+    use rspack_benchmark::Criterion;
+
+    pub fn bench(c: &mut Criterion) {
+      ($register)(c);
+    }
+
+    criterion_group!(case, bench);
+  };
+}
+
 pub mod build_chunk_graph;
 pub mod build_module_graph;
 pub mod bundle_basic_react_development;

--- a/xtask/benchmark/cases/module_graph_api.rs
+++ b/xtask/benchmark/cases/module_graph_api.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::module_graph_api::module_graph_api_benchmark(c);
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/module_graph_api.rs
+++ b/xtask/benchmark/cases/module_graph_api.rs
@@ -1,8 +1,1 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
-  crate::groups::module_graph_api::module_graph_api_benchmark(c);
-}
-
-criterion_group!(case, bench);
+case_entry!(crate::groups::module_graph_api::module_graph_api_benchmark);

--- a/xtask/benchmark/cases/persistent_cache_restore.rs
+++ b/xtask/benchmark/cases/persistent_cache_restore.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::persistent_cache::persistent_cache_restore_benchmark(c);
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/persistent_cache_restore.rs
+++ b/xtask/benchmark/cases/persistent_cache_restore.rs
@@ -1,8 +1,3 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
+case_entry!(|c| {
   crate::groups::persistent_cache::persistent_cache_restore_benchmark(c);
-}
-
-criterion_group!(case, bench);
+});

--- a/xtask/benchmark/cases/persistent_cache_restore_after_single_file_change.rs
+++ b/xtask/benchmark/cases/persistent_cache_restore_after_single_file_change.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::persistent_cache::persistent_cache_restore_after_single_file_change_benchmark(c);
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/persistent_cache_restore_after_single_file_change.rs
+++ b/xtask/benchmark/cases/persistent_cache_restore_after_single_file_change.rs
@@ -1,8 +1,3 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
+case_entry!(|c| {
   crate::groups::persistent_cache::persistent_cache_restore_after_single_file_change_benchmark(c);
-}
-
-criterion_group!(case, bench);
+});

--- a/xtask/benchmark/cases/scan_dependencies.rs
+++ b/xtask/benchmark/cases/scan_dependencies.rs
@@ -1,0 +1,8 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  crate::groups::scan_dependencies::benchmark_scan_dependencies(c);
+}
+
+criterion_group!(case, bench);

--- a/xtask/benchmark/cases/scan_dependencies.rs
+++ b/xtask/benchmark/cases/scan_dependencies.rs
@@ -1,8 +1,1 @@
-use criterion::criterion_group;
-use rspack_benchmark::Criterion;
-
-pub fn bench(c: &mut Criterion) {
-  crate::groups::scan_dependencies::benchmark_scan_dependencies(c);
-}
-
-criterion_group!(case, bench);
+case_entry!(crate::groups::scan_dependencies::benchmark_scan_dependencies);


### PR DESCRIPTION
## Summary

- Split non-stage benchmark registration into per-case entrypoint files under `xtask/benchmark/cases`.
- Keep benchmark implementations in `xtask/benchmark/benches/groups` while shortening CodSpeed callgrind profile-part paths for KCachegrind readability.
- Cover build graph, module graph API, scan dependencies, bundle variants, and persistent cache cases.

## Related links

Follow-up to #13969.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).