### PR TITLE
fix(ci): repair broken rustup shim chain on macos-latest

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -23,8 +23,17 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        if ! command -v rustup &> /dev/null ; then
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+        # The macos-latest runner image ships a Homebrew `rustup-init` and
+        # populates ~/.cargo/bin/{cargo,rustc,rustup,...} as symlinks to it.
+        # `rustup-init` is the installer, not the multi-call rustup binary,
+        # so `cargo test` ends up invoking the installer and fails with
+        # "unexpected argument 'test'". Detect a working rustup via
+        # `rustup show`; if it isn't, wipe the broken shim dir and install
+        # a real rustup. ~/.rustup/toolchains (the cached toolchain) is left
+        # untouched so the rustup-cache restore still hits.
+        if ! rustup show >/dev/null 2>&1 ; then
+          rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y --no-modify-path
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi
 

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -27,7 +27,7 @@ runs:
         # ~/.cargo/bin/* to it; that installer doesn't proxy cargo/rustc, so
         # `cargo test` dies with "unexpected argument 'test'". Wipe the shim
         # dir only when rustup actually resolves to rustup-init.
-        [[ "$(readlink -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" 2>/dev/null)" == */rustup-init ]] && rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
+        [[ "$(realpath "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" 2>/dev/null)" == */rustup-init ]] && rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y --no-modify-path
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -34,7 +34,12 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        if ! command -v rustup &> /dev/null ; then
+        # Probe cargo, not rustup: macos-latest also ships a working
+        # /opt/homebrew/bin/rustup alongside the broken ~/.cargo/bin shim,
+        # so `command -v rustup` would skip install even after the wipe
+        # above. cargo is what we actually need — and what gets re-created
+        # by the installer's proxy hardlinks.
+        if ! command -v cargo &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -73,12 +73,12 @@ runs:
       shell: bash
       # macos-latest images symlink ~/.cargo/bin/{cargo,rustc,rustup,...} to
       # Homebrew's rustup-init (installer-only, no cargo/rustc proxy). The
-      # Swatinem cargo cache also captures ~/.cargo/bin, so even if we
-      # wiped earlier the broken shims come back on restore. Wipe + curl
-      # install AFTER the cargo cache restore so the proxies are real for
-      # the rest of the job. ~/.rustup/toolchains is untouched, and the
-      # post-step save will then cache the fixed ~/.cargo/bin going forward.
+      # Swatinem cargo cache also captures ~/.cargo/bin, so any earlier
+      # repair gets undone on cache restore. Detect the broken symlink
+      # here and run rustup-init -y to replace the shims with real proxy
+      # binaries. ~/.rustup/toolchains is untouched.
       run: |
-        rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
-        curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-        echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+        if [[ "$(readlink "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" 2>/dev/null)" == */rustup-init ]]; then
+          rustup-init -y --default-toolchain none
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+        fi

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -23,25 +23,11 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        # The macos-latest runner image ships Homebrew's `rustup-init` and
-        # populates ~/.cargo/bin/{cargo,rustc,rustup,...} as symlinks pointing
-        # back to it. `rustup-init` is only the installer — it doesn't proxy
-        # `cargo`/`rustc`, so `cargo test` ends up in the installer's arg
-        # parser and fails with "unexpected argument 'test'". A bare
-        # `command -v rustup` passes because the symlink exists, leaving the
-        # broken chain in place. Detect that exact case by resolving where
-        # `rustup` points; if it lands on `rustup-init`, wipe the shim dir
-        # so the official installer below can create real proxy binaries.
-        # ~/.rustup/toolchains (the cached toolchain) is left untouched.
-        rustup_bin=$(command -v rustup 2>/dev/null || true)
-        if [ -n "$rustup_bin" ]; then
-          resolved=$(readlink -f "$rustup_bin" 2>/dev/null || echo "$rustup_bin")
-          case "$resolved" in
-            */rustup-init)
-              rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
-              ;;
-          esac
-        fi
+        # macos-latest ships Homebrew's `rustup-init` and symlinks
+        # ~/.cargo/bin/* to it; that installer doesn't proxy cargo/rustc, so
+        # `cargo test` dies with "unexpected argument 'test'". Wipe the shim
+        # dir only when rustup actually resolves to rustup-init.
+        [[ "$(readlink -f "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" 2>/dev/null)" == */rustup-init ]] && rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y --no-modify-path
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -19,15 +19,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Wipe broken rustup shim on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      # The macos-latest runner image ships Homebrew's rustup-init (just the
+      # installer) and symlinks ~/.cargo/bin/{cargo,rustc,rustup,...} to it.
+      # That installer doesn't proxy cargo/rustc, so `cargo test` dies with
+      # "unexpected argument 'test'". Nuke the shim dir so the installer
+      # below lays down a real rustup with working proxies. ~/.rustup/
+      # toolchains is untouched, so the rustup-cache restore still hits.
+      run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
+
     - name: Install rustup, if needed
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        # macos-latest ships Homebrew's `rustup-init` and symlinks
-        # ~/.cargo/bin/* to it; that installer doesn't proxy cargo/rustc, so
-        # `cargo test` dies with "unexpected argument 'test'". Wipe the shim
-        # dir only when rustup actually resolves to rustup-init.
-        [[ "$(realpath "${CARGO_HOME:-$HOME/.cargo}/bin/rustup" 2>/dev/null)" == */rustup-init ]] && rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y --no-modify-path
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         if ! command -v rustup &> /dev/null ; then
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y --no-modify-path
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi
 

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -19,27 +19,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Wipe broken rustup shim on macOS
-      if: runner.os == 'macOS'
-      shell: bash
-      # The macos-latest runner image ships Homebrew's rustup-init (just the
-      # installer) and symlinks ~/.cargo/bin/{cargo,rustc,rustup,...} to it.
-      # That installer doesn't proxy cargo/rustc, so `cargo test` dies with
-      # "unexpected argument 'test'". Nuke the shim dir so the installer
-      # below lays down a real rustup with working proxies. ~/.rustup/
-      # toolchains is untouched, so the rustup-cache restore still hits.
-      run: rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
-
     - name: Install rustup, if needed
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        # Probe cargo, not rustup: macos-latest also ships a working
-        # /opt/homebrew/bin/rustup alongside the broken ~/.cargo/bin shim,
-        # so `command -v rustup` would skip install even after the wipe
-        # above. cargo is what we actually need — and what gets re-created
-        # by the installer's proxy hardlinks.
-        if ! command -v cargo &> /dev/null ; then
+        if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi
@@ -83,3 +67,18 @@ runs:
       with:
         key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if == 'true' }}
