### PR TITLE
chore(build): fix empty napi-binding.d.ts on subsequent builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,6 +3702,7 @@ dependencies = [
  "rayon",
  "regex",
  "rspack_allocator",
+ "rspack_binding_build",
  "rspack_browserslist",
  "rspack_cacheable",
  "rspack_collections",

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -131,6 +131,9 @@ parking_lot = { version = "=0.12.5", features = ["nightly"] }
 rspack_tracing = { workspace = true }
 sftrace-setup  = { workspace = true, optional = true }
 
+[build-dependencies]
+rspack_binding_build = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/crates/rspack_binding_api/build.rs
+++ b/crates/rspack_binding_api/build.rs
@@ -1,3 +1,10 @@
 fn main() {
+  // Registers `cargo::rerun-if-env-changed=NAPI_FORCE_BUILD_RSPACK_BINDING_API`
+  // so cargo recompiles this crate (re-running the `#[napi]` proc macros that
+  // emit type-def files into `NAPI_TYPE_DEF_TMP_FOLDER`) when the napi CLI bumps
+  // that env var under `--no-dts-cache`. Without this, second-and-later builds
+  // produce an empty `napi-binding.d.ts`.
+  rspack_binding_build::setup();
+
   println!("cargo::rustc-check-cfg=cfg(tokio_unstable)");
 }


### PR DESCRIPTION
## Summary

Re-add `napi_build::setup()` to `rspack_binding_api/build.rs` so cargo correctly reruns the `#[napi]` proc macros when the napi CLI bumps `NAPI_FORCE_BUILD_RSPACK_BINDING_API` under `--no-dts-cache`.

## Why

Running `pnpm build:binding:dev` a second time would overwrite `crates/node_binding/napi-binding.d.ts` with a 0-byte file.

Root cause chain:

1. `crates/node_binding/scripts/build.js` always passes `--no-dts-cache` to `napi build`.
2. With `--no-dts-cache`, the napi CLI creates a fresh timestamped `target/napi-rs/rspack_node-<hash>_<ts>/` directory for type-def output on every run, and sets `NAPI_FORCE_BUILD_<CRATE>=<new-ts>` for every workspace crate depending on `napi-derive`, to force the proc macros to re-emit type-def files into the new directory.
3. For cargo to honor that env-var change, the crate's `build.rs` must register `cargo::rerun-if-env-changed=NAPI_FORCE_BUILD_<CRATE>` — exactly what `napi_build::setup()` does.
4. `rspack_binding_api/build.rs` did not call it (only `cargo::rustc-check-cfg=cfg(tokio_unstable)`), so cargo considered the crate up-to-date on the 2nd run, skipped recompilation, and emitted nothing into the new tmp folder. Since `node_binding/src/lib.rs` itself has zero `#[napi]` items and ~all of them live in `rspack_binding_api`, the folder ended up empty.
5. `generateTypeDef` returned `{ exports: [], dts: '' }` and the empty dts was written to disk; because `exports.length === 0`, it was also not pushed to `outputs`, so the `--pipe "node dts-header.js"` step did not run to prepend the banner either.

Evidence before the fix — the first run's tmp folder is populated, every subsequent run is empty:

```
target/napi-rs/rspack_node-f9407922_1778608021042/rspack_binding_api/   ← 1st run, populated
target/napi-rs/rspack_node-f9407922_1778608354939/                      ← empty
target/napi-rs/rspack_node-f9407922_1778608401353/                      ← empty
target/napi-rs/rspack_node-f9407922_1778608420143/                      ← empty
```

After the fix, every run's folder contains `rspack_binding_api/`.

## Regression history

- #9162 enabled `--no-dts-cache` by default and added `napi_build::setup()` to `rspack_binding_values/build.rs` to pair with it.
- #10770 split `rspack_node` into `rspack_binding_api`, but the new `rspack_binding_api/build.rs` did not carry over the `napi_build::setup()` call. This PR restores the equivalent.

## Changes

- `crates/rspack_binding_api/build.rs`: call `rspack_binding_build::setup()` (which calls `napi_build::setup()`), matching the pattern in `node_binding/build.rs` and `rspack_binding_builder_testing/build.rs`.
- `crates/rspack_binding_api/Cargo.toml`: add `[build-dependencies] rspack_binding_build = { workspace = true }`.

## Test plan

- [x] `cargo check -p rspack_binding_api` succeeds.
- [x] `rm -rf target/napi-rs && pnpm build:binding:dev && pnpm build:binding:dev` produces a non-empty `crates/node_binding/napi-binding.d.ts` after the second run, and each `target/napi-rs/rspack_node-*` folder contains `rspack_binding_api/`.