### PR TITLE
fix(ci): avoid browser e2e watcher

### DIFF
--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -97,7 +97,7 @@ jobs:
           image: mcr.microsoft.com/playwright:v1.59.1-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker/run
           # .tool_cache is required by pnpm
-          options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
+          options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}} --ulimit nofile=1048576:1048576
           script: |
             print_fd_usage() {
               local label="$1"

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -73,11 +73,10 @@ jobs:
           image: mcr.microsoft.com/playwright:v1.59.1-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker/run
           # .tool_cache is required by pnpm
-          options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}} --ulimit nofile=1048576:1048576
+          options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
             export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
             export WASM=1
-            ulimit -Sn "$(ulimit -Hn)"
             pnpm run build:js
             pnpm run test:e2e-browser
   test:

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -22,6 +22,30 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Print fd usage at CI start
+        if: inputs.target == 'wasm32-wasip1-threads'
+        run: |
+          print_fd_usage() {
+            local label="$1"
+
+            echo "::group::fd usage (${label})"
+            echo "process fd soft limit: $(ulimit -Sn)"
+            echo "process fd hard limit: $(ulimit -Hn)"
+            if [[ -r /proc/sys/fs/file-max ]]; then
+              echo "system fd max: $(cat /proc/sys/fs/file-max)"
+            fi
+            if [[ -r /proc/sys/fs/file-nr ]]; then
+              read -r system_fd_allocated system_fd_unused system_fd_max < /proc/sys/fs/file-nr
+              echo "system fd allocated=${system_fd_allocated} unused=${system_fd_unused} max=${system_fd_max}"
+            fi
+            if [[ -d /proc/self/fd ]]; then
+              echo "current process fd count: $(find /proc/self/fd -mindepth 1 -maxdepth 1 2>/dev/null | wc -l)"
+            fi
+            echo "::endgroup::"
+          }
+
+          print_fd_usage "ci start"
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -75,10 +99,34 @@ jobs:
           # .tool_cache is required by pnpm
           options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
+            print_fd_usage() {
+              local label="$1"
+
+              echo "::group::fd usage (${label})"
+              echo "process fd soft limit: $(ulimit -Sn)"
+              echo "process fd hard limit: $(ulimit -Hn)"
+              if [[ -r /proc/sys/fs/file-max ]]; then
+                echo "system fd max: $(cat /proc/sys/fs/file-max)"
+              fi
+              if [[ -r /proc/sys/fs/file-nr ]]; then
+                read -r system_fd_allocated system_fd_unused system_fd_max < /proc/sys/fs/file-nr
+                echo "system fd allocated=${system_fd_allocated} unused=${system_fd_unused} max=${system_fd_max}"
+              fi
+              if [[ -d /proc/self/fd ]]; then
+                echo "current process fd count: $(find /proc/self/fd -mindepth 1 -maxdepth 1 2>/dev/null | wc -l)"
+              fi
+              echo "::endgroup::"
+            }
+
             export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
             export WASM=1
             pnpm run build:js
+            print_fd_usage "before e2e-browser-test"
+            set +e
             pnpm run test:e2e-browser
+            e2e_browser_status=$?
+            print_fd_usage "after e2e-browser-test"
+            exit "$e2e_browser_status"
   test:
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: 60

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -22,30 +22,6 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Print fd usage at CI start
-        if: inputs.target == 'wasm32-wasip1-threads'
-        run: |
-          print_fd_usage() {
-            local label="$1"
-
-            echo "::group::fd usage (${label})"
-            echo "process fd soft limit: $(ulimit -Sn)"
-            echo "process fd hard limit: $(ulimit -Hn)"
-            if [[ -r /proc/sys/fs/file-max ]]; then
-              echo "system fd max: $(cat /proc/sys/fs/file-max)"
-            fi
-            if [[ -r /proc/sys/fs/file-nr ]]; then
-              read -r system_fd_allocated system_fd_unused system_fd_max < /proc/sys/fs/file-nr
-              echo "system fd allocated=${system_fd_allocated} unused=${system_fd_unused} max=${system_fd_max}"
-            fi
-            if [[ -d /proc/self/fd ]]; then
-              echo "current process fd count: $(find /proc/self/fd -mindepth 1 -maxdepth 1 2>/dev/null | wc -l)"
-            fi
-            echo "::endgroup::"
-          }
-
-          print_fd_usage "ci start"
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -99,34 +75,11 @@ jobs:
           # .tool_cache is required by pnpm
           options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}} --ulimit nofile=1048576:1048576
           script: |
-            print_fd_usage() {
-              local label="$1"
-
-              echo "::group::fd usage (${label})"
-              echo "process fd soft limit: $(ulimit -Sn)"
-              echo "process fd hard limit: $(ulimit -Hn)"
-              if [[ -r /proc/sys/fs/file-max ]]; then
-                echo "system fd max: $(cat /proc/sys/fs/file-max)"
-              fi
-              if [[ -r /proc/sys/fs/file-nr ]]; then
-                read -r system_fd_allocated system_fd_unused system_fd_max < /proc/sys/fs/file-nr
-                echo "system fd allocated=${system_fd_allocated} unused=${system_fd_unused} max=${system_fd_max}"
-              fi
-              if [[ -d /proc/self/fd ]]; then
-                echo "current process fd count: $(find /proc/self/fd -mindepth 1 -maxdepth 1 2>/dev/null | wc -l)"
-              fi
-              echo "::endgroup::"
-            }
-
             export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
             export WASM=1
+            ulimit -Sn "$(ulimit -Hn)"
             pnpm run build:js
-            print_fd_usage "before e2e-browser-test"
-            set +e
             pnpm run test:e2e-browser
-            e2e_browser_status=$?
-            print_fd_usage "after e2e-browser-test"
-            exit "$e2e_browser_status"
   test:
     runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: 60

--- a/tests/e2e-browser/playwright.config.ts
+++ b/tests/e2e-browser/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     ...devices['Desktop Chrome'],
   },
   webServer: {
-    command: 'npx rsbuild dev',
+    command: 'npx rsbuild build && npx rsbuild preview --port 8900',
     port: 8900,
     reuseExistingServer: !process.env.CI,
     timeout: 60 * 1000,


### PR DESCRIPTION
## Summary

Avoid the flaky browser e2e `EMFILE` failure by no longer starting Rsbuild's watch-based dev server in the Playwright `webServer`.

The browser e2e only needs to serve the built page once, so it now runs `rsbuild build` followed by `rsbuild preview --port 8900`. This avoids Chokidar/native watcher setup during CI and removes the temporary fd/ulimit debug logging from the workflow.

Related failure: https://github.com/web-infra-dev/rspack/actions/runs/25654958179/job/75302142464?pr=13984

## Validation

- `git diff --check`
- Parsed `.github/workflows/reusable-build-test.yml` as YAML
- Checked the browser e2e workflow script with `bash -n` after substituting the GitHub expression
- CI validation is running on the latest pushed commit
