### PR TITLE
perf: cache reserved name atom set

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -56,7 +56,7 @@ use crate::{
   filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
   merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
-  reserved_names::RESERVED_NAMES,
+  reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
@@ -997,7 +997,7 @@ impl Module for ConcatenatedModule {
     // Generate source code and analyze scopes
     // Prepare a ReplaceSource for the final source
     //
-    let mut all_used_names: HashSet<Atom> = RESERVED_NAMES.iter().map(|s| Atom::new(*s)).collect();
+    let mut all_used_names: HashSet<Atom> = RESERVED_NAMES_ATOM_SET.clone();
 
     let arc_map = Arc::new(module_to_info_map);
 

--- a/crates/rspack_core/src/reserved_names.rs
+++ b/crates/rspack_core/src/reserved_names.rs
@@ -1,3 +1,8 @@
+use std::sync::LazyLock;
+
+use rustc_hash::FxHashSet;
+use swc_core::atoms::Atom;
+
 pub const RESERVED_NAMES: [&str; 188] = [
   "__rspack_default_export",
   "__rspack_ns_object",
@@ -188,3 +193,21 @@ pub const RESERVED_NAMES: [&str; 188] = [
   "onmousedown",
   "onsubmit",
 ];
+
+pub static RESERVED_NAMES_ATOM_SET: LazyLock<FxHashSet<Atom>> =
+  LazyLock::new(|| RESERVED_NAMES.iter().map(|name| Atom::new(*name)).collect());
+
+#[cfg(test)]
+mod tests {
+  use swc_core::atoms::Atom;
+
+  use super::{RESERVED_NAMES, RESERVED_NAMES_ATOM_SET};
+
+  #[test]
+  fn reserved_names_atom_set_matches_reserved_names() {
+    assert_eq!(RESERVED_NAMES_ATOM_SET.len(), RESERVED_NAMES.len());
+    for name in RESERVED_NAMES {
+      assert!(RESERVED_NAMES_ATOM_SET.contains(&Atom::new(name)));
+    }
+  }
+}

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   RuntimeGlobals, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName,
   UsedNameItem, collect_ident, escape_name_atom_ref, find_new_name, find_target,
   get_cached_readable_identifier, get_js_chunk_filename_template, get_module_directives,
-  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES,
+  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
   rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
@@ -952,18 +952,15 @@ var {} = {{}};
 
     let module_graph = compilation.get_module_graph();
 
-    let mut all_used_names: FxHashSet<Atom> = RESERVED_NAMES
-      .iter()
-      .map(|s| Atom::new(*s))
-      .chain(chunk_link.hoisted_modules.iter().flat_map(|m| {
-        let info = &concate_modules_map[m];
-        info
-          .as_concatenated()
-          .global_scope_ident
-          .iter()
-          .map(|ident| ident.id.sym.clone())
-      }))
-      .collect();
+    let mut all_used_names: FxHashSet<Atom> = RESERVED_NAMES_ATOM_SET.clone();
+    all_used_names.extend(chunk_link.hoisted_modules.iter().flat_map(|m| {
+      let info = &concate_modules_map[m];
+      info
+        .as_concatenated()
+        .global_scope_ident
+        .iter()
+        .map(|ident| ident.id.sym.clone())
+    }));
 
     // merge all all_used_names from hoisted modules
     for id in &chunk_link.hoisted_modules {

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -34,7 +34,7 @@ use rspack_core::{
   SourceType,
   concatenated_module::find_new_name,
   render_init_fragments,
-  reserved_names::RESERVED_NAMES,
+  reserved_names::RESERVED_NAMES_ATOM_SET,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
   split_readable_identifier,
 };
@@ -1026,8 +1026,7 @@ var {} = {{}};
 
     let mut inlined_modules_to_info: IdentifierMap<InlinedModuleInfo> = IdentifierMap::default();
     let mut non_inlined_module_through_idents: Vec<ConcatenatedModuleIdent> = Vec::new();
-    let mut all_used_names: HashSet<Atom> =
-      RESERVED_NAMES.iter().map(|item| Atom::new(*item)).collect();
+    let mut all_used_names: HashSet<Atom> = RESERVED_NAMES_ATOM_SET.clone();
     let mut renamed_inline_modules: IdentifierMap<Arc<dyn Source>> = IdentifierMap::default();
 
     let render_module_results = rspack_parallel::scope::<_, _>(|token| {
@@ -1089,7 +1088,7 @@ var {} = {{}};
           Ok(RenameInfoPatch {
             inlined_modules_to_info: IdentifierMap::default(),
             non_inlined_module_through_idents: Vec::new(),
-            all_used_names: RESERVED_NAMES.iter().map(|item| Atom::new(*item)).collect(),
+            all_used_names: RESERVED_NAMES_ATOM_SET.clone(),
           })
         },
         |mut acc, (rendered_module, m)| {
@@ -1243,7 +1242,7 @@ var {} = {{}};
           Ok(RenameInfoPatch {
             inlined_modules_to_info: IdentifierMap::default(),
             non_inlined_module_through_idents: Vec::new(),
-            all_used_names: RESERVED_NAMES.iter().map(|item| Atom::new(*item)).collect(),
+            all_used_names: RESERVED_NAMES_ATOM_SET.clone(),
           })
         },
         |acc, chunk| match acc {


### PR DESCRIPTION
## Summary

- Add a shared `LazyLock<FxHashSet<Atom>>` for reserved JavaScript names in `rspack_core::reserved_names`.
- Replace repeated `RESERVED_NAMES.iter().map(...).collect()` calls with clones of the cached atom set.
- Add a focused unit test to keep the cached atom set aligned with the source reserved-name list.

## Impact

This avoids rebuilding the reserved-name atom set at multiple hot call sites while preserving the existing mutable `HashSet` behavior at each use site.

## Validation

- `cargo test -p rspack_core reserved_names_atom_set_matches_reserved_names`
- `cargo check -p rspack_plugin_javascript -p rspack_plugin_esm_library`
- `cargo fmt --all --check`
- `git diff --check`