### PR TITLE
chore(ci): remove unused tmate debugger composite

### DIFF
--- a/.github/actions/debugger/action.yml
+++ b/.github/actions/debugger/action.yml
@@ -1,9 +1,0 @@
-name: Debug action
-
-description: Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)
-
-runs:
-  using: composite
-  steps:
-    - name: Debug
-      uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,6 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
   pull_request:
     types: [opened, synchronize]
   push:


### PR DESCRIPTION
## Summary

Delete `.github/actions/debugger/` (a composite action wrapping `mxschmitt/action-tmate`) and the matching orphan `workflow_dispatch.inputs.debug_enabled` from `.github/workflows/ci.yml`.

Both are unused dead code today and removing them eliminates a latent foot-gun.

## Verification

```
$ grep -rn "actions/debugger" .github/
(empty — no callers anywhere in the repo)

$ grep -rn "debug_enabled" .github/
(empty after this PR)
```

## Why delete rather than gate

`mxschmitt/action-tmate` opens an interactive SSH session on the runner with the workflow's secrets in env. The composite currently has no `if:` gate, so any caller wiring it up gets a "shell-for-anyone-who-can-dispatch" semantics by default.

The obvious fix is to add an actor allowlist `if:` to the composite. But that fix is **security theater** against the actual threat model: a malicious actor with `write` access (or a compromised maintainer account) can simply add their own `uses: mxschmitt/action-tmate@...` step somewhere else and bypass the composite entirely. The real defense for that threat is at the access-control / branch-protection / required-review layer — not in the workflow file.

What the composite *does* meaningfully expose is a **future-self foot-gun**: a contributor who `uses: ./.github/actions/debugger` without thinking about access control would silently introduce that "shell-for-anyone" semantics. Deleting the unused composite removes that trap entirely. When tmate debugging is actually needed in the future, the contributor adding it can think about access control up front, in context, alongside the actual job that needs debugging.

Defense by deletion > defense by gate.

## Diff

```
.github/actions/debugger/action.yml |  9 ---------
.github/workflows/ci.yml            |  6 ------
2 files changed, 15 deletions(-)
```

## Test plan

- [ ] CI still passes (no workflow currently uses the deleted composite, so removal is purely subtractive)
- [ ] Manual `workflow_dispatch` of CI still works — only the unused `debug_enabled` input is gone; `workflow_dispatch:` itself is preserved