### PR TITLE
chore(deps): tighten pnpm install safeguards

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,11 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   timezone: 'Asia/Shanghai',
-  extends: [':dependencyDashboard', 'helpers:pinGitHubActionDigests'],
+  extends: [
+    ':dependencyDashboard',
+    'helpers:pinGitHubActionDigests',
+    'github>rstackjs/renovate:security',
+  ],
   schedule: ['before 8am on saturday'],
   enabledManagers: ['github-actions', 'cargo', 'npm'],
   ignorePaths: [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,14 +15,27 @@ packages:
   # this following is used to test resolve in monorepo
   - 'tests/rspack-test/normalCases/resolve/pnpm-workspace/packages/*'
 
+allowBuilds:
+  '@parcel/watcher': false
+  core-js: false
+  'es5-ext': false
+  'esbuild': false
+
 dedupePeers: true
+
+# Reduce the risk of installing compromised packages
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'
 
 patchedDependencies:
   webpack-sources@3.3.4: patches/webpack-sources@3.3.4.patch
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - 'core-js'
-  - 'es5-ext'
-  - 'esbuild'
+# Prevent un-reviewed build scripts
+strictDepBuilds: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ allowBuilds:
   '@parcel/watcher': false
   core-js: false
   'es5-ext': false
-  'esbuild': false
+  'esbuild': true
 
 dedupePeers: true
 


### PR DESCRIPTION
## Summary

This PR tightens pnpm workspace install safeguards by requiring reviewed dependency build scripts and adding a one-day minimum release age for installed packages. Rspack ecosystem packages are excluded from the release-age delay so workspace and ecosystem packages can still be consumed without waiting.

Use shared Renovate config: https://github.com/rstackjs/renovate/blob/main/security.json

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).