### PR TITLE
test: print benchmark compilation errors

### DIFF
--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -14,6 +14,8 @@ use rspack_error::Diagnostic;
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
 use rspack_tasks::{CURRENT_COMPILER_CONTEXT, within_compiler_context_for_testing_sync};
 
+use crate::groups::diagnostics::assert_no_compilation_errors;
+
 pub(crate) static NUM_MODULES: usize = 10000;
 
 pub(crate) async fn prepare_large_code_splitting_case(
@@ -191,7 +193,7 @@ pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
     compiler.compilation.exports_info_artifact = exports_info_artifact.into();
   });
 
-  assert!(compiler.compilation.get_errors().next().is_none());
+  assert_no_compilation_errors(&compiler.compilation, "build_chunk_graph benchmark setup");
   let compiler = RefCell::new(compiler);
 
   c.bench_function("rust@build_chunk_graph", |b| {
@@ -203,6 +205,7 @@ pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
       |_| {
         let mut compiler = compiler.borrow_mut();
         build_chunk_graph::build_chunk_graph(&mut compiler.compilation).unwrap();
+        assert_no_compilation_errors(&compiler.compilation, "build_chunk_graph benchmark pass");
         assert_eq!(
           compiler
             .compilation
@@ -276,10 +279,7 @@ pub fn build_module_graph_benchmark_inner(c: &mut Criterion) {
             .await
             .unwrap();
         });
-        assert!(
-          compiler.compilation.get_errors().next().is_none(),
-          "build_module_graph benchmark setup should not produce compilation errors"
-        );
+        assert_no_compilation_errors(&compiler.compilation, "build_module_graph benchmark setup");
       },
       |_| {
         let mut compiler = compiler.borrow_mut();
@@ -288,10 +288,7 @@ pub fn build_module_graph_benchmark_inner(c: &mut Criterion) {
             .await
             .unwrap();
         });
-        assert!(
-          compiler.compilation.get_errors().next().is_none(),
-          "build_module_graph benchmark pass should not produce compilation errors"
-        );
+        assert_no_compilation_errors(&compiler.compilation, "build_module_graph benchmark pass");
         assert_eq!(
           compiler.compilation.get_module_graph().modules_len(),
           NUM_MODULES + NUM_MODULES / 10

--- a/xtask/benchmark/benches/groups/bundle.rs
+++ b/xtask/benchmark/benches/groups/bundle.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use criterion::Criterion;
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
 
-use crate::groups::bundle::util::{CompilerBuilderGenerator, derive_projects};
+use crate::groups::{
+  bundle::util::{CompilerBuilderGenerator, derive_projects},
+  diagnostics::assert_no_compilation_errors,
+};
 
 pub mod basic_react;
 pub mod threejs;
@@ -33,9 +36,10 @@ pub(crate) fn bundle_benchmark_case(c: &mut Criterion, target_id: &str) {
         )
       },
       |(compiler_context, mut compiler)| {
+        let context = format!("bundle@{id} benchmark build");
         rt.block_on(within_compiler_context(compiler_context, async move {
           compiler.run().await.unwrap();
-          assert!(compiler.compilation.get_errors().next().is_none());
+          assert_no_compilation_errors(&compiler.compilation, &context);
         }))
       },
       criterion::BatchSize::PerIteration,

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -36,7 +36,9 @@ use rspack_plugin_split_chunks::{
 use rustc_hash::FxHashMap;
 use tokio::runtime::Runtime;
 
-use crate::groups::build_chunk_graph::prepare_large_code_splitting_case;
+use crate::groups::{
+  build_chunk_graph::prepare_large_code_splitting_case, diagnostics::assert_no_compilation_errors,
+};
 
 const GENERAL_STAGE_NUM_MODULES: usize = 3000;
 const CONCAT_GROUPS: usize = 160;
@@ -1841,13 +1843,6 @@ fn count_assigned_export_used_names(compilation: &Compilation) -> usize {
         .count()
     })
     .sum()
-}
-
-fn assert_no_compilation_errors(compilation: &Compilation, context: &str) {
-  assert!(
-    compilation.get_errors().next().is_none(),
-    "{context} should not produce compilation errors"
-  );
 }
 
 fn create_split_chunks_plugin() -> SplitChunksPlugin {

--- a/xtask/benchmark/benches/groups/diagnostics.rs
+++ b/xtask/benchmark/benches/groups/diagnostics.rs
@@ -1,0 +1,20 @@
+use rspack_core::Compilation;
+
+pub(crate) fn assert_no_compilation_errors(compilation: &Compilation, context: &str) {
+  let errors = compilation
+    .get_errors()
+    .map(|diagnostic| {
+      diagnostic
+        .render_report(false)
+        .unwrap_or_else(|render_error| {
+          format!("{diagnostic:#?}\nFailed to render compilation diagnostic: {render_error}")
+        })
+    })
+    .collect::<Vec<_>>();
+
+  assert!(
+    errors.is_empty(),
+    "{context} should not produce compilation errors:\n{}",
+    errors.join("\n\n")
+  );
+}

--- a/xtask/benchmark/benches/groups/mod.rs
+++ b/xtask/benchmark/benches/groups/mod.rs
@@ -1,6 +1,7 @@
 pub mod build_chunk_graph;
 pub mod bundle;
 pub mod compilation_stages;
+pub mod diagnostics;
 pub mod module_graph_api;
 pub mod persistent_cache;
 pub mod scan_dependencies;

--- a/xtask/benchmark/benches/groups/module_graph_api.rs
+++ b/xtask/benchmark/benches/groups/module_graph_api.rs
@@ -11,7 +11,10 @@ use rspack_core::{
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
 use rspack_tasks::within_compiler_context_for_testing_sync;
 
-use crate::groups::build_chunk_graph::{NUM_MODULES, prepare_large_code_splitting_case};
+use crate::groups::{
+  build_chunk_graph::{NUM_MODULES, prepare_large_code_splitting_case},
+  diagnostics::assert_no_compilation_errors,
+};
 
 pub fn module_graph_api_benchmark(c: &mut Criterion) {
   within_compiler_context_for_testing_sync(|| {
@@ -70,10 +73,7 @@ pub fn module_graph_api_benchmark_inner(c: &mut Criterion) {
       .unwrap();
   });
 
-  assert!(
-    compiler.compilation.get_errors().next().is_none(),
-    "module_graph_api benchmark setup should not produce compilation errors"
-  );
+  assert_no_compilation_errors(&compiler.compilation, "module_graph_api benchmark setup");
 
   let dependency_ids = {
     let module_graph = compiler.compilation.get_module_graph();

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -16,7 +16,7 @@ use rspack_core::{
 use rspack_fs::{NativeFileSystem, NoopFileSystem};
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
 
-use super::bundle::basic_react;
+use super::{bundle::basic_react, diagnostics::assert_no_compilation_errors};
 
 static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
 const BENCHCASE_NAME: &str = "basic-react";
@@ -180,6 +180,7 @@ async fn run_compiler(project_dir: &Path, cache_dir: &Path) {
 
   within_compiler_context(compiler_context, async move {
     compiler.run().await.unwrap();
+    assert_no_compilation_errors(&compiler.compilation, "persistent cache benchmark build");
     compiler.close().await.unwrap();
   })
   .await;


### PR DESCRIPTION
## Summary

- Add a shared benchmark assertion helper that renders compilation diagnostics when errors are present.
- Apply the check to bundle, build graph, module graph API, persistent cache, and compilation stage benchmarks.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).