### PR TITLE
chore(ci): replace archived actions-rs/cargo with bare cargo invocations

### DIFF
--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -64,16 +64,10 @@ jobs:
         run: cargo workspaces exec cargo check --all-targets --locked
 
       - name: Run Clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --tests -- -D warnings
+        run: cargo clippy --workspace --all-targets --tests -- -D warnings
 
       - name: Run rustfmt
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Install taplo
         run: cargo install taplo-cli --locked


### PR DESCRIPTION
## Summary

Replace the two `actions-rs/cargo` steps in `.github/workflows/reusable-rust-test.yml` with direct `cargo clippy` / `cargo fmt` invocations.

## Why

The [`actions-rs/` GitHub organization](https://github.com/actions-rs) is **archived** and no longer maintained. Its SHA-pinned references are still resolvable today, but if the org is ever deleted or reclaimed, every workflow referencing those SHAs will fail to start. This is preventive maintenance — not a response to an active attacker, just retiring an abandoned dependency before it becomes a hard failure.

## Behavior

Identical:

| Step | Before | After |
|---|---|---|
| Run Clippy | `actions-rs/cargo` with `command: clippy`, `args: --workspace --all-targets --tests -- -D warnings` | `cargo clippy --workspace --all-targets --tests -- -D warnings` |
| Run rustfmt | `actions-rs/cargo` with `command: fmt`, `args: --all -- --check` | `cargo fmt --all -- --check` |

Same subcommand, same arguments. No semantic change.

## Why bare `cargo` works (no additional toolchain step needed)

The surrounding `rust_check` job already installs the Rust toolchain at line 41 via the local `./.github/actions/rustup` composite:

```yaml
- name: Install Rust Toolchain
  uses: ./.github/actions/rustup
  with:
    save-if: true
    key: check
```

This composite provides clippy and rustfmt components alongside cargo, so bare invocations resolve correctly. The other steps in the same job (`cargo codegen`, `cargo check`, `cargo workspaces exec cargo check`) already use bare `run: cargo ...` — this PR brings clippy and rustfmt in line with them.

## Diff

`1 file changed, 2 insertions(+), 8 deletions(-)`.

## Test plan

- [ ] CI passes — specifically the `rust_check` job's `Run Clippy` and `Run rustfmt` steps still execute and behave identically.