### PR TITLE
test: restore persistent cache CodSpeed profile grouping

### DIFF
--- a/xtask/benchmark/benches/benches.rs
+++ b/xtask/benchmark/benches/benches.rs
@@ -44,6 +44,5 @@ criterion_main!(
   stages::real_content_hash::stage,
   stages::create_concatenate_module::stage,
   stages::concatenate_module_code_generation::stage,
-  cases::persistent_cache_restore::case,
-  cases::persistent_cache_restore_after_single_file_change::case
+  groups::persistent_cache::persistent_cache
 );

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -8,7 +8,7 @@ use std::{
   },
 };
 
-use criterion::{BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, criterion_group};
 use rspack_core::{
   CacheOptions, Mode,
   cache::persistent::{PersistentCacheOptions, snapshot::SnapshotOptions, storage::StorageOptions},
@@ -32,35 +32,45 @@ const UPDATED_TEXT: &str = "Hello from cache";
 // This benchmark intentionally keeps setup light and does not perform extra
 // correctness validation of cache state. Functional/cache-correctness behavior
 // is covered by dedicated test cases elsewhere.
-pub fn persistent_cache_restore_benchmark(c: &mut Criterion) {
+pub fn persistent_cache_benchmark(c: &mut Criterion) {
+  let mut group = c.benchmark_group("persistent_cache");
+  let rt = rspack_benchmark::build_tokio_rt();
+  let pending_cleanup = RefCell::new(Vec::new());
+
   persistent_cache_benchmark_case(
-    c,
+    &mut group,
+    &rt,
+    &pending_cleanup,
     "rust@persistent_cache_restore@basic-react-development",
     |_| {},
   );
-}
 
-pub fn persistent_cache_restore_after_single_file_change_benchmark(c: &mut Criterion) {
   persistent_cache_benchmark_case(
-    c,
+    &mut group,
+    &rt,
+    &pending_cleanup,
     "rust@persistent_cache_restore_after_single_file_change@basic-react-development",
     |measured_case| {
       mutate_leaf_module(&measured_case.project_dir);
     },
   );
+
+  group.finish();
+
+  cleanup_pending_workspaces(&pending_cleanup);
 }
 
+criterion_group!(persistent_cache, persistent_cache_benchmark);
+
 fn persistent_cache_benchmark_case<F>(
-  c: &mut Criterion,
+  group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+  rt: &tokio::runtime::Runtime,
+  pending_cleanup: &RefCell<Vec<PathBuf>>,
   benchmark_id: &str,
   prepare_restore_case: F,
 ) where
   F: Fn(&PreparedCase),
 {
-  let mut group = c.benchmark_group("persistent_cache");
-  let rt = rspack_benchmark::build_tokio_rt();
-  let pending_cleanup = RefCell::new(Vec::new());
-
   group.bench_function(benchmark_id, |b| {
     b.iter_batched(
       || {
@@ -87,10 +97,6 @@ fn persistent_cache_benchmark_case<F>(
       BatchSize::PerIteration,
     );
   });
-
-  group.finish();
-
-  cleanup_pending_workspaces(&pending_cleanup);
 }
 
 struct PreparedCase {

--- a/xtask/benchmark/cases/mod.rs
+++ b/xtask/benchmark/cases/mod.rs
@@ -18,6 +18,4 @@ pub mod bundle_basic_react_production_sourcemap;
 pub mod bundle_threejs_development;
 pub mod bundle_threejs_production_sourcemap;
 pub mod module_graph_api;
-pub mod persistent_cache_restore;
-pub mod persistent_cache_restore_after_single_file_change;
 pub mod scan_dependencies;

--- a/xtask/benchmark/cases/persistent_cache_restore.rs
+++ b/xtask/benchmark/cases/persistent_cache_restore.rs
@@ -1,3 +1,0 @@
-case_entry!(|c| {
-  crate::groups::persistent_cache::persistent_cache_restore_benchmark(c);
-});

--- a/xtask/benchmark/cases/persistent_cache_restore_after_single_file_change.rs
+++ b/xtask/benchmark/cases/persistent_cache_restore_after_single_file_change.rs
@@ -1,3 +1,0 @@
-case_entry!(|c| {
-  crate::groups::persistent_cache::persistent_cache_restore_after_single_file_change_benchmark(c);
-});


### PR DESCRIPTION
## Summary

- Restore persistent cache restore benchmarks to the original `groups/persistent_cache.rs::persistent_cache::persistent_cache_benchmark` Criterion group.
- Keep the split case entrypoints for the other benchmarks, but remove the persistent cache case wrappers so CodSpeed profile data is attached to the original restore benchmark entrypoint.
- This targets the #13971 CodSpeed profile display regression where the new persistent cache restore entries no longer show the full build-stage callgraph even though the raw callgrind profile part still contains those frames.

## Related links

- Regression from https://github.com/web-infra-dev/rspack/pull/13971

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).