+
+    - name: Refresh rustup proxies on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      # macos-latest images symlink ~/.cargo/bin/{cargo,rustc,rustup,...} to
+      # Homebrew's rustup-init (installer-only, no cargo/rustc proxy). The
+      # Swatinem cargo cache also captures ~/.cargo/bin, so even if we
+      # wiped earlier the broken shims come back on restore. Wipe + curl
+      # install AFTER the cargo cache restore so the proxies are real for
+      # the rest of the job. ~/.rustup/toolchains is untouched, and the
+      # post-step save will then cache the fixed ~/.cargo/bin going forward.
+      run: |
+        rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
+        curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+        echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -23,16 +23,26 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        # The macos-latest runner image ships a Homebrew `rustup-init` and
-        # populates ~/.cargo/bin/{cargo,rustc,rustup,...} as symlinks to it.
-        # `rustup-init` is the installer, not the multi-call rustup binary,
-        # so `cargo test` ends up invoking the installer and fails with
-        # "unexpected argument 'test'". Detect a working rustup via
-        # `rustup show`; if it isn't, wipe the broken shim dir and install
-        # a real rustup. ~/.rustup/toolchains (the cached toolchain) is left
-        # untouched so the rustup-cache restore still hits.
-        if ! rustup show >/dev/null 2>&1 ; then
-          rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
+        # The macos-latest runner image ships Homebrew's `rustup-init` and
+        # populates ~/.cargo/bin/{cargo,rustc,rustup,...} as symlinks pointing
+        # back to it. `rustup-init` is only the installer — it doesn't proxy
+        # `cargo`/`rustc`, so `cargo test` ends up in the installer's arg
+        # parser and fails with "unexpected argument 'test'". A bare
+        # `command -v rustup` passes because the symlink exists, leaving the
+        # broken chain in place. Detect that exact case by resolving where
+        # `rustup` points; if it lands on `rustup-init`, wipe the shim dir
+        # so the official installer below can create real proxy binaries.
+        # ~/.rustup/toolchains (the cached toolchain) is left untouched.
+        rustup_bin=$(command -v rustup 2>/dev/null || true)
+        if [ -n "$rustup_bin" ]; then
+          resolved=$(readlink -f "$rustup_bin" 2>/dev/null || echo "$rustup_bin")
+          case "$resolved" in
+            */rustup-init)
+              rm -rf "${CARGO_HOME:-$HOME/.cargo}/bin"
+              ;;
+          esac
+        fi
+        if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y --no-modify-path
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -179,37 +179,9 @@ jobs:
           echo '[profile.test]' >> Cargo.toml
           echo 'debug = false' >> Cargo.toml
 
