### PR TITLE
refactor: replace regex with regex-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,7 +3587,7 @@ dependencies = [
  "derive_more",
  "enum-tag",
  "insta",
- "regex",
+ "regex-lite",
  "rspack_browserslist",
  "rspack_core",
  "rspack_error",
@@ -3700,7 +3706,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_allocator",
  "rspack_browserslist",
  "rspack_cacheable",
@@ -3831,7 +3837,7 @@ version = "0.100.3"
 dependencies = [
  "browserslist-rs",
  "lightningcss",
- "regex",
+ "regex-lite",
 ]
 
 [[package]]
@@ -3846,7 +3852,7 @@ dependencies = [
  "json",
  "lightningcss",
  "once_cell",
- "regex",
+ "regex-lite",
  "rkyv 0.8.8",
  "rspack-allocative",
  "rspack_cacheable_macros",
@@ -3929,7 +3935,7 @@ dependencies = [
  "paste",
  "pretty_assertions",
  "rayon",
- "regex",
+ "regex-lite",
  "rkyv 0.8.8",
  "rspack_cacheable",
  "rspack_collections",
@@ -4149,7 +4155,7 @@ dependencies = [
  "hex",
  "indoc",
  "once_cell",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_core",
  "rspack_error",
@@ -4297,7 +4303,7 @@ version = "0.100.3"
 dependencies = [
  "cow-utils",
  "futures",
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
@@ -4344,7 +4350,7 @@ dependencies = [
  "futures",
  "glob",
  "pathdiff",
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_hash",
@@ -4366,7 +4372,7 @@ dependencies = [
  "css-module-lexer",
  "heck",
  "once_cell",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4408,7 +4414,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "memchr",
- "regex",
+ "regex-lite",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
@@ -4490,7 +4496,7 @@ dependencies = [
  "cow-utils",
  "futures",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4518,7 +4524,7 @@ dependencies = [
 name = "rspack_plugin_externals"
 version = "0.100.3"
 dependencies = [
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
@@ -4534,7 +4540,7 @@ dependencies = [
  "async-trait",
  "cow-utils",
  "itertools 0.14.0",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4631,7 +4637,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "rayon",
- "regex",
+ "regex-lite",
  "regress",
  "rspack_cacheable",
  "rspack_collections",
@@ -4696,7 +4702,8 @@ name = "rspack_plugin_library"
 version = "0.100.3"
 dependencies = [
  "futures",
- "regex",
+ "regex-lite",
+ "regress",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
@@ -4719,7 +4726,7 @@ dependencies = [
  "lightningcss",
  "parcel_sourcemap",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_hash",
@@ -4759,7 +4766,7 @@ dependencies = [
  "async-trait",
  "camino",
  "itertools 0.14.0",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4842,7 +4849,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_hash",
@@ -4889,7 +4896,7 @@ dependencies = [
  "futures",
  "indoc",
  "once_cell",
- "regex",
+ "regex-lite",
  "rspack-allocative",
  "rspack_cacheable",
  "rspack_collections",
@@ -4962,7 +4969,7 @@ name = "rspack_plugin_rstest"
 version = "0.100.3"
 dependencies = [
  "camino",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -4984,7 +4991,7 @@ dependencies = [
  "derive_more",
  "futures",
  "itertools 0.14.0",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -5019,7 +5026,7 @@ dependencies = [
  "cow-utils",
  "napi",
  "once_cell",
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_fs",
@@ -5058,7 +5065,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
@@ -5082,7 +5089,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -5110,7 +5117,7 @@ dependencies = [
  "cow-utils",
  "once_cell",
  "rayon",
- "regex",
+ "regex-lite",
  "rspack_core",
  "rspack_error",
  "rspack_hash",
@@ -5162,7 +5169,7 @@ version = "0.100.3"
 dependencies = [
  "cow-utils",
  "napi",
- "regex",
+ "regex-lite",
  "regex-syntax",
  "regress",
  "rspack_cacheable",
@@ -5310,7 +5317,7 @@ dependencies = [
  "json-escape-simd",
  "memchr",
  "once_cell",
- "regex",
+ "regex-lite",
  "rspack-allocative",
  "rspack_cacheable",
  "rspack_paths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ proc-macro2         = { version = "1.0.106", default-features = false }
 prost               = { version = "0.13", default-features = false }
 quote               = { version = "1.0.45", default-features = false }
 rayon               = { version = "1.12.0", default-features = false }
-regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
+regex               = { package = "regex-lite", version = "0.1.9", default-features = false, features = ["std", "string"] }
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
@@ -331,6 +331,9 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package.regex]
+opt-level = "s"
+
+[profile.release.package.regex-lite]
 opt-level = "s"
 
 [profile.release.package.rspack_error]

--- a/crates/rspack_plugin_library/Cargo.toml
+++ b/crates/rspack_plugin_library/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace       = true
 [dependencies]
 futures                                = { workspace = true }
 regex                                  = { workspace = true }
+regress                                = { workspace = true }
 rspack_collections                     = { workspace = true }
 rspack_core                            = { workspace = true }
 rspack_error                           = { workspace = true }

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -2,6 +2,7 @@ use std::{hash::Hash, sync::LazyLock};
 
 use futures::future::join_all;
 use regex::Regex;
+use regress::Regex as RegressRegex;
 use rspack_core::{
   AsyncModulesArtifact, BoxModule, CanInlineUse, Chunk, ChunkUkey,
   CodeGenerationDataTopLevelDeclarations, Compilation,
@@ -588,12 +589,29 @@ static KEYWORD_REGEXP: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"^(await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|super|switch|static|this|throw|try|true|typeof|var|void|while|with|yield)$").expect("should init regex")
 });
 
-static IDENTIFIER_REGEXP: LazyLock<Regex> = LazyLock::new(|| {
-  Regex::new(r"^[\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}]*$")
-    .expect("should init regex")
+static IDENTIFIER_REGEXP: LazyLock<RegressRegex> = LazyLock::new(|| {
+  RegressRegex::with_flags(
+    r"^[\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}]*$",
+    "u",
+  )
+  .expect("should init regex")
 });
 
 #[inline]
 fn is_name_valid(v: &str) -> bool {
-  !KEYWORD_REGEXP.is_match(v) && IDENTIFIER_REGEXP.is_match(v)
+  !KEYWORD_REGEXP.is_match(v) && IDENTIFIER_REGEXP.find(v).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::is_name_valid;
+
+  #[test]
+  fn accepts_unicode_identifier_names() {
+    assert!(is_name_valid("变量"));
+    assert!(is_name_valid("$foo_1"));
+    assert!(is_name_valid("_foo"));
+    assert!(!is_name_valid("123-hello world"));
+    assert!(!is_name_valid("class"));
+  }
 }

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -78,9 +78,7 @@ impl HashRustRegex {
         's' => {
           builder.dot_matches_new_line(true);
         }
-        'u' => {
-          builder.unicode(true);
-        }
+        'u' => {}
         // Keep JS regexp flags for metadata compatibility.
         'g' | 'y' => {}
         _ => {

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -20,7 +20,7 @@ indexmap         = { workspace = true }
 itoa             = { workspace = true }
 json-escape-simd = { workspace = true }
 memchr           = { workspace = true }
-regex            = { workspace = true, features = ["pattern"] }
+regex            = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_paths     = { workspace = true }
 rustc-hash       = { workspace = true }

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -194,7 +194,9 @@ pub fn insert_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {
 fn split_keep<'a>(r: &Regex, text: &'a str) -> Vec<&'a str> {
   let mut result = Vec::new();
   let mut last = 0;
-  for (index, matched) in text.match_indices(r) {
+  for matched in r.find_iter(text) {
+    let index = matched.start();
+    let matched = matched.as_str();
     if last != index {
       result.push(&text[last..index]);
     }


### PR DESCRIPTION
## Summary

Replace Rspack's direct workspace `regex` dependency with `regex-lite` to reduce regex dependency size/compile overhead for direct uses.

This keeps the dependency name as `regex` via Cargo package rename so existing call sites remain mostly unchanged, and updates the incompatible API/syntax uses:

- remove `RegexBuilder::unicode(...)` usage for `regex-lite`
- replace `str::match_indices(regex)` with `Regex::find_iter(...)`
- remove the unsupported `pattern` feature request from `rspack_util`
- replace the library plugin's Unicode character-class identifier regex with `regress`, since `regex-lite` does not support `\p{...}` classes

Third-party dependencies may still pull in `regex` transitively.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation:

- `cargo check -p rspack_plugin_library`
- `cargo build -p rspack_plugin_library`
- `cargo test -p rspack_plugin_library --lib`
- `cargo check -p rspack --lib`
- `cargo test -p rspack_regex -p rspack_util`
- `cargo fmt --all --check`
- `pnpm run build:binding:dev`
- `git diff --check`