### PR TITLE
[codex] Test rspack-sources PR 235

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
 dependencies = [
  "bytes",
- "rkyv 0.8.8",
+ "rkyv 0.8.16",
  "serde",
 ]
 
@@ -3534,19 +3534,19 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.8"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck 0.8.0",
  "bytes",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.0",
  "indexmap",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
  "rend 0.5.2",
- "rkyv_derive 0.8.8",
+ "rkyv_derive 0.8.16",
  "tinyvec",
  "uuid",
 ]
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.8"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3848,7 +3848,7 @@ dependencies = [
  "lightningcss",
  "once_cell",
  "regex",
- "rkyv 0.8.8",
+ "rkyv 0.8.16",
  "rspack-allocative",
  "rspack_cacheable_macros",
  "rspack_resolver",
@@ -3931,7 +3931,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "regex",
- "rkyv 0.8.8",
+ "rkyv 0.8.16",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_dojang",
@@ -5198,12 +5198,11 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a15922f723c63a408f81a7813cfe5133578057c6b9d94e94b29b3e29f51dd"
+source = "git+https://github.com/rstackjs/rspack-sources?rev=fcaa1d1d86b85eb0e62ef49bb4abe17f4ecce722#fcaa1d1d86b85eb0e62ef49bb4abe17f4ecce722"
 dependencies = [
  "dyn-clone",
  "memchr",
- "rkyv 0.8.8",
+ "rkyv 0.8.16",
  "rustc-hash",
  "serde",
  "simd-json",
@@ -5891,7 +5890,7 @@ dependencies = [
  "hstr",
  "once_cell",
  "rancor",
- "rkyv 0.8.8",
+ "rkyv 0.8.16",
  "serde",
 ]
 
@@ -5913,7 +5912,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rancor",
- "rkyv 0.8.8",
+ "rkyv 0.8.16",
  "rustc-hash",
  "serde",
  "siphasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ regex               = { version = "1.12.3", default-features = false, features =
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
 rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
-rspack_sources      = { version = "=0.4.22", default-features = false, features = ["rspack_cacheable"] }
+rspack_sources      = { git = "https://github.com/rstackjs/rspack-sources", rev = "fcaa1d1d86b85eb0e62ef49bb4abe17f4ecce722", default-features = false, features = ["rspack_cacheable"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }
@@ -126,7 +126,7 @@ napi-derive = { version = "3.5.5", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }
-rkyv      = { version = "=0.8.8", default-features = false, features = ["std", "bytecheck"] }
+rkyv      = { version = "=0.8.16", default-features = false, features = ["std", "bytecheck"] }
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.8", default-features = false }


### PR DESCRIPTION
## Summary

- Point `rspack_sources` at rstackjs/rspack-sources#235 (`fcaa1d1d86b85eb0e62ef49bb4abe17f4ecce722`) so Rspack CI can validate the proposed source map hot path changes.
- Update workspace `rkyv` from `0.8.8` to `0.8.16`, matching the dependency required by that `rspack_sources` PR.

## Validation

- `pnpm run build:binding:dev`

## Performance validation

- PR CI started, including CodSpeed Rust/Binding benchmark jobs.
- Ecosystem Benchmark triggered for this PR: https://github.com/web-infra-dev/rspack/actions/runs/25841948977

This is a draft PR for CI/performance validation only.