### PR TITLE
docs: update NestJS guide

### DIFF
--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -2,14 +2,296 @@
 description: 'Use NestJS with Rspack, covering setup, configuration, integration details, and framework-specific development patterns.'
 ---
 
+import { PackageManagerTabs } from '@theme';
+
 # NestJS
 
-Rspack not only supports building frontend projects but also supports building Node.js App like NestJS.
-Rspack provides NestJS [example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) for reference.
+Rspack can build Node.js applications such as [NestJS](https://nestjs.com/). Compared with using `tsc` directly, Rspack can bundle application code, transform TypeScript with SWC, support development-time HMR, and keep runtime dependencies external when needed.
+
+## How to use
+
+Rspack provides two ways to build NestJS applications:
+
+- **Use the example**: Start from the [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) in `rstack-examples`, which contains a complete `rspack.config.mjs`, development script, production build script, and HMR entry.
+- **Manually configure Rspack**: Follow this document to add the required Rspack configuration to an existing NestJS project.
+
+## Example
+
+The [rstack-examples](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) repository contains a complete NestJS application built with Rspack.
+
+## Install dependencies
+
+Install Rspack and the helper dependencies used by the NestJS example:
+
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin cross-env -D" />
+
+For a minimal NestJS application, install the NestJS runtime dependencies as usual:
+
+<PackageManagerTabs command="add @nestjs/common @nestjs/core @nestjs/platform-express reflect-metadata rxjs" />
+
+## Basic concepts
+
+NestJS applications run in Node.js, so the Rspack configuration should target the Node.js runtime and preserve the framework metadata that NestJS reads at runtime.
+
+- **Node.js target** (`target: 'node'`): Generates output suitable for Node.js instead of the browser.
+- **Decorator metadata**: NestJS relies on TypeScript decorators and emitted metadata for dependency injection, controllers, routes, guards, interceptors, and other framework features.
+- **External dependencies**: Server applications usually do not need to bundle every package in `node_modules`. Externalizing dependencies keeps the bundle smaller and allows Node.js to load packages normally at runtime.
+- **Development HMR**: In development, the Node.js process needs to restart or accept updates after Rspack rebuilds the server bundle.
+
+## Configure Rspack
+
+The following configuration is adapted from the NestJS example:
+
+```js title="rspack.config.mjs"
+// @ts-check
+import { defineConfig } from '@rspack/cli';
+import { rspack } from '@rspack/core';
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import nodeExternals from 'webpack-node-externals';
+
+const isProduction = process.env.BUILD === 'true';
+
+export default defineConfig({
+  context: import.meta.dirname,
+  target: 'node',
+  entry: {
+    main: isProduction
+      ? './src/main.ts'
+      : ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+  output: {
+    clean: true,
+  },
+  resolve: {
+    extensions: ['...', '.ts', '.tsx', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              parser: {
+                decorators: true,
+              },
+              transform: {
+                legacyDecorator: true,
+                decoratorMetadata: true,
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  optimization: {
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+          mangle: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+        },
+      }),
+    ],
+  },
+  externalsType: 'commonjs',
+  plugins: [
+    !process.env.BUILD &&
+      new RunScriptWebpackPlugin({
+        name: 'main.js',
+        autoRestart: false,
+      }),
+  ],
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+});
+```
+
+## Configure scripts
+
+Use `rspack dev` for development and set `BUILD=true` for production builds:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "cross-env BUILD=true rspack build",
+    "dev": "rspack dev",
+    "start": "node dist/main.js"
+  }
+}
+```
+
+- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
+- `build`: Creates a production bundle without the HMR polling entry.
+- `start`: Runs the production output with Node.js.
+
+## Configure TypeScript decorators
+
+NestJS uses decorators such as `@Module()`, `@Controller()`, `@Injectable()`, and `@Get()`. Configure `builtin:swc-loader` to parse TypeScript decorators and emit decorator metadata:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              parser: {
+                decorators: true,
+              },
+              transform: {
+                legacyDecorator: true,
+                decoratorMetadata: true,
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecoratorMetadata` enabled in `tsconfig.json` so TypeScript tooling and Rspack's SWC transform follow the same assumptions:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+## Configure development HMR
+
+For Node.js applications, Rspack uses the polling HMR runtime:
+
+```js title="rspack.config.mjs"
+export default {
+  entry: {
+    main: ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+};
+```
+
+Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+};
+```
+
+Add HMR handling to the NestJS bootstrap file so the old application instance is closed before the updated module is accepted:
+
+```ts title="src/main.ts"
+declare const module: any;
+
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+  if (module.hot) {
+    module.hot.accept();
+    module.hot.dispose(() => app.close());
+  }
+}
+
+bootstrap();
+```
+
+`RunScriptWebpackPlugin` starts the generated `main.js` file during development:
+
+```js title="rspack.config.mjs"
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+
+export default {
+  plugins: [
+    new RunScriptWebpackPlugin({
+      name: 'main.js',
+      autoRestart: false,
+    }),
+  ],
+};
+```
+
+## Externalize dependencies
+
+Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`:
+
+```js title="rspack.config.mjs"
+import nodeExternals from 'webpack-node-externals';
+
+export default {
+  externalsType: 'commonjs',
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+};
+```
+
+The HMR polling runtime must be allowlisted in development so it is bundled into the server output instead of being treated as an external dependency.
+
+## Configure production minification
+
+When minifying a NestJS server bundle, keep class names and function names. NestJS APIs such as execution context and metadata reflection can depend on stable class and handler function references.
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  optimization: {
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+          mangle: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+        },
+      }),
+    ],
+  },
+};
+```
 
 ## Native node modules
 
-When building Node.js applications with Rspack, you may encounter dependencies that include Node.js native addon dependencies (`.node` modules). Because `.node` modules cannot be packaged into JavaScript artifacts, special handling is usually required. node-loader can be used to handle addon packaging very well.
+When building Node.js applications with Rspack, you may encounter dependencies that include Node.js native addon dependencies (`.node` modules). Because `.node` modules cannot be packaged into JavaScript artifacts, special handling is usually required. [node-loader](https://www.npmjs.com/package/node-loader) can be used to handle addon packaging.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -49,15 +49,14 @@ import { rspack } from '@rspack/core';
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 import nodeExternals from 'webpack-node-externals';
 
-const isProduction = process.env.BUILD === 'true';
-
 export default defineConfig({
   context: import.meta.dirname,
   target: 'node',
   entry: {
-    main: isProduction
-      ? './src/main.ts'
-      : ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main:
+      process.env.BUILD === 'true'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
   output: {
     clean: true,
@@ -186,16 +185,15 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so use `isProduction` to switch between the production entry and the development entry:
+For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so switch the entry based on `process.env.BUILD === 'true'`:
 
 ```js title="rspack.config.mjs"
