### PR TITLE
fix(rslib): emit type-only isolated dts dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,6 +4827,7 @@ dependencies = [
  "rspack_fs",
  "rspack_hash",
  "rspack_hook",
+ "rspack_javascript_compiler",
  "rspack_paths",
  "rspack_plugin_asset",
  "rspack_plugin_externals",

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -170,7 +170,7 @@ pub struct BuildInfo {
   pub inline_exports: bool,
   pub collected_typescript_info: Option<CollectedTypeScriptInfo>,
   pub rsc: Option<RscMeta>,
-  pub isolated_dts: Option<IsolatedDts>,
+  pub isolated_dts: Option<Box<IsolatedDts>>,
   /// Stores external fields from the JS side (Record<string, any>),
   /// while other properties are stored in KnownBuildInfo.
   #[cacheable(with=AsPreset)]

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -133,6 +133,7 @@ pub type CssExports = FxIndexMap<String, FxIndexSet<CssExport>>;
 pub struct IsolatedDts {
   pub resource_path: String,
   pub code: String,
+  pub references: Vec<String>,
 }
 
 #[cacheable]

--- a/crates/rspack_javascript_compiler/src/compiler/mod.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/mod.rs
@@ -52,5 +52,6 @@ impl TransformOutput {
 #[derive(Debug, Clone)]
 pub struct IsolatedDtsTransformOutput {
   pub code: String,
+  pub references: Vec<String>,
   pub diagnostics: Vec<String>,
 }

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -36,7 +36,11 @@ use swc_core::{
       Syntax, TsSyntax, parse_file_as_commonjs, parse_file_as_module, parse_file_as_program,
       parse_file_as_script,
     },
-    transforms::base::helpers::{self, Helpers},
+    transforms::base::{
+      helpers::{self, Helpers},
+      resolver,
+    },
+    visit::VisitMutWith,
   },
 };
 use swc_error_reporters::handler::try_with_handler;
@@ -136,6 +140,53 @@ impl JavaScriptCompiler {
       };
 
       Ok(IsolatedDtsTransformOutput { code, diagnostics })
+    })
+  }
+
+  /// Generate isolated declaration output from a source string for callers that
+  /// are outside the normal loader transform path.
+  pub fn emit_isolated_dts_from_source(
+    &self,
+    source: String,
+    filename: Arc<FileName>,
+    syntax: Syntax,
+    target: EsVersion,
+  ) -> Result<IsolatedDtsTransformOutput> {
+    self.run(|| {
+      let comments = SingleThreadedComments::default();
+      let fm = self.cm.new_source_file(filename.clone(), source);
+      let unresolved_mark = Mark::new();
+      let top_level_mark = Mark::new();
+      let is_typescript = syntax.typescript();
+      let mut program = try_with_handler(self.cm.clone(), Default::default(), |handler| {
+        let mut had_error = false;
+        let mut errors = vec![];
+        let program = parse_file_as_program(&fm, syntax, target, Some(&comments), &mut errors);
+
+        for error in errors {
+          error.into_diagnostic(handler).emit();
+          had_error = true;
+        }
+
+        let program = program.map_err(|error| {
+          error.into_diagnostic(handler).emit();
+          anyhow::Error::msg("Syntax Error")
+        })?;
+
+        if had_error {
+          bail!("Syntax Error");
+        }
+
+        Ok(program)
+      })
+      .map_err(|error| error.to_pretty_error())?;
+      program.visit_mut_with(&mut resolver(
+        unresolved_mark,
+        top_level_mark,
+        is_typescript,
+      ));
+
+      self.emit_isolated_dts(&program, filename, unresolved_mark, target, &comments)
     })
   }
 }

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -5,12 +5,13 @@
  * Author Donny/강동윤
  * Copyright (c)
  */
-use std::{cell::RefCell, collections::HashSet, fs::File, path::PathBuf, rc::Rc, sync::Arc};
+use std::{cell::RefCell, fs::File, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::{Context, bail};
 use indoc::formatdoc;
 use rspack_error::Result;
 use rspack_util::{base64, source_map::SourceMapKind, swc::minify_file_comments};
+use rustc_hash::FxHashSet as HashSet;
 use swc_config::{is_module::IsModule, merge::Merge};
 pub use swc_core::base::config::Options as SwcOptions;
 use swc_core::{
@@ -228,34 +229,34 @@ impl Visit for DtsReferenceCollector {
     // Matches import declarations, for example:
     //   import type { Foo } from "./foo";
     //   import "./foo";
-    self.push(node.src.value.to_string_lossy().to_string());
+    self.push(node.src.value.to_string_lossy().into_owned());
   }
 
   fn visit_export_all(&mut self, node: &ExportAll) {
     // Matches export-all declarations, for example:
     //   export * from "./foo";
-    self.push(node.src.value.to_string_lossy().to_string());
+    self.push(node.src.value.to_string_lossy().into_owned());
   }
 
   fn visit_named_export(&mut self, node: &NamedExport) {
     // Matches named re-exports, for example:
     //   export type { Foo } from "./foo";
     if let Some(src) = &node.src {
-      self.push(src.value.to_string_lossy().to_string());
+      self.push(src.value.to_string_lossy().into_owned());
     }
   }
 
   fn visit_ts_import_type(&mut self, node: &TsImportType) {
     // Matches inline import types, for example:
     //   export type Foo = import("./foo").Foo;
-    self.push(node.arg.value.to_string_lossy().to_string());
+    self.push(node.arg.value.to_string_lossy().into_owned());
     node.visit_children_with(self);
   }
 
   fn visit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef) {
     // Matches TypeScript import-equals declarations, for example:
     //   import Foo = require("./foo");
-    self.push(node.expr.value.to_string_lossy().to_string());
+    self.push(node.expr.value.to_string_lossy().into_owned());
   }
 }
 

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -125,7 +125,9 @@ impl JavaScriptCompiler {
       // Collect declaration references from the FastDts output AST before codegen.
       // Rslib uses these references to complete type-only declaration outputs without
       // parsing the generated .d.ts string again.
-      let references = collect_isolated_dts_references(&program);
+      let mut collector = DtsReferenceCollector::default();
+      program.visit_with(&mut collector);
+      let references = collector.references;
 
       let code = {
         let mut buf = Vec::new();
@@ -202,12 +204,6 @@ impl JavaScriptCompiler {
       self.emit_isolated_dts(&program, filename, unresolved_mark, target, &comments)
     })
   }
-}
-
-fn collect_isolated_dts_references(program: &Program) -> Vec<String> {
-  let mut collector = DtsReferenceCollector::default();
-  program.visit_with(&mut collector);
-  collector.references
 }
 
 #[derive(Default)]

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -5,7 +5,7 @@
  * Author Donny/강동윤
  * Copyright (c)
  */
