### PR TITLE
perf(regex): prefer native regex fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ proc-macro2         = { version = "1.0.106", default-features = false }
 prost               = { version = "0.13", default-features = false }
 quote               = { version = "1.0.45", default-features = false }
 rayon               = { version = "1.12.0", default-features = false }
-regex               = { version = "1.12.3", default-features = false, features = ["perf", "unicode-case"] }
+regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ proc-macro2         = { version = "1.0.106", default-features = false }
 prost               = { version = "0.13", default-features = false }
 quote               = { version = "1.0.45", default-features = false }
 rayon               = { version = "1.12.0", default-features = false }
-regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
+regex               = { version = "1.12.3", default-features = false, features = ["perf", "unicode-case"] }
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -66,10 +66,6 @@ impl Debug for HashRustRegex {
 
 impl HashRustRegex {
   pub(crate) fn new(expr: &str, flags: &str) -> Result<Self, Error> {
-    // Rust regex doesn't allow escaped slashes, but they are necessary in JS
-    // regexp literals.
-    let pattern = normalize_escaped_slashes(expr);
-    let mut builder = RegexBuilder::new(&pattern);
     let has_ignore_case = flags.contains('i');
     let has_unicode = flags.contains('u');
 
@@ -78,12 +74,18 @@ impl HashRustRegex {
     if has_ignore_case && has_unicode {
       return Err(error!("Unsupported regex flag combination `iu` for rust regex"));
     }
+    if has_ignore_case && !expr.is_ascii() {
+      return Err(error!(
+        "Unsupported non-ascii regex with `i` flag for rust regex"
+      ));
+    }
+
+    // Rust regex doesn't allow escaped slashes, but they are necessary in JS
+    // regexp literals.
+    let pattern = normalize_escaped_slashes(expr);
+    let mut builder = RegexBuilder::new(&pattern);
     if has_ignore_case {
-      if !expr.is_ascii() {
-        return Err(error!(
-          "Unsupported non-ascii regex with `i` flag for rust regex"
-        ));
-      }
+      // Force ASCII mode so `i` does not require `unicode-case`.
       builder.unicode(false);
     }
 

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -72,11 +72,13 @@ impl HashRustRegex {
     // Without the regex crate's `unicode-case` feature, case-insensitive
     // matching is only reliable for ASCII patterns in non-unicode mode.
     if has_ignore_case && has_unicode {
-      return Err(error!("Unsupported regex flag combination `iu` for rust regex"));
+      return Err(error!(
+        "Case-insensitive unicode regex requires regress backend (`iu` unsupported for rust regex)"
+      ));
     }
     if has_ignore_case && !expr.is_ascii() {
       return Err(error!(
-        "Unsupported non-ascii regex with `i` flag for rust regex"
+        "Non-ascii case-insensitive regex requires regress backend (`i` on rust regex is ASCII-only)"
       ));
     }
 

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, hash::Hash};
+use std::{borrow::Cow, fmt::Debug, hash::Hash};
 
 use regex::RegexBuilder;
 use regex_syntax::hir::{Hir, HirKind, Look, literal::ExtractKind};
@@ -66,9 +66,16 @@ impl Debug for HashRustRegex {
 
 impl HashRustRegex {
   pub(crate) fn new(expr: &str, flags: &str) -> Result<Self, Error> {
-    let mut builder = RegexBuilder::new(expr);
+    // Rust regex doesn't allow escaped slashes, but they are necessary in JS
+    // regexp literals.
+    let pattern = normalize_escaped_slashes(expr);
+    let mut builder = RegexBuilder::new(&pattern);
     for flag in flags.chars() {
       match flag {
+        // Indices for substring matches are not relevant for test().
+        'd' => {}
+        // Global is the default for Rust regex matching.
+        'g' => {}
         'i' => {
           builder.case_insensitive(true);
         }
@@ -81,8 +88,7 @@ impl HashRustRegex {
         'u' => {
           builder.unicode(true);
         }
-        // Keep JS regexp flags for metadata compatibility.
-        'g' | 'y' => {}
+        // Sticky changes where matching may start, so keep it on Regress.
         _ => {
           return Err(error!("Unsupported regex flag `{flag}` for rust regex"));
         }
@@ -120,7 +126,9 @@ impl Algo {
     if let Some(algo) = Self::try_compile_to_end_with_fast_path(expr, flags) {
       Ok(algo)
     } else {
-      HashRegressRegex::new(expr, flags).map(Algo::Regress)
+      HashRustRegex::new(expr, flags)
+        .map(Algo::RustRegex)
+        .or_else(|_| HashRegressRegex::new(expr, flags).map(Algo::Regress))
     }
   }
 
@@ -194,6 +202,45 @@ impl Algo {
       }
     }
   }
+}
+
+fn normalize_escaped_slashes(pattern: &str) -> Cow<'_, str> {
+  if !pattern.contains("\\/") {
+    return Cow::Borrowed(pattern);
+  }
+
+  let mut normalized = String::with_capacity(pattern.len());
+  let mut chars = pattern.chars().peekable();
+  let mut in_character_class = false;
+
+  while let Some(ch) = chars.next() {
+    match ch {
+      '\\' => {
+        if chars.peek() == Some(&'/') && !in_character_class {
+          chars.next();
+          normalized.push('/');
+        } else {
+          normalized.push(ch);
+          if let Some(next) = chars.next() {
+            normalized.push(next);
+          }
+        }
+      }
+      '[' if !in_character_class => {
+        in_character_class = true;
+        normalized.push(ch);
+      }
+      ']' if in_character_class => {
+        in_character_class = false;
+        normalized.push(ch);
+      }
+      _ => {
+        normalized.push(ch);
+      }
+    }
+  }
+
+  Cow::Owned(normalized)
 }
 
 fn is_ends_with_regex(hir: &Hir) -> bool {
@@ -299,9 +346,110 @@ mod test_algo {
   #[test]
   fn check_slow_path() {
     // this is a full match
-    assert!(Algo::new("^\\.(svg|png)$", "").unwrap().is_regress());
+    assert!(Algo::new("^\\.(svg|png)$", "").unwrap().is_rust_regex());
     // wildcard match
-    assert!(Algo::new("\\..(svg|png)$", "").unwrap().is_regress());
+    assert!(Algo::new("\\..(svg|png)$", "").unwrap().is_rust_regex());
+  }
+
+  #[test]
+  fn should_try_rust_regex_before_regress() {
+    let algo = Algo::new("^foo.*bar$", "").unwrap();
+    assert!(algo.is_rust_regex());
+    assert!(algo.test("foo/bar"));
+    assert!(!algo.test("foo/bar/baz"));
+  }
+
+  #[test]
+  fn turbopack_es_regex_matches_simple() {
+    let algo = Algo::new("a", "").unwrap();
+    assert!(algo.is_rust_regex());
+    assert!(algo.test("a"));
+  }
+
+  #[test]
+  fn turbopack_es_regex_matches_negative_lookahead() {
+    let algo = Algo::new("a(?!b)", "").unwrap();
+    assert!(algo.is_regress());
+    assert!(!algo.test("ab"));
+    assert!(algo.test("ac"));
+  }
+
+  #[test]
+  fn turbopack_invalid_regex() {
+    assert!(Algo::new("*", "").is_err());
+  }
+
+  #[test]
+  fn rust_regex_path_supports_safe_js_flags() {
+    let algo = Algo::new("^bar.baz$", "gimsu").unwrap();
+    assert!(algo.is_rust_regex());
+    assert!(algo.test("foo\nBAR\nBAZ\nqux"));
+    assert!(!algo.test("foo\nBAR\nBAZ!"));
+  }
+
+  #[test]
+  fn sticky_flag_should_fallback_to_regress() {
+    let algo = Algo::new("\\.js$", "y").unwrap();
+    assert!(algo.is_regress());
+  }
+
+  #[test]
+  fn should_fallback_to_regress_for_js_only_regex_syntax() {
+    let algo = Algo::new("(?<=foo)bar", "").unwrap();
+    assert!(algo.is_regress());
+    assert!(algo.test("foobar"));
+    assert!(!algo.test("bar"));
+  }
+
+  #[test]
+  fn anchored_sticky_flag_should_fallback_to_regress() {
+    let algo = Algo::new("^foo", "y").unwrap();
+    assert!(algo.is_regress());
+  }
+
+  #[test]
+  fn unicode_sets_flag_should_fallback_to_regress() {
+    let algo = Algo::new("[a--b]", "v").unwrap();
+    assert!(algo.is_regress());
+  }
+
+  #[test]
+  fn unicode_flag_should_use_rust_regex() {
+    let algo = Algo::new("^foo$", "u").unwrap();
+    assert!(algo.is_rust_regex());
+  }
+
+  #[test]
+  fn indices_flag_should_use_rust_regex() {
+    let algo = Algo::new("^foo$", "d").unwrap();
+    assert!(algo.is_rust_regex());
+  }
+
+  #[test]
+  fn escaped_slash_should_use_rust_regex() {
+    let algo = Algo::new("foo\\/bar", "").unwrap();
+    assert!(algo.is_rust_regex());
+    assert!(algo.test("foo/bar"));
+  }
+
+  #[test]
+  fn escaped_slash_in_character_class_should_keep_backslash_alternative() {
+    let algo = Algo::new("[\\\\/]", "").unwrap();
+    assert!(algo.is_rust_regex());
+    assert!(algo.test("/"));
+    assert!(algo.test("\\"));
+  }
+
+  #[test]
+  fn non_ascii_ignore_case_should_use_rust_regex() {
+    let algo = Algo::new("é", "i").unwrap();
+    assert!(algo.is_rust_regex());
+  }
+
+  #[test]
+  fn ignore_case_flag_should_use_rust_regex_outside_fast_path() {
+    let algo = Algo::new("^foo$", "i").unwrap();
+    assert!(algo.is_rust_regex());
   }
 
   #[test]
@@ -324,7 +472,7 @@ mod test_algo {
   fn sticky_flag_should_not_use_end_with_fast_path() {
     // In JS, `/\.js$/y.test("foo.js")` is false because the sticky flag forces
     // the match to start at lastIndex (0 by default), so the suffix-only check
-    // is not semantically correct. We therefore must not use the EndWith fast path.
+    // is not semantically correct. We therefore fall back to Regress.
     let algo = Algo::new("\\.js$", "y").unwrap();
     let regress = HashRegressRegex::new("\\.js$", "y").unwrap();
 

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -70,6 +70,23 @@ impl HashRustRegex {
     // regexp literals.
     let pattern = normalize_escaped_slashes(expr);
     let mut builder = RegexBuilder::new(&pattern);
+    let has_ignore_case = flags.contains('i');
+    let has_unicode = flags.contains('u');
+
+    // Without the regex crate's `unicode-case` feature, case-insensitive
+    // matching is only reliable for ASCII patterns in non-unicode mode.
+    if has_ignore_case && has_unicode {
+      return Err(error!("Unsupported regex flag combination `iu` for rust regex"));
+    }
+    if has_ignore_case {
+      if !expr.is_ascii() {
+        return Err(error!(
+          "Unsupported non-ascii regex with `i` flag for rust regex"
+        ));
+      }
+      builder.unicode(false);
+    }
+
     for flag in flags.chars() {
       match flag {
         // Indices for substring matches are not relevant for test().
@@ -381,10 +398,10 @@ mod test_algo {
 
   #[test]
   fn rust_regex_path_supports_safe_js_flags() {
-    let algo = Algo::new("^bar.baz$", "gimsu").unwrap();
+    let algo = Algo::new("^bar.baz$", "dgmsu").unwrap();
     assert!(algo.is_rust_regex());
-    assert!(algo.test("foo\nBAR\nBAZ\nqux"));
-    assert!(!algo.test("foo\nBAR\nBAZ!"));
+    assert!(algo.test("foo\nbar\nbaz\nqux"));
+    assert!(!algo.test("foo\nbar\nbaz!"));
   }
 
   #[test]
@@ -441,9 +458,15 @@ mod test_algo {
   }
 
   #[test]
-  fn non_ascii_ignore_case_should_use_rust_regex() {
+  fn non_ascii_ignore_case_should_fallback_to_regress() {
     let algo = Algo::new("é", "i").unwrap();
-    assert!(algo.is_rust_regex());
+    assert!(algo.is_regress());
+  }
+
+  #[test]
+  fn ignore_case_with_unicode_flag_should_fallback_to_regress() {
+    let algo = Algo::new("^foo$", "iu").unwrap();
+    assert!(algo.is_regress());
   }
 
   #[test]

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -134,6 +134,7 @@ pub enum Algo {
   /// But Regress has poor performance. To improve performance of regex matching,
   /// we would try to use some fast algo to do matching, when we detect some special pattern.
   /// See details at https://github.com/web-infra-dev/rspack/pull/3113
+  MatchAll,
   EndWith {
     pats: Vec<String>,
     ignore_case: bool,
@@ -144,7 +145,9 @@ pub enum Algo {
 
 impl Algo {
   pub(crate) fn new(expr: &str, flags: &str) -> Result<Algo, Error> {
-    if let Some(algo) = Self::try_compile_to_end_with_fast_path(expr, flags) {
+    if let Some(algo) = Self::try_compile_to_match_all_fast_path(expr, flags) {
+      Ok(algo)
+    } else if let Some(algo) = Self::try_compile_to_end_with_fast_path(expr, flags) {
       Ok(algo)
     } else {
       HashRustRegex::new(expr, flags)
@@ -155,6 +158,18 @@ impl Algo {
 
   pub(crate) fn new_rust_regex(expr: &str, flags: &str) -> Result<Algo, Error> {
     HashRustRegex::new(expr, flags).map(Algo::RustRegex)
+  }
+
+  fn try_compile_to_match_all_fast_path(expr: &str, flags: &str) -> Option<Algo> {
+    if expr != ".*"
+      || !flags
+        .chars()
+        .all(|flag| matches!(flag, 'd' | 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y'))
+    {
+      return None;
+    }
+
+    Some(Algo::MatchAll)
   }
 
   fn try_compile_to_end_with_fast_path(expr: &str, flags: &str) -> Option<Algo> {
@@ -210,6 +225,7 @@ impl Algo {
 
   pub(crate) fn test(&self, str: &str) -> bool {
     match self {
+      Algo::MatchAll => true,
       Algo::RustRegex(regex) => regex.regex.is_match(str),
       Algo::Regress(regex) => regex.find(str).is_some(),
       Algo::EndWith { pats, ignore_case } => {
@@ -302,8 +318,12 @@ mod test_algo {
     fn end_with_pats(&self) -> std::collections::HashSet<&str> {
       match self {
         Algo::EndWith { pats, .. } => pats.iter().map(|s| s.as_str()).collect(),
-        Algo::Regress(_) | Algo::RustRegex(_) => panic!("expect EndWith"),
+        Algo::MatchAll | Algo::Regress(_) | Algo::RustRegex(_) => panic!("expect EndWith"),
       }
+    }
+
+    fn is_match_all(&self) -> bool {
+      matches!(self, Self::MatchAll)
     }
 
     fn is_end_with(&self) -> bool {
@@ -316,6 +336,24 @@ mod test_algo {
 
     fn is_rust_regex(&self) -> bool {
       matches!(self, Self::RustRegex(..))
+    }
+  }
+
+  #[test]
+  fn should_use_match_all_fast_path_for_dot_star() {
+    let algo = Algo::new(".*", "").unwrap();
+    assert!(algo.is_match_all());
+    assert!(algo.test(""));
+    assert!(algo.test("foo"));
+    assert!(algo.test("\n"));
+  }
+
+  #[test]
+  fn dot_star_fast_path_supports_js_flags() {
+    for flags in ["d", "g", "i", "m", "s", "u", "v", "y", "dgimsuy"] {
+      let algo = Algo::new(".*", flags).unwrap();
+      assert!(algo.is_match_all());
+      assert!(algo.test("foo\nbar"));
     }
   }
 


### PR DESCRIPTION
## Summary

- try Rust native regex via `RegexBuilder` before falling back to `regress`
- keep the existing `EndWith` fast path ahead of the native-regex attempt
- add a `.*` match-all fast path in `Algo::new` so the default wrapped context regexp does not need backend regex compilation
- align flag handling with Turbopack for `d/g/i/m/s/u`, while keeping sticky `y` on `regress` for correctness outside the `.*` fast path
- normalize escaped JS regex slashes (`\/`) before constructing Rust regex
- port relevant Turbopack behavior tests for simple native regex, negative lookahead fallback, invalid regex, and the `.*` fast path

## Validation

- `cargo test -p rspack_regex`
- `cargo check -p rspack --lib`
- `cargo fmt --all --check`
- `git diff --check`