-const isProduction = process.env.BUILD === 'true';
-
 export default {
   entry: {
-    main: isProduction
-      ? './src/main.ts'
-      : ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main:
+      process.env.BUILD === 'true'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
 };
 ```

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -182,7 +182,7 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so switch the entry based on `process.env.NODE_ENV === 'production'`:
+Production builds must not include the polling HMR runtime. Add `@rspack/core/hot/poll` only to the development entry, and switch the entry based on `process.env.NODE_ENV === 'production'`:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -198,7 +198,7 @@ export default {
 };
 ```
 
-If the production bundle still includes `@rspack/core/hot/poll`, the Node.js application will crash at runtime because HMR is not available in production mode.
+If the production bundle still includes `@rspack/core/hot/poll`, the Node.js application will crash at runtime because HMR is not available in build mode.
 
 Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
 

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -182,7 +182,7 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-Production builds must not include the polling HMR runtime. Add `@rspack/core/hot/poll` only to the development entry, and switch the entry based on `process.env.NODE_ENV === 'production'`:
+Add `@rspack/core/hot/poll` only to the development entry, since including it in the production bundle will crash the Node.js application because HMR is not available in build mode:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -194,8 +194,6 @@ export default {
   },
 };
 ```
-
-If the production bundle still includes `@rspack/core/hot/poll`, the Node.js application will crash at runtime because HMR is not available in build mode.
 
 Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
 

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -186,15 +186,21 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-For Node.js applications, Rspack uses the polling HMR runtime:
+For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so use `isProduction` to switch between the production entry and the development entry:
 
 ```js title="rspack.config.mjs"
