### PR TITLE
feat: track static esm namespace keys

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},
-  ecma::ast::{BinExpr, BinaryOp, Callee, Expr, Ident, ImportDecl},
+  ecma::ast::{BinExpr, BinaryOp, Callee, Expr, Ident, ImportDecl, Lit, VarDeclarator},
 };
 
 use super::{
@@ -16,14 +16,16 @@ use crate::{
   utils::object_properties::get_attributes,
   visitors::{
     AllowedMemberTypes, AtomMembers, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo,
-    TagInfoData, get_non_optional_member_chain_from_expr,
-    get_non_optional_member_chain_from_member, get_non_optional_part,
+    TagInfoData, VariableDeclaration, VariableDeclarationKind,
+    get_non_optional_member_chain_from_expr, get_non_optional_member_chain_from_member,
+    get_non_optional_part, scope_info::VariableInfoFlags,
   },
 };
 
 pub struct ESMImportDependencyParserPlugin;
 
 pub const ESM_SPECIFIER_TAG: &str = "_identifier__esm_specifier_tag__";
+pub const ESM_STATIC_PROPERTY_KEY_TAG: &str = "_identifier__esm_static_property_key__";
 
 #[derive(Debug, Clone)]
 pub struct ESMSpecifierData {
@@ -34,6 +36,11 @@ pub struct ESMSpecifierData {
   pub source_order: i32,
   pub phase: ImportPhase,
   pub attributes: Option<ImportAttributes>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ESMStaticPropertyKeyData {
+  pub value: Atom,
 }
 
 #[rspack_macros::implemented_javascript_parser_hooks]
@@ -96,6 +103,9 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     } else {
       ImportPhase::Evaluation
     };
+    if id.is_none() {
+      parser.has_esm_namespace_import = true;
+    }
     parser.tag_variable::<ESMSpecifierData>(
       name.clone(),
       ESM_SPECIFIER_TAG,
@@ -112,8 +122,37 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     Some(true)
   }
 
+  fn declarator(
+    &self,
+    parser: &mut JavascriptParser,
+    declarator: &VarDeclarator,
+    declaration: VariableDeclaration<'_>,
+  ) -> Option<bool> {
+    if !matches!(declaration.kind(), VariableDeclarationKind::Const) {
+      return None;
+    }
+    if !parser.has_esm_namespace_import {
+      return None;
+    }
+
+    let name = declarator.name.as_ident()?;
+    let init = declarator.init.as_ref()?;
+    let value = static_property_key(init)?;
+    parser.tag_variable_with_flags(
+      name.id.sym.clone(),
+      ESM_STATIC_PROPERTY_KEY_TAG,
+      Some(ESMStaticPropertyKeyData { value }),
+      VariableInfoFlags::NORMAL,
+    );
+
+    None
+  }
+
   fn binary_expression(&self, parser: &mut JavascriptParser, expr: &BinExpr) -> Option<bool> {
     if expr.op != BinaryOp::In {
+      return None;
+    }
+    if !parser.has_esm_namespace_import {
       return None;
     }
     let right = parser.evaluate_expression(&expr.right);
@@ -138,15 +177,19 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       } else {
         return None;
       };
-    let left = parser.evaluate_expression(&expr.left);
-    if left.could_have_side_effects() {
-      return None;
-    }
-    let left = left.as_string()?;
+    let left = if let Some(value) = parser.get_esm_static_property_key(&expr.left) {
+      value
+    } else {
+      let left = parser.evaluate_expression(&expr.left);
+      if left.could_have_side_effects() {
+        return None;
+      }
+      left.as_string()?.into()
+    };
     let members = right.members().map(|v| v.as_slice()).unwrap_or_default();
     let direct_import = members.is_empty();
     ids.extend(members.iter().cloned());
-    ids.push(left.into());
+    ids.push(left);
 
     let range = DependencyRange::from(expr.span);
     let loc = parser.to_dependency_location(range);
@@ -278,6 +321,16 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     ids.extend(non_optional_members.iter().cloned());
     let direct_import = members.is_empty();
     let ns_access = settings.namespace_import && !ids.is_empty();
+    let export_presence_mode = if ns_access
+      && callee
+        .as_member()
+        .is_some_and(|member| parser.has_esm_static_property_key_member(member))
+      && parser.is_esm_static_property_key_guarded(&settings.source, &settings.name, ids.as_slice())
+    {
+      ExportPresenceMode::None
+    } else {
+      ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options)
+    };
     let mut dep = ESMImportSpecifierDependency::new(
       settings.source,
       settings.name,
@@ -289,7 +342,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       true,
       direct_import,
       ns_access,
-      ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+      export_presence_mode,
       // we don't need to pass destructuring properties here, since this is a call expr,
       // pass destructuring properties here won't help for tree shaking.
       None,
@@ -344,6 +397,14 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     let mut ids = settings.ids;
     ids.extend(non_optional_members.iter().cloned());
     let ns_access = settings.namespace_import && !ids.is_empty();
+    let export_presence_mode = if ns_access
+      && parser.has_esm_static_property_key_member(member_expr)
+      && parser.is_esm_static_property_key_guarded(&settings.source, &settings.name, ids.as_slice())
+    {
+      ExportPresenceMode::None
+    } else {
+      ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options)
+    };
     let referenced_properties_in_destructuring = parser
       .destructuring_assignment_properties
       .get(&member_expr.span())
@@ -359,7 +420,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       false,
       false, // x.xx()
       ns_access,
-      ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+      export_presence_mode,
       referenced_properties_in_destructuring,
       settings.phase,
       settings.attributes,
@@ -375,4 +436,28 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
 
     Some(true)
   }
