### PR TITLE
docs: add Node app guide

### DIFF
--- a/website/docs/en/guide/tech/_meta.json
+++ b/website/docs/en/guide/tech/_meta.json
@@ -8,6 +8,7 @@
   "preact",
   "vue",
   "next",
+  "node",
   "nestjs",
   "solid",
   "svelte"

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -24,7 +24,7 @@ Install the common Node.js build dependencies from the [Node.js guide](/guide/te
 
 ## Basic concepts
 
-NestJS applications run in Node.js, so the runtime target, external dependencies, development scripts, and native addon handling can follow the common [Node.js configuration](/guide/tech/node). The main NestJS-specific requirement is decorator metadata, which NestJS uses at runtime.
+NestJS applications run in Node.js, so most configurations can follow the common [Node.js configuration](/guide/tech/node). The main NestJS-specific requirement is decorator metadata, which NestJS uses at runtime.
 
 - **Decorator metadata**: Enable TypeScript decorators and emitted metadata so dependency injection, controllers, routes, guards, interceptors, and other NestJS features work correctly.
 - **HMR cleanup**: When development HMR updates the server bundle, close the previous Nest application instance before accepting the update.

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -1,16 +1,16 @@
 ---
-description: 'Use NestJS with Rspack, covering setup, configuration, integration details, and framework-specific development patterns.'
+description: 'Use NestJS with Rspack, including setup, TypeScript decorators, development HMR, and production minification.'
 ---
 
 import { PackageManagerTabs } from '@theme';
 
 # NestJS
 
-Rspack can build Node.js applications such as [NestJS](https://nestjs.com/). Compared with using `tsc` directly, Rspack can bundle application code, transform TypeScript with SWC, support development-time HMR, and keep runtime dependencies external when needed.
+Rspack can build [NestJS](https://nestjs.com/) applications with the same Node.js runtime setup used by other server applications. Compared with `tsc`, Rspack can bundle application code, transform TypeScript with SWC, enable development HMR, and leave runtime dependencies external when needed.
 
 ## How to use
 
-You can follow this document to manually add the required Rspack configuration to an existing NestJS project. The [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) in `rstack-examples` is also available as a reference, and contains a complete `rspack.config.mjs`, development script, production build script, and HMR entry.
+Start with the common [Node.js application configuration](/guide/tech/node), then add the NestJS settings described below. You can also use the [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) in `rstack-examples` as a reference. It includes a complete `rspack.config.mjs`, development script, production build script, and HMR entry.
 
 ## Example
 
@@ -18,26 +18,21 @@ The [rstack-examples](https://github.com/rstackjs/rstack-examples/tree/main/rspa
 
 ## Install dependencies
 
-Install Rspack and the helper dependencies used by the NestJS example:
-
-<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin -D" />
-
-For a minimal NestJS application, install the NestJS runtime dependencies as usual:
+Install the common Node.js build dependencies from the [Node.js guide](/guide/tech/node#install-dependencies), then install the NestJS runtime packages:
 
 <PackageManagerTabs command="add @nestjs/common @nestjs/core @nestjs/platform-express reflect-metadata rxjs" />
 
 ## Basic concepts
 
-NestJS applications run in Node.js, so the Rspack configuration should target the Node.js runtime and preserve the framework metadata that NestJS reads at runtime.
+NestJS applications run in Node.js, so the runtime target, external dependencies, development scripts, and native addon handling can follow the common [Node.js configuration](/guide/tech/node). The main NestJS-specific requirement is decorator metadata, which NestJS uses at runtime.
 
-- **Node.js target** ([`target: 'node'`](/config/target)): Generates output suitable for Node.js instead of the browser.
-- **Decorator metadata**: NestJS relies on TypeScript decorators and emitted metadata for dependency injection, controllers, routes, guards, interceptors, and other framework features.
-- **External dependencies**: Server applications usually do not need to bundle every package in `node_modules`. Externalizing dependencies keeps the bundle smaller and allows Node.js to load packages normally at runtime.
-- **Development HMR**: In development, the Node.js process needs to restart or accept updates after Rspack rebuilds the server bundle.
+- **Decorator metadata**: Enable TypeScript decorators and emitted metadata so dependency injection, controllers, routes, guards, interceptors, and other NestJS features work correctly.
+- **HMR cleanup**: When development HMR updates the server bundle, close the previous Nest application instance before accepting the update.
+- **Production minification**: Keep class and function names stable because NestJS may use them through metadata reflection and execution context APIs.
 
 ## Configure Rspack
 
-The following configuration is adapted from the NestJS example:
+The following configuration is adapted from the NestJS example. It combines the common Node.js setup with the decorator metadata options required by NestJS:
 
 ```js title="rspack.config.mjs"
 // @ts-check
@@ -122,7 +117,7 @@ export default defineConfig({
 
 ## Configure scripts
 
-Use `rspack dev` for development and `rspack build` for production builds:
+Use `rspack dev` during development and `rspack build` for production:
 
 ```json title="package.json"
 {
@@ -136,11 +131,11 @@ Use `rspack dev` for development and `rspack build` for production builds:
 
 - `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
 - `build`: Creates a production bundle without the HMR polling entry.
-- `start`: Runs the production output with Node.js.
+- `start`: Runs the production bundle with Node.js.
 
 ## Configure TypeScript decorators
 
-NestJS uses decorators such as `@Module()`, `@Controller()`, `@Injectable()`, and `@Get()`. Configure `builtin:swc-loader` to parse TypeScript decorators and emit decorator metadata:
+NestJS uses decorators such as `@Module()`, `@Controller()`, `@Injectable()`, and `@Get()`. Configure `builtin:swc-loader` so SWC can parse these decorators and emit the metadata NestJS needs:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -169,7 +164,7 @@ export default {
 };
 ```
 
-If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecoratorMetadata` enabled in `tsconfig.json` so TypeScript tooling and Rspack's SWC transform follow the same assumptions:
+If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecoratorMetadata` enabled in `tsconfig.json` so TypeScript and Rspack use the same decorator assumptions:
 
 ```json title="tsconfig.json"
 {
@@ -182,7 +177,7 @@ If your project also runs `tsc`, keep `experimentalDecorators` and `emitDecorato
 
 ## Configure development HMR
 
-Add `@rspack/core/hot/poll` only to the development entry, since including it in the production bundle will crash the Node.js application because HMR is not available in build mode:
+Add `@rspack/core/hot/poll` only in development. If it is included in the production bundle, the Node.js application will fail at runtime because HMR is not available in build mode:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -195,19 +190,7 @@ export default {
 };
 ```
 
-Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
-
-```js title="rspack.config.mjs"
-export default {
-  devServer: {
-    devMiddleware: {
-      writeToDisk: true,
-    },
-  },
-};
-```
-
-Add HMR handling to the NestJS bootstrap file so the old application instance is closed before the updated module is accepted:
+Add HMR handling to the NestJS bootstrap file. This closes the old application instance before accepting the updated module:
 
 ```ts title="src/main.ts"
 declare const module: any;
@@ -227,43 +210,11 @@ async function bootstrap() {
 bootstrap();
 ```
 
-`RunScriptWebpackPlugin` starts the generated `main.js` file during development:
-
-```js title="rspack.config.mjs"
-import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
-
-export default {
-  plugins: [
-    new RunScriptWebpackPlugin({
-      name: 'main.js',
-      autoRestart: false,
-    }),
-  ],
-};
-```
-
-## Externalize dependencies
-
-Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`:
-
-```js title="rspack.config.mjs"
-import nodeExternals from 'webpack-node-externals';
-
-export default {
-  externalsType: 'commonjs',
-  externals: [
-    nodeExternals({
-      allowlist: [/@rspack\/core\/hot\/poll/],
-    }),
-  ],
-};
-```
-
-The HMR polling runtime must be allowlisted in development so it is bundled into the server output instead of being treated as an external dependency.
+See [Node.js - Configure development HMR](/guide/tech/node#configure-development-hmr) for the shared Rspack entry, `writeToDisk`, `RunScriptWebpackPlugin`, and externals allowlist settings used with this bootstrap code.
 
 ## Configure production minification
 
-When minifying a NestJS server bundle, keep class names and function names. NestJS APIs such as execution context and metadata reflection can depend on stable class and handler function references.
+When minifying a NestJS server bundle, keep class names and function names. NestJS can rely on stable class and handler references through metadata reflection and execution context APIs.
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
@@ -290,24 +241,4 @@ export default {
 
 ## Native node modules
 
-When building Node.js applications with Rspack, you may encounter dependencies that include Node.js native addon dependencies (`.node` modules). Because `.node` modules cannot be packaged into JavaScript artifacts, special handling is usually required. [node-loader](https://www.npmjs.com/package/node-loader) can be used to handle addon packaging.
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    rules: [
-      {
-        test: /\.node$/,
-        use: [
-          {
-            loader: 'node-loader',
-            options: {
-              name: '[path][name].[ext]',
-            },
-          },
-        ],
-      },
-    ],
-  },
-};
-```
+If a NestJS dependency includes a Node.js native addon (`.node` module), follow [Node.js - Native node modules](/guide/tech/node#native-node-modules) to emit the addon with `asset/resource` and let Node.js load it at runtime.

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # NestJS
 
-Rspack can build [NestJS](https://nestjs.com/) applications with the same Node.js runtime setup used by other server applications. Compared with `tsc`, Rspack can bundle application code, transform TypeScript with SWC, enable development HMR, and leave runtime dependencies external when needed.
+Rspack can build [NestJS](https://nestjs.com/) applications. Compared with `tsc`, Rspack can bundle application code, transform TypeScript with SWC, enable development HMR, and leave runtime dependencies external when needed.
 
 ## How to use
 

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -52,6 +52,8 @@ export default defineConfig({
   },
   output: {
     clean: true,
+    filename: '[name].mjs',
+    module: true,
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -94,11 +96,10 @@ export default defineConfig({
       }),
     ],
   },
-  externalsType: 'commonjs',
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.js',
+        name: 'main.mjs',
         autoRestart: false,
       }),
   ],
@@ -109,6 +110,7 @@ export default defineConfig({
   },
   externals: [
     nodeExternals({
+      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
@@ -124,12 +126,12 @@ Use `rspack dev` during development and `rspack build` for production:
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.js"
+    "start": "node dist/main.mjs"
   }
 }
 ```
 
-- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
+- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.mjs`.
 - `build`: Creates a production bundle without the HMR polling entry.
 - `start`: Runs the production bundle with Node.js.
 
@@ -210,7 +212,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-See [Node.js - Configure development HMR](/guide/tech/node#configure-development-hmr) for the shared Rspack entry, `writeToDisk`, `RunScriptWebpackPlugin`, and externals allowlist settings used with this bootstrap code.
+See [Node.js - Configure development HMR](/guide/tech/node#configure-development-hmr) for the shared Rspack entry, `writeToDisk`, `RunScriptWebpackPlugin`, and externals allowlist settings used with this bootstrap code. If your project needs CommonJS output, see [Node.js - Use CommonJS output](/guide/tech/node#use-commonjs-output).
 
 ## Configure production minification
 

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -52,8 +52,10 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    filename: '[name].mjs',
     module: true,
+    chunkFormat: 'module',
+    chunkLoading: 'import',
+    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],

--- a/website/docs/en/guide/tech/nestjs.mdx
+++ b/website/docs/en/guide/tech/nestjs.mdx
@@ -52,10 +52,6 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    module: true,
-    chunkFormat: 'module',
-    chunkLoading: 'import',
-    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -101,7 +97,7 @@ export default defineConfig({
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.mjs',
+        name: 'main.js',
         autoRestart: false,
       }),
   ],
@@ -112,7 +108,6 @@ export default defineConfig({
   },
   externals: [
     nodeExternals({
-      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
@@ -128,12 +123,12 @@ Use `rspack dev` during development and `rspack build` for production:
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.mjs"
+    "start": "node dist/main.js"
   }
 }
 ```
 
-- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.mjs`.
+- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
 - `build`: Creates a production bundle without the HMR polling entry.
 - `start`: Runs the production bundle with Node.js.
 
@@ -214,7 +209,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-See [Node.js - Configure development HMR](/guide/tech/node#configure-development-hmr) for the shared Rspack entry, `writeToDisk`, `RunScriptWebpackPlugin`, and externals allowlist settings used with this bootstrap code. If your project needs CommonJS output, see [Node.js - Use CommonJS output](/guide/tech/node#use-commonjs-output).
+See [Node.js - Configure development HMR](/guide/tech/node#configure-development-hmr) for the shared Rspack entry, `writeToDisk`, `RunScriptWebpackPlugin`, and externals allowlist settings used with this bootstrap code. If your project needs ESM output, see [Node.js - Use ESM output](/guide/tech/node#use-esm-output).
 
 ## Configure production minification
 

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -42,8 +42,10 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    filename: '[name].mjs',
     module: true,
+    chunkFormat: 'module',
+    chunkLoading: 'import',
+    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -1,0 +1,208 @@
+---
+description: 'Use Rspack to build Node.js applications, covering runtime targets, external dependencies, development scripts, and native addons.'
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Node.js
+
+Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime.
+
+## Install dependencies
+
+Install Rspack and the helper dependencies used by the examples on this page:
+
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin -D" />
+
+## Basic concepts
+
+- **Node.js target** ([`target: 'node'`](/config/target)): Generates output suitable for Node.js instead of the browser.
+- **External dependencies**: Server applications usually do not need to bundle every package in `node_modules`. Externalizing dependencies keeps the bundle smaller and allows Node.js to load packages normally at runtime.
+- **Development HMR**: In development, the Node.js process needs to restart or accept updates after Rspack rebuilds the server bundle.
+- **Native addons**: Dependencies or application code may reference `.node` files. These files need to be emitted as separate assets and loaded by Node.js at runtime.
+
+## Configure Rspack
+
+The following configuration targets Node.js, externalizes `node_modules`, writes development output to disk, and starts the generated bundle during development:
+
+```js title="rspack.config.mjs"
+// @ts-check
+import { defineConfig } from '@rspack/cli';
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import nodeExternals from 'webpack-node-externals';
+
+export default defineConfig({
+  context: import.meta.dirname,
+  target: 'node',
+  entry: {
+    main:
+      process.env.NODE_ENV === 'production'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+  output: {
+    clean: true,
+  },
+  resolve: {
+    extensions: ['...', '.ts', '.tsx', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            jsc: {
+              parser: {
+                syntax: 'typescript',
+              },
+            },
+          },
+        },
+      },
+      {
+        test: /\.node$/,
+        type: 'asset/resource',
+      },
+    ],
+  },
+  externalsType: 'commonjs',
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+  plugins: [
+    process.env.NODE_ENV !== 'production' &&
+      new RunScriptWebpackPlugin({
+        name: 'main.js',
+        autoRestart: false,
+      }),
+  ],
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+});
+```
+
+## Configure scripts
+
+Use `rspack dev` for development and `rspack build` for production builds:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "rspack build",
+    "dev": "rspack dev",
+    "start": "node dist/main.js"
+  }
+}
+```
+
+- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
+- `build`: Creates a production bundle without the HMR polling entry.
+- `start`: Runs the production output with Node.js.
+
+## Configure development HMR
+
+Add `@rspack/core/hot/poll` only to the development entry, since including it in the production bundle will crash the Node.js application because HMR is not available in build mode:
+
+```js title="rspack.config.mjs"
+export default {
+  entry: {
+    main:
+      process.env.NODE_ENV === 'production'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+};
+```
+
+Because the server process is started from the generated bundle, `devServer.devMiddleware.writeToDisk` must be enabled:
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+};
+```
+
+`RunScriptWebpackPlugin` starts the generated `main.js` file during development:
+
+```js title="rspack.config.mjs"
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+
+export default {
+  plugins: [
+    new RunScriptWebpackPlugin({
+      name: 'main.js',
+      autoRestart: false,
+    }),
+  ],
+};
+```
+
+The HMR polling runtime must be allowlisted when `webpack-node-externals` is used so it is bundled into the server output instead of being treated as an external dependency.
+
+## Externalize dependencies
+
+Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`:
+
+```js title="rspack.config.mjs"
+import nodeExternals from 'webpack-node-externals';
+
+export default {
+  externalsType: 'commonjs',
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+};
+```
+
+## Native node modules
+
+When building Node.js applications with Rspack, you may encounter dependencies that include Node.js native addon dependencies (`.node` modules). Because `.node` modules cannot be packaged into JavaScript artifacts, emit them as assets and load them with Node.js.
+
+```js title="rspack.config.mjs"
+export default {
+  target: 'node',
+  output: {
+    // Use the default publicPath or `publicPath: 'auto'` so emitted addon
+    // URLs stay relative to the generated bundle.
+  },
+  module: {
+    rules: [
+      {
+        test: /\.node$/,
+        type: 'asset/resource',
+      },
+    ],
+  },
+};
+```
+
+Then load the emitted addon from application code with `dlopen`:
+
+```js title="src/addon.mjs"
+import { dlopen } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const file = new URL('./file.node', import.meta.url);
+const addon = { exports: {} };
+
+try {
+  dlopen(addon, fileURLToPath(file));
+} catch (error) {
+  // Handle addon loading errors here.
+}
+
+export default addon.exports;
+```

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -8,9 +8,7 @@ import { PackageManagerTabs } from '@theme';
 
 Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime.
 
-::::tip
-For modern Node.js applications, follow the [ESM guide](/guide/features/esm) to configure ESM output.
-::::
+For modern Node.js applications, see [Use ESM output](#use-esm-output).
 
 ## Install dependencies
 

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -173,9 +173,6 @@ import nodeExternals from 'webpack-node-externals';
 export default {
   output: {
     module: true,
-    chunkFormat: 'module',
-    chunkLoading: 'import',
-    workerChunkLoading: 'import',
   },
   externals: [
     nodeExternals({

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # Node.js
 
-Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime.
+Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime. The examples on this page use ESM output by default.
 
 ## Install dependencies
 
@@ -23,7 +23,7 @@ Install Rspack and the helper dependencies used by the examples on this page:
 
 ## Configure Rspack
 
-The following configuration targets Node.js, externalizes `node_modules`, writes development output to disk, and starts the generated bundle during development:
+The following configuration targets Node.js, emits an ESM bundle, externalizes `node_modules`, writes development output to disk, and starts the generated bundle during development:
 
 ```js title="rspack.config.mjs"
 // @ts-check
@@ -42,6 +42,8 @@ export default defineConfig({
   },
   output: {
     clean: true,
+    filename: '[name].mjs',
+    module: true,
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -67,16 +69,16 @@ export default defineConfig({
       },
     ],
   },
-  externalsType: 'commonjs',
   externals: [
     nodeExternals({
+      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.js',
+        name: 'main.mjs',
         autoRestart: false,
       }),
   ],
@@ -97,12 +99,12 @@ Use `rspack dev` for development and `rspack build` for production builds:
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.js"
+    "start": "node dist/main.mjs"
   }
 }
 ```
 
-- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
+- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.mjs`.
 - `build`: Creates a production bundle without the HMR polling entry.
 - `start`: Runs the production output with Node.js.
 
@@ -133,7 +135,7 @@ export default {
 };
 ```
 
-`RunScriptWebpackPlugin` starts the generated `main.js` file during development:
+`RunScriptWebpackPlugin` starts the generated `main.mjs` file during development:
 
 ```js title="rspack.config.mjs"
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
@@ -141,7 +143,7 @@ import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 export default {
   plugins: [
     new RunScriptWebpackPlugin({
-      name: 'main.js',
+      name: 'main.mjs',
       autoRestart: false,
     }),
   ],
@@ -152,17 +154,46 @@ The HMR polling runtime must be allowlisted when `webpack-node-externals` is use
 
 ## Externalize dependencies
 
-Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`:
+Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`. For ESM output, set `importType: 'module'` so external dependencies are loaded with ESM imports:
 
 ```js title="rspack.config.mjs"
 import nodeExternals from 'webpack-node-externals';
 
 export default {
+  externals: [
+    nodeExternals({
+      importType: 'module',
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+};
+```
+
+## Use CommonJS output
+
+For older Node.js applications that still need CommonJS output, use `.js` output files, start `main.js`, and externalize dependencies as CommonJS modules:
+
+```js title="rspack.config.mjs"
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import nodeExternals from 'webpack-node-externals';
+
+export default {
+  output: {
+    filename: '[name].js',
+  },
   externalsType: 'commonjs',
   externals: [
     nodeExternals({
+      importType: 'commonjs',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
+  ],
+  plugins: [
+    process.env.NODE_ENV !== 'production' &&
+      new RunScriptWebpackPlugin({
+        name: 'main.js',
+        autoRestart: false,
+      }),
   ],
 };
 ```

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -8,6 +8,10 @@ import { PackageManagerTabs } from '@theme';
 
 Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime.
 
+::::tip
+For modern Node.js applications, follow the [ESM guide](/guide/features/esm) to configure ESM output.
+::::
+
 ## Install dependencies
 
 Install Rspack and the helper dependencies used by the examples on this page:

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # Node.js
 
-Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime. The examples on this page use ESM output by default.
+Rspack can build Node.js applications by bundling application code, transforming TypeScript with SWC, keeping runtime dependencies external, and emitting assets that Node.js can load at runtime.
 
 ## Install dependencies
 
@@ -23,7 +23,7 @@ Install Rspack and the helper dependencies used by the examples on this page:
 
 ## Configure Rspack
 
-The following configuration targets Node.js, emits an ESM bundle, externalizes `node_modules`, writes development output to disk, and starts the generated bundle during development:
+The following configuration targets Node.js, externalizes `node_modules`, writes development output to disk, and starts the generated bundle during development:
 
 ```js title="rspack.config.mjs"
 // @ts-check
@@ -42,10 +42,6 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    module: true,
-    chunkFormat: 'module',
-    chunkLoading: 'import',
-    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -69,14 +65,13 @@ export default defineConfig({
   },
   externals: [
     nodeExternals({
-      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.mjs',
+        name: 'main.js',
         autoRestart: false,
       }),
   ],
@@ -97,12 +92,12 @@ Use `rspack dev` for development and `rspack build` for production builds:
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.mjs"
+    "start": "node dist/main.js"
   }
 }
 ```
 
-- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.mjs`.
+- `dev`: Runs Rspack Dev Server, writes the server bundle to disk, and starts `dist/main.js`.
 - `build`: Creates a production bundle without the HMR polling entry.
 - `start`: Runs the production output with Node.js.
 
@@ -133,7 +128,7 @@ export default {
 };
 ```
 
-`RunScriptWebpackPlugin` starts the generated `main.mjs` file during development:
+`RunScriptWebpackPlugin` starts the generated `main.js` file during development:
 
 ```js title="rspack.config.mjs"
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
@@ -141,7 +136,7 @@ import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 export default {
   plugins: [
     new RunScriptWebpackPlugin({
-      name: 'main.mjs',
+      name: 'main.js',
       autoRestart: false,
     }),
   ],
@@ -152,7 +147,7 @@ The HMR polling runtime must be allowlisted when `webpack-node-externals` is use
 
 ## Externalize dependencies
 
-Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`. For ESM output, set `importType: 'module'` so external dependencies are loaded with ESM imports:
+Use [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) to externalize packages from `node_modules`:
 
 ```js title="rspack.config.mjs"
 import nodeExternals from 'webpack-node-externals';
@@ -160,38 +155,31 @@ import nodeExternals from 'webpack-node-externals';
 export default {
   externals: [
     nodeExternals({
-      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
 };
 ```
 
-## Use CommonJS output
+## Use ESM output
 
-For older Node.js applications that still need CommonJS output, use `.js` output files, start `main.js`, and externalize dependencies as CommonJS modules:
+For modern Node.js applications, you can output ESM bundles. See [ESM](/guide/features/esm) for the full ESM output guide. When using `webpack-node-externals` with ESM output, add `importType: 'module'` so external dependencies are loaded with ESM imports:
 
 ```js title="rspack.config.mjs"
-import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 import nodeExternals from 'webpack-node-externals';
 
 export default {
   output: {
-    filename: '[name].js',
+    module: true,
+    chunkFormat: 'module',
+    chunkLoading: 'import',
+    workerChunkLoading: 'import',
   },
-  externalsType: 'commonjs',
   externals: [
     nodeExternals({
-      importType: 'commonjs',
+      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
-  ],
-  plugins: [
-    process.env.NODE_ENV !== 'production' &&
-      new RunScriptWebpackPlugin({
-        name: 'main.js',
-        autoRestart: false,
-      }),
   ],
 };
 ```

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -51,15 +51,11 @@ export default defineConfig({
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.(?:js|mjs|jsx|ts|tsx)$/,
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            jsc: {
-              parser: {
-                syntax: 'typescript',
-              },
-            },
+            detectSyntax: 'auto',
           },
         },
       },

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -163,7 +163,7 @@ export default {
 
 ## Use ESM output
 
-For modern Node.js applications, you can output ESM bundles. See [ESM](/guide/features/esm) for the full ESM output guide. When using `webpack-node-externals` with ESM output, add `importType: 'module'` so external dependencies are loaded with ESM imports:
+For modern Node.js applications, follow the [ESM guide](/guide/features/esm) to output ESM bundles. When using `webpack-node-externals` with ESM output, add `importType: 'module'` so external dependencies are loaded with ESM imports:
 
 ```js title="rspack.config.mjs"
 import nodeExternals from 'webpack-node-externals';

--- a/website/docs/en/guide/tech/node.mdx
+++ b/website/docs/en/guide/tech/node.mdx
@@ -51,13 +51,13 @@ export default defineConfig({
   module: {
     rules: [
       {
-        test: /\.(?:js|mjs|jsx|ts|tsx)$/,
-        use: {
-          loader: 'builtin:swc-loader',
-          options: {
-            detectSyntax: 'auto',
-          },
+        test: /\.(?:js|mjs|ts)$/,
+        exclude: [/node_modules/],
+        loader: 'builtin:swc-loader',
+        options: {
+          detectSyntax: 'auto',
         },
+        type: 'javascript/auto',
       },
       {
         test: /\.node$/,

--- a/website/docs/zh/guide/tech/_meta.json
+++ b/website/docs/zh/guide/tech/_meta.json
@@ -8,6 +8,7 @@
   "preact",
   "vue",
   "next",
+  "node",
   "nestjs",
   "solid",
   "svelte"

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # NestJS
 
-Rspack 可以使用通用的 Node.js runtime 配置来构建 [NestJS](https://nestjs.com/) 应用。相比直接使用 `tsc`，Rspack 可以打包应用代码、通过 SWC 转译 TypeScript、支持开发阶段 HMR，并在需要时将运行时依赖作为 external 处理。
+Rspack 可以用于构建 [NestJS](https://nestjs.com/) 应用。相比直接使用 `tsc`，Rspack 可以打包应用代码、通过 SWC 转译 TypeScript、支持开发阶段 HMR，并在需要时将运行时依赖作为 external 处理。
 
 ## 如何使用
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -52,8 +52,10 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    filename: '[name].mjs',
     module: true,
+    chunkFormat: 'module',
+    chunkLoading: 'import',
+    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -24,7 +24,7 @@ Rspack 可以使用通用的 Node.js runtime 配置来构建 [NestJS](https://ne
 
 ## 基本概念
 
-NestJS 应用运行在 Node.js 中，因此 runtime target、external 依赖、开发脚本和 native addon 处理都可以复用通用的 [Node.js 配置](/guide/tech/node)。除此之外，NestJS 还需要 decorator metadata，框架会在运行时读取这些信息。
+NestJS 应用运行在 Node.js 中，因此大部分配置都与通用的 [Node.js 配置](/guide/tech/node) 一致。除此之外，NestJS 还需要 decorator metadata，框架会在运行时读取这些信息。
 
 - **Decorator metadata**：启用 TypeScript decorators 和 decorator metadata，保证依赖注入、控制器、路由、守卫、拦截器等 NestJS 能力正常工作。
 - **HMR cleanup**：开发阶段 HMR 更新服务端 bundle 时，需要在接受更新前关闭旧的 Nest 应用实例。

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -52,6 +52,8 @@ export default defineConfig({
   },
   output: {
     clean: true,
+    filename: '[name].mjs',
+    module: true,
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -94,11 +96,10 @@ export default defineConfig({
       }),
     ],
   },
-  externalsType: 'commonjs',
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.js',
+        name: 'main.mjs',
         autoRestart: false,
       }),
   ],
@@ -109,6 +110,7 @@ export default defineConfig({
   },
   externals: [
     nodeExternals({
+      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
@@ -124,12 +126,12 @@ export default defineConfig({
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.js"
+    "start": "node dist/main.mjs"
   }
 }
 ```
 
-- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
+- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.mjs`。
 - `build`：创建不包含 HMR polling 入口的生产 bundle。
 - `start`：使用 Node.js 运行生产 bundle。
 
@@ -210,7 +212,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-通用的 Rspack entry、`writeToDisk`、`RunScriptWebpackPlugin` 和 externals allowlist 设置请参考 [Node.js - 配置开发 HMR](/guide/tech/node#配置开发-hmr)。
+通用的 Rspack entry、`writeToDisk`、`RunScriptWebpackPlugin` 和 externals allowlist 设置请参考 [Node.js - 配置开发 HMR](/guide/tech/node#配置开发-hmr)。如果你的项目需要 CommonJS 输出，请参考 [Node.js - 使用 CommonJS 输出](/guide/tech/node#使用-commonjs-输出)。
 
 ## 配置生产压缩
 

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -1,16 +1,16 @@
 ---
-description: '在 Rspack 中使用 NestJS 的指南，涵盖环境配置、集成方式、调试要点、开发模式与常见问题处理。'
+description: '在 Rspack 中使用 NestJS，涵盖环境配置、TypeScript decorators、开发阶段 HMR 和生产压缩。'
 ---
 
 import { PackageManagerTabs } from '@theme';
 
 # NestJS
 
-Rspack 可以用于构建 [NestJS](https://nestjs.com/) 等 Node.js 应用。相比直接使用 `tsc`，Rspack 可以打包应用代码、通过 SWC 转译 TypeScript、支持开发阶段 HMR，并在需要时 external 运行时依赖。
+Rspack 可以使用通用的 Node.js runtime 配置来构建 [NestJS](https://nestjs.com/) 应用。相比直接使用 `tsc`，Rspack 可以打包应用代码、通过 SWC 转译 TypeScript、支持开发阶段 HMR，并在需要时将运行时依赖作为 external 处理。
 
 ## 如何使用
 
-你可以参考当前文档，为已有 NestJS 项目手动添加所需的 Rspack 配置。`rstack-examples` 中的 [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs) 也可作为参考，它包含完整的 `rspack.config.mjs`、开发脚本、生产构建脚本和 HMR 入口。
+请先参考通用的 [Node.js 应用配置](/guide/tech/node)，再补充本文介绍的 NestJS 配置。你也可以参考 `rstack-examples` 中的 [NestJS example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/nestjs)，其中包含完整的 `rspack.config.mjs`、开发脚本、生产构建脚本和 HMR 入口。
 
 ## 示例
 
@@ -18,26 +18,21 @@ Rspack 可以用于构建 [NestJS](https://nestjs.com/) 等 Node.js 应用。相
 
 ## 安装依赖
 
-安装 Rspack 以及 NestJS 示例中使用到的辅助依赖：
-
-<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin -D" />
-
-对于一个最小的 NestJS 应用，请照常安装 NestJS 运行时依赖：
+先按 [Node.js 指南](/guide/tech/node#安装依赖)安装通用的 Node.js 构建依赖，然后安装 NestJS 运行时依赖：
 
 <PackageManagerTabs command="add @nestjs/common @nestjs/core @nestjs/platform-express reflect-metadata rxjs" />
 
 ## 基本概念
 
-NestJS 应用运行在 Node.js 中，因此 Rspack 配置需要面向 Node.js runtime，并保留 NestJS 在运行时读取的框架 metadata。
+NestJS 应用运行在 Node.js 中，因此 runtime target、external 依赖、开发脚本和 native addon 处理都可以复用通用的 [Node.js 配置](/guide/tech/node)。除此之外，NestJS 还需要 decorator metadata，框架会在运行时读取这些信息。
 
-- **Node.js target**（[`target: 'node'`](/config/target)）：生成适用于 Node.js 而不是浏览器的产物。
-- **Decorator metadata**：NestJS 依赖 TypeScript decorators 和生成的 metadata 来实现依赖注入、控制器、路由、守卫、拦截器等框架能力。
-- **External dependencies**：服务端应用通常不需要把 `node_modules` 中的所有包都打进 bundle。External 依赖可以减小 bundle 体积，并让 Node.js 在运行时正常加载依赖。
-- **Development HMR**：开发环境下，Node.js 进程需要在 Rspack 重新构建服务端 bundle 后重启或接受更新。
+- **Decorator metadata**：启用 TypeScript decorators 和 decorator metadata，保证依赖注入、控制器、路由、守卫、拦截器等 NestJS 能力正常工作。
+- **HMR cleanup**：开发阶段 HMR 更新服务端 bundle 时，需要在接受更新前关闭旧的 Nest 应用实例。
+- **Production minification**：保留 class name 和 function name，因为 NestJS 可能会通过 metadata reflection 和 execution context API 使用对应的引用。
 
 ## 配置 Rspack
 
-以下配置改编自 NestJS 示例：
+以下配置改编自 NestJS 示例，它组合了通用 Node.js 配置和 NestJS 所需的 decorator metadata 选项：
 
 ```js title="rspack.config.mjs"
 // @ts-check
@@ -122,7 +117,7 @@ export default defineConfig({
 
 ## 配置脚本
 
-使用 `rspack dev` 进行开发，并使用 `rspack build` 进行生产构建：
+开发阶段使用 `rspack dev`，生产构建使用 `rspack build`：
 
 ```json title="package.json"
 {
@@ -136,11 +131,11 @@ export default defineConfig({
 
 - `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
 - `build`：创建不包含 HMR polling 入口的生产 bundle。
-- `start`：使用 Node.js 运行生产产物。
+- `start`：使用 Node.js 运行生产 bundle。
 
 ## 配置 TypeScript decorators
 
-NestJS 使用 `@Module()`、`@Controller()`、`@Injectable()`、`@Get()` 等 decorators。你需要配置 `builtin:swc-loader` 来解析 TypeScript decorators 并生成 decorator metadata：
+NestJS 使用 `@Module()`、`@Controller()`、`@Injectable()`、`@Get()` 等 decorators。需要配置 `builtin:swc-loader`，让 SWC 能够解析这些 decorators，并生成 NestJS 需要的 metadata：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -169,7 +164,7 @@ export default {
 };
 ```
 
-如果项目同时运行 `tsc`，请在 `tsconfig.json` 中启用 `experimentalDecorators` 和 `emitDecoratorMetadata`，让 TypeScript 工具链和 Rspack 的 SWC 转换保持一致：
+如果项目同时运行 `tsc`，请在 `tsconfig.json` 中启用 `experimentalDecorators` 和 `emitDecoratorMetadata`，让 TypeScript 和 Rspack 使用一致的 decorator 配置：
 
 ```json title="tsconfig.json"
 {
@@ -182,7 +177,7 @@ export default {
 
 ## 配置开发 HMR
 
-只在开发入口中添加 `@rspack/core/hot/poll`；如果生产 bundle 中包含它，Node.js 应用会在运行时崩溃，因为 build mode 下不会启用 HMR：
+只在开发入口中添加 `@rspack/core/hot/poll`。如果生产 bundle 中包含它，Node.js 应用会在运行时失败，因为 build mode 下不会启用 HMR：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -195,19 +190,7 @@ export default {
 };
 ```
 
-由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
-
-```js title="rspack.config.mjs"
-export default {
-  devServer: {
-    devMiddleware: {
-      writeToDisk: true,
-    },
-  },
-};
-```
-
-在 NestJS bootstrap 文件中添加 HMR 处理，让旧的应用实例在接受更新前被关闭：
+在 NestJS bootstrap 文件中添加 HMR 处理，在接受更新前关闭旧的应用实例：
 
 ```ts title="src/main.ts"
 declare const module: any;
@@ -227,43 +210,11 @@ async function bootstrap() {
 bootstrap();
 ```
 
-`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.js` 文件：
-
-```js title="rspack.config.mjs"
-import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
-
-export default {
-  plugins: [
-    new RunScriptWebpackPlugin({
-      name: 'main.js',
-      autoRestart: false,
-    }),
-  ],
-};
-```
-
-## External 依赖
-
-使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包：
-
-```js title="rspack.config.mjs"
-import nodeExternals from 'webpack-node-externals';
-
-export default {
-  externalsType: 'commonjs',
-  externals: [
-    nodeExternals({
-      allowlist: [/@rspack\/core\/hot\/poll/],
-    }),
-  ],
-};
-```
-
-开发环境下，HMR polling runtime 必须加入 allowlist，这样它会被打进服务端产物，而不是被当作外部依赖处理。
+通用的 Rspack entry、`writeToDisk`、`RunScriptWebpackPlugin` 和 externals allowlist 设置请参考 [Node.js - 配置开发 HMR](/guide/tech/node#配置开发-hmr)。
 
 ## 配置生产压缩
 
-压缩 NestJS 服务端 bundle 时，需要保留 class name 和 function name。NestJS 的 execution context、metadata reflection 等机制可能依赖稳定的 class 和 handler function 引用。
+压缩 NestJS 服务端 bundle 时，需要保留 class name 和 function name。NestJS 可能会通过 metadata reflection 和 execution context API 使用对应的 class 与 handler 引用。
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
@@ -290,24 +241,4 @@ export default {
 
 ## Native node modules
 
-当使用 Rspack 构建 Node.js 应用时，可能会碰到一些依赖包含 Node.js native addon 依赖（`.node` 模块）。因为 `.node` 模块无法打包进 JavaScript 产物里，所以通常需要特殊处理。可以使用 [node-loader](https://www.npmjs.com/package/node-loader) 处理 addon 的打包。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    rules: [
-      {
-        test: /\.node$/,
-        use: [
-          {
-            loader: 'node-loader',
-            options: {
-              name: '[path][name].[ext]',
-            },
-          },
-        ],
-      },
-    ],
-  },
-};
-```
+如果 NestJS 依赖中包含 Node.js native addon（`.node` 模块），请参考 [Node.js - Native node modules](/guide/tech/node#native-node-modules)，使用 `asset/resource` 输出 addon，并让 Node.js 在运行时加载。

--- a/website/docs/zh/guide/tech/nestjs.mdx
+++ b/website/docs/zh/guide/tech/nestjs.mdx
@@ -52,10 +52,6 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    module: true,
-    chunkFormat: 'module',
-    chunkLoading: 'import',
-    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -101,7 +97,7 @@ export default defineConfig({
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.mjs',
+        name: 'main.js',
         autoRestart: false,
       }),
   ],
@@ -112,7 +108,6 @@ export default defineConfig({
   },
   externals: [
     nodeExternals({
-      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
@@ -128,12 +123,12 @@ export default defineConfig({
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.mjs"
+    "start": "node dist/main.js"
   }
 }
 ```
 
-- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.mjs`。
+- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
 - `build`：创建不包含 HMR polling 入口的生产 bundle。
 - `start`：使用 Node.js 运行生产 bundle。
 
@@ -214,7 +209,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-通用的 Rspack entry、`writeToDisk`、`RunScriptWebpackPlugin` 和 externals allowlist 设置请参考 [Node.js - 配置开发 HMR](/guide/tech/node#配置开发-hmr)。如果你的项目需要 CommonJS 输出，请参考 [Node.js - 使用 CommonJS 输出](/guide/tech/node#使用-commonjs-输出)。
+通用的 Rspack entry、`writeToDisk`、`RunScriptWebpackPlugin` 和 externals allowlist 设置请参考 [Node.js - 配置开发 HMR](/guide/tech/node#配置开发-hmr)。如果你的项目需要 ESM 输出，请参考 [Node.js - 使用 ESM 输出](/guide/tech/node#使用-esm-输出)。
 
 ## 配置生产压缩
 

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -42,8 +42,10 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    filename: '[name].mjs',
     module: true,
+    chunkFormat: 'module',
+    chunkLoading: 'import',
+    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -1,0 +1,208 @@
+---
+description: '使用 Rspack 构建 Node.js 应用，涵盖 runtime target、external 依赖、开发脚本和 native addon。'
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Node.js
+
+Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。
+
+## 安装依赖
+
+安装 Rspack 以及本文示例中使用到的辅助依赖：
+
+<PackageManagerTabs command="add @rspack/core @rspack/cli @rspack/dev-server webpack-node-externals run-script-webpack-plugin -D" />
+
+## 基本概念
+
+- **Node.js target**（[`target: 'node'`](/config/target)）：生成适用于 Node.js 而不是浏览器的产物。
+- **External dependencies**：服务端应用通常不需要把 `node_modules` 中的所有包都打进 bundle。External 依赖可以减小 bundle 体积，并让 Node.js 在运行时正常加载依赖。
+- **Development HMR**：开发环境下，Node.js 进程需要在 Rspack 重新构建服务端 bundle 后重启或接受更新。
+- **Native addons**：依赖或应用代码可能会引用 `.node` 文件。这类文件需要作为独立资源输出，并由 Node.js 在运行时加载。
+
+## 配置 Rspack
+
+以下配置面向 Node.js，external `node_modules`，在开发阶段将产物写入磁盘，并启动生成的 bundle：
+
+```js title="rspack.config.mjs"
+// @ts-check
+import { defineConfig } from '@rspack/cli';
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import nodeExternals from 'webpack-node-externals';
+
+export default defineConfig({
+  context: import.meta.dirname,
+  target: 'node',
+  entry: {
+    main:
+      process.env.NODE_ENV === 'production'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+  output: {
+    clean: true,
+  },
+  resolve: {
+    extensions: ['...', '.ts', '.tsx', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            jsc: {
+              parser: {
+                syntax: 'typescript',
+              },
+            },
+          },
+        },
+      },
+      {
+        test: /\.node$/,
+        type: 'asset/resource',
+      },
+    ],
+  },
+  externalsType: 'commonjs',
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+  plugins: [
+    process.env.NODE_ENV !== 'production' &&
+      new RunScriptWebpackPlugin({
+        name: 'main.js',
+        autoRestart: false,
+      }),
+  ],
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+});
+```
+
+## 配置脚本
+
+使用 `rspack dev` 进行开发，并使用 `rspack build` 进行生产构建：
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "rspack build",
+    "dev": "rspack dev",
+    "start": "node dist/main.js"
+  }
+}
+```
+
+- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
+- `build`：创建不包含 HMR polling 入口的生产 bundle。
+- `start`：使用 Node.js 运行生产产物。
+
+## 配置开发 HMR
+
+只在开发入口中添加 `@rspack/core/hot/poll`；如果生产 bundle 中包含它，Node.js 应用会在运行时崩溃，因为 build mode 下不会启用 HMR：
+
+```js title="rspack.config.mjs"
+export default {
+  entry: {
+    main:
+      process.env.NODE_ENV === 'production'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
+  },
+};
+```
+
+由于服务端进程会从生成的 bundle 启动，因此需要启用 `devServer.devMiddleware.writeToDisk`：
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    devMiddleware: {
+      writeToDisk: true,
+    },
+  },
+};
+```
+
+`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.js` 文件：
+
+```js title="rspack.config.mjs"
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+
+export default {
+  plugins: [
+    new RunScriptWebpackPlugin({
+      name: 'main.js',
+      autoRestart: false,
+    }),
+  ],
+};
+```
+
+使用 `webpack-node-externals` 时，HMR polling runtime 必须加入 allowlist，这样它会被打进服务端产物，而不是被当作外部依赖处理。
+
+## External 依赖
+
+使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包：
+
+```js title="rspack.config.mjs"
+import nodeExternals from 'webpack-node-externals';
+
+export default {
+  externalsType: 'commonjs',
+  externals: [
+    nodeExternals({
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+};
+```
+
+## Native node modules
+
+当使用 Rspack 构建 Node.js 应用时，可能会碰到一些依赖包含 Node.js native addon 依赖（`.node` 模块）。因为 `.node` 模块无法打包进 JavaScript 产物里，所以应该把它们作为资源输出，并交给 Node.js 加载。
+
+```js title="rspack.config.mjs"
+export default {
+  target: 'node',
+  output: {
+    // 使用默认 publicPath 或 `publicPath: 'auto'`，让输出的 addon URL
+    // 保持相对于生成 bundle 的路径。
+  },
+  module: {
+    rules: [
+      {
+        test: /\.node$/,
+        type: 'asset/resource',
+      },
+    ],
+  },
+};
+```
+
+然后在应用代码中通过 `dlopen` 加载输出后的 addon：
+
+```js title="src/addon.mjs"
+import { dlopen } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const file = new URL('./file.node', import.meta.url);
+const addon = { exports: {} };
+
+try {
+  dlopen(addon, fileURLToPath(file));
+} catch (error) {
+  // 在这里处理 addon 加载错误。
+}
+
+export default addon.exports;
+```

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -8,6 +8,10 @@ import { PackageManagerTabs } from '@theme';
 
 Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。
 
+::::tip
+对于现代 Node.js 应用，建议参考 [ESM 指南](/guide/features/esm)配置 ESM 输出。
+::::
+
 ## 安装依赖
 
 安装 Rspack 以及本文示例中使用到的辅助依赖：

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -173,9 +173,6 @@ import nodeExternals from 'webpack-node-externals';
 export default {
   output: {
     module: true,
-    chunkFormat: 'module',
-    chunkLoading: 'import',
-    workerChunkLoading: 'import',
   },
   externals: [
     nodeExternals({

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -8,9 +8,7 @@ import { PackageManagerTabs } from '@theme';
 
 Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。
 
-::::tip
-对于现代 Node.js 应用，建议参考 [ESM 指南](/guide/features/esm)配置 ESM 输出。
-::::
+对于现代 Node.js 应用，请参考[使用 ESM 输出](#使用-esm-输出)。
 
 ## 安装依赖
 

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # Node.js
 
-Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。
+Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。本文示例默认使用 ESM 输出。
 
 ## 安装依赖
 
@@ -23,7 +23,7 @@ Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转�
 
 ## 配置 Rspack
 
-以下配置面向 Node.js，external `node_modules`，在开发阶段将产物写入磁盘，并启动生成的 bundle：
+以下配置面向 Node.js，输出 ESM bundle，external `node_modules`，在开发阶段将产物写入磁盘，并启动生成的 bundle：
 
 ```js title="rspack.config.mjs"
 // @ts-check
@@ -42,6 +42,8 @@ export default defineConfig({
   },
   output: {
     clean: true,
+    filename: '[name].mjs',
+    module: true,
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -67,16 +69,16 @@ export default defineConfig({
       },
     ],
   },
-  externalsType: 'commonjs',
   externals: [
     nodeExternals({
+      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.js',
+        name: 'main.mjs',
         autoRestart: false,
       }),
   ],
@@ -97,12 +99,12 @@ export default defineConfig({
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.js"
+    "start": "node dist/main.mjs"
   }
 }
 ```
 
-- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
+- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.mjs`。
 - `build`：创建不包含 HMR polling 入口的生产 bundle。
 - `start`：使用 Node.js 运行生产产物。
 
@@ -133,7 +135,7 @@ export default {
 };
 ```
 
-`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.js` 文件：
+`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.mjs` 文件：
 
 ```js title="rspack.config.mjs"
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
@@ -141,7 +143,7 @@ import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 export default {
   plugins: [
     new RunScriptWebpackPlugin({
-      name: 'main.js',
+      name: 'main.mjs',
       autoRestart: false,
     }),
   ],
@@ -152,17 +154,46 @@ export default {
 
 ## External 依赖
 
-使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包：
+使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包。对于 ESM 输出，请设置 `importType: 'module'`，让 external 依赖通过 ESM import 加载：
 
 ```js title="rspack.config.mjs"
 import nodeExternals from 'webpack-node-externals';
 
 export default {
+  externals: [
+    nodeExternals({
+      importType: 'module',
+      allowlist: [/@rspack\/core\/hot\/poll/],
+    }),
+  ],
+};
+```
+
+## 使用 CommonJS 输出
+
+如果旧的 Node.js 应用仍然需要 CommonJS 输出，可以使用 `.js` 产物、启动 `main.js`，并把 external 依赖作为 CommonJS 模块加载：
+
+```js title="rspack.config.mjs"
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import nodeExternals from 'webpack-node-externals';
+
+export default {
+  output: {
+    filename: '[name].js',
+  },
   externalsType: 'commonjs',
   externals: [
     nodeExternals({
+      importType: 'commonjs',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
+  ],
+  plugins: [
+    process.env.NODE_ENV !== 'production' &&
+      new RunScriptWebpackPlugin({
+        name: 'main.js',
+        autoRestart: false,
+      }),
   ],
 };
 ```

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -163,7 +163,7 @@ export default {
 
 ## 使用 ESM 输出
 
-现代 Node.js 应用可以输出 ESM bundle。完整配置请参考 [ESM](/guide/features/esm)。当 `webpack-node-externals` 与 ESM 输出一起使用时，需要添加 `importType: 'module'`，让 external 依赖通过 ESM import 加载：
+对于现代 Node.js 应用，建议参考 [ESM 指南](/guide/features/esm)输出 ESM bundle。当 `webpack-node-externals` 与 ESM 输出一起使用时，需要添加 `importType: 'module'`，让 external 依赖通过 ESM import 加载：
 
 ```js title="rspack.config.mjs"
 import nodeExternals from 'webpack-node-externals';

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -6,7 +6,7 @@ import { PackageManagerTabs } from '@theme';
 
 # Node.js
 
-Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。本文示例默认使用 ESM 输出。
+Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转译 TypeScript、external 运行时依赖，并输出 Node.js 可在运行时加载的资源。
 
 ## 安装依赖
 
@@ -23,7 +23,7 @@ Rspack 可以用于构建 Node.js 应用：打包应用代码、通过 SWC 转�
 
 ## 配置 Rspack
 
-以下配置面向 Node.js，输出 ESM bundle，external `node_modules`，在开发阶段将产物写入磁盘，并启动生成的 bundle：
+以下配置面向 Node.js，external `node_modules`，在开发阶段将产物写入磁盘，并启动生成的 bundle：
 
 ```js title="rspack.config.mjs"
 // @ts-check
@@ -42,10 +42,6 @@ export default defineConfig({
   },
   output: {
     clean: true,
-    module: true,
-    chunkFormat: 'module',
-    chunkLoading: 'import',
-    workerChunkLoading: 'import',
   },
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -69,14 +65,13 @@ export default defineConfig({
   },
   externals: [
     nodeExternals({
-      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
   plugins: [
     process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
-        name: 'main.mjs',
+        name: 'main.js',
         autoRestart: false,
       }),
   ],
@@ -97,12 +92,12 @@ export default defineConfig({
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev",
-    "start": "node dist/main.mjs"
+    "start": "node dist/main.js"
   }
 }
 ```
 
-- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.mjs`。
+- `dev`：运行 Rspack Dev Server，将服务端 bundle 写入磁盘，并启动 `dist/main.js`。
 - `build`：创建不包含 HMR polling 入口的生产 bundle。
 - `start`：使用 Node.js 运行生产产物。
 
@@ -133,7 +128,7 @@ export default {
 };
 ```
 
-`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.mjs` 文件：
+`RunScriptWebpackPlugin` 会在开发阶段启动生成的 `main.js` 文件：
 
 ```js title="rspack.config.mjs"
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
@@ -141,7 +136,7 @@ import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 export default {
   plugins: [
     new RunScriptWebpackPlugin({
-      name: 'main.mjs',
+      name: 'main.js',
       autoRestart: false,
     }),
   ],
@@ -152,7 +147,7 @@ export default {
 
 ## External 依赖
 
-使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包。对于 ESM 输出，请设置 `importType: 'module'`，让 external 依赖通过 ESM import 加载：
+使用 [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) external `node_modules` 中的包：
 
 ```js title="rspack.config.mjs"
 import nodeExternals from 'webpack-node-externals';
@@ -160,38 +155,31 @@ import nodeExternals from 'webpack-node-externals';
 export default {
   externals: [
     nodeExternals({
-      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
   ],
 };
 ```
 
-## 使用 CommonJS 输出
+## 使用 ESM 输出
 
-如果旧的 Node.js 应用仍然需要 CommonJS 输出，可以使用 `.js` 产物、启动 `main.js`，并把 external 依赖作为 CommonJS 模块加载：
+现代 Node.js 应用可以输出 ESM bundle。完整配置请参考 [ESM](/guide/features/esm)。当 `webpack-node-externals` 与 ESM 输出一起使用时，需要添加 `importType: 'module'`，让 external 依赖通过 ESM import 加载：
 
 ```js title="rspack.config.mjs"
-import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 import nodeExternals from 'webpack-node-externals';
 
 export default {
   output: {
-    filename: '[name].js',
+    module: true,
+    chunkFormat: 'module',
+    chunkLoading: 'import',
+    workerChunkLoading: 'import',
   },
-  externalsType: 'commonjs',
   externals: [
     nodeExternals({
-      importType: 'commonjs',
+      importType: 'module',
       allowlist: [/@rspack\/core\/hot\/poll/],
     }),
-  ],
-  plugins: [
-    process.env.NODE_ENV !== 'production' &&
-      new RunScriptWebpackPlugin({
-        name: 'main.js',
-        autoRestart: false,
-      }),
   ],
 };
 ```

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -51,15 +51,11 @@ export default defineConfig({
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.(?:js|mjs|jsx|ts|tsx)$/,
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            jsc: {
-              parser: {
-                syntax: 'typescript',
-              },
-            },
+            detectSyntax: 'auto',
           },
         },
       },

--- a/website/docs/zh/guide/tech/node.mdx
+++ b/website/docs/zh/guide/tech/node.mdx
@@ -51,13 +51,13 @@ export default defineConfig({
   module: {
     rules: [
       {
-        test: /\.(?:js|mjs|jsx|ts|tsx)$/,
-        use: {
-          loader: 'builtin:swc-loader',
-          options: {
-            detectSyntax: 'auto',
-          },
+        test: /\.(?:js|mjs|ts)$/,
+        exclude: [/node_modules/],
+        loader: 'builtin:swc-loader',
+        options: {
+          detectSyntax: 'auto',
         },
+        type: 'javascript/auto',
       },
       {
         test: /\.node$/,


### PR DESCRIPTION
## Summary

- Add a new Node.js guide under Languages and Frameworks for common Node app configuration.
- Guide Node.js and NestJS examples toward ESM output by default, with CommonJS output documented in a separate section.
- Move shared Node app guidance out of the NestJS guide and link NestJS users to the new page first.
- Update native `.node` module guidance to use `asset/resource` and runtime loading instead of `node-loader`.

## Validation

- `pnpm --dir website exec cspell docs/en/guide/tech/node.mdx docs/zh/guide/tech/node.mdx docs/en/guide/tech/nestjs.mdx docs/zh/guide/tech/nestjs.mdx`
- `pnpm --dir website exec case-police docs/en/guide/tech/node.mdx docs/zh/guide/tech/node.mdx docs/en/guide/tech/nestjs.mdx docs/zh/guide/tech/nestjs.mdx`
- Commit hook: `pnpm --dir website run check:spell`

---
_This response was generated by OpenAI Codex._