-      - name: Diagnostics before rspack test
-        if: matrix.array.runner == '"macos-latest"'
-        shell: bash
-        run: |
-          echo "PATH=$PATH"
-          echo "--- which/type ---"
-          which -a cargo rustc rustup rustup-init 2>&1 || true
-          type -a cargo rustc rustup 2>&1 || true
-          echo "--- ~/.cargo/bin ---"
-          ls -la "$HOME/.cargo/bin" 2>&1 || true
-          echo "--- /opt/homebrew/bin/{rustup,rustup-init,cargo} ---"
-          ls -la /opt/homebrew/bin/rustup /opt/homebrew/bin/rustup-init /opt/homebrew/bin/cargo 2>&1 || true
-          echo "--- ~/.rustup ---"
-          ls -la "$HOME/.rustup" 2>&1 || true
-          cat "$HOME/.rustup/settings.toml" 2>&1 || true
-          echo "--- version probes ---"
-          rustup --version 2>&1 || true
-          "$HOME/.cargo/bin/rustup" --version 2>&1 || true
-          /opt/homebrew/bin/rustup --version 2>&1 || true
-
       - name: Run rspack test
-        id: watcher_test
         run: |
           cargo test -p rspack_watcher -- --nocapture
-
-      - name: Setup tmate session on macOS failure
-        if: failure() && matrix.array.runner == '"macos-latest"'
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
-        with:
-          limit-access-to-actor: true
-        timeout-minutes: 30
 
   test_required_check:
     name: Rust Test Required Check

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -179,9 +179,37 @@ jobs:
           echo '[profile.test]' >> Cargo.toml
           echo 'debug = false' >> Cargo.toml
 
+      - name: Diagnostics before rspack test
+        if: matrix.array.runner == '"macos-latest"'
+        shell: bash
+        run: |
+          echo "PATH=$PATH"
+          echo "--- which/type ---"
+          which -a cargo rustc rustup rustup-init 2>&1 || true
+          type -a cargo rustc rustup 2>&1 || true
+          echo "--- ~/.cargo/bin ---"
+          ls -la "$HOME/.cargo/bin" 2>&1 || true
+          echo "--- /opt/homebrew/bin/{rustup,rustup-init,cargo} ---"
+          ls -la /opt/homebrew/bin/rustup /opt/homebrew/bin/rustup-init /opt/homebrew/bin/cargo 2>&1 || true
+          echo "--- ~/.rustup ---"
+          ls -la "$HOME/.rustup" 2>&1 || true
+          cat "$HOME/.rustup/settings.toml" 2>&1 || true
+          echo "--- version probes ---"
+          rustup --version 2>&1 || true
+          "$HOME/.cargo/bin/rustup" --version 2>&1 || true
+          /opt/homebrew/bin/rustup --version 2>&1 || true
+
       - name: Run rspack test
+        id: watcher_test
         run: |
           cargo test -p rspack_watcher -- --nocapture
+
+      - name: Setup tmate session on macOS failure
+        if: failure() && matrix.array.runner == '"macos-latest"'
+        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
+        with:
+          limit-access-to-actor: true
+        timeout-minutes: 30
 
   test_required_check:
     name: Rust Test Required Check


### PR DESCRIPTION
## Summary

- The `macos-latest` runner image ships Homebrew's `rustup-init` and populates `~/.cargo/bin/{cargo,rustc,rustup,...}` as symlinks pointing back to it. `rustup-init` is the installer binary, not the multi-call rustup proxy.
- The current `command -v rustup` probe sees the symlink and skips reinstall. `rustup toolchain install` still works via the `rustup` argv proxy, but `cargo test` invokes the installer's arg parser and dies with `unexpected argument 'test'` — surfaced on https://github.com/web-infra-dev/rspack/actions/runs/25848161725/job/75948085190.
- Switch the probe to `rustup show`, which only succeeds against a real rustup. On failure, wipe `~/.cargo/bin` (only the broken symlinks — `~/.rustup/toolchains` is untouched, so the rustup-cache restore still hits) and install a real rustup via the official script.

## Test plan

- [ ] Re-run `Run Rust Tests / Rust watcher test - "macos-latest"` (the job that originally failed) and confirm `cargo test -p rspack_watcher` proceeds past arg-parsing.
- [ ] Confirm rustup-cache restore still reports a hit on a subsequent run.
- [ ] Sanity-check non-macOS jobs (`runner.os != 'Windows'` branch covers Linux too) are unaffected — `rustup show` succeeds on a healthy install so the new branch is a no-op there.