+}
+
+fn static_property_key(expr: &Expr) -> Option<Atom> {
+  match expr {
+    Expr::Lit(lit) => static_property_key_from_lit(lit),
+    _ => None,
+  }
+}
+
+fn static_property_key_from_lit(lit: &Lit) -> Option<Atom> {
+  Some(match lit {
+    Lit::Str(s) => s.value.to_atom_lossy().into_owned(),
+    Lit::Bool(b) => {
+      if b.value {
+        "true".into()
+      } else {
+        "false".into()
+      }
+    }
+    Lit::Null(_) => "null".into(),
+    Lit::Num(n) => n.value.to_string().into(),
+    Lit::BigInt(i) => i.value.to_string().into(),
+    Lit::Regex(_) | Lit::JSXText(_) => return None,
+  })
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -50,7 +50,10 @@ pub(crate) use self::{
   drive::JavaScriptParserPluginDrive,
   esm_detection_parser_plugin::ESMDetectionParserPlugin,
   esm_export_dependency_parser_plugin::ESMExportDependencyParserPlugin,
-  esm_import_dependency_parser_plugin::ESMImportDependencyParserPlugin,
+  esm_import_dependency_parser_plugin::{
+    ESM_SPECIFIER_TAG, ESM_STATIC_PROPERTY_KEY_TAG, ESMImportDependencyParserPlugin,
+    ESMSpecifierData, ESMStaticPropertyKeyData,
+  },
   esm_top_level_this_plugin::ESMTopLevelThisParserPlugin,
   exports_info_api_plugin::ExportsInfoApiPlugin,
   import_meta_context_dependency_parser_plugin::ImportMetaContextDependencyParserPlugin,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -35,7 +35,7 @@ use swc_core::{
   common::{BytePos, Mark, Span, Spanned, comments::Comments},
   ecma::{
     ast::{
-      ArrayPat, AssignPat, AssignTargetPat, CallExpr, Decl, Expr, Ident, Lit, MemberExpr,
+      ArrayPat, AssignPat, AssignTargetPat, BinaryOp, CallExpr, Decl, Expr, Ident, Lit, MemberExpr,
       MetaPropExpr, MetaPropKind, ObjectPat, ObjectPatProp, OptCall, OptChainBase, OptChainExpr,
       Pat, Program, RestPat, Stmt, ThisExpr,
     },
@@ -48,8 +48,10 @@ use crate::{
   dependency::{DependencyBranchGuard, local_module::LocalModule, set_dependency_branch_guards},
   parser_and_generator::ParserRuntimeRequirementsData,
   parser_plugin::{
-    self, ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
-    JavascriptParserPlugin, RequireReferencesState, inner_graph::state::InnerGraphState,
+    self, ESM_SPECIFIER_TAG, ESM_STATIC_PROPERTY_KEY_TAG, ESMSpecifierData,
+    ESMStaticPropertyKeyData, ImportsReferencesState, InnerGraphParserPlugin,
+    JavaScriptParserPluginDrive, JavascriptParserPlugin, RequireReferencesState,
+    inner_graph::state::InnerGraphState,
   },
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{
@@ -95,6 +97,7 @@ where
 pub type AtomMembers = SmallVec<[Atom; 2]>;
 pub type OptionalMembers = SmallVec<[bool; 2]>;
 pub type MemberRanges = SmallVec<[Span; 2]>;
+pub(crate) type ESMStaticPropertyKeyBranchGuard = (Atom, Atom, Vec<Atom>);
 
 #[derive(Debug)]
 pub struct ExtractedMemberExpressionChainData<'ast> {
@@ -391,6 +394,8 @@ pub struct JavascriptParser<'parser> {
   pub(crate) parser_exports_state: Option<bool>,
   pub(crate) local_modules: Vec<LocalModule>,
   pub(crate) last_esm_import_order: i32,
+  pub(crate) has_esm_namespace_import: bool,
+  pub(crate) esm_static_property_key_branch_guards: Vec<ESMStaticPropertyKeyBranchGuard>,
   pub(crate) inner_graph: InnerGraphState,
   pub(crate) side_effects_item: Option<SideEffectsBailoutItemWithSpan>,
   pub(crate) is_renaming: Option<Atom>,
@@ -578,6 +583,8 @@ impl<'parser> JavascriptParser<'parser> {
       inner_graph: InnerGraphState::new(),
       parse_meta,
       local_modules: Default::default(),
+      has_esm_namespace_import: false,
+      esm_static_property_key_branch_guards: Vec::new(),
       side_effects_item: None,
       parser_runtime_requirements,
       is_renaming: None,
@@ -1080,7 +1087,7 @@ impl<'parser> JavascriptParser<'parser> {
   }
 
   pub fn extract_member_expression_chain<'ast>(
-    &self,
+    &mut self,
     expr: ExprRef<'ast>,
   ) -> ExtractedMemberExpressionChainData<'ast> {
     let mut object = expr;
@@ -1092,17 +1099,45 @@ impl<'parser> JavascriptParser<'parser> {
       match object {
         ExprRef::Member(expr) => {
           if let Some(computed) = expr.prop.as_computed() {
-            let Expr::Lit(lit) = &*computed.expr else {
-              break;
-            };
-            let value = match lit {
-              Lit::Str(s) => s.value.clone(),
-              Lit::Bool(b) => if b.value { "true" } else { "false" }.into(),
-              Lit::Null(_) => "null".into(),
-              Lit::Num(n) => n.value.to_string().into(),
-              Lit::BigInt(i) => i.value.to_string().into(),
-              Lit::Regex(r) => r.exp.clone().into(),
-              Lit::JSXText(_) => unreachable!(),
+            let value = if let Expr::Lit(lit) = &*computed.expr {
+              match lit {
+                Lit::Str(s) => s.value.clone(),
+                Lit::Bool(b) => if b.value { "true" } else { "false" }.into(),
+                Lit::Null(_) => "null".into(),
+                Lit::Num(n) => n.value.to_string().into(),
+                Lit::BigInt(i) => i.value.to_string().into(),
+                Lit::Regex(r) => r.exp.clone().into(),
+                Lit::JSXText(_) => unreachable!(),
+              }
+            } else {
+              if !self.has_esm_namespace_import {
+                break;
+              }
+              if !self.is_esm_namespace_member_object(expr.obj.as_ref()) {
+                break;
+              }
+              if let Some(value) = self.get_esm_static_property_key(&computed.expr) {
+                value.into()
+              } else {
+                let evaluated = self.evaluate_expression(&computed.expr);
+                if evaluated.could_have_side_effects() {
+                  break;
+                }
+                // Static member names are stored as strings because JS coerces primitive
+                // computed property keys with ToPropertyKey, e.g. ns[1] accesses "1".
+                if !(evaluated.is_string()
+                  || evaluated.is_number()
+                  || evaluated.is_bool()
+                  || evaluated.is_null()
+                  || evaluated.is_undefined())
+                {
+                  break;
+                }
+                let Some(value) = evaluated.as_string() else {
+                  break;
+                };
+                value.into()
+              }
             };
             // Since members are not used across rspack javascript parser plugin,
             // we directly makes it atom here
@@ -1135,6 +1170,109 @@ impl<'parser> JavascriptParser<'parser> {
       members_optionals,
       member_ranges,
     }
+  }
+
+  fn is_esm_namespace_member_object(&mut self, expr: &Expr) -> bool {
+    let mut object = expr;
+    loop {
+      match object {
+        Expr::Member(member) => {
+          object = member.obj.as_ref();
+        }
+        Expr::Ident(ident) => {
+          let Some(variable_name) = self
+            .get_variable_info(&ident.sym)
+            .and_then(|info| info.name.clone())
+          else {
+            return false;
+          };
+          return self
+            .get_tag_data::<ESMSpecifierData>(&variable_name, ESM_SPECIFIER_TAG)
+            .is_some_and(|data| data.namespace_import);
+        }
+        _ => return false,
+      }
+    }
+  }
+
+  pub fn get_esm_static_property_key(&mut self, expr: &Expr) -> Option<Atom> {
+    let Expr::Ident(ident) = expr else {
+      return None;
+    };
+    let variable_name = self
+      .get_variable_info(&ident.sym)
+      .and_then(|info| info.name.clone())?;
+    self
+      .get_tag_data::<ESMStaticPropertyKeyData>(&variable_name, ESM_STATIC_PROPERTY_KEY_TAG)
+      .map(|data| data.value.clone())
+  }
+
+  pub fn get_esm_static_property_key_in_operator_guard(
+    &mut self,
+    expr: &Expr,
+  ) -> Option<ESMStaticPropertyKeyBranchGuard> {
+    let mut expr = expr;
+    while let Expr::Paren(paren) = expr {
+      expr = &paren.expr;
+    }
+    let Expr::Bin(expr) = expr else {
+      return None;
+    };
+    if expr.op != BinaryOp::In {
+      return None;
+    }
+    let right = self.evaluate_expression(&expr.right);
+    if !right.is_identifier() {
+      return None;
+    }
+    let ExportedVariableInfo::VariableInfo(variable) = right.root_info() else {
+      return None;
+    };
+    let settings = self.get_variable_tag_data::<ESMSpecifierData>(*variable, ESM_SPECIFIER_TAG)?;
+    if !settings.namespace_import {
+      return None;
+    }
+
+    let source = settings.source.clone();
+    let name = settings.name.clone();
+    let mut ids = settings.ids.clone();
+    ids.extend(
+      right
+        .members()
+        .map(|members| members.iter().cloned())
+        .unwrap_or_default(),
+    );
+    ids.push(self.get_esm_static_property_key(&expr.left)?);
+    Some((source, name, ids.into_vec()))
+  }
+
+  pub fn is_esm_static_property_key_guarded(
+    &self,
+    source: &Atom,
+    name: &Atom,
+    ids: &[Atom],
+  ) -> bool {
+    self.esm_static_property_key_branch_guards.iter().any(
+      |(guard_source, guard_name, guard_ids)| {
+        guard_source == source && guard_name == name && ids.starts_with(guard_ids)
+      },
+    )
+  }
+
+  pub fn has_esm_static_property_key_member(&mut self, member_expr: &MemberExpr) -> bool {
+    let mut member = Some(member_expr);
+    while let Some(current) = member {
+      if let Some(computed) = current.prop.as_computed()
+        && self.get_esm_static_property_key(&computed.expr).is_some()
+      {
+        return true;
+      }
+      member = match current.obj.as_ref() {
+        Expr::Member(member) => Some(member),
+        _ => None,
+      };
+    }
+    false
   }
 
   fn enter_ident<F>(&mut self, ident: &Ident, on_ident: F)

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -107,6 +107,20 @@ impl JavascriptParser<'_> {
     self.dependency_branch_guards.truncate(old_len);
   }
 
+  fn with_esm_static_property_key_branch_guard(
+    &mut self,
+    guard: Option<super::ESMStaticPropertyKeyBranchGuard>,
+    f: impl FnOnce(&mut Self),
+  ) {
+    if let Some(guard) = guard {
+      self.esm_static_property_key_branch_guards.push(guard);
+      f(self);
+      self.esm_static_property_key_branch_guards.pop();
+    } else {
+      f(self);
+    }
+  }
+
   fn esm_import_condition_dependencies(
     &self,
     start: usize,
@@ -496,6 +510,8 @@ impl JavascriptParser<'_> {
       }
     } else {
       let mut test_walked = false;
+      let esm_static_property_key_guard =
+        self.get_esm_static_property_key_in_operator_guard(&stmt.test);
       let branch_condition = Self::branch_condition_templates_for_imported_bool(&stmt.test)
         .and_then(|(consequent, alternate)| {
           let dep_start = self.next_dependency_idx();
@@ -515,10 +531,16 @@ impl JavascriptParser<'_> {
       }
       if let Some((consequent_condition, _)) = &branch_condition {
         self.with_dependency_branch_guards(std::iter::once(consequent_condition.clone()), |this| {
-          this.walk_nested_statement(&stmt.cons)
+          this.with_esm_static_property_key_branch_guard(
+            esm_static_property_key_guard.clone(),
+            |this| this.walk_nested_statement(&stmt.cons),
+          )
         });
       } else {
-        self.walk_nested_statement(&stmt.cons);
+        self.with_esm_static_property_key_branch_guard(
+          esm_static_property_key_guard.clone(),
+          |this| this.walk_nested_statement(&stmt.cons),
+        );
       }
       let consequent_terminated = self.terminated;
       self.terminated = None;

--- a/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/index.js
@@ -1,0 +1,26 @@
+import * as ns from "./lib";
+import { barUsed, bazUsed, fooUsed } from "./lib";
+
+it("should track const property keys on esm namespace access", () => {
+	const fooKey = "foo";
+	const barKey = "bar";
+
+	expect(ns[fooKey]).toBe("foo");
+	expect(barKey in ns).toBe(true);
+
+	expect(fooUsed).toBe(true);
+	expect(barUsed).toBe(true);
+	expect(bazUsed).toBe(false);
+});
+
+it("should not error when guarded static keys are missing", () => {
+	const missingKey = "missing";
+	const unguardedMissingKey = "unguardedMissing";
+
+	expect(missingKey in ns).toBe(false);
+	if (missingKey in ns) {
+		expect(ns[missingKey]).toBe(undefined);
+		expect(ns[missingKey].prop).toBe(undefined);
+	}
+	expect(ns[unguardedMissingKey]).toBe(undefined);
+});

--- a/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/lib.js
+++ b/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/lib.js
@@ -1,0 +1,7 @@
+export const foo = "foo";
+export const bar = "bar";
+export const baz = "baz";
+
+export const fooUsed = __webpack_exports_info__.foo.used;
+export const barUsed = __webpack_exports_info__.bar.used;
+export const bazUsed = __webpack_exports_info__.baz.used;

--- a/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/package.json
+++ b/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  module: {
+    parser: {
+      javascript: {
+        exportsPresence: 'warn',
+      },
+    },
+  },
+  optimization: {
+    sideEffects: true,
+    usedExports: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/warnings.js
+++ b/tests/rspack-test/configCases/tree-shaking/esm-namespace-static-key/warnings.js
@@ -1,0 +1,5 @@
+module.exports = [
+  [
+    /export 'unguardedMissing'.*was not found in '\.\/lib' \(possible exports: bar, barUsed, baz, bazUsed, foo, fooUsed\)/,
+  ],
+];


### PR DESCRIPTION
## Summary

- add an ESM import parser tag for static primitive const property keys
- allow computed member chain evaluation only when the root is an ESM namespace import
- add a tree-shaking config case for `ns[key]` and `key in ns` preserving precise referenced exports

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Testing

- `cargo fmt --all --check`
- `cargo check -p rspack_plugin_javascript`
- `PATH=/Users/bytedance/.nvm/versions/node/v22.21.1/bin:$PATH pnpm --dir tests/rspack-test run test -t "esm-namespace-static-key"`