### PR TITLE
perf: improve build_module_graph performance

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1837,10 +1837,7 @@ impl ModuleOptionsBuilder {
 }
 
 fn extension_rule(extension: &str) -> RuleSetCondition {
-  RuleSetCondition::Regexp(
-    RspackRegex::new(&format!("{}$", regex::escape(extension)))
-      .expect("should initialize default extension regex"),
-  )
+  RuleSetCondition::EndsWith(extension.to_owned())
 }
 
 fn default_rules(async_web_assembly: bool, css: bool) -> Vec<ModuleRule> {

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1824,17 +1824,11 @@ impl ModuleOptionsBuilder {
 
     let default_rules = default_rules(async_web_assembly, css);
 
+    let mut rules = default_rules;
+    rules.append(&mut self.rules);
+
     Ok(ModuleOptions {
-      rules: vec![
-        ModuleRule {
-          rules: Some(default_rules),
-          ..Default::default()
-        },
-        ModuleRule {
-          rules: Some(std::mem::take(&mut self.rules)),
-          ..Default::default()
-        },
-      ],
+      rules,
       parser: self.parser.take(),
       generator: self.generator.take(),
       no_parse: self.no_parse.take(),

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -298,7 +298,6 @@ mod tests {
   }
 }
 
-const HYPHEN: char = '-';
 const EXCLAMATION: char = '!';
 const DOT: char = '.';
 const SLASH: char = '/';
@@ -367,7 +366,7 @@ impl NormalModuleFactory {
     let mut missing_dependencies = Default::default();
 
     let plugin_driver = &self.plugin_driver;
-    let loader_resolver = self.get_loader_resolver();
+    let mut loader_resolver = None;
 
     let mut match_resource_data = None;
     let mut match_module_type = None;
@@ -381,8 +380,10 @@ impl NormalModuleFactory {
     let mut unresolved_resource = data.request.as_str();
     if scheme.is_none() {
       let mut request_without_match_resource = data.request.as_str();
+      let mut has_match_resource = false;
       request_without_match_resource = {
         if let Ok((resource, full_matched)) = match_resource(request_without_match_resource) {
+          has_match_resource = true;
           let match_resource = {
             let mut chars = resource.chars();
             let first_char = chars.next();
@@ -435,61 +436,60 @@ impl NormalModuleFactory {
         }
       };
 
-      scheme = get_scheme(request_without_match_resource);
+      if has_match_resource {
+        scheme = get_scheme(request_without_match_resource);
+      }
       if scheme.is_none() && context_scheme.is_none() {
-        let mut request = request_without_match_resource.chars();
-        let first_char = request.next();
-        let second_char = request.next();
+        let request_bytes = request_without_match_resource.as_bytes();
+        let first_byte = request_bytes.first().copied();
+        let second_byte = request_bytes.get(1).copied();
 
-        if first_char.is_none() {
+        if first_byte.is_none() {
           return Err(EmptyDependency::new(dependency.range()).into());
         }
 
         // See: https://webpack.js.org/concepts/loaders/#inline
-        no_pre_auto_loaders =
-          matches!(first_char, Some(HYPHEN)) && matches!(second_char, Some(EXCLAMATION));
-        no_auto_loaders = no_pre_auto_loaders || matches!(first_char, Some(EXCLAMATION));
-        no_pre_post_auto_loaders =
-          matches!(first_char, Some(EXCLAMATION)) && matches!(second_char, Some(EXCLAMATION));
+        no_pre_auto_loaders = first_byte == Some(b'-') && second_byte == Some(b'!');
+        no_auto_loaders = no_pre_auto_loaders || first_byte == Some(b'!');
+        no_pre_post_auto_loaders = first_byte == Some(b'!') && second_byte == Some(b'!');
 
-        let mut raw_elements = {
-          let s = match request_without_match_resource.char_indices().nth({
-            if no_pre_auto_loaders || no_pre_post_auto_loaders {
-              2
-            } else if no_auto_loaders {
-              1
-            } else {
-              0
-            }
-          }) {
-            Some((pos, _)) => &request_without_match_resource[pos..],
-            None => request_without_match_resource,
-          };
-          split_element(s)
+        let request = if no_pre_auto_loaders || no_pre_post_auto_loaders {
+          &request_without_match_resource[2..]
+        } else if no_auto_loaders {
+          &request_without_match_resource[1..]
+        } else {
+          request_without_match_resource
         };
 
-        unresolved_resource = raw_elements
-          .pop()
-          .ok_or_else(|| error!("Invalid request: {request_without_match_resource}"))?;
+        if request.contains(EXCLAMATION) {
+          let mut raw_elements = split_element(request);
 
-        inline_loaders.extend(raw_elements.into_iter().map(|r| {
-          let resource = parse_resource(r);
-          let ident = resource.as_ref().and_then(|r| {
-            r.query
-              .as_ref()
-              .and_then(|q| q.starts_with("??").then(|| &q[2..]))
-          });
-          ModuleRuleUseLoader {
-            loader: r.to_owned(),
-            options: ident.and_then(|ident| {
-              data
-                .options
-                .__references
-                .get(ident)
-                .map(|object| object.to_string())
-            }),
-          }
-        }));
+          unresolved_resource = raw_elements
+            .pop()
+            .ok_or_else(|| error!("Invalid request: {request_without_match_resource}"))?;
+
+          inline_loaders.extend(raw_elements.into_iter().map(|r| {
+            let resource = parse_resource(r);
+            let ident = resource.as_ref().and_then(|r| {
+              r.query
+                .as_ref()
+                .and_then(|q| q.starts_with("??").then(|| &q[2..]))
+            });
+            ModuleRuleUseLoader {
+              loader: r.to_owned(),
+              options: ident.and_then(|ident| {
+                data
+                  .options
+                  .__references
+                  .get(ident)
+                  .map(|object| object.to_string())
+              }),
+            }
+          }));
+        } else {
+          unresolved_resource = request;
+        }
+
         scheme = get_scheme(unresolved_resource);
       } else {
         unresolved_resource = request_without_match_resource;
@@ -618,8 +618,10 @@ module.exports = "data:,";
 
     let mut resolved_inline_loaders = vec![];
     for l in inline_loaders {
-      resolved_inline_loaders
-        .push(resolve_each(plugin_driver, &data.context, &loader_resolver, &l).await?)
+      let resolver = loader_resolver
+        .get_or_insert_with(|| self.get_loader_resolver())
+        .clone();
+      resolved_inline_loaders.push(resolve_each(plugin_driver, &data.context, &resolver, &l).await?)
     }
 
     let user_request = {
@@ -685,14 +687,19 @@ module.exports = "data:,";
       );
 
       for l in post_loaders {
-        all_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        let resolver = loader_resolver
+          .get_or_insert_with(|| self.get_loader_resolver())
+          .clone();
+        all_loaders.push(resolve_each(plugin_driver, &self.options.context, &resolver, &l).await?)
       }
 
       let mut resolved_normal_loaders = vec![];
       for l in normal_loaders {
+        let resolver = loader_resolver
+          .get_or_insert_with(|| self.get_loader_resolver())
+          .clone();
         resolved_normal_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+          .push(resolve_each(plugin_driver, &self.options.context, &resolver, &l).await?)
       }
 
       if match_resource_data.is_some() {
@@ -704,8 +711,10 @@ module.exports = "data:,";
       }
 
       for l in pre_loaders {
-        all_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        let resolver = loader_resolver
+          .get_or_insert_with(|| self.get_loader_resolver())
+          .clone();
+        all_loaders.push(resolve_each(plugin_driver, &self.options.context, &resolver, &l).await?)
       }
 
       all_loaders

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -889,6 +889,7 @@ pub type RuleSetConditionFnMatcher =
 
 pub enum RuleSetCondition {
   String(String),
+  EndsWith(String),
   Regexp(RspackRegex),
   Logical(Box<RuleSetLogicalConditions>),
   Array {
@@ -902,6 +903,7 @@ impl fmt::Debug for RuleSetCondition {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Self::String(i) => i.fmt(f),
+      Self::EndsWith(i) => f.debug_tuple("EndsWith").field(i).finish(),
       Self::Regexp(i) => i.fmt(f),
       Self::Logical(i) => i.fmt(f),
       Self::Array { items, .. } => items.fmt(f),
@@ -952,7 +954,7 @@ impl RuleSetCondition {
 
   fn can_sync(&self) -> bool {
     match self {
-      Self::String(_) | Self::Regexp(_) => true,
+      Self::String(_) | Self::EndsWith(_) | Self::Regexp(_) => true,
       Self::Logical(logical) => logical.can_sync,
       Self::Array { can_sync, .. } => *can_sync,
       Self::Func(_) => false,
@@ -965,6 +967,12 @@ impl RuleSetCondition {
         data
           .as_str()
           .map(|data| data.starts_with(s))
+          .unwrap_or_default(),
+      )),
+      Self::EndsWith(s) => Some(Ok(
+        data
+          .as_str()
+          .map(|data| data.ends_with(s))
           .unwrap_or_default(),
       )),
       Self::Regexp(r) => Some(Ok(
@@ -1004,7 +1012,7 @@ impl RuleSetCondition {
   fn try_match_async<'a>(&'a self, data: DataRef<'a>) -> BoxFuture<'a, Result<bool>> {
     Box::pin(async move {
       match self {
-        Self::String(_) | Self::Regexp(_) => self
+        Self::String(_) | Self::EndsWith(_) | Self::Regexp(_) => self
           .try_match_sync(data)
           .expect("non-function condition should match synchronously"),
         Self::Logical(g) => g.try_match_async(data).await,
@@ -1017,6 +1025,7 @@ impl RuleSetCondition {
   fn match_when_empty_sync(&self) -> Option<Result<bool>> {
     match self {
       RuleSetCondition::String(s) => Some(Ok(s.is_empty())),
+      RuleSetCondition::EndsWith(s) => Some(Ok(s.is_empty())),
       RuleSetCondition::Regexp(rspack_regex) => Some(Ok(rspack_regex.test(""))),
       RuleSetCondition::Logical(logical) => logical.match_when_empty_sync(),
       RuleSetCondition::Array { items, .. } => {
@@ -1048,6 +1057,7 @@ impl RuleSetCondition {
     Box::pin(async move {
       let res = match self {
         RuleSetCondition::String(_)
+        | RuleSetCondition::EndsWith(_)
         | RuleSetCondition::Regexp(_)
         | RuleSetCondition::Array { .. } => self
           .match_when_empty_sync()

--- a/crates/rspack_macros/src/javascript_parser_plugin_hooks.rs
+++ b/crates/rspack_macros/src/javascript_parser_plugin_hooks.rs
@@ -58,16 +58,19 @@ fn expand_impl(input: &mut ItemImpl) -> Result<()> {
     hook_variants.push(hook_variant_ident(&func.sig.ident)?);
   }
 
-  let body = if let Some(first) = hook_variants.first() {
-    let rest = &hook_variants[1..];
+  let body = if hook_variants.is_empty() {
     quote! {
-      ::rspack_plugin_javascript::JavascriptParserPluginHooks::empty()
-        .with(::rspack_plugin_javascript::JavascriptParserPluginHook::#first)
-        #(.with(::rspack_plugin_javascript::JavascriptParserPluginHook::#rest))*
+      const IMPLEMENTED_HOOKS: ::rspack_plugin_javascript::JavascriptParserPluginHooks =
+        ::rspack_plugin_javascript::JavascriptParserPluginHooks::empty();
+      IMPLEMENTED_HOOKS
     }
   } else {
     quote! {
-      ::rspack_plugin_javascript::JavascriptParserPluginHooks::empty()
+      const IMPLEMENTED_HOOKS: ::rspack_plugin_javascript::JavascriptParserPluginHooks =
+        ::rspack_plugin_javascript::JavascriptParserPluginHooks::from_bits(
+          0u64 #(| (1u64 << (::rspack_plugin_javascript::JavascriptParserPluginHook::#hook_variants as u8)))*
+        );
+      IMPLEMENTED_HOOKS
     }
   };
 

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -70,11 +70,125 @@ impl Debug for ArcPath {
 
 impl ArcPath {
   pub fn new(path: Arc<Path>) -> Self {
-    let mut hasher = FxHasher::default();
-    path.hash(&mut hasher);
-    let hash = hasher.finish();
+    let hash = hash_path(&path);
     Self { path, hash }
   }
+}
+
+#[cfg(unix)]
+fn hash_path(path: &Path) -> u64 {
+  use std::os::unix::ffi::OsStrExt;
+
+  let bytes = path.as_os_str().as_bytes();
+  if is_canonical_unix_path(bytes) {
+    return hash_bytes(bytes);
+  }
+
+  let mut normalized = Vec::with_capacity(bytes.len());
+  normalize_unix_path(bytes, &mut normalized);
+  hash_bytes(&normalized)
+}
+
+#[cfg(unix)]
+fn normalize_unix_path(bytes: &[u8], normalized: &mut Vec<u8>) {
+  let mut index = 0;
+  let rooted = bytes.first() == Some(&b'/');
+  let mut needs_separator = false;
+
+  if rooted {
+    normalized.push(b'/');
+    while index < bytes.len() && bytes[index] == b'/' {
+      index += 1;
+    }
+  }
+
+  let mut emitted_component = false;
+  while index < bytes.len() {
+    while index < bytes.len() && bytes[index] == b'/' {
+      index += 1;
+    }
+
+    let start = index;
+    while index < bytes.len() && bytes[index] != b'/' {
+      index += 1;
+    }
+
+    if start == index {
+      break;
+    }
+
+    let component = &bytes[start..index];
+    match component {
+      // `Path::components` only preserves a leading `.` for relative paths.
+      b"." if !rooted && !emitted_component => {
+        normalized.push(b'.');
+        emitted_component = true;
+        needs_separator = true;
+      }
+      b"." => {}
+      _ => {
+        if needs_separator {
+          normalized.push(b'/');
+        }
+        normalized.extend_from_slice(component);
+        emitted_component = true;
+        needs_separator = true;
+      }
+    }
+  }
+}
+
+#[cfg(unix)]
+fn hash_bytes(bytes: &[u8]) -> u64 {
+  let mut hasher = FxHasher::default();
+  hasher.write(bytes);
+  hasher.finish()
+}
+
+#[cfg(unix)]
+fn is_canonical_unix_path(bytes: &[u8]) -> bool {
+  if bytes.is_empty() || bytes == b"/" || bytes == b"." {
+    return true;
+  }
+
+  if bytes.ends_with(b"/") {
+    return false;
+  }
+
+  let mut index = 0;
+  let rooted = bytes[0] == b'/';
+  if rooted {
+    index = 1;
+    if bytes.get(index) == Some(&b'/') || bytes.get(index) == Some(&b'.') {
+      return false;
+    }
+  } else if bytes.starts_with(b"./") {
+    index = 2;
+    if index == bytes.len() || bytes.get(index) == Some(&b'/') || bytes.get(index) == Some(&b'.') {
+      return false;
+    }
+  } else if bytes[0] == b'/' {
+    return false;
+  }
+
+  while index < bytes.len() {
+    if bytes[index] == b'/' {
+      let next = index + 1;
+      if next == bytes.len() || bytes[next] == b'/' || bytes[next] == b'.' {
+        return false;
+      }
+    }
+    index += 1;
+  }
+
+  true
+}
+
+#[cfg(not(unix))]
+fn hash_path(path: &Path) -> u64 {
+  let mut hasher = FxHasher::default();
+  path.hash(&mut hasher);
+  hasher.finish()
 }
 
 impl Deref for ArcPath {
@@ -159,3 +273,29 @@ pub type ArcPathDashSet = DashSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
 /// A standard `IndexSet` using `ArcPath` as the key type with a custom `Hasher`
 /// that just uses the precomputed hash for speed instead of calculating it.
 pub type ArcPathIndexSet = IndexSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn arc_path_hash_preserves_path_equivalence() {
+    for (a, b) in [
+      ("a//b", "a/b"),
+      ("a/./b", "a/b"),
+      ("a/.", "a"),
+      ("/.", "/"),
+      ("//a///b", "/a/b"),
+    ] {
+      assert_eq!(Path::new(a), Path::new(b));
+      assert_eq!(ArcPath::from(a), ArcPath::from(b));
+    }
+  }
+
+  #[test]
+  fn arc_path_hash_preserves_distinct_current_dir_prefix() {
+    assert_ne!(Path::new("./a"), Path::new("a"));
+    assert_ne!(ArcPath::from("./a"), ArcPath::from("a"));
+    assert_ne!(ArcPath::from(""), ArcPath::from("."));
+  }
+}

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -151,34 +151,41 @@ fn is_canonical_unix_path(bytes: &[u8]) -> bool {
     return true;
   }
 
-  if bytes.ends_with(b"/") {
-    return false;
+  let rooted = bytes[0] == b'/';
+  let mut index = usize::from(rooted);
+  let mut is_first_component = true;
+
+  if index == bytes.len() {
+    return true;
   }
 
-  let mut index = 0;
-  let rooted = bytes[0] == b'/';
-  if rooted {
-    index = 1;
-    if bytes.get(index) == Some(&b'/') || bytes.get(index) == Some(&b'.') {
-      return false;
-    }
-  } else if bytes.starts_with(b"./") {
-    index = 2;
-    if index == bytes.len() || bytes.get(index) == Some(&b'/') || bytes.get(index) == Some(&b'.') {
-      return false;
-    }
-  } else if bytes[0] == b'/' {
+  if bytes[index] == b'/' {
     return false;
   }
 
   while index < bytes.len() {
-    if bytes[index] == b'/' {
-      let next = index + 1;
-      if next == bytes.len() || bytes[next] == b'/' || bytes[next] == b'.' {
+    let start = index;
+    while index < bytes.len() && bytes[index] != b'/' {
+      index += 1;
+    }
+
+    if start == index {
+      return false;
+    }
+
+    let component = &bytes[start..index];
+    if component == b"." && (rooted || !is_first_component) {
+      return false;
+    }
+
+    is_first_component = false;
+
+    if index < bytes.len() {
+      index += 1;
+      if index == bytes.len() || bytes[index] == b'/' {
         return false;
       }
     }
-    index += 1;
   }
 
   true
@@ -297,5 +304,14 @@ mod tests {
     assert_ne!(Path::new("./a"), Path::new("a"));
     assert_ne!(ArcPath::from("./a"), ArcPath::from("a"));
     assert_ne!(ArcPath::from(""), ArcPath::from("."));
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn arc_path_hash_treats_dot_prefixed_names_as_canonical() {
+    assert!(is_canonical_unix_path(b"a/.hidden/file.js"));
+    assert!(is_canonical_unix_path(b"/a/.pnpm/pkg"));
+    assert!(is_canonical_unix_path(b"./.pnpm/pkg"));
+    assert!(!is_canonical_unix_path(b"a/./file.js"));
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -148,6 +148,10 @@ impl JavascriptParserPluginHooks {
     Self(0)
   }
 
+  pub const fn from_bits(bits: u64) -> Self {
+    Self(bits)
+  }
+
   pub const fn all() -> Self {
     Self(JavascriptParserPluginHook::ALL_MASK)
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/location_advancer.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/location_advancer.rs
@@ -16,6 +16,15 @@ impl DependencyLocationAdvancer {
     Self::default()
   }
 
+  #[inline]
+  fn utf16_len(segment: &str) -> usize {
+    if segment.is_ascii() {
+      segment.len()
+    } else {
+      segment.encode_utf16().count()
+    }
+  }
+
   /// Advance a source position from one byte offset to another, counting newlines and UTF-16 columns.
   /// Optimized with ASCII fast-paths and SIMD reverse searching.
   fn advance_pos(
@@ -31,20 +40,16 @@ impl DependencyLocationAdvancer {
     let segment = &source[from_off..to_off];
     let bytes = segment.as_bytes();
 
-    let (newline_count, last_newline_idx) = memchr::memchr_iter(b'\n', bytes)
-      .enumerate()
-      .last()
-      .map_or((0, None), |(count, idx)| (count + 1, Some(idx)));
-
-    if let Some(last_idx) = last_newline_idx {
+    if let Some(last_idx) = memchr::memrchr(b'\n', bytes) {
+      let newline_count = memchr::memchr_iter(b'\n', bytes).count();
       let line = from_pos
         .line
         .checked_add(u32::try_from(newline_count).ok()?)?;
       let after_newline = &segment[last_idx + 1..];
-      let column = u32::try_from(after_newline.encode_utf16().count() + 1).ok()?; // 1-based column
+      let column = u32::try_from(Self::utf16_len(after_newline) + 1).ok()?; // 1-based column
       Some(SourcePosition { line, column })
     } else {
-      let column_advance = u32::try_from(segment.encode_utf16().count()).ok()?;
+      let column_advance = u32::try_from(Self::utf16_len(segment)).ok()?;
       Some(SourcePosition {
         line: from_pos.line,
         column: from_pos.column.checked_add(column_advance)?,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -420,11 +420,11 @@ impl<'parser> JavascriptParser<'parser> {
     parse_meta: ParseMeta,
     parser_runtime_requirements: &'parser ParserRuntimeRequirementsData,
   ) -> Self {
-    let warning_diagnostics: Vec<Diagnostic> = Vec::with_capacity(4);
-    let errors = Vec::with_capacity(4);
-    let dependencies = Vec::with_capacity(64);
-    let blocks = Vec::with_capacity(64);
-    let presentational_dependencies = Vec::with_capacity(64);
+    let warning_diagnostics: Vec<Diagnostic> = Vec::new();
+    let errors = Vec::new();
+    let dependencies = Vec::with_capacity(16);
+    let blocks = Vec::new();
+    let presentational_dependencies = Vec::with_capacity(16);
     let parser_exports_state: Option<bool> = None;
 
     let mut plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(32 + parser_plugins.len());

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -107,6 +107,10 @@ pub enum Algo {
   /// But Regress has poor performance. To improve performance of regex matching,
   /// we would try to use some fast algo to do matching, when we detect some special pattern.
   /// See details at https://github.com/web-infra-dev/rspack/pull/3113
+  EndWithOne {
+    pat: String,
+    ignore_case: bool,
+  },
   EndWith {
     pats: Vec<String>,
     ignore_case: bool,
@@ -173,7 +177,14 @@ impl Algo {
         }
       }
 
-      Some(Algo::EndWith { pats, ignore_case })
+      if pats.len() == 1 {
+        Some(Algo::EndWithOne {
+          pat: pats.pop().expect("should have one suffix"),
+          ignore_case,
+        })
+      } else {
+        Some(Algo::EndWith { pats, ignore_case })
+      }
     } else {
       None
     }
@@ -183,6 +194,13 @@ impl Algo {
     match self {
       Algo::RustRegex(regex) => regex.regex.is_match(str),
       Algo::Regress(regex) => regex.find(str).is_some(),
+      Algo::EndWithOne { pat, ignore_case } => {
+        if *ignore_case {
+          ends_with_ascii_case_insensitive(str, pat)
+        } else {
+          str.ends_with(pat)
+        }
+      }
       Algo::EndWith { pats, ignore_case } => {
         if *ignore_case {
           pats
@@ -233,13 +251,14 @@ mod test_algo {
   impl Algo {
     fn end_with_pats(&self) -> std::collections::HashSet<&str> {
       match self {
+        Algo::EndWithOne { pat, .. } => std::collections::HashSet::from([pat.as_str()]),
         Algo::EndWith { pats, .. } => pats.iter().map(|s| s.as_str()).collect(),
         Algo::Regress(_) | Algo::RustRegex(_) => panic!("expect EndWith"),
       }
     }
 
     fn is_end_with(&self) -> bool {
-      matches!(self, Self::EndWith { .. })
+      matches!(self, Self::EndWithOne { .. } | Self::EndWith { .. })
     }
 
     fn is_regress(&self) -> bool {


### PR DESCRIPTION
## Summary

Optimize several `build_module_graph` hot paths found in local CodSpeed/Callgrind profiling.

- Precompute JavaScript parser plugin hook bitmasks in the proc macro output.
- Avoid extra normal module factory work for common requests: lazy loader resolver creation, skip inline loader splitting when no `!`, avoid a repeated scheme scan, and flatten default module rules.
- Reduce source location advancement cost with ASCII/newline fast paths.
- Speed up `ArcPath` hash creation on Unix canonical paths, including dot-prefixed path components such as `.pnpm`.
- Reduce default JavaScript parser vector preallocation for mostly-empty result collections.
- Add a single-suffix regex fast path and use direct `EndsWith` matching for built-in extension rules.

## Benchmark

Local `build_module_graph` CodSpeed simulation, comparing against a fresh baseline from the pre-optimization parent commit:

- Baseline total `Ir`: `1,814,540,662`
- Latest total `Ir`: `1,756,671,449`
- Delta: `-57,869,213 Ir` (`-3.19%`)
- Latest CodSpeed report: https://codspeed.io/web-infra-dev/rspack/runs/6a042791ea41accc18c6b787
- Latest local callgrind output: `/tmp/rspack-codspeed-build-module-graph-endswith-rule/profile.CaiNhys5xp.out/329694.out`

## Validation

- `cargo test -p rspack_paths arc_path_hash -- --nocapture`
- `cargo test -p rspack_plugin_javascript location_advancer -- --nocapture`
- `cargo test -p rspack_regex end_with -- --nocapture`
- `cargo check -p rspack_plugin_javascript`
- `cargo check -p rspack_core -p rspack`
- `pnpm run build:bench`
- `codspeed run -m simulation -- cargo codspeed run -m simulation build_module_graph`