### PR TITLE
test: add native binding multi-load test

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -26,7 +26,8 @@
     "build:dev:browser": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads RSPACK_TARGET_BROWSER=1 node scripts/build.js",
     "build:release:browser": "DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads RSPACK_TARGET_BROWSER=1 node scripts/build.js --profile release-wasi",
     "move-binding": "node scripts/move-binding",
-    "test": "tsc -p tsconfig.type-test.json",
+    "test:native": "node --test tests/load-multiple-native-bindings.test.cjs",
+    "test": "tsc -p tsconfig.type-test.json && pnpm run test:native",
     "wasm-add-external-debug": "node scripts/add-external-debug-info.js rspack.wasm32-wasi.wasm rspack.wasm32-wasi.debug.wasm"
   },
   "homepage": "https://rspack.rs",

--- a/crates/node_binding/tests/load-multiple-native-bindings.test.cjs
+++ b/crates/node_binding/tests/load-multiple-native-bindings.test.cjs
@@ -1,0 +1,187 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const bindingDir = path.resolve(__dirname, '..');
+
+test(
+  'loads the native binding twice from different paths',
+  { skip: isWasm() },
+  (t) => {
+    const nativeBindingPath = findNativeBinding();
+    const copyDir = mkdtempSync(path.join(tmpdir(), 'rspack-binding-'));
+    const copiedBindingPath = path.join(
+      copyDir,
+      path.basename(nativeBindingPath),
+    );
+
+    t.after(() => {
+      try {
+        rmSync(copyDir, { recursive: true, force: true });
+      } catch (error) {
+        if (process.platform !== 'win32') {
+          throw error;
+        }
+      }
+    });
+
+    copyFileSync(nativeBindingPath, copiedBindingPath);
+
+    const loadResult = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        `
+const assert = require("node:assert/strict");
+const firstBinding = require(${JSON.stringify(nativeBindingPath)});
+const secondBinding = require(${JSON.stringify(copiedBindingPath)});
+
+assert.notStrictEqual(firstBinding, secondBinding);
+assert.equal(typeof firstBinding.EXPECTED_RSPACK_CORE_VERSION, "string");
+assert.equal(
+	secondBinding.EXPECTED_RSPACK_CORE_VERSION,
+	firstBinding.EXPECTED_RSPACK_CORE_VERSION
+);
+`,
+      ],
+      { encoding: 'utf8' },
+    );
+
+    assert.equal(
+      loadResult.status,
+      0,
+      childProcessError(loadResult, nativeBindingPath, copiedBindingPath),
+    );
+  },
+);
+
+function findNativeBinding() {
+  const candidates = nativeBindingCandidates().map((fileName) =>
+    path.join(bindingDir, fileName),
+  );
+  const nativeBindingPath = candidates.find(existsSync);
+
+  if (!nativeBindingPath) {
+    throw new Error(
+      `Cannot find a native binding for ${process.platform}-${process.arch}. Looked for:\n${candidates.join('\n')}`,
+    );
+  }
+
+  return nativeBindingPath;
+}
+
+function isWasm() {
+  return process.env.WASM === '1' || process.env.NAPI_RS_FORCE_WASI === '1';
+}
+
+function nativeBindingCandidates() {
+  switch (process.platform) {
+    case 'darwin':
+      return [
+        'rspack.darwin-universal.node',
+        `rspack.darwin-${process.arch}.node`,
+      ];
+    case 'freebsd':
+      return [`rspack.freebsd-${process.arch}.node`];
+    case 'linux':
+      return linuxBindingCandidates();
+    case 'openharmony':
+      return [`rspack.linux-${process.arch}-ohos.node`];
+    case 'win32':
+      return [`rspack.win32-${process.arch}-msvc.node`];
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+function linuxBindingCandidates() {
+  if (process.arch === 'arm') {
+    return isMusl()
+      ? ['rspack.linux-arm-musleabihf.node', 'rspack.linux-arm-gnueabihf.node']
+      : ['rspack.linux-arm-gnueabihf.node', 'rspack.linux-arm-musleabihf.node'];
+  }
+
+  if (process.arch === 'ppc64' || process.arch === 's390x') {
+    return [`rspack.linux-${process.arch}-gnu.node`];
+  }
+
+  const libcCandidates = isMusl() ? ['musl', 'gnu'] : ['gnu', 'musl'];
+  return libcCandidates.map(
+    (libc) => `rspack.linux-${process.arch}-${libc}.node`,
+  );
+}
+
+function isMusl() {
+  let musl = false;
+
+  if (process.platform === 'linux') {
+    musl = isMuslFromFilesystem();
+    if (musl === null) {
+      musl = isMuslFromReport();
+    }
+    if (musl === null) {
+      musl = isMuslFromChildProcess();
+    }
+  }
+
+  return musl;
+}
+
+function isMuslFromFilesystem() {
+  try {
+    return readFileSync('/usr/bin/ldd', 'utf8').includes('musl');
+  } catch {
+    return null;
+  }
+}
+
+function isMuslFromReport() {
+  let report = null;
+  if (typeof process.report?.getReport === 'function') {
+    process.report.excludeNetwork = true;
+    report = process.report.getReport();
+  }
+  if (!report) {
+    return null;
+  }
+  if (report.header && report.header.glibcVersionRuntime) {
+    return false;
+  }
+  if (Array.isArray(report.sharedObjects)) {
+    return report.sharedObjects.some(
+      (file) => file.includes('libc.musl-') || file.includes('ld-musl-'),
+    );
+  }
+  return false;
+}
+
+function isMuslFromChildProcess() {
+  try {
+    const result = spawnSync('ldd', ['--version'], { encoding: 'utf8' });
+    return `${result.stdout ?? ''}${result.stderr ?? ''}`.includes('musl');
+  } catch {
+    return false;
+  }
+}
+
+function childProcessError(result, nativeBindingPath, copiedBindingPath) {
+  return [
+    'Expected the native binding and its copied file to load in one process.',
+    `Native binding: ${nativeBindingPath}`,
+    `Copied binding: ${copiedBindingPath}`,
+    result.signal ? `Signal: ${result.signal}` : `Exit code: ${result.status}`,
+    result.stdout ? `stdout:\n${result.stdout}` : '',
+    result.stderr ? `stderr:\n${result.stderr}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}


### PR DESCRIPTION
## Summary

- add a Node built-in test that copies the compiled native `.node` binding to a temporary path
- require the original binding and copied binding in one child process to cover loading multiple Rspack native bindings in the same process
- run the native multi-load test from `@rspack/binding`'s default `test` script so CI's `pnpm run test:ci -> pnpm run test:unit` path covers it
- skip the native-only test in WASM mode (`WASM=1` or `NAPI_RS_FORCE_WASI=1`)

## Related links

N/A

## Verification

- `cargo search mimalloc --limit 5`: latest `mimalloc` is `0.1.50`
- `cargo info mimalloc`: current workspace version is `0.1.50`
- `cargo search libmimalloc-sys --limit 5`: latest `libmimalloc-sys` is `0.1.47`
- `cargo info libmimalloc-sys`: lockfile version is `0.1.47`
- `cargo update -p mimalloc -p libmimalloc-sys --dry-run`: 0 packages to update
- `cargo tree -i libmimalloc-sys -p rspack_node --locked`: `rspack_node -> rspack_allocator -> mimalloc v0.1.50 -> libmimalloc-sys v0.1.47`
- `pnpm run build:binding:dev`: rebuilt `rspack.darwin-arm64.node` with current lockfile
- `pnpm exec prettier package.json tests/load-multiple-native-bindings.test.cjs --write`
- `pnpm exec tsc -p tsconfig.type-test.json`
- `WASM=1 pnpm run test:native`: skipped as expected
- `pnpm run test`: now enters `test:native` and still fails locally because the child process receives `SIGSEGV` after loading the original binding and then the copied binding. This reproduces the native multi-load problem with the current latest mimalloc stack and is expected to be covered by native CI.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).