### PR TITLE
[codex] Reuse prehashed resolver paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,8 +5172,7 @@ dependencies = [
 [[package]]
 name = "rspack_resolver"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606bcaac4a8be081bf58ae173408ec104c89e0eb90196f9b91aeda30bd2f6365"
+source = "git+https://github.com/rstackjs/rspack-resolver?branch=codex%2Fprehash-path-dependencies#1bef3bc84fc7a0181942399c0b61a516a82b8c6a"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "rspack_resolver"
 version = "0.8.0"
-source = "git+https://github.com/rstackjs/rspack-resolver?branch=codex%2Fprehash-path-dependencies#1bef3bc84fc7a0181942399c0b61a516a82b8c6a"
+source = "git+https://github.com/rstackjs/rspack-resolver?branch=codex%2Fprehash-path-dependencies#c5d3b9df28180b8e23dc5671e26cbf28206427d8"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rayon               = { version = "1.12.0", default-features = false }
 regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
-rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
+rspack_resolver     = { git = "https://github.com/rstackjs/rspack-resolver", branch = "codex/prehash-path-dependencies", features = ["package_json_raw_json_api", "yarn_pnp"], default-features = false }
 rspack_sources      = { version = "=0.4.22", default-features = false, features = ["rspack_cacheable"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -7,7 +7,7 @@ use std::{
 use rspack_error::{Error, Severity, cyan, yellow};
 use rspack_fs::ReadableFileSystem;
 use rspack_loader_runner::DescriptionData;
-use rspack_paths::{ArcPathSet, AssertUtf8};
+use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
 use rspack_util::location::byte_line_column_to_offset;
 
 use super::{ResolveResult, Resource, boxfs::BoxFS};
@@ -167,20 +167,26 @@ impl Resolver {
     ResolveDependencies,
   ) {
     let resolver = &self.resolver;
-    let mut context = Default::default();
+    let mut context = rspack_resolver::ResolvePreHashedContext::default();
     let result = resolver
-      .resolve_with_context(path, request, &mut context)
+      .resolve_with_prehashed_context(path, request, &mut context)
       .await;
     let dependencies = ResolveDependencies {
       file_dependencies: context
         .file_dependencies
         .into_iter()
-        .map(Into::into)
+        .map(|dependency| {
+          let hash = dependency.precomputed_hash();
+          ArcPath::from_path_buf_with_hash(dependency.into_path_buf(), hash)
+        })
         .collect(),
       missing_dependencies: context
         .missing_dependencies
         .into_iter()
-        .map(Into::into)
+        .map(|dependency| {
+          let hash = dependency.precomputed_hash();
+          ArcPath::from_path_buf_with_hash(dependency.into_path_buf(), hash)
+        })
         .collect(),
     };
     let result = match result {

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -18,9 +18,14 @@ pub async fn module_rules_matcher<'a>(
   matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Result<()> {
   let matched_rules_len = matched_rules.len();
+  let resource_path = resource_data
+    .path()
+    .unwrap_or_else(|| Utf8Path::new(""))
+    .as_str();
   if let Some(result) = module_rules_matcher_sync(
     rules,
     resource_data,
+    resource_path,
     issuer,
     issuer_layer,
     dependency,
@@ -33,6 +38,7 @@ pub async fn module_rules_matcher<'a>(
   module_rules_matcher_async(
     rules,
     resource_data,
+    resource_path,
     issuer,
     issuer_layer,
     dependency,
@@ -45,6 +51,7 @@ pub async fn module_rules_matcher<'a>(
 fn module_rules_matcher_sync<'a>(
   rules: &'a [ModuleRule],
   resource_data: &ResourceData,
+  resource_path: &str,
   issuer: Option<&'a str>,
   issuer_layer: Option<&'a str>,
   dependency: &DependencyCategory,
@@ -55,6 +62,7 @@ fn module_rules_matcher_sync<'a>(
     match module_rule_matcher_sync(
       rule,
       resource_data,
+      resource_path,
       issuer,
       issuer_layer,
       dependency,
@@ -72,6 +80,7 @@ fn module_rules_matcher_sync<'a>(
 async fn module_rules_matcher_async<'a>(
   rules: &'a [ModuleRule],
   resource_data: &ResourceData,
+  resource_path: &str,
   issuer: Option<&'a str>,
   issuer_layer: Option<&'a str>,
   dependency: &DependencyCategory,
@@ -82,6 +91,7 @@ async fn module_rules_matcher_async<'a>(
     module_rule_matcher_async(
       rule,
       resource_data,
+      resource_path,
       issuer,
       issuer_layer,
       dependency,
@@ -146,9 +156,14 @@ pub async fn module_rule_matcher<'a>(
   matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Result<bool> {
   let matched_rules_len = matched_rules.len();
+  let resource_path = resource_data
+    .path()
+    .unwrap_or_else(|| Utf8Path::new(""))
+    .as_str();
   if let Some(result) = module_rule_matcher_sync(
     module_rule,
     resource_data,
+    resource_path,
     issuer,
     issuer_layer,
     dependency,
@@ -161,6 +176,7 @@ pub async fn module_rule_matcher<'a>(
   module_rule_matcher_async(
     module_rule,
     resource_data,
+    resource_path,
     issuer,
     issuer_layer,
     dependency,
@@ -173,6 +189,7 @@ pub async fn module_rule_matcher<'a>(
 fn module_rule_matcher_sync<'a>(
   module_rule: &'a ModuleRule,
   resource_data: &ResourceData,
+  resource_path: &str,
   issuer: Option<&'a str>,
   issuer_layer: Option<&'a str>,
   dependency: &DependencyCategory,
@@ -182,11 +199,6 @@ fn module_rule_matcher_sync<'a>(
   if let Some(test_rule) = &module_rule.rspack_resource {
     ensure_sync_matched!(test_rule.try_match_sync(resource_data.resource().into()));
   }
-
-  let resource_path = resource_data
-    .path()
-    .unwrap_or_else(|| Utf8Path::new(""))
-    .as_str();
 
   if let Some(test_rule) = &module_rule.test {
     ensure_sync_matched!(test_rule.try_match_sync(resource_path.into()));
@@ -284,6 +296,7 @@ fn module_rule_matcher_sync<'a>(
     match module_rules_matcher_sync(
       rules,
       resource_data,
+      resource_path,
       issuer,
       issuer_layer,
       dependency,
@@ -302,6 +315,7 @@ fn module_rule_matcher_sync<'a>(
       match module_rule_matcher_sync(
         rule,
         resource_data,
+        resource_path,
         issuer,
         issuer_layer,
         dependency,
@@ -329,6 +343,7 @@ fn module_rule_matcher_sync<'a>(
 async fn module_rule_matcher_async<'a>(
   module_rule: &'a ModuleRule,
   resource_data: &ResourceData,
+  resource_path: &str,
   issuer: Option<&'a str>,
   issuer_layer: Option<&'a str>,
   dependency: &DependencyCategory,
@@ -340,13 +355,6 @@ async fn module_rule_matcher_async<'a>(
   {
     return Ok(false);
   }
-
-  // Include all modules that pass test assertion. If you supply a Rule.test option, you cannot also supply a `Rule.resource`.
-  // See: https://webpack.js.org/configuration/module/#ruletest
-  let resource_path = resource_data
-    .path()
-    .unwrap_or_else(|| Utf8Path::new(""))
-    .as_str();
 
   if let Some(test_rule) = &module_rule.test
     && !test_rule.try_match(resource_path.into()).await?

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -54,7 +54,7 @@ impl<'a> AssertUtf8 for &'a Path {
 }
 
 #[cacheable(with=Custom)]
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct ArcPath {
   path: Arc<Path>,
   // Pre-calculating and caching the hash value upon creation, making hashing operations
@@ -69,13 +69,39 @@ impl Debug for ArcPath {
 }
 
 impl ArcPath {
+  #[inline]
   pub fn new(path: Arc<Path>) -> Self {
-    let mut hasher = FxHasher::default();
-    path.hash(&mut hasher);
-    let hash = hasher.finish();
+    let hash = Self::hash_path(path.as_ref());
     Self { path, hash }
   }
+
+  #[inline]
+  pub fn from_path_buf_with_hash(path: PathBuf, hash: u64) -> Self {
+    Self::new_with_hash(path.into(), hash)
+  }
+
+  #[inline]
+  fn new_with_hash(path: Arc<Path>, hash: u64) -> Self {
+    debug_assert_eq!(hash, Self::hash_path(path.as_ref()));
+    Self { path, hash }
+  }
+
+  #[inline]
+  fn hash_path(path: &Path) -> u64 {
+    let mut hasher = FxHasher::default();
+    path.hash(&mut hasher);
+    hasher.finish()
+  }
 }
+
+impl PartialEq for ArcPath {
+  #[inline]
+  fn eq(&self, other: &Self) -> bool {
+    self.hash == other.hash && (Arc::ptr_eq(&self.path, &other.path) || self.path == other.path)
+  }
+}
+
+impl Eq for ArcPath {}
 
 impl Deref for ArcPath {
   type Target = Arc<Path>;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1320,10 +1320,15 @@ impl<'parser> JavascriptParser<'parser> {
       match ast {
         Program::Module(m) => {
           self.set_strict(true);
-          self.prev_statement = None;
-          self.module_pre_walk_module_items(&m.body);
-          self.prev_statement = None;
-          self.pre_walk_module_items(&m.body);
+          self.is_esm = true;
+          if Self::module_items_need_module_pre_walk(&m.body) {
+            self.prev_statement = None;
+            self.module_pre_walk_module_items(&m.body);
+          }
+          if Self::module_items_need_pre_walk(&m.body) {
+            self.prev_statement = None;
+            self.pre_walk_module_items(&m.body);
+          }
           self.prev_statement = None;
           self.block_pre_walk_module_items(&m.body);
           self.prev_statement = None;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
@@ -11,6 +11,18 @@ use crate::{
 };
 
 impl JavascriptParser<'_> {
+  pub(super) fn module_items_need_module_pre_walk(statements: &[ModuleItem]) -> bool {
+    statements.iter().any(|statement| match statement {
+      ModuleItem::ModuleDecl(ModuleDecl::Import(_) | ModuleDecl::ExportAll(_)) => true,
+      ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(decl)) => {
+        decl.src.is_some()
+          || decl.specifiers.len() == 1
+            && matches!(decl.specifiers.first(), Some(ExportSpecifier::Namespace(_)))
+      }
+      ModuleItem::ModuleDecl(_) | ModuleItem::Stmt(_) => false,
+    })
+  }
+
   pub fn module_pre_walk_module_items(&mut self, statements: &Vec<ModuleItem>) {
     for statement in statements {
       self.statement_path.push(statement.span().into());

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use swc_core::{
   common::Spanned,
   ecma::ast::{
-    ArrayPat, AssignExpr, BlockStmt, CatchClause, DoWhileStmt, ForHead, ForInStmt, ForOfStmt,
+    ArrayPat, AssignExpr, BlockStmt, CatchClause, Decl, DoWhileStmt, ForHead, ForInStmt, ForOfStmt,
     ForStmt, IfStmt, LabeledStmt, ModuleDecl, ModuleItem, ObjectPat, ObjectPatProp, Pat, Stmt,
     SwitchCase, SwitchStmt, TryStmt, VarDeclarator, WhileStmt, WithStmt,
   },
@@ -20,6 +20,64 @@ use crate::{
 };
 
 impl JavascriptParser<'_> {
+  pub(super) fn module_items_need_pre_walk(statements: &[ModuleItem]) -> bool {
+    statements.iter().any(|statement| match statement {
+      ModuleItem::ModuleDecl(_) => false,
+      ModuleItem::Stmt(stmt) => Self::stmt_needs_pre_walk(stmt),
+    })
+  }
+
+  fn stmts_need_pre_walk(statements: &[Stmt]) -> bool {
+    statements.iter().any(Self::stmt_needs_pre_walk)
+  }
+
+  fn stmt_needs_pre_walk(statement: &Stmt) -> bool {
+    match statement {
+      Stmt::Block(stmt) => Self::stmts_need_pre_walk(&stmt.stmts),
+      Stmt::With(stmt) => Self::stmt_needs_pre_walk(&stmt.body),
+      Stmt::Labeled(stmt) => Self::stmt_needs_pre_walk(&stmt.body),
+      Stmt::If(stmt) => {
+        Self::stmt_needs_pre_walk(&stmt.cons)
+          || stmt.alt.as_deref().is_some_and(Self::stmt_needs_pre_walk)
+      }
+      Stmt::Switch(stmt) => stmt
+        .cases
+        .iter()
+        .any(|case| Self::stmts_need_pre_walk(&case.cons)),
+      Stmt::Try(stmt) => {
+        Self::stmts_need_pre_walk(&stmt.block.stmts)
+          || stmt
+            .handler
+            .as_ref()
+            .is_some_and(|handler| Self::stmts_need_pre_walk(&handler.body.stmts))
+          || stmt
+            .finalizer
+            .as_ref()
+            .is_some_and(|finalizer| Self::stmts_need_pre_walk(&finalizer.stmts))
+      }
+      Stmt::While(stmt) => Self::stmt_needs_pre_walk(&stmt.body),
+      Stmt::DoWhile(stmt) => Self::stmt_needs_pre_walk(&stmt.body),
+      Stmt::For(stmt) => {
+        stmt
+          .init
+          .as_ref()
+          .is_some_and(|init| init.as_var_decl().is_some())
+          || Self::stmt_needs_pre_walk(&stmt.body)
+      }
+      Stmt::ForIn(stmt) => {
+        matches!(stmt.left, ForHead::VarDecl(_) | ForHead::UsingDecl(_))
+          || Self::stmt_needs_pre_walk(&stmt.body)
+      }
+      Stmt::ForOf(stmt) => {
+        matches!(stmt.left, ForHead::VarDecl(_) | ForHead::UsingDecl(_))
+          || Self::stmt_needs_pre_walk(&stmt.body)
+      }
+      Stmt::Decl(Decl::Fn(_) | Decl::Var(_)) => true,
+      Stmt::Decl(_) | Stmt::Expr(_) | Stmt::Empty(_) | Stmt::Debugger(_) => false,
+      Stmt::Return(_) | Stmt::Break(_) | Stmt::Continue(_) | Stmt::Throw(_) => false,
+    }
+  }
+
   pub fn pre_walk_module_items(&mut self, statements: &Vec<ModuleItem>) {
     for statement in statements {
       self.pre_walk_module_item(statement);


### PR DESCRIPTION
## Summary

- Reuse resolver-provided precomputed path hashes when converting file and missing dependencies into `ArcPath` sets.
- Add an `ArcPath::from_path_buf_with_hash` constructor and make `ArcPath` equality check the cached hash before comparing full paths.
- Skip JavaScript module pre-walk passes when a module has no declarations/statements that those passes can act on.
- Reuse the resolved module rule resource path across rule matching instead of recomputing it for each nested rule.
- Update the resolver dependency to include cached package-json path joins.
- Temporarily point `rspack_resolver` at the resolver PR branch so this draft can compile against the new API.

## Why

`build_module_graph` receives dependency paths from `rspack_resolver`, deduplicates them, and then converts them into Rspack's prehashed `ArcPath` sets. Before this change, those paths were hashed again during conversion. This PR uses the prehashed resolver context from rstackjs/rspack-resolver#206 to avoid that extra full `Path` hash work.

The parser walk change removes two no-op JavaScript pre-walk traversals for modules where the pass cannot create bindings or module import/export dependencies. This produced a measurable instruction-count reduction locally, though it is still below the requested 10% target.

The rule matcher change hoists `ResourceData::path()` once per rule set/single-rule match so sync and async rule checks can reuse the same `&str` while preserving the existing matching order and fallback behavior.

The resolver dependency update avoids joining `package.json` paths repeatedly from the same cached directory during package-json reads and dependency recording.

## Dependency

Depends on rstackjs/rspack-resolver#206. Before this can be marked ready, replace the temporary git dependency with the published resolver version containing `ResolvePreHashedContext`.

## Micro-Optimization Progress

Target benchmark: `rust@build_module_graph`
Measurement mode: local Criterion plus Callgrind/CodSpeed Valgrind fork
Primary metric: Callgrind `Ir` for the benchmark useful segment

| Commit | Benchmark | Mode | Before | After | Delta | Checks | Notes |
| --- | --- | --- | ---: | ---: | ---: | --- | --- |
| `0394d0afcf` | `rust@build_module_graph` | Criterion vs parent | `[176.32 ms 184.60 ms 193.61 ms]` | `[172.44 ms 191.84 ms 218.00 ms]` | no significant change | `cargo check -p rspack_paths -p rspack_core`; `cargo test -p rspack_paths` | Resolver prehash reuse; CodSpeed reported no performance change. |
| `7a21e93b80` | `rust@build_module_graph` | Callgrind `Ir` | `4,380,134,836` | `4,217,447,382` | `-3.7%` | `cargo fmt --check`; `cargo check -p rspack_plugin_javascript`; `cargo test -p rspack_plugin_javascript --lib` | Skips empty JS module pre-walk passes. Criterion short run: `[172.89 ms 177.90 ms 183.45 ms]`, no statistically significant change. |
| `f7df7f257b` | `rust@build_module_graph` | Callgrind `Ir` | `4,217,447,382` | `4,215,709,867` | `-0.04%` | `cargo fmt --check`; `cargo check -p rspack_core`; `cargo test -p rspack_core module_rules` | Hoists rule resource path lookup. Test filter compiled successfully but matched 0 tests. |
| `745d1cd351` | `rust@build_module_graph` | Callgrind `Ir` | `4,215,709,867` | `4,177,020,822` | `-0.92%` | `cargo check -p rspack_core`; resolver `cargo fmt --check`; resolver `cargo check`; resolver `cargo test package_json` | Updates to resolver `c5d3b9df`, which caches package-json path joins. Resolver full `cargo test` was attempted: 124 passed, 6 PnP fixture tests failed with `NotFound(...)`. |

## Validation

- `cargo check -p rspack_paths -p rspack_core`
- `cargo test -p rspack_paths`
- `cargo fmt --check`
- `cargo check -p rspack_plugin_javascript`
- `cargo test -p rspack_plugin_javascript --lib`
- `cargo check -p rspack_core`
- `cargo test -p rspack_core module_rules`
- `cargo check -p rspack_core`
- Resolver: `cargo fmt --check`
- Resolver: `cargo check`
- Resolver: `cargo test package_json`