### PR TITLE
perf: reduce build module graph allocations

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/process_dependencies.rs
@@ -27,20 +27,27 @@ impl Task<TaskContext> for ProcessDependenciesTask {
       dependencies,
       from_unlazy,
     } = *self;
-    let mut sorted_dependencies = HashMap::default();
-
-    // First mark all dependencies as added
-    for dependency_id in &dependencies {
-      context
-        .artifact
-        .affected_dependencies
-        .mark_as_add(dependency_id);
-    }
+    let mut sorted_dependencies: HashMap<Cow<str>, Vec<_>> = HashMap::default();
+    sorted_dependencies.reserve(dependencies.len());
 
     let module_graph = &mut context.artifact.module_graph;
+    let module = module_graph
+      .module_by_identifier(&original_module_identifier)
+      .expect("Module expected");
+    let original_module_source = module.as_normal_module().and_then(|m| m.source().cloned());
+    let original_module_context = module.get_context();
+    let original_module_issuer = module
+      .as_normal_module()
+      .and_then(|m| m.name_for_condition());
+    let original_module_layer = module.get_layer().cloned();
+    let original_module_resolve_options = module.get_resolve_options();
 
     for dependency_id in dependencies {
       let dependency = module_graph.dependency_by_id(&dependency_id);
+      context
+        .artifact
+        .affected_dependencies
+        .mark_as_add(&dependency_id);
       // FIXME: now only module/context dependency can put into resolve queue.
       // FIXME: should align webpack
       let resource_identifier = if let Some(module_dependency) = dependency.as_module_dependency() {
@@ -65,21 +72,13 @@ impl Task<TaskContext> for ProcessDependenciesTask {
       if let Some(resource_identifier) = resource_identifier {
         sorted_dependencies
           .entry(resource_identifier)
-          .or_insert(vec![])
+          .or_default()
           .push(dependency.clone());
       }
     }
 
-    let module = module_graph
-      .module_by_identifier(&original_module_identifier)
-      .expect("Module expected");
-
-    let mut res: Vec<Box<dyn Task<TaskContext>>> = vec![];
+    let mut res: Vec<Box<dyn Task<TaskContext>>> = Vec::with_capacity(sorted_dependencies.len());
     for dependencies in sorted_dependencies.into_values() {
-      let original_module_source = module_graph
-        .module_by_identifier(&original_module_identifier)
-        .and_then(|m| m.as_normal_module())
-        .and_then(|m| m.source().cloned());
       let dependency = &dependencies[0];
       let dependency_type = dependency.dependency_type();
       // TODO move module_factory calculate to dependency factories
@@ -98,15 +97,13 @@ impl Task<TaskContext> for ProcessDependenciesTask {
         compiler_id: context.compiler_id,
         compilation_id: context.compilation_id,
         module_factory,
-        original_module_identifier: Some(module.identifier()),
-        original_module_context: module.get_context(),
-        original_module_source,
-        issuer: module
-          .as_normal_module()
-          .and_then(|module| module.name_for_condition()),
-        issuer_layer: module.get_layer().cloned(),
+        original_module_identifier: Some(original_module_identifier),
+        original_module_context: original_module_context.clone(),
+        original_module_source: original_module_source.clone(),
+        issuer: original_module_issuer.clone(),
+        issuer_layer: original_module_layer.clone(),
         dependencies,
-        resolve_options: module.get_resolve_options(),
+        resolve_options: original_module_resolve_options.clone(),
         options: context.compiler_options.clone(),
         resolver_factory: context.resolver_factory.clone(),
         from_unlazy,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -419,14 +419,55 @@ impl<'parser> JavascriptParser<'parser> {
     parse_meta: ParseMeta,
     parser_runtime_requirements: &'parser ParserRuntimeRequirementsData,
   ) -> Self {
-    let warning_diagnostics: Vec<Diagnostic> = Vec::with_capacity(4);
-    let errors = Vec::with_capacity(4);
-    let dependencies = Vec::with_capacity(64);
-    let blocks = Vec::with_capacity(64);
-    let presentational_dependencies = Vec::with_capacity(64);
+    let warning_diagnostics: Vec<Diagnostic> = Vec::new();
+    let errors = Vec::new();
+    let dependencies = Vec::new();
+    let blocks = Vec::new();
+    let presentational_dependencies = Vec::new();
     let parser_exports_state: Option<bool> = None;
 
-    let mut plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(32 + parser_plugins.len());
+    let mut plugin_capacity = parser_plugins.len() + 5;
+    if matches!(module_type, ModuleType::JsAuto | ModuleType::JsDynamic) {
+      plugin_capacity += 2;
+    }
+    if module_type.is_js_auto() || module_type.is_js_esm() {
+      plugin_capacity += 6;
+    }
+    if compiler_options.amd.is_some() && (module_type.is_js_auto() || module_type.is_js_dynamic()) {
+      plugin_capacity += 3;
+    }
+    if module_type.is_js_auto() || module_type.is_js_dynamic() {
+      plugin_capacity += 2;
+      let commonjs_exports = javascript_options
+        .commonjs
+        .as_ref()
+        .map_or(JavascriptParserCommonjsExportsOption::Enable, |commonjs| {
+          commonjs.exports
+        });
+      if commonjs_exports != JavascriptParserCommonjsExportsOption::Disable {
+        plugin_capacity += 1;
+      }
+    }
+    let handle_cjs =
+      (module_type.is_js_auto() || module_type.is_js_dynamic()) && compiler_options.node.is_some();
+    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
+    if handle_cjs || handle_esm {
+      plugin_capacity += 1;
+    }
+    if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {
+      plugin_capacity += 6;
+    }
+    if compiler_options.optimization.inline_exports {
+      plugin_capacity += 1;
+    }
+    if compiler_options.optimization.inner_graph {
+      plugin_capacity += 1;
+    }
+    if compiler_options.optimization.side_effects.is_true() {
+      plugin_capacity += 1;
+    }
+
+    let mut plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(plugin_capacity);
 
     plugins.append(parser_plugins);
 
@@ -492,9 +533,6 @@ impl<'parser> JavascriptParser<'parser> {
 
     // NodeStuffPlugin: handle __dirname/__filename/global (CJS) and import.meta.dirname/filename (ESM)
     // CJS features require node options; ESM features are always available for ESM-capable modules
-    let handle_cjs =
-      (module_type.is_js_auto() || module_type.is_js_dynamic()) && compiler_options.node.is_some();
-    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
     if handle_cjs || handle_esm {
       plugins.push(Box::new(parser_plugin::NodeStuffPlugin::new(
         handle_cjs, handle_esm,


### PR DESCRIPTION
## Micro-Optimization Progress

Target benchmark: `rust@build_module_graph`
Measurement mode: `valgrind DHAT heap bytes`
Baseline command: `CODSPEED_CARGO_WORKSPACE_ROOT=$PWD RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases RAYON_NUM_THREADS=1 valgrind --tool=dhat --num-callers=30 <benchmark-binary> build_module_graph`

| Commit | Benchmark | Bytes Before | Bytes After | Delta | Checks | Notes |
| --- | --- | ---: | ---: | ---: | --- | --- |
| `296511a596` | `rust@build_module_graph` | 6,851,469,420 | 6,475,442,282 | -5.49% | `cargo fmt --all`; `cargo check -p rspack_core -p rspack_plugin_javascript --all-targets`; `pnpm run build:binding:dev` | DHAT with system allocator fallback; target for 5% was <= 6,508,895,949 bytes |

Notes:
- Branch was opened early as a draft before product optimization edits.
- CodSpeed memory mode failed locally because its memtrack process requires sudo; local Valgrind fallback data is being collected separately.
- Baseline profile: `optimization-artifacts/valgrind-dhat/20260515T002350Z/system-allocator/build_module_graph.baseline.dhat.out`
- After profile: `optimization-artifacts/valgrind-dhat/20260515T002350Z/system-allocator/build_module_graph.after1.dhat.out`