### PR TITLE
perf: optimize Atom hash collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5242,6 +5242,7 @@ version = "0.100.2"
 dependencies = [
  "insta",
  "rspack_javascript_compiler",
+ "rspack_util",
  "rustc-hash",
  "swc_core",
 ]
@@ -5323,6 +5324,7 @@ dependencies = [
  "swc_core",
  "swc_plugin_runner",
  "unicase",
+ "ustr-fxhash",
  "wasi-common",
  "wasmtime",
 ]

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -9,7 +9,7 @@ use anymap::CloneAny;
 use rspack_collections::IdentifierMap;
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
 use rspack_sources::BoxSource;
-use rspack_util::atom::Atom;
+use rspack_util::atom::AtomHashSet;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use serde::Serialize;
 
@@ -80,15 +80,15 @@ impl CodeGenerationDataAssetInfo {
 
 #[derive(Clone, Debug)]
 pub struct CodeGenerationDataTopLevelDeclarations {
-  inner: FxHashSet<Atom>,
+  inner: AtomHashSet,
 }
 
 impl CodeGenerationDataTopLevelDeclarations {
-  pub fn new(inner: FxHashSet<Atom>) -> Self {
+  pub fn new(inner: AtomHashSet) -> Self {
     Self { inner }
   }
 
-  pub fn inner(&self) -> &FxHashSet<Atom> {
+  pub fn inner(&self) -> &AtomHashSet {
     &self.inner
   }
 }

--- a/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_graph_cache_artifact.rs
@@ -10,8 +10,8 @@ use get_exports_type::*;
 use get_mode::*;
 use get_side_effects_connection_state::*;
 use module_graph_hash::*;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use swc_core::atoms::Atom;
+use rspack_util::atom::{Atom, AtomHashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   ConcatenationEntry, ConnectionState, DependencyId, ExportInfo, ExportsType, ModuleIdentifier,
@@ -388,7 +388,7 @@ pub struct ExportModeUnused {
 
 #[derive(Debug, Clone)]
 pub struct ExportModeEmptyStar {
-  pub hidden: Option<HashSet<Atom>>,
+  pub hidden: Option<AtomHashSet>,
 }
 
 #[derive(Debug, Clone)]
@@ -427,14 +427,14 @@ pub struct ExportModeNormalReexport {
 
 #[derive(Debug, Clone)]
 pub struct ExportModeDynamicReexport {
-  pub ignored: HashSet<Atom>,
-  pub hidden: Option<HashSet<Atom>>,
+  pub ignored: AtomHashSet,
+  pub hidden: Option<AtomHashSet>,
 }
 
 #[derive(Debug, Default)]
 pub struct StarReexportsInfo {
-  pub exports: Option<HashSet<Atom>>,
-  pub checked: Option<HashSet<Atom>>,
-  pub ignored_exports: HashSet<Atom>,
-  pub hidden: Option<HashSet<Atom>>,
+  pub exports: Option<AtomHashSet>,
+  pub checked: Option<AtomHashSet>,
+  pub ignored_exports: AtomHashSet,
+  pub hidden: Option<AtomHashSet>,
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/lazy_barrel_artifact.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/lazy_barrel_artifact.rs
@@ -3,8 +3,8 @@ use rspack_cacheable::{
   with::{AsMap, AsPreset, AsVec},
 };
 use rspack_collections::IdentifierMap;
-use rspack_util::atom::Atom;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rspack_util::atom::{Atom, AtomHashMap, AtomHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::{BoxDependency, DependencyId, ModuleIdentifier};
 
@@ -18,16 +18,16 @@ pub enum ForwardId {
 #[derive(Debug)]
 pub enum ForwardedIdSet {
   All,
-  IdSet(FxHashSet<Atom>),
+  IdSet(AtomHashSet),
 }
 
 impl ForwardedIdSet {
   pub fn empty() -> Self {
-    Self::IdSet(FxHashSet::default())
+    Self::IdSet(AtomHashSet::default())
   }
 
   pub fn from_dependencies(dependencies: &[BoxDependency]) -> Self {
-    let mut set = FxHashSet::default();
+    let mut set = AtomHashSet::default();
     for dep in dependencies {
       match dep.forward_id() {
         ForwardId::All => return Self::All,
@@ -87,11 +87,11 @@ pub enum LazyUntil {
 #[derive(Debug, Default)]
 pub struct LazyDependencies {
   #[cacheable(with=AsMap<AsPreset, AsPreset>)]
-  forward_id_to_request: FxHashMap<Atom, Atom>,
+  forward_id_to_request: AtomHashMap<Atom>,
   #[cacheable(with=AsMap<AsPreset>)]
-  request_to_dependencies: FxHashMap<Atom, FxHashSet<DependencyId>>,
+  request_to_dependencies: AtomHashMap<FxHashSet<DependencyId>>,
   #[cacheable(with=AsVec<AsPreset>)]
-  terminal_forward_ids: FxHashSet<Atom>,
+  terminal_forward_ids: AtomHashSet,
   fallback_dependencies: FxHashSet<DependencyId>,
 }
 

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -21,15 +21,15 @@ use rspack_sources::{
 };
 use rspack_util::{
   SpanExt,
+  atom::{Atom, AtomHashMap, AtomHashSet, AtomIndexMap, AtomIndexSet},
   ext::DynHash,
-  fx_hash::{FxIndexMap, FxIndexSet},
+  fx_hash::FxIndexMap,
   itoa, json_stringify, json_stringify_str,
   source_map::SourceMapKind,
   swc::join_atom,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::{
-  atoms::Atom,
   common::{Spanned, SyntaxContext, comments::SingleThreadedComments},
   ecma::visit::swc_ecma_ast,
 };
@@ -63,7 +63,7 @@ use crate::{
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
 define_hook!(ConcatenatedModuleExportsDefinitions: SeriesBail(exports_definitions: &mut ExportsDefinitionArgs, is_entry_module: bool) -> bool);
-define_hook!(ConcatenatedModuleConcatenatedInfo: Series(compilation: &Compilation, module: ModuleIdentifier, runtime: Option<&RuntimeSpec>, info: &mut ConcatenatedModuleInfo, all_used_names: &mut HashSet<Atom>));
+define_hook!(ConcatenatedModuleConcatenatedInfo: Series(compilation: &Compilation, module: ModuleIdentifier, runtime: Option<&RuntimeSpec>, info: &mut ConcatenatedModuleInfo, all_used_names: &mut AtomHashSet));
 
 #[derive(Debug, Default)]
 pub struct ConcatenatedModuleHooks {
@@ -149,13 +149,13 @@ static REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
 #[derive(Default)]
 struct NameAllocator {
-  used_names: HashSet<Atom>,
+  used_names: AtomHashSet,
   used_strings: HashSet<String>,
-  suffix_counters: HashMap<Atom, u32>,
+  suffix_counters: AtomHashMap<u32>,
 }
 
 impl NameAllocator {
-  fn new(used_names: HashSet<Atom>) -> Self {
+  fn new(used_names: AtomHashSet) -> Self {
     let mut used_strings: HashSet<String> = HashSet::default();
     used_strings.reserve(used_names.len());
     for name in &used_names {
@@ -165,7 +165,7 @@ impl NameAllocator {
     Self {
       used_names,
       used_strings,
-      suffix_counters: HashMap::default(),
+      suffix_counters: AtomHashMap::default(),
     }
   }
 
@@ -280,7 +280,7 @@ impl ConcatenationEntryExternal {
 
 #[derive(Clone, Debug, Default)]
 pub struct ConcatenatedImportMapItem {
-  pub specifiers: HashSet<Atom>,
+  pub specifiers: AtomHashSet,
   pub namespace: Option<Atom>,
 }
 
@@ -299,9 +299,9 @@ pub struct ConcatenatedModuleInfo {
   pub has_ast: bool,
   pub source: Option<ReplaceSource>,
   pub internal_source: Option<Arc<dyn Source>>,
-  pub internal_names: HashMap<Atom, Atom>,
-  pub export_map: Option<HashMap<Atom, String>>,
-  pub raw_export_map: Option<HashMap<Atom, String>>,
+  pub internal_names: AtomHashMap<Atom>,
+  pub export_map: Option<AtomHashMap<String>>,
+  pub raw_export_map: Option<AtomHashMap<String>>,
   pub import_map: ConcatenatedImportMap,
   pub namespace_object_name: Option<Atom>,
   pub interop_namespace_object_used: bool,
@@ -312,7 +312,7 @@ pub struct ConcatenatedModuleInfo {
   pub interop_default_access_name: Option<Atom>,
   pub global_scope_ident: Vec<ConcatenatedModuleIdent>,
   pub idents: Vec<ConcatenatedModuleIdent>,
-  pub all_used_names: HashSet<Atom>,
+  pub all_used_names: AtomHashSet,
   pub binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>>,
 
   pub public_path_auto_replacement: Option<bool>,
@@ -997,7 +997,7 @@ impl Module for ConcatenatedModule {
     // Generate source code and analyze scopes
     // Prepare a ReplaceSource for the final source
     //
-    let mut all_used_names: HashSet<Atom> = RESERVED_NAMES.iter().map(|s| Atom::new(*s)).collect();
+    let mut all_used_names: AtomHashSet = RESERVED_NAMES.iter().map(|s| Atom::new(*s)).collect();
 
     let arc_map = Arc::new(module_to_info_map);
 
@@ -1037,7 +1037,7 @@ impl Module for ConcatenatedModule {
       module_to_info_map.insert(id, module_info);
     }
 
-    let mut top_level_declarations: HashSet<Atom> = HashSet::default();
+    let mut top_level_declarations = AtomHashSet::default();
     let mut public_path_auto_replace: bool = false;
     let mut static_url_replace: bool = false;
 
@@ -1521,9 +1521,9 @@ impl Module for ConcatenatedModule {
     // Move it off the critical path once all replacements are applied.
     fast_set(&mut changes, Vec::new());
 
-    let mut exports_map: FxIndexMap<Atom, String> = FxIndexMap::default();
-    let mut unused_exports: FxIndexSet<Atom> = FxIndexSet::default();
-    let mut inlined_exports: FxIndexSet<Atom> = FxIndexSet::default();
+    let mut exports_map = AtomIndexMap::<String>::default();
+    let mut unused_exports = AtomIndexSet::default();
+    let mut inlined_exports = AtomIndexSet::default();
 
     let root_info = module_to_info_map
       .get(&self.root_module_ctxt.id)
@@ -2603,7 +2603,7 @@ impl ConcatenatedModule {
       module_info.global_ctxt = semantic.unresolved_scope_id().to_ctxt();
 
       let top_level_scope_id = semantic.top_level_scope_id();
-      let mut all_used_names = HashSet::default();
+      let mut all_used_names = AtomHashSet::default();
       all_used_names.reserve(ids.len());
       module_info.idents.reserve(ids.len());
       module_info.global_scope_ident.reserve(ids.len());
@@ -3305,7 +3305,7 @@ pub fn is_esm_dep_like(dep: &BoxDependency) -> bool {
   )
 }
 
-pub fn find_new_name(old_name: &str, used_names: &HashSet<Atom>, extra_info: &[Atom]) -> Atom {
+pub fn find_new_name(old_name: &str, used_names: &AtomHashSet, extra_info: &[Atom]) -> Atom {
   let mut name = old_name.to_string();
 
   for info_part in extra_info {

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -35,13 +35,13 @@ use rspack_cacheable::{
   cacheable,
   with::{AsPreset, AsVec},
 };
+use rspack_util::atom::{Atom, AtomHashSet};
 pub use runtime_requirements_dependency::{
   RuntimeRequirementsDependency, RuntimeRequirementsDependencyTemplate,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 pub use static_exports_dependency::{StaticExportsDependency, StaticExportsSpec};
-use swc_core::ecma::atoms::Atom;
 
 use crate::{
   ConnectionState, EvaluatedInlinableValue, ExportsInfoArtifact, ExportsType,
@@ -114,8 +114,8 @@ pub struct ExportsSpec {
   pub terminal_binding: Option<bool>,
   pub from: Option<ModuleGraphConnection>,
   pub dependencies: Option<Vec<ModuleIdentifier>>,
-  pub hide_export: Option<FxHashSet<Atom>>,
-  pub exclude_exports: Option<FxHashSet<Atom>>,
+  pub hide_export: Option<AtomHashSet>,
+  pub exclude_exports: Option<AtomHashSet>,
 }
 
 impl ExportsSpec {

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -1,5 +1,4 @@
-use rspack_util::atom::Atom;
-use rustc_hash::FxHashSet;
+use rspack_util::atom::{Atom, AtomHashSet};
 
 use crate::{
   CanInlineUse, DependencyId, ExportInfo, ExportInfoData, ExportProvided, ExportsInfoData,
@@ -43,7 +42,7 @@ impl ExportsInfoData {
   pub fn set_unknown_exports_provided(
     &mut self,
     can_mangle: bool,
-    exclude_exports: Option<&FxHashSet<Atom>>,
+    exclude_exports: Option<&AtomHashSet>,
     target_key: Option<DependencyId>,
     target_module: Option<DependencyId>,
     priority: Option<u8>,

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -5,8 +5,10 @@ use rspack_cacheable::{
   cacheable,
   with::{AsPreset, AsVec},
 };
-use rspack_util::{atom::Atom, json_stringify, ryu_js};
-use rustc_hash::FxHashSet as HashSet;
+use rspack_util::{
+  atom::{Atom, AtomHashSet},
+  json_stringify, ryu_js,
+};
 
 use crate::{DependencyId, property_access};
 
@@ -199,7 +201,7 @@ pub struct UsedByExports {
 }
 
 impl UsedByExports {
-  pub fn set(exports: HashSet<Atom>) -> Self {
+  pub fn set(exports: AtomHashSet) -> Self {
     Self {
       condition: UsedByExportsCondition::Set(exports),
       deferred_pure_checks: Vec::new(),
@@ -225,7 +227,7 @@ impl UsedByExports {
 #[cacheable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UsedByExportsCondition {
-  Set(#[cacheable(with=AsVec<AsPreset>)] HashSet<Atom>),
+  Set(#[cacheable(with=AsVec<AsPreset>)] AtomHashSet),
   Bool(bool),
 }
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -6,7 +6,7 @@ use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
 use rspack_util::{ext::DynHash, json_stringify_str, source_map::SourceMapKind};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet};
+use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::{
@@ -460,7 +460,7 @@ impl ExternalModule {
       user_request,
       factory_meta: None,
       build_info: BuildInfo {
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: Some(Default::default()),
         strict: true,
         ..Default::default()
       },

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -19,7 +19,7 @@ use rspack_hash::RspackHashDigest;
 use rspack_paths::ArcPathSet;
 use rspack_sources::BoxSource;
 use rspack_util::{
-  atom::Atom,
+  atom::{Atom, AtomHashSet, AtomIndexMap},
   ext::{AsAny, DynHash},
   fx_hash::{FxIndexMap, FxIndexSet},
   source_map::ModuleSourceMapConfig,
@@ -88,7 +88,7 @@ pub struct RscMeta {
   pub is_cjs: bool,
 
   #[cacheable(with=AsMap<AsPreset, AsPreset>)]
-  pub action_ids: FxIndexMap<Atom, Atom>,
+  pub action_ids: AtomIndexMap<Atom>,
 }
 
 #[cacheable]
@@ -150,7 +150,7 @@ pub struct BuildInfo {
   pub build_dependencies: ArcPathSet,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]
-  pub esm_named_exports: HashSet<Atom>,
+  pub esm_named_exports: AtomHashSet,
   pub all_star_exports: Vec<DependencyId>,
   pub need_create_require: bool,
   #[cacheable(with=AsOption<AsPreset>)]
@@ -160,9 +160,9 @@ pub struct BuildInfo {
   pub css_exports: Option<CssExports>,
   pub css_local_names: Option<HashMap<String, String>>,
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  pub side_effects_free: Option<HashSet<Atom>>,
+  pub side_effects_free: Option<AtomHashSet>,
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
-  pub top_level_declarations: Option<HashSet<Atom>>,
+  pub top_level_declarations: Option<AtomHashSet>,
   pub module_concatenation_bailout: Option<String>,
   pub assets: BindingCell<HashMap<String, CompilationAsset>>,
   pub module: bool,
@@ -191,7 +191,7 @@ impl Default for BuildInfo {
       missing_dependencies: ArcPathSet::default(),
       build_dependencies: ArcPathSet::default(),
       value_dependencies: HashMap::default(),
-      esm_named_exports: HashSet::default(),
+      esm_named_exports: AtomHashSet::default(),
       all_star_exports: Vec::default(),
       need_create_require: false,
       json_data: None,

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -9,9 +9,11 @@ use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_hash::RspackHashDigest;
 use rspack_loader_runner::{AdditionalData, ParseMeta, ResourceData};
 use rspack_sources::BoxSource;
-use rspack_util::{ext::AsAny, source_map::SourceMapKind};
-use rustc_hash::{FxHashMap, FxHashSet};
-use swc_core::atoms::Atom;
+use rspack_util::{
+  atom::{AtomHashMap, AtomHashSet},
+  ext::AsAny,
+  source_map::SourceMapKind,
+};
 
 use crate::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BoxLoader, BoxModuleDependency,
@@ -48,9 +50,9 @@ pub struct ParseContext<'a> {
 #[derive(Debug, Default, Clone)]
 pub struct CollectedTypeScriptInfo {
   #[cacheable(with=AsVec<AsPreset>)]
-  pub type_exports: FxHashSet<Atom>,
+  pub type_exports: AtomHashSet,
   #[cacheable(with=AsMap<AsPreset>)]
-  pub exported_enums: FxHashMap<Atom, TSEnumValue>,
+  pub exported_enums: AtomHashMap<TSEnumValue>,
 }
 
 pub const COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY: &str = "rspack-collected-ts-info";
@@ -58,17 +60,17 @@ pub const COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY: &str = "rspack-collected-ts-
 #[cacheable]
 #[derive(Debug, Default, Clone)]
 pub struct TSEnumValue(
-  #[cacheable(with=AsMap<AsPreset>)] FxHashMap<Atom, Option<EvaluatedInlinableValue>>,
+  #[cacheable(with=AsMap<AsPreset>)] AtomHashMap<Option<EvaluatedInlinableValue>>,
 );
 
 impl TSEnumValue {
-  pub fn new(value: FxHashMap<Atom, Option<EvaluatedInlinableValue>>) -> Self {
+  pub fn new(value: AtomHashMap<Option<EvaluatedInlinableValue>>) -> Self {
     Self(value)
   }
 }
 
 impl Deref for TSEnumValue {
-  type Target = FxHashMap<Atom, Option<EvaluatedInlinableValue>>;
+  type Target = AtomHashMap<Option<EvaluatedInlinableValue>>;
 
   fn deref(&self) -> &Self::Target {
     &self.0

--- a/crates/rspack_loader_swc/src/collect_ts_info.rs
+++ b/crates/rspack_loader_swc/src/collect_ts_info.rs
@@ -2,8 +2,9 @@ use rspack_core::{CollectedTypeScriptInfo, EvaluatedInlinableValue, TSEnumValue}
 use rspack_swc_plugin_ts_collector::{
   EnumMemberValue, ExportedEnumCollector, TypeExportsCollector,
 };
+use rspack_util::atom::AtomHashMap;
 use rustc_hash::FxHashMap;
-use swc::atoms::{Atom, Wtf8Atom};
+use swc::atoms::Wtf8Atom;
 use swc_core::{
   common::SyntaxContext,
   ecma::{ast::Program, visit::VisitWith},
@@ -20,8 +21,7 @@ pub fn collect_typescript_info(
   if options.type_exports.unwrap_or_default() {
     program.visit_with(&mut TypeExportsCollector::new(&mut type_exports));
   }
-  let mut exported_enums: FxHashMap<Atom, FxHashMap<Wtf8Atom, EnumMemberValue>> =
-    Default::default();
+  let mut exported_enums: AtomHashMap<FxHashMap<Wtf8Atom, EnumMemberValue>> = Default::default();
   if let Some(kind) = &options.exported_enum {
     program.visit_with(&mut ExportedEnumCollector::new(
       matches!(kind, CollectingEnumKind::ConstOnly),

--- a/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
@@ -10,7 +10,7 @@ use std::{
 
 use indoc::formatdoc;
 use rspack_core::{RscMeta, RscModuleType};
-use rspack_util::fx_hash::FxIndexMap;
+use rspack_util::{atom::AtomIndexMap, fx_hash::FxIndexMap};
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -767,7 +767,7 @@ impl<'a, C: Comments> ServerActions<'a, C> {
     let action_ids = export_names_ordered_by_reference_id
       .iter()
       .map(|(ref_id, export_name)| ((**ref_id).clone(), export_name.atom().into_owned()))
-      .collect::<FxIndexMap<_, _>>();
+      .collect::<AtomIndexMap<_>>();
 
     let mut rsc_meta = self.rsc_meta.borrow_mut();
     match rsc_meta.as_mut() {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -21,7 +21,7 @@ pub use rspack_core::{CssExport, CssExports};
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, Severity, TWithDiagnosticArray};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::{
-  atom::Atom,
+  atom::{Atom, AtomHashSet},
   ext::DynHash,
   fx_hash::{FxIndexMap, FxIndexSet},
 };
@@ -789,7 +789,7 @@ fn get_unused_local_ident(
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> CodeGenerationDataUnusedLocalIdent {
   let exports_names = exports.iter().fold(
-    FxHashMap::<&str, FxHashSet<Atom>>::default(),
+    FxHashMap::<&str, AtomHashSet>::default(),
     |mut map, (name, css_exports)| {
       css_exports.iter().for_each(|css_export| {
         if let Some(set) = map.get_mut(css_export.orig_name.as_str()) {
@@ -797,7 +797,7 @@ fn get_unused_local_ident(
         } else {
           map.insert(
             &css_export.orig_name,
-            FxHashSet::from_iter([Atom::from(name.clone())]),
+            AtomHashSet::from_iter([Atom::from(name.clone())]),
           );
         }
       });

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -6,8 +6,10 @@ use rspack_core::{
   ModuleIdentifier, RuntimeCodeTemplate, RuntimeGlobals, find_new_name,
   rspack_sources::{ConcatSource, RawStringSource},
 };
-use rspack_util::fx_hash::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
-use swc_core::atoms::Atom;
+use rspack_util::{
+  atom::{Atom, AtomHashMap, AtomHashSet, AtomIndexMap, AtomIndexSet},
+  fx_hash::{FxHashMap, FxIndexMap, FxIndexSet},
+};
 
 #[derive(Debug, Clone)]
 pub enum Ref {
@@ -71,14 +73,14 @@ pub struct ExternalInterop {
   pub default_exported: Option<Atom>,
   pub namespace_object: Option<Atom>,
   pub namespace_object2: Option<Atom>,
-  pub property_access: FxIndexMap<Atom, Atom>,
+  pub property_access: AtomIndexMap<Atom>,
 }
 
 fn get_or_create_interop_name(
   required_symbol: &mut Option<Atom>,
   field: &mut Option<Atom>,
   suffix: &str,
-  used_names: &mut FxHashSet<Atom>,
+  used_names: &mut AtomHashSet,
 ) -> Atom {
   if required_symbol.is_none() {
     let new_name = find_new_name("", used_names, &[]);
@@ -102,7 +104,7 @@ fn get_or_create_interop_name(
 }
 
 impl ExternalInterop {
-  pub fn namespace(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn namespace(&mut self, used_names: &mut AtomHashSet) -> Atom {
     get_or_create_interop_name(
       &mut self.required_symbol,
       &mut self.namespace_object,
@@ -111,7 +113,7 @@ impl ExternalInterop {
     )
   }
 
-  pub fn namespace2(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn namespace2(&mut self, used_names: &mut AtomHashSet) -> Atom {
     get_or_create_interop_name(
       &mut self.required_symbol,
       &mut self.namespace_object2,
@@ -120,7 +122,7 @@ impl ExternalInterop {
     )
   }
 
-  pub fn default_access(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn default_access(&mut self, used_names: &mut AtomHashSet) -> Atom {
     get_or_create_interop_name(
       &mut self.required_symbol,
       &mut self.default_access,
@@ -129,7 +131,7 @@ impl ExternalInterop {
     )
   }
 
-  pub fn default_exported(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn default_exported(&mut self, used_names: &mut AtomHashSet) -> Atom {
     if self.required_symbol.is_none() {
       let new_name = find_new_name("", used_names, &[]);
       used_names.insert(new_name.clone());
@@ -147,7 +149,7 @@ impl ExternalInterop {
     default_exported_symbol
   }
 
-  pub fn property_access(&mut self, atom: &Atom, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn property_access(&mut self, atom: &Atom, used_names: &mut AtomHashSet) -> Atom {
     self.property_access.get(atom).cloned().unwrap_or_else(|| {
       let local_name = find_new_name(atom, used_names, &[]);
       used_names.insert(local_name.clone());
@@ -259,28 +261,28 @@ pub struct ChunkLinkContext {
   specifier order doesn't matter, we can sort them based on name
   Map<module_id, Map<local_name, export_name>>
   */
-  exports: FxHashMap<Atom, FxIndexSet<Atom>>,
+  exports: AtomHashMap<AtomIndexSet>,
 
   /**
   symbols that this chunk provides
   */
-  pub exported_symbols: FxHashSet<Atom>,
+  pub exported_symbols: AtomHashSet,
 
   /**
   exports that need to be re-exported
   Map<chunk, Map<local_name, export_name>>
   */
-  re_exports: FxIndexMap<ReExportFrom, FxHashMap<Atom, FxHashSet<Atom>>>,
+  re_exports: FxIndexMap<ReExportFrom, AtomHashMap<AtomHashSet>>,
 
   /**
    * re exports in raw form, used for rendering export * from 'module'
    */
-  pub raw_star_exports: FxIndexMap<String, FxIndexSet<Atom>>,
+  pub raw_star_exports: FxIndexMap<String, AtomIndexSet>,
 
   /**
   import order matters, it affects execution order
   */
-  pub imports: IdentifierIndexMap<FxHashMap<Atom, Atom>>,
+  pub imports: IdentifierIndexMap<AtomHashMap<Atom>>,
 
   /**
   raw import statements
@@ -328,7 +330,7 @@ pub struct ChunkLinkContext {
   /**
   all used symbols in current chunk
   */
-  pub used_names: FxHashSet<Atom>,
+  pub used_names: AtomHashSet,
 
   /**
   whether `__webpack_require__` is exported by a runtime module instead of chunk exports
@@ -366,21 +368,19 @@ impl ChunkLinkContext {
     }
   }
 
-  pub fn exports(&self) -> &FxHashMap<Atom, FxIndexSet<Atom>> {
+  pub fn exports(&self) -> &AtomHashMap<AtomIndexSet> {
     &self.exports
   }
 
-  pub fn exports_mut(&mut self) -> &mut FxHashMap<Atom, FxIndexSet<Atom>> {
+  pub fn exports_mut(&mut self) -> &mut AtomHashMap<AtomIndexSet> {
     &mut self.exports
   }
 
-  pub fn re_exports(&self) -> &FxIndexMap<ReExportFrom, FxHashMap<Atom, FxHashSet<Atom>>> {
+  pub fn re_exports(&self) -> &FxIndexMap<ReExportFrom, AtomHashMap<AtomHashSet>> {
     &self.re_exports
   }
 
-  pub fn re_exports_mut(
-    &mut self,
-  ) -> &mut FxIndexMap<ReExportFrom, FxHashMap<Atom, FxHashSet<Atom>>> {
+  pub fn re_exports_mut(&mut self) -> &mut FxIndexMap<ReExportFrom, AtomHashMap<AtomHashSet>> {
     &mut self.re_exports
   }
 }

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -25,7 +25,7 @@ use rspack_plugin_javascript::{
 use rspack_plugin_runtime::should_export_webpack_require_for_module_chunk_loading;
 use rspack_util::{
   SpanExt,
-  atom::Atom,
+  atom::{Atom, AtomHashMap, AtomHashSet, AtomIndexSet},
   fx_hash::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet},
 };
 use swc_core::common::{SyntaxContext, comments::SingleThreadedComments};
@@ -61,9 +61,9 @@ impl<V> GetMut<ModuleIdentifier, V> for IdentifierIndexMap<V> {
 static START_EXPORTS: LazyLock<Atom> = LazyLock::new(|| "*".into());
 #[derive(Default, Debug)]
 pub(crate) struct ExportsContext {
-  exports: FxHashMap<Atom, FxIndexSet<Atom>>,
-  exported_symbols: FxHashSet<Atom>,
-  re_exports: FxIndexMap<ReExportFrom, FxHashMap<Atom, FxHashSet<Atom>>>,
+  exports: AtomHashMap<AtomIndexSet>,
+  exported_symbols: AtomHashSet,
+  re_exports: FxIndexMap<ReExportFrom, AtomHashMap<AtomHashSet>>,
 }
 
 enum ExternalImportBinding {
@@ -171,7 +171,7 @@ impl EsmLibraryPlugin {
   #[cfg(test)]
   fn reserve_module_external_namespace_import_locals(
     init_fragments: &ChunkInitFragments,
-    used_names: &mut FxHashSet<Atom>,
+    used_names: &mut AtomHashSet,
     namespace_imports: Option<&mut FxHashMap<RawImportSource, Atom>>,
   ) {
     Self::reserve_module_external_namespace_import_locals_in_render_order(
@@ -193,7 +193,7 @@ impl EsmLibraryPlugin {
 
   fn reserve_module_external_namespace_import_locals_in_render_order<'a>(
     init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
-    used_names: &mut FxHashSet<Atom>,
+    used_names: &mut AtomHashSet,
     namespace_imports: Option<&mut FxHashMap<RawImportSource, Atom>>,
   ) {
     let mut namespace_imports = namespace_imports;
@@ -215,14 +215,14 @@ impl EsmLibraryPlugin {
   #[cfg(test)]
   fn reserve_module_external_top_level_decls(
     init_fragments: &ChunkInitFragments,
-    used_names: &mut FxHashSet<Atom>,
+    used_names: &mut AtomHashSet,
   ) {
     Self::reserve_module_external_top_level_decls_in_render_order([init_fragments], used_names);
   }
 
   fn reserve_module_external_top_level_decls_in_render_order<'a>(
     init_fragment_groups: impl IntoIterator<Item = &'a ChunkInitFragments>,
-    used_names: &mut FxHashSet<Atom>,
+    used_names: &mut AtomHashSet,
   ) {
     for init_fragment in
       Self::collect_module_external_fragments_in_render_order(init_fragment_groups)
@@ -233,7 +233,7 @@ impl EsmLibraryPlugin {
 
   fn assign_external_candidate_name(
     readable_identifier: &str,
-    candidate_used_names: &mut FxHashSet<Atom>,
+    candidate_used_names: &mut AtomHashSet,
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
   ) -> Atom {
     let name = find_new_name(
@@ -573,7 +573,7 @@ impl EsmLibraryPlugin {
         },
       );
     let mut escaped_names =
-      FxHashMap::with_capacity_and_hasher(escaped_name_entries.len(), Default::default());
+      AtomHashMap::with_capacity_and_hasher(escaped_name_entries.len(), Default::default());
     for (name, escaped_name) in escaped_name_entries {
       escaped_names.insert(name, escaped_name);
     }
@@ -945,14 +945,14 @@ var {} = {{}};
     concate_modules_map: &mut IdentifierIndexMap<ModuleInfo>,
     external_module_init_fragments: &IdentifierMap<ChunkInitFragments>,
     chunk_link: &mut ChunkLinkContext,
-    escaped_names: &FxHashMap<Atom, Atom>,
+    escaped_names: &AtomHashMap<Atom>,
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
   ) {
     let context = &compilation.options.context;
 
     let module_graph = compilation.get_module_graph();
 
-    let mut all_used_names: FxHashSet<Atom> = RESERVED_NAMES
+    let mut all_used_names: AtomHashSet = RESERVED_NAMES
       .iter()
       .map(|s| Atom::new(*s))
       .chain(chunk_link.hoisted_modules.iter().flat_map(|m| {
@@ -1038,7 +1038,7 @@ var {} = {{}};
         get_cached_readable_identifier(id, module_graph, &compilation.module_static_cache, context);
 
       if let ModuleInfo::Concatenated(concate_info) = info {
-        let mut internal_names = FxHashMap::default();
+        let mut internal_names = AtomHashMap::default();
 
         // registered import map
         if let Some(import_map) = &concate_info.import_map {
@@ -1559,7 +1559,7 @@ var {} = {{}};
                 concate_info.global_ctxt = semantic.unresolved_scope_id().to_ctxt();
 
                 let top_level_scope_id = semantic.top_level_scope_id();
-                let mut all_used_names = FxHashSet::default();
+                let mut all_used_names = AtomHashSet::default();
                 all_used_names.reserve(ids.len());
                 concate_info.idents.reserve(ids.len());
                 concate_info.global_scope_ident.reserve(ids.len());
@@ -1652,7 +1652,7 @@ var {} = {{}};
     m: ModuleIdentifier,
     from: Option<ModuleIdentifier>,
     symbol: Option<Atom>,
-    all_used_names: &mut FxHashSet<Atom>,
+    all_used_names: &mut AtomHashSet,
     required: &'a mut IdentifierIndexMap<ExternalInterop>,
   ) -> &'a mut ExternalInterop {
     let require_info: &mut ExternalInterop = required.entry(m).or_insert(ExternalInterop {
@@ -1885,7 +1885,7 @@ var {} = {{}};
     required: &mut IdentifierIndexMap<ExternalInterop>,
     link: &mut FxHashMap<ChunkUkey, ChunkLinkContext>,
     needed_namespace_objects: &mut IdentifierIndexSet,
-    entry_imports: &mut IdentifierIndexMap<FxHashMap<Atom, Atom>>,
+    entry_imports: &mut IdentifierIndexMap<AtomHashMap<Atom>>,
     exports: &mut FxHashMap<ChunkUkey, ExportsContext>,
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
     allow_rename: bool,
@@ -2147,7 +2147,7 @@ var {} = {{}};
         entry_module,
         None,
         None,
-        &mut FxHashSet::default(),
+        &mut AtomHashSet::default(),
         required,
       );
     }
@@ -2188,7 +2188,7 @@ var {} = {{}};
       .chunk_by_ukey
       .keys()
       .map(|chunk| (*chunk, Default::default()))
-      .collect::<FxHashMap<ChunkUkey, IdentifierIndexMap<FxHashMap<Atom, Atom>>>>();
+      .collect::<FxHashMap<ChunkUkey, IdentifierIndexMap<AtomHashMap<Atom>>>>();
 
     // const symbol = __webpack_require__(module);
     let mut required = FxHashMap::<ChunkUkey, IdentifierIndexMap<ExternalInterop>>::default();
@@ -2922,7 +2922,7 @@ var {} = {{}};
     asi_safe: Option<bool>,
     already_visited: &mut FxHashSet<ExportInfo>,
     required: &mut IdentifierIndexMap<ExternalInterop>,
-    all_used_names: &mut FxHashSet<Atom>,
+    all_used_names: &mut AtomHashSet,
   ) -> Option<Ref> {
     let module = mg
       .module_by_identifier(info_id)
@@ -3344,7 +3344,7 @@ fn normal_render(
 mod tests {
   use rspack_core::{ChunkInitFragments, ChunkUkey, InitFragmentKey, ModuleIdentifier};
   use rspack_util::{
-    atom::Atom,
+    atom::{Atom, AtomHashSet},
     fx_hash::{FxHashMap, FxHashSet},
   };
 
@@ -3409,7 +3409,7 @@ mod tests {
         None,
       )),
     ];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
     let mut namespace_imports = FxHashMap::default();
 
     EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
@@ -3452,7 +3452,7 @@ mod tests {
         InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
         None,
       ))];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
     let mut namespace_imports = FxHashMap::default();
 
     EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
@@ -3510,7 +3510,7 @@ mod tests {
         InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
         None,
       ))];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
     let mut namespace_imports = FxHashMap::default();
 
     EsmLibraryPlugin::reserve_module_external_namespace_import_locals_in_render_order(
@@ -3548,7 +3548,7 @@ mod tests {
       InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
       None,
     ))];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
     let mut namespace_imports = FxHashMap::default();
     let mut required = Default::default();
 
@@ -3591,7 +3591,7 @@ mod tests {
       InitFragmentKey::ModuleExternal("node-commonjs".into()),
       None,
     ))];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
 
     EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
       &init_fragments,
@@ -3616,7 +3616,7 @@ mod tests {
       "__rspack_createRequire".into(),
       "__rspack_createRequire_require".into(),
     ]))];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
 
     EsmLibraryPlugin::reserve_module_external_top_level_decls(
       &init_fragments,
@@ -3655,7 +3655,7 @@ mod tests {
         "__rspack_createRequire_require_0".into(),
       ])),
     ];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
 
     EsmLibraryPlugin::reserve_module_external_top_level_decls(
       &init_fragments,
@@ -3681,7 +3681,7 @@ mod tests {
       )
       .with_top_level_decl_symbols(vec!["provided_identifier".into()]),
     )];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
 
     EsmLibraryPlugin::reserve_module_external_top_level_decls(
       &init_fragments,
@@ -3694,8 +3694,8 @@ mod tests {
   #[test]
   fn external_candidate_name_does_not_claim_chunk_top_level_name() {
     let module = ModuleIdentifier::from("test_module");
-    let mut candidate_used_names = FxHashSet::default();
-    let mut chunk_used_names = FxHashSet::default();
+    let mut candidate_used_names = AtomHashSet::default();
+    let mut chunk_used_names = AtomHashSet::default();
     let mut required = Default::default();
     let escaped_identifiers =
       FxHashMap::from_iter([("./lib.js".to_string(), vec![Atom::from("lib")])]);

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   incremental::Mutation, split_readable_identifier,
 };
 use rspack_util::{
-  atom::Atom,
+  atom::{Atom, AtomHashSet},
   fx_hash::{FxDashSet, FxHashMap, FxHashSet},
 };
 
@@ -644,7 +644,7 @@ pub(crate) fn analyze_dyn_import_targets(
     // Step 1: Collect export names per module per chunk (for non-strict, non-external,
     // concatenated modules) to detect export name conflicts between modules sharing a chunk.
     let exports_info_artifact = &compilation.exports_info_artifact;
-    let mut chunk_module_exports: FxHashMap<ChunkUkey, Vec<(_, FxHashSet<Atom>)>> =
+    let mut chunk_module_exports: FxHashMap<ChunkUkey, Vec<(_, AtomHashSet)>> =
       FxHashMap::default();
     for module_id in &sorted_targets {
       if !concatenated_modules.contains(module_id) {
@@ -667,7 +667,7 @@ pub(crate) fn analyze_dyn_import_targets(
         continue;
       }
       let exports_info = exports_info_artifact.get_exports_info_data(module_id);
-      let export_names: FxHashSet<Atom> = exports_info
+      let export_names: AtomHashSet = exports_info
         .exports()
         .iter()
         .filter(|(_, ei)| {
@@ -707,7 +707,7 @@ pub(crate) fn analyze_dyn_import_targets(
 
     // Step 3: Only assign namespace names when needed (namespace used as a whole or has conflicts)
     // Track used names per chunk to avoid collisions between multiple dyn targets
-    let mut chunk_used_names: FxHashMap<ChunkUkey, FxHashSet<Atom>> = FxHashMap::default();
+    let mut chunk_used_names: FxHashMap<ChunkUkey, AtomHashSet> = FxHashMap::default();
 
     for module_id in &sorted_targets {
       if !concatenated_modules.contains(module_id) {

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -17,8 +17,8 @@ use rspack_plugin_javascript::{
 };
 use rspack_util::{
   SpanExt,
-  atom::Atom,
-  fx_hash::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet},
+  atom::{Atom, AtomHashMap},
+  fx_hash::{FxHashSet, FxIndexMap, FxIndexSet},
 };
 
 use crate::{
@@ -243,7 +243,7 @@ impl EsmLibraryPlugin {
     let mut render_source = ConcatSource::default();
     let mut export_specifiers: FxIndexSet<Cow<str>> = Default::default();
     let mut export_default = None;
-    let mut imported_chunks = FxIndexMap::<ChunkUkey, FxHashMap<Atom, Atom>>::default();
+    let mut imported_chunks = FxIndexMap::<ChunkUkey, AtomHashMap<Atom>>::default();
     let mut runtime_requirements =
       *ChunkGraph::get_chunk_runtime_requirements(compilation, chunk_ukey);
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -13,8 +13,7 @@ use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, property_access,
   to_normal_comment,
 };
-use rustc_hash::FxHashSet;
-use swc_core::atoms::Atom;
+use rspack_util::atom::{Atom, AtomHashSet};
 
 use super::ExportsBase;
 use crate::dependency::commonjs::OBJECT_PROTOTYPE_METHODS;
@@ -71,7 +70,7 @@ impl CommonJsExportRequireDependency {
     exports_info_artifact: &ExportsInfoArtifact,
     runtime: Option<&RuntimeSpec>,
     imported_module: &ModuleIdentifier,
-  ) -> Option<FxHashSet<Atom>> {
+  ) -> Option<AtomHashSet> {
     let ids = self.get_ids(mg);
     let mut imported_exports_info =
       Some(exports_info_artifact.get_exports_info_data(imported_module));
@@ -127,7 +126,7 @@ impl CommonJsExportRequireDependency {
       ExportsType::Namespace
     );
 
-    let mut exports = FxHashSet::default();
+    let mut exports = AtomHashSet::default();
 
     if no_extra_imports {
       let Some(exports_info) = &exports_info else {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -26,7 +26,7 @@ use rspack_core::{
   property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
-use rspack_util::json_stringify;
+use rspack_util::{atom::AtomHashSet, json_stringify};
 use rustc_hash::{FxHashSet as HashSet, FxHasher};
 use swc_core::ecma::atoms::Atom;
 
@@ -97,7 +97,7 @@ impl ESMExportImportedSpecifierDependency {
   }
 
   // Because it is shared by multiply ESMExportImportedSpecifierDependency, so put it to `BuildInfo`
-  pub fn active_exports<'a>(&self, module_graph: &'a ModuleGraph) -> &'a HashSet<Atom> {
+  pub fn active_exports<'a>(&self, module_graph: &'a ModuleGraph) -> &'a AtomHashSet {
     let build_info = module_graph
       .get_parent_module(&self.id)
       .and_then(|ident| module_graph.module_by_identifier(ident))
@@ -329,7 +329,7 @@ impl ESMExportImportedSpecifierDependency {
       UsageState::Unused
     );
 
-    let ignored_exports: HashSet<Atom> = {
+    let ignored_exports: AtomHashSet = {
       let mut e = self.active_exports(module_graph).clone();
       e.insert("default".into());
       e
@@ -347,7 +347,7 @@ impl ESMExportImportedSpecifierDependency {
           .into_iter()
           .take(other_star_exports.names_slice)
           .filter(|name| !ignored_exports.contains(name))
-          .collect::<HashSet<_>>()
+          .collect::<AtomHashSet>()
       });
 
     if !no_extra_exports && !no_extra_imports {
@@ -358,10 +358,10 @@ impl ESMExportImportedSpecifierDependency {
       };
     }
 
-    let mut exports = HashSet::default();
-    let mut checked = HashSet::default();
+    let mut exports = AtomHashSet::default();
+    let mut checked = AtomHashSet::default();
     let mut hidden = if hidden_exports.is_some() {
-      Some(HashSet::default())
+      Some(AtomHashSet::default())
     } else {
       None
     };

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -2,7 +2,7 @@ use rspack_core::{
   BoxDependency, Dependency, DependencyId, DependencyRange, UsedByExports,
   UsedByExportsDeferredPureCheck,
 };
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, atom::AtomHashSet};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::{
   atoms::Atom,
@@ -202,7 +202,7 @@ impl InnerGraphParserPlugin {
             let finalized_set = set
               .iter()
               .map(|item| item.to_atom(&state.symbol_map))
-              .collect::<HashSet<_>>();
+              .collect::<AtomHashSet>();
             UsedByExports::set(finalized_set)
           }
           InnerGraphMapValue::True => UsedByExports::bool(true),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -1,5 +1,4 @@
 use rspack_util::atom::Atom;
-use rustc_hash::FxHashSet;
 
 use super::{
   JavascriptParserPlugin,
@@ -34,7 +33,7 @@ impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
 
   fn finish(&self, parser: &mut JavascriptParser) -> Option<bool> {
     if parser.build_info.top_level_declarations.is_none() {
-      parser.build_info.top_level_declarations = Some(FxHashSet::default());
+      parser.build_info.top_level_declarations = Some(Default::default());
     }
     let variables: Vec<_> = parser
       .get_all_variables_from_current_scope()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -3,8 +3,7 @@ use std::sync::LazyLock;
 use rspack_core::{
   DeferredPureCheck, Dependency, DependencyRange, ModuleDependency, SideEffectsBailoutItemWithSpan,
 };
-use rspack_util::SpanExt;
-use rustc_hash::FxHashSet;
+use rspack_util::{SpanExt, atom::AtomHashSet};
 use swc_core::{
   atoms::Atom,
   common::{
@@ -48,7 +47,7 @@ impl SideEffectsParserPlugin {
 }
 
 struct PureAnnotation<'a> {
-  side_effects_free: FxHashSet<Atom>,
+  side_effects_free: AtomHashSet,
   parser: &'a JavascriptParser<'a>,
 }
 
@@ -159,14 +158,14 @@ impl<'a> Visit for PureAnnotation<'a> {
   }
 }
 
-fn collect_pure_function_acceptable_names(program: &Program) -> FxHashSet<Atom> {
+fn collect_pure_function_acceptable_names(program: &Program) -> AtomHashSet {
   // Names a user can list in `pureFunctions` and have actually take effect:
   //   - any top-level binding (function/class/var decl or import) — so calls
   //     to local helpers and imported identifiers can be marked pure;
   //   - export aliases of local bindings (`export { foo as bar }`) and the
   //     `default` keyword for default-exported functions/arrows — preserves
   //     the original "configure on the source module" workflow.
-  let mut names = FxHashSet::default();
+  let mut names = AtomHashSet::default();
   let mut insert = |name: &Atom| {
     names.insert(name.clone());
   };
@@ -244,7 +243,7 @@ fn collect_pure_function_acceptable_names(program: &Program) -> FxHashSet<Atom> 
 fn collect_defined_configured_side_effects_free(
   program: &Program,
   configured_side_effects_free: &[String],
-) -> FxHashSet<Atom> {
+) -> AtomHashSet {
   let acceptable = collect_pure_function_acceptable_names(program);
 
   configured_side_effects_free
@@ -323,7 +322,7 @@ fn visit_module_decl_defined_binding_names(decl: &ModuleDecl, f: &mut impl FnMut
   }
 }
 
-fn collect_duplicate_top_level_names(program: &Program) -> FxHashSet<Atom> {
+fn collect_duplicate_top_level_names(program: &Program) -> AtomHashSet {
   let mut counts = rustc_hash::FxHashMap::<Atom, usize>::default();
   let mut count_name = |name: &Atom| {
     *counts.entry(name.clone()).or_default() += 1;
@@ -371,7 +370,7 @@ fn try_mark_auto_side_effects_free_var_decl(
   export_name: Option<&Atom>,
   unresolved_ctxt: SyntaxContext,
   comments: Option<&dyn Comments>,
-  duplicate_names: &FxHashSet<Atom>,
+  duplicate_names: &AtomHashSet,
 ) {
   if !matches!(var_decl.kind, VarDeclKind::Const) {
     return;
@@ -425,7 +424,7 @@ fn try_mark_auto_side_effects_free_stmt(
   stmt: &Stmt,
   unresolved_ctxt: SyntaxContext,
   comments: Option<&dyn Comments>,
-  duplicate_names: &FxHashSet<Atom>,
+  duplicate_names: &AtomHashSet,
 ) {
   match stmt {
     Stmt::Decl(Decl::Fn(fn_decl)) => {
@@ -468,7 +467,7 @@ fn try_mark_auto_side_effects_free_module_decl(
   decl: &ModuleDecl,
   unresolved_ctxt: SyntaxContext,
   comments: Option<&dyn Comments>,
-  duplicate_names: &FxHashSet<Atom>,
+  duplicate_names: &AtomHashSet,
 ) {
   match decl {
     ModuleDecl::ExportDefaultExpr(default_expr) => {
@@ -568,7 +567,7 @@ fn mark_auto_side_effects_free_program(
   program: &Program,
   unresolved_ctxt: SyntaxContext,
   comments: Option<&dyn Comments>,
-  duplicate_names: &FxHashSet<Atom>,
+  duplicate_names: &AtomHashSet,
 ) {
   match program {
     Program::Module(module) => {
@@ -628,7 +627,7 @@ impl JavascriptParserPlugin for SideEffectsParserPlugin {
       //    unlock later candidates regardless of declaration order.
       // use a raw swc visitor so that we can find all pure functions before the parser visit the ast
       let mut pure_annotation = PureAnnotation {
-        side_effects_free: FxHashSet::default(),
+        side_effects_free: AtomHashSet::default(),
         parser,
       };
       ast.visit_with(&mut pure_annotation);
@@ -653,7 +652,7 @@ impl JavascriptParserPlugin for SideEffectsParserPlugin {
           .build_info
           .side_effects_free
           .as_ref()
-          .map_or(0, FxHashSet::len);
+          .map_or(0, AtomHashSet::len);
         mark_auto_side_effects_free_program(
           parser,
           self.analyze_side_effects_free,
@@ -666,7 +665,7 @@ impl JavascriptParserPlugin for SideEffectsParserPlugin {
           .build_info
           .side_effects_free
           .as_ref()
-          .map_or(0, FxHashSet::len);
+          .map_or(0, AtomHashSet::len);
         if next_len == prev_len {
           break;
         }

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use rayon::prelude::*;
-use rustc_hash::{FxHashMap, FxHashSet as HashSet};
+use rspack_util::atom::AtomHashSet;
+use rustc_hash::FxHashMap;
 pub mod api_plugin;
 mod drive;
 mod flag_dependency_exports_plugin;
@@ -105,7 +106,7 @@ struct InlinedModuleInfo {
 struct RenameInfoPatch {
   inlined_modules_to_info: IdentifierMap<InlinedModuleInfo>,
   non_inlined_module_through_idents: Vec<ConcatenatedModuleIdent>,
-  all_used_names: HashSet<Atom>,
+  all_used_names: AtomHashSet,
 }
 
 #[plugin]
@@ -1026,7 +1027,7 @@ var {} = {{}};
 
     let mut inlined_modules_to_info: IdentifierMap<InlinedModuleInfo> = IdentifierMap::default();
     let mut non_inlined_module_through_idents: Vec<ConcatenatedModuleIdent> = Vec::new();
-    let mut all_used_names: HashSet<Atom> =
+    let mut all_used_names: AtomHashSet =
       RESERVED_NAMES.iter().map(|item| Atom::new(*item)).collect();
     let mut renamed_inline_modules: IdentifierMap<Arc<dyn Source>> = IdentifierMap::default();
 

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -1,5 +1,5 @@
 use bitflags::bitflags;
-use rustc_hash::FxHashMap;
+use rspack_util::atom::AtomHashMap;
 use slotmap::{KeyData, SlotMap, new_key_type};
 use swc_core::atoms::Atom;
 
@@ -300,7 +300,7 @@ impl VariableInfo {
 #[derive(Debug)]
 pub struct ScopeInfo {
   parent: Option<ScopeInfoId>,
-  map: FxHashMap<Atom, VariableInfoId>,
+  map: AtomHashMap<VariableInfoId>,
   pub is_strict: bool,
 }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -16,7 +16,6 @@ use rspack_core::{
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::{json_stringify_str, source_map::SourceMapKind};
-use rustc_hash::FxHashSet;
 
 use super::{
   container_exposed_dependency::ContainerExposedDependency, container_plugin::ExposeOptions,
@@ -65,7 +64,7 @@ impl ContainerEntryModule {
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: Some(Default::default()),
         ..Default::default()
       },
       build_meta: BuildMeta {
@@ -93,7 +92,7 @@ impl ContainerEntryModule {
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: Some(Default::default()),
         ..Default::default()
       },
       build_meta: BuildMeta {

--- a/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
@@ -8,8 +8,7 @@ use rspack_core::{
   ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, ResourceIdentifier, RuntimeSpec,
   create_exports_object_referenced,
 };
-use rspack_util::fx_hash::FxIndexSet;
-use swc_core::atoms::Atom;
+use rspack_util::atom::AtomIndexSet;
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -17,7 +16,7 @@ pub struct ClientReferenceDependency {
   id: DependencyId,
   request: String,
   #[cacheable(with=AsVec<AsPreset>)]
-  referenced_exports: FxIndexSet<Atom>,
+  referenced_exports: AtomIndexSet,
   is_server_side_rendering: bool,
   resource_identifier: ResourceIdentifier,
   factorize_info: FactorizeInfo,
@@ -26,7 +25,7 @@ pub struct ClientReferenceDependency {
 impl ClientReferenceDependency {
   pub fn new(
     request: String,
-    referenced_exports: FxIndexSet<Atom>,
+    referenced_exports: AtomIndexSet,
     is_server_side_rendering: bool,
   ) -> Self {
     let resource_identifier = format!("rsc-client-reference={request}").into();

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -8,9 +8,12 @@ use rspack_plugin_javascript::dependency::{
   CommonJsExportRequireDependency, ESMExportImportedSpecifierDependency,
   ESMImportSpecifierDependency,
 };
-use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
+use rspack_util::{
+  atom::{Atom, AtomIndexMap, AtomIndexSet},
+  fx_hash::{FxIndexMap, FxIndexSet},
+};
 use rustc_hash::{FxHashMap, FxHashSet};
-use swc_core::atoms::{Atom, Wtf8Atom};
+use swc_core::atoms::Wtf8Atom;
 
 use crate::{
   constants::{IMAGE_REGEX, LAYERS_NAMES},
@@ -19,7 +22,7 @@ use crate::{
 };
 
 // { [request to inject into client compilation]: [exported names] }
-pub type ClientComponentImports = FxIndexMap<String, FxIndexSet<Atom>>;
+pub type ClientComponentImports = FxIndexMap<String, AtomIndexSet>;
 // { [server entry path]: [`import.meta.rspackRsc` importer paths] }
 // Used only to let `loadCss()` importers inherit their nearest server entry CSS files.
 pub type ImportMetaRscImporters = FxHashMap<String, FxIndexSet<String>>;
@@ -289,7 +292,7 @@ fn add_client_import(
   let assumed_source_type =
     get_assumed_source_type(module, if is_cjs_module { "commonjs" } else { "auto" });
 
-  let client_imports_set: &mut FxIndexSet<Atom> = client_component_imports
+  let client_imports_set: &mut AtomIndexSet = client_component_imports
     .entry(mod_request.to_string())
     .or_default();
 
@@ -302,12 +305,18 @@ fn add_client_import(
     // or there's nothing in collected imports are empty.
     // we should include the whole module.
     if !is_first_visit_module && !client_imports_set.contains(&Atom::from("*")) {
-      client_component_imports.insert(mod_request.to_string(), FxIndexSet::from_iter(["*".into()]));
+      client_component_imports.insert(
+        mod_request.to_string(),
+        AtomIndexSet::from_iter(["*".into()]),
+      );
     }
   } else {
     let is_auto_module_source_type = assumed_source_type == "auto";
     if is_auto_module_source_type {
-      client_component_imports.insert(mod_request.to_string(), FxIndexSet::from_iter(["*".into()]));
+      client_component_imports.insert(
+        mod_request.to_string(),
+        AtomIndexSet::from_iter(["*".into()]),
+      );
     } else {
       // If it's not analyzed as named ESM exports, e.g. if it's mixing `export *` with named exports,
       // We'll include all modules since it's not able to do tree-shaking.
@@ -328,7 +337,7 @@ fn add_client_import(
 }
 
 // Gives { id: name } record of actions from the build info.
-fn get_actions_from_build_info(module: &dyn Module) -> Option<&FxIndexMap<Atom, Atom>> {
+fn get_actions_from_build_info(module: &dyn Module) -> Option<&AtomIndexMap<Atom>> {
   let rsc = get_module_rsc_information(module)?;
   Some(&rsc.action_ids)
 }

--- a/crates/rspack_plugin_rsc/src/plugin_state.rs
+++ b/crates/rspack_plugin_rsc/src/plugin_state.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::with::{AsPreset, AsVec};
 use rspack_collections::IdentifierSet;
 use rspack_core::CompilerId;
 use rspack_util::{
-  atom::Atom,
+  atom::{Atom, AtomIndexSet},
   fx_hash::{FxDashMap, FxIndexSet},
 };
 use rustc_hash::FxHashMap;
@@ -24,7 +24,7 @@ pub type RootCssImports = FxIndexSet<String>;
 pub struct ClientModuleImport {
   pub request: String,
   #[cacheable(with=AsVec<AsPreset>)]
-  pub ids: FxIndexSet<Atom>,
+  pub ids: AtomIndexSet,
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -19,9 +19,11 @@ use rspack_core::{
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_plugin_javascript::dependency::ImportEagerDependency;
-use rspack_util::{fx_hash::FxIndexSet, source_map::SourceMapKind};
-use rustc_hash::{FxHashMap, FxHashSet};
-use swc_core::ecma::atoms::Atom;
+use rspack_util::{
+  atom::{Atom, AtomIndexSet},
+  source_map::SourceMapKind,
+};
+use rustc_hash::FxHashMap;
 
 use crate::{
   client_reference_dependency::ClientReferenceDependency,
@@ -81,7 +83,7 @@ impl RscEntryModule {
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
+        top_level_declarations: Some(Default::default()),
         ..Default::default()
       },
       build_meta: BuildMeta {
@@ -384,7 +386,7 @@ fn push_value(identifier: &mut String, value: &str) {
   identifier.push_str(value);
 }
 
-fn create_referenced_specifiers(ids: &FxIndexSet<Atom>) -> Option<Vec<ReferencedSpecifier>> {
+fn create_referenced_specifiers(ids: &AtomIndexSet) -> Option<Vec<ReferencedSpecifier>> {
   if ids.is_empty() || ids.iter().any(|id| id == "*") {
     return None;
   }

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -29,6 +29,7 @@ serde            = { workspace = true }
 serde_json       = { workspace = true }
 sugar_path       = { workspace = true }
 unicase          = { workspace = true }
+ustr             = { workspace = true }
 
 swc_config = { workspace = true }
 swc_core   = { workspace = true, features = ["__common", "base", "ecma_ast"] }

--- a/crates/rspack_util/src/atom.rs
+++ b/crates/rspack_util/src/atom.rs
@@ -1,6 +1,18 @@
+use std::{
+  collections::{HashMap, HashSet},
+  hash::BuildHasherDefault,
+};
+
+use indexmap::{IndexMap, IndexSet};
 use swc_core::ecma::ast::ModuleExportName;
+use ustr::IdentityHasher;
 
 pub type Atom = swc_core::atoms::Atom;
+
+pub type AtomHashSet = HashSet<Atom, BuildHasherDefault<IdentityHasher>>;
+pub type AtomHashMap<V> = HashMap<Atom, V, BuildHasherDefault<IdentityHasher>>;
+pub type AtomIndexSet = IndexSet<Atom, BuildHasherDefault<IdentityHasher>>;
+pub type AtomIndexMap<V> = IndexMap<Atom, V, BuildHasherDefault<IdentityHasher>>;
 
 pub trait ModuleExportNameExt {
   fn atom_ref(&self) -> &Atom;

--- a/crates/swc_plugin_ts_collector/Cargo.toml
+++ b/crates/swc_plugin_ts_collector/Cargo.toml
@@ -7,8 +7,9 @@ repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
 
 [dependencies]
-rustc-hash = { workspace = true }
-swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit", "ecma_parser"] }
+rspack_util = { workspace = true }
+rustc-hash  = { workspace = true }
+swc_core    = { workspace = true, features = ["common", "ecma_ast", "ecma_visit", "ecma_parser"] }
 
 [dev-dependencies]
 insta                      = { workspace = true }

--- a/crates/swc_plugin_ts_collector/src/enums.rs
+++ b/crates/swc_plugin_ts_collector/src/enums.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rspack_util::atom::{AtomHashMap, AtomHashSet};
+use rustc_hash::FxHashMap;
 use swc_core::{
   atoms::{Atom, Wtf8Atom, wtf8::Wtf8Buf},
   common::SyntaxContext,
@@ -19,10 +20,10 @@ type EnumKeyValueMap = FxHashMap<Wtf8Atom, EnumMemberValue>;
 #[derive(Debug)]
 pub struct ExportedEnumCollector<'a> {
   const_only: bool,
-  export_idents: FxHashSet<Atom>,
-  bailout_idents: FxHashSet<Atom>,
+  export_idents: AtomHashSet,
+  bailout_idents: AtomHashSet,
   unresolved_ctxt: SyntaxContext,
-  collected: &'a mut FxHashMap<Atom, EnumKeyValueMap>,
+  collected: &'a mut AtomHashMap<EnumKeyValueMap>,
 }
 
 #[derive(Debug, Clone)]
@@ -36,7 +37,7 @@ impl<'a> ExportedEnumCollector<'a> {
   pub fn new(
     const_only: bool,
     unresolved_ctxt: SyntaxContext,
-    collected: &'a mut FxHashMap<Atom, EnumKeyValueMap>,
+    collected: &'a mut AtomHashMap<EnumKeyValueMap>,
   ) -> Self {
     Self {
       const_only,

--- a/crates/swc_plugin_ts_collector/src/type_exports.rs
+++ b/crates/swc_plugin_ts_collector/src/type_exports.rs
@@ -1,4 +1,4 @@
-use rustc_hash::{FxHashMap, FxHashSet};
+use rspack_util::atom::{AtomHashMap, AtomHashSet};
 use swc_core::{
   atoms::Atom,
   ecma::{
@@ -9,14 +9,14 @@ use swc_core::{
 
 #[derive(Debug)]
 pub struct TypeExportsCollector<'a> {
-  type_idents: FxHashSet<Atom>,
-  export_idents: FxHashMap<Atom, Atom>,
+  type_idents: AtomHashSet,
+  export_idents: AtomHashMap<Atom>,
 
-  type_exports: &'a mut FxHashSet<Atom>,
+  type_exports: &'a mut AtomHashSet,
 }
 
 impl<'a> TypeExportsCollector<'a> {
-  pub fn new(type_exports: &'a mut FxHashSet<Atom>) -> Self {
+  pub fn new(type_exports: &'a mut AtomHashSet) -> Self {
     Self {
       type_idents: Default::default(),
       export_idents: Default::default(),

--- a/crates/swc_plugin_ts_collector/tests/fixture.rs
+++ b/crates/swc_plugin_ts_collector/tests/fixture.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rspack_javascript_compiler::{JavaScriptCompiler, transform::SwcOptions};
 use rspack_swc_plugin_ts_collector::{ExportedEnumCollector, TypeExportsCollector};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rspack_util::atom::{AtomHashMap, AtomHashSet};
 use swc_core::{
   common::{FileName, SyntaxContext, comments::SingleThreadedComments},
   ecma::{
@@ -53,7 +53,7 @@ fn type_exports() {
     let compiler = JavaScriptCompiler::new();
     let mut options = SwcOptions::default();
     options.config.jsc.syntax = Some(Syntax::Typescript(TsSyntax::default()));
-    let mut type_exports_results = FxHashSet::default();
+    let mut type_exports_results = AtomHashSet::default();
     let comments = Rc::new(SingleThreadedComments::default());
     let _ = compiler
       .transform(
@@ -83,7 +83,7 @@ fn enums() {
     let compiler = JavaScriptCompiler::new();
     let mut options = SwcOptions::default();
     options.config.jsc.syntax = Some(Syntax::Typescript(TsSyntax::default()));
-    let mut enum_results = FxHashMap::default();
+    let mut enum_results = AtomHashMap::default();
     let comments = Rc::new(SingleThreadedComments::default());
     let _ = compiler
       .transform(


### PR DESCRIPTION
## Summary

- add AtomHashSet, AtomHashMap, AtomIndexSet, and AtomIndexMap aliases backed by ustr::IdentityHasher
- switch Atom-keyed hash/index collections across core, JS, CSS, ESM library, RSC, loader SWC, and TS collector code paths
- keep compound-key collections on their existing hashers to avoid misusing identity hashing

## Why

Atom already writes a precomputed u64 hash. Using IdentityHasher avoids feeding that hash through FxHasher again for collections keyed directly by Atom.

## Validation

- cargo fmt --all --check
- cargo check -p rspack_util -p rspack_swc_plugin_ts_collector -p rspack_core -p rspack_loader_swc -p rspack_plugin_javascript -p rspack_plugin_css -p rspack_plugin_esm_library -p rspack_plugin_rsc -p rspack_plugin_mf