+const isProduction = process.env.BUILD === 'true';
+
 export default {
   entry: {
-    main: ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main: isProduction
+      ? './src/main.ts'
+      : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
 };
 ```
+
+If the production bundle still includes `@rspack/core/hot/poll`, the Node.js application may crash at runtime because HMR is not available in production mode.
 
 Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
 

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -101,7 +101,7 @@ export default defineConfig({
   },
   externalsType: 'commonjs',
   plugins: [
-    !process.env.BUILD &&
+    process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
         name: 'main.js',
         autoRestart: false,

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -20,7 +20,7 @@ The [rstack-examples](https://github.com/rstackjs/rstack-examples/tree/main/rspa
 
 Install Rspack and the helper dependencies used by the NestJS example:
 
-<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin cross-env -D" />
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin -D" />
 
 For a minimal NestJS application, install the NestJS runtime dependencies as usual:
 
@@ -51,7 +51,7 @@ export default defineConfig({
   target: 'node',
   entry: {
     main:
-      process.env.BUILD === 'true'
+      process.env.NODE_ENV === 'production'
         ? './src/main.ts'
         : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
@@ -122,12 +122,12 @@ export default defineConfig({
 
 ## Configure scripts
 
-Use `rspack dev` for development and set `BUILD=true` for production builds:
+Use `rspack dev` for development and `rspack build` for production builds:
 
 ```json title="package.json"
 {
   "scripts": {
-    "build": "cross-env BUILD=true rspack build",
+    "build": "rspack build",
     "dev": "rspack dev",
     "start": "node dist/main.js"
   }
@@ -182,13 +182,13 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so switch the entry based on `process.env.BUILD === 'true'`. The example uses `BUILD=true` because this switch is tied to `rspack build` output, not to the broader `NODE_ENV` value:
+For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so switch the entry based on `process.env.NODE_ENV === 'production'`:
 
 ```js title="rspack.config.mjs"
 export default {
   entry: {
     main:
-      process.env.BUILD === 'true'
+      process.env.NODE_ENV === 'production'
         ? './src/main.ts'
         : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -10,10 +10,7 @@ Rspack can build Node.js applications such as [NestJS](https://nestjs.com/). Com
 
 ## How to use
 
-Rspack provides two ways to build NestJS applications:
-
-- **Use the example**: Start from the [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) in `rstack-examples`, which contains a complete `rspack.config.mjs`, development script, production build script, and HMR entry.
-- **Manually configure Rspack**: Follow this document to add the required Rspack configuration to an existing NestJS project.
+You can follow this document to manually add the required Rspack configuration to an existing NestJS project. The [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) in `rstack-examples` is also available as a reference, and contains a complete `rspack.config.mjs`, development script, production build script, and HMR entry.
 
 ## Example
 
@@ -33,7 +30,7 @@ For a minimal NestJS application, install the NestJS runtime dependencies as usu
 
 NestJS applications run in Node.js, so the Rspack configuration should target the Node.js runtime and preserve the framework metadata that NestJS reads at runtime.
 
-- **Node.js target** (`target: 'node'`): Generates output suitable for Node.js instead of the browser.
+- **Node.js target** ([`target: 'node'`](/config/target)): Generates output suitable for Node.js instead of the browser.
 - **Decorator metadata**: NestJS relies on TypeScript decorators and emitted metadata for dependency injection, controllers, routes, guards, interceptors, and other framework features.
 - **External dependencies**: Server applications usually do not need to bundle every package in `node_modules`. Externalizing dependencies keeps the bundle smaller and allows Node.js to load packages normally at runtime.
 - **Development HMR**: In development, the Node.js process needs to restart or accept updates after Rspack rebuilds the server bundle.
@@ -185,7 +182,7 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so switch the entry based on `process.env.BUILD === 'true'`:
+For Node.js applications, Rspack uses the polling HMR runtime in development. The HMR polling entry must be disabled for production builds, so switch the entry based on `process.env.BUILD === 'true'`. The example uses `BUILD=true` because this switch is tied to `rspack build` output, not to the broader `NODE_ENV` value:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -200,7 +200,7 @@ export default {
 };
 ```
 
-If the production bundle still includes `@rspack/core/hot/poll`, the Node.js application may crash at runtime because HMR is not available in production mode.
+If the production bundle still includes `@rspack/core/hot/poll`, the Node.js application will crash at runtime because HMR is not available in production mode.
 
 Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -10,10 +10,7 @@ Rspack 可以用于构建 [NestJS](https://nestjs.com/) 等 Node.js 应用。相
 
 ## 如何使用
 
-Rspack 提供两种方式来构建 NestJS 应用：
-
-- **使用示例**：从 `rstack-examples` 中的 [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) 开始，它包含完整的 `rspack.config.mjs`、开发脚本、生产构建脚本和 HMR 入口。
-- **手动配置 Rspack**：你可以参考当前文档，为已有 NestJS 项目添加所需的 Rspack 配置。
+你可以参考当前文档，为已有 NestJS 项目手动添加所需的 Rspack 配置。`rstack-examples` 中的 [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) 也可作为参考，它包含完整的 `rspack.config.mjs`、开发脚本、生产构建脚本和 HMR 入口。
 
 ## 示例
 
@@ -33,7 +30,7 @@ Rspack 提供两种方式来构建 NestJS 应用：
 
 NestJS 应用运行在 Node.js 中，因此 Rspack 配置需要面向 Node.js runtime，并保留 NestJS 在运行时读取的框架 metadata。
 
-- **Node.js target**（`target: 'node'`）：生成适用于 Node.js 而不是浏览器的产物。
+- **Node.js target**（[`target: 'node'`](/config/target)）：生成适用于 Node.js 而不是浏览器的产物。
 - **Decorator metadata**：NestJS 依赖 TypeScript decorators 和生成的 metadata 来实现依赖注入、控制器、路由、守卫、拦截器等框架能力。
 - **External dependencies**：服务端应用通常不需要把 `node_modules` 中的所有包都打进 bundle。External 依赖可以减小 bundle 体积，并让 Node.js 在运行时正常加载依赖。
 - **Development HMR**：开发环境下，Node.js 进程需要在 Rspack 重新构建服务端 bundle 后重启或接受更新。
@@ -185,7 +182,7 @@ export default {
 
 ## 配置开发 HMR
 
-对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要根据 `process.env.BUILD === 'true'` 切换入口：
+对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要根据 `process.env.BUILD === 'true'` 切换入口。示例使用 `BUILD=true`，是因为这个开关对应的是 `rspack build` 产物，而不是更宽泛的 `NODE_ENV` 值：
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -20,7 +20,7 @@ Rspack 可以用于构建 [NestJS](https://nestjs.com/) 等 Node.js 应用。相
 
 安装 Rspack 以及 NestJS 示例中使用到的辅助依赖：
 
-<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin cross-env -D" />
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin -D" />
 
 对于一个最小的 NestJS 应用，请照常安装 NestJS 运行时依赖：
 
@@ -51,7 +51,7 @@ export default defineConfig({
   target: 'node',
   entry: {
     main:
-      process.env.BUILD === 'true'
+      process.env.NODE_ENV === 'production'
         ? './src/main.ts'
         : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
@@ -122,12 +122,12 @@ export default defineConfig({
 
 ## 配置脚本
 
-使用 `rspack dev` 进行开发，并在生产构建时设置 `BUILD=true`：
+使用 `rspack dev` 进行开发，并使用 `rspack build` 进行生产构建：
 
 ```json title="package.json"
 {
   "scripts": {
-    "build": "cross-env BUILD=true rspack build",
+    "build": "rspack build",
     "dev": "rspack dev",
     "start": "node dist/main.js"
   }
@@ -182,13 +182,13 @@ export default {
 
 ## 配置开发 HMR
 
-对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要根据 `process.env.BUILD === 'true'` 切换入口。示例使用 `BUILD=true`，是因为这个开关对应的是 `rspack build` 产物，而不是更宽泛的 `NODE_ENV` 值：
+对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要根据 `process.env.NODE_ENV === 'production'` 切换入口：
 
 ```js title="rspack.config.mjs"
 export default {
   entry: {
     main:
-      process.env.BUILD === 'true'
+      process.env.NODE_ENV === 'production'
         ? './src/main.ts'
         : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -186,15 +186,21 @@ export default {
 
 ## 配置开发 HMR
 
-对于 Node.js 应用，Rspack 使用 polling HMR runtime：
+对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要通过 `isProduction` 在生产入口和开发入口之间切换：
 
 ```js title="rspack.config.mjs"
+const isProduction = process.env.BUILD === 'true';
+
 export default {
   entry: {
-    main: ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main: isProduction
+      ? './src/main.ts'
+      : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
 };
 ```
+
+如果生产 bundle 中仍然包含 `@rspack/core/hot/poll`，Node.js 应用可能会在运行时崩溃，因为生产模式下不会启用 HMR。
 
 由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -200,7 +200,7 @@ export default {
 };
 ```
 
-如果生产 bundle 中仍然包含 `@rspack/core/hot/poll`，Node.js 应用可能会在运行时崩溃，因为生产模式下不会启用 HMR。
+如果生产 bundle 中仍然包含 `@rspack/core/hot/poll`，Node.js 应用会在运行时崩溃，因为生产模式下不会启用 HMR。
 
 由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -198,7 +198,7 @@ export default {
 };
 ```
 
-如果生产 bundle 中仍然包含 `@rspack/core/hot/poll`，Node.js 应用会在运行时崩溃，因为生产模式下不会启用 HMR。
+如果生产 bundle 中仍然包含 `@rspack/core/hot/poll`，Node.js 应用会在运行时崩溃，因为 build mode 下不会启用 HMR。
 
 由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -101,7 +101,7 @@ export default defineConfig({
   },
   externalsType: 'commonjs',
   plugins: [
-    !process.env.BUILD &&
+    process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
         name: 'main.js',
         autoRestart: false,

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -49,15 +49,14 @@ import { rspack } from '@rspack/core';
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 import nodeExternals from 'webpack-node-externals';
 
-const isProduction = process.env.BUILD === 'true';
-
 export default defineConfig({
   context: import.meta.dirname,
   target: 'node',
   entry: {
-    main: isProduction
-      ? './src/main.ts'
-      : ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main:
+      process.env.BUILD === 'true'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
   output: {
     clean: true,
@@ -186,16 +185,15 @@ export default {
 
 ## 配置开发 HMR
 
-对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要通过 `isProduction` 在生产入口和开发入口之间切换：
+对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要根据 `process.env.BUILD === 'true'` 切换入口：
 
 ```js title="rspack.config.mjs"
-const isProduction = process.env.BUILD === 'true';
-
 export default {
   entry: {
-    main: isProduction
-      ? './src/main.ts'
-      : ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main:
+      process.env.BUILD === 'true'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
 };
 ```

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -182,7 +182,7 @@ export default {
 
 ## 配置开发 HMR
 
-生产构建不能包含 polling HMR runtime。只在开发入口中添加 `@rspack/core/hot/poll`，并根据 `process.env.NODE_ENV === 'production'` 切换入口：
+只在开发入口中添加 `@rspack/core/hot/poll`；如果生产 bundle 中包含它，Node.js 应用会在运行时崩溃，因为 build mode 下不会启用 HMR：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -194,8 +194,6 @@ export default {
   },
 };
 ```
-
-如果生产 bundle 中仍然包含 `@rspack/core/hot/poll`，Node.js 应用会在运行时崩溃，因为 build mode 下不会启用 HMR。
 
 由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -1,14 +1,297 @@
 ---
-description: '在 Rspack 中使用NestJS的指南，涵盖环境配置、集成方式、调试要点、开发模式与常见问题处理。'
+description: '在 Rspack 中使用 NestJS 的指南，涵盖环境配置、集成方式、调试要点、开发模式与常见问题处理。'
 ---
+
+import { PackageManagerTabs } from '@theme';
 
 # NestJS
 
-Rspack 不仅能用于构建前端应用，也可以用于构建 Node.js 应用，你可以使用 Rspack 来构建 NestJS，Rspack 提供了一个 [NestJS Example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) 的例子供参考。
+Rspack 可以用于构建 [NestJS](https://nestjs.com/) 等 Node.js 应用。相比直接使用 `tsc`，Rspack 可以打包应用代码、通过 SWC 转译 TypeScript、支持开发阶段 HMR，并在需要时 external 运行时依赖。
+
+## 如何使用
+
+Rspack 提供两种方式来构建 NestJS 应用：
+
+- **使用示例**：从 `rstack-examples` 中的 [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) 开始，它包含完整的 `rspack.config.mjs`、开发脚本、生产构建脚本和 HMR 入口。
+- **手动配置 Rspack**：你可以参考当前文档，为已有 NestJS 项目添加所需的 Rspack 配置。
+
+## 示例
+
+[rstack-examples](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) 仓库包含了使用 Rspack 构建 NestJS 应用的完整示例。
+
+## 安装依赖
+
+安装 Rspack 以及 NestJS 示例中使用到的辅助依赖：
+
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin cross-env -D" />
+
+对于一个最小的 NestJS 应用，请照常安装 NestJS 运行时依赖：
+
+<PackageManagerTabs command="add @nestjs/common @nestjs/core @nestjs/platform-express reflect-metadata rxjs" />
+
+## 基本概念
+
+NestJS 应用运行在 Node.js 中，因此 Rspack 配置需要面向 Node.js runtime，并保留 NestJS 在运行时读取的框架 metadata。
+
+- **Node.js target**（`target: 'node'`）：生成适用于 Node.js 而不是浏览器的产物。
+- **Decorator metadata**：NestJS 依赖 TypeScript decorators 和生成的 metadata 来实现依赖注入、控制器、路由、守卫、拦截器等框架能力。
+- **External dependencies**：服务端应用通常不需要把 `node_modules` 中的所有包都打进 bundle。External 依赖可以减小 bundle 体积，并让 Node.js 在运行时正常加载依赖。
+- **Development HMR**：开发环境下，Node.js 进程需要在 Rspack 重新构建服务端 bundle 后重启或接受更新。
+
+## 配置 Rspack
+
+以下配置改编自 NestJS 示例：
+
+```js title="rspack.config.mjs"
+// @ts-check
+import { defineConfig } from '@rspack/cli';
+import { rspack } from '@rspack/core';
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import nodeExternals from 'webpack-node-externals';
+
+const isProduction = process.env.BUILD === 'true';
+
+export default defineConfig({
+  context: import.meta.dirname,
+  target: 'node',
+  entry: {
+    main: isProduction
+      ? './src/main.ts'
+      : ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+  output: {
+    clean: true,
+  },
+  resolve: {
+    extensions: ['...', '.ts', '.tsx', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              parser: {
+                decorators: true,
+              },
+              transform: {
+                legacyDecorator: true,
+                decoratorMetadata: true,
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  optimization: {
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+          mangle: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+        },
+      }),
+    ],
+  },
+  externalsType: 'commonjs',
+  plugins: [
+    !process.env.BUILD &&
+      new RunScriptWebpackPlugin({
+        name: 'main.js',
+        autoRestart: false,
+      }),
+  ],
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+});
+```
+
+## 配置脚本
+
+使用 `rspack dev` 进行开发，并在生产构建时设置 `BUILD=true`：
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "cross-env BUILD=true rspack build",
+    "dev": "rspack dev",
+    "start": "node dist/main.js"
+  }
+}
+```
+
+- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
+- `build`：创建不包含 HMR polling 入口的生产 bundle。
+- `start`：使用 Node.js 运行生产产物。
+
+## 配置 TypeScript decorators
+
+NestJS 使用 `@Module()`、`@Controller()`、`@Injectable()`、`@Get()` 等 decorators。你需要配置 `builtin:swc-loader` 来解析 TypeScript decorators 并生成 decorator metadata：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              parser: {
+                decorators: true,
+              },
+              transform: {
+                legacyDecorator: true,
+                decoratorMetadata: true,
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+如果项目同时运行 `tsc`，请在 `tsconfig.json` 中启用 `experimentalDecorators` 和 `emitDecoratorMetadata`，让 TypeScript 工具链和 Rspack 的 SWC 转换保持一致：
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+## 配置开发 HMR
+
+对于 Node.js 应用，Rspack 使用 polling HMR runtime：
+
+```js title="rspack.config.mjs"
+export default {
+  entry: {
+    main: ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+};
+```
+
+由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+};
+```
+
+在 NestJS bootstrap 文件中添加 HMR 处理，让旧的应用实例在接受更新前被关闭：
+
+```ts title="src/main.ts"
+declare const module: any;
+
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+  if (module.hot) {
+    module.hot.accept();
+    module.hot.dispose(() => app.close());
+  }
+}
+
+bootstrap();
+```
+
+`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.js` 文件：
+
+```js title="rspack.config.mjs"
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+
+export default {
+  plugins: [
+    new RunScriptWebpackPlugin({
+      name: 'main.js',
+      autoRestart: false,
+    }),
+  ],
+};
+```
+
+## External 依赖
+
+使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包：
+
+```js title="rspack.config.mjs"
+import nodeExternals from 'webpack-node-externals';
+
+export default {
+  externalsType: 'commonjs',
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+};
+```
+
+开发环境下，HMR polling runtime 必须加入 allowlist，这样它会被打进服务端产物，而不是被当作外部依赖处理。
+
+## 配置生产压缩
+
+压缩 NestJS 服务端 bundle 时，需要保留 class name 和 function name。NestJS 的 execution context、metadata reflection 等机制可能依赖稳定的 class 和 handler function 引用。
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  optimization: {
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+          mangle: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+        },
+      }),
+    ],
+  },
+};
+```
 
 ## Native node modules
 
-当使用 Rspack 构建 Node.js 应用时，可能会碰到一些依赖包含 Node.js native addon 依赖（`.node` 模块），因为 `.node` 无法打包进 JS 产物里，因此一般需要特殊处理，通过 [node-loader](https://www.npmjs.com/package/node-loader) 可以很好的处理 addon 的打包。
+当使用 Rspack 构建 Node.js 应用时，可能会碰到一些依赖包含 Node.js native addon 依赖（`.node` 模块）。因为 `.node` 模块无法打包进 JavaScript 产物里，所以通常需要特殊处理。可以使用 [node-loader](https://www.npmjs.com/package/node-loader) 处理 addon 的打包。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -182,7 +182,7 @@ export default {
 
 ## 配置开发 HMR
 
-对于 Node.js 应用，Rspack 在开发环境使用 polling HMR runtime。生产构建必须关闭 HMR polling entry，因此需要根据 `process.env.NODE_ENV === 'production'` 切换入口：
+生产构建不能包含 polling HMR runtime。只在开发入口中添加 `@rspack/core/hot/poll`，并根据 `process.env.NODE_ENV === 'production'` 切换入口：
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

- Expand the NestJS technology guide into a fuller setup and configuration walkthrough.
- Sync the guide with the latest `rstack-examples/rspack/nestjs` Rspack configuration.
- Document dependencies, scripts, SWC decorator metadata, development HMR, externals, production minification, and native node module handling for both English and Chinese docs.

## Validation

- `pnpm exec prettier --check website/docs/en/guide/tech/nestjs.mdx website/docs/zh/guide/tech/nestjs.mdx`
- Commit hook: `pnpm --dir website run check:spell` via lint-staged
