### PR TITLE
chore(deps): update swc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5987,9 +5987,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "65.0.4"
+version = "65.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b86be5373e799721f0e249e888ee902927ed14094179475fade2473babdd4d1"
+checksum = "5cb28adfd0302ee7c5f0de598f353c8d1f2ef1fb033a3691d0f9a7e448ac8a2c"
 dependencies = [
  "par-core",
  "swc",
@@ -6293,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "52.0.5"
+version = "52.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04e438d1cbf78281d8fa81768a0bdabd11840fe9232b3e65222ae6b02bf557b"
+checksum = "880f65e54a32d58e4d85dbb8370c9618be926b56b42e5c5f48bdb4ebb3dfbb99"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -6329,9 +6329,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "39.0.2"
+version = "39.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b13829b24cbdb2d7a08282bd968af8a258fd762c918df9a7b82291d44068bbc"
+checksum = "76e6934ad1cf59a947528f034943be40d06fb3332def0d71db29ba6ad8181283"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6478,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "42.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e58612045e827e7d3ae9f1dc6ae3590ba9abc6a3d93ff2adf27350ab409822"
+checksum = "1f0c8ee943a8f9099391cecef5b3eafc98aba64dfa5f6f7cd336a32989d92d1a"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -6582,9 +6582,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2098c7da8c4f235342ec1f7a0eb61264214d4d1b3185a0d43b2833543745b3ca"
+checksum = "939eb773b1a69df8be73b0bda3135b61dd5fa47eb495817fea392b0779351fb3"
 dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
@@ -6667,9 +6667,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "29.1.0"
+version = "29.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e64243f2c9e9c9e631a18b42ad51f62137cf4f57b21fb93b1d58836322c2c81"
+checksum = "3d69b480aa02b5ff2ab951478d8e7633eeda42940aeb5fe0386eebc19dd3b1e4"
 dependencies = [
  "dragonbox_ecma",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,8 +132,8 @@ rkyv      = { version = "=0.8.8", default-features = false, features = ["std", "
 pnp                 = { version = "0.12.8", default-features = false }
 swc                 = { version = "63.0.0", default-features = false }
 swc_config          = { version = "4.0.1", default-features = false }
-swc_core            = { version = "65.0.4", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "52.0.5", default-features = false }
+swc_core            = { version = "65.1.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "52.0.6", default-features = false }
 swc_error_reporters = { version = "23.0.0", default-features = false }
 swc_html            = { version = "33.0.0", default-features = false }
 swc_html_minifier   = { version = "52.0.0", default-features = false }

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "65.0.4"
+  "65.1.0"
 }
 
 /// The version of the JavaScript `@rspack/core` package.


### PR DESCRIPTION
## Summary

- update `swc_core` from `65.0.4` to `65.1.0`
- update `swc_ecma_minifier` from `52.0.5` to `52.0.6`
- refresh the affected SWC transitive crates in `Cargo.lock`

## Validation

- `cargo build -p rspack_node --profile profiling --locked --no-default-features --features plugin,perfetto`
- GitHub CI will validate the PR branch

## Notes

This PR is intended to validate the latest SWC crate updates in CI before deciding whether to keep the upgrade.