### PR TITLE
ci: verify wasm e2e file limits

### DIFF
--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -73,10 +73,19 @@ jobs:
           image: mcr.microsoft.com/playwright:v1.59.1-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker/run
           # .tool_cache is required by pnpm
-          options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
+          options: >-
+            --ulimit nofile=1048576:1048576
+            -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
             export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
             export WASM=1
+            echo "nofile soft limit: $(ulimit -Sn)"
+            echo "nofile hard limit: $(ulimit -Hn)"
+            for key in max_user_instances max_user_watches max_queued_events; do
+              if [[ -r "/proc/sys/fs/inotify/$key" ]]; then
+                echo "fs.inotify.$key=$(cat "/proc/sys/fs/inotify/$key")"
+              fi
+            done
             pnpm run build:js
             pnpm run test:e2e-browser
   test:


### PR DESCRIPTION
## Summary

This is a verification PR for the flaky `Test WASM / E2E Testing` failure in https://github.com/web-infra-dev/rspack/actions/runs/25648532109/job/75282599056.

The failed job died before running the browser test because `npx rsbuild dev` could not create a chokidar watcher and threw `EMFILE: too many open files` while watching `tests/e2e-browser/rsbuild.config.ts`.

## Changes

- Raise the Docker `nofile` limit for the WASM browser E2E job with `--ulimit nofile=1048576:1048576`.
- Print `ulimit` and Linux inotify quota values inside the container before `pnpm run test:e2e-browser`.

## Validation intent

If the job passes, it supports the hypothesis that the flaky failure was caused by the container file descriptor limit. If it still fails with `EMFILE`, the printed `fs.inotify.*` values should help distinguish an inotify quota issue from a plain `nofile` limit issue.

## Local checks

- `git diff --check`