### PR TITLE
refactor(core): share generator options

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -742,7 +742,6 @@ export interface JsBuildMeta {
   exportsType?: undefined | 'unset' | 'default' | 'namespace' | 'flagged' | 'dynamic'
   defaultObject?: undefined | 'false' | 'redirect' | 'redirect-warn'
   sideEffectFree?: boolean
-  exportsFinalName?: Array<[string, string]> | undefined
 }
 
 export interface JsBuildTimeExecutionOption {

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -797,8 +797,6 @@ pub struct JsBuildMeta {
   #[napi(ts_type = "undefined | 'false' | 'redirect' | 'redirect-warn'")]
   pub default_object: Option<String>,
   pub side_effect_free: Option<bool>,
-  #[napi(ts_type = "Array<[string, string]> | undefined")]
-  pub exports_final_name: Option<Vec<Vec<String>>>,
 }
 
 impl From<JsBuildMeta> for BuildMeta {
@@ -808,7 +806,6 @@ impl From<JsBuildMeta> for BuildMeta {
       has_top_level_await,
       esm,
       default_object: raw_default_object,
-      exports_final_name: raw_exports_final_name,
       side_effect_free,
       exports_type: raw_exports_type,
     } = value;
@@ -837,23 +834,6 @@ impl From<JsBuildMeta> for BuildMeta {
       BuildMetaExportsType::Unset
     };
 
-    let exports_final_name = raw_exports_final_name.map(|exports_name| {
-      exports_name
-        .into_iter()
-        .map(|export_name| {
-          let first = export_name
-            .first()
-            .expect("The buildMeta exportsFinalName item should have first value")
-            .clone();
-          let second = export_name
-            .get(1)
-            .expect("The buildMeta exportsFinalName item should have second value")
-            .clone();
-          (first, second)
-        })
-        .collect::<Vec<_>>()
-    });
-
     Self {
       strict_esm_module: strict_esm_module.unwrap_or_default(),
       has_top_level_await: has_top_level_await.unwrap_or_default(),
@@ -861,7 +841,6 @@ impl From<JsBuildMeta> for BuildMeta {
       exports_type,
       default_object,
       side_effect_free,
-      exports_final_name,
     }
   }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -23,7 +23,7 @@ pub struct FactorizeTask {
   pub module_factory: Arc<dyn ModuleFactory>,
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub original_module_source: Option<BoxSource>,
-  pub original_module_context: Option<Box<Context>>,
+  pub original_module_context: Option<Context>,
   pub issuer: Option<Box<str>>,
   pub issuer_layer: Option<ModuleLayer>,
   pub dependencies: Vec<BoxDependency>,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
@@ -99,7 +99,7 @@ impl Task<TaskContext> for ProcessDependenciesTask {
         compilation_id: context.compilation_id,
         module_factory,
         original_module_identifier: Some(module.identifier()),
-        original_module_context: module.get_context(),
+        original_module_context: module.get_context().cloned(),
         original_module_source,
         issuer: module
           .as_normal_module()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2105,8 +2105,8 @@ impl Module for ConcatenatedModule {
     }
   }
 
-  fn get_context(&self) -> Option<Box<Context>> {
-    self.root_module_ctxt.context.clone().map(Box::new)
+  fn get_context(&self) -> Option<&Context> {
+    self.root_module_ctxt.context.as_ref()
   }
 
   // Port from https://github.com/webpack/webpack/blob/main/lib/ConcatenatedModule.js#L1120

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -297,8 +297,6 @@ pub struct BuildMeta {
   pub default_object: BuildMetaDefaultObject,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub side_effect_free: Option<bool>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub exports_final_name: Option<Vec<(String, String)>>,
 }
 
 // webpack build info

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -473,7 +473,7 @@ pub trait Module:
     None
   }
 
-  fn get_context(&self) -> Option<Box<Context>> {
+  fn get_context(&self) -> Option<&Context> {
     None
   }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -104,7 +104,7 @@ pub struct NormalModule {
 
   id: ModuleIdentifier,
   /// Context of this module
-  context: Box<Context>,
+  context: Context,
   /// Request with loaders from config
   #[cacheable(with=AsPreset)]
   request: Ustr,
@@ -198,7 +198,7 @@ impl NormalModule {
       blocks: Vec::new(),
       dependencies: Vec::new(),
       id: ModuleIdentifier::from(id.as_ref()),
-      context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
+      context: context.unwrap_or_else(|| get_context(&resource_data)),
       request,
       user_request,
       raw_request,
@@ -751,8 +751,8 @@ impl Module for NormalModule {
     }
   }
 
-  fn get_context(&self) -> Option<Box<Context>> {
-    Some(self.context.clone())
+  fn get_context(&self) -> Option<&Context> {
+    Some(&self.context)
   }
 
   fn get_layer(&self) -> Option<&ModuleLayer> {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -133,7 +133,7 @@ pub struct NormalModule {
   /// Parser options derived from [Rule.parser]
   parser_options: Option<Arc<ParserOptions>>,
   /// Generator options derived from [Rule.generator]
-  generator_options: Option<GeneratorOptions>,
+  generator_options: Option<Arc<GeneratorOptions>>,
   /// enable/disable extracting source map
   extract_source_map: Option<bool>,
 
@@ -180,7 +180,7 @@ impl NormalModule {
     layer: Option<ModuleLayer>,
     parser_and_generator: Box<dyn ParserAndGenerator>,
     parser_options: Option<Arc<ParserOptions>>,
-    generator_options: Option<GeneratorOptions>,
+    generator_options: Option<Arc<GeneratorOptions>>,
     match_resource: Option<ResourceData>,
     resource_data: Arc<ResourceData>,
     resolve_options: Option<Arc<Resolve>>,
@@ -302,15 +302,15 @@ impl NormalModule {
   }
 
   pub fn get_generator_options(&self) -> Option<&GeneratorOptions> {
-    self.generator_options.as_ref()
+    self.generator_options.as_deref()
   }
 
   pub fn get_generator_options_mut(&mut self) -> Option<&mut GeneratorOptions> {
-    self.generator_options.as_mut()
+    self.generator_options.as_mut().map(Arc::make_mut)
   }
 
   pub fn set_generator_options(&mut self, generator_options: Option<GeneratorOptions>) {
-    self.generator_options = generator_options;
+    self.generator_options = generator_options.map(Arc::new);
   }
 }
 
@@ -489,7 +489,7 @@ impl Module for NormalModule {
 
     let is_binary = self
       .generator_options
-      .as_ref()
+      .as_deref()
       .and_then(|g| match g {
         GeneratorOptions::Asset(g) => g.binary,
         GeneratorOptions::AssetInline(g) => g.binary,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -177,9 +177,9 @@ impl NormalModule {
 
   #[allow(clippy::too_many_arguments)]
   pub fn new(
-    request: String,
-    user_request: String,
-    raw_request: String,
+    request: Ustr,
+    user_request: Ustr,
+    raw_request: Ustr,
     module_type: impl Into<ModuleType>,
     layer: Option<ModuleLayer>,
     parser_and_generator: Box<dyn ParserAndGenerator>,
@@ -193,15 +193,15 @@ impl NormalModule {
     extract_source_map: Option<bool>,
   ) -> Self {
     let module_type = module_type.into();
-    let id = Self::create_id(&module_type, layer.as_ref(), &request);
+    let id = Self::create_id(&module_type, layer.as_ref(), request.as_str());
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
       id: ModuleIdentifier::from(id.as_ref()),
       context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
-      request: Ustr::from(request.as_str()),
-      user_request: Ustr::from(user_request.as_str()),
-      raw_request: Ustr::from(raw_request.as_str()),
+      request,
+      user_request,
+      raw_request,
       module_type,
       layer,
       parser_and_generator,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -28,6 +28,7 @@ use rspack_util::{
 };
 use serde_json::json;
 use tracing::{Instrument, info_span};
+use ustr::Ustr;
 
 use crate::{
   AsyncDependenciesBlockIdentifier, BoxDependencyTemplate, BoxLoader, BoxModule,
@@ -105,11 +106,14 @@ pub struct NormalModule {
   /// Context of this module
   context: Box<Context>,
   /// Request with loaders from config
-  request: String,
+  #[cacheable(with=AsPreset)]
+  request: Ustr,
   /// Request intended by user (without loaders from config)
-  user_request: String,
+  #[cacheable(with=AsPreset)]
+  user_request: Ustr,
   /// Request without resolving
-  raw_request: String,
+  #[cacheable(with=AsPreset)]
+  raw_request: Ustr,
   /// The resolved module type of a module
   module_type: ModuleType,
   /// Layer of the module
@@ -195,9 +199,9 @@ impl NormalModule {
       dependencies: Vec::new(),
       id: ModuleIdentifier::from(id.as_ref()),
       context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
-      request,
-      user_request,
-      raw_request,
+      request: Ustr::from(request.as_str()),
+      user_request: Ustr::from(user_request.as_str()),
+      raw_request: Ustr::from(raw_request.as_str()),
       module_type,
       layer,
       parser_and_generator,
@@ -240,19 +244,19 @@ impl NormalModule {
   }
 
   pub fn request(&self) -> &str {
-    &self.request
+    self.request.as_str()
   }
 
   pub fn user_request(&self) -> &str {
-    &self.user_request
+    self.user_request.as_str()
   }
 
-  pub fn user_request_mut(&mut self) -> &mut String {
-    &mut self.user_request
+  pub fn set_user_request(&mut self, user_request: impl AsRef<str>) {
+    self.user_request = Ustr::from(user_request.as_ref());
   }
 
   pub fn raw_request(&self) -> &str {
-    &self.raw_request
+    self.raw_request.as_str()
   }
 
   pub fn loaders(&self) -> &[BoxLoader] {
@@ -359,7 +363,7 @@ impl Module for NormalModule {
   }
 
   fn readable_identifier(&self, context: &Context) -> Cow<'_, str> {
-    Cow::Owned(context.shorten(&self.user_request))
+    Cow::Owned(context.shorten(self.user_request.as_str()))
   }
 
   fn size(&self, source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
@@ -563,7 +567,7 @@ impl Module for NormalModule {
         module_parser_options: self.parser_options.as_deref(),
         module_type: &self.module_type,
         module_layer: self.layer.as_ref(),
-        module_user_request: &self.user_request,
+        module_user_request: self.user_request.as_str(),
         module_match_resource: self.match_resource.as_ref(),
         module_source_map_kind: self.source_map_kind,
         loaders: &self.loaders,
@@ -645,7 +649,7 @@ impl Module for NormalModule {
     let Some(source) = &self.source else {
       return Err(error!(
         "Failed to generate code because ast or source is not set for module {}",
-        self.request
+        self.request.as_str()
       ));
     };
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -17,8 +17,8 @@ use crate::{
   ParserAndGenerator, ParserOptions, ParserOptionsMap, RawModule, Resolve, ResolveArgs,
   ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory, ResourceData,
   ResourceParsedData, RunnerContext, RuntimeGlobals, SharedPluginDriver,
-  diagnostics::EmptyDependency, module_rules_matcher, parse_resource, resolve,
-  stringify_loaders_and_resource,
+  diagnostics::EmptyDependency, module_rules_matcher, options::GeneratorOptionsMap, parse_resource,
+  resolve, stringify_loaders_and_resource,
 };
 
 define_hook!(NormalModuleFactoryBeforeResolve: SeriesBail(data: &mut ModuleFactoryCreateData) -> bool,tracing=false);
@@ -191,6 +191,104 @@ fn merge_parser_options_with_local(
   }
 }
 
+fn create_global_generator_options_cache(
+  generator_options: Option<&GeneratorOptionsMap>,
+) -> HashMap<String, Arc<GeneratorOptions>> {
+  let mut cache = HashMap::new();
+  let Some(generator_options) = generator_options else {
+    return cache;
+  };
+
+  for (key, options) in generator_options.iter() {
+    cache.insert(key.clone(), Arc::new(options.clone()));
+  }
+
+  for module_type in [
+    ModuleType::AssetInline,
+    ModuleType::AssetResource,
+    ModuleType::CssAuto,
+    ModuleType::CssModule,
+    ModuleType::Json,
+  ] {
+    if let Some(options) = resolve_global_generator_options(generator_options, &module_type) {
+      cache.insert(module_type.as_str().to_owned(), Arc::new(options));
+    }
+  }
+
+  cache
+}
+
+fn resolve_global_generator_options(
+  generator_options: &GeneratorOptionsMap,
+  module_type: &ModuleType,
+) -> Option<GeneratorOptions> {
+  let options = generator_options.get(module_type.as_str());
+  match module_type {
+    ModuleType::AssetInline | ModuleType::AssetResource => rspack_util::merge_from_optional_with(
+      generator_options.get("asset").cloned(),
+      options,
+      |asset_options, options| match (asset_options, options) {
+        (GeneratorOptions::Asset(a), GeneratorOptions::AssetInline(b)) => {
+          GeneratorOptions::AssetInline(Into::<AssetInlineGeneratorOptions>::into(a).merge_from(b))
+        }
+        (GeneratorOptions::Asset(a), GeneratorOptions::AssetResource(b)) => {
+          GeneratorOptions::AssetResource(
+            Into::<AssetResourceGeneratorOptions>::into(a).merge_from(b),
+          )
+        }
+        _ => unreachable!(),
+      },
+    ),
+    ModuleType::CssAuto | ModuleType::CssModule => rspack_util::merge_from_optional_with(
+      generator_options.get("css").cloned(),
+      options,
+      |css_options, options| match (css_options, options) {
+        (GeneratorOptions::Css(a), GeneratorOptions::CssAuto(b)) => {
+          GeneratorOptions::CssAuto(Into::<CssAutoGeneratorOptions>::into(a).merge_from(b))
+        }
+        (GeneratorOptions::Css(a), GeneratorOptions::CssModule(b)) => {
+          GeneratorOptions::CssModule(Into::<CssModuleGeneratorOptions>::into(a).merge_from(b))
+        }
+        _ => unreachable!(),
+      },
+    ),
+    ModuleType::Json => rspack_util::merge_from_optional_with(
+      generator_options.get("json").cloned(),
+      options,
+      |json_options, options| match (json_options, options) {
+        (GeneratorOptions::Json(a), GeneratorOptions::Json(b)) => {
+          GeneratorOptions::Json(a.merge_from(b))
+        }
+        _ => unreachable!(),
+      },
+    ),
+    _ => options.cloned(),
+  }
+}
+
+fn merge_generator_options_with_local(
+  global_generator: Option<Arc<GeneratorOptions>>,
+  local_generator: Option<&GeneratorOptions>,
+) -> Option<Arc<GeneratorOptions>> {
+  match (global_generator, local_generator) {
+    (None, None) => None,
+    (None, Some(local)) => Some(Arc::new(local.clone())),
+    (Some(global), None) => Some(global),
+    (Some(global), Some(local)) => Some(Arc::new(match (&*global, local) {
+      (GeneratorOptions::Asset(_), GeneratorOptions::Asset(_))
+      | (GeneratorOptions::AssetInline(_), GeneratorOptions::AssetInline(_))
+      | (GeneratorOptions::AssetResource(_), GeneratorOptions::AssetResource(_))
+      | (GeneratorOptions::Css(_), GeneratorOptions::Css(_))
+      | (GeneratorOptions::CssAuto(_), GeneratorOptions::CssAuto(_))
+      | (GeneratorOptions::CssModule(_), GeneratorOptions::CssModule(_))
+      | (GeneratorOptions::Json(_), GeneratorOptions::Json(_)) => {
+        Arc::as_ref(&global).clone().merge_from(local)
+      }
+      (global, _) => global.clone(),
+    })),
+  }
+}
+
 #[derive(Debug, Default)]
 pub struct NormalModuleFactoryHooks {
   pub before_resolve: NormalModuleFactoryBeforeResolveHook,
@@ -214,6 +312,7 @@ pub struct NormalModuleFactoryHooks {
 pub struct NormalModuleFactory {
   options: Arc<CompilerOptions>,
   global_parser_options: HashMap<String, Arc<ParserOptions>>,
+  global_generator_options: HashMap<String, Arc<GeneratorOptions>>,
   loader_resolver_factory: Arc<ResolverFactory>,
   plugin_driver: SharedPluginDriver,
 }
@@ -242,7 +341,10 @@ impl ModuleFactory for NormalModuleFactory {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::JavascriptParserOptions;
+  use crate::{
+    AssetGeneratorOptions, AssetResourceGeneratorOptions, JavascriptParserOptions,
+    JsonGeneratorOptions,
+  };
 
   #[test]
   fn reuse_global_parser_options_when_local_options_are_empty() {
@@ -280,6 +382,66 @@ mod tests {
   }
 
   #[test]
+  fn reuse_global_generator_options_when_local_options_are_empty() {
+    let global = Arc::new(GeneratorOptions::Json(JsonGeneratorOptions {
+      json_parse: Some(true),
+    }));
+
+    let resolved = merge_generator_options_with_local(Some(Arc::clone(&global)), None)
+      .expect("global generator options should be reused");
+
+    assert!(Arc::ptr_eq(&resolved, &global));
+  }
+
+  #[test]
+  fn merge_local_generator_options_into_global_generator_options() {
+    let global = Arc::new(GeneratorOptions::Json(JsonGeneratorOptions {
+      json_parse: Some(true),
+    }));
+    let local = GeneratorOptions::Json(JsonGeneratorOptions {
+      json_parse: Some(false),
+    });
+
+    let resolved = merge_generator_options_with_local(Some(global), Some(&local))
+      .expect("merged generator options should exist");
+
+    let options = resolved
+      .get_json()
+      .expect("json generator options should be resolved");
+    assert_eq!(options.json_parse, Some(false));
+  }
+
+  #[test]
+  fn cache_merged_global_generator_options_by_module_type() {
+    let generator_options = GeneratorOptionsMap::from_iter([
+      (
+        "asset".to_string(),
+        GeneratorOptions::Asset(AssetGeneratorOptions {
+          emit: Some(false),
+          ..Default::default()
+        }),
+      ),
+      (
+        "asset/resource".to_string(),
+        GeneratorOptions::AssetResource(AssetResourceGeneratorOptions {
+          binary: Some(true),
+          ..Default::default()
+        }),
+      ),
+    ]);
+
+    let cache = create_global_generator_options_cache(Some(&generator_options));
+    let resolved = cache
+      .get(ModuleType::AssetResource.as_str())
+      .expect("asset/resource generator options should be cached")
+      .get_asset_resource()
+      .expect("asset/resource generator options should be resolved");
+
+    assert_eq!(resolved.emit, Some(false));
+    assert_eq!(resolved.binary, Some(true));
+  }
+
+  #[test]
   fn reuse_create_data_resource_resolve_data_for_normal_module() {
     let resource_data = ResourceData::new_with_resource("/a.js".to_string());
     let mut create_data = NormalModuleCreateData {
@@ -311,9 +473,12 @@ impl NormalModuleFactory {
     plugin_driver: SharedPluginDriver,
   ) -> Self {
     let global_parser_options = create_global_parser_options_cache(options.module.parser.as_ref());
+    let global_generator_options =
+      create_global_generator_options_cache(options.module.generator.as_ref());
     Self {
       options,
       global_parser_options,
+      global_generator_options,
       loader_resolver_factory,
       plugin_driver,
     }
@@ -749,7 +914,7 @@ module.exports = "data:,";
         )
       })?(
       resolved_parser_options.as_deref(),
-      resolved_generator_options.as_ref(),
+      resolved_generator_options.as_deref(),
     );
     self
       .plugin_driver
@@ -909,75 +1074,17 @@ module.exports = "data:,";
     module_type: &ModuleType,
     parser: Option<ParserOptions>,
     generator: Option<GeneratorOptions>,
-  ) -> (Option<Arc<ParserOptions>>, Option<GeneratorOptions>) {
+  ) -> (Option<Arc<ParserOptions>>, Option<Arc<GeneratorOptions>>) {
     let global_parser = self
       .global_parser_options
       .get(module_type.as_str())
       .map(Arc::clone);
-    let global_generator = self.options.module.generator.as_ref().and_then(|g| {
-      let options = g.get(module_type.as_str());
-
-      match module_type {
-        ModuleType::AssetInline | ModuleType::AssetResource => {
-          rspack_util::merge_from_optional_with(
-            g.get("asset").cloned(),
-            options,
-            |asset_options, options| match (asset_options, options) {
-              (GeneratorOptions::Asset(a), GeneratorOptions::AssetInline(b)) => {
-                GeneratorOptions::AssetInline(
-                  Into::<AssetInlineGeneratorOptions>::into(a).merge_from(b),
-                )
-              }
-              (GeneratorOptions::Asset(a), GeneratorOptions::AssetResource(b)) => {
-                GeneratorOptions::AssetResource(
-                  Into::<AssetResourceGeneratorOptions>::into(a).merge_from(b),
-                )
-              }
-              _ => unreachable!(),
-            },
-          )
-        }
-        ModuleType::CssAuto | ModuleType::CssModule => rspack_util::merge_from_optional_with(
-          g.get("css").cloned(),
-          options,
-          |css_options, options| match (css_options, options) {
-            (GeneratorOptions::Css(a), GeneratorOptions::CssAuto(b)) => {
-              GeneratorOptions::CssAuto(Into::<CssAutoGeneratorOptions>::into(a).merge_from(b))
-            }
-            (GeneratorOptions::Css(a), GeneratorOptions::CssModule(b)) => {
-              GeneratorOptions::CssModule(Into::<CssModuleGeneratorOptions>::into(a).merge_from(b))
-            }
-            _ => unreachable!(),
-          },
-        ),
-        ModuleType::Json => rspack_util::merge_from_optional_with(
-          g.get("json").cloned(),
-          options,
-          |json_options, options| match (json_options, options) {
-            (GeneratorOptions::Json(a), GeneratorOptions::Json(b)) => {
-              GeneratorOptions::Json(a.merge_from(b))
-            }
-            _ => unreachable!(),
-          },
-        ),
-        _ => options.cloned(),
-      }
-    });
+    let global_generator = self
+      .global_generator_options
+      .get(module_type.as_str())
+      .map(Arc::clone);
     let parser = merge_parser_options_with_local(global_parser, parser.as_ref());
-    let generator = rspack_util::merge_from_optional_with(
-      global_generator,
-      generator.as_ref(),
-      |global, local| match (&global, local) {
-        (GeneratorOptions::Asset(_), GeneratorOptions::Asset(_))
-        | (GeneratorOptions::AssetInline(_), GeneratorOptions::AssetInline(_))
-        | (GeneratorOptions::AssetResource(_), GeneratorOptions::AssetResource(_))
-        | (GeneratorOptions::Css(_), GeneratorOptions::Css(_))
-        | (GeneratorOptions::CssAuto(_), GeneratorOptions::CssAuto(_))
-        | (GeneratorOptions::CssModule(_), GeneratorOptions::CssModule(_))
-        | (GeneratorOptions::Json(_), GeneratorOptions::Json(_)) => global.merge_from(local),
-        _ => global,
-      },
-    );
+    let generator = merge_generator_options_with_local(global_generator, generator.as_ref());
     (parser, generator)
   }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -5,6 +5,7 @@ use rspack_hook::define_hook;
 use rspack_loader_runner::{Loader, Scheme, get_scheme};
 use rspack_util::MergeFrom;
 use sugar_path::SugarPath;
+use ustr::Ustr;
 use winnow::prelude::*;
 
 use crate::{
@@ -966,9 +967,9 @@ module.exports = "data:,";
     } else {
       let resource_resolve_data = create_data.resource_resolve_data.take_shared();
       NormalModule::new(
-        create_data.request.clone(),
-        create_data.user_request.clone(),
-        create_data.raw_request.clone(),
+        Ustr::from(create_data.request.as_str()),
+        Ustr::from(create_data.user_request.as_str()),
+        Ustr::from(create_data.raw_request.as_str()),
         resolved_module_type,
         resolved_module_layer,
         resolved_parser_and_generator,

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -124,8 +124,8 @@ impl Module for LazyCompilationProxyModule {
     &MODULE_TYPE
   }
 
-  fn get_context(&self) -> Option<Box<Context>> {
-    Some(self.context.clone())
+  fn get_context(&self) -> Option<&Context> {
+    Some(&self.context)
   }
 
   fn get_layer(&self) -> Option<&ModuleLayer> {

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -155,8 +155,8 @@ impl Module for ConsumeSharedModule {
     Some(self.lib_ident.as_str().into())
   }
 
-  fn get_context(&self) -> Option<Box<Context>> {
-    Some(Box::new(self.context.clone()))
+  fn get_context(&self) -> Option<&Context> {
+    Some(&self.context)
   }
 
   fn get_exports_type(


### PR DESCRIPTION
## Summary

- Store `NormalModule` generator options behind `Arc`, matching the existing parser options sharing model.
- Cache global generator options in `NormalModuleFactory`, including merged asset/css/json variants, so modules can reuse identical global generator config.
- Keep mutable access copy-on-write via `Arc::make_mut` for callers that adjust per-module generator options.
- Add unit coverage for global generator reuse, local merge behavior, and merged global generator cache entries.

## Validation

- `cargo fmt --all --check`
- `cargo test -p rspack_core normal_module_factory --locked`
- `cargo check --workspace --all-targets --locked`