-use std::{cell::RefCell, fs::File, path::PathBuf, rc::Rc, sync::Arc};
+use std::{cell::RefCell, collections::HashSet, fs::File, path::PathBuf, rc::Rc, sync::Arc};
 
 use anyhow::{Context, bail};
 use indoc::formatdoc;
@@ -27,7 +27,10 @@ use swc_core::{
     errors::Handler,
   },
   ecma::{
-    ast::{EsVersion, Pass, Program},
+    ast::{
+      EsVersion, ExportAll, ImportDecl, NamedExport, Pass, Program, TsExternalModuleRef,
+      TsImportType,
+    },
     codegen::{
       self, Emitter, Node,
       text_writer::{self, WriteJs},
@@ -40,7 +43,7 @@ use swc_core::{
       helpers::{self, Helpers},
       resolver,
     },
-    visit::VisitMutWith,
+    visit::{Visit, VisitMutWith, VisitWith},
   },
 };
 use swc_error_reporters::handler::try_with_handler;
@@ -118,6 +121,11 @@ impl JavaScriptCompiler {
         }
       };
 
+      // Collect declaration references from the FastDts output AST before codegen.
+      // Rslib uses these references to complete type-only declaration outputs without
+      // parsing the generated .d.ts string again.
+      let references = collect_isolated_dts_references(&program);
+
       let code = {
         let mut buf = Vec::new();
         {
@@ -139,7 +147,11 @@ impl JavaScriptCompiler {
         unsafe { String::from_utf8_unchecked(buf) }
       };
 
-      Ok(IsolatedDtsTransformOutput { code, diagnostics })
+      Ok(IsolatedDtsTransformOutput {
+        code,
+        references,
+        diagnostics,
+      })
     })
   }
 
@@ -188,6 +200,62 @@ impl JavaScriptCompiler {
 
       self.emit_isolated_dts(&program, filename, unresolved_mark, target, &comments)
     })
+  }
+}
+
+fn collect_isolated_dts_references(program: &Program) -> Vec<String> {
+  let mut collector = DtsReferenceCollector::default();
+  program.visit_with(&mut collector);
+  collector.references
+}
+
+#[derive(Default)]
+struct DtsReferenceCollector {
+  references: Vec<String>,
+  seen: HashSet<String>,
+}
+
+impl DtsReferenceCollector {
+  fn push(&mut self, value: String) {
+    if self.seen.insert(value.clone()) {
+      self.references.push(value);
+    }
+  }
+}
+
+impl Visit for DtsReferenceCollector {
+  fn visit_import_decl(&mut self, node: &ImportDecl) {
+    // Matches import declarations, for example:
+    //   import type { Foo } from "./foo";
+    //   import "./foo";
+    self.push(node.src.value.to_string_lossy().to_string());
+  }
+
+  fn visit_export_all(&mut self, node: &ExportAll) {
+    // Matches export-all declarations, for example:
+    //   export * from "./foo";
+    self.push(node.src.value.to_string_lossy().to_string());
+  }
+
+  fn visit_named_export(&mut self, node: &NamedExport) {
+    // Matches named re-exports, for example:
+    //   export type { Foo } from "./foo";
+    if let Some(src) = &node.src {
+      self.push(src.value.to_string_lossy().to_string());
+    }
+  }
+
+  fn visit_ts_import_type(&mut self, node: &TsImportType) {
+    // Matches inline import types, for example:
+    //   export type Foo = import("./foo").Foo;
+    self.push(node.arg.value.to_string_lossy().to_string());
+    node.visit_children_with(self);
+  }
+
+  fn visit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef) {
+    // Matches TypeScript import-equals declarations, for example:
+    //   import Foo = require("./foo");
+    self.push(node.expr.value.to_string_lossy().to_string());
   }
 }
 

--- a/crates/rspack_loader_swc/src/isolated_dts.rs
+++ b/crates/rspack_loader_swc/src/isolated_dts.rs
@@ -10,6 +10,7 @@ pub(crate) fn set_build_info(
   resource_path: &Utf8Path,
   compiler_context: &Utf8Path,
   code: String,
+  references: Vec<String>,
 ) {
   // BuildInfo is persisted in cache, so avoid storing checkout-specific absolute paths.
   let relative_resource_path = resource_path
@@ -25,6 +26,7 @@ pub(crate) fn set_build_info(
   build_info.isolated_dts = Some(IsolatedDts {
     resource_path,
     code,
+    references,
   });
 }
 

--- a/crates/rspack_loader_swc/src/isolated_dts.rs
+++ b/crates/rspack_loader_swc/src/isolated_dts.rs
@@ -23,11 +23,11 @@ pub(crate) fn set_build_info(
   }
   .to_slash_lossy()
   .into_owned();
-  build_info.isolated_dts = Some(IsolatedDts {
+  build_info.isolated_dts = Some(Box::new(IsolatedDts {
     resource_path,
     code,
     references,
-  });
+  }));
 }
 
 pub(crate) fn handle_isolated_dts_diagnostics(diagnostics: Vec<String>) -> Result<()> {

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -226,6 +226,7 @@ impl SwcLoader {
         resource_path.as_path(),
         loader_context.context.options.context.as_path(),
         isolated_dts.code,
+        isolated_dts.references,
       );
     }
 

--- a/crates/rspack_plugin_rslib/Cargo.toml
+++ b/crates/rspack_plugin_rslib/Cargo.toml
@@ -8,20 +8,21 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cow-utils                = { workspace = true }
-pathdiff                 = { workspace = true }
-rspack_cacheable         = { workspace = true }
-rspack_collections       = { workspace = true }
-rspack_core              = { workspace = true }
-rspack_error             = { workspace = true }
-rspack_fs                = { workspace = true }
-rspack_hash              = { workspace = true }
-rspack_hook              = { workspace = true }
-rspack_paths             = { workspace = true }
-rspack_plugin_asset      = { workspace = true }
-rspack_plugin_externals  = { workspace = true }
-rspack_plugin_javascript = { workspace = true }
-rspack_util              = { workspace = true }
+cow-utils                  = { workspace = true }
+pathdiff                   = { workspace = true }
+rspack_cacheable           = { workspace = true }
+rspack_collections         = { workspace = true }
+rspack_core                = { workspace = true }
+rspack_error               = { workspace = true }
+rspack_fs                  = { workspace = true }
+rspack_hash                = { workspace = true }
+rspack_hook                = { workspace = true }
+rspack_javascript_compiler = { workspace = true }
+rspack_paths               = { workspace = true }
+rspack_plugin_asset        = { workspace = true }
+rspack_plugin_externals    = { workspace = true }
+rspack_plugin_javascript   = { workspace = true }
+rspack_util                = { workspace = true }
 
 async-trait = { workspace = true }
 rustc-hash  = { workspace = true }

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -12,11 +12,10 @@ use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::node_path::NodePath;
 use swc_core::{
-  common::{FileName, SourceMap, comments::SingleThreadedComments},
+  common::FileName,
   ecma::{
-    ast::{EsVersion, ExportAll, ImportDecl, NamedExport, TsExternalModuleRef, TsImportType},
-    parser::{Syntax, TsSyntax, parse_file_as_module},
-    visit::{Visit, VisitWith},
+    ast::EsVersion,
+    parser::{Syntax, TsSyntax},
   },
 };
 
@@ -58,9 +57,8 @@ pub(crate) async fn complete_isolated_dts_outputs(
   while let Some(dts) = queue.pop_front() {
     let issuer = resolve_path(&compiler_root, &dts.resource_path);
     let issuer_dir = issuer.parent().unwrap_or(compiler_root.as_path());
-    let references = collect_dts_references(&issuer, &dts.code)?;
 
-    for request in references {
+    for request in dts.references {
       let (result, resolve_dependencies) = resolver
         .resolve_with_context(issuer_dir.as_std_path(), &request)
         .await;
@@ -94,6 +92,7 @@ pub(crate) async fn complete_isolated_dts_outputs(
       let dts = IsolatedDts {
         resource_path: resource_path.as_str().to_string(),
         code: dts_output.code,
+        references: dts_output.references,
       };
       queue.push_back(dts.clone());
       outputs.push(dts);
@@ -183,89 +182,6 @@ fn type_resolve_options(tsconfig: Option<TsconfigOptions>) -> Resolve {
     fully_specified: Some(false),
     tsconfig,
     ..Default::default()
-  }
-}
-
-fn collect_dts_references(resource_path: &Utf8Path, code: &str) -> Result<Vec<String>> {
-  let cm = Arc::<SourceMap>::default();
-  let comments = SingleThreadedComments::default();
-  let fm = cm.new_source_file(
-    Arc::new(FileName::Real(
-      resource_path.to_path_buf().into_std_path_buf(),
-    )),
-    code.to_string(),
-  );
-  let mut errors = Vec::new();
-  let module = parse_file_as_module(
-    &fm,
-    Syntax::Typescript(TsSyntax {
-      dts: true,
-      ..Default::default()
-    }),
-    EsVersion::EsNext,
-    Some(&comments),
-    &mut errors,
-  )
-  .map_err(|err| {
-    error!(
-      "Failed to parse generated declaration file for {}: {:?}",
-      resource_path, err
-    )
-  })?;
-
-  if let Some(error) = errors.into_iter().next() {
-    return Err(error!(
-      "Failed to parse generated declaration file for {}: {:?}",
-      resource_path, error
-    ));
-  }
-
-  let mut collector = DtsReferenceCollector::default();
-  module.visit_with(&mut collector);
-  Ok(collector.references)
-}
-
-#[derive(Default)]
-struct DtsReferenceCollector {
-  references: Vec<String>,
-  seen: HashSet<String>,
-}
-
-impl DtsReferenceCollector {
-  fn push(&mut self, value: impl Into<String>) {
-    let value = value.into();
-    if self.seen.insert(value.clone()) {
-      self.references.push(value);
-    }
-  }
-}
-
-impl Visit for DtsReferenceCollector {
-  fn visit_import_decl(&mut self, node: &ImportDecl) {
-    self.push(node.src.value.to_string_lossy().to_string());
-  }
-
-  fn visit_export_all(&mut self, node: &ExportAll) {
-    self.push(node.src.value.to_string_lossy().to_string());
-  }
-
-  fn visit_named_export(&mut self, node: &NamedExport) {
-    if let Some(src) = &node.src {
-      self.push(src.value.to_string_lossy().to_string());
-    }
-  }
-
-  fn visit_ts_import_type(&mut self, node: &TsImportType) {
-    // Matches inline import types, for example:
-    //   export type Foo = import("./foo").Foo;
-    self.push(node.arg.value.to_string_lossy().to_string());
-    node.visit_children_with(self);
-  }
-
-  fn visit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef) {
-    // Matches TypeScript import-equals declarations, for example:
-    //   import Foo = require("./foo");
-    self.push(node.expr.value.to_string_lossy().to_string());
   }
 }
 

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -1,0 +1,311 @@
+use std::{
+  collections::{HashSet, VecDeque},
+  sync::Arc,
+};
+
+use rspack_core::{
+  Compilation, DependencyCategory, IsolatedDts, Resolve, ResolveDependencies,
+  ResolveOptionsWithDependencyType, ResolveResult, TsconfigOptions, TsconfigReferences,
+};
+use rspack_error::{Result, error};
+use rspack_javascript_compiler::JavaScriptCompiler;
+use rspack_paths::{Utf8Path, Utf8PathBuf};
+use rspack_util::node_path::NodePath;
+use swc_core::{
+  common::{FileName, SourceMap, comments::SingleThreadedComments},
+  ecma::{
+    ast::{EsVersion, ExportAll, ImportDecl, NamedExport, TsExternalModuleRef, TsImportType},
+    parser::{Syntax, TsSyntax, parse_file_as_module},
+    visit::{Visit, VisitWith},
+  },
+};
+
+use crate::plugin::SwcEmitDtsOptions;
+
+pub(crate) async fn complete_isolated_dts_outputs(
+  compilation: &mut Compilation,
+  options: &SwcEmitDtsOptions,
+  roots: Vec<IsolatedDts>,
+) -> Result<Vec<IsolatedDts>> {
+  if roots.is_empty() {
+    return Ok(roots);
+  }
+
+  let compiler_root = compilation.options.context.as_path().to_path_buf();
+  let root_dir = resolve_path(&compiler_root, &options.root_dir);
+  let fs = compilation.input_filesystem.clone();
+  let tsconfig = default_tsconfig_options(compilation, &compiler_root, &fs).await;
+  let resolver = compilation
+    .resolver_factory
+    .get(ResolveOptionsWithDependencyType {
+      resolve_options: Some(Box::new(type_resolve_options(tsconfig))),
+      resolve_to_context: false,
+      dependency_category: DependencyCategory::Esm,
+    });
+  let javascript_compiler = JavaScriptCompiler::new();
+
+  let mut outputs = Vec::with_capacity(roots.len());
+  let mut queue = VecDeque::with_capacity(roots.len());
+  let mut seen: HashSet<Utf8PathBuf> = HashSet::default();
+
+  for dts in roots {
+    let resource_path = resolve_path(&compiler_root, &dts.resource_path);
+    seen.insert(resource_path);
+    queue.push_back(dts.clone());
+    outputs.push(dts);
+  }
+
+  while let Some(dts) = queue.pop_front() {
+    let issuer = resolve_path(&compiler_root, &dts.resource_path);
+    let issuer_dir = issuer.parent().unwrap_or(compiler_root.as_path());
+    let references = collect_dts_references(&issuer, &dts.code)?;
+
+    for request in references {
+      let (result, resolve_dependencies) = resolver
+        .resolve_with_context(issuer_dir.as_std_path(), &request)
+        .await;
+      add_resolve_dependencies(compilation, resolve_dependencies);
+      let Ok(ResolveResult::Resource(resource)) = result else {
+        continue;
+      };
+
+      let resource_path = resource.path.node_normalize();
+      if !is_supported_ts_source(&resource_path) || !resource_path.starts_with(&root_dir) {
+        continue;
+      }
+
+      compilation
+        .file_dependencies
+        .insert(resource_path.clone().into_std_path_buf().into());
+
+      if !seen.insert(resource_path.clone()) {
+        continue;
+      }
+
+      let source = fs.read_to_string(&resource_path).await?;
+      let dts_output = javascript_compiler.emit_isolated_dts_from_source(
+        source,
+        Arc::new(FileName::Real(resource_path.clone().into_std_path_buf())),
+        source_syntax(&resource_path),
+        EsVersion::EsNext,
+      )?;
+      handle_isolated_dts_diagnostics(&resource_path, dts_output.diagnostics)?;
+
+      let dts = IsolatedDts {
+        resource_path: resource_path.as_str().to_string(),
+        code: dts_output.code,
+      };
+      queue.push_back(dts.clone());
+      outputs.push(dts);
+    }
+  }
+
+  Ok(outputs)
+}
+
+fn resolve_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {
+  let path = Utf8Path::new(value);
+  if path.is_absolute() {
+    path.to_path_buf().node_normalize()
+  } else {
+    base.node_join(path).node_normalize()
+  }
+}
+
+fn add_resolve_dependencies(
+  compilation: &mut Compilation,
+  resolve_dependencies: ResolveDependencies,
+) {
+  compilation
+    .file_dependencies
+    .extend(resolve_dependencies.file_dependencies);
+  compilation
+    .missing_dependencies
+    .extend(resolve_dependencies.missing_dependencies);
+}
+
+async fn default_tsconfig_options(
+  compilation: &mut Compilation,
+  compiler_root: &Utf8Path,
+  fs: &Arc<dyn rspack_fs::ReadableFileSystem>,
+) -> Option<TsconfigOptions> {
+  if compilation.options.resolve.tsconfig.is_some() {
+    return None;
+  }
+
+  let tsconfig = compiler_root.node_join("tsconfig.json");
+  match fs.metadata(&tsconfig).await {
+    Ok(metadata) if metadata.is_file => {
+      compilation
+        .file_dependencies
+        .insert(tsconfig.clone().into_std_path_buf().into());
+      Some(TsconfigOptions {
+        config_file: tsconfig,
+        references: TsconfigReferences::Disabled,
+      })
+    }
+    _ => {
+      compilation
+        .missing_dependencies
+        .insert(tsconfig.into_std_path_buf().into());
+      None
+    }
+  }
+}
+
+fn type_resolve_options(tsconfig: Option<TsconfigOptions>) -> Resolve {
+  Resolve {
+    extensions: Some(vec![
+      ".ts".into(),
+      ".tsx".into(),
+      ".mts".into(),
+      ".cts".into(),
+      ".d.ts".into(),
+      ".d.mts".into(),
+      ".d.cts".into(),
+      "...".into(),
+    ]),
+    extension_alias: Some(vec![
+      (
+        ".js".into(),
+        vec![".ts".into(), ".tsx".into(), ".d.ts".into(), ".js".into()],
+      ),
+      (".jsx".into(), vec![".tsx".into(), ".jsx".into()]),
+      (
+        ".mjs".into(),
+        vec![".mts".into(), ".d.mts".into(), ".mjs".into()],
+      ),
+      (
+        ".cjs".into(),
+        vec![".cts".into(), ".d.cts".into(), ".cjs".into()],
+      ),
+    ]),
+    fully_specified: Some(false),
+    tsconfig,
+    ..Default::default()
+  }
+}
+
+fn collect_dts_references(resource_path: &Utf8Path, code: &str) -> Result<Vec<String>> {
+  let cm = Arc::<SourceMap>::default();
+  let comments = SingleThreadedComments::default();
+  let fm = cm.new_source_file(
+    Arc::new(FileName::Real(
+      resource_path.to_path_buf().into_std_path_buf(),
+    )),
+    code.to_string(),
+  );
+  let mut errors = Vec::new();
+  let module = parse_file_as_module(
+    &fm,
+    Syntax::Typescript(TsSyntax {
+      dts: true,
+      ..Default::default()
+    }),
+    EsVersion::EsNext,
+    Some(&comments),
+    &mut errors,
+  )
+  .map_err(|err| {
+    error!(
+      "Failed to parse generated declaration file for {}: {:?}",
+      resource_path, err
+    )
+  })?;
+
+  if let Some(error) = errors.into_iter().next() {
+    return Err(error!(
+      "Failed to parse generated declaration file for {}: {:?}",
+      resource_path, error
+    ));
+  }
+
+  let mut collector = DtsReferenceCollector::default();
+  module.visit_with(&mut collector);
+  Ok(collector.references)
+}
+
+#[derive(Default)]
+struct DtsReferenceCollector {
+  references: Vec<String>,
+  seen: HashSet<String>,
+}
+
+impl DtsReferenceCollector {
+  fn push(&mut self, value: impl Into<String>) {
+    let value = value.into();
+    if self.seen.insert(value.clone()) {
+      self.references.push(value);
+    }
+  }
+}
+
+impl Visit for DtsReferenceCollector {
+  fn visit_import_decl(&mut self, node: &ImportDecl) {
+    self.push(node.src.value.to_string_lossy().to_string());
+  }
+
+  fn visit_export_all(&mut self, node: &ExportAll) {
+    self.push(node.src.value.to_string_lossy().to_string());
+  }
+
+  fn visit_named_export(&mut self, node: &NamedExport) {
+    if let Some(src) = &node.src {
+      self.push(src.value.to_string_lossy().to_string());
+    }
+  }
+
+  fn visit_ts_import_type(&mut self, node: &TsImportType) {
+    // Matches inline import types, for example:
+    //   export type Foo = import("./foo").Foo;
+    self.push(node.arg.value.to_string_lossy().to_string());
+    node.visit_children_with(self);
+  }
+
+  fn visit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef) {
+    // Matches TypeScript import-equals declarations, for example:
+    //   import Foo = require("./foo");
+    self.push(node.expr.value.to_string_lossy().to_string());
+  }
+}
+
+fn is_supported_ts_source(path: &Utf8Path) -> bool {
+  !is_declaration_file(path) && matches!(path.extension(), Some("ts" | "tsx" | "mts" | "cts"))
+}
+
+fn is_declaration_file(path: &Utf8Path) -> bool {
+  let path = path.as_str();
+  path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts")
+}
+
+fn source_syntax(path: &Utf8Path) -> Syntax {
+  // Declaration completion only needs to parse TypeScript sources for fast dts.
+  // Keep this intentionally minimal instead of reusing swc-loader transform options.
+  Syntax::Typescript(TsSyntax {
+    tsx: matches!(path.extension(), Some("tsx")),
+    decorators: true,
+    disallow_ambiguous_jsx_like: matches!(path.extension(), Some("mts" | "cts")),
+    ..Default::default()
+  })
+}
+
+fn handle_isolated_dts_diagnostics(
+  resource_path: &Utf8Path,
+  diagnostics: Vec<String>,
+) -> Result<()> {
+  let mut diagnostics = diagnostics.into_iter();
+  let Some(first) = diagnostics.next() else {
+    return Ok(());
+  };
+  let remaining = diagnostics.collect::<Vec<_>>();
+  let help = if remaining.is_empty() {
+    String::new()
+  } else {
+    format!("\n{}", remaining.join("\n"))
+  };
+
+  Err(error!(
+    "Failed to generate declaration files for {}.\n{}{}",
+    resource_path, first, help
+  ))
+}

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -32,7 +32,7 @@ struct IsolatedDtsReferences {
 pub(crate) async fn complete_isolated_dts_outputs(
   compilation: &mut Compilation,
   options: &SwcEmitDtsOptions,
-  roots: Vec<Box<IsolatedDts>>,
+  roots: Vec<IsolatedDts>,
 ) -> Result<Vec<IsolatedDtsAsset>> {
   if roots.is_empty() {
     return Ok(Vec::new());
@@ -41,12 +41,12 @@ pub(crate) async fn complete_isolated_dts_outputs(
   let mut outputs = Vec::with_capacity(roots.len());
   let mut queue = VecDeque::with_capacity(roots.len());
 
-  for dts in roots {
-    let IsolatedDts {
-      resource_path,
-      code,
-      references,
-    } = *dts;
+  for IsolatedDts {
+    resource_path,
+    code,
+    references,
+  } in roots
+  {
     let has_references = !references.is_empty();
     if has_references {
       queue.push_back(IsolatedDtsReferences {

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -1,7 +1,4 @@
-use std::{
-  collections::{HashSet, VecDeque},
-  sync::Arc,
-};
+use std::{collections::VecDeque, sync::Arc};
 
 use rspack_core::{
   Compilation, DependencyCategory, IsolatedDts, Resolve, ResolveDependencies,
@@ -11,6 +8,7 @@ use rspack_error::{Result, error};
 use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::node_path::NodePath;
+use rustc_hash::FxHashSet as HashSet;
 use swc_core::{
   common::FileName,
   ecma::{
@@ -21,13 +19,49 @@ use swc_core::{
 
 use crate::plugin::SwcEmitDtsOptions;
 
+pub(crate) struct IsolatedDtsAsset {
+  pub resource_path: String,
+  pub code: String,
+}
+
+struct IsolatedDtsReferences {
+  issuer_resource_path: String,
+  references: Vec<String>,
+}
+
 pub(crate) async fn complete_isolated_dts_outputs(
   compilation: &mut Compilation,
   options: &SwcEmitDtsOptions,
   roots: Vec<IsolatedDts>,
-) -> Result<Vec<IsolatedDts>> {
+) -> Result<Vec<IsolatedDtsAsset>> {
   if roots.is_empty() {
-    return Ok(roots);
+    return Ok(Vec::new());
+  }
+
+  let mut outputs = Vec::with_capacity(roots.len());
+  let mut queue = VecDeque::with_capacity(roots.len());
+
+  for IsolatedDts {
+    resource_path,
+    code,
+    references,
+  } in roots
+  {
+    let has_references = !references.is_empty();
+    if has_references {
+      queue.push_back(IsolatedDtsReferences {
+        issuer_resource_path: resource_path.clone(),
+        references,
+      });
+    }
+    outputs.push(IsolatedDtsAsset {
+      resource_path,
+      code,
+    });
+  }
+
+  if queue.is_empty() {
+    return Ok(outputs);
   }
 
   let compiler_root = compilation.options.context.as_path().to_path_buf();
@@ -41,24 +75,21 @@ pub(crate) async fn complete_isolated_dts_outputs(
       resolve_to_context: false,
       dependency_category: DependencyCategory::Esm,
     });
-  let javascript_compiler = JavaScriptCompiler::new();
+  let mut javascript_compiler = None;
+  let mut seen: HashSet<Utf8PathBuf> = outputs
+    .iter()
+    .map(|output| resolve_path(&compiler_root, &output.resource_path))
+    .collect();
 
-  let mut outputs = Vec::with_capacity(roots.len());
-  let mut queue = VecDeque::with_capacity(roots.len());
-  let mut seen: HashSet<Utf8PathBuf> = HashSet::default();
-
-  for dts in roots {
-    let resource_path = resolve_path(&compiler_root, &dts.resource_path);
-    seen.insert(resource_path);
-    queue.push_back(dts.clone());
-    outputs.push(dts);
-  }
-
-  while let Some(dts) = queue.pop_front() {
-    let issuer = resolve_path(&compiler_root, &dts.resource_path);
+  while let Some(IsolatedDtsReferences {
+    issuer_resource_path,
+    references,
+  }) = queue.pop_front()
+  {
+    let issuer = resolve_path(&compiler_root, &issuer_resource_path);
     let issuer_dir = issuer.parent().unwrap_or(compiler_root.as_path());
 
-    for request in dts.references {
+    for request in references {
       let (result, resolve_dependencies) = resolver
         .resolve_with_context(issuer_dir.as_std_path(), &request)
         .await;
@@ -72,30 +103,37 @@ pub(crate) async fn complete_isolated_dts_outputs(
         continue;
       }
 
-      compilation
-        .file_dependencies
-        .insert(resource_path.clone().into_std_path_buf().into());
-
       if !seen.insert(resource_path.clone()) {
         continue;
       }
 
+      compilation
+        .file_dependencies
+        .insert(resource_path.clone().into_std_path_buf().into());
+
       let source = fs.read_to_string(&resource_path).await?;
-      let dts_output = javascript_compiler.emit_isolated_dts_from_source(
-        source,
-        Arc::new(FileName::Real(resource_path.clone().into_std_path_buf())),
-        source_syntax(&resource_path),
-        EsVersion::EsNext,
-      )?;
+      let dts_output = javascript_compiler
+        .get_or_insert_with(JavaScriptCompiler::new)
+        .emit_isolated_dts_from_source(
+          source,
+          Arc::new(FileName::Real(resource_path.clone().into_std_path_buf())),
+          source_syntax(&resource_path),
+          EsVersion::EsNext,
+        )?;
       handle_isolated_dts_diagnostics(&resource_path, dts_output.diagnostics)?;
 
-      let dts = IsolatedDts {
-        resource_path: resource_path.as_str().to_string(),
+      let has_references = !dts_output.references.is_empty();
+      let resource_path = resource_path.as_str().to_string();
+      if has_references {
+        queue.push_back(IsolatedDtsReferences {
+          issuer_resource_path: resource_path.clone(),
+          references: dts_output.references,
+        });
+      }
+      outputs.push(IsolatedDtsAsset {
+        resource_path,
         code: dts_output.code,
-        references: dts_output.references,
-      };
-      queue.push_back(dts.clone());
-      outputs.push(dts);
+      });
     }
   }
 

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -1,8 +1,8 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use rspack_core::{
-  Compilation, DependencyCategory, IsolatedDts, Resolve, ResolveDependencies,
-  ResolveOptionsWithDependencyType, ResolveResult, TsconfigOptions, TsconfigReferences,
+  Compilation, DependencyCategory, IsolatedDts, Resolve, ResolveOptionsWithDependencyType,
+  ResolveResult, TsconfigOptions, TsconfigReferences,
 };
 use rspack_error::{Result, error};
 use rspack_javascript_compiler::JavaScriptCompiler;
@@ -93,13 +93,25 @@ pub(crate) async fn complete_isolated_dts_outputs(
       let (result, resolve_dependencies) = resolver
         .resolve_with_context(issuer_dir.as_std_path(), &request)
         .await;
-      add_resolve_dependencies(compilation, resolve_dependencies);
+      compilation
+        .file_dependencies
+        .extend(resolve_dependencies.file_dependencies);
+      compilation
+        .missing_dependencies
+        .extend(resolve_dependencies.missing_dependencies);
       let Ok(ResolveResult::Resource(resource)) = result else {
         continue;
       };
 
       let resource_path = resource.path.node_normalize();
-      if !is_supported_ts_source(&resource_path) || !resource_path.starts_with(&root_dir) {
+      let resource_path_str = resource_path.as_str();
+      let resource_extension = resource_path.extension();
+      let is_declaration_file = resource_path_str.ends_with(".d.ts")
+        || resource_path_str.ends_with(".d.mts")
+        || resource_path_str.ends_with(".d.cts");
+      let is_supported_ts_source =
+        !is_declaration_file && matches!(resource_extension, Some("ts" | "tsx" | "mts" | "cts"));
+      if !is_supported_ts_source || !resource_path.starts_with(&root_dir) {
         continue;
       }
 
@@ -107,17 +119,26 @@ pub(crate) async fn complete_isolated_dts_outputs(
         continue;
       }
 
+      let std_resource_path = resource_path.clone().into_std_path_buf();
       compilation
         .file_dependencies
-        .insert(resource_path.clone().into_std_path_buf().into());
+        .insert(std_resource_path.clone().into());
 
       let source = fs.read_to_string(&resource_path).await?;
+      // Declaration completion only needs to parse TypeScript sources for fast dts.
+      // Keep this intentionally minimal instead of reusing swc-loader transform options.
+      let syntax = Syntax::Typescript(TsSyntax {
+        tsx: matches!(resource_extension, Some("tsx")),
+        decorators: true,
+        disallow_ambiguous_jsx_like: matches!(resource_extension, Some("mts" | "cts")),
+        ..Default::default()
+      });
       let dts_output = javascript_compiler
         .get_or_insert_with(JavaScriptCompiler::new)
         .emit_isolated_dts_from_source(
           source,
-          Arc::new(FileName::Real(resource_path.clone().into_std_path_buf())),
-          source_syntax(&resource_path),
+          Arc::new(FileName::Real(std_resource_path)),
+          syntax,
           EsVersion::EsNext,
         )?;
       handle_isolated_dts_diagnostics(&resource_path, dts_output.diagnostics)?;
@@ -147,18 +168,6 @@ fn resolve_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {
   } else {
     base.node_join(path).node_normalize()
   }
-}
-
-fn add_resolve_dependencies(
-  compilation: &mut Compilation,
-  resolve_dependencies: ResolveDependencies,
-) {
-  compilation
-    .file_dependencies
-    .extend(resolve_dependencies.file_dependencies);
-  compilation
-    .missing_dependencies
-    .extend(resolve_dependencies.missing_dependencies);
 }
 
 async fn default_tsconfig_options(
@@ -221,26 +230,6 @@ fn type_resolve_options(tsconfig: Option<TsconfigOptions>) -> Resolve {
     tsconfig,
     ..Default::default()
   }
-}
-
-fn is_supported_ts_source(path: &Utf8Path) -> bool {
-  !is_declaration_file(path) && matches!(path.extension(), Some("ts" | "tsx" | "mts" | "cts"))
-}
-
-fn is_declaration_file(path: &Utf8Path) -> bool {
-  let path = path.as_str();
-  path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts")
-}
-
-fn source_syntax(path: &Utf8Path) -> Syntax {
-  // Declaration completion only needs to parse TypeScript sources for fast dts.
-  // Keep this intentionally minimal instead of reusing swc-loader transform options.
-  Syntax::Typescript(TsSyntax {
-    tsx: matches!(path.extension(), Some("tsx")),
-    decorators: true,
-    disallow_ambiguous_jsx_like: matches!(path.extension(), Some("mts" | "cts")),
-    ..Default::default()
-  })
 }
 
 fn handle_isolated_dts_diagnostics(

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -32,7 +32,7 @@ struct IsolatedDtsReferences {
 pub(crate) async fn complete_isolated_dts_outputs(
   compilation: &mut Compilation,
   options: &SwcEmitDtsOptions,
-  roots: Vec<IsolatedDts>,
+  roots: Vec<Box<IsolatedDts>>,
 ) -> Result<Vec<IsolatedDtsAsset>> {
   if roots.is_empty() {
     return Ok(Vec::new());
@@ -41,12 +41,12 @@ pub(crate) async fn complete_isolated_dts_outputs(
   let mut outputs = Vec::with_capacity(roots.len());
   let mut queue = VecDeque::with_capacity(roots.len());
 
-  for IsolatedDts {
-    resource_path,
-    code,
-    references,
-  } in roots
-  {
+  for dts in roots {
+    let IsolatedDts {
+      resource_path,
+      code,
+      references,
+    } = *dts;
     let has_references = !references.is_empty();
     if has_references {
       queue.push_back(IsolatedDtsReferences {

--- a/crates/rspack_plugin_rslib/src/lib.rs
+++ b/crates/rspack_plugin_rslib/src/lib.rs
@@ -1,6 +1,7 @@
 mod asset;
 pub mod dyn_import_external;
 mod hashbang_parser_plugin;
+mod isolated_dts;
 mod parser_plugin;
 mod plugin;
 mod react_directives_parser_plugin;

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -352,7 +352,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let dts_outputs = compilation
     .get_module_graph()
     .modules()
-    .filter_map(|(_, module)| module.build_info().isolated_dts.clone())
+    .filter_map(|(_, module)| module.build_info().isolated_dts.as_deref().cloned())
     .collect::<Vec<_>>();
   if dts_outputs.is_empty() {
     return Ok(());

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -8,9 +8,9 @@ use pathdiff::diff_paths;
 use rspack_core::{
   AssetEmittedInfo, AssetInfo, BuildModuleGraphArtifact, ChunkUkey, Compilation, CompilationAsset,
   CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
-  CompilerAssetEmitted, CompilerCompilation, DependencyType, ExportsInfoArtifact, IsolatedDts,
-  ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin,
-  RuntimeCodeTemplate, SideEffectsOptimizeArtifact, get_module_directives, get_module_hashbang,
+  CompilerAssetEmitted, CompilerCompilation, DependencyType, ExportsInfoArtifact, ModuleType,
+  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, RuntimeCodeTemplate,
+  SideEffectsOptimizeArtifact, get_module_directives, get_module_hashbang,
   rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, error};
@@ -31,7 +31,7 @@ use crate::{
     cutout_star_re_export_externals,
   },
   hashbang_parser_plugin::HashbangParserPlugin,
-  isolated_dts::complete_isolated_dts_outputs,
+  isolated_dts::{IsolatedDtsAsset, complete_isolated_dts_outputs},
   parser_plugin::RslibParserPlugin,
   react_directives_parser_plugin::ReactDirectivesParserPlugin,
 };
@@ -50,20 +50,40 @@ pub struct SwcEmitDtsOptions {
   pub declaration_dir: String,
 }
 
+struct EmitIsolatedDtsAssetContext {
+  compiler_root: Utf8PathBuf,
+  resolved_root_dir: Utf8PathBuf,
+  resolved_declaration_dir: Utf8PathBuf,
+  output_path: Utf8PathBuf,
+}
+
+impl EmitIsolatedDtsAssetContext {
+  fn new(compilation: &Compilation, emit_dts_options: &SwcEmitDtsOptions) -> Self {
+    let compiler_root = compilation.options.context.as_path().to_path_buf();
+    Self {
+      resolved_root_dir: resolve_emit_dts_path(&compiler_root, &emit_dts_options.root_dir),
+      resolved_declaration_dir: resolve_emit_dts_path(
+        &compiler_root,
+        &emit_dts_options.declaration_dir,
+      ),
+      output_path: compilation.options.output.path.clone(),
+      compiler_root,
+    }
+  }
+}
+
 fn emit_isolated_dts_asset(
   compilation: &mut Compilation,
-  emit_dts_options: &SwcEmitDtsOptions,
-  dts: IsolatedDts,
+  context: &EmitIsolatedDtsAssetContext,
+  dts: IsolatedDtsAsset,
 ) -> Result<()> {
-  let IsolatedDts {
+  let IsolatedDtsAsset {
     resource_path,
     code,
-    ..
   } = dts;
-  let compiler_root = compilation.options.context.as_path();
-  let raw_resource_path = Utf8PathBuf::from(&resource_path);
+  let raw_resource_path = Utf8Path::new(&resource_path);
   // Cached isolated dts metadata stores resource paths relative to the compiler context.
-  let resource_path = resolve_emit_dts_path(compiler_root, &resource_path);
+  let resource_path = resolve_emit_dts_path(&context.compiler_root, &resource_path);
   // AssetInfo.source_filename is expected to be relative to the compilation context.
   let source_filename = if raw_resource_path.is_relative() {
     Some(
@@ -73,32 +93,32 @@ fn emit_isolated_dts_asset(
         .into_owned(),
     )
   } else {
-    diff_paths(resource_path.as_std_path(), compiler_root.as_std_path())
-      .map(|path| path.to_string_lossy().cow_replace('\\', "/").into_owned())
+    diff_paths(
+      resource_path.as_std_path(),
+      context.compiler_root.as_std_path(),
+    )
+    .map(|path| path.to_string_lossy().cow_replace('\\', "/").into_owned())
   };
-  let resolved_root_dir = resolve_emit_dts_path(compiler_root, &emit_dts_options.root_dir);
-  let resolved_declaration_dir =
-    resolve_emit_dts_path(compiler_root, &emit_dts_options.declaration_dir);
-  let output_path = compilation.options.output.path.clone();
   let output_relative_path = resource_path
-    .strip_prefix(&resolved_root_dir)
+    .strip_prefix(&context.resolved_root_dir)
     .map_err(|_| {
       error!(
         "Failed to emit declaration files for {} because it is outside rootDir {}",
-        resource_path, resolved_root_dir
+        resource_path, context.resolved_root_dir
       )
     })?;
-  let declaration_file_path = resolved_declaration_dir
+  let declaration_file_path = context
+    .resolved_declaration_dir
     .join(output_relative_path)
     .with_extension(declaration_extension(&resource_path));
   let filename = diff_paths(
     declaration_file_path.as_std_path(),
-    output_path.as_std_path(),
+    context.output_path.as_std_path(),
   )
     .ok_or_else(|| {
       error!(
         "Failed to emit declaration files for {} because declarationDir {} can not be relativized against output.path {}",
-        resource_path, resolved_declaration_dir, output_path
+        resource_path, context.resolved_declaration_dir, context.output_path
       )
     })?
     .to_string_lossy()
@@ -338,10 +358,15 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .modules()
     .filter_map(|(_, module)| module.build_info().isolated_dts.clone())
     .collect::<Vec<_>>();
+  if dts_outputs.is_empty() {
+    return Ok(());
+  }
+
   let dts_outputs = complete_isolated_dts_outputs(compilation, options, dts_outputs).await?;
+  let emit_context = EmitIsolatedDtsAssetContext::new(compilation, options);
 
   for dts in dts_outputs {
-    emit_isolated_dts_asset(compilation, options, dts)?;
+    emit_isolated_dts_asset(compilation, &emit_context, dts)?;
   }
 
   Ok(())

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -110,7 +110,11 @@ fn emit_isolated_dts_asset(
   let declaration_file_path = context
     .resolved_declaration_dir
     .join(output_relative_path)
-    .with_extension(declaration_extension(&resource_path));
+    .with_extension(match resource_path.extension() {
+      Some("mts") => "d.mts",
+      Some("cts") => "d.cts",
+      _ => "d.ts",
+    });
   let filename = diff_paths(
     declaration_file_path.as_std_path(),
     context.output_path.as_std_path(),
@@ -137,14 +141,6 @@ fn emit_isolated_dts_asset(
   );
 
   Ok(())
-}
-
-fn declaration_extension(resource_path: &Utf8Path) -> &'static str {
-  match resource_path.extension() {
-    Some("mts") => "d.mts",
-    Some("cts") => "d.cts",
-    _ => "d.ts",
-  }
 }
 
 fn resolve_emit_dts_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -58,6 +58,7 @@ fn emit_isolated_dts_asset(
   let IsolatedDts {
     resource_path,
     code,
+    ..
   } = dts;
   let compiler_root = compilation.options.context.as_path();
   let raw_resource_path = Utf8PathBuf::from(&resource_path);

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -89,7 +89,7 @@ fn emit_isolated_dts_asset(
     })?;
   let declaration_file_path = resolved_declaration_dir
     .join(output_relative_path)
-    .with_extension("d.ts");
+    .with_extension(declaration_extension(&resource_path));
   let filename = diff_paths(
     declaration_file_path.as_std_path(),
     output_path.as_std_path(),
@@ -116,6 +116,14 @@ fn emit_isolated_dts_asset(
   );
 
   Ok(())
+}
+
+fn declaration_extension(resource_path: &Utf8Path) -> &'static str {
+  match resource_path.extension() {
+    Some("mts") => "d.mts",
+    Some("cts") => "d.cts",
+    _ => "d.ts",
+  }
 }
 
 fn resolve_emit_dts_path(base: &Utf8Path, value: &str) -> Utf8PathBuf {

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -31,6 +31,7 @@ use crate::{
     cutout_star_re_export_externals,
   },
   hashbang_parser_plugin::HashbangParserPlugin,
+  isolated_dts::complete_isolated_dts_outputs,
   parser_plugin::RslibParserPlugin,
   react_directives_parser_plugin::ReactDirectivesParserPlugin,
 };
@@ -328,6 +329,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .modules()
     .filter_map(|(_, module)| module.build_info().isolated_dts.clone())
     .collect::<Vec<_>>();
+  let dts_outputs = complete_isolated_dts_outputs(compilation, options, dts_outputs).await?;
 
   for dts in dts_outputs {
     emit_isolated_dts_asset(compilation, options, dts)?;

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/alias/foo.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/alias/foo.ts
@@ -1,0 +1,3 @@
+export type Foo = {
+  alias: boolean;
+};

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/alias/mixed.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/alias/mixed.ts
@@ -1,0 +1,5 @@
+export type MixedFoo = {
+  mixed: string;
+};
+
+export const mixedValue = "mixed";

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
@@ -2,6 +2,10 @@ export interface Foo {
   value: string;
 }
 
+export type { Foo as TypeOnlyFoo } from "./types/foo";
+export type { Foo as AliasFoo } from "@/foo";
+export type { MixedFoo as AliasMixedFoo } from "@/mixed";
+
 export const foo: Foo = { value: "bar" };
 
 const fs = __non_webpack_require__("node:fs");
@@ -18,5 +22,45 @@ it("should emit declaration assets only through RslibPlugin", () => {
 
   expect(foo).toEqual({ value: "bar" });
   expect(dts).toContain("export interface Foo");
+  expect(dts).toContain("export type { Foo as TypeOnlyFoo }");
+  expect(dts).toContain("./types/foo");
+  expect(dts).toContain("export type { Foo as AliasFoo }");
+  expect(dts).toContain("@/foo");
+  expect(dts).toContain("export type { MixedFoo as AliasMixedFoo }");
+  expect(dts).toContain("@/mixed");
   expect(dts).toContain("export declare const foo: Foo;");
+
+  const typeOnlyDts = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../configCases/rslib/emit-isolated-dts/dist/types/types/foo.d.ts",
+    ),
+    "utf-8",
+  );
+
+  expect(typeOnlyDts).toContain("export type Foo");
+  expect(typeOnlyDts).toContain("label: string");
+
+  const aliasDts = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../configCases/rslib/emit-isolated-dts/dist/types/alias/foo.d.ts",
+    ),
+    "utf-8",
+  );
+
+  expect(aliasDts).toContain("export type Foo");
+  expect(aliasDts).toContain("alias: boolean");
+
+  const aliasMixedDts = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../configCases/rslib/emit-isolated-dts/dist/types/alias/mixed.d.ts",
+    ),
+    "utf-8",
+  );
+
+  expect(aliasMixedDts).toContain("export type MixedFoo");
+  expect(aliasMixedDts).toContain("mixed: string");
+  expect(aliasMixedDts).toContain("export declare const mixedValue");
 });

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
@@ -5,6 +5,8 @@ export interface Foo {
 export type { Foo as TypeOnlyFoo } from "./types/foo";
 export type { Foo as AliasFoo } from "@/foo";
 export type { MixedFoo as AliasMixedFoo } from "@/mixed";
+import { mtsValue } from "./module.mts";
+export { mtsValue };
 
 export const foo: Foo = { value: "bar" };
 
@@ -21,6 +23,7 @@ it("should emit declaration assets only through RslibPlugin", () => {
   );
 
   expect(foo).toEqual({ value: "bar" });
+  expect(mtsValue).toEqual({ module: "mts" });
   expect(dts).toContain("export interface Foo");
   expect(dts).toContain("export type { Foo as TypeOnlyFoo }");
   expect(dts).toContain("./types/foo");
@@ -63,4 +66,16 @@ it("should emit declaration assets only through RslibPlugin", () => {
   expect(aliasMixedDts).toContain("export type MixedFoo");
   expect(aliasMixedDts).toContain("mixed: string");
   expect(aliasMixedDts).toContain("export declare const mixedValue");
+
+  const mtsDts = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../configCases/rslib/emit-isolated-dts/dist/types/module.d.mts",
+    ),
+    "utf-8",
+  );
+
+  expect(mtsDts).toContain("export type MtsFoo");
+  expect(mtsDts).toContain('module: "mts"');
+  expect(mtsDts).toContain("export declare const mtsValue");
 });

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/module.mts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/module.mts
@@ -1,0 +1,5 @@
+export type MtsFoo = {
+  module: "mts";
+};
+
+export const mtsValue: MtsFoo = { module: "mts" };

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/rspack.config.js
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/rspack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.[cm]?ts$/,
         type: 'javascript/auto',
         use: {
           loader: 'builtin:swc-loader',

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/tsconfig.json
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./alias/*"]
+    }
+  }
+}

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/types/foo.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/types/foo.ts
@@ -1,0 +1,3 @@
+export type Foo = {
+  label: string;
+};


### PR DESCRIPTION
## Summary

This PR fixes RslibPlugin isolated dts output for type-only dependencies. When an entry declaration re-exports types from a TS file that is not part of the module graph, RslibPlugin now follows generated declaration references, resolves them with the bundler resolver, generates isolated declarations for the referenced TS sources, and emits the corresponding `.d.ts` assets.

## Related links

https://github.com/web-infra-dev/rspack/pull/13872

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).