### PR TITLE
refactor: reduce scan_dependencies parser overhead

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -130,7 +130,7 @@ pub struct CallExpressionInfo<'ast> {
 
 #[derive(Debug)]
 pub struct ExpressionExpressionInfo {
-  pub name: String,
+  pub name: Atom,
   pub root_info: ExportedVariableInfo,
   pub members: AtomMembers,
   pub members_optionals: OptionalMembers,
@@ -143,7 +143,11 @@ pub enum ExportedVariableInfo {
   VariableInfo(VariableInfoId),
 }
 
-fn object_and_members_to_name(object: &Atom, members_reversed: &[impl AsRef<str>]) -> String {
+fn object_and_members_to_name(object: &Atom, members_reversed: &[impl AsRef<str>]) -> Atom {
+  if members_reversed.is_empty() {
+    return object.clone();
+  }
+
   let total_len = object.len()
     + members_reversed.len()
     + members_reversed
@@ -158,7 +162,7 @@ fn object_and_members_to_name(object: &Atom, members_reversed: &[impl AsRef<str>
     name.push('.');
     name.push_str(member.as_ref());
   }
-  name
+  name.into()
 }
 
 pub trait RootName {


### PR DESCRIPTION
## Micro-Optimization Progress

Target benchmark: `rust@scan_dependencies@three_module`
Measurement mode: `codspeed simulation`
Baseline command: `pnpm run bench:rust:local -- scan_dependencies`
Baseline commit: `5b4782a65accebf17cd49bbeb2ba42a5c5327027`
Baseline CodSpeed run: https://codspeed.io/web-infra-dev/rspack/runs/6a06765db60bab7f31a49186

| Commit | Benchmark | Ir Before | Ir After | Delta | Checks | Notes |
| ------ | --------- | --------- | -------- | ----- | ------ | ----- |
| `7558ddbe6d` | `rust@scan_dependencies@three_module` | `38,986,119` | `38,851,876` | `-134,243 (-0.34%)` | `cargo check -p rspack_plugin_javascript`; `pnpm run bench:rust:local -- scan_dependencies` | Store expression names as `Atom` so bare roots reuse existing atoms and member names do not need later string-to-atom conversion. Final CodSpeed run: https://codspeed.io/web-infra-dev/rspack/runs/6a0679cb62a038abd1e8d030 |
