### PR TITLE
refactor(core): remove unused exports final name metadata

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -742,7 +742,6 @@ export interface JsBuildMeta {
   exportsType?: undefined | 'unset' | 'default' | 'namespace' | 'flagged' | 'dynamic'
   defaultObject?: undefined | 'false' | 'redirect' | 'redirect-warn'
   sideEffectFree?: boolean
-  exportsFinalName?: Array<[string, string]> | undefined
 }
 
 export interface JsBuildTimeExecutionOption {

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -797,8 +797,6 @@ pub struct JsBuildMeta {
   #[napi(ts_type = "undefined | 'false' | 'redirect' | 'redirect-warn'")]
   pub default_object: Option<String>,
   pub side_effect_free: Option<bool>,
-  #[napi(ts_type = "Array<[string, string]> | undefined")]
-  pub exports_final_name: Option<Vec<Vec<String>>>,
 }
 
 impl From<JsBuildMeta> for BuildMeta {
@@ -808,7 +806,6 @@ impl From<JsBuildMeta> for BuildMeta {
       has_top_level_await,
       esm,
       default_object: raw_default_object,
-      exports_final_name: raw_exports_final_name,
       side_effect_free,
       exports_type: raw_exports_type,
     } = value;
@@ -837,23 +834,6 @@ impl From<JsBuildMeta> for BuildMeta {
       BuildMetaExportsType::Unset
     };
 
-    let exports_final_name = raw_exports_final_name.map(|exports_name| {
-      exports_name
-        .into_iter()
-        .map(|export_name| {
-          let first = export_name
-            .first()
-            .expect("The buildMeta exportsFinalName item should have first value")
-            .clone();
-          let second = export_name
-            .get(1)
-            .expect("The buildMeta exportsFinalName item should have second value")
-            .clone();
-          (first, second)
-        })
-        .collect::<Vec<_>>()
-    });
-
     Self {
       strict_esm_module: strict_esm_module.unwrap_or_default(),
       has_top_level_await: has_top_level_await.unwrap_or_default(),
@@ -861,7 +841,6 @@ impl From<JsBuildMeta> for BuildMeta {
       exports_type,
       default_object,
       side_effect_free,
-      exports_final_name,
     }
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -297,8 +297,6 @@ pub struct BuildMeta {
   pub default_object: BuildMetaDefaultObject,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub side_effect_free: Option<bool>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  pub exports_final_name: Option<Vec<(String, String)>>,
 }
 
 // webpack build info

--- a/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
@@ -62,7 +62,7 @@ __rspack_async_done();
 },
 "./wasm.wasm"(module, exports, __webpack_require__) {
 var __rspack_instantiate__ = function ([rspack_import_0, rspack_import_1]) {
-return __webpack_require__.v(exports, module.id, "e777786177103fda" , {
+return __webpack_require__.v(exports, module.id, "a6713fea1064f4d3" , {
 "./module": {
 "getNumber": rspack_import_0.getNumber
 },
@@ -78,7 +78,7 @@ __webpack_require__.a(module, async function (__rspack_load_async_deps, __rspack
 
     var __rspack_async_deps = __rspack_load_async_deps([rspack_import_0, rspack_import_1]);
     var [rspack_import_0, rspack_import_1] = __rspack_async_deps.then ? (await __rspack_async_deps)() : __rspack_async_deps;
-    await __webpack_require__.v(exports, module.id, "e777786177103fda" , {
+    await __webpack_require__.v(exports, module.id, "a6713fea1064f4d3" , {
 "./module": {
 "getNumber": rspack_import_0.getNumber
 },

--- a/tests/rspack-test/builtinCases/plugin-wasm/v128/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/v128/__snapshots__/output.snap.txt
@@ -15,7 +15,7 @@ __rspack_async_done();
 
 },
 "./v128.wasm"(module, exports, __webpack_require__) {
-module.exports = __webpack_require__.v(exports, module.id, "80508a12102fcf23" );
+module.exports = __webpack_require__.v(exports, module.id, "a32782c316f3bc9b" );
 
 },
 

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: fb0d3e29fe9f1df3,
+			      hash: ab4d81bf47aea773,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 8a6cffec89eed4fa,
+			  hash: 48be6dd9fe1e1073,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (f33764317b131701)
+Rspack compiled successfully (7762259ba9d01658)

--- a/tests/rspack-test/statsOutputCases/wasm-explorer-examples-sync/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/wasm-explorer-examples-sync/__snapshots__/stats.txt
@@ -1,17 +1,17 @@
 assets by path *.wasm xx KiB
-  asset ad41658e96d8163b.module.wasm xx bytes [emitted] [immutable]
-  asset 675b695aa295b810.module.wasm xx bytes [emitted] [immutable]
-  asset d721b2404ff371da.module.wasm xx bytes [emitted] [immutable]
-  asset 304f41ed8aa46cbb.module.wasm xx bytes [emitted] [immutable]
-  asset 5fde5d910acc4fe1.module.wasm xx bytes [emitted] [immutable]
-  asset c8b87a4f03233e44.module.wasm xx bytes [emitted] [immutable]
+  asset 5b1cf9eabe97b5fa.module.wasm xx bytes [emitted] [immutable]
+  asset d6fb27cc8ba95963.module.wasm xx bytes [emitted] [immutable]
+  asset dd6d2a216fd153df.module.wasm xx bytes [emitted] [immutable]
+  asset 1b3ca18da9ba7585.module.wasm xx bytes [emitted] [immutable]
+  asset d570402154524085.module.wasm xx bytes [emitted] [immutable]
+  asset 41d0d47cfd218be6.module.wasm xx bytes [emitted] [immutable]
 assets by path *.js xx KiB
   asset bundle.js xx KiB [emitted] (name: main)
   asset 549.bundle.js xx KiB [emitted]
   asset 440.bundle.js xx bytes [emitted] (id hint: vendors)
 chunk (runtime: main) 440.bundle.js (id hint: vendors) xx bytes [rendered] split chunk (cache group: defaultVendors)
   ./node_modules/env.js xx bytes [built] [code generated]
-chunk (runtime: main) 304f41ed8aa46cbb.module.wasm, 549.bundle.js, 5fde5d910acc4fe1.module.wasm, 675b695aa295b810.module.wasm, ad41658e96d8163b.module.wasm, c8b87a4f03233e44.module.wasm, d721b2404ff371da.module.wasm xx KiB (javascript) xx KiB (wasm) [rendered]
+chunk (runtime: main) 1b3ca18da9ba7585.module.wasm, 41d0d47cfd218be6.module.wasm, 549.bundle.js, 5b1cf9eabe97b5fa.module.wasm, d570402154524085.module.wasm, d6fb27cc8ba95963.module.wasm, dd6d2a216fd153df.module.wasm xx KiB (javascript) xx KiB (wasm) [rendered]
   ./Q_rsqrt.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]
   ./duff.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]
   ./fact.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]


### PR DESCRIPTION
## Summary
- Remove unused `exports_final_name` metadata from core module build metadata.
- Remove the corresponding `exportsFinalName` field from the binding API and generated napi types.

## Validation
- `cargo fmt --all --check`
- `cargo check -p rspack_core -p rspack_binding_api --all-targets --locked`
