### PR TITLE
feat: tree shake namespace default reexport

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -6,6 +6,7 @@ use rspack_util::SpanExt;
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned, comments::CommentKind},
+  ecma::ast::Expr,
 };
 
 use super::{
@@ -30,6 +31,41 @@ use crate::{
 };
 
 pub struct ESMExportDependencyParserPlugin;
+
+fn create_default_exported_namespace_dependency(
+  parser: &mut JavascriptParser,
+  statement: ExportDefaultDeclaration,
+  expr: ExportDefaultExpression,
+) -> Option<ESMExportImportedSpecifierDependency> {
+  let ExportDefaultExpression::Expr(Expr::Ident(ident)) = expr else {
+    return None;
+  };
+  let settings = parser
+    .get_tag_data::<ESMSpecifierData>(&ident.sym, ESM_SPECIFIER_TAG)
+    .filter(|settings| settings.namespace_import && settings.ids.is_empty())?
+    .clone();
+  let statement_span = statement.span();
+  let mut dep = ESMExportImportedSpecifierDependency::new(
+    settings.source,
+    settings.source_order,
+    vec![],
+    Some(JS_DEFAULT_KEYWORD.clone()),
+    None,
+    statement_span.into(),
+    ESMExportImportedSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+    settings.phase,
+    settings.attributes,
+    parser.to_dependency_location(DependencyRange::from(statement_span)),
+  );
+  if parser
+    .factory_meta
+    .and_then(|meta| meta.side_effect_free)
+    .unwrap_or_default()
+  {
+    dep.set_lazy();
+  }
+  Some(dep)
+}
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
@@ -243,8 +279,16 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
   ) -> Option<bool> {
     let expr_span = expr.span();
     let statement_span = statement.span();
+    if let Some(dep) = create_default_exported_namespace_dependency(parser, statement, expr) {
+      parser.add_presentational_dependency(Box::new(ConstDependency::new(
+        DependencyRange::new(statement_span.real_lo(), expr_span.real_lo()),
+        "".into(),
+      )));
+      parser.add_dependency(Box::new(dep));
+      return Some(true);
+    }
 
-    let dep: ESMExportExpressionDependency = ESMExportExpressionDependency::new(
+    let dep = ESMExportExpressionDependency::new(
       expr_span.into(),
       statement_span.into(),
       parser

--- a/tests/rspack-test/normalCases/esm/default-namespace-reexport/cycle-middle.js
+++ b/tests/rspack-test/normalCases/esm/default-namespace-reexport/cycle-middle.js
@@ -1,0 +1,3 @@
+import * as ns from "./cycle-source";
+
+export default ns;

--- a/tests/rspack-test/normalCases/esm/default-namespace-reexport/cycle-source.js
+++ b/tests/rspack-test/normalCases/esm/default-namespace-reexport/cycle-source.js
@@ -1,0 +1,10 @@
+import cycleDefault from "./cycle-middle";
+
+export let observed;
+try {
+	observed = cycleDefault;
+} catch (error) {
+	observed = `${error.name}:${error.message}`;
+}
+
+export const value = 1;

--- a/tests/rspack-test/normalCases/esm/default-namespace-reexport/index.js
+++ b/tests/rspack-test/normalCases/esm/default-namespace-reexport/index.js
@@ -1,0 +1,16 @@
+import api, * as middle from "./middle";
+import * as source from "./source";
+import cycleDefault from "./cycle-middle";
+import * as cycleSource from "./cycle-source";
+
+it("should export the imported namespace object as default", () => {
+	expect(api).toBe(source);
+	expect(middle.default).toBe(source);
+	expect(api.default).toBe("default");
+	expect(api.named).toBe("named");
+});
+
+it("should follow imported-specifier reexport behavior in cycles", () => {
+	expect(cycleDefault).toBe(cycleSource);
+	expect(cycleSource.observed).toBeUndefined();
+});

--- a/tests/rspack-test/normalCases/esm/default-namespace-reexport/middle.js
+++ b/tests/rspack-test/normalCases/esm/default-namespace-reexport/middle.js
@@ -1,0 +1,3 @@
+import * as ns from "./source";
+
+export default ns;

--- a/tests/rspack-test/normalCases/esm/default-namespace-reexport/source.js
+++ b/tests/rspack-test/normalCases/esm/default-namespace-reexport/source.js
@@ -1,0 +1,2 @@
+export default "default";
+export const named = "named";

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/__snapshots__/treeshaking.snap.txt
@@ -1,0 +1,4 @@
+```js title=main.js
+exports unused: false
+unused used: false
+```

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/index.js
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/index.js
@@ -1,0 +1,4 @@
+import api from "./middle";
+import { unusedUsed, usedUsed } from "./source";
+
+console.log(api.used, usedUsed, unusedUsed);

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/middle.js
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/middle.js
@@ -1,0 +1,3 @@
+import * as ns from "./source";
+
+export default ns;

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/package.json
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/rspack.config.js
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/rspack.config.js
@@ -1,0 +1,13 @@
+const { DefinePlugin } = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    sideEffects: true,
+  },
+  plugins: [
+    new DefinePlugin({
+      'process.env.NODE_ENV': "'development'",
+    }),
+  ],
+};

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/source.js
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/source.js
@@ -1,0 +1,5 @@
+export const used = "used";
+export const unused = "unused";
+
+export const usedUsed = __webpack_exports_info__.used.used;
+export const unusedUsed = __webpack_exports_info__.unused.used;

--- a/tests/rspack-test/treeShakingCases/default-namespace-reexport/test.config.js
+++ b/tests/rspack-test/treeShakingCases/default-namespace-reexport/test.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	snapshotContent(content) {
+		const unusedUsed = /const unusedUsed = (true|false);/.exec(content)?.[1];
+		return [
+			`exports unused: ${/\\bunused: \\(\\) =>/.test(content)}`,
+			`unused used: ${unusedUsed}`
+		].join("\n");
+	}
+};


### PR DESCRIPTION
## Summary

- Treat `export default ns` for namespace imports as a namespace reexport dependency so nested default namespace usage can propagate to the source module.
- Remove the need for `ESMExportExpressionDependency` to own or proxy a module dependency for this narrow case.
- Add a tree-shaking regression where `api.used` keeps `used` and shakes `unused` through a default namespace export.

eg. Now we can tree shake pattern like this, only preserve used properties of namespace symbol `ns`

```js
import * as ns from './request'

export default ns
```
