### PR TITLE
chore(ci): pin actions/{download,upload}-artifact to immutable SHAs

### DIFF
--- a/.github/actions/artifact/download/action.yml
+++ b/.github/actions/artifact/download/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Download artifact from github
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       if: ${{ !startsWith(runner.name, 'rspack') || inputs.force-use-github-only == 'true' }}
       with:
         name: ${{ inputs.name }}

--- a/.github/actions/artifact/upload/action.yml
+++ b/.github/actions/artifact/upload/action.yml
@@ -28,7 +28,7 @@ runs:
         overwrite: true
 
     - name: Upload artifact to github
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload Valgrind temporary files
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: codspeed-valgrind-tmp-${{ inputs.target }}
           path: ${{ runner.temp }}/codspeed-valgrind-tmp

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -79,7 +79,7 @@ jobs:
         run: pnpm i
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -98,7 +98,7 @@ jobs:
         run: pnpm i
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
           pattern: bindings-*

--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm i
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
           pattern: bindings-*

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload Test Reporter
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rstest-event-reports-${{ inputs.target }}-node${{ matrix.node }}
           path: '*-report.txt'

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -99,7 +99,7 @@ jobs:
         run: pnpm i
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
           pattern: bindings-*


### PR DESCRIPTION
## Summary

- Pin every `actions/download-artifact` and `actions/upload-artifact` reference under `.github/` to a commit SHA plus a `# vX.Y.Z` comment.


## Changes

| File | From | To |
|---|---|---|
| `.github/actions/artifact/download/action.yml` | `actions/download-artifact@v4.1.7` | `@65a9edc5...` `# v4.1.7` |
| `.github/actions/artifact/upload/action.yml` | `actions/upload-artifact@v4` | `@ea165f8d...` `# v4.6.2` |
| `.github/workflows/bench-rust.yml` | `actions/upload-artifact@v4` | `@ea165f8d...` `# v4.6.2` |
| `.github/workflows/preview-commit.yml` | `actions/download-artifact@v4.1.7` | `@65a9edc5...` `# v4.1.7` |
| `.github/workflows/release-canary.yml` | `actions/download-artifact@v4.1.7` | `@65a9edc5...` `# v4.1.7` |
| `.github/workflows/release-debug.yml` | `actions/download-artifact@v4.1.7` | `@65a9edc5...` `# v4.1.7` |
| `.github/workflows/reusable-build-test.yml` | `actions/upload-artifact@v4` | `@ea165f8d...` `# v4.6.2` |
| `.github/workflows/reusable-release-npm.yml` | `actions/download-artifact@v4.1.7` | `@65a9edc5...` `# v4.1.7` |

8 files, 8 single-line replacements. No semantic change to workflow behavior.

Resolved SHAs (verified against upstream tags):

```txt
gh api repos/actions/download-artifact/git/ref/tags/v4.1.7 --jq .object.sha
# 65a9edc5881444af0b9093a5e628f2fe47ea3b2e

gh api repos/actions/upload-artifact/git/ref/tags/v4.6.2 --jq .object.sha
# ea165f8d65b6e75b540449e92b4886f43607fa02
```



## Test plan

- [x] CI passes (workflows still resolve and run the pinned SHAs)
- [x] Manually confirm `grep -rE "actions/(upload|download)-artifact@v[0-9]" .github/` returns empty
- [ ] On the next release dispatch, confirm the artifact upload/download steps still succeed