### PR TITLE
fix: align sync module rule resource matching

### DIFF
--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -188,8 +188,18 @@ fn module_rule_matcher_sync<'a>(
     .unwrap_or_else(|| Utf8Path::new(""))
     .as_str();
 
-  if let Some(test_rule) = &module_rule.test {
-    ensure_sync_matched!(test_rule.try_match_sync(resource_path.into()));
+  let test_unmatched = if let Some(test_rule) = &module_rule.test {
+    match test_rule.try_match_sync(resource_path.into()) {
+      Some(Ok(true)) => false,
+      Some(Ok(false)) => true,
+      Some(Err(err)) => return Some(Err(err)),
+      None => return None,
+    }
+  } else {
+    false
+  };
+  if test_unmatched {
+    return Some(Ok(false));
   } else if let Some(resource_rule) = &module_rule.resource {
     ensure_sync_matched!(resource_rule.try_match_sync(resource_path.into()));
   }

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/async-entry.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/async-entry.js
@@ -1,0 +1,1 @@
+module.exports = ["async-entry"];

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/async-runtime.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/async-runtime.js
@@ -1,0 +1,1 @@
+module.exports = ["async-runtime"];

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/entry.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/entry.js
@@ -1,0 +1,1 @@
+module.exports = ["entry"];

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/index.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/index.js
@@ -1,0 +1,6 @@
+it("should require both test and resource to match", function () {
+	expect(require("./entry")).toEqual(["entry", "matched"]);
+	expect(require("./runtime")).toEqual(["runtime"]);
+	expect(require("./async-entry")).toEqual(["async-entry", "matched"]);
+	expect(require("./async-runtime")).toEqual(["async-runtime"]);
+});

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/loader.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/loader.js
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+	return source + "\nmodule.exports.push(\"matched\");";
+};

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/rspack.config.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        resource: /[\\/]entry\.js$/,
+        loader: './loader',
+      },
+      {
+        test: (resource) => /\.js$/.test(resource),
+        resource: /[\\/]async-entry\.js$/,
+        loader: './loader',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/rule-set/test-and-resource/runtime.js
+++ b/tests/rspack-test/configCases/rule-set/test-and-resource/runtime.js
@@ -1,0 +1,1 @@
+module.exports = ["runtime"];


### PR DESCRIPTION
## Summary

- make the sync module rule matcher check `resource` even when `test` is present
- add a config case covering rules that require both `test` and `resource` to match

## Root cause

The sync fast path used `else if` for `resource`, so a rule with both `test` and `resource` skipped the `resource` condition whenever `test` matched. The async matcher treats those conditions as conjunctive, so the two paths could select different rules.

## Checks

- `PATH=/Users/bytedance/.nvm/versions/node/v22.18.0/bin:$PATH pnpm run build:binding:dev`
- `PATH=/Users/bytedance/.nvm/versions/node/v22.18.0/bin:$PATH pnpm run test -t "configCases/rule-set/test-and-resource"`
- `cargo fmt --all --check`