### PR TITLE
security(release): drop .npmrc NPM_TOKEN write, rely on npm trusted publishing

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -10,7 +10,6 @@ const __dirname = path.dirname(__filename);
 
 export async function publish_handler(mode, options) {
   console.log('options:', options);
-  const npmrcPath = `${process.env.HOME}/.npmrc`;
   const root = process.cwd();
   const version = await getLastVersion(root);
   const name = await getPkgName(root);
@@ -24,17 +23,6 @@ export async function publish_handler(mode, options) {
     name.startsWith('@rspack/')
   ) {
     throw Error('Latest tag cannot be prerelease version');
-  }
-
-  if (fs.existsSync(npmrcPath)) {
-    console.info('Found existing .npmrc file');
-  } else {
-    console.info('No .npmrc file found, creating one');
-
-    fs.writeFileSync(
-      npmrcPath,
-      `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`,
-    );
   }
 
   await publish(options);


### PR DESCRIPTION
## Summary

- Delete the `~/.npmrc` `_authToken` write from `scripts/release/publish.mjs`.
- `pnpm publish` now authenticates against npmjs.com via the workflow's OIDC token (npm trusted publishing), instead of a long-lived `NPM_TOKEN` secret.
- Removes the highest-blast-radius credential in the release pipeline — the same class of static token whose exfiltration enabled the [TanStack 2026-05-11 npm supply-chain compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem).

## Why this is needed even though `--provenance` is already set

`--provenance` and **trusted publishing** are independent:

- `--provenance`: signs a SLSA attestation about the build using the workflow's OIDC token. Already enabled.
- **Trusted publishing**: replaces the publish credential itself with an OIDC token. Requires (a) npmjs.com trusted publisher binding per package, and (b) no static `_authToken` to shadow it.

On `pnpm < 11.0.7` (rspack is on `pnpm@10.33.4`), a configured `_authToken` takes precedence over OIDC. Therefore, despite trusted publishers being configured on npmjs.com, releases have been authenticating with the long-lived `NPM_TOKEN` all along. Removing the `.npmrc` write is what actually flips the release flow to OIDC.

## Prerequisite (must already be true before merge)

- [ ] Every `@rspack/*` package on npmjs.com has a Trusted Publisher binding for:
  - `web-infra-dev/rspack` + workflow `reusable-release-npm.yml` + environment `npm`
  - `web-infra-dev/rspack` + workflow `release-canary.yml` + environment `npm-canary`
  - `web-infra-dev/rspack` + workflow `release-debug.yml` + environment `npm-canary`

  Without these bindings on **every** workspace package (12+: `@rspack/core`, `@rspack/cli`, `@rspack/binding` plus the 10 `@rspack/binding-<platform>` packages, etc.), pnpm 10.x has no fallback to static token and the corresponding package's `pnpm publish` will 401.

## Diff

```diff
- const npmrcPath = `${process.env.HOME}/.npmrc`;
  ...
- if (fs.existsSync(npmrcPath)) {
-   console.info('Found existing .npmrc file');
- } else {
-   console.info('No .npmrc file found, creating one');
-   fs.writeFileSync(
-     npmrcPath,
-     `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`,
-   );
- }
```

12 deletions, 0 additions.

## Test plan

- [ ] Trigger **Release Canary** with `dry_run: true` (manually via workflow_dispatch). Confirm `pnpm publish` in the log negotiates auth via OIDC — log line should reference the trusted publisher / OIDC handshake rather than reading `_authToken` from `~/.npmrc`. If any package 401s, that package's trusted-publisher binding on npmjs.com is missing or misconfigured — fix before merge.
- [ ] After dry-run passes, trigger a non-dry canary release on `latest` tag to confirm a real publish flows through.
- [ ] Confirm the published canary tarball still ships with provenance attestation (visible via `npm view @rspack/binding-wasm32-wasi --json` → `dist.attestations`).

## Required after-merge actions

- [ ] Delete `NPM_TOKEN` secret from the `npm` GitHub environment.
- [ ] Delete `NPM_TOKEN` secret from the `npm-canary` GitHub environment.

After both deletions, the long-lived credential has zero remaining consumers in the repo (`grep -rn NPM_TOKEN .` should match only documentation or this PR's history).

## Follow-ups (separate PRs)

- Bump `pnpm` to `>= 11.0.7` so OIDC takes precedence over any future `_authToken` regression, and so failed OIDC negotiation transparently falls back to a static token (defense in depth).
- Add a regression guard in `publish.mjs` that hard-fails if `process.env.NPM_TOKEN` is set, preventing accidental reintroduction.