### PR TITLE
ci: debug flaky macOS rust_watcher_test (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -1,13 +1,8 @@
 name: CI Diff
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    # Ignore md files in PR to skip workflow when only documentation changes
-    paths-ignore:
-      - '**/*.md'
-      - 'website/**'
-
+  # NOTE: pull_request trigger temporarily disabled while we hunt the flaky
+  # macOS watcher-test failure on a slim CI. Restore before merging.
   push:
     branches:
       - main

--- a/.github/workflows/ci-dylint.yaml
+++ b/.github/workflows/ci-dylint.yaml
@@ -1,16 +1,8 @@
 name: CI-Dylint
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - '.github/workflows/ci-dylint.yaml'
-      - '.github/actions/rustup/**'
-      - 'crates/**'
-      - 'linting/**'
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'rust-toolchain.toml'
+  # NOTE: pull_request trigger temporarily disabled while we hunt the flaky
+  # macOS watcher-test failure on a slim CI. Restore before merging.
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -1,8 +1,8 @@
 name: CI-Lint
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  # NOTE: pull_request trigger temporarily disabled while we hunt the flaky
+  # macOS watcher-test failure on a slim CI. Restore before merging.
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -1,5 +1,7 @@
 name: CI-Rust
 
+# NOTE: temporarily slimmed down to reproduce a flaky macOS watcher-test
+# failure (see PR description). Restore from main before merging.
 on:
   pull_request:
     types: [opened, synchronize]
@@ -18,24 +20,61 @@ on:
       - 'rust-toolchain.toml'
     tags-ignore:
       - '**'
+
 jobs:
-  rust_tests:
-    name: Run Rust Tests
-    uses: ./.github/workflows/reusable-rust-test.yml
+  rust_watcher_test_macos:
+    name: Run Rust Tests / Rust watcher test - "macos-latest"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          save-if: true
+          key: test-os-macos-latest
+
+      - name: Change profile.test
+        shell: bash
+        run: |
+          echo '[profile.test]' >> Cargo.toml
+          echo 'debug = false' >> Cargo.toml
+
+      - name: Diagnostics before test
+        if: always()
+        shell: bash
+        run: |
+          echo "PATH=$PATH"
+          which cargo || true
+          which rustc || true
+          which rustup || true
+          ls -la "$HOME/.cargo/bin" || true
+          cargo --version || true
+          rustc --version || true
+          rustup show || true
+
+      - name: Run rspack test
+        id: watcher_test
+        run: |
+          cargo test -p rspack_watcher -- --nocapture
+
+      - name: Setup tmate session on failure
+        if: failure()
+        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
+        with:
+          limit-access-to-actor: true
+        timeout-minutes: 30
 
   test_required_check:
-    # this job will be used for GitHub actions to determine required job success or not;
-    # When code changed, it will check if any of the test jobs failed.
-    # When *only* doc changed, it will run as success directly
     name: Rust Test Required Check
-    needs: [rust_tests]
+    needs: [rust_watcher_test_macos]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Log
         run: echo ${{ needs.*.result }}
       - name: Test check
-        if: ${{ needs.rust_tests.result != 'success' }}
+        if: ${{ needs.rust_watcher_test_macos.result != 'success' }}
         run: echo "Tests Failed" && exit 1
       - name: No check to Run test
         run: echo "Success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
-  pull_request:
-    types: [opened, synchronize]
+  # NOTE: pull_request trigger temporarily disabled while we hunt the flaky
+  # macOS watcher-test failure on a slim CI. Restore before merging.
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Debug PR — **do not merge**. Goal is to reproduce the flaky `Run Rust Tests / Rust watcher test - "macos-latest"` failure seen on https://github.com/web-infra-dev/rspack/actions/runs/25841934965/job/75928950537, save CI resources while iterating, and grab a live shell on the runner the moment it fails.

### What changed

- `ci-rust.yaml`: dropped the reusable workflow call; only runs the single macOS watcher test job. Added a diagnostics step (`PATH`, `which`, `--version`) before the test and a tmate session gated on `failure()` with `limit-access-to-actor: true`.
- `ci.yml`, `ci-lint.yaml`, `ci-dylint.yaml`, `ci-diff.yml`: temporarily removed the `pull_request` trigger so this debug PR doesn't burn the whole CI fleet on every push.

### Observed failure mode

```
error: error: unexpected argument 'test' found
Usage: rustup-init[EXE] [OPTIONS]
```

`cargo test -p rspack_watcher` was being intercepted by `rustup-init` rather than real `cargo` — looks like the `~/.cargo/bin` PATH on the macOS runner contained the rustup installer shim instead of a populated toolchain. The diagnostics step should make the next failure self-explanatory; the tmate step lets us SSH in and inspect.

### Plan

- Wait for this PR's CI; if the failure reproduces, attach to the tmate session.
- If it does not reproduce, push empty commits to retry.

### Revert before any landing

The workflow trigger and job-set changes here should be reverted before this branch could ever land on `main`.