### PR TITLE
fix: enable mimalloc local_dynamic_tls on macOS

### DIFF
--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -10,12 +10,9 @@ version.workspace = true
 sftrace-setup = { workspace = true, optional = true }
 tracy-client  = { workspace = true, optional = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
 mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
 mimalloc = { workspace = true, features = ["v3"] }

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -11,12 +11,9 @@ version.workspace = true
 criterion = { workspace = true }
 tokio     = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 # Keep benchmark allocator features aligned with rspack_allocator.
 mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
 mimalloc = { workspace = true, features = ["v3"] }


### PR DESCRIPTION
## Summary

- Enable mimalloc `local_dynamic_tls` for macOS in `rspack_allocator`.
- Keep `xtask/benchmark` mimalloc features aligned with the allocator crate.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation:

- `pnpm exec taplo fmt --check crates/rspack_allocator/Cargo.toml xtask/benchmark/Cargo.toml`
- `cargo check -p rspack_allocator`
- `cargo check -p rspack_benchmark --lib`