### PR TITLE
chore: reduce duplicate rustix dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,11 +2539,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memfd"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 0.38.42",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -5384,7 +5384,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7126,11 +7126,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 0.38.42",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -248,7 +248,6 @@ skip = [
     { crate = "supports-color", reason = "external dependency"},
     { crate = "zerocopy", reason = "external dependency"},
     { crate = "linux-raw-sys", reason = "external dependency"},
-    { crate = "rustix", reason = "external dependency"},
     { crate = "ctor", reason = "external dependency"},
     { crate = "windows-link", reason = "external dependency"},
 ]


### PR DESCRIPTION
## Summary

- Upgrade transitive `terminal_size` from `0.4.1` to `0.4.4` so the default dependency graph uses `rustix 1.0.8`.
- Upgrade `memfd` from `0.6.4` to `0.6.5` where compatible.
- Remove the `rustix` duplicate skip from `deny.toml` for the default cargo-deny graph.

## Note

`system-interface 0.27.3` still depends on `rustix 0.38.42` when resolving `--all-features --target all` through `wasi-common 35.0.0`. `system-interface 0.27.3` is currently the latest available version, so fully removing that duplicate would require a larger `wasi-common`/`wasmtime` upgrade rather than just updating `terminal_size`.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_error`
- `cargo check -p rspack_util --all-features`
- `cargo metadata --format-version=1 --locked` shows only `rustix 1.0.8` in the default resolved graph.
- `cargo tree -i rustix@0.38.42 --all-features --target all --depth 4` shows the remaining old `rustix` comes from `system-interface -> wasi-common`.

---
_This response was generated by OpenAI Codex._