### PR TITLE
chore: upgrade mimalloc to 0.1.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,12 +2369,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -2589,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.0", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
 miette              = { version = "7.6.0", default-features = false }
-mimalloc            = { version = "0.1.48", default-features = false }
+mimalloc            = { version = "0.1.50", default-features = false }
 mime_guess          = { version = "2.0.5", default-features = false, features = ["rev-mappings"] }
 notify              = { version = "8.2.0", default-features = false }
 num-bigint          = { version = "0.4.6", default-features = false }

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -12,13 +12,13 @@ tracy-client  = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Turned on `local_dynamic_tls` to avoid issue: https://github.com/microsoft/mimalloc/issues/147
-mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [lints]
 workspace = true

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -13,13 +13,13 @@ tokio     = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Keep benchmark allocator features aligned with rspack_allocator.
-mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 # Make rust analyzer happy


### PR DESCRIPTION
## Summary

- Upgrade workspace `mimalloc` from `0.1.48` to `0.1.50`.
- Update `Cargo.lock` to `libmimalloc-sys` `0.1.47`.
- Remove the explicit `v3` feature usage because newer `mimalloc` uses v3 by default and exposes `v2` as the opt-in alternative.
- Keep Linux `local_dynamic_tls` and benchmark allocator feature alignment.

## Related links

- https://github.com/purpleprotocol/mimalloc_rust/releases/tag/v0.1.50

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
