### PR TITLE
feat: optimize generated getter for const export 

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1296,7 +1296,7 @@ impl CompilationOptimizeModules for CompilationOptimizeModulesTap {
   async fn run(
     &self,
     _compilation: &Compilation,
-    _circular_modules: &mut IdentifierSet,
+    _circular_modules: &mut Option<IdentifierSet>,
     _diagnostics: &mut Vec<rspack_error::Diagnostic>,
   ) -> rspack_error::Result<Option<bool>> {
     self.function.call_with_sync(()).await

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -114,7 +114,7 @@ define_hook!(CompilationDependencyReferencedExports: Sync(
 define_hook!(CompilationConcatenationScope: SeriesBail(compilation: &Compilation, curr_module: ModuleIdentifier) -> ConcatenationScope);
 define_hook!(CompilationOptimizeDependencies: SeriesBail(compilation: &Compilation, side_effects_optimize_artifact: &mut SideEffectsOptimizeArtifact,  build_module_graph_artifact: &mut BuildModuleGraphArtifact, exports_info_artifact: &mut ExportsInfoArtifact,
  diagnostics: &mut Vec<Diagnostic>) -> bool);
-define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, circular_modules: &mut IdentifierSet, diagnostics: &mut Vec<Diagnostic>) -> bool);
+define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, circular_modules: &mut Option<IdentifierSet>, diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationAfterOptimizeModules: Series(compilation: &Compilation));
 define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeTree: Series(compilation: &Compilation));
@@ -272,7 +272,7 @@ pub struct Compilation {
 
   pub minimize_persistent_cache_artifact: Option<MinimizePersistentCacheArtifact>,
 
-  pub circular_modules: StealCell<IdentifierSet>,
+  pub circular_modules: StealCell<Option<IdentifierSet>>,
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
   pub build_chunk_graph_artifact: BuildChunkGraphArtifact,
@@ -378,7 +378,7 @@ impl Compilation {
 
       async_modules_artifact: StealCell::new(AsyncModulesArtifact::default()),
       imported_by_defer_modules_artifact: StealCell::new(Default::default()),
-      circular_modules: StealCell::new(Default::default()),
+      circular_modules: StealCell::new(None),
       dependencies_diagnostics_artifact: StealCell::new(DependenciesDiagnosticsArtifact::default()),
       exports_info_artifact: StealCell::new(ExportsInfoArtifact::default()),
       side_effects_optimize_artifact: StealCell::new(Default::default()),

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -54,7 +54,7 @@ use crate::{
   ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
   SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set,
   filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
+  merge_runtime_condition_non_false, module_update_hash, property_access,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -1629,8 +1629,8 @@ impl Module for ConcatenatedModule {
         .iter()
         .map(|(key, value)| {
           format!(
-            "\n  {}: {}",
-            property_name(key).expect("should convert to property_name"),
+            "\n  {}, {}",
+            json_stringify_str(key),
             runtime_template.returning_function(value, "")
           )
         })
@@ -1661,7 +1661,7 @@ impl Module for ConcatenatedModule {
 
         result.add(RawStringSource::from_static("\n// EXPORTS\n"));
         result.add(RawStringSource::from(format!(
-          "{}({}, {{{}\n}});\n",
+          "{}({}, [{}\n]);\n",
           runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
           runtime_template.render_exports_argument(exports_argument),
           definitions.join(",")
@@ -1742,8 +1742,8 @@ impl Module for ConcatenatedModule {
           );
 
           ns_obj.push(format!(
-            "\n  {}: {}",
-            property_name(&used_name).expect("should have property_name"),
+            "\n  {}, {}",
+            json_stringify_str(&used_name),
             runtime_template.returning_function(&final_name.name, "")
           ));
         }
@@ -1752,7 +1752,7 @@ impl Module for ConcatenatedModule {
       let name = name_space_name.expect("should have name_space_name");
       let define_getters = if !ns_obj.is_empty() {
         format!(
-          "{}({}, {{ {} }});\n",
+          "{}({}, [{}\n]);\n",
           runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
           name,
           ns_obj.join(",")

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -238,7 +238,7 @@ fn render_module_external_remapping(
   create_namespace_object_name: &str,
   wrap_namespace_getter_name: &str,
 ) -> String {
-  let properties = remapping
+  let definitions = remapping
     .iter()
     .map(|remapping| {
       let access = format!(
@@ -260,19 +260,12 @@ fn render_module_external_remapping(
         runtime_template.returning_function(&access, "")
       };
 
-      format!(
-        "{}: {getter}",
-        module_external_remapping_property_key(&remapping.exposed_name)
-      )
+      format!("{}, {getter}", json_stringify_str(&remapping.exposed_name))
     })
     .collect::<Vec<_>>()
     .join(", ");
 
-  format!("{create_namespace_object_name}({{{properties}}})")
-}
-
-fn module_external_remapping_property_key(exposed_name: &str) -> String {
-  format!("[{}]", json_stringify_str(exposed_name))
+  format!("{create_namespace_object_name}([{definitions}])")
 }
 
 fn get_source_for_module_external(

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -16,7 +16,7 @@ use swc_core::ecma::atoms::Atom;
 
 use crate::{
   ExportsArgument, GenerateContext, ModuleCodeTemplate, RuntimeCondition, RuntimeGlobals,
-  merge_runtime, property_name,
+  merge_runtime,
 };
 
 static NEXT_INIT_FRAGMENT_KEY_UNIQUE_ID: AtomicU32 = AtomicU32::new(0);
@@ -85,7 +85,7 @@ impl InitFragmentKey {
         res
       }
       InitFragmentKey::ESMExports => {
-        let mut export_map: Vec<(Atom, Atom)> = vec![];
+        let mut export_map: Vec<(Atom, ESMExportBinding)> = vec![];
         let mut iter = fragments.into_iter();
         let first = iter
           .next()
@@ -95,15 +95,17 @@ impl InitFragmentKey {
           .downcast::<ESMExportInitFragment>()
           .expect("fragment of InitFragmentKey::ESMExports should be a ESMExportInitFragment");
         let export_argument = first.exports_argument;
+        let is_circular_module = first.is_circular_module;
         export_map.extend(first.export_map);
         for fragment in iter {
           let fragment = fragment
             .into_any()
             .downcast::<ESMExportInitFragment>()
             .expect("fragment of InitFragmentKey::ESMExports should be a ESMExportInitFragment");
+          debug_assert_eq!(is_circular_module, fragment.is_circular_module);
           export_map.extend(fragment.export_map);
         }
-        ESMExportInitFragment::new(export_argument, export_map).boxed()
+        ESMExportInitFragment::new(export_argument, export_map, is_circular_module).boxed()
       }
       InitFragmentKey::AwaitDependencies => {
         let promises = fragments.into_iter().map(|f| f.into_any().downcast::<AwaitDependenciesInitFragment>().expect("fragment of InitFragmentKey::AwaitDependencies should be a AwaitDependenciesInitFragment")).flat_map(|f| f.promises).collect();
@@ -349,17 +351,29 @@ impl<C> InitFragment<C> for NormalInitFragment {
 }
 
 #[derive(Debug, Clone, Hash)]
+pub enum ESMExportBinding {
+  Getter(Atom),
+  Value(Atom),
+}
+
+#[derive(Debug, Clone, Hash)]
 pub struct ESMExportInitFragment {
   exports_argument: ExportsArgument,
   // TODO: should be a map
-  export_map: Vec<(Atom, Atom)>,
+  export_map: Vec<(Atom, ESMExportBinding)>,
+  is_circular_module: bool,
 }
 
 impl ESMExportInitFragment {
-  pub fn new(exports_argument: ExportsArgument, export_map: Vec<(Atom, Atom)>) -> Self {
+  pub fn new(
+    exports_argument: ExportsArgument,
+    export_map: Vec<(Atom, ESMExportBinding)>,
+    is_circular_module: bool,
+  ) -> Self {
     Self {
       exports_argument,
       export_map,
+      is_circular_module,
     }
   }
 }
@@ -370,30 +384,41 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
 
     self.export_map.sort_by(|a, b| a.0.cmp(&b.0));
     let exports = format!(
-      "{{\n  {}\n}}",
+      "[\n  {}\n]",
       self
         .export_map
         .iter()
-        .map(|s| {
-          let prop = property_name(&s.0)?;
-          Ok(format!(
-            "{}: {}",
-            prop,
-            runtime_template.returning_function(&s.1, "")
-          ))
+        .map(|(name, binding)| {
+          let name = rspack_util::json_stringify_str(name);
+          match binding {
+            ESMExportBinding::Getter(value) => format!(
+              "{}, {}",
+              name,
+              runtime_template.returning_function(value, "")
+            ),
+            ESMExportBinding::Value(value) => format!("{}, 0, {}", name, value),
+          }
         })
-        .collect::<Result<Vec<_>>>()?
+        .collect::<Vec<_>>()
         .join(",\n  ")
     );
 
-    let res = InitFragmentContents {
-      start: format!(
-        "{}({}, {});\n",
-        runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
-        runtime_template.render_exports_argument(self.exports_argument),
-        exports
-      ),
-      end: None,
+    let content = format!(
+      "{}({}, {});\n",
+      runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
+      runtime_template.render_exports_argument(self.exports_argument),
+      exports
+    );
+    let res = if self.is_circular_module {
+      InitFragmentContents {
+        start: content,
+        end: None,
+      }
+    } else {
+      InitFragmentContents {
+        start: String::new(),
+        end: Some(format!("\n{content}")),
+      }
     };
     Ok(res)
   }

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -361,14 +361,14 @@ pub struct ESMExportInitFragment {
   exports_argument: ExportsArgument,
   // TODO: should be a map
   export_map: Vec<(Atom, ESMExportBinding)>,
-  is_circular_module: bool,
+  is_circular_module: Option<bool>,
 }
 
 impl ESMExportInitFragment {
   pub fn new(
     exports_argument: ExportsArgument,
     export_map: Vec<(Atom, ESMExportBinding)>,
-    is_circular_module: bool,
+    is_circular_module: Option<bool>,
   ) -> Self {
     Self {
       exports_argument,
@@ -409,7 +409,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
       runtime_template.render_exports_argument(self.exports_argument),
       exports
     );
-    let res = if self.is_circular_module {
+    let res = if matches!(self.is_circular_module, None | Some(true)) {
       InitFragmentContents {
         start: content,
         end: None,

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -396,7 +396,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
               name,
               runtime_template.returning_function(value, "")
             ),
-            ESMExportBinding::Value(value) => format!("{}, 0, {}", name, value),
+            ESMExportBinding::Value(value) => format!("{name}, 0, {value}"),
           }
         })
         .collect::<Vec<_>>()

--- a/crates/rspack_plugin_circular_dependencies/src/circular_dependency_rspack_plugin.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/circular_dependency_rspack_plugin.rs
@@ -362,7 +362,7 @@ impl CircularDependencyRspackPlugin {
 async fn optimize_modules(
   &self,
   compilation: &Compilation,
-  _circular_modules: &mut IdentifierSet,
+  _circular_modules: &mut Option<IdentifierSet>,
   diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   if let Some(on_start) = &self.options.on_start {

--- a/crates/rspack_plugin_circular_dependencies/src/circular_modules_info_plugin.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/circular_modules_info_plugin.rs
@@ -301,12 +301,12 @@ fn should_ignore_dependency_type(ty: DependencyType) -> bool {
 async fn optimize_modules(
   &self,
   compilation: &Compilation,
-  circular_modules: &mut IdentifierSet,
+  circular_modules: &mut Option<IdentifierSet>,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   let module_graph = compilation.get_module_graph();
   let graph = CycleGraph::build(module_graph);
-  *circular_modules = CycleDetector::new(&graph).find_circular_modules();
+  *circular_modules = Some(CycleDetector::new(&graph).find_circular_modules());
   Ok(None)
 }
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   RuntimeGlobals, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName,
   UsedNameItem, collect_ident, escape_name_atom_ref, find_new_name, find_target,
   get_cached_readable_identifier, get_js_chunk_filename_template, get_module_directives,
-  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
+  get_module_hashbang, property_access, reserved_names::RESERVED_NAMES_ATOM_SET,
   rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
@@ -776,8 +776,8 @@ impl EsmLibraryPlugin {
               }
 
               ns_obj.push(format!(
-                "\n  {}: {}",
-                property_name(&used_name).expect("should have property_name"),
+                "\n  {}, {}",
+                rspack_util::json_stringify_str(&used_name),
                 runtime_template.returning_function(&binding.render(), "")
               ));
             }
@@ -828,7 +828,7 @@ impl EsmLibraryPlugin {
               r#"var {} = {};
 Object.keys({}).forEach(function(key) {{
   if (key !== "default" && key !== "__esModule") {{
-    {}({}, {{ [key]: function() {{ return {}[key]; }} }});
+    {}({}, [key, function() {{ return {}[key]; }}]);
   }}
 }});
 "#,
@@ -844,7 +844,7 @@ Object.keys({}).forEach(function(key) {{
           };
           let define_getters = if !ns_obj.is_empty() {
             format!(
-              "{}({}, {{ {} }});\n",
+              "{}({}, [{}\n]);\n",
               runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
               name,
               ns_obj.join(",")

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -166,7 +166,10 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
     } = code_generatable_context;
 
     let module_identifier = module.identifier();
-    let is_circular_module = compilation.circular_modules.contains(&module_identifier);
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module_identifier));
 
     if let Some(declaration) = &dep.declaration {
       let name = match declaration {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -4,7 +4,7 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, DEFAULT_EXPORT, Dependency, DependencyCodeGeneration,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, ESMExportInitFragment, ExportNameOrSpec, ExportsInfoArtifact,
+  DependencyType, ESMExportBinding, ESMExportInitFragment, ExportNameOrSpec, ExportsInfoArtifact,
   ExportsOfExportsSpec, ExportsSpec, ForwardId, ModuleGraph, ModuleGraphCacheArtifact,
   SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedName, property_access,
   rspack_sources::ReplacementEnforce,
@@ -166,6 +166,7 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
     } = code_generatable_context;
 
     let module_identifier = module.identifier();
+    let is_circular_module = compilation.circular_modules.contains(&module_identifier);
 
     if let Some(declaration) = &dep.declaration {
       let name = match declaration {
@@ -202,8 +203,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
               .collect_vec()
               .join("")
               .into(),
-            Atom::from(format!("/* export default binding */ {name}")),
+            ESMExportBinding::Getter(Atom::from(format!("/* export default binding */ {name}"))),
           )],
+          is_circular_module,
         )));
       } else {
         // do nothing for unused or inlined
@@ -244,8 +246,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
                   .collect_vec()
                   .join("")
                   .into(),
-                DEFAULT_EXPORT.into(),
+                ESMExportBinding::Getter(DEFAULT_EXPORT.into()),
               )],
+              is_circular_module,
             )));
             format!("/* export default */ const {DEFAULT_EXPORT} = ")
           } else {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -850,8 +850,7 @@ impl ESMExportImportedSpecifierDependency {
       json_stringify(&module_id),
       mode
     );
-    let mut export_map = vec![];
-    export_map.push((key.into(), ESMExportBinding::Getter(value.into())));
+    let export_map = vec![(key.into(), ESMExportBinding::Getter(value.into()))];
     let cache_var = format!("var {name}_deferred_namespace_cache;\n");
 
     (

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -10,8 +10,8 @@ use rspack_core::{
   AsContextDependency, ChunkGraph, ConditionalInitFragment, ConnectionState, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyCondition, DependencyConditionFn,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, DetermineExportAssignmentsKey, ESMExportInitFragment, ExportMode,
-  ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
+  DependencyType, DetermineExportAssignmentsKey, ESMExportBinding, ESMExportInitFragment,
+  ExportMode, ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
   ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
   ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
@@ -23,7 +23,7 @@ use rspack_core::{
   StarReexportsInfo, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
   collect_referenced_export_items, create_exports_object_referenced, create_no_exports_referenced,
   filter_runtime, get_exports_type, get_runtime_key, get_terminal_binding, property_access,
-  property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
+  render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_util::json_stringify;
@@ -769,7 +769,7 @@ impl ESMExportImportedSpecifierDependency {
 
         let mut content = format!(
           r"
-/* reexport */ var __rspack_reexport = {{}};
+/* reexport */ var __rspack_reexport = [];
 /* reexport */ for( {} __rspack_import_key in {import_var}) ",
           if supports_const { "const" } else { "var" }
         );
@@ -785,7 +785,7 @@ impl ESMExportImportedSpecifierDependency {
             rspack_util::json_stringify_str(item)
           );
         }
-        content += "__rspack_reexport[__rspack_import_key] =";
+        content += "__rspack_reexport.push(__rspack_import_key, ";
 
         // Arrow getters capture the loop variable by reference.
         // They are only correct when the loop binding is block-scoped (const/let), not var.
@@ -795,6 +795,7 @@ impl ESMExportImportedSpecifierDependency {
           content +=
             &format!("function(key) {{ return {import_var}[key]; }}.bind(0, __rspack_import_key)");
         }
+        content += ");";
 
         let module = mg
           .module_by_identifier(&module.identifier())
@@ -840,11 +841,17 @@ impl ESMExportImportedSpecifierDependency {
       runtime_template,
       ..
     } = ctxt;
+    let is_circular_module = compilation.circular_modules.contains(&module.identifier());
     let module_id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, target_module);
     let mode = render_make_deferred_namespace_mode_from_exports_type(exports_type);
+    let value = format!(
+      "/* reexport deferred namespace object */ {name}_deferred_namespace_cache || ({name}_deferred_namespace_cache = {}({}, {}))",
+      runtime_template.render_runtime_globals(&RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT),
+      json_stringify(&module_id),
+      mode
+    );
     let mut export_map = vec![];
-    export_map.push((key.into(), format!("/* reexport deferred namespace object */ {name}_deferred_namespace_cache || ({name}_deferred_namespace_cache = {}({}, {}))", runtime_template
-                .render_runtime_globals(&RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT), json_stringify(&module_id), mode).into()));
+    export_map.push((key.into(), ESMExportBinding::Getter(value.into())));
     let cache_var = format!("var {name}_deferred_namespace_cache;\n");
 
     (
@@ -855,7 +862,11 @@ impl ESMExportImportedSpecifierDependency {
         InitFragmentKey::ESMDeferImportNamespaceObjectFragment(cache_var),
         None,
       ),
-      ESMExportInitFragment::new(module.get_exports_argument(), export_map),
+      ESMExportInitFragment::new(
+        module.get_exports_argument(),
+        export_map,
+        is_circular_module,
+      ),
     )
   }
 
@@ -868,9 +879,20 @@ impl ESMExportImportedSpecifierDependency {
     value_key: ValueKey,
   ) -> ESMExportInitFragment {
     let return_value = Self::get_return_value(name.to_owned(), value_key);
+    let is_circular_module = ctxt
+      .compilation
+      .circular_modules
+      .contains(&ctxt.module.identifier());
     let mut export_map = vec![];
-    export_map.push((key.into(), format!("/* {comment} */ {return_value}").into()));
-    ESMExportInitFragment::new(ctxt.module.get_exports_argument(), export_map)
+    export_map.push((
+      key.into(),
+      ESMExportBinding::Getter(format!("/* {comment} */ {return_value}").into()),
+    ));
+    ESMExportInitFragment::new(
+      ctxt.module.get_exports_argument(),
+      export_map,
+      is_circular_module,
+    )
   }
 
   fn get_reexport_fake_namespace_object_fragments(
@@ -882,9 +904,11 @@ impl ESMExportImportedSpecifierDependency {
   ) -> (NormalInitFragment, ESMExportInitFragment) {
     let TemplateContext {
       module,
+      compilation,
       runtime_template,
       ..
     } = ctxt;
+    let is_circular_module = compilation.circular_modules.contains(&module.identifier());
     let mut export_map = vec![];
     let value = format!(
       r"/* reexport fake namespace object from non-ESM */ {name}_namespace_cache || ({name}_namespace_cache = {}({name}{}))",
@@ -895,7 +919,7 @@ impl ESMExportImportedSpecifierDependency {
         format!(", {fake_type}")
       }
     );
-    export_map.push((key.into(), value.into()));
+    export_map.push((key.into(), ESMExportBinding::Getter(value.into())));
     let cache_var = format!("var {name}_namespace_cache;\n");
 
     (
@@ -906,7 +930,11 @@ impl ESMExportImportedSpecifierDependency {
         InitFragmentKey::ESMFakeNamespaceObjectFragment(cache_var),
         None,
       ),
-      ESMExportInitFragment::new(module.get_exports_argument(), export_map),
+      ESMExportInitFragment::new(
+        module.get_exports_argument(),
+        export_map,
+        is_circular_module,
+      ),
     )
   }
 
@@ -943,13 +971,13 @@ impl ESMExportImportedSpecifierDependency {
     let return_value = Self::get_return_value(name.clone(), value_key);
     let exports_name = module.get_exports_argument();
     format!(
-      "if({}({}, {})) {}({}, {{ {}: function() {{ return {}; }} }});\n",
+      "if({}({}, {})) {}({}, [{}, function() {{ return {}; }}]);\n",
       runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),
       name,
       rspack_util::json_stringify_str(&first_value_key),
       runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
       runtime_template.render_exports_argument(exports_name),
-      property_name(&key).expect("should have property_name"),
+      rspack_util::json_stringify_str(&key),
       return_value
     )
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -841,7 +841,10 @@ impl ESMExportImportedSpecifierDependency {
       runtime_template,
       ..
     } = ctxt;
-    let is_circular_module = compilation.circular_modules.contains(&module.identifier());
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module.identifier()));
     let module_id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, target_module);
     let mode = render_make_deferred_namespace_mode_from_exports_type(exports_type);
     let value = format!(
@@ -881,7 +884,8 @@ impl ESMExportImportedSpecifierDependency {
     let is_circular_module = ctxt
       .compilation
       .circular_modules
-      .contains(&ctxt.module.identifier());
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&ctxt.module.identifier()));
     let mut export_map = vec![];
     export_map.push((
       key.into(),
@@ -907,7 +911,10 @@ impl ESMExportImportedSpecifierDependency {
       runtime_template,
       ..
     } = ctxt;
-    let is_circular_module = compilation.circular_modules.contains(&module.identifier());
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module.identifier()));
     let mut export_map = vec![];
     let value = format!(
       r"/* reexport fake namespace object from non-ESM */ {name}_namespace_cache || ({name}_namespace_cache = {}({name}{}))",

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -3,14 +3,14 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ESMExportInitFragment, EvaluatedInlinableValue,
+  DependencyTemplateType, DependencyType, ESMExportBinding, ESMExportInitFragment,
   ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, LazyUntil,
   ModuleGraph, ModuleGraphCacheArtifact, SideEffectsStateArtifact, TSEnumValue, TemplateContext,
   TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
-use crate::is_export_inlined;
+use crate::{ConstValue, is_export_inlined};
 
 // Create _webpack_require__.d(__webpack_exports__, {}) for each export.
 #[cacheable]
@@ -23,7 +23,7 @@ pub struct ESMExportSpecifierDependency {
   name: Atom,
   #[cacheable(with=AsPreset)]
   value: Atom, // id
-  inline: Option<EvaluatedInlinableValue>,
+  const_value: Option<ConstValue>,
   enum_value: Option<TSEnumValue>,
 }
 
@@ -31,7 +31,7 @@ impl ESMExportSpecifierDependency {
   pub fn new(
     name: Atom,
     value: Atom,
-    inline: Option<EvaluatedInlinableValue>,
+    const_value: Option<ConstValue>,
     enum_value: Option<TSEnumValue>,
     range: DependencyRange,
     loc: Option<DependencyLocation>,
@@ -39,7 +39,7 @@ impl ESMExportSpecifierDependency {
     Self {
       name,
       value,
-      inline,
+      const_value,
       enum_value,
       range,
       loc,
@@ -75,7 +75,10 @@ impl Dependency for ESMExportSpecifierDependency {
     Some(ExportsSpec {
       exports: ExportsOfExportsSpec::Names(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
         name: self.name.clone(),
-        inlinable: self.inline.clone(),
+        inlinable: self
+          .const_value
+          .as_ref()
+          .and_then(|const_value| const_value.as_inlinable().cloned()),
         exports: self.enum_value.as_ref().map(|enum_value| {
           enum_value
             .iter()
@@ -209,9 +212,16 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       }
       UsedName::Inlined(_) => return,
     };
+    let is_circular_module = compilation.circular_modules.contains(&module.identifier());
+    let binding = if dep.const_value.is_some() && !is_circular_module {
+      ESMExportBinding::Value(dep.value.clone())
+    } else {
+      ESMExportBinding::Getter(dep.value.clone())
+    };
     init_fragments.push(Box::new(ESMExportInitFragment::new(
       module.get_exports_argument(),
-      vec![(used_name, dep.value.clone())],
+      vec![(used_name, binding)],
+      is_circular_module,
     )));
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -212,8 +212,11 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       }
       UsedName::Inlined(_) => return,
     };
-    let is_circular_module = compilation.circular_modules.contains(&module.identifier());
-    let binding = if dep.const_value.is_some() && !is_circular_module {
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module.identifier()));
+    let binding = if matches!(is_circular_module, Some(false)) && dep.const_value.is_some() {
       ESMExportBinding::Value(dep.value.clone())
     } else {
       ESMExportBinding::Getter(dep.value.clone())

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -12,7 +12,7 @@ use swc_core::{
 use super::{
   DEFAULT_STAR_JS_WORD, JS_DEFAULT_KEYWORD, JavascriptParserPlugin,
   esm_import_dependency_parser_plugin::{ESM_SPECIFIER_TAG, ESMSpecifierData},
-  inline_const::{INLINABLE_CONST_TAG, InlinableConstData},
+  inline_const::{ConstValueData, INLINABLE_CONST_TAG},
   inner_graph::state::InnerGraphMapUsage,
 };
 use crate::{
@@ -177,8 +177,8 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       }
       Box::new(dep) as BoxDependency
     } else {
-      let inlinable = parser
-        .get_tag_data::<InlinableConstData>(local_id, INLINABLE_CONST_TAG)
+      let const_value = parser
+        .get_tag_data::<ConstValueData>(local_id, INLINABLE_CONST_TAG)
         .map(|data| data.value.clone());
       let enum_value = parser
         .build_info
@@ -198,7 +198,7 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
         } else {
           local_id.clone()
         },
-        inlinable,
+        const_value,
         enum_value,
         statement.span().into(),
         loc,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -1,6 +1,10 @@
+use rspack_cacheable::cacheable;
 use rspack_core::EvaluatedInlinableValue;
 use rspack_util::ryu_js;
-use swc_core::ecma::ast::VarDeclarator;
+use swc_core::ecma::{
+  ast::{ObjectPatProp, Pat, VarDeclarator},
+  atoms::Atom,
+};
 
 use super::JavascriptParserPlugin;
 use crate::{
@@ -17,15 +21,39 @@ use crate::{
 pub const INLINABLE_CONST_TAG: &str = "inlinable const";
 
 #[derive(Debug, Clone)]
-pub struct InlinableConstData {
-  pub value: EvaluatedInlinableValue,
+pub struct ConstValueData {
+  pub value: ConstValue,
+}
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub enum ConstValue {
+  NoInlinable,
+  Inlinable(EvaluatedInlinableValue),
+}
+
+impl ConstValue {
+  pub fn as_inlinable(&self) -> Option<&EvaluatedInlinableValue> {
+    match self {
+      ConstValue::Inlinable(v) => Some(v),
+      _ => None,
+    }
+  }
 }
 
 #[derive(Default)]
-pub struct InlineConstPlugin;
+pub struct ConstValuePlugin {
+  inline: bool,
+}
+
+impl ConstValuePlugin {
+  pub fn new(inline: bool) -> Self {
+    Self { inline }
+  }
+}
 
 #[rspack_macros::implemented_javascript_parser_hooks]
-impl JavascriptParserPlugin for InlineConstPlugin {
+impl JavascriptParserPlugin for ConstValuePlugin {
   fn evaluate_identifier(
     &self,
     parser: &mut JavascriptParser,
@@ -41,8 +69,12 @@ impl JavascriptParserPlugin for InlineConstPlugin {
     let tag_info = parser
       .definitions_db
       .expect_get_tag_info(parser.current_tag_info?);
-    let data = InlinableConstData::downcast(tag_info.data.clone()?);
-    Some(match data.value {
+    let data = ConstValueData::downcast(tag_info.data.clone()?);
+    let value = match data.value {
+      ConstValue::NoInlinable => return None,
+      ConstValue::Inlinable(v) => v,
+    };
+    Some(match value {
       EvaluatedInlinableValue::Null => evaluate_to_null(start, end),
       EvaluatedInlinableValue::Undefined => evaluate_to_undefined(start, end),
       EvaluatedInlinableValue::Boolean(v) => evaluate_to_boolean(v, start, end),
@@ -60,21 +92,69 @@ impl JavascriptParserPlugin for InlineConstPlugin {
     if !parser.is_top_level_scope() {
       return None;
     }
-    if matches!(declaration.kind(), VariableDeclarationKind::Const)
-      && let Some(name) = declarator.name.as_ident()
-      && let Some(init) = &declarator.init
-    {
-      let evaluated = parser.evaluate_expression(init);
-      if let Some(inlinable) = to_evaluated_inlinable_value(&evaluated) {
-        parser.tag_variable_with_flags(
-          name.id.sym.clone(),
-          INLINABLE_CONST_TAG,
-          Some(InlinableConstData { value: inlinable }),
-          VariableInfoFlags::NORMAL,
+    if !matches!(declaration.kind(), VariableDeclarationKind::Const) || declarator.init.is_none() {
+      return None;
+    }
+
+    if let Some(name) = declarator.name.as_ident() {
+      let const_value = if self.inline {
+        let evaluated = parser.evaluate_expression(
+          declarator
+            .init
+            .as_ref()
+            .expect("init should exist for const value"),
         );
+        match to_evaluated_inlinable_value(&evaluated) {
+          Some(v) => ConstValue::Inlinable(v),
+          None => ConstValue::NoInlinable,
+        }
+      } else {
+        ConstValue::NoInlinable
+      };
+      tag_const_variable(parser, name.id.sym.clone(), const_value);
+    } else {
+      tag_const_pattern(parser, &declarator.name);
+    }
+
+    None
+  }
+}
+
+fn tag_const_variable(parser: &mut JavascriptParser, name: Atom, value: ConstValue) {
+  parser.tag_variable_with_flags(
+    name,
+    INLINABLE_CONST_TAG,
+    Some(ConstValueData { value }),
+    VariableInfoFlags::NORMAL,
+  );
+}
+
+fn tag_const_pattern(parser: &mut JavascriptParser, pattern: &Pat) {
+  match pattern {
+    Pat::Ident(ident) => {
+      tag_const_variable(parser, ident.id.sym.clone(), ConstValue::NoInlinable);
+    }
+    Pat::Array(array) => {
+      for elem in array.elems.iter().flatten() {
+        tag_const_pattern(parser, elem);
       }
     }
-    None
+    Pat::Assign(assign) => {
+      tag_const_pattern(parser, &assign.left);
+    }
+    Pat::Object(object) => {
+      for prop in &object.props {
+        match prop {
+          ObjectPatProp::KeyValue(prop) => tag_const_pattern(parser, &prop.value),
+          ObjectPatProp::Assign(prop) => {
+            tag_const_variable(parser, prop.key.sym.clone(), ConstValue::NoInlinable);
+          }
+          ObjectPatProp::Rest(rest) => tag_const_pattern(parser, &rest.arg),
+        }
+      }
+    }
+    Pat::Rest(rest) => tag_const_pattern(parser, &rest.arg),
+    Pat::Invalid(_) | Pat::Expr(_) => {}
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -338,14 +338,11 @@ impl InnerGraphParserPlugin {
   ) -> TopLevelSymbol {
     parser.define_variable(name.clone());
 
-    let existing = parser.get_variable_info(name);
-    if let Some(existing) = existing
-      && let Some(tag_info) = existing.tag_info
-      && let tag_info = parser.definitions_db.expect_get_tag_info(tag_info)
-      && tag_info.tag == TOP_LEVEL_SYMBOL
-      && let Some(tag_data) = tag_info.data.as_deref()
+    if let Some(existing) = parser
+      .get_tag_data::<TopLevelSymbol>(name, TOP_LEVEL_SYMBOL)
+      .copied()
     {
-      return *TopLevelSymbol::downcast_ref(tag_data);
+      return existing;
     }
 
     let symbol = parser.inner_graph.new_top_level_symbol(name.clone());

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -57,7 +57,7 @@ pub(crate) use self::{
   import_meta_plugin::{ImportMetaDisabledPlugin, ImportMetaPlugin},
   import_parser_plugin::{ImportParserPlugin, ImportsReferencesState},
   initialize_evaluating::InitializeEvaluating,
-  inline_const::InlineConstPlugin,
+  inline_const::{ConstValue, ConstValuePlugin},
   inner_graph::{connection_active_used_by_exports, plugin::*, runtime_condition_used_by_exports},
   is_included_plugin::IsIncludedPlugin,
   javascript_meta_info_plugin::JavascriptMetaInfoPlugin,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -517,10 +517,13 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(parser_plugin::OverrideStrictPlugin));
     }
 
-    if compiler_options.optimization.inline_exports {
+    let inline_exports = compiler_options.optimization.inline_exports;
+    if inline_exports {
       build_info.inline_exports = true;
-      plugins.push(Box::new(parser_plugin::InlineConstPlugin));
     }
+    plugins.push(Box::new(parser_plugin::ConstValuePlugin::new(
+      inline_exports,
+    )));
     if compiler_options.optimization.inner_graph {
       plugins.push(Box::new(parser_plugin::InnerGraphParserPlugin::new(
         unresolved_mark,

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -316,10 +316,10 @@ impl Module for ContainerEntryModule {
           {require_name}.federation = {{ instance: undefined,bundlerRuntime: undefined }}
           var factory = ()=>{factory};
           var initShareContainer = {init_share_container_fn};
-    {runtime}({exports}, {{ 
-        get: function() {{ return factory;}},
-        init: function() {{ return initShareContainer;}}
-    }});
+    {runtime}({exports}, [
+        "get", function() {{ return factory;}},
+        "init", function() {{ return initShareContainer;}}
+    ]);
     "#,
         require_name = require_name,
         runtime = runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
@@ -356,10 +356,10 @@ impl Module for ContainerEntryModule {
 
       format!(
         r#"
-{}({}, {{
-	get: {},
-	init: {}
-}});"#,
+{}({}, [
+	"get", {},
+	"init", {}
+]);"#,
         define_property_getters,
         runtime_template.render_exports_argument(ExportsArgument::Exports),
         runtime_template.returning_function(&get_container, ""),
@@ -387,10 +387,10 @@ var init = function(shareScope, initScope) {{
   {share_scope_map}[name] = shareScope;
   return {initialize_sharing}(name, initScope);
 }}
-{define_property_getters}({exports}, {{
-	get: {export_get},
-	init: {export_init}
-}});"#,
+{define_property_getters}({exports}, [
+	"get", {export_get},
+	"init", {export_init}
+]);"#,
         exports = runtime_template.render_exports_argument(ExportsArgument::Exports),
         current_remote_get_scope =
           runtime_template.render_runtime_globals(&RuntimeGlobals::CURRENT_REMOTE_GET_SCOPE),

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -471,7 +471,7 @@ async fn optimize_dependencies(
 async fn optimize_modules(
   &self,
   _compilation: &Compilation,
-  _circular_modules: &mut IdentifierSet,
+  _circular_modules: &mut Option<IdentifierSet>,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   self.sealing_hooks_report("optimize modules", 7).await?;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.ejs
@@ -3,6 +3,6 @@
 	var getter = module && module.__esModule ?
 		<%- returningFunction("module['default']", "") %> :
 		<%- returningFunction("module", "") %>;
-	<%- DEFINE_PROPERTY_GETTERS %>(getter, { a: getter });
+	<%- DEFINE_PROPERTY_GETTERS %>(getter, ["a", getter]);
 	return getter;
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_fake_namespace_object.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_fake_namespace_object.ejs
@@ -14,13 +14,17 @@ var leafPrototypes;
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  <%- MAKE_NAMESPACE_OBJECT %>(ns);
-	var def = {};
+	<%- MAKE_NAMESPACE_OBJECT %>(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach(<%- basicFunction("key") %> { def[key] = <%- returningFunction("value[key]", "") %> });
+		Object.getOwnPropertyNames(current).forEach(<%- basicFunction("key") %> {
+			def.push(key, <%- returningFunction("value[key]", "") %>);
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = <%- returningFunction("value", "") %>;
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	<%- DEFINE_PROPERTY_GETTERS %>(ns, def);
 	return ns;
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
@@ -1,7 +1,11 @@
 <%- DEFINE_PROPERTY_GETTERS %> = <%- basicFunction("exports, definition") %> {
-	for(var key in definition) {
-        if(<%- HAS_OWN_PROPERTY %>(definition, key) && !<%- HAS_OWN_PROPERTY %>(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!<%- HAS_OWN_PROPERTY %>(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -170,16 +170,22 @@ export class HotUpdatePlugin {
           if (
             module.constructor.name === 'DefinePropertyGettersRuntimeModule'
           ) {
+            // HMR tests re-execute modules and redefine the same export keys, so
+            // the test-only runtime keeps export descriptors configurable (`configurable: true`).
             module.source.source = Buffer.from(
               `
-										${RuntimeGlobals.definePropertyGetters} = function (exports, definition) {
-												for (var key in definition) {
-														if (${RuntimeGlobals.hasOwnProperty}(definition, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										`,
+${RuntimeGlobals.definePropertyGetters} = function (exports, definition) {
+    var i = 0;
+    while(i < definition.length) {
+        var key = definition[i++];
+        var binding = definition[i++];
+        var descriptor = binding === 0 ? { configurable: true, enumerable: true, value: definition[i++] } : { configurable: true, enumerable: true, get: binding };
+        if (!${RuntimeGlobals.hasOwnProperty}(exports, key)) {
+            Object.defineProperty(exports, key, descriptor);
+        }
+    }
+};
+`,
               'utf-8',
             );
           }

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -268,7 +268,9 @@ export class RspackOptionsApply {
     if (options.optimization.providedExports) {
       new FlagDependencyExportsPlugin().apply(compiler);
     }
-    new CircularModulesInfoPlugin().apply(compiler);
+    if (options.mode === 'production') {
+      new CircularModulesInfoPlugin().apply(compiler);
+    }
     if (options.optimization.usedExports) {
       new FlagDependencyUsagePlugin(
         options.optimization.usedExports === 'global',

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -22,6 +22,7 @@ import {
   AsyncWebAssemblyModulesPlugin,
   BundlerInfoRspackPlugin,
   ChunkPrefetchPreloadPlugin,
+  CircularModulesInfoPlugin,
   CommonJsChunkFormatPlugin,
   CssModulesPlugin,
   DataUriPlugin,
@@ -267,6 +268,7 @@ export class RspackOptionsApply {
     if (options.optimization.providedExports) {
       new FlagDependencyExportsPlugin().apply(compiler);
     }
+    new CircularModulesInfoPlugin().apply(compiler);
     if (options.optimization.usedExports) {
       new FlagDependencyUsagePlugin(
         options.optimization.usedExports === 'global',

--- a/tests/rspack-test/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
@@ -195,16 +195,15 @@ console.log(console.log(console.log));
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "DO_NOT_CONVERTED7", () => (DO_NOT_CONVERTED7),
+  "DO_NOT_CONVERTED9", () => (DO_NOT_CONVERTED9),
+  "default", () => (__rspack_default_export)
+]);
 const DO_NOT_CONVERTED7 = 402;
 const DO_NOT_CONVERTED9 = 403;
 /* export default */ const __rspack_default_export = (401); // DO_NOT_CONVERTED8
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "DO_NOT_CONVERTED7", 0, DO_NOT_CONVERTED7,
-  "DO_NOT_CONVERTED9", 0, DO_NOT_CONVERTED9,
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
@@ -195,15 +195,16 @@ console.log(console.log(console.log));
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  DO_NOT_CONVERTED7: () => (DO_NOT_CONVERTED7),
-  DO_NOT_CONVERTED9: () => (DO_NOT_CONVERTED9),
-  "default": () => (__rspack_default_export)
-});
 const DO_NOT_CONVERTED7 = 402;
 const DO_NOT_CONVERTED9 = 403;
 /* export default */ const __rspack_default_export = (401); // DO_NOT_CONVERTED8
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "DO_NOT_CONVERTED7", 0, DO_NOT_CONVERTED7,
+  "DO_NOT_CONVERTED9", 0, DO_NOT_CONVERTED9,
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/builtinCases/plugin-javascript/hashbang/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/hashbang/__snapshots__/output.snap.txt
@@ -13,13 +13,14 @@ console.log("index", _lib__rspack_import_0.foo);
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  foo: () => (foo)
-});
 //#!/usr/bin/env node
 
 const foo = 42;
 console.log("lib", foo);
+
+__webpack_require__.d(__webpack_exports__, [
+  "foo", 0, foo
+]);
 
 
 },

--- a/tests/rspack-test/builtinCases/plugin-javascript/hashbang/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/hashbang/__snapshots__/output.snap.txt
@@ -13,14 +13,13 @@ console.log("index", _lib__rspack_import_0.foo);
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "foo", () => (foo)
+]);
 //#!/usr/bin/env node
 
 const foo = 42;
 console.log("lib", foo);
-
-__webpack_require__.d(__webpack_exports__, [
-  "foo", 0, foo
-]);
 
 
 },

--- a/tests/rspack-test/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
@@ -21,6 +21,9 @@ function a() {
 "./name.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 const lib = {
 	get: () => {
 		return "my-name";
@@ -28,10 +31,6 @@ const lib = {
 };
 
 /* export default */ const __rspack_default_export = (lib);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
@@ -21,9 +21,6 @@ function a() {
 "./name.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 const lib = {
 	get: () => {
 		return "my-name";
@@ -31,6 +28,10 @@ const lib = {
 };
 
 /* export default */ const __rspack_default_export = (lib);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
@@ -24,10 +24,10 @@ var __webpack_exports__ = (__webpack_exec__("./index.js"));
 "./module.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.a(module, async function (__rspack_load_async_deps, __rspack_async_done) { try {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  getNumber: () => (getNumber),
-  result: () => (result)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "getNumber", () => (getNumber),
+  "result", () => (result)
+]);
 /* import */ var _wasm_wasm__rspack_import_0 = __webpack_require__("./wasm.wasm");
 var __rspack_async_deps = __rspack_load_async_deps([_wasm_wasm__rspack_import_0]);
 _wasm_wasm__rspack_import_0 = (__rspack_async_deps.then ? (await __rspack_async_deps)() : __rspack_async_deps)[0];
@@ -45,9 +45,9 @@ __rspack_async_done();
 "./module2.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.a(module, async function (__rspack_load_async_deps, __rspack_async_done) { try {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  getNumber: () => (getNumber)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "getNumber", () => (getNumber)
+]);
 /* import */ var _wasm_wasm__rspack_import_0 = __webpack_require__("./wasm.wasm");
 var __rspack_async_deps = __rspack_load_async_deps([_wasm_wasm__rspack_import_0]);
 _wasm_wasm__rspack_import_0 = (__rspack_async_deps.then ? (await __rspack_async_deps)() : __rspack_async_deps)[0];

--- a/tests/rspack-test/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
@@ -3,10 +3,11 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["child_a_js"], {
 "./child/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = "a";
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },
@@ -19,10 +20,11 @@ const a = "a";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["child_b_js"], {
 "./child/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b)
-});
 const b = "b";
+
+__webpack_require__.d(__webpack_exports__, [
+  "b", 0, b
+]);
 
 
 },

--- a/tests/rspack-test/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
@@ -3,11 +3,10 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["child_a_js"], {
 "./child/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const a = "a";
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = "a";
 
 
 },
@@ -20,11 +19,10 @@ __webpack_require__.d(__webpack_exports__, [
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["child_b_js"], {
 "./child/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const b = "b";
-
 __webpack_require__.d(__webpack_exports__, [
-  "b", 0, b
+  "b", () => (b)
 ]);
+const b = "b";
 
 
 },

--- a/tests/rspack-test/builtinCases/samples/mangle-exports/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/samples/mangle-exports/__snapshots__/output.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  Z: () => (answer)
-});
 const answer = 103330;
+
+__webpack_require__.d(__webpack_exports__, [
+  "Z", 0, answer
+]);
 
 
 },
@@ -17,11 +18,12 @@ _lib__rspack_import_0/* .answer */.Z;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  Z: () => (/* reexport safe */ _answer__rspack_import_0.Z)
-});
 /* import */ var _answer__rspack_import_0 = __webpack_require__("./answer.js");
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "Z", () => (/* reexport safe */ _answer__rspack_import_0.Z)
+]);
 
 
 },

--- a/tests/rspack-test/builtinCases/samples/mangle-exports/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/samples/mangle-exports/__snapshots__/output.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const answer = 103330;
-
 __webpack_require__.d(__webpack_exports__, [
-  "Z", 0, answer
+  "Z", () => (answer)
 ]);
+const answer = 103330;
 
 
 },
@@ -18,12 +17,11 @@ _lib__rspack_import_0/* .answer */.Z;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-/* import */ var _answer__rspack_import_0 = __webpack_require__("./answer.js");
-
-
 __webpack_require__.d(__webpack_exports__, [
   "Z", () => (/* reexport safe */ _answer__rspack_import_0.Z)
 ]);
+/* import */ var _answer__rspack_import_0 = __webpack_require__("./answer.js");
+
 
 
 },

--- a/tests/rspack-test/builtinCases/swc-loader/minify/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/swc-loader/minify/__snapshots__/output.snap.txt
@@ -3,14 +3,13 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "Button", () => (Button),
+  "button", () => (button)
+]);
 /*! Legal Comment */ // normal comment
 const Button = ()=>/*#__PURE__*/ jsx('button', {});
 const button = /* @__PURE__ */ new Button();
-
-__webpack_require__.d(__webpack_exports__, [
-  "Button", 0, Button,
-  "button", 0, button
-]);
 
 
 },

--- a/tests/rspack-test/builtinCases/swc-loader/minify/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/swc-loader/minify/__snapshots__/output.snap.txt
@@ -3,13 +3,14 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  Button: () => (Button),
-  button: () => (button)
-});
 /*! Legal Comment */ // normal comment
 const Button = ()=>/*#__PURE__*/ jsx('button', {});
 const button = /* @__PURE__ */ new Button();
+
+__webpack_require__.d(__webpack_exports__, [
+  "Button", 0, Button,
+  "button", 0, button
+]);
 
 
 },

--- a/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/rspack.config.js
@@ -57,9 +57,9 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
       __webpack_require__.r(__webpack_exports__);
       const res = modFactory();
       for (const key in res) {
-        __webpack_require__.d(__webpack_exports__, {
-          [key]: () => res[key],
-        });
+        __webpack_require__.d(__webpack_exports__, [
+          key, () => res[key],
+        ]);
       }
     };
 

--- a/tests/rspack-test/configCases/code-generation/import-export-format-2/index.js
+++ b/tests/rspack-test/configCases/code-generation/import-export-format-2/index.js
@@ -33,17 +33,17 @@ it("should use the same accessor syntax for import and export", function () {
 	/*********** DO NOT MATCH BELOW THIS LINE ***********/
 
 	// Checking harmonyexportinitfragment.js formation of standard export fragment
-	expectSourceToContain(source, "bar: () => (bar)");
+	expectSourceToContain(source, "\"bar\", 0, bar");
 
 	// Checking formation of imports
 	expectSourceToMatch(source, `${regexEscape("const { harmonyexport_cjsimport } = (__webpack_require__(")}\\d+${regexEscape(")/* .bar */.bar);")}`);
 	expectSourceToMatch(source, `${regexEscape("const harmonyexport_cjsimportdefault = (__webpack_require__(")}\\d+${regexEscape(")/* [\"default\"] */[\"default\"]);")}`);
 
 	// Checking concatenatedmodule.js formation of exports
-	expectSourceToContain(source, "mod3: () => (/* reexport */ harmony_module_3_namespaceObject)");
+	expectSourceToContain(source, "\"mod3\", () => (/* reexport */ harmony_module_3_namespaceObject)");
 
 	// Checking concatenatedmodule.js formation of namespace objects
-	expectSourceToContain(source, "apple: () => (apple)");
+	expectSourceToContain(source, "\"apple\", () => (apple)");
 
 	// Do not break default option
 	expectSourceToContain(source, "[\"default\"] = (___CSS_LOADER_EXPORT___)");

--- a/tests/rspack-test/configCases/code-generation/import-export-format/index.js
+++ b/tests/rspack-test/configCases/code-generation/import-export-format/index.js
@@ -30,15 +30,15 @@ it("should use the same accessor syntax for import and export", function () {
 	// Note that there are no quotes around the "a" and "b" properties in the following lines.
 
 	// Checking harmonyexportinitfragment.js formation of standard export fragment
-	expectSourceToContain(source, "a: () => (bar)");
+	expectSourceToContain(source, "\"a\", 0, bar");
 
 	// Checking formation of imports
 	expectSourceToContain(source, "harmony_module/* .bar */.a;");
 	expectSourceToMatch(source, `${regexEscape("const { harmonyexport_cjsimport } = (__webpack_require__(")}\\d+${regexEscape(")/* .bar */.a);")}`);
 
 	// Checking concatenatedmodule.js formation of exports
-	expectSourceToContain(source, "a: () => (/* reexport */ harmony_module_3_namespaceObject)");
+	expectSourceToContain(source, "\"a\", () => (/* reexport */ harmony_module_3_namespaceObject)");
 
 	// Checking concatenatedmodule.js formation of namespace objects
-	expectSourceToContain(source, "a: () => (apple)");
+	expectSourceToContain(source, "\"a\", () => (apple)");
 });

--- a/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/index.js
+++ b/tests/rspack-test/configCases/concatenate-modules/deterministic-export-comments/index.js
@@ -10,7 +10,7 @@ it("should render concatenated export comments in deterministic order", () => {
 
 	/*********** DO NOT MATCH BELOW THIS LINE ***********/
 
-	expectSourceToContain(source, "usedA: () => (/* binding */ usedA)");
-	expectSourceToContain(source, "usedB: () => (/* binding */ usedB)");
+	expectSourceToContain(source, "\"usedA\", () => (/* binding */ usedA)");
+	expectSourceToContain(source, "\"usedB\", () => (/* binding */ usedB)");
 	expectSourceToContain(source, "// UNUSED EXPORTS: unusedA, unusedB");
 });

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case1.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case1.txt
@@ -7,13 +7,13 @@ __webpack_require__.add({
 __webpack_require__.r(__webpack_exports__);
 /* import */ var external1__rspack_import_0 = __webpack_require__(322);
 
-/* reexport */ var __rspack_reexport = {};
-/* reexport */ for( const __rspack_import_key in external1__rspack_import_0) if(__rspack_import_key !== "default") __rspack_reexport[__rspack_import_key] =() => external1__rspack_import_0[__rspack_import_key]
+/* reexport */ var __rspack_reexport = [];
+/* reexport */ for( const __rspack_import_key in external1__rspack_import_0) if(__rspack_import_key !== "default") __rspack_reexport.push(__rspack_import_key, () => external1__rspack_import_0[__rspack_import_key]);
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
 /* import */ var external2__rspack_import_1 = __webpack_require__(101);
 
-/* reexport */ var __rspack_reexport = {};
-/* reexport */ for( const __rspack_import_key in external2__rspack_import_1) if(__rspack_import_key !== "default") __rspack_reexport[__rspack_import_key] =() => external2__rspack_import_1[__rspack_import_key]
+/* reexport */ var __rspack_reexport = [];
+/* reexport */ for( const __rspack_import_key in external2__rspack_import_1) if(__rspack_import_key !== "default") __rspack_reexport.push(__rspack_import_key, () => external2__rspack_import_1[__rspack_import_key]);
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
 
 

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/const-export.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/const-export.js
@@ -1,0 +1,9 @@
+export const literal = "literal";
+
+const local = "local";
+export { local as renamed };
+
+const source = { destructured: "destructured" };
+export const { destructured } = source;
+
+export const [arrayValue] = ["array"];

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-a.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-a.js
@@ -1,0 +1,7 @@
+import { readCyclicConst } from "./cycle-b";
+
+export const cyclicConst = "cyclic";
+
+export function readFromCycle() {
+	return readCyclicConst();
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-b.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-b.js
@@ -1,0 +1,5 @@
+import { cyclicConst } from "./cycle-a";
+
+export function readCyclicConst() {
+	return cyclicConst;
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/function-export.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/function-export.js
@@ -1,0 +1,3 @@
+export function fn() {
+	return "fn";
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/index.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/index.js
@@ -1,0 +1,44 @@
+import * as constExports from "./const-export";
+import * as cyclicExports from "./cycle-a";
+import * as functionExports from "./function-export";
+import * as letExports from "./let-export";
+
+it("should bind const exports as readonly values", () => {
+	expectValueDescriptor(constExports, "literal", "literal");
+	expectValueDescriptor(constExports, "renamed", "local");
+	expectValueDescriptor(constExports, "destructured", "destructured");
+	expectValueDescriptor(constExports, "arrayValue", "array");
+});
+
+it("should keep non-const exports as getters", () => {
+	expectGetterDescriptor(letExports, "counter");
+	expectGetterDescriptor(functionExports, "fn");
+});
+
+it("should keep const exports in circular modules as getters", () => {
+	expectGetterDescriptor(cyclicExports, "cyclicConst");
+	expect(cyclicExports.readFromCycle()).toBe("cyclic");
+});
+
+function expectValueDescriptor(ns, key, value) {
+	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
+	expect(descriptor).toEqual(
+		expect.objectContaining({
+			enumerable: true,
+			writable: false,
+			value
+		})
+	);
+	expect(descriptor.get).toBe(undefined);
+}
+
+function expectGetterDescriptor(ns, key) {
+	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
+	expect(descriptor).toEqual(
+		expect.objectContaining({
+			enumerable: true,
+			get: expect.any(Function)
+		})
+	);
+	expect(Object.prototype.hasOwnProperty.call(descriptor, "value")).toBe(false);
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/let-export.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/let-export.js
@@ -1,0 +1,5 @@
+export let counter = 0;
+
+export function setCounter(value) {
+	counter = value;
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   optimization: {
     concatenateModules: false,
     inlineExports: false,

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/rspack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  optimization: {
+    concatenateModules: false,
+    inlineExports: false,
+    mangleExports: false,
+    usedExports: false,
+  },
+};

--- a/tests/rspack-test/configCases/parsing/rspack-issue-6934/index.js
+++ b/tests/rspack-test/configCases/parsing/rspack-issue-6934/index.js
@@ -3,5 +3,5 @@ import { A } from './b.js';
 it("should not generate duplicated ESM exports when using named exports and named exports from", () => {
 	A;
 	let file = fs.readFileSync(__filename, "utf-8")
-	expect(file.split(`A: () => (/* reexport safe */`)).toHaveLength(3)
+	expect(file.split(`"A", () => (/* reexport safe */`)).toHaveLength(3)
 })

--- a/tests/rspack-test/configCases/rsdoctor/assets/rspack.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/assets/rspack.config.js
@@ -37,19 +37,19 @@ module.exports = {
 							Array [
 							  Object {
 							    path: a.js,
-							    size: 4240,
+							    size: 4337,
 							  },
 							  Object {
 							    path: b.js,
-							    size: 4240,
+							    size: 4337,
 							  },
 							  Object {
 							    path: c_js.js,
-							    size: 221,
+							    size: 219,
 							  },
 							  Object {
 							    path: d_js.js,
-							    size: 221,
+							    size: 219,
 							  },
 							]
 						`);

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -88,9 +88,9 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
         __webpack_require__.r(__webpack_exports__);
         const res = modFactory();
         for (const key in res) {
-          __webpack_require__.d(__webpack_exports__, {
-            [key]: () => res[key],
-          });
+          __webpack_require__.d(__webpack_exports__, [
+            key, () => res[key],
+          ]);
         }
       };
 

--- a/tests/rspack-test/esmOutputCases/basic/export-shared-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/export-shared-namespace/__snapshots__/esm.snap.txt
@@ -22,12 +22,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -53,9 +58,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./shared.js
 var shared_namespaceObject = {};
 __webpack_require__.r(shared_namespaceObject);
-__webpack_require__.d(shared_namespaceObject, { 
-  a: () => (a),
-  b: () => (b) });
+__webpack_require__.d(shared_namespaceObject, [
+  "a", () => (a),
+  "b", () => (b)
+]);
 
 
 // ./shared.js

--- a/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/esm.snap.txt
@@ -94,7 +94,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -102,12 +102,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_module_decorator
 (() => {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
@@ -11,8 +11,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./dynamic.js?1
 var dynamic1_namespaceObject = {};
 __webpack_require__.r(dynamic1_namespaceObject);
-__webpack_require__.d(dynamic1_namespaceObject, { 
-  "default": () => (dynamic1) });
+__webpack_require__.d(dynamic1_namespaceObject, [
+  "default", () => (dynamic1)
+]);
 
 
 // ./dynamic.js?1
@@ -41,12 +42,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
@@ -3,15 +3,17 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./a.js
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
-__webpack_require__.d(a_namespaceObject, { 
-  value: () => (value) });
+__webpack_require__.d(a_namespaceObject, [
+  "value", () => (value)
+]);
 
 
 // NAMESPACE OBJECT: ./b.js
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
-__webpack_require__.d(b_namespaceObject, { 
-  value: () => (b_value) });
+__webpack_require__.d(b_namespaceObject, [
+  "value", () => (b_value)
+]);
 
 
 // ./a.js
@@ -53,12 +55,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
@@ -27,12 +27,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -58,17 +63,19 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./m1.js
 var m1_namespaceObject = {};
 __webpack_require__.r(m1_namespaceObject);
-__webpack_require__.d(m1_namespaceObject, { 
-  "default": () => (m1),
-  value: () => (value) });
+__webpack_require__.d(m1_namespaceObject, [
+  "default", () => (m1),
+  "value", () => (value)
+]);
 
 
 // NAMESPACE OBJECT: ./m2.js
 var m2_namespaceObject = {};
 __webpack_require__.r(m2_namespaceObject);
-__webpack_require__.d(m2_namespaceObject, { 
-  "default": () => (m2),
-  value: () => (m2_value) });
+__webpack_require__.d(m2_namespaceObject, [
+  "default", () => (m2),
+  "value", () => (m2_value)
+]);
 
 
 // ./m1.js

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-module-external-namespace-default-named-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-module-external-namespace-default-named-collision/__snapshots__/esm.snap.txt
@@ -28,12 +28,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -61,17 +66,19 @@ import foo_runtime, { foo } from "./foo-runtime.mjs";
 // NAMESPACE OBJECT: ./a.js
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
-__webpack_require__.d(a_namespaceObject, { 
-  "default": () => (a),
-  shared: () => (shared) });
+__webpack_require__.d(a_namespaceObject, [
+  "default", () => (a),
+  "shared", () => (shared)
+]);
 
 
 // NAMESPACE OBJECT: ./b.js
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
-__webpack_require__.d(b_namespaceObject, { 
-  namedFoo: () => (foo),
-  shared: () => (b_shared) });
+__webpack_require__.d(b_namespaceObject, [
+  "namedFoo", () => (foo),
+  "shared", () => (b_shared)
+]);
 
 
 // ./foo-runtime.mjs?4fe1

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-duplicate-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-duplicate-external/__snapshots__/esm.snap.txt
@@ -21,12 +21,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -54,18 +59,20 @@ import fs, { readFile, readFileSync } from "fs";
 // NAMESPACE OBJECT: ./a.js
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
-__webpack_require__.d(a_namespaceObject, { 
-  fsDefault: () => (fs),
-  readFile: () => (readFile),
-  readFileSync: () => (readFileSync) });
+__webpack_require__.d(a_namespaceObject, [
+  "fsDefault", () => (fs),
+  "readFile", () => (readFile),
+  "readFileSync", () => (readFileSync)
+]);
 
 
 // NAMESPACE OBJECT: ./b.js
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
-__webpack_require__.d(b_namespaceObject, { 
-  marker: () => (marker),
-  readFile: () => (readFile) });
+__webpack_require__.d(b_namespaceObject, [
+  "marker", () => (marker),
+  "readFile", () => (readFile)
+]);
 
 
 // fs?2aa6

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-namespace-named-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-namespace-named-external/__snapshots__/esm.snap.txt
@@ -21,12 +21,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -55,16 +60,18 @@ import { resolve } from "path";
 // NAMESPACE OBJECT: ./a.js
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
-__webpack_require__.d(a_namespaceObject, { 
-  resolve: () => (__rspack_external_path) });
+__webpack_require__.d(a_namespaceObject, [
+  "resolve", () => (__rspack_external_path)
+]);
 
 
 // NAMESPACE OBJECT: ./b.js
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
-__webpack_require__.d(b_namespaceObject, { 
-  marker: () => (marker),
-  resolve: () => (resolve) });
+__webpack_require__.d(b_namespaceObject, [
+  "marker", () => (marker),
+  "resolve", () => (resolve)
+]);
 
 
 // path?2d49

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-three-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-three-modules/__snapshots__/esm.snap.txt
@@ -27,28 +27,31 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./a.js
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
-__webpack_require__.d(a_namespaceObject, { 
-  "default": () => (a),
-  id: () => (id),
-  name: () => (a_name) });
+__webpack_require__.d(a_namespaceObject, [
+  "default", () => (a),
+  "id", () => (id),
+  "name", () => (a_name)
+]);
 
 
 // NAMESPACE OBJECT: ./b.js
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
-__webpack_require__.d(b_namespaceObject, { 
-  "default": () => (b),
-  id: () => (b_id),
-  name: () => (b_name) });
+__webpack_require__.d(b_namespaceObject, [
+  "default", () => (b),
+  "id", () => (b_id),
+  "name", () => (b_name)
+]);
 
 
 // NAMESPACE OBJECT: ./c.js
 var c_namespaceObject = {};
 __webpack_require__.r(c_namespaceObject);
-__webpack_require__.d(c_namespaceObject, { 
-  "default": () => (c),
-  id: () => (c_id),
-  name: () => (c_name) });
+__webpack_require__.d(c_namespaceObject, [
+  "default", () => (c),
+  "id", () => (c_id),
+  "name", () => (c_name)
+]);
 
 
 // ./a.js
@@ -77,12 +80,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-treeshake-real-conflict/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-treeshake-real-conflict/__snapshots__/esm.snap.txt
@@ -23,12 +23,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -54,17 +59,19 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./a.js
 var a_namespaceObject = {};
 __webpack_require__.r(a_namespaceObject);
-__webpack_require__.d(a_namespaceObject, { 
-  foo: () => (foo),
-  value: () => (value) });
+__webpack_require__.d(a_namespaceObject, [
+  "foo", () => (foo),
+  "value", () => (value)
+]);
 
 
 // NAMESPACE OBJECT: ./b.js
 var b_namespaceObject = {};
 __webpack_require__.r(b_namespaceObject);
-__webpack_require__.d(b_namespaceObject, { 
-  bar: () => (bar),
-  value: () => (b_value) });
+__webpack_require__.d(b_namespaceObject, [
+  "bar", () => (bar),
+  "value", () => (b_value)
+]);
 
 
 // ./a.js

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
@@ -57,7 +57,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -80,26 +80,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
@@ -84,7 +84,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -107,26 +107,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/dynamic-import/magic-comment/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/magic-comment/__snapshots__/esm.snap.txt
@@ -46,7 +46,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -54,12 +54,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {
@@ -85,17 +90,19 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./m1.js
 var m1_namespaceObject = {};
 __webpack_require__.r(m1_namespaceObject);
-__webpack_require__.d(m1_namespaceObject, { 
-  "default": () => (m1),
-  value: () => (value) });
+__webpack_require__.d(m1_namespaceObject, [
+  "default", () => (m1),
+  "value", () => (value)
+]);
 
 
 // NAMESPACE OBJECT: ./m2.js
 var m2_namespaceObject = {};
 __webpack_require__.r(m2_namespaceObject);
-__webpack_require__.d(m2_namespaceObject, { 
-  "default": () => (m2),
-  value: () => (m2_value) });
+__webpack_require__.d(m2_namespaceObject, [
+  "default", () => (m2),
+  "value", () => (m2_value)
+]);
 
 
 // ./m1.js

--- a/tests/rspack-test/esmOutputCases/externals/array-request-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/array-request-module/__snapshots__/esm.snap.txt
@@ -30,7 +30,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -38,12 +38,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
@@ -5,8 +5,9 @@ const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 // NAMESPACE OBJECT: ./exports.js
 var exports_namespaceObject = {};
 __webpack_require__.r(exports_namespaceObject);
-__webpack_require__.d(exports_namespaceObject, { 
-  sources: () => (index_js_namespaceObject) });
+__webpack_require__.d(exports_namespaceObject, [
+  "sources", () => (index_js_namespaceObject)
+]);
 
 
 // webpack-sources
@@ -44,12 +45,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module-with-own-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module-with-own-export/__snapshots__/esm.snap.txt
@@ -5,13 +5,14 @@ import * as __rspack_external_fs from "fs";
 // NAMESPACE OBJECT: ./reexport-external.js
 var reexport_external_namespaceObject = {};
 __webpack_require__.r(reexport_external_namespaceObject);
-__webpack_require__.d(reexport_external_namespaceObject, { 
-  marker: () => (marker),
-  readFile: () => (readFile) });
+__webpack_require__.d(reexport_external_namespaceObject, [
+  "marker", () => (marker),
+  "readFile", () => (readFile)
+]);
 var reexport_external_namespaceObject_starExports = __rspack_external_fs;
 Object.keys(reexport_external_namespaceObject_starExports).forEach(function(key) {
   if (key !== "default" && key !== "__esModule") {
-    __webpack_require__.d(reexport_external_namespaceObject, { [key]: function() { return reexport_external_namespaceObject_starExports[key]; } });
+    __webpack_require__.d(reexport_external_namespaceObject, [key, function() { return reexport_external_namespaceObject_starExports[key]; }]);
   }
 });
 
@@ -46,12 +47,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module/__snapshots__/esm.snap.txt
@@ -8,7 +8,7 @@ __webpack_require__.r(reexport_external_namespaceObject);
 var reexport_external_namespaceObject_starExports = __rspack_external_fs;
 Object.keys(reexport_external_namespaceObject_starExports).forEach(function(key) {
   if (key !== "default" && key !== "__esModule") {
-    __webpack_require__.d(reexport_external_namespaceObject, { [key]: function() { return reexport_external_namespaceObject_starExports[key]; } });
+    __webpack_require__.d(reexport_external_namespaceObject, [key, function() { return reexport_external_namespaceObject_starExports[key]; }]);
   }
 });
 
@@ -39,12 +39,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
@@ -25,9 +25,9 @@ def(exports)
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 /* import */ var _dynamic_exports__rspack_import_0 = __webpack_require__(/*! ./dynamic-exports */ "./dynamic-exports.js");
 /* import */ var _dynamic_exports__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_dynamic_exports__rspack_import_0);
-if(__webpack_require__.o(_dynamic_exports__rspack_import_0, "readFile")) __webpack_require__.d(__webpack_exports__, { readFile: function() { return _dynamic_exports__rspack_import_0.readFile; } });
+if(__webpack_require__.o(_dynamic_exports__rspack_import_0, "readFile")) __webpack_require__.d(__webpack_exports__, ["readFile", function() { return _dynamic_exports__rspack_import_0.readFile; }]);
 /* import */ var fs__rspack_import_1 = __webpack_require__(/*! fs */ "fs");
-if(__webpack_require__.o(fs__rspack_import_1, "readFile")) __webpack_require__.d(__webpack_exports__, { readFile: function() { return fs__rspack_import_1.readFile; } });
+if(__webpack_require__.o(fs__rspack_import_1, "readFile")) __webpack_require__.d(__webpack_exports__, ["readFile", function() { return fs__rspack_import_1.readFile; }]);
 
 
 // side effects
@@ -97,7 +97,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -105,12 +105,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/interop/access-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/access-exports/__snapshots__/esm.snap.txt
@@ -60,7 +60,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -68,12 +68,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/interop/access-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/access-module/__snapshots__/esm.snap.txt
@@ -61,7 +61,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -69,12 +69,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/interop/correct-order/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/correct-order/__snapshots__/esm.snap.txt
@@ -73,7 +73,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -81,12 +81,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/interop/entry-exports-type-defaut/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/entry-exports-type-defaut/__snapshots__/esm.snap.txt
@@ -80,7 +80,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -88,12 +88,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
@@ -68,7 +68,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -76,12 +76,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
@@ -40,26 +40,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/basic-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-capture/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (foo) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (foo)
+]);
 
 
 // ./foo.js
@@ -32,12 +33,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/basic-cjs-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-cjs-capture/__snapshots__/esm.snap.txt
@@ -72,26 +72,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/default-only-object/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/default-only-object/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./dep.js
 var dep_namespaceObject = {};
 __webpack_require__.r(dep_namespaceObject);
-__webpack_require__.d(dep_namespaceObject, { 
-  "default": () => (dep) });
+__webpack_require__.d(dep_namespaceObject, [
+  "default", () => (dep)
+]);
 
 
 // ./dep.js
@@ -34,12 +35,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/empty-modules-default-property/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/empty-modules-default-property/__snapshots__/esm.snap.txt
@@ -77,7 +77,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -85,12 +85,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -71,26 +71,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/export-namespace-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-namespace-as/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./dep.js
 var dep_namespaceObject = {};
 __webpack_require__.r(dep_namespaceObject);
-__webpack_require__.d(dep_namespaceObject, { 
-  bar: () => (bar),
-  foo: () => (foo) });
+__webpack_require__.d(dep_namespaceObject, [
+  "bar", () => (bar),
+  "foo", () => (foo)
+]);
 
 
 // ./dep.js
@@ -33,12 +34,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./index.js
 var index_namespaceObject = {};
 __webpack_require__.r(index_namespaceObject);
-__webpack_require__.d(index_namespaceObject, { 
-  foo: () => (foo),
-  ns: () => (index_namespaceObject) });
+__webpack_require__.d(index_namespaceObject, [
+  "foo", () => (foo),
+  "ns", () => (index_namespaceObject)
+]);
 
 
 // ./index.js
@@ -30,12 +31,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -72,26 +72,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (foo) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (foo)
+]);
 
 
 // ./foo.js
@@ -32,12 +33,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./index.js
 var index_namespaceObject = {};
 __webpack_require__.r(index_namespaceObject);
-__webpack_require__.d(index_namespaceObject, { 
-  foo: () => (foo),
-  ns: () => (index_namespaceObject) });
+__webpack_require__.d(index_namespaceObject, [
+  "foo", () => (foo),
+  "ns", () => (index_namespaceObject)
+]);
 
 
 // ./index.js
@@ -33,12 +34,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-export-namespace-as-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-export-namespace-as-capture/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (foo) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (foo)
+]);
 
 
 // ./foo.js
@@ -32,12 +33,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-export-star-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-export-star-as/__snapshots__/esm.snap.txt
@@ -3,15 +3,17 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./bar.js
 var bar_namespaceObject = {};
 __webpack_require__.r(bar_namespaceObject);
-__webpack_require__.d(bar_namespaceObject, { 
-  bar: () => (bar) });
+__webpack_require__.d(bar_namespaceObject, [
+  "bar", () => (bar)
+]);
 
 
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  barNs: () => (bar_namespaceObject) });
+__webpack_require__.d(foo_namespaceObject, [
+  "barNs", () => (bar_namespaceObject)
+]);
 
 
 // ./bar.js
@@ -42,12 +44,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-re-export-star-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-re-export-star-capture/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./bar.js
 var bar_namespaceObject = {};
 __webpack_require__.r(bar_namespaceObject);
-__webpack_require__.d(bar_namespaceObject, { 
-  foo: () => ((/* inlined export .foo */123)) });
+__webpack_require__.d(bar_namespaceObject, [
+  "foo", () => ((/* inlined export .foo */123))
+]);
 
 
 // ./bar.js
@@ -32,12 +33,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/missing-export-capture/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  x: () => (x) });
+__webpack_require__.d(foo_namespaceObject, [
+  "x", () => (x)
+]);
 
 
 // ./foo.js
@@ -30,12 +31,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/missing-export-cjs-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/missing-export-cjs-capture/__snapshots__/esm.snap.txt
@@ -70,26 +70,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/no-treeshake-object/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/no-treeshake-object/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./namespace.js
 var namespace_namespaceObject = {};
 __webpack_require__.r(namespace_namespaceObject);
-__webpack_require__.d(namespace_namespaceObject, { 
-  foo: () => (foo) });
+__webpack_require__.d(namespace_namespaceObject, [
+  "foo", () => (foo)
+]);
 
 
 // ./namespace.js
@@ -41,12 +42,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/optimization-in-operator/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/optimization-in-operator/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  c: () => (c) });
+__webpack_require__.d(foo_namespaceObject, [
+  "c", () => (c)
+]);
 
 
 // ./foo.js
@@ -46,12 +47,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/optional-chaining/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/optional-chaining/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./util.js
 var util_namespaceObject = {};
 __webpack_require__.r(util_namespaceObject);
-__webpack_require__.d(util_namespaceObject, { 
-  foo: () => (foo) });
+__webpack_require__.d(util_namespaceObject, [
+  "foo", () => (foo)
+]);
 
 
 // ./util.js
@@ -38,12 +39,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-named-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-named-missing-export-capture/__snapshots__/esm.snap.txt
@@ -8,8 +8,9 @@ __webpack_require__.r(bar_namespaceObject);
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (bar_namespaceObject.foo) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (bar_namespaceObject.foo)
+]);
 
 
 // ./bar.js
@@ -37,12 +38,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-namespace-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-namespace-missing-export-capture/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./bar.js
 var bar_namespaceObject = {};
 __webpack_require__.r(bar_namespaceObject);
-__webpack_require__.d(bar_namespaceObject, { 
-  x: () => (x) });
+__webpack_require__.d(bar_namespaceObject, [
+  "x", () => (x)
+]);
 
 
 // ./bar.js
@@ -30,12 +31,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (foo),
-  ns: () => (foo_namespaceObject) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (foo),
+  "ns", () => (foo_namespaceObject)
+]);
 
 
 // ./foo.js
@@ -33,12 +34,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-self-import-export-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-self-import-export-as-namespace/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (foo),
-  ns: () => (foo_namespaceObject) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (foo),
+  "ns", () => (foo_namespaceObject)
+]);
 
 
 // ./foo.js
@@ -36,12 +37,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-star-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-star-missing-export-capture/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  x: () => ((/* inlined export .x */123)) });
+__webpack_require__.d(foo_namespaceObject, [
+  "x", () => ((/* inlined export .x */123))
+]);
 
 
 // ./foo.js
@@ -30,12 +31,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-star/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-star/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo1: () => (foo1),
-  foo2: () => (foo2) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo1", () => (foo1),
+  "foo2", () => (foo2)
+]);
 
 
 // ./foo.js
@@ -40,12 +41,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/reexport-self-cycle/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/reexport-self-cycle/__snapshots__/esm.snap.txt
@@ -3,10 +3,11 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./other.js
 var other_namespaceObject = {};
 __webpack_require__.r(other_namespaceObject);
-__webpack_require__.d(other_namespaceObject, { 
-  bar: () => (bar),
-  foo: () => (foo),
-  other: () => (other_namespaceObject) });
+__webpack_require__.d(other_namespaceObject, [
+  "bar", () => (bar),
+  "foo", () => (foo),
+  "other", () => (other_namespaceObject)
+]);
 
 
 // ./other.js
@@ -39,12 +40,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/self-import-cycle/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/self-import-cycle/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./index.js
 var index_namespaceObject = {};
 __webpack_require__.r(index_namespaceObject);
-__webpack_require__.d(index_namespaceObject, { 
-  keys: () => (keys),
-  p: () => (p) });
+__webpack_require__.d(index_namespaceObject, [
+  "keys", () => (keys),
+  "p", () => (p)
+]);
 
 
 // ./index.js
@@ -35,12 +36,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/side-effect-free-modules-default-property/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/side-effect-free-modules-default-property/__snapshots__/esm.snap.txt
@@ -77,7 +77,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -85,12 +85,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
@@ -76,26 +76,36 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  foo: () => (foo) });
+__webpack_require__.d(foo_namespaceObject, [
+  "foo", () => (foo)
+]);
 
 
 // ./foo.js
@@ -32,12 +33,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/tostring-inlined-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/tostring-inlined-namespace/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  bar: () => (bar) });
+__webpack_require__.d(foo_namespaceObject, [
+  "bar", () => (bar)
+]);
 
 
 // ./foo.js
@@ -40,12 +41,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/namespace/tostring-static-resolution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/tostring-static-resolution/__snapshots__/esm.snap.txt
@@ -3,8 +3,9 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  bar: () => (bar) });
+__webpack_require__.d(foo_namespaceObject, [
+  "bar", () => (bar)
+]);
 
 
 // ./foo.js
@@ -32,12 +33,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
@@ -60,7 +60,7 @@ __webpack_require__.d(x, y);
 return x;
 };
 var __rspack_wrap_module_external_namespace_node_events_0a6aefe7 = (x) => (() => (x));
-module.exports = __rspack_create_module_external_namespace_node_events_0a6aefe7({["a"]: () => (__rspack_external_node_events_0a6aefe7.EventEmitter), ["b"]: () => (__rspack_external_node_events_0a6aefe7.once)});
+module.exports = __rspack_create_module_external_namespace_node_events_0a6aefe7(["a", () => (__rspack_external_node_events_0a6aefe7.EventEmitter), "b", () => (__rspack_external_node_events_0a6aefe7.once)]);
 
 },
 });
@@ -99,12 +99,17 @@ __webpack_require__.m = __webpack_modules__;
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_module_decorator
 (() => {
@@ -144,15 +149,16 @@ __webpack_require__.add({
   !*** ./src/wrapped.js ***!
   \************************/
 (module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (/* reexport safe */ node_events__rspack_import_0.a),
-  b: () => (/* reexport safe */ node_events__rspack_import_0.b)
-});
 /* import */ var node_events__rspack_import_0 = __webpack_require__(/*! node:events */ "node:events?df85");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
 console.log.bind(module);
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (/* reexport safe */ node_events__rspack_import_0.a),
+  "b", () => (/* reexport safe */ node_events__rspack_import_0.b)
+]);
 
 
 },

--- a/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/__snapshots__/esm.snap.txt
@@ -14,8 +14,9 @@ import { types_namespaceObject } from "./types.mjs";
 // NAMESPACE OBJECT: ./src/rules/duplicate-package/index.js
 var duplicate_package_namespaceObject = {};
 __webpack_require__.r(duplicate_package_namespaceObject);
-__webpack_require__.d(duplicate_package_namespaceObject, { 
-  value: () => (value) });
+__webpack_require__.d(duplicate_package_namespaceObject, [
+  "value", () => (value)
+]);
 
 
 // ./src/rules/duplicate-package/index.js
@@ -34,8 +35,9 @@ import { __webpack_require__ } from "../../runtime.mjs";
 // NAMESPACE OBJECT: ./src/rules/duplicate-package/types.js
 var types_namespaceObject = {};
 __webpack_require__.r(types_namespaceObject);
-__webpack_require__.d(types_namespaceObject, { 
-  J: () => (CheckVersionMap) });
+__webpack_require__.d(types_namespaceObject, [
+  "J", () => (CheckVersionMap)
+]);
 
 
 // ./src/rules/duplicate-package/types.js
@@ -54,12 +56,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/esm.snap.txt
@@ -90,12 +90,17 @@ __webpack_require__.m = __webpack_modules__;
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_module_decorator
 (() => {
@@ -135,15 +140,16 @@ __webpack_require__.add({
   !*** ./src/wrapped.js ***!
   \************************/
 (module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  E: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  Z: () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs?2159");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
 console.log.bind(module)
+
+__webpack_require__.d(__webpack_exports__, [
+  "E", () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  "Z", () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
+]);
 
 
 },

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/esm.snap.txt
@@ -100,7 +100,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -108,12 +108,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_module_decorator
 (() => {
@@ -153,16 +158,17 @@ __webpack_require__.add({
   !*** ./src/wrapped.js ***!
   \************************/
 (module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  E: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  Z: () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 /* import */ var fs__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(fs__rspack_import_0);
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
 console.log.bind(module)
+
+__webpack_require__.d(__webpack_exports__, [
+  "E", () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  "Z", () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
+]);
 
 
 },

--- a/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/esm.snap.txt
@@ -17,13 +17,14 @@ exports.bar = 2
   \****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  bar: () => (/* reexport safe */ _bar__rspack_import_0.bar),
-  foo: () => (foo)
-});
 /* import */ var _bar__rspack_import_0 = __webpack_require__(/*! ./bar */ "./bar.js");
 const foo = 1
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "bar", () => (/* reexport safe */ _bar__rspack_import_0.bar),
+  "foo", 0, foo
+]);
 
 
 },
@@ -81,12 +82,17 @@ __webpack_require__.m = __webpack_modules__;
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
@@ -5,13 +5,14 @@ import * as __rspack_external_fs from "fs";
 // NAMESPACE OBJECT: ./externals.js
 var externals_namespaceObject = {};
 __webpack_require__.r(externals_namespaceObject);
-__webpack_require__.d(externals_namespaceObject, { 
-  "default": () => (__rspack_external_fs["default"]),
-  readFile: () => (__rspack_external_fs.readFile) });
+__webpack_require__.d(externals_namespaceObject, [
+  "default", () => (__rspack_external_fs["default"]),
+  "readFile", () => (__rspack_external_fs.readFile)
+]);
 var externals_namespaceObject_starExports = __rspack_external_fs;
 Object.keys(externals_namespaceObject_starExports).forEach(function(key) {
   if (key !== "default" && key !== "__esModule") {
-    __webpack_require__.d(externals_namespaceObject, { [key]: function() { return externals_namespaceObject_starExports[key]; } });
+    __webpack_require__.d(externals_namespaceObject, [key, function() { return externals_namespaceObject_starExports[key]; }]);
   }
 });
 
@@ -53,12 +54,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
@@ -10,24 +10,25 @@ __webpack_require__.add({
   \****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  lib: () => (lib)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 
-/* reexport */ var __rspack_reexport = {};
-/* reexport */ for( const __rspack_import_key in fs__rspack_import_0) if(["default","lib"].indexOf(__rspack_import_key) < 0) __rspack_reexport[__rspack_import_key] =() => fs__rspack_import_0[__rspack_import_key]
+/* reexport */ var __rspack_reexport = [];
+/* reexport */ for( const __rspack_import_key in fs__rspack_import_0) if(["default","lib"].indexOf(__rspack_import_key) < 0) __rspack_reexport.push(__rspack_import_key, () => fs__rspack_import_0[__rspack_import_key]);
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
 /* import */ var _lib2__rspack_import_1 = __webpack_require__(/*! ./lib2 */ "./lib2.js");
 
-/* reexport */ var __rspack_reexport = {};
-/* reexport */ for( const __rspack_import_key in _lib2__rspack_import_1) if(["default","lib"].indexOf(__rspack_import_key) < 0) __rspack_reexport[__rspack_import_key] =() => _lib2__rspack_import_1[__rspack_import_key]
+/* reexport */ var __rspack_reexport = [];
+/* reexport */ for( const __rspack_import_key in _lib2__rspack_import_1) if(["default","lib"].indexOf(__rspack_import_key) < 0) __rspack_reexport.push(__rspack_import_key, () => _lib2__rspack_import_1[__rspack_import_key]);
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
 
 
 
 
 const lib = 42
+
+__webpack_require__.d(__webpack_exports__, [
+  "lib", 0, lib
+]);
 
 
 },
@@ -37,16 +38,10 @@ const lib = 42
   \*****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  fs: () => (/* reexport safe */ _lib3__rspack_import_1.fs),
-  lib2: () => (lib2),
-  lib3: () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */42)),
-  lib4: () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */24))
-});
 /* import */ var path__rspack_import_0 = __webpack_require__(/*! path */ "path");
 
-/* reexport */ var __rspack_reexport = {};
-/* reexport */ for( const __rspack_import_key in path__rspack_import_0) if(["default","lib2"].indexOf(__rspack_import_key) < 0) __rspack_reexport[__rspack_import_key] =() => path__rspack_import_0[__rspack_import_key]
+/* reexport */ var __rspack_reexport = [];
+/* reexport */ for( const __rspack_import_key in path__rspack_import_0) if(["default","lib2"].indexOf(__rspack_import_key) < 0) __rspack_reexport.push(__rspack_import_key, () => path__rspack_import_0[__rspack_import_key]);
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
 /* import */ var _lib3__rspack_import_1 = __webpack_require__(/*! ./lib3 */ "./lib3.js");
 
@@ -55,6 +50,13 @@ __webpack_require__.d(__webpack_exports__, {
 
 const lib2 = 42
 
+__webpack_require__.d(__webpack_exports__, [
+  "fs", () => (/* reexport safe */ _lib3__rspack_import_1.fs),
+  "lib2", 0, lib2,
+  "lib3", () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */42)),
+  "lib4", () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */24))
+]);
+
 
 },
 "./lib3.js"
@@ -62,9 +64,6 @@ const lib2 = 42
   !*** ./lib3.js ***!
   \*****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  fs: () => (/* reexport module object */ fs__rspack_import_0)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 const lib3 = 42
 
@@ -72,6 +71,10 @@ const lib_local = 24
 
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "fs", () => (/* reexport module object */ fs__rspack_import_0)
+]);
 
 
 },
@@ -151,12 +154,17 @@ __webpack_require__.m = __webpack_modules__;
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_register_module
 (() => {

--- a/tests/rspack-test/esmOutputCases/re-exports/default-namespace-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/default-namespace-external/__snapshots__/esm.snap.txt
@@ -5,9 +5,10 @@ import fs, * as __rspack_external_fs from "fs";
 // NAMESPACE OBJECT: ./file.js
 var file_namespaceObject = {};
 __webpack_require__.r(file_namespaceObject);
-__webpack_require__.d(file_namespaceObject, { 
-  fsNs: () => (__rspack_external_fs),
-  value: () => (value) });
+__webpack_require__.d(file_namespaceObject, [
+  "fsNs", () => (__rspack_external_fs),
+  "value", () => (value)
+]);
 
 
 // fs?42cb
@@ -37,12 +38,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/re-exports/default-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/default-re-export-external/__snapshots__/esm.snap.txt
@@ -5,9 +5,10 @@ import fs from "fs";
 // NAMESPACE OBJECT: ./file.js
 var file_namespaceObject = {};
 __webpack_require__.r(file_namespaceObject);
-__webpack_require__.d(file_namespaceObject, { 
-  fsDefault: () => (fs),
-  value: () => (value) });
+__webpack_require__.d(file_namespaceObject, [
+  "fsDefault", () => (fs),
+  "value", () => (value)
+]);
 
 
 // fs?42cb
@@ -37,12 +38,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/re-exports/string-export-star-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/string-export-star-as-namespace/__snapshots__/esm.snap.txt
@@ -3,9 +3,10 @@ import { __webpack_require__ } from "./runtime.mjs";
 // NAMESPACE OBJECT: ./foo.js
 var foo_namespaceObject = {};
 __webpack_require__.r(foo_namespaceObject);
-__webpack_require__.d(foo_namespaceObject, { 
-  named: () => (named),
-  "some import": () => (someImport) });
+__webpack_require__.d(foo_namespaceObject, [
+  "named", () => (named),
+  "some import", () => (someImport)
+]);
 
 
 // ./foo.js
@@ -37,12 +38,17 @@ var __webpack_require__ = {};
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/esm.snap.txt
@@ -9,17 +9,10 @@ __webpack_require__.add({
   \******************/
 (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  fs: () => (/* reexport safe */ fs__rspack_import_0["default"]),
-  named: () => (/* reexport safe */ (/* inlined export _lib__rspack_import_1 */42)),
-  r: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  readFile: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  starExports: () => (/* reexport safe */ (/* inlined export _lib2__rspack_import_2 */42))
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 
-/* reexport */ var __rspack_reexport = {};
-/* reexport */ for( const __rspack_import_key in fs__rspack_import_0) if(["r","named","default","fs","starExports","readFile"].indexOf(__rspack_import_key) < 0) __rspack_reexport[__rspack_import_key] =() => fs__rspack_import_0[__rspack_import_key]
+/* reexport */ var __rspack_reexport = [];
+/* reexport */ for( const __rspack_import_key in fs__rspack_import_0) if(["r","named","default","fs","starExports","readFile"].indexOf(__rspack_import_key) < 0) __rspack_reexport.push(__rspack_import_key, () => fs__rspack_import_0[__rspack_import_key]);
 /* reexport */ __webpack_require__.d(__webpack_exports__, __rspack_reexport);
 /* module decorator */ module = __webpack_require__.hmd(module);
 
@@ -44,6 +37,14 @@ it('should compile and import success', async () => {
 	expect(r).toBeDefined()
 	expect(readFile).toBeDefined()
 })
+
+__webpack_require__.d(__webpack_exports__, [
+  "fs", () => (/* reexport safe */ fs__rspack_import_0["default"]),
+  "named", () => (/* reexport safe */ (/* inlined export _lib__rspack_import_1 */42)),
+  "r", () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  "readFile", () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  "starExports", () => (/* reexport safe */ (/* inlined export _lib2__rspack_import_2 */42))
+]);
 
 
 },
@@ -99,12 +100,17 @@ __webpack_require__.m = __webpack_modules__;
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/esm_module_decorator
 (() => {

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
@@ -48,7 +48,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -56,12 +56,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
@@ -43,7 +43,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -51,12 +51,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
@@ -43,7 +43,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -51,12 +51,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
@@ -43,7 +43,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -51,12 +51,17 @@ __webpack_require__.n = (module) => {
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+	var i = 0;
+	while(i < definition.length) {
+		var key = definition[i++];
+		var binding = definition[i++];
+		var descriptor = binding === 0 ? { enumerable: true, value: definition[i++] } : { enumerable: true, get: binding };
+		if(!__webpack_require__.o(exports, key)) {
+			Object.defineProperty(exports, key, descriptor);
+		}
+	}
 };
+
 })();
 // webpack/runtime/has_own_property
 (() => {

--- a/tests/rspack-test/hotCases/asset/parser-and-generator-states/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/asset/parser-and-generator-states/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 2639
+- Update: main.LAST_HASH.hot-update.js, size: 2638
 
 ## Manifest
 
@@ -36,14 +36,13 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _logo_svg__rspack_import_0 = __webpack_require__("./logo.svg");
 
 
 /* export default */ const __rspack_default_export = ((typeof _logo_svg__rspack_import_0) + ' result');
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./logo.svg"(module) {

--- a/tests/rspack-test/hotCases/asset/parser-and-generator-states/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/asset/parser-and-generator-states/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 2638
+- Update: main.LAST_HASH.hot-update.js, size: 2639
 
 ## Manifest
 
@@ -36,13 +36,14 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _logo_svg__rspack_import_0 = __webpack_require__("./logo.svg");
 
 
 /* export default */ const __rspack_default_export = ((typeof _logo_svg__rspack_import_0) + ' result');
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./logo.svg"(module) {

--- a/tests/rspack-test/hotCases/child-compiler/issue-9706/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/child-compiler/issue-9706/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: test.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 550
+- Update: main.LAST_HASH.hot-update.js, size: 548
 
 ## Manifest
 
@@ -35,12 +35,13 @@
 self["rspackHotUpdate"]("main", {
 "./report-child-assets-loader.js!./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  assets: () => (assets),
-  "default": () => (__rspack_default_export)
-});
 const assets = ["test.js"];
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "assets", 0, assets,
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/child-compiler/issue-9706/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/child-compiler/issue-9706/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: test.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 548
+- Update: main.LAST_HASH.hot-update.js, size: 552
 
 ## Manifest
 
@@ -35,13 +35,12 @@
 self["rspackHotUpdate"]("main", {
 "./report-child-assets-loader.js!./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const assets = ["test.js"];
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
-  "assets", 0, assets,
+  "assets", () => (assets),
   "default", () => (__rspack_default_export)
 ]);
+const assets = ["test.js"];
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/chunk/accept-system-import-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunk/accept-system-import-webpackhot/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Bundle: chunk_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 273
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 272
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 276
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 275
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,10 +38,11 @@
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
@@ -65,10 +66,11 @@ var value = 2;
 self["rspackHotUpdate"]("chunk_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/chunk/accept-system-import-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunk/accept-system-import-webpackhot/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Bundle: chunk_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 276
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 275
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 275
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 274
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,11 +38,10 @@
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },
@@ -66,11 +65,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("chunk_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/chunk/accept-system-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunk/accept-system-import/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Bundle: chunk_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 273
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 272
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 276
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 275
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,10 +38,11 @@
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
@@ -65,10 +66,11 @@ var value = 2;
 self["rspackHotUpdate"]("chunk_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/chunk/accept-system-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunk/accept-system-import/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Bundle: chunk_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 276
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 275
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 275
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 274
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,11 +38,10 @@
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },
@@ -66,11 +65,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("chunk_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/chunk/ensure-chunk-change-to-promise-all/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunk/ensure-chunk-change-to-promise-all/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: file_js.chunk.CURRENT_HASH.js
 - Bundle: vendors-node_modules_vue_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 94
-- Update: file_js.LAST_HASH.hot-update.js, size: 380
-- Update: main.LAST_HASH.hot-update.js, size: 651
+- Update: file_js.LAST_HASH.hot-update.js, size: 383
+- Update: main.LAST_HASH.hot-update.js, size: 654
 
 ## Manifest
 
@@ -37,11 +37,12 @@
 self["rspackHotUpdate"]("file_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  Vue: () => (/* reexport safe */ vue__rspack_import_0.Vue)
-});
 /* import */ var vue__rspack_import_0 = __webpack_require__("./node_modules/vue.js");
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "Vue", () => (/* reexport safe */ vue__rspack_import_0.Vue)
+]);
 
 
 },
@@ -65,12 +66,13 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("main", {
 "./chunk.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  test: () => (test)
-});
 function test(count) {
   return Promise.all(/* import() */ [__webpack_require__.e("vendors-node_modules_vue_js"), __webpack_require__.e("file_js")]).then(__webpack_require__.bind(__webpack_require__, "./file.js")).then(({ React, Vue }) => count === 0 ? React : Vue)
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "test", () => (test)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/chunk/ensure-chunk-change-to-promise-all/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunk/ensure-chunk-change-to-promise-all/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: file_js.chunk.CURRENT_HASH.js
 - Bundle: vendors-node_modules_vue_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 94
-- Update: file_js.LAST_HASH.hot-update.js, size: 383
-- Update: main.LAST_HASH.hot-update.js, size: 654
+- Update: file_js.LAST_HASH.hot-update.js, size: 382
+- Update: main.LAST_HASH.hot-update.js, size: 653
 
 ## Manifest
 
@@ -37,12 +37,11 @@
 self["rspackHotUpdate"]("file_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var vue__rspack_import_0 = __webpack_require__("./node_modules/vue.js");
-
-
 __webpack_require__.d(__webpack_exports__, [
   "Vue", () => (/* reexport safe */ vue__rspack_import_0.Vue)
 ]);
+/* import */ var vue__rspack_import_0 = __webpack_require__("./node_modules/vue.js");
+
 
 
 },
@@ -66,13 +65,12 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("main", {
 "./chunk.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-function test(count) {
-  return Promise.all(/* import() */ [__webpack_require__.e("vendors-node_modules_vue_js"), __webpack_require__.e("file_js")]).then(__webpack_require__.bind(__webpack_require__, "./file.js")).then(({ React, Vue }) => count === 0 ? React : Vue)
-}
-
 __webpack_require__.d(__webpack_exports__, [
   "test", () => (test)
 ]);
+function test(count) {
+  return Promise.all(/* import() */ [__webpack_require__.e("vendors-node_modules_vue_js"), __webpack_require__.e("file_js")]).then(__webpack_require__.bind(__webpack_require__, "./file.js")).then(({ React, Vue }) => count === 0 ? React : Vue)
+}
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/dynamic-system-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/dynamic-system-import/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 52
-- Update: chunk1_js.LAST_HASH.hot-update.js, size: 276
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 276
+- Update: chunk1_js.LAST_HASH.hot-update.js, size: 275
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 275
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,11 +38,10 @@
 self["rspackHotUpdate"]("chunk1_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },
@@ -66,11 +65,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/dynamic-system-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/dynamic-system-import/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 52
-- Update: chunk1_js.LAST_HASH.hot-update.js, size: 273
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 273
+- Update: chunk1_js.LAST_HASH.hot-update.js, size: 276
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 276
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,10 +38,11 @@
 self["rspackHotUpdate"]("chunk1_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
@@ -65,10 +66,11 @@ var value = 2;
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/system-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/system-import/__snapshots__/web/1.snap.txt
@@ -9,8 +9,8 @@
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Bundle: chunk_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 490
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 489
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 496
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 495
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -40,19 +40,21 @@
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
 "./file2.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 4;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
@@ -77,19 +79,21 @@ var value = 4;
 self["rspackHotUpdate"]("chunk_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
 "./file2.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 4;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/system-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/system-import/__snapshots__/web/1.snap.txt
@@ -9,8 +9,8 @@
 - Bundle: chunk2_js.chunk.CURRENT_HASH.js
 - Bundle: chunk_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: chunk2_js.LAST_HASH.hot-update.js, size: 496
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 495
+- Update: chunk2_js.LAST_HASH.hot-update.js, size: 494
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 493
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -40,21 +40,19 @@
 self["rspackHotUpdate"]("chunk2_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },
 "./file2.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 4;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 4;
 
 
 },
@@ -79,21 +77,19 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("chunk_js", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },
 "./file2.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 4;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 4;
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
 - Update: main.LAST_HASH.hot-update.js, size: 571
 - Update: runtime~main.LAST_HASH.hot-update.js, size: 18983
-- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
+- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 375
 
 ## Manifest
 
@@ -737,10 +737,11 @@ chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind
 self["rspackHotUpdate"]("vendors-node_modules_vendor_js", {
 "./node_modules/vendor.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
 - Update: main.LAST_HASH.hot-update.js, size: 571
 - Update: runtime~main.LAST_HASH.hot-update.js, size: 18983
-- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 375
+- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
 
 ## Manifest
 
@@ -737,11 +737,10 @@ chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind
 self["rspackHotUpdate"]("vendors-node_modules_vendor_js", {
 "./node_modules/vendor.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/code-generation/this-in-accept-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/code-generation/this-in-accept-webpackhot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 471
+- Update: main.LAST_HASH.hot-update.js, size: 470
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("ok2");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 },

--- a/tests/rspack-test/hotCases/code-generation/this-in-accept-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/code-generation/this-in-accept-webpackhot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 470
+- Update: main.LAST_HASH.hot-update.js, size: 471
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("ok2");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/code-generation/this-in-accept/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/code-generation/this-in-accept/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 471
+- Update: main.LAST_HASH.hot-update.js, size: 470
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("ok2");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 },

--- a/tests/rspack-test/hotCases/code-generation/this-in-accept/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/code-generation/this-in-accept/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 470
+- Update: main.LAST_HASH.hot-update.js, size: 471
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("ok2");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/concat/reload-compat-flag/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-compat-flag/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 469
+- Update: 889.LAST_HASH.hot-update.js, size: 470
 
 ## Manifest
 
@@ -34,12 +34,13 @@
 self["rspackHotUpdate"](889, {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 
 
 /* export default */ const __rspack_default_export = ("ok2");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 458
+- Update: 889.LAST_HASH.hot-update.js, size: 459
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"](889, {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 459
+- Update: 889.LAST_HASH.hot-update.js, size: 460
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"](889, {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (20);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/conditional-runtime/accept-conditional/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/conditional-runtime/accept-conditional/__snapshots__/web/1.snap.txt
@@ -10,8 +10,8 @@
 - Bundle: shared.chunk.CURRENT_HASH.js
 - Manifest: [runtime of dep1_js-dep2_js-worker_js].LAST_HASH.hot-update.json, size: 49
 - Manifest: main.LAST_HASH.hot-update.json, size: 48
-- Update: dep1_js-dep2_js-worker_js.LAST_HASH.hot-update.js, size: 486
-- Update: dep1_js-module_js.LAST_HASH.hot-update.js, size: 347
+- Update: dep1_js-dep2_js-worker_js.LAST_HASH.hot-update.js, size: 487
+- Update: dep1_js-module_js.LAST_HASH.hot-update.js, size: 348
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -48,10 +48,11 @@
 self["rspackHotUpdate"]("dep1_js-dep2_js-worker_js", {
 "./dep1.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (43);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -82,10 +83,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("dep1_js-module_js", {
 "./dep1.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (43);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/conditional-runtime/accept-conditional/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/conditional-runtime/accept-conditional/__snapshots__/web/1.snap.txt
@@ -10,8 +10,8 @@
 - Bundle: shared.chunk.CURRENT_HASH.js
 - Manifest: [runtime of dep1_js-dep2_js-worker_js].LAST_HASH.hot-update.json, size: 49
 - Manifest: main.LAST_HASH.hot-update.json, size: 48
-- Update: dep1_js-dep2_js-worker_js.LAST_HASH.hot-update.js, size: 487
-- Update: dep1_js-module_js.LAST_HASH.hot-update.js, size: 348
+- Update: dep1_js-dep2_js-worker_js.LAST_HASH.hot-update.js, size: 486
+- Update: dep1_js-module_js.LAST_HASH.hot-update.js, size: 347
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -48,11 +48,10 @@
 self["rspackHotUpdate"]("dep1_js-dep2_js-worker_js", {
 "./dep1.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (43);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (43);
 
 
 },
@@ -83,11 +82,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("dep1_js-module_js", {
 "./dep1.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (43);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (43);
 
 
 },

--- a/tests/rspack-test/hotCases/context/request-position/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/context/request-position/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lib_a_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 87
-- Update: main.LAST_HASH.hot-update.js, size: 1240
+- Update: main.LAST_HASH.hot-update.js, size: 1244
 
 ## Manifest
 
@@ -36,15 +36,14 @@ self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "fn", () => (fn)
+]);
 const fn = async function () {
   const name = "a";
   const wrap = v => v;
   return wrap((await __webpack_require__("./lib lazy recursive ^\\.\\/.*\\.js$")(`./${name}.js`)));
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "fn", 0, fn
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/context/request-position/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/context/request-position/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lib_a_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 87
-- Update: main.LAST_HASH.hot-update.js, size: 1242
+- Update: main.LAST_HASH.hot-update.js, size: 1240
 
 ## Manifest
 
@@ -36,14 +36,15 @@ self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  fn: () => (fn)
-});
 const fn = async function () {
   const name = "a";
   const wrap = v => v;
   return wrap((await __webpack_require__("./lib lazy recursive ^\\.\\/.*\\.js$")(`./${name}.js`)));
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "fn", 0, fn
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/css/css-extract/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-extract/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 978
+- Update: main.LAST_HASH.hot-update.js, size: 980
 
 ## Manifest
 
@@ -35,24 +35,26 @@
 self["rspackHotUpdate"]("main", {
 "./entry.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _index_module_css__rspack_import_0 = __webpack_require__("./index.module.css");
 
 module.hot.accept();
 // modify
 /* export default */ const __rspack_default_export = (_index_module_css__rspack_import_0["default"]);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./index.module.css"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 // extracted by css-extract-rspack-plugin
 /* export default */ const __rspack_default_export = ({"bar":"gVlquue4Gts5AqVo"});
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 

--- a/tests/rspack-test/hotCases/css/css-extract/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-extract/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 980
+- Update: main.LAST_HASH.hot-update.js, size: 978
 
 ## Manifest
 
@@ -35,26 +35,24 @@
 self["rspackHotUpdate"]("main", {
 "./entry.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _index_module_css__rspack_import_0 = __webpack_require__("./index.module.css");
 
 module.hot.accept();
 // modify
 /* export default */ const __rspack_default_export = (_index_module_css__rspack_import_0["default"]);
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./index.module.css"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-// extracted by css-extract-rspack-plugin
-/* export default */ const __rspack_default_export = ({"bar":"gVlquue4Gts5AqVo"});
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+// extracted by css-extract-rspack-plugin
+/* export default */ const __rspack_default_export = ({"bar":"gVlquue4Gts5AqVo"});
 
 },
 

--- a/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 6127
+- Update: main.hot-update.js, size: 6126
 
 ## Manifest
 
@@ -63,6 +63,10 @@ __webpack_require__.r(__webpack_exports__);
 },
 "../../../../../../../../packages/rspack/dist/cssExtractHmr.js"(__unused_rspack___webpack_module__, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "cssReload", () => (cssReload),
+  "normalizeUrl", () => (normalizeUrl)
+]);
 function normalizeUrl(url) {
     let urlString = url.trim();
     if (/^data:/i.test(urlString)) return urlString;
@@ -162,11 +166,6 @@ function cssReload(moduleId, options) {
     };
 }
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "cssReload", () => (cssReload),
-  "normalizeUrl", () => (normalizeUrl)
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 6024
+- Update: main.hot-update.js, size: 6127
 
 ## Manifest
 
@@ -63,10 +63,6 @@ __webpack_require__.r(__webpack_exports__);
 },
 "../../../../../../../../packages/rspack/dist/cssExtractHmr.js"(__unused_rspack___webpack_module__, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  cssReload: () => (cssReload),
-  normalizeUrl: () => (normalizeUrl)
-});
 function normalizeUrl(url) {
     let urlString = url.trim();
     if (/^data:/i.test(urlString)) return urlString;
@@ -167,6 +163,11 @@ function cssReload(moduleId, options) {
 }
 
 
+__webpack_require__.d(__webpack_exports__, [
+  "cssReload", () => (cssReload),
+  "normalizeUrl", () => (normalizeUrl)
+]);
+
 
 },
 
@@ -174,14 +175,18 @@ function cssReload(moduleId, options) {
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, definition) {
+    var i = 0;
+    while(i < definition.length) {
+        var key = definition[i++];
+        var binding = definition[i++];
+        var descriptor = binding === 0 ? { configurable: true, enumerable: true, value: definition[i++] } : { configurable: true, enumerable: true, get: binding };
+        if (!__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, descriptor);
+        }
+    }
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/define/issue-6962/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/define/issue-6962/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 511
+- Update: main.LAST_HASH.hot-update.js, size: 510
 
 ## Manifest
 
@@ -34,12 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-if (module.hot.data && module.hot.data.crash) throw new Error();
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+if (module.hot.data && module.hot.data.crash) throw new Error();
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/define/issue-6962/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/define/issue-6962/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 510
+- Update: main.LAST_HASH.hot-update.js, size: 511
 
 ## Manifest
 
@@ -34,11 +34,12 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 if (module.hot.data && module.hot.data.crash) throw new Error();
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/determinism/issue-10174/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/determinism/issue-10174/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 463
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./hot.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/determinism/issue-10174/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/determinism/issue-10174/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 463
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./hot.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: [runtime of chunk2_js].LAST_HASH.hot-update.json, size: 60
 - Manifest: main.LAST_HASH.hot-update.json, size: 41
-- Update: main.LAST_HASH.hot-update.js, size: 18382
+- Update: main.LAST_HASH.hot-update.js, size: 18383
 
 ## Manifest
 
@@ -45,10 +45,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (42);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: [runtime of chunk2_js].LAST_HASH.hot-update.json, size: 60
 - Manifest: main.LAST_HASH.hot-update.json, size: 41
-- Update: main.LAST_HASH.hot-update.js, size: 18383
+- Update: main.LAST_HASH.hot-update.js, size: 18382
 
 ## Manifest
 
@@ -45,11 +45,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (42);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (42);
 
 
 },

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 52
-- Update: main.LAST_HASH.hot-update.js, size: 467
+- Update: main.LAST_HASH.hot-update.js, size: 468
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (42);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 52
-- Update: main.LAST_HASH.hot-update.js, size: 468
+- Update: main.LAST_HASH.hot-update.js, size: 467
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (42);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (42);
 
 
 },

--- a/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
-- Update: main.LAST_HASH.hot-update.js, size: 18383
+- Update: main.LAST_HASH.hot-update.js, size: 18382
 
 ## Manifest
 
@@ -29,11 +29,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (42);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (42);
 
 
 },

--- a/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
-- Update: main.LAST_HASH.hot-update.js, size: 18382
+- Update: main.LAST_HASH.hot-update.js, size: 18383
 
 ## Manifest
 
@@ -29,10 +29,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (42);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/decline-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/decline-webpackhot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/decline-webpackhot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/decline-webpackhot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/decline/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/decline/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/decline/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/decline/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/events/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/events/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 2276
+- Update: main.LAST_HASH.hot-update.js, size: 2283
 
 ## Manifest
 
@@ -46,67 +46,74 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./e.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./g.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./i.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
 throw new Error("Error while loading module i");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./j.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
 throw new Error("Error while loading module j");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./l.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
 throw new Error("Error while loading module l");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/events/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/events/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 2283
+- Update: main.LAST_HASH.hot-update.js, size: 2276
 
 ## Manifest
 
@@ -46,74 +46,67 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
 "./e.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
 "./g.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
 "./i.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-throw new Error("Error while loading module i");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
+throw new Error("Error while loading module i");
 
 
 },
 "./j.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-throw new Error("Error while loading module j");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
+throw new Error("Error while loading module j");
 
 
 },
 "./l.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-throw new Error("Error while loading module l");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
+throw new Error("Error while loading module l");
 
 
 },

--- a/tests/rspack-test/hotCases/errors/self-decline/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/self-decline/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/self-decline/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/self-decline/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/3.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 739
+- Update: main.LAST_HASH.hot-update.js, size: 741
 
 ## Manifest
 
@@ -36,19 +36,21 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted-ignored/__snapshots__/web/3.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 741
+- Update: main.LAST_HASH.hot-update.js, size: 739
 
 ## Manifest
 
@@ -36,21 +36,19 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/errors/unaccepted/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/errors/unaccepted/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 420
+- Update: main.LAST_HASH.hot-update.js, size: 419
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./node_modules/dep1/file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 417
+- Update: main.LAST_HASH.hot-update.js, size: 420
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./node_modules/dep1/file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/esm-dependency-import/module-hot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/esm-dependency-import/module-hot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 420
+- Update: main.LAST_HASH.hot-update.js, size: 419
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./node_modules/dep1/file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/esm-dependency-import/module-hot/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/esm-dependency-import/module-hot/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 417
+- Update: main.LAST_HASH.hot-update.js, size: 420
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./node_modules/dep1/file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/auto-import-multiple/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/auto-import-multiple/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 451
+- Update: main.LAST_HASH.hot-update.js, size: 454
 
 ## Manifest
 
@@ -41,10 +41,11 @@ module.exports = 20;
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/auto-import-multiple/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/auto-import-multiple/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 454
+- Update: main.LAST_HASH.hot-update.js, size: 453
 
 ## Manifest
 
@@ -41,11 +41,10 @@ module.exports = 20;
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/auto-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/auto-import/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 399
+- Update: main.LAST_HASH.hot-update.js, size: 402
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/auto-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/auto-import/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 402
+- Update: main.LAST_HASH.hot-update.js, size: 401
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/auto-reexport/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/auto-reexport/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 399
+- Update: main.LAST_HASH.hot-update.js, size: 403
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
-  "value", 0, value
+  "value", () => (value)
 ]);
+const value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/auto-reexport/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/auto-reexport/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 401
+- Update: main.LAST_HASH.hot-update.js, size: 399
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 const value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", 0, value
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/cjs-analyze-changed/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/cjs-analyze-changed/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 720
+- Update: main.LAST_HASH.hot-update.js, size: 719
 
 ## Manifest
 
@@ -41,14 +41,13 @@ exports["default"] = 1;
 "./reexport.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _file__rspack_import_0 = __webpack_require__("./file.js");
 
 /* export default */ const __rspack_default_export = (_file__rspack_import_0["default"]);
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/harmony/cjs-analyze-changed/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/harmony/cjs-analyze-changed/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 719
+- Update: main.LAST_HASH.hot-update.js, size: 720
 
 ## Manifest
 
@@ -41,13 +41,14 @@ exports["default"] = 1;
 "./reexport.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _file__rspack_import_0 = __webpack_require__("./file.js");
 
 /* export default */ const __rspack_default_export = (_file__rspack_import_0["default"]);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 463
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+/* export default */ const __rspack_default_export = (3);
 
 },
 

--- a/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/hash/hot-index/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 463
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 

--- a/tests/rspack-test/hotCases/hashing/exports-info-influence/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hashing/exports-info-influence/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1252
+- Update: main.LAST_HASH.hot-update.js, size: 1253
 
 ## Manifest
 
@@ -35,9 +35,6 @@
 self["rspackHotUpdate"]("main", {
 "./referencer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 /* import */ var _module__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_module__rspack_import_0);
 /* import */ var external__rspack_import_1 = __webpack_require__("external");
@@ -45,6 +42,10 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 /* export default */ const __rspack_default_export = (`${_module__rspack_import_0.test} ${external__rspack_import_1.test}`);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -57,7 +58,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 

--- a/tests/rspack-test/hotCases/hashing/exports-info-influence/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hashing/exports-info-influence/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1253
+- Update: main.LAST_HASH.hot-update.js, size: 1252
 
 ## Manifest
 
@@ -35,6 +35,9 @@
 self["rspackHotUpdate"]("main", {
 "./referencer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 /* import */ var _module__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_module__rspack_import_0);
 /* import */ var external__rspack_import_1 = __webpack_require__("external");
@@ -42,10 +45,6 @@ __webpack_require__.r(__webpack_exports__);
 
 
 /* export default */ const __rspack_default_export = (`${_module__rspack_import_0.test} ${external__rspack_import_1.test}`);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/hashing/full-hash-main/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hashing/full-hash-main/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: thing_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: thing_js.LAST_HASH.hot-update.js, size: 339
+- Update: thing_js.LAST_HASH.hot-update.js, size: 338
 
 ## Manifest
 
@@ -59,11 +59,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("thing_js", {
 "./thing.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/hashing/full-hash-main/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hashing/full-hash-main/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: thing_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: thing_js.LAST_HASH.hot-update.js, size: 338
+- Update: thing_js.LAST_HASH.hot-update.js, size: 339
 
 ## Manifest
 
@@ -59,10 +59,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("thing_js", {
 "./thing.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: modules_demo_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 69
-- Update: main.LAST_HASH.hot-update.js, size: 470
+- Update: main.LAST_HASH.hot-update.js, size: 471
 - Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1042
 
 ## Manifest
@@ -38,10 +38,11 @@
 self["rspackHotUpdate"]("main", {
 "./generation.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: modules_demo_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 69
-- Update: main.LAST_HASH.hot-update.js, size: 471
+- Update: main.LAST_HASH.hot-update.js, size: 470
 - Update: modules_demo_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1042
 
 ## Manifest
@@ -38,11 +38,10 @@
 self["rspackHotUpdate"]("main", {
 "./generation.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: modules_module_js.chunk.CURRENT_HASH.js
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 71
-- Update: main.LAST_HASH.hot-update.js, size: 471
+- Update: main.LAST_HASH.hot-update.js, size: 470
 - Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1054
 
 ## Manifest
@@ -39,11 +39,10 @@
 self["rspackHotUpdate"]("main", {
 "./generation.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/context/__snapshots__/web/2.snap.txt
@@ -10,7 +10,7 @@
 - Bundle: modules_module_js.chunk.CURRENT_HASH.js
 - Bundle: modules_module_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 71
-- Update: main.LAST_HASH.hot-update.js, size: 470
+- Update: main.LAST_HASH.hot-update.js, size: 471
 - Update: modules_module_js_lazy-compilation-proxy.LAST_HASH.hot-update.js, size: 1054
 
 ## Manifest
@@ -39,10 +39,11 @@
 self["rspackHotUpdate"]("main", {
 "./generation.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lazy_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 468
+- Update: main.LAST_HASH.hot-update.js, size: 467
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (43);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (43);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lazy_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 467
+- Update: main.LAST_HASH.hot-update.js, size: 468
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (43);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lazy_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 467
+- Update: main.LAST_HASH.hot-update.js, size: 468
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (44);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/lazy-compilation/unrelated/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: lazy_js_lazy-compilation-proxy.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 468
+- Update: main.LAST_HASH.hot-update.js, size: 467
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (44);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (44);
 
 
 },

--- a/tests/rspack-test/hotCases/loader/import-module-1/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/loader/import-module-1/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 474
+- Update: main.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/loader/import-module-1/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/loader/import-module-1/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 473
+- Update: main.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 549
+- Update: main.LAST_HASH.hot-update.js, size: 550
 
 ## Manifest
 
@@ -34,12 +34,13 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _cycle2_a__rspack_import_0 = __webpack_require__("./cycle2/a.js");
 
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 550
+- Update: main.LAST_HASH.hot-update.js, size: 549
 
 ## Manifest
 
@@ -34,13 +34,12 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _cycle2_a__rspack_import_0 = __webpack_require__("./cycle2/a.js");
-
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _cycle2_a__rspack_import_0 = __webpack_require__("./cycle2/a.js");
+
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 545
+- Update: main.LAST_HASH.hot-update.js, size: 546
 
 ## Manifest
 
@@ -34,12 +34,13 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _common__rspack_import_0 = __webpack_require__("./common.js");
 
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 546
+- Update: main.LAST_HASH.hot-update.js, size: 545
 
 ## Manifest
 
@@ -34,13 +34,12 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _common__rspack_import_0 = __webpack_require__("./common.js");
-
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _common__rspack_import_0 = __webpack_require__("./common.js");
+
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 189
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-cycle/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 189
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-module/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 45
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 463
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("a");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("a");
 
 
 },

--- a/tests/rspack-test/hotCases/make/clean-isolated-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/clean-isolated-module/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 45
-- Update: main.LAST_HASH.hot-update.js, size: 463
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("a");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/fix-issuer/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/fix-issuer/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 56
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/fix-issuer/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/fix-issuer/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 56
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 63
-- Update: main.LAST_HASH.hot-update.js, size: 470
+- Update: main.LAST_HASH.hot-update.js, size: 469
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("file");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("file");
 
 
 },

--- a/tests/rspack-test/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/make/issue-10915/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 63
-- Update: main.LAST_HASH.hot-update.js, size: 469
+- Update: main.LAST_HASH.hot-update.js, size: 470
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("file");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 758
+- Update: main.LAST_HASH.hot-update.js, size: 756
 
 ## Manifest
 
@@ -35,21 +35,19 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("a");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("a");
 
 
 },

--- a/tests/rspack-test/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/make/rebuild-abnormal-module/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 756
+- Update: main.LAST_HASH.hot-update.js, size: 758
 
 ## Manifest
 
@@ -35,19 +35,21 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("a");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/module/build-info/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/module/build-info/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 474
+- Update: main.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/module/build-info/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/module/build-info/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 473
+- Update: main.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/newTreeshaking/auto-reexport/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/newTreeshaking/auto-reexport/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 399
+- Update: main.LAST_HASH.hot-update.js, size: 403
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
-  "value", 0, value
+  "value", () => (value)
 ]);
+const value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/newTreeshaking/auto-reexport/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/newTreeshaking/auto-reexport/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 401
+- Update: main.LAST_HASH.hot-update.js, size: 399
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 const value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", 0, value
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/newTreeshaking/re-export-optimization/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/newTreeshaking/re-export-optimization/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 986
+- Update: main.LAST_HASH.hot-update.js, size: 984
 
 ## Manifest
 
@@ -35,24 +35,22 @@
 self["rspackHotUpdate"]("main", {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ('bar');
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ('bar');
 
 
 },
 "./entry.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _reexport__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _reexport__rspack_import_1 = __webpack_require__("./bar.js");
 
 /* export default */ const __rspack_default_export = (_reexport__rspack_import_0["default"] + _reexport__rspack_import_1["default"]);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/newTreeshaking/re-export-optimization/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/newTreeshaking/re-export-optimization/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 984
+- Update: main.LAST_HASH.hot-update.js, size: 986
 
 ## Manifest
 
@@ -35,22 +35,24 @@
 self["rspackHotUpdate"]("main", {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ('bar');
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./entry.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _reexport__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _reexport__rspack_import_1 = __webpack_require__("./bar.js");
 
 /* export default */ const __rspack_default_export = (_reexport__rspack_import_0["default"] + _reexport__rspack_import_1["default"]);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: 10.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: 1e1.LAST_HASH.hot-update.js, size: 269
-- Update: main.LAST_HASH.hot-update.js, size: 583
+- Update: 1e1.LAST_HASH.hot-update.js, size: 272
+- Update: main.LAST_HASH.hot-update.js, size: 584
 
 ## Manifest
 
@@ -37,10 +37,11 @@
 self["rspackHotUpdate"]("1e1", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 1.5;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
@@ -64,10 +65,11 @@ var value = 1.5;
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (() => __webpack_require__.e(/* import() | 10 */ 10).then(__webpack_require__.bind(__webpack_require__, "./chunk2.js")));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/1.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: 10.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 51
-- Update: 1e1.LAST_HASH.hot-update.js, size: 272
-- Update: main.LAST_HASH.hot-update.js, size: 584
+- Update: 1e1.LAST_HASH.hot-update.js, size: 271
+- Update: main.LAST_HASH.hot-update.js, size: 583
 
 ## Manifest
 
@@ -37,11 +37,10 @@
 self["rspackHotUpdate"]("1e1", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 1.5;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 1.5;
 
 
 },
@@ -65,11 +64,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (() => __webpack_require__.e(/* import() | 10 */ 10).then(__webpack_require__.bind(__webpack_require__, "./chunk2.js")));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (() => __webpack_require__.e(/* import() | 10 */ 10).then(__webpack_require__.bind(__webpack_require__, "./chunk2.js")));
 
 
 },

--- a/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/2.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: 1e1.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 46
-- Update: 10.LAST_HASH.hot-update.js, size: 267
-- Update: main.LAST_HASH.hot-update.js, size: 587
+- Update: 10.LAST_HASH.hot-update.js, size: 266
+- Update: main.LAST_HASH.hot-update.js, size: 586
 
 ## Manifest
 
@@ -37,11 +37,10 @@
 self["rspackHotUpdate"](10, {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 3;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 3;
 
 
 },
@@ -65,11 +64,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (() => __webpack_require__.e(/* import() | 1e1 */ "1e1").then(__webpack_require__.bind(__webpack_require__, "./chunk.js")));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (() => __webpack_require__.e(/* import() | 1e1 */ "1e1").then(__webpack_require__.bind(__webpack_require__, "./chunk.js")));
 
 
 },

--- a/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/add-remove-chunks/__snapshots__/web/2.snap.txt
@@ -8,8 +8,8 @@
 - Bundle: 1e1.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 46
-- Update: 10.LAST_HASH.hot-update.js, size: 264
-- Update: main.LAST_HASH.hot-update.js, size: 586
+- Update: 10.LAST_HASH.hot-update.js, size: 267
+- Update: main.LAST_HASH.hot-update.js, size: 587
 
 ## Manifest
 
@@ -37,10 +37,11 @@
 self["rspackHotUpdate"](10, {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },
@@ -64,10 +65,11 @@ var value = 3;
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (() => __webpack_require__.e(/* import() | 1e1 */ "1e1").then(__webpack_require__.bind(__webpack_require__, "./chunk.js")));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/numeric-ids/production/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/production/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 396
+- Update: 889.LAST_HASH.hot-update.js, size: 399
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"](889, {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/parsing/hot-api-optional-chaining/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/parsing/hot-api-optional-chaining/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/parsing/hot-api-optional-chaining/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/parsing/hot-api-optional-chaining/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/plugins/html/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/plugins/html/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 398
+- Update: main.LAST_HASH.hot-update.js, size: 402
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const value = 1;
 __webpack_require__.d(__webpack_exports__, [
-  "value", 0, value
+  "value", () => (value)
 ]);
-
+const value = 1;
 
 },
 

--- a/tests/rspack-test/hotCases/plugins/html/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/plugins/html/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 400
+- Update: main.LAST_HASH.hot-update.js, size: 398
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 const value = 1;
+__webpack_require__.d(__webpack_exports__, [
+  "value", 0, value
+]);
+
 
 },
 

--- a/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 489
+- Update: main.LAST_HASH.hot-update.js, size: 488
 
 ## Manifest
 
@@ -34,12 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-throw new Error("Failed");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
+throw new Error("Failed");
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 488
+- Update: main.LAST_HASH.hot-update.js, size: 489
 
 ## Manifest
 
@@ -34,11 +34,12 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
 throw new Error("Failed");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 461
+- Update: main.LAST_HASH.hot-update.js, size: 462
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 462
+- Update: main.LAST_HASH.hot-update.js, size: 461
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 912
+- Update: main.LAST_HASH.hot-update.js, size: 1011
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -47,14 +48,18 @@ __webpack_require__.d(__webpack_exports__, {
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, definition) {
+    var i = 0;
+    while(i < definition.length) {
+        var key = definition[i++];
+        var binding = definition[i++];
+        var descriptor = binding === 0 ? { configurable: true, enumerable: true, value: definition[i++] } : { configurable: true, enumerable: true, get: binding };
+        if (!__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, descriptor);
+        }
+    }
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1011
+- Update: main.LAST_HASH.hot-update.js, size: 1010
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./loader.js!./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 999
+- Update: main.LAST_HASH.hot-update.js, size: 998
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 900
+- Update: main.LAST_HASH.hot-update.js, size: 999
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -47,14 +48,18 @@ __webpack_require__.d(__webpack_exports__, {
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, definition) {
+    var i = 0;
+    while(i < definition.length) {
+        var key = definition[i++];
+        var binding = definition[i++];
+        var descriptor = binding === 0 ? { configurable: true, enumerable: true, value: definition[i++] } : { configurable: true, enumerable: true, get: binding };
+        if (!__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, descriptor);
+        }
+    }
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 40
-- Update: main.LAST_HASH.hot-update.js, size: 471
+- Update: main.LAST_HASH.hot-update.js, size: 470
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("ok2");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("ok2");
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 40
-- Update: main.LAST_HASH.hot-update.js, size: 470
+- Update: main.LAST_HASH.hot-update.js, size: 471
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("ok2");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 882
+- Update: main.LAST_HASH.hot-update.js, size: 884
 
 ## Manifest
 
@@ -35,24 +35,26 @@
 self["rspackHotUpdate"]("main", {
 "./inner.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 module.hot.accept();
 
 /* export default */ const __rspack_default_export = ("-inner");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _inner__rspack_import_0 = __webpack_require__("./inner.js");
 
 
 /* export default */ const __rspack_default_export = ("ok3" + _inner__rspack_import_0["default"]);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-removal-self-accepted/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 884
+- Update: main.LAST_HASH.hot-update.js, size: 882
 
 ## Manifest
 
@@ -35,26 +35,24 @@
 self["rspackHotUpdate"]("main", {
 "./inner.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-module.hot.accept();
-
-/* export default */ const __rspack_default_export = ("-inner");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+module.hot.accept();
+
+/* export default */ const __rspack_default_export = ("-inner");
 
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _inner__rspack_import_0 = __webpack_require__("./inner.js");
 
 
 /* export default */ const __rspack_default_export = ("ok3" + _inner__rspack_import_0["default"]);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 722
+- Update: main.LAST_HASH.hot-update.js, size: 717
 
 ## Manifest
 
@@ -34,17 +34,18 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  getError: () => (getError),
-  id: () => (id)
-});
 module.hot.data.store.error = false;
 module.hot.data.store.value = 2;
 /* export default */ const __rspack_default_export = (() => { throw new Error("should not happen") });
 const getError = () => { throw new Error("should not happen") };
 const id = module.id;
 throw new Error("Failed");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "getError", 0, getError,
+  "id", 0, id
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 717
+- Update: main.LAST_HASH.hot-update.js, size: 726
 
 ## Manifest
 
@@ -34,18 +34,17 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "getError", () => (getError),
+  "id", () => (id)
+]);
 module.hot.data.store.error = false;
 module.hot.data.store.value = 2;
 /* export default */ const __rspack_default_export = (() => { throw new Error("should not happen") });
 const getError = () => { throw new Error("should not happen") };
 const id = module.id;
 throw new Error("Failed");
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "getError", 0, getError,
-  "id", 0, id
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1134
+- Update: main.LAST_HASH.hot-update.js, size: 1227
 
 ## Manifest
 
@@ -35,16 +35,17 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  getError: () => (getError),
-  id: () => (id)
-});
 module.hot.data.store.error = false;
 module.hot.data.store.value = 4;
 /* export default */ const __rspack_default_export = (() => { throw new Error("should not happen") });
 const getError = () => { throw new Error("should not happen") };
 const id = module.id;
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "getError", 0, getError,
+  "id", 0, id
+]);
 
 
 },
@@ -53,14 +54,18 @@ const id = module.id;
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, definition) {
+    var i = 0;
+    while(i < definition.length) {
+        var key = definition[i++];
+        var binding = definition[i++];
+        var descriptor = binding === 0 ? { configurable: true, enumerable: true, value: definition[i++] } : { configurable: true, enumerable: true, get: binding };
+        if (!__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, descriptor);
+        }
+    }
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1227
+- Update: main.LAST_HASH.hot-update.js, size: 1236
 
 ## Manifest
 
@@ -35,17 +35,16 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "getError", () => (getError),
+  "id", () => (id)
+]);
 module.hot.data.store.error = false;
 module.hot.data.store.value = 4;
 /* export default */ const __rspack_default_export = (() => { throw new Error("should not happen") });
 const getError = () => { throw new Error("should not happen") };
 const id = module.id;
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "getError", 0, getError,
-  "id", 0, id
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/circular/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/circular/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 884
+- Update: main.LAST_HASH.hot-update.js, size: 885
 
 ## Manifest
 
@@ -36,9 +36,9 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var ___rspack_import_0 = __webpack_require__("./index.js");
 /* import */ var _b__rspack_import_1 = __webpack_require__("./b.js");
 
@@ -49,10 +49,11 @@ __webpack_require__.d(__webpack_exports__, {
 },
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/circular/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/circular/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 885
+- Update: main.LAST_HASH.hot-update.js, size: 884
 
 ## Manifest
 
@@ -49,11 +49,10 @@ __webpack_require__.d(__webpack_exports__, [
 },
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: b_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 572
+- Update: main.LAST_HASH.hot-update.js, size: 571
 
 ## Manifest
 
@@ -37,11 +37,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() */ "b_js").then(__webpack_require__.bind(__webpack_require__, "./b.js")));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() */ "b_js").then(__webpack_require__.bind(__webpack_require__, "./b.js")));
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: b_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 571
+- Update: main.LAST_HASH.hot-update.js, size: 572
 
 ## Manifest
 
@@ -37,10 +37,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() */ "b_js").then(__webpack_require__.bind(__webpack_require__, "./b.js")));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: b_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 35
-- Update: b_js.LAST_HASH.hot-update.js, size: 342
+- Update: b_js.LAST_HASH.hot-update.js, size: 341
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,11 +38,10 @@
 self["rspackHotUpdate"]("b_js", {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("version b2");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("version b2");
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: b_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 35
-- Update: b_js.LAST_HASH.hot-update.js, size: 341
+- Update: b_js.LAST_HASH.hot-update.js, size: 342
 - Update: main.LAST_HASH.hot-update.js, size: 181
 
 ## Manifest
@@ -38,10 +38,11 @@
 self["rspackHotUpdate"]("b_js", {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("version b2");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/3.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: a_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 572
+- Update: main.LAST_HASH.hot-update.js, size: 571
 
 ## Manifest
 
@@ -37,11 +37,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() */ "a_js").then(__webpack_require__.bind(__webpack_require__, "./a.js")));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() */ "a_js").then(__webpack_require__.bind(__webpack_require__, "./a.js")));
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-chunk/__snapshots__/web/3.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: a_js.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 571
+- Update: main.LAST_HASH.hot-update.js, size: 572
 
 ## Manifest
 
@@ -37,10 +37,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() */ "a_js").then(__webpack_require__.bind(__webpack_require__, "./a.js")));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 662
+- Update: main.LAST_HASH.hot-update.js, size: 663
 
 ## Manifest
 
@@ -36,10 +36,11 @@
 self["rspackHotUpdate"]("main", {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 663
+- Update: main.LAST_HASH.hot-update.js, size: 662
 
 ## Manifest
 
@@ -36,11 +36,10 @@
 self["rspackHotUpdate"]("main", {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+/* export default */ const __rspack_default_export = (1);
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 774
+- Update: main.LAST_HASH.hot-update.js, size: 776
 
 ## Manifest
 
@@ -36,18 +36,20 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (module.id);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* reexport safe */ _a__rspack_import_0["default"])
-});
 /* import */ var _a__rspack_import_0 = __webpack_require__("./a.js");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* reexport safe */ _a__rspack_import_0["default"])
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/dispose-removed-module/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 776
+- Update: main.LAST_HASH.hot-update.js, size: 774
 
 ## Manifest
 
@@ -36,20 +36,18 @@
 self["rspackHotUpdate"]("main", {
 "./a.js"(module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (module.id);
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+/* export default */ const __rspack_default_export = (module.id);
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _a__rspack_import_0 = __webpack_require__("./a.js");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (/* reexport safe */ _a__rspack_import_0["default"])
 ]);
+/* import */ var _a__rspack_import_0 = __webpack_require__("./a.js");
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/hmr-circular/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/hmr-circular/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 45
-- Update: main.LAST_HASH.hot-update.js, size: 479
+- Update: main.LAST_HASH.hot-update.js, size: 478
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./entry.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("new_entry.js");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("new_entry.js");
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/hmr-circular/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/hmr-circular/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 45
-- Update: main.LAST_HASH.hot-update.js, size: 478
+- Update: main.LAST_HASH.hot-update.js, size: 479
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./entry.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("new_entry.js");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/import-after-download/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/import-after-download/__snapshots__/web/1.snap.txt
@@ -9,8 +9,8 @@
 - Bundle: chunk_js.CURRENT_HASH.js
 - Bundle: unaffected-chunk_js.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 339
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 340
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -38,10 +38,11 @@
 self["rspackHotUpdate"]("chunk_js", {
 "./inner.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (20);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -65,10 +66,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/import-after-download/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/import-after-download/__snapshots__/web/1.snap.txt
@@ -9,8 +9,8 @@
 - Bundle: chunk_js.CURRENT_HASH.js
 - Bundle: unaffected-chunk_js.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
-- Update: chunk_js.LAST_HASH.hot-update.js, size: 340
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: chunk_js.LAST_HASH.hot-update.js, size: 339
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -38,11 +38,10 @@
 self["rspackHotUpdate"]("chunk_js", {
 "./inner.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (20);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (20);
 
 
 },
@@ -66,11 +65,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/replace-runtime-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/replace-runtime-module/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: b.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
-- Update: main.LAST_HASH.hot-update.js, size: 572
+- Update: main.LAST_HASH.hot-update.js, size: 573
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() | b */ "b").then(__webpack_require__.bind(__webpack_require__, "./b.js")));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/replace-runtime-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/replace-runtime-module/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: b.chunk.CURRENT_HASH.js
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 39
-- Update: main.LAST_HASH.hot-update.js, size: 573
+- Update: main.LAST_HASH.hot-update.js, size: 572
 
 ## Manifest
 
@@ -35,11 +35,10 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() | b */ "b").then(__webpack_require__.bind(__webpack_require__, "./b.js")));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (__webpack_require__.e(/* import() | b */ "b").then(__webpack_require__.bind(__webpack_require__, "./b.js")));
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/require-disposed-module-warning/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/require-disposed-module-warning/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 592
+- Update: main.LAST_HASH.hot-update.js, size: 593
 
 ## Manifest
 
@@ -35,10 +35,11 @@ self["rspackHotUpdate"]("main", {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("b");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/runtime/require-disposed-module-warning/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/require-disposed-module-warning/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 36
-- Update: main.LAST_HASH.hot-update.js, size: 593
+- Update: main.LAST_HASH.hot-update.js, size: 592
 
 ## Manifest
 
@@ -35,11 +35,10 @@ self["rspackHotUpdate"]("main", {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("b");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("b");
 
 
 },

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42334
+- Update: main.LAST_HASH.hot-update.js, size: 42476
 
 ## Manifest
 
@@ -39,15 +39,16 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
-  getValue: () => (getValue)
-});
 /* import */ var common__rspack_import_0 = __webpack_require__("webpack/sharing/consume/default/common/./common?1");
 /* import */ var common__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(common__rspack_import_0);
 
 
 const getValue = () => __webpack_require__.e(/* import() */ "webpack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "webpack/sharing/consume/default/common2/./common?2", 23));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
+  "getValue", 0, getValue
+]);
 
 
 },
@@ -60,7 +61,7 @@ __webpack_require__.n = (module) => {
 	var getter = module && module.__esModule ?
 		() => (module['default']) :
 		() => (module);
-	__webpack_require__.d(getter, { a: getter });
+	__webpack_require__.d(getter, ["a", getter]);
 	return getter;
 };
 
@@ -83,16 +84,21 @@ __webpack_require__.t = function(value, mode) {
 		if((mode & 16) && typeof value.then === 'function') return value;
 	}
 	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
+	__webpack_require__.r(ns);
+	var def = [], defLoc = -1;
 	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
 	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+		Object.getOwnPropertyNames(current).forEach((key) => {
+			def.push(key, () => (value[key]));
+			if(defLoc === -1 && key === 'default') defLoc = def.length - 1;
+		});
 	}
-	def['default'] = () => (value);
+	if(defLoc >= 0) def.splice(defLoc, 1, 0, value);
+	else def.push('default', 0, value);
 	__webpack_require__.d(ns, def);
 	return ns;
 };
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42476
+- Update: main.LAST_HASH.hot-update.js, size: 42480
 
 ## Manifest
 
@@ -39,16 +39,15 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
+  "getValue", () => (getValue)
+]);
 /* import */ var common__rspack_import_0 = __webpack_require__("webpack/sharing/consume/default/common/./common?1");
 /* import */ var common__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(common__rspack_import_0);
 
 
 const getValue = () => __webpack_require__.e(/* import() */ "webpack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "webpack/sharing/consume/default/common2/./common?2", 23));
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
-  "getValue", 0, getValue
-]);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 465
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 465
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 463
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+/* export default */ const __rspack_default_export = (3);
 
 },
 

--- a/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/disable/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 463
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 519
+- Update: main.LAST_HASH.hot-update.js, size: 518
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 518
+- Update: main.LAST_HASH.hot-update.js, size: 519
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 519
+- Update: main.LAST_HASH.hot-update.js, size: 518
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 518
+- Update: main.LAST_HASH.hot-update.js, size: 519
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 517
+- Update: main.LAST_HASH.hot-update.js, size: 518
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 

--- a/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/source-map/enable/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 518
+- Update: main.LAST_HASH.hot-update.js, size: 517
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+/* export default */ const __rspack_default_export = (3);
 
 },
 

--- a/tests/rspack-test/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 463
+- Update: main.LAST_HASH.hot-update.js, size: 464
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 

--- a/tests/rspack-test/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 464
+- Update: main.LAST_HASH.hot-update.js, size: 463
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
-
+/* export default */ const __rspack_default_export = (2);
 
 },
 

--- a/tests/rspack-test/hotCases/status/check/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/status/check/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 399
+- Update: main.LAST_HASH.hot-update.js, size: 402
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 var value = 2;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/status/check/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/status/check/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 402
+- Update: main.LAST_HASH.hot-update.js, size: 401
 
 ## Manifest
 
@@ -34,11 +34,10 @@
 self["rspackHotUpdate"]("main", {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-var value = 2;
-
 __webpack_require__.d(__webpack_exports__, [
   "value", () => (value)
 ]);
+var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/unexpected-invalidation/used-exports/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/unexpected-invalidation/used-exports/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 517
+- Update: main.LAST_HASH.hot-update.js, size: 518
 
 ## Manifest
 
@@ -34,11 +34,12 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* reexport safe */ _subject__rspack_import_0.def)
-});
 /* import */ var _subject__rspack_import_0 = __webpack_require__("./subject.js");
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* reexport safe */ _subject__rspack_import_0.def)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/unexpected-invalidation/used-exports/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/unexpected-invalidation/used-exports/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 518
+- Update: main.LAST_HASH.hot-update.js, size: 517
 
 ## Manifest
 
@@ -34,12 +34,11 @@
 self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _subject__rspack_import_0 = __webpack_require__("./subject.js");
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (/* reexport safe */ _subject__rspack_import_0.def)
 ]);
+/* import */ var _subject__rspack_import_0 = __webpack_require__("./subject.js");
+
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/1.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/1.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/2.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/2.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/3.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/3.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/4.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/4.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/5.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/5.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/6.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/6.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/6.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/6.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/7.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/7.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/7.snap.txt
+++ b/tests/rspack-test/hotCases/worker/issue-5597/__snapshots__/web/7.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/1.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 999
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 844
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 1002
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 846
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -86,30 +86,33 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
 /* export default */ const __rspack_default_export = (1);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleS.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("moduleS");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -134,21 +137,23 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("module");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 /* export default */ const __rspack_default_export = (1);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -179,10 +184,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/1.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 1002
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 846
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 999
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 844
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -86,33 +86,30 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
-/* export default */ const __rspack_default_export = (1);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
+/* export default */ const __rspack_default_export = (1);
+
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },
 "./moduleS.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("moduleS");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("moduleS");
 
 
 },
@@ -137,23 +134,21 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("module");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("module");
 
 
 },
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
-/* export default */ const __rspack_default_export = (1);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
+/* export default */ const __rspack_default_export = (1);
+
 
 
 },
@@ -184,11 +179,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/2.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 792
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 555
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 846
+- Update: shared.LAST_HASH.hot-update.js, size: 790
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 554
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 844
 
 ## Manifest
 
@@ -85,25 +85,23 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
-/* export default */ const __rspack_default_export = (2);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
+/* export default */ const __rspack_default_export = (2);
+
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
-/* export default */ const __rspack_default_export = (2);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
+/* export default */ const __rspack_default_export = (2);
+
 
 
 },
@@ -127,13 +125,12 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
-/* export default */ const __rspack_default_export = (2);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
+/* export default */ const __rspack_default_export = (2);
+
 
 
 },
@@ -165,23 +162,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = ("module");
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = ("module");
 
 
 },
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
-/* export default */ const __rspack_default_export = (2);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
+/* export default */ const __rspack_default_export = (2);
+
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/2.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 790
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 554
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 844
+- Update: shared.LAST_HASH.hot-update.js, size: 792
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 555
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 846
 
 ## Manifest
 
@@ -85,23 +85,25 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
 /* export default */ const __rspack_default_export = (2);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
 /* export default */ const __rspack_default_export = (2);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -125,12 +127,13 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 /* export default */ const __rspack_default_export = (2);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -162,21 +165,23 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = ("module");
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 /* export default */ const __rspack_default_export = (2);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/3.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 707
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 554
+- Update: shared.LAST_HASH.hot-update.js, size: 709
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 555
 
 ## Manifest
 
@@ -85,21 +85,23 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
 /* export default */ const __rspack_default_export = (3);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -123,10 +125,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -157,12 +160,13 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 /* export default */ const __rspack_default_export = (3);
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/3.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 709
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 555
+- Update: shared.LAST_HASH.hot-update.js, size: 707
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 554
 
 ## Manifest
 
@@ -85,23 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
-/* export default */ const __rspack_default_export = (3);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _moduleS__rspack_import_0 = __webpack_require__("./moduleS.js");
+/* export default */ const __rspack_default_export = (3);
+
 
 
 },
@@ -125,11 +123,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },
@@ -160,13 +157,12 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
-/* export default */ const __rspack_default_export = (3);
-
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
+/* export default */ const __rspack_default_export = (3);
+
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/4.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 71
 - Manifest: main.LAST_HASH.hot-update.json, size: 56
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 765
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 612
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 767
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 613
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -87,20 +87,22 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -124,11 +126,12 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -159,10 +162,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (4);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/4.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/4.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 71
 - Manifest: main.LAST_HASH.hot-update.json, size: 56
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 767
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 613
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 765
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 612
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -87,22 +87,20 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },
@@ -126,12 +124,11 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
 
 
 },
@@ -162,11 +159,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (4);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (4);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/5.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 908
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 613
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 613
+- Update: shared.LAST_HASH.hot-update.js, size: 906
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 612
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 612
 
 ## Manifest
 
@@ -87,23 +87,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
 
 
 },
@@ -127,12 +125,11 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
 
 
 },
@@ -163,12 +160,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (5);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (5);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/5.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/5.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 906
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 612
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 612
+- Update: shared.LAST_HASH.hot-update.js, size: 908
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 613
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 613
 
 ## Manifest
 
@@ -87,21 +87,23 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -125,11 +127,12 @@ if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -160,11 +163,12 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (5);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/6.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/6.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 765
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 612
+- Update: shared.LAST_HASH.hot-update.js, size: 767
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 613
 
 ## Manifest
 
@@ -87,20 +87,22 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -124,10 +126,11 @@ if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -158,11 +161,12 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (6);
 if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/6.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/6.snap.txt
@@ -17,9 +17,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 43
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 767
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 613
+- Update: shared.LAST_HASH.hot-update.js, size: 765
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 612
 
 ## Manifest
 
@@ -87,22 +87,20 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunkS_js").then(__webpack_require__.bind(__webpack_require__, "./chunkS.js"));
 
 
 },
@@ -126,11 +124,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
 
 
 },
@@ -161,12 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (6);
-if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (6);
+if (Math.random() < 0) __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/7.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/7.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 91
 - Manifest: main.LAST_HASH.hot-update.json, size: 54
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 624
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
+- Update: shared.LAST_HASH.hot-update.js, size: 626
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
 
 ## Manifest
 
@@ -85,19 +85,21 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -121,10 +123,11 @@ __webpack_require__.d(__webpack_exports__, {
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -155,10 +158,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (7);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/7.snap.txt
+++ b/tests/rspack-test/hotCases/worker/move-between-runtime/__snapshots__/web/7.snap.txt
@@ -15,9 +15,9 @@
 - Manifest: [runtime of workerB_js].LAST_HASH.hot-update.json, size: 91
 - Manifest: main.LAST_HASH.hot-update.json, size: 54
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: shared.LAST_HASH.hot-update.js, size: 626
-- Update: workerA_js.LAST_HASH.hot-update.js, size: 474
-- Update: workerB_js.LAST_HASH.hot-update.js, size: 474
+- Update: shared.LAST_HASH.hot-update.js, size: 624
+- Update: workerA_js.LAST_HASH.hot-update.js, size: 473
+- Update: workerB_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -85,21 +85,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("shared", {
 "./moduleAs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },
 "./moduleBs.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },
@@ -123,11 +121,10 @@ __webpack_require__.d(__webpack_exports__, [
 self["rspackHotUpdate"]("workerA_js", {
 "./moduleA.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },
@@ -158,11 +155,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("workerB_js", {
 "./moduleB.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (7);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (7);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: worker_js.LAST_HASH.hot-update.js, size: 472
+- Update: worker_js.LAST_HASH.hot-update.js, size: 471
 
 ## Manifest
 
@@ -68,11 +68,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("worker_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (2);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: worker_js.LAST_HASH.hot-update.js, size: 471
+- Update: worker_js.LAST_HASH.hot-update.js, size: 472
 
 ## Manifest
 
@@ -68,10 +68,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("worker_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (2);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: worker_js.LAST_HASH.hot-update.js, size: 471
+- Update: worker_js.LAST_HASH.hot-update.js, size: 472
 
 ## Manifest
 
@@ -68,10 +68,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("worker_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (3);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/2.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: worker_js.LAST_HASH.hot-update.js, size: 472
+- Update: worker_js.LAST_HASH.hot-update.js, size: 471
 
 ## Manifest
 
@@ -68,11 +68,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("worker_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (3);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (3);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/3.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: worker_js.LAST_HASH.hot-update.js, size: 473
+- Update: worker_js.LAST_HASH.hot-update.js, size: 472
 
 ## Manifest
 
@@ -68,11 +68,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("worker_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* export default */ const __rspack_default_export = (42);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (42);
 
 
 },

--- a/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/worker/update-in-worker/__snapshots__/web/3.snap.txt
@@ -9,7 +9,7 @@
 - Manifest: [runtime of worker_js].LAST_HASH.hot-update.json, size: 33
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 181
-- Update: worker_js.LAST_HASH.hot-update.js, size: 472
+- Update: worker_js.LAST_HASH.hot-update.js, size: 473
 
 ## Manifest
 
@@ -68,10 +68,11 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 self["rspackHotUpdate"]("worker_js", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (42);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/normalCases/parsing/harmony-duplicate-export/index.js
+++ b/tests/rspack-test/normalCases/parsing/harmony-duplicate-export/index.js
@@ -21,7 +21,8 @@ it("should not overwrite when using star export (known exports)", function () {
 	expect(x4).toBe("b");
 	expect(x5).toBe("c");
 	expect(x6).toBe("a");
-	expect(x7).toBe("b"); // Looks wrong, but is irrelevant as this is an error anyway
+	// Different from webpack, but is irrelevant as this is an error anyway
+	expect(x7).toBe("d");
 });
 
 it("should not overwrite when using star export (unknown exports)", function () {
@@ -31,5 +32,6 @@ it("should not overwrite when using star export (unknown exports)", function () 
 	expect(y4).toBe("b");
 	expect(y5).toBe("c");
 	expect(y6).toBe("a");
-	expect(y7).toBe("b"); // Looks wrong, but is irrelevant as this is an error anyway
+	// Different from webpack, but is irrelevant as this is an error anyway
+	expect(y7).toBe("d");
 });

--- a/tests/rspack-test/normalCases/parsing/harmony-duplicate-export/index.js
+++ b/tests/rspack-test/normalCases/parsing/harmony-duplicate-export/index.js
@@ -22,7 +22,7 @@ it("should not overwrite when using star export (known exports)", function () {
 	expect(x5).toBe("c");
 	expect(x6).toBe("a");
 	// Different from webpack, but is irrelevant as this is an error anyway
-	expect(x7).toBe("d");
+	expect(x7).toBeOneOf(["b", "d"]);
 });
 
 it("should not overwrite when using star export (unknown exports)", function () {
@@ -33,5 +33,5 @@ it("should not overwrite when using star export (unknown exports)", function () 
 	expect(y5).toBe("c");
 	expect(y6).toBe("a");
 	// Different from webpack, but is irrelevant as this is an error anyway
-	expect(y7).toBe("d");
+	expect(y7).toBeOneOf(["b", "d"]);
 });

--- a/tests/rspack-test/statsAPICases/additional-chunks.js
+++ b/tests/rspack-test/statsAPICases/additional-chunks.js
@@ -61,10 +61,10 @@ module.exports = {
 			      assets: Array [
 			        Object {
 			          name: entryB.js,
-			          size: 3169,
+			          size: 3304,
 			        },
 			      ],
-			      assetsSize: 3169,
+			      assetsSize: 3304,
 			      auxiliaryAssets: undefined,
 			      auxiliaryAssetsSize: undefined,
 			      childAssets: undefined,

--- a/tests/rspack-test/statsAPICases/assets.js
+++ b/tests/rspack-test/statsAPICases/assets.js
@@ -39,7 +39,7 @@ module.exports = {
 			        related: Object {},
 			      },
 			      name: entryB.js,
-			      size: 3169,
+			      size: 3304,
 			      type: asset,
 			    },
 			    Object {

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -59,7 +59,7 @@ module.exports = {
 			      isOverSizeLimit: false,
 			      name: main.js,
 			      related: Array [],
-			      size: 403,
+			      size: 465,
 			      type: asset,
 			    },
 			  ],
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: ab4d81bf47aea773,
+			      hash: 0e8ab4a78b10ca98,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -437,7 +437,7 @@ module.exports = {
 			      size: 192,
 			      sizes: Object {
 			        javascript: 192,
-			        runtime: 647,
+			        runtime: 744,
 			      },
 			      type: chunk,
 			    },
@@ -447,10 +447,10 @@ module.exports = {
 			      assets: Array [
 			        Object {
 			          name: main.js,
-			          size: 403,
+			          size: 465,
 			        },
 			      ],
-			      assetsSize: 403,
+			      assetsSize: 465,
 			      auxiliaryAssets: Array [],
 			      auxiliaryAssetsSize: 0,
 			      childAssets: Object {},
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 48be6dd9fe1e1073,
+			  hash: d6a30233ad6155ac,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -1106,9 +1106,9 @@ module.exports = {
 			      preOrderIndex: undefined,
 			      providedExports: Array [],
 			      reasons: Array [],
-			      size: 285,
+			      size: 382,
 			      sizes: Object {
-			        runtime: 285,
+			        runtime: 382,
 			      },
 			      type: module,
 			      usedExports: null,
@@ -1204,10 +1204,10 @@ module.exports = {
 			      assets: Array [
 			        Object {
 			          name: main.js,
-			          size: 403,
+			          size: 465,
 			        },
 			      ],
-			      assetsSize: 403,
+			      assetsSize: 465,
 			      auxiliaryAssets: Array [],
 			      auxiliaryAssetsSize: 0,
 			      childAssets: Object {},
@@ -1235,9 +1235,9 @@ module.exports = {
 			builtAt: false,
 			version: false
 		})).toMatchInlineSnapshot(`
-			asset main.js 403 bytes [emitted] (name: main)
+			asset main.js 465 bytes [emitted] (name: main)
 			orphan modules 192 bytes [orphan] 4 modules
-			runtime modules 647 bytes 3 modules
+			runtime modules 744 bytes 3 modules
 			./fixtures/esm/abc.js + 3 modules 192 bytes [code generated]
 			  [no exports]
 			  [no exports used]

--- a/tests/rspack-test/statsAPICases/nested-modules.js
+++ b/tests/rspack-test/statsAPICases/nested-modules.js
@@ -29,9 +29,9 @@ module.exports = {
 		expect(concatedModule).toBeTruthy();
 		expect(stats?.toString(statsOptions))
 			.toMatchInlineSnapshot(`
-				asset main.js 403 bytes [emitted] (name: main)
+				asset main.js 465 bytes [emitted] (name: main)
 				orphan modules 192 bytes [orphan] 4 modules
-				runtime modules 647 bytes 3 modules
+				runtime modules 744 bytes 3 modules
 				./fixtures/esm/abc.js + 3 modules 192 bytes [code generated]
 				  | orphan modules 192 bytes [orphan] 4 modules
 				Rspack compiled successfully

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 99bbf509c54b9cc6.js xx KiB [emitted] [immutable] (name: main)
+asset 1b083f8ac9875f46.js xx KiB [emitted] [immutable] (name: main)
 asset 7b129503d319bd23.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -6,11 +6,11 @@ runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset b-runtime~main-5ee5a9d8cad7385e.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset b-runtime~main-7ad7278e37795dde.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset b-main-8680a888f1bf9eb6.js xx bytes [emitted] [immutable] (name: main)
 asset b-all-b_js-9176ed8ced1de96c.js xx bytes [emitted] [immutable] (id hint: all)
 asset b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-5ee5a9d8cad7385e.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-9176ed8ced1de96c.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
+Entrypoint main xx KiB = b-runtime~main-7ad7278e37795dde.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-9176ed8ced1de96c.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -20,10 +20,10 @@ Rspack x.x.x compiled successfully in X s
 assets by chunk xx bytes (id hint: all)
   asset c-all-b_js-0f2306cb10798728.js xx bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-a87e28008385c9d2.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-093938981140c5ac.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-a87e28008385c9d2.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+Entrypoint main xx KiB = c-runtime~main-093938981140c5ac.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/side-effects-optimization/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/side-effects-optimization/__snapshots__/stats.txt
@@ -1,5 +1,5 @@
 asset main.js xx KiB [emitted] (name: main)
-runtime modules xx bytes 4 modules
+runtime modules xx KiB 4 modules
 cacheable modules xx KiB
   modules by path ./node_modules/big-module/*.js xx bytes
     ./node_modules/big-module/index.js xx bytes [built] [code generated]
@@ -29,7 +29,7 @@ cacheable modules xx KiB
 Rspack x.x.x compiled successfully in X s
 
 asset main.no-side.js xx KiB [emitted] (name: main)
-runtime modules xx bytes 4 modules
+runtime modules xx KiB 4 modules
 cacheable modules xx KiB
   modules by path ./node_modules/big-module/*.js xx bytes
     ./node_modules/big-module/index.js xx bytes [built] [code generated]

--- a/tests/rspack-test/treeShakingCases/array-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/array-side-effects/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,16 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  app: () => (app)
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
 function app() {}
 
 app.prototype.result = _lib__rspack_import_0.result;
+
+__webpack_require__.d(__webpack_exports__, [
+  "app", () => (app)
+]);
 
 
 },
@@ -22,12 +23,13 @@ app.prototype.result = _lib__rspack_import_0.result;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (result)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
+
+__webpack_require__.d(__webpack_exports__, [
+  "result", 0, result
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/array-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/array-side-effects/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "app", () => (app)
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
 function app() {}
 
 app.prototype.result = _lib__rspack_import_0.result;
-
-__webpack_require__.d(__webpack_exports__, [
-  "app", () => (app)
-]);
 
 
 },
@@ -23,13 +22,12 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "result", () => (result)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
-
-__webpack_require__.d(__webpack_exports__, [
-  "result", 0, result
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/assign-with-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/assign-with-side-effects/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,16 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  app: () => (app)
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
 function app() {}
 
 app.prototype.result = _lib__rspack_import_0.result;
+
+__webpack_require__.d(__webpack_exports__, [
+  "app", () => (app)
+]);
 
 
 },
@@ -22,12 +23,13 @@ app.prototype.result = _lib__rspack_import_0.result;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (result)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
+
+__webpack_require__.d(__webpack_exports__, [
+  "result", 0, result
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/assign-with-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/assign-with-side-effects/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "app", () => (app)
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
 function app() {}
 
 app.prototype.result = _lib__rspack_import_0.result;
-
-__webpack_require__.d(__webpack_exports__, [
-  "app", () => (app)
-]);
 
 
 },
@@ -23,13 +22,12 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "result", () => (result)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
-
-__webpack_require__.d(__webpack_exports__, [
-  "result", 0, result
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/basic/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/basic/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const answer = 103330;
-
 __webpack_require__.d(__webpack_exports__, [
-  "answer", 0, answer
+  "answer", () => (answer)
 ]);
+const answer = 103330;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/basic/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/basic/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  answer: () => (answer)
-});
 const answer = 103330;
+
+__webpack_require__.d(__webpack_exports__, [
+  "answer", 0, answer
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/bb/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/bb/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const ccc = 30;
-
 __webpack_require__.d(__webpack_exports__, [
-  "ccc", 0, ccc
+  "ccc", () => (ccc)
 ]);
+const ccc = 30;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/bb/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/bb/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  ccc: () => (ccc)
-});
 const ccc = 30;
+
+__webpack_require__.d(__webpack_exports__, [
+  "ccc", 0, ccc
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./antd/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "locales", () => (locales)
+]);
 /* import */ var _locale_zh__rspack_import_0 = __webpack_require__("./locale_zh.js");
 
 const locales = {
@@ -9,10 +12,6 @@ const locales = {
 };
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "locales", 0, locales
-]);
 
 
 },
@@ -26,14 +25,13 @@ function test() {}
 
 },
 "./locale_zh.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _zh_locale__rspack_import_0 = __webpack_require__("./zh_locale.js");
 
 
 /* export default */ const __rspack_default_export = (_zh_locale__rspack_import_0["default"]);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./antd/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  locales: () => (locales)
-});
 /* import */ var _locale_zh__rspack_import_0 = __webpack_require__("./locale_zh.js");
 
 const locales = {
@@ -12,6 +9,10 @@ const locales = {
 };
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "locales", 0, locales
+]);
 
 
 },
@@ -25,13 +26,14 @@ function test() {}
 
 },
 "./locale_zh.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _zh_locale__rspack_import_0 = __webpack_require__("./zh_locale.js");
 
 
 /* export default */ const __rspack_default_export = (_zh_locale__rspack_import_0["default"]);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/cjs-tree-shaking-basic/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cjs-tree-shaking-basic/__snapshots__/treeshaking.snap.txt
@@ -3,12 +3,11 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "answer", () => (answer)
+]);
 
 const answer = 42;
-
-__webpack_require__.d(__webpack_exports__, [
-  "answer", 0, answer
-]);
 
 
 },
@@ -21,11 +20,10 @@ __webpack_require__("./answer.js");
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const myanswer = "anyser";
-
 __webpack_require__.d(__webpack_exports__, [
-  "myanswer", 0, myanswer
+  "myanswer", () => (myanswer)
 ]);
+const myanswer = "anyser";
 
 
 },

--- a/tests/rspack-test/treeShakingCases/cjs-tree-shaking-basic/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cjs-tree-shaking-basic/__snapshots__/treeshaking.snap.txt
@@ -3,11 +3,12 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  answer: () => (answer)
-});
 
 const answer = 42;
+
+__webpack_require__.d(__webpack_exports__, [
+  "answer", 0, answer
+]);
 
 
 },
@@ -20,10 +21,11 @@ __webpack_require__("./answer.js");
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  myanswer: () => (myanswer)
-});
 const myanswer = "anyser";
+
+__webpack_require__.d(__webpack_exports__, [
+  "myanswer", 0, myanswer
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/class-extend/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/class-extend/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  v: () => (v)
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
@@ -15,6 +12,10 @@ function foo() {
 }
 
 const v = _lib__rspack_import_0.value;
+
+__webpack_require__.d(__webpack_exports__, [
+  "v", 0, v
+]);
 
 
 },
@@ -27,12 +28,13 @@ _app__rspack_import_0.v;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 class Lib {}
 
 const value = 1;
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", 0, value
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/class-extend/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/class-extend/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "v", () => (v)
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
@@ -12,10 +15,6 @@ function foo() {
 }
 
 const v = _lib__rspack_import_0.value;
-
-__webpack_require__.d(__webpack_exports__, [
-  "v", 0, v
-]);
 
 
 },
@@ -28,13 +27,12 @@ _app__rspack_import_0.v;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "value", () => (value)
+]);
 class Lib {}
 
 const value = 1;
-
-__webpack_require__.d(__webpack_exports__, [
-  "value", 0, value
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
@@ -3,22 +3,20 @@
 "./child/child/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-const value = "dynamic";
-
 __webpack_require__.d(__webpack_exports__, [
-  "value", 0, value
+  "value", () => (value)
 ]);
+const value = "dynamic";
 
 
 },
 "./child/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-const value = "dynamic";
-
 __webpack_require__.d(__webpack_exports__, [
-  "value", 0, value
+  "value", () => (value)
 ]);
+const value = "dynamic";
 
 
 },

--- a/tests/rspack-test/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/context-module/__snapshots__/treeshaking.snap.txt
@@ -3,20 +3,22 @@
 "./child/child/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 const value = "dynamic";
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", 0, value
+]);
 
 
 },
 "./child/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  value: () => (value)
-});
 const value = "dynamic";
+
+__webpack_require__.d(__webpack_exports__, [
+  "value", 0, value
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./src/App.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _containers__rspack_import_0 = __webpack_require__("./src/containers/containers.js");
 
 const { PlatformProvider } = _containers__rspack_import_0;
@@ -16,12 +13,16 @@ const Index = () => {
 
 /* export default */ const __rspack_default_export = (Index);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./src/containers/containers.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  PlatformProvider: () => (/* reexport safe */ _platform_container__rspack_import_0.PlatformProvider)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "PlatformProvider", () => (/* reexport safe */ _platform_container__rspack_import_0.PlatformProvider)
+]);
 /* import */ var _platform_container__rspack_import_0 = __webpack_require__("./src/containers/platform-container/index.js");
 
 
@@ -30,11 +31,12 @@ __webpack_require__.d(__webpack_exports__, {
 
 },
 "./src/containers/platform-container/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  PlatformProvider: () => (PlatformProvider)
-});
 const usePlatform = 3;
 const PlatformProvider = 1000;
+
+__webpack_require__.d(__webpack_exports__, [
+  "PlatformProvider", 0, PlatformProvider
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cyclic-reference-export-all/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./src/App.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _containers__rspack_import_0 = __webpack_require__("./src/containers/containers.js");
 
 const { PlatformProvider } = _containers__rspack_import_0;
@@ -12,10 +15,6 @@ const Index = () => {
 };
 
 /* export default */ const __rspack_default_export = (Index);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },
@@ -31,12 +30,11 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./src/containers/platform-container/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "PlatformProvider", () => (PlatformProvider)
+]);
 const usePlatform = 3;
 const PlatformProvider = 1000;
-
-__webpack_require__.d(__webpack_exports__, [
-  "PlatformProvider", 0, PlatformProvider
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/default_export/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/default_export/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,19 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "answer", () => (answer)
+]);
 const answer = 103330;
 // export default answer;
-
-__webpack_require__.d(__webpack_exports__, [
-  "answer", 0, answer
-]);
 
 
 },
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (result),
+  "render", () => (render)
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
@@ -24,11 +27,6 @@ function render() {
 
 function result() {}
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (result),
-  "render", () => (render)
-]);
-
 
 },
 "./index.js"(__unused_rspack_module, __unused_rspack___webpack_exports__, __webpack_require__) {
@@ -40,16 +38,15 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "myanswer", () => (myanswer),
+  "secret", () => (secret)
+]);
 /* import */ var _answer__rspack_import_0 = __webpack_require__("./answer.js");
 
 const secret = "888";
 const myanswer = _answer__rspack_import_0.answer,
 	result = 20000;
-
-__webpack_require__.d(__webpack_exports__, [
-  "myanswer", 0, myanswer,
-  "secret", 0, secret
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/default_export/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/default_export/__snapshots__/treeshaking.snap.txt
@@ -2,19 +2,16 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  answer: () => (answer)
-});
 const answer = 103330;
 // export default answer;
+
+__webpack_require__.d(__webpack_exports__, [
+  "answer", 0, answer
+]);
 
 
 },
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (result),
-  render: () => (render)
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
@@ -27,6 +24,11 @@ function render() {
 
 function result() {}
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (result),
+  "render", () => (render)
+]);
+
 
 },
 "./index.js"(__unused_rspack_module, __unused_rspack___webpack_exports__, __webpack_require__) {
@@ -38,15 +40,16 @@ function result() {}
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  myanswer: () => (myanswer),
-  secret: () => (secret)
-});
 /* import */ var _answer__rspack_import_0 = __webpack_require__("./answer.js");
 
 const secret = "888";
 const myanswer = _answer__rspack_import_0.answer,
 	result = 20000;
+
+__webpack_require__.d(__webpack_exports__, [
+  "myanswer", 0, myanswer,
+  "secret", 0, secret
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_1/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_1/__snapshots__/treeshaking.snap.txt
@@ -7,13 +7,12 @@ const a = "bar";
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 /* import */ var _bar__rspack_import_0 = __webpack_require__("./bar.js");
 const a = "foo";
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_1/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_1/__snapshots__/treeshaking.snap.txt
@@ -7,12 +7,13 @@ const a = "bar";
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 /* import */ var _bar__rspack_import_0 = __webpack_require__("./bar.js");
 const a = "foo";
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_2/__snapshots__/treeshaking.snap.txt
@@ -7,21 +7,23 @@ const a = "bar";
 
 },
 "./baz.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = "baz";
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (/* reexport safe */ _baz__rspack_import_0.a)
-});
 /* import */ var _baz__rspack_import_0 = __webpack_require__("./baz.js");
 /* import */ var _bar__rspack_import_1 = __webpack_require__("./bar.js");
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (/* reexport safe */ _baz__rspack_import_0.a)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/explicit_named_export_higher_priority_2/__snapshots__/treeshaking.snap.txt
@@ -7,23 +7,21 @@ const a = "bar";
 
 },
 "./baz.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const a = "baz";
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = "baz";
 
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (/* reexport safe */ _baz__rspack_import_0.a)
+]);
 /* import */ var _baz__rspack_import_0 = __webpack_require__("./baz.js");
 /* import */ var _bar__rspack_import_1 = __webpack_require__("./bar.js");
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", () => (/* reexport safe */ _baz__rspack_import_0.a)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export-imported-import-all-as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-imported-import-all-as/__snapshots__/treeshaking.snap.txt
@@ -10,11 +10,10 @@ _answer__rspack_import_0;
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const result = "";
-
 __webpack_require__.d(__webpack_exports__, [
-  "result", 0, result
+  "result", () => (result)
 ]);
+const result = "";
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export-imported-import-all-as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-imported-import-all-as/__snapshots__/treeshaking.snap.txt
@@ -10,10 +10,11 @@ _answer__rspack_import_0;
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (result)
-});
 const result = "";
+
+__webpack_require__.d(__webpack_exports__, [
+  "result", 0, result
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export-named-decl-as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-named-decl-as/__snapshots__/treeshaking.snap.txt
@@ -3,13 +3,12 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./src/answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _plugin_formatNumber__rspack_import_0 = __webpack_require__("./src/plugin/formatNumber.js");
-
-
-
 __webpack_require__.d(__webpack_exports__, [
   "formatNumber", () => (/* reexport safe */ _plugin_formatNumber__rspack_import_0["default"])
 ]);
+/* import */ var _plugin_formatNumber__rspack_import_0 = __webpack_require__("./src/plugin/formatNumber.js");
+
+
 
 
 },
@@ -21,16 +20,15 @@ console.log(_answer__rspack_import_0);
 
 },
 "./src/plugin/formatNumber.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (formatNumber_default)
+]);
 function formatNumber(config) {}
 const plugin = cls => {
 	cls.prototype.formatNumber = formatNumber;
 };
 var formatNumber_default = plugin;
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (formatNumber_default)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export-named-decl-as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-named-decl-as/__snapshots__/treeshaking.snap.txt
@@ -3,12 +3,13 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./src/answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  formatNumber: () => (/* reexport safe */ _plugin_formatNumber__rspack_import_0["default"])
-});
 /* import */ var _plugin_formatNumber__rspack_import_0 = __webpack_require__("./src/plugin/formatNumber.js");
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "formatNumber", () => (/* reexport safe */ _plugin_formatNumber__rspack_import_0["default"])
+]);
 
 
 },
@@ -20,15 +21,16 @@ console.log(_answer__rspack_import_0);
 
 },
 "./src/plugin/formatNumber.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (formatNumber_default)
-});
 function formatNumber(config) {}
 const plugin = cls => {
 	cls.prototype.formatNumber = formatNumber;
 };
 var formatNumber_default = plugin;
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (formatNumber_default)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export-star-chain/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-star-chain/__snapshots__/treeshaking.snap.txt
@@ -2,35 +2,37 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./colors/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const red = "red";
-
 __webpack_require__.d(__webpack_exports__, [
-  "red", 0, red
+  "red", () => (red)
 ]);
+const red = "red";
 
 
 },
 "./colors/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const blue = "blue";
-
 __webpack_require__.d(__webpack_exports__, [
-  "blue", 0, blue
+  "blue", () => (blue)
 ]);
+const blue = "blue";
 
 
 },
 "./colors/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-/* import */ var _result__rspack_import_0 = __webpack_require__("./colors/result.js");
-
-
 __webpack_require__.d(__webpack_exports__, [
   "result", () => (/* reexport safe */ _result__rspack_import_0.result)
 ]);
+/* import */ var _result__rspack_import_0 = __webpack_require__("./colors/result.js");
+
 
 
 },
 "./colors/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "blue", () => (/* reexport safe */ _b__rspack_import_1.blue),
+  "red", () => (/* reexport safe */ _a__rspack_import_0.red),
+  "result", () => (/* reexport safe */ _c__rspack_import_2.result)
+]);
 /* import */ var _a__rspack_import_0 = __webpack_require__("./colors/a.js");
 /* import */ var _b__rspack_import_1 = __webpack_require__("./colors/b.js");
 /* import */ var _c__rspack_import_2 = __webpack_require__("./colors/c.js");
@@ -38,20 +40,13 @@ __webpack_require__.r(__webpack_exports__);
 
 
 
-__webpack_require__.d(__webpack_exports__, [
-  "blue", () => (/* reexport safe */ _b__rspack_import_1.blue),
-  "red", () => (/* reexport safe */ _a__rspack_import_0.red),
-  "result", () => (/* reexport safe */ _c__rspack_import_2.result)
-]);
-
 
 },
 "./colors/result.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const result = "ssss";
-
 __webpack_require__.d(__webpack_exports__, [
-  "result", 0, result
+  "result", () => (result)
 ]);
+const result = "ssss";
 
 
 },
@@ -66,11 +61,10 @@ _export__rspack_import_1.Something;
 
 },
 "./something/Something.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-class Something {}
-
 __webpack_require__.d(__webpack_exports__, [
   "Something", () => (Something)
 ]);
+class Something {}
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export-star-chain/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-star-chain/__snapshots__/treeshaking.snap.txt
@@ -2,37 +2,35 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./colors/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  red: () => (red)
-});
 const red = "red";
+
+__webpack_require__.d(__webpack_exports__, [
+  "red", 0, red
+]);
 
 
 },
 "./colors/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  blue: () => (blue)
-});
 const blue = "blue";
+
+__webpack_require__.d(__webpack_exports__, [
+  "blue", 0, blue
+]);
 
 
 },
 "./colors/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (/* reexport safe */ _result__rspack_import_0.result)
-});
 /* import */ var _result__rspack_import_0 = __webpack_require__("./colors/result.js");
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "result", () => (/* reexport safe */ _result__rspack_import_0.result)
+]);
 
 
 },
 "./colors/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  blue: () => (/* reexport safe */ _b__rspack_import_1.blue),
-  red: () => (/* reexport safe */ _a__rspack_import_0.red),
-  result: () => (/* reexport safe */ _c__rspack_import_2.result)
-});
 /* import */ var _a__rspack_import_0 = __webpack_require__("./colors/a.js");
 /* import */ var _b__rspack_import_1 = __webpack_require__("./colors/b.js");
 /* import */ var _c__rspack_import_2 = __webpack_require__("./colors/c.js");
@@ -40,13 +38,20 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 
+__webpack_require__.d(__webpack_exports__, [
+  "blue", () => (/* reexport safe */ _b__rspack_import_1.blue),
+  "red", () => (/* reexport safe */ _a__rspack_import_0.red),
+  "result", () => (/* reexport safe */ _c__rspack_import_2.result)
+]);
+
 
 },
 "./colors/result.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (result)
-});
 const result = "ssss";
+
+__webpack_require__.d(__webpack_exports__, [
+  "result", 0, result
+]);
 
 
 },
@@ -61,10 +66,11 @@ _export__rspack_import_1.Something;
 
 },
 "./something/Something.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  Something: () => (Something)
-});
 class Something {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "Something", () => (Something)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/export_star/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export_star/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b),
-  bar: () => (/* reexport module object */ _foo__rspack_import_0),
-  c: () => (/* reexport safe */ _result__rspack_import_1.c)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "b", () => (b),
+  "bar", () => (/* reexport module object */ _foo__rspack_import_0),
+  "c", () => (/* reexport safe */ _result__rspack_import_1.c)
+]);
 /* import */ var _foo__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _result__rspack_import_1 = __webpack_require__("./result.js");
 function b() {}
@@ -18,13 +18,13 @@ function b() {}
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a),
-  b: () => (/* reexport safe */ _bar__rspack_import_0.b),
-  bar: () => (/* reexport safe */ _bar__rspack_import_0.bar),
-  c: () => (/* reexport safe */ _bar__rspack_import_0.c),
-  foo: () => (foo)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a),
+  "b", () => (/* reexport safe */ _bar__rspack_import_0.b),
+  "bar", () => (/* reexport safe */ _bar__rspack_import_0.bar),
+  "c", () => (/* reexport safe */ _bar__rspack_import_0.c),
+  "foo", () => (foo)
+]);
 /* import */ var _bar__rspack_import_0 = __webpack_require__("./bar.js");
 /* import */ var _result__rspack_import_1 = __webpack_require__("./result.js");
 const a = 3;
@@ -43,9 +43,9 @@ _foo__rspack_import_0.bar.a;
 
 },
 "./result.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  c: () => (c)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "c", () => (c)
+]);
 /* import */ var _foo__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _bar__rspack_import_1 = __webpack_require__("./bar.js");
 const c = 103330;

--- a/tests/rspack-test/treeShakingCases/export_star_conflict_export_no_error/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export_star_conflict_export_no_error/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b)
-});
+__webpack_require__.d(__webpack_exports__, [
+  "b", () => (b)
+]);
 /* import */ var _foo_js__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _result_js__rspack_import_1 = __webpack_require__("./result.js");
 function b() {}

--- a/tests/rspack-test/treeShakingCases/import-as-default/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-as-default/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,12 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 var a = 1;
 /* export default */ const __rspack_default_export = (a);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-as-default/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-as-default/__snapshots__/treeshaking.snap.txt
@@ -2,12 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-var a = 1;
-/* export default */ const __rspack_default_export = (a);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+var a = 1;
+/* export default */ const __rspack_default_export = (a);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-export-all-as-a-empty-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-export-all-as-a-empty-module/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,6 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  aaa: () => (/* reexport module object */ _app__rspack_import_0),
-  routes: () => (routes)
-});
 /* import */ var _answer__rspack_import_1 = __webpack_require__("./answer.js");
 /* import */ var _answer__rspack_import_1_default = /*#__PURE__*/__webpack_require__.n(_answer__rspack_import_1);
 /* import */ var _app__rspack_import_0 = __webpack_require__("./app.js");
@@ -16,6 +12,11 @@ __webpack_require__.d(__webpack_exports__, {
 const routes = {
 	answer: _answer__rspack_import_1.something
 };
+
+__webpack_require__.d(__webpack_exports__, [
+  "aaa", () => (/* reexport module object */ _app__rspack_import_0),
+  "routes", 0, routes
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-export-all-as-a-empty-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-export-all-as-a-empty-module/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,10 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "aaa", () => (/* reexport module object */ _app__rspack_import_0),
+  "routes", () => (routes)
+]);
 /* import */ var _answer__rspack_import_1 = __webpack_require__("./answer.js");
 /* import */ var _answer__rspack_import_1_default = /*#__PURE__*/__webpack_require__.n(_answer__rspack_import_1);
 /* import */ var _app__rspack_import_0 = __webpack_require__("./app.js");
@@ -12,11 +16,6 @@
 const routes = {
 	answer: _answer__rspack_import_1.something
 };
-
-__webpack_require__.d(__webpack_exports__, [
-  "aaa", () => (/* reexport module object */ _app__rspack_import_0),
-  "routes", 0, routes
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-optional-chaining/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-optional-chaining/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  app: () => (app)
-});
 const app = "app";
+
+__webpack_require__.d(__webpack_exports__, [
+  "app", 0, app
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-optional-chaining/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-optional-chaining/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const app = "app";
-
 __webpack_require__.d(__webpack_exports__, [
-  "app", 0, app
+  "app", () => (app)
 ]);
+const app = "app";
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-star-as-and-export/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-star-as-and-export/__snapshots__/treeshaking.snap.txt
@@ -11,10 +11,11 @@ _app__rspack_import_0;
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 20000;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-star-as-and-export/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-star-as-and-export/__snapshots__/treeshaking.snap.txt
@@ -11,11 +11,10 @@ _app__rspack_import_0;
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-const a = 20000;
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = 20000;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-var-assign-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-var-assign-side-effects/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Something.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-class Something {}
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (Something)
 ]);
+class Something {}
 
 
 },

--- a/tests/rspack-test/treeShakingCases/import-var-assign-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/import-var-assign-side-effects/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Something.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (Something)
-});
 class Something {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (Something)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/inherit_export_map_should_lookup_in_dfs_order/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/inherit_export_map_should_lookup_in_dfs_order/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const c = "a";
-
 __webpack_require__.d(__webpack_exports__, [
-  "c", 0, c
+  "c", () => (c)
 ]);
+const c = "a";
 
 
 },
@@ -17,30 +16,28 @@ const c = "bar";
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a),
+  "b", () => (/* reexport safe */ _foo__rspack_import_0.b),
+  "c", () => (/* reexport safe */ _foo__rspack_import_0.c)
+]);
 /* import */ var _foo__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _bar__rspack_import_1 = __webpack_require__("./bar.js");
 
 
 const a = 3;
 
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a,
-  "b", () => (/* reexport safe */ _foo__rspack_import_0.b),
-  "c", () => (/* reexport safe */ _foo__rspack_import_0.c)
-]);
-
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "b", () => (b),
+  "c", () => (/* reexport safe */ _a_js__rspack_import_0.c)
+]);
 /* import */ var _a_js__rspack_import_0 = __webpack_require__("./a.js");
 
 const a = "foo";
 const b = "foo";
-
-__webpack_require__.d(__webpack_exports__, [
-  "b", 0, b,
-  "c", () => (/* reexport safe */ _a_js__rspack_import_0.c)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/inherit_export_map_should_lookup_in_dfs_order/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/inherit_export_map_should_lookup_in_dfs_order/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  c: () => (c)
-});
 const c = "a";
+
+__webpack_require__.d(__webpack_exports__, [
+  "c", 0, c
+]);
 
 
 },
@@ -16,28 +17,30 @@ const c = "bar";
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a),
-  b: () => (/* reexport safe */ _foo__rspack_import_0.b),
-  c: () => (/* reexport safe */ _foo__rspack_import_0.c)
-});
 /* import */ var _foo__rspack_import_0 = __webpack_require__("./foo.js");
 /* import */ var _bar__rspack_import_1 = __webpack_require__("./bar.js");
 
 
 const a = 3;
 
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a,
+  "b", () => (/* reexport safe */ _foo__rspack_import_0.b),
+  "c", () => (/* reexport safe */ _foo__rspack_import_0.c)
+]);
+
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b),
-  c: () => (/* reexport safe */ _a_js__rspack_import_0.c)
-});
 /* import */ var _a_js__rspack_import_0 = __webpack_require__("./a.js");
 
 const a = "foo";
 const b = "foo";
+
+__webpack_require__.d(__webpack_exports__, [
+  "b", 0, b,
+  "c", () => (/* reexport safe */ _a_js__rspack_import_0.c)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/issue-4637/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/issue-4637/__snapshots__/treeshaking.snap.txt
@@ -40,9 +40,6 @@ ConsoleExporterWeb = (function () {
 
 },
 "<PNPM_INNER>/@swc/helpers/esm/_create_class.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  _: () => (_create_class)
-});
 function _defineProperties(target, props) {
     for (var i = 0; i < props.length; i++) {
         var descriptor = props[i];
@@ -61,6 +58,10 @@ function _create_class(Constructor, protoProps, staticProps) {
     return Constructor;
 }
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "_", () => (_create_class)
+]);
 
 
 }

--- a/tests/rspack-test/treeShakingCases/issue-4637/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/issue-4637/__snapshots__/treeshaking.snap.txt
@@ -40,6 +40,9 @@ ConsoleExporterWeb = (function () {
 
 },
 "<PNPM_INNER>/@swc/helpers/esm/_create_class.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "_", () => (_create_class)
+]);
 function _defineProperties(target, props) {
     for (var i = 0; i < props.length; i++) {
         var descriptor = props[i];
@@ -58,10 +61,6 @@ function _create_class(Constructor, protoProps, staticProps) {
     return Constructor;
 }
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "_", () => (_create_class)
-]);
 
 
 }

--- a/tests/rspack-test/treeShakingCases/issues_3198/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/issues_3198/__snapshots__/treeshaking.snap.txt
@@ -9,11 +9,10 @@ _test__rspack_import_0.obj.test = 1;
 
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const obj = {};
-
 __webpack_require__.d(__webpack_exports__, [
-  "obj", 0, obj
+  "obj", () => (obj)
 ]);
+const obj = {};
 
 
 },

--- a/tests/rspack-test/treeShakingCases/issues_3198/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/issues_3198/__snapshots__/treeshaking.snap.txt
@@ -9,10 +9,11 @@ _test__rspack_import_0.obj.test = 1;
 
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  obj: () => (obj)
-});
 const obj = {};
+
+__webpack_require__.d(__webpack_exports__, [
+  "obj", 0, obj
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/local-binding-reachable1/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/local-binding-reachable1/__snapshots__/treeshaking.snap.txt
@@ -2,19 +2,17 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Layout.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  defaults: () => (defaults)
-});
 const defaults = {
 	test: 1000
 };
 
+__webpack_require__.d(__webpack_exports__, [
+  "defaults", 0, defaults
+]);
+
 
 },
 "./export.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  Something: () => (Something)
-});
 /* import */ var _Layout__rspack_import_0 = __webpack_require__("./Layout.js");
 
 function callit() {
@@ -22,6 +20,10 @@ function callit() {
 }
 var Sider = callit();
 var Something = 20000;
+
+__webpack_require__.d(__webpack_exports__, [
+  "Something", () => (Something)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/local-binding-reachable1/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/local-binding-reachable1/__snapshots__/treeshaking.snap.txt
@@ -2,17 +2,19 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Layout.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "defaults", () => (defaults)
+]);
 const defaults = {
 	test: 1000
 };
 
-__webpack_require__.d(__webpack_exports__, [
-  "defaults", 0, defaults
-]);
-
 
 },
 "./export.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "Something", () => (Something)
+]);
 /* import */ var _Layout__rspack_import_0 = __webpack_require__("./Layout.js");
 
 function callit() {
@@ -20,10 +22,6 @@ function callit() {
 }
 var Sider = callit();
 var Something = 20000;
-
-__webpack_require__.d(__webpack_exports__, [
-  "Something", () => (Something)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/local-binding-reachable2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/local-binding-reachable2/__snapshots__/treeshaking.snap.txt
@@ -2,17 +2,19 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Layout.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "defaults", () => (defaults)
+]);
 const defaults = {
 	test: 1000
 };
 
-__webpack_require__.d(__webpack_exports__, [
-  "defaults", 0, defaults
-]);
-
 
 },
 "./export.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "Something", () => (Something)
+]);
 /* import */ var _Layout__rspack_import_0 = __webpack_require__("./Layout.js");
 
 class Test {
@@ -20,10 +22,6 @@ class Test {
 }
 var Sider = new Test();
 var Something = 333;
-
-__webpack_require__.d(__webpack_exports__, [
-  "Something", () => (Something)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/local-binding-reachable2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/local-binding-reachable2/__snapshots__/treeshaking.snap.txt
@@ -2,19 +2,17 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Layout.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  defaults: () => (defaults)
-});
 const defaults = {
 	test: 1000
 };
 
+__webpack_require__.d(__webpack_exports__, [
+  "defaults", 0, defaults
+]);
+
 
 },
 "./export.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  Something: () => (Something)
-});
 /* import */ var _Layout__rspack_import_0 = __webpack_require__("./Layout.js");
 
 class Test {
@@ -22,6 +20,10 @@ class Test {
 }
 var Sider = new Test();
 var Something = 333;
+
+__webpack_require__.d(__webpack_exports__, [
+  "Something", () => (Something)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/module-rule-side-effects1/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/module-rule-side-effects1/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/module-rule-side-effects1/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/module-rule-side-effects1/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const a = 3;
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = 3;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/module-rule-side-effects2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/module-rule-side-effects2/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/module-rule-side-effects2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/module-rule-side-effects2/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const a = 3;
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = 3;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/named-export-decl-with-src-eval/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/named-export-decl-with-src-eval/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function cccc() {}
-
 __webpack_require__.d(__webpack_exports__, [
   "cccc", () => (cccc)
 ]);
+function cccc() {}
 
 
 },

--- a/tests/rspack-test/treeShakingCases/named-export-decl-with-src-eval/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/named-export-decl-with-src-eval/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  cccc: () => (cccc)
-});
 function cccc() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "cccc", () => (cccc)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/named_export_alias/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/named_export_alias/__snapshots__/treeshaking.snap.txt
@@ -2,17 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Something.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  something: () => (something)
-});
 function something() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "something", () => (something)
+]);
 
 
 },
 "./export.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (a)
-});
 /* import */ var _Something__rspack_import_0 = __webpack_require__("./Something.js");
 
 
@@ -20,6 +18,10 @@ var a = function test() {
 	_Something__rspack_import_0.something;
 };
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (a)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/named_export_alias/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/named_export_alias/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,17 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./Something.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function something() {}
-
 __webpack_require__.d(__webpack_exports__, [
   "something", () => (something)
 ]);
+function something() {}
 
 
 },
 "./export.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (a)
+]);
 /* import */ var _Something__rspack_import_0 = __webpack_require__("./Something.js");
 
 
@@ -18,10 +20,6 @@ var a = function test() {
 	_Something__rspack_import_0.something;
 };
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (a)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/namespace-access-var-decl-rhs/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/namespace-access-var-decl-rhs/__snapshots__/treeshaking.snap.txt
@@ -2,24 +2,22 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 const a = {
 	a: ""
 };
 
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
-
 
 },
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "b", () => (b)
+]);
 const b = {
 	b: ""
 };
-
-__webpack_require__.d(__webpack_exports__, [
-  "b", 0, b
-]);
 
 
 },
@@ -32,6 +30,9 @@ console.log(_lib__rspack_import_0.getDocPermissionTextSendMe);
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "getDocPermissionTextSendMe", () => (getDocPermissionTextSendMe)
+]);
 /* import */ var _enum_js__rspack_import_0 = __webpack_require__("./a.js");
 /* import */ var _enum_js__rspack_import_1 = __webpack_require__("./b.js");
 
@@ -51,10 +52,6 @@ class Doc extends Record({}) {
 }
 
 Doc.fromJS = data => new Doc(data);
-
-__webpack_require__.d(__webpack_exports__, [
-  "getDocPermissionTextSendMe", () => (getDocPermissionTextSendMe)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/namespace-access-var-decl-rhs/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/namespace-access-var-decl-rhs/__snapshots__/treeshaking.snap.txt
@@ -2,22 +2,24 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = {
 	a: ""
 };
 
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
+
 
 },
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b)
-});
 const b = {
 	b: ""
 };
+
+__webpack_require__.d(__webpack_exports__, [
+  "b", 0, b
+]);
 
 
 },
@@ -30,9 +32,6 @@ console.log(_lib__rspack_import_0.getDocPermissionTextSendMe);
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  getDocPermissionTextSendMe: () => (getDocPermissionTextSendMe)
-});
 /* import */ var _enum_js__rspack_import_0 = __webpack_require__("./a.js");
 /* import */ var _enum_js__rspack_import_1 = __webpack_require__("./b.js");
 
@@ -52,6 +51,10 @@ class Doc extends Record({}) {
 }
 
 Doc.fromJS = data => new Doc(data);
+
+__webpack_require__.d(__webpack_exports__, [
+  "getDocPermissionTextSendMe", () => (getDocPermissionTextSendMe)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/nested-import-3/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/nested-import-3/__snapshots__/treeshaking.snap.txt
@@ -2,12 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 const a = 103330;
 const b = 103330;
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/nested-import-3/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/nested-import-3/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,12 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 103330;
 const b = 103330;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/nested-import-4/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/nested-import-4/__snapshots__/treeshaking.snap.txt
@@ -2,12 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 const a = 103330;
 const b = 103330;
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/nested-import-4/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/nested-import-4/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,12 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./answer.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 103330;
 const b = 103330;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/prune-bailout-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/prune-bailout-module/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (300);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/prune-bailout-module/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/prune-bailout-module/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-/* export default */ const __rspack_default_export = (300);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (300);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
@@ -2,14 +2,13 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "A", () => (A)
+]);
 const A = 1;
 const B = 1;
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "A", 0, A
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
@@ -2,13 +2,14 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  A: () => (A)
-});
 const A = 1;
 const B = 1;
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "A", 0, A
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 
 function res() {
 	answer;
 }
 const a = 3;
 /* unused export default */ var __rspack_default_export = (/*#__PURE__*/(/* unused pure expression or super */ null && (res())));
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,16 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 
 function res() {
 	answer;
 }
 const a = 3;
 /* unused export default */ var __rspack_default_export = (/*#__PURE__*/(/* unused pure expression or super */ null && (res())));
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/pure_comments_new_expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure_comments_new_expr/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  marker: () => (marker)
-});
 function createSet() {
 	return new Set();
 }
@@ -15,6 +12,10 @@ let directNew = /*#__PURE__*/ (/* unused pure expression or super */ null && (ne
 let extraTextNew = /* #__PURE__ additional text */ (/* unused pure expression or super */ null && (new Set()));
 let atPureNew = /* @__PURE__ additional text */ (/* unused pure expression or super */ null && (new Set()));
 let notPureComment = /* note: keep webpack-compatible #__PURE__ syntax here */ createSet();
+
+__webpack_require__.d(__webpack_exports__, [
+  "marker", 0, marker
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/pure_comments_new_expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/pure_comments_new_expr/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "marker", () => (marker)
+]);
 function createSet() {
 	return new Set();
 }
@@ -12,10 +15,6 @@ let directNew = /*#__PURE__*/ (/* unused pure expression or super */ null && (ne
 let extraTextNew = /* #__PURE__ additional text */ (/* unused pure expression or super */ null && (new Set()));
 let atPureNew = /* @__PURE__ additional text */ (/* unused pure expression or super */ null && (new Set()));
 let notPureComment = /* note: keep webpack-compatible #__PURE__ syntax here */ createSet();
-
-__webpack_require__.d(__webpack_exports__, [
-  "marker", 0, marker
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/react-redux-like/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/react-redux-like/__snapshots__/treeshaking.snap.txt
@@ -11,24 +11,22 @@ _foo__rspack_import_1["default"];
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 function Provider() {}
 
 /* export default */ const __rspack_default_export = (Provider);
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./selector.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function useSelector() {
-	return "";
-}
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (useSelector)
 ]);
+function useSelector() {
+	return "";
+}
 
 
 },

--- a/tests/rspack-test/treeShakingCases/react-redux-like/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/react-redux-like/__snapshots__/treeshaking.snap.txt
@@ -11,22 +11,24 @@ _foo__rspack_import_1["default"];
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 function Provider() {}
 
 /* export default */ const __rspack_default_export = (Provider);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./selector.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (useSelector)
-});
 function useSelector() {
 	return "";
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (useSelector)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport-all-as-multi-level-nested/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport-all-as-multi-level-nested/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./package/autogen/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 
 function a() {}
 
@@ -9,19 +12,14 @@ function dddd() {}
 
 
 
-__webpack_require__.d(__webpack_exports__, [
-  "a", () => (a)
-]);
-
 
 },
 "./package/autogen/aa.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "aa", () => (aa)
+]);
 const aa = 3;
 const cc = 3;
-
-__webpack_require__.d(__webpack_exports__, [
-  "aa", 0, aa
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport-all-as-multi-level-nested/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport-all-as-multi-level-nested/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./package/autogen/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 
 function a() {}
 
@@ -12,14 +9,19 @@ function dddd() {}
 
 
 
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
+
 
 },
 "./package/autogen/aa.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  aa: () => (aa)
-});
 const aa = 3;
 const cc = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "aa", 0, aa
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport-all-as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport-all-as/__snapshots__/treeshaking.snap.txt
@@ -2,13 +2,12 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./package/autogen/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function a() {}
-
-function dddd() {}
-
 __webpack_require__.d(__webpack_exports__, [
   "a", () => (a)
 ]);
+function a() {}
+
+function dddd() {}
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport-all-as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport-all-as/__snapshots__/treeshaking.snap.txt
@@ -2,12 +2,13 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./package/autogen/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 function a() {}
 
 function dddd() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport_default_as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport_default_as/__snapshots__/treeshaking.snap.txt
@@ -2,19 +2,21 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (test)
-});
 function test() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (test)
+]);
 
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  Select: () => (/* reexport safe */ _bar__rspack_import_0["default"])
-});
 /* import */ var _bar__rspack_import_0 = __webpack_require__("./bar.js");
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "Select", () => (/* reexport safe */ _bar__rspack_import_0["default"])
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport_default_as/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport_default_as/__snapshots__/treeshaking.snap.txt
@@ -2,21 +2,19 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function test() {}
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (test)
 ]);
+function test() {}
 
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-/* import */ var _bar__rspack_import_0 = __webpack_require__("./bar.js");
-
-
 __webpack_require__.d(__webpack_exports__, [
   "Select", () => (/* reexport safe */ _bar__rspack_import_0["default"])
 ]);
+/* import */ var _bar__rspack_import_0 = __webpack_require__("./bar.js");
+
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport_entry_elimination/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport_entry_elimination/__snapshots__/treeshaking.snap.txt
@@ -2,20 +2,22 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _c_js__rspack_import_0 = __webpack_require__("./c.js");
 
 /* export default */ const __rspack_default_export = (2000 + _c_js__rspack_import_0["default"]);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (10);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/reexport_entry_elimination/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/reexport_entry_elimination/__snapshots__/treeshaking.snap.txt
@@ -2,22 +2,20 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _c_js__rspack_import_0 = __webpack_require__("./c.js");
 
 /* export default */ const __rspack_default_export = (2000 + _c_js__rspack_import_0["default"]);
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-/* export default */ const __rspack_default_export = (10);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (10);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rename-export-from-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rename-export-from-import/__snapshots__/treeshaking.snap.txt
@@ -2,14 +2,13 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "q", () => (/* reexport safe */ _lib__rspack_import_0.question)
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "q", () => (/* reexport safe */ _lib__rspack_import_0.question)
-]);
 
 
 },
@@ -21,13 +20,12 @@ _app__rspack_import_0.q;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "question", () => (question)
+]);
 const answer = "1";
 
 const question = "2";
-
-__webpack_require__.d(__webpack_exports__, [
-  "question", 0, question
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rename-export-from-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rename-export-from-import/__snapshots__/treeshaking.snap.txt
@@ -2,13 +2,14 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  q: () => (/* reexport safe */ _lib__rspack_import_0.question)
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "q", () => (/* reexport safe */ _lib__rspack_import_0.question)
+]);
 
 
 },
@@ -20,12 +21,13 @@ _app__rspack_import_0.q;
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  question: () => (question)
-});
 const answer = "1";
 
 const question = "2";
+
+__webpack_require__.d(__webpack_exports__, [
+  "question", 0, question
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports-function-argument/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports-function-argument/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "bar", () => (bar),
+  "default", () => (__rspack_default_export)
+]);
 var foo = function () {
 	return 42;
 };
@@ -11,11 +15,6 @@ var foo = function () {
 function bar() {
 	return contrivedExample(foo);
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "bar", () => (bar),
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports-function-argument/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports-function-argument/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  bar: () => (bar),
-  "default": () => (__rspack_default_export)
-});
 var foo = function () {
 	return 42;
 };
@@ -15,6 +11,11 @@ var foo = function () {
 function bar() {
 	return contrivedExample(foo);
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "bar", () => (bar),
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 var Foo = function () {
 	console.log("side effect");
 	this.isFoo = true;
@@ -17,6 +14,10 @@ Foo.prototype = {
 		return 42;
 	}
 };
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unmodified-default-exports/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 var Foo = function () {
 	console.log("side effect");
 	this.isFoo = true;
@@ -14,10 +17,6 @@ Foo.prototype = {
 		return 42;
 	}
 };
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-called-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-called-import/__snapshots__/treeshaking.snap.txt
@@ -9,9 +9,6 @@
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __rspack_default_export)
-});
 /* import */ var _dead__rspack_import_0 = __webpack_require__("./dead.js");
 
 
@@ -22,6 +19,10 @@ __webpack_require__.d(__webpack_exports__, {
 function foodead() {
 	return "foo" + dead();
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-called-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-called-import/__snapshots__/treeshaking.snap.txt
@@ -9,6 +9,9 @@
 
 },
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 /* import */ var _dead__rspack_import_0 = __webpack_require__("./dead.js");
 
 
@@ -19,10 +22,6 @@
 function foodead() {
 	return "foo" + dead();
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (/* export default binding */ __rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-default-exports/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-default-exports/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "foo", () => (foo)
+]);
 var foo = { value: 1 };
 
 function mutate(obj) {
@@ -10,10 +13,6 @@ function mutate(obj) {
 }
 
 /* unused export default */ var __rspack_default_export = (mutate(foo));
-
-__webpack_require__.d(__webpack_exports__, [
-  "foo", () => (foo)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-default-exports/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-default-exports/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  foo: () => (foo)
-});
 var foo = { value: 1 };
 
 function mutate(obj) {
@@ -13,6 +10,10 @@ function mutate(obj) {
 }
 
 /* unused export default */ var __rspack_default_export = (mutate(foo));
+
+__webpack_require__.d(__webpack_exports__, [
+  "foo", () => (foo)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-inner-functions-and-classes/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-inner-functions-and-classes/__snapshots__/treeshaking.snap.txt
@@ -24,6 +24,10 @@ console.log(getClass().name);
 
 },
 "./stuff.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "bar", () => (bar),
+  "baz", () => (Baz)
+]);
 function foo() {
 	console.log("outer foo");
 }
@@ -55,11 +59,6 @@ function Baz() {
 }
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "bar", () => (bar),
-  "baz", () => (Baz)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-inner-functions-and-classes/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-inner-functions-and-classes/__snapshots__/treeshaking.snap.txt
@@ -24,10 +24,6 @@ console.log(getClass().name);
 
 },
 "./stuff.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  bar: () => (bar),
-  baz: () => (Baz)
-});
 function foo() {
 	console.log("outer foo");
 }
@@ -59,6 +55,11 @@ function Baz() {
 }
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "bar", () => (bar),
+  "baz", () => (Baz)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-var/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-var/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,16 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  foo: () => (foo)
-});
 var foo = "lol";
 var bar = "wut";
 
 var baz = (/* unused pure expression or super */ null && (bar || foo));
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "foo", () => (foo)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/rollup-unused-var/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/rollup-unused-var/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./foo.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "foo", () => (foo)
+]);
 var foo = "lol";
 var bar = "wut";
 
 var baz = (/* unused pure expression or super */ null && (bar || foo));
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "foo", () => (foo)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-analyzed/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-analyzed/__snapshots__/treeshaking.snap.txt
@@ -10,13 +10,14 @@
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __rspack_default_export)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
 /* export default */ function __rspack_default_export() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-analyzed/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-analyzed/__snapshots__/treeshaking.snap.txt
@@ -10,14 +10,13 @@
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
 /* export default */ function __rspack_default_export() {}
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (/* export default binding */ __rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-export-default-expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-export-default-expr/__snapshots__/treeshaking.snap.txt
@@ -2,14 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b)
-});
 
 
 /* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (a)));
 
 const b = 1;
+
+__webpack_require__.d(__webpack_exports__, [
+  "b", 0, b
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-export-default-expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-export-default-expr/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,14 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "b", () => (b)
+]);
 
 
 /* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (a)));
 
 const b = 1;
-
-__webpack_require__.d(__webpack_exports__, [
-  "b", 0, b
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-flagged-only/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-flagged-only/__snapshots__/treeshaking.snap.txt
@@ -2,13 +2,14 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  something: () => (/* reexport safe */ _lib__rspack_import_0["default"])
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 /* import */ var _src_a__rspack_import_1 = __webpack_require__("./src/a.js");
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "something", () => (/* reexport safe */ _lib__rspack_import_0["default"])
+]);
 
 
 },
@@ -21,13 +22,14 @@ __webpack_require__.d(__webpack_exports__, {
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __rspack_default_export)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
 /* export default */ function __rspack_default_export() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-flagged-only/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-flagged-only/__snapshots__/treeshaking.snap.txt
@@ -2,14 +2,13 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "something", () => (/* reexport safe */ _lib__rspack_import_0["default"])
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 /* import */ var _src_a__rspack_import_1 = __webpack_require__("./src/a.js");
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "something", () => (/* reexport safe */ _lib__rspack_import_0["default"])
-]);
 
 
 },
@@ -22,14 +21,13 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
 /* export default */ function __rspack_default_export() {}
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (/* export default binding */ __rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-prune/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-prune/__snapshots__/treeshaking.snap.txt
@@ -11,12 +11,13 @@
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  something: () => (something)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
+
+__webpack_require__.d(__webpack_exports__, [
+  "something", 0, something
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-prune/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-prune/__snapshots__/treeshaking.snap.txt
@@ -11,13 +11,12 @@
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "something", () => (something)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
-
-__webpack_require__.d(__webpack_exports__, [
-  "something", 0, something
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-two/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-two/__snapshots__/treeshaking.snap.txt
@@ -10,13 +10,14 @@
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* export default binding */ __rspack_default_export)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
 /* export default */ function __rspack_default_export() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/side-effects-two/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/side-effects-two/__snapshots__/treeshaking.snap.txt
@@ -10,14 +10,13 @@
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (/* export default binding */ __rspack_default_export)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
 /* export default */ function __rspack_default_export() {}
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (/* export default binding */ __rspack_default_export)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/simple-namespace-access/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/simple-namespace-access/__snapshots__/treeshaking.snap.txt
@@ -12,6 +12,10 @@ console.log(_maths_js__rspack_import_0.square);
 
 },
 "./maths.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "square", () => (square),
+  "xxx", () => (/* reexport module object */ _test_js__rspack_import_0)
+]);
 /* import */ var _test_js__rspack_import_0 = __webpack_require__("./test.js");
 // maths.js
 
@@ -30,20 +34,14 @@ function cube(x) {
 
 
 
-__webpack_require__.d(__webpack_exports__, [
-  "square", () => (square),
-  "xxx", () => (/* reexport module object */ _test_js__rspack_import_0)
-]);
-
 
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function test() {}
-function ccc() {}
-
 __webpack_require__.d(__webpack_exports__, [
   "test", () => (test)
 ]);
+function test() {}
+function ccc() {}
 
 
 },

--- a/tests/rspack-test/treeShakingCases/simple-namespace-access/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/simple-namespace-access/__snapshots__/treeshaking.snap.txt
@@ -12,10 +12,6 @@ console.log(_maths_js__rspack_import_0.square);
 
 },
 "./maths.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  square: () => (square),
-  xxx: () => (/* reexport module object */ _test_js__rspack_import_0)
-});
 /* import */ var _test_js__rspack_import_0 = __webpack_require__("./test.js");
 // maths.js
 
@@ -34,14 +30,20 @@ function cube(x) {
 
 
 
+__webpack_require__.d(__webpack_exports__, [
+  "square", () => (square),
+  "xxx", () => (/* reexport module object */ _test_js__rspack_import_0)
+]);
+
 
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  test: () => (test)
-});
 function test() {}
 function ccc() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "test", () => (test)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/static-class/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/static-class/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 /* import */ var _b_js__rspack_import_0 = __webpack_require__("./b.js");
 
 
@@ -23,14 +20,19 @@ class Result {
 
 const a = 3;
 
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
+
 
 },
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  bb: () => (bb)
-});
 const bb = 2;
 const cc = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "bb", 0, bb
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/static-class/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/static-class/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 /* import */ var _b_js__rspack_import_0 = __webpack_require__("./b.js");
 
 
@@ -20,19 +23,14 @@ class Result {
 
 const a = 3;
 
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
-
 
 },
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "bb", () => (bb)
+]);
 const bb = 2;
 const cc = 3;
-
-__webpack_require__.d(__webpack_exports__, [
-  "bb", 0, bb
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/transitive-bailout/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/transitive-bailout/__snapshots__/treeshaking.snap.txt
@@ -2,13 +2,12 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a),
+  "b", () => (b)
+]);
 const a = 3;
 const b = 3;
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a,
-  "b", 0, b
-]);
 
 
 },
@@ -31,13 +30,12 @@ _answer__rspack_import_0.test;
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* import */ var _a_js__rspack_import_0 = __webpack_require__("./a.js");
-
-
 __webpack_require__.d(__webpack_exports__, [
   "a", () => (/* reexport safe */ _a_js__rspack_import_0.a),
   "b", () => (/* reexport safe */ _a_js__rspack_import_0.b)
 ]);
+/* import */ var _a_js__rspack_import_0 = __webpack_require__("./a.js");
+
 
 
 },

--- a/tests/rspack-test/treeShakingCases/transitive-bailout/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/transitive-bailout/__snapshots__/treeshaking.snap.txt
@@ -2,12 +2,13 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a),
-  b: () => (b)
-});
 const a = 3;
 const b = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a,
+  "b", 0, b
+]);
 
 
 },
@@ -30,12 +31,13 @@ _answer__rspack_import_0.test;
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (/* reexport safe */ _a_js__rspack_import_0.a),
-  b: () => (/* reexport safe */ _a_js__rspack_import_0.b)
-});
 /* import */ var _a_js__rspack_import_0 = __webpack_require__("./a.js");
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (/* reexport safe */ _a_js__rspack_import_0.a),
+  "b", () => (/* reexport safe */ _a_js__rspack_import_0.b)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/transitive_side_effects_when_analyze/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/transitive_side_effects_when_analyze/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,16 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 /* import */ var _side_effects_js__rspack_import_0 = __webpack_require__("./side-effects.js");
 /* import */ var _side_effects_js__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_side_effects_js__rspack_import_0);
 
 
 
 const a = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/transitive_side_effects_when_analyze/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/transitive_side_effects_when_analyze/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,15 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 /* import */ var _side_effects_js__rspack_import_0 = __webpack_require__("./side-effects.js");
 /* import */ var _side_effects_js__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_side_effects_js__rspack_import_0);
 
 
 
 const a = 3;
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/tree-shaking-false-with-side-effect-true/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-false-with-side-effect-true/__snapshots__/treeshaking.snap.txt
@@ -2,18 +2,20 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./ b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  b: () => (b)
-});
 const b = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "b", 0, b
+]);
 
 
 },
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/tree-shaking-false-with-side-effect-true/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-false-with-side-effect-true/__snapshots__/treeshaking.snap.txt
@@ -2,20 +2,18 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./ b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const b = 3;
-
 __webpack_require__.d(__webpack_exports__, [
-  "b", 0, b
+  "b", () => (b)
 ]);
+const b = 3;
 
 
 },
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const a = 3;
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = 3;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/tree-shaking-interop/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-interop/__snapshots__/treeshaking.snap.txt
@@ -3,11 +3,10 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["bar_js"], {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-function test() {}
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (test)
 ]);
+function test() {}
 
 
 },
@@ -20,16 +19,15 @@ __webpack_require__.d(__webpack_exports__, [
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 __webpack_require__.e(/* import() */ "bar_js").then(__webpack_require__.bind(__webpack_require__, "./bar.js")).then(mod => {
 	console.log(mod);
 });
 const a = "a";
 
 exports.test = 30;
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/tree-shaking-interop/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-interop/__snapshots__/treeshaking.snap.txt
@@ -3,10 +3,11 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["bar_js"], {
 "./bar.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (test)
-});
 function test() {}
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (test)
+]);
 
 
 },
@@ -19,15 +20,16 @@ function test() {}
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 __webpack_require__.e(/* import() */ "bar_js").then(__webpack_require__.bind(__webpack_require__, "./bar.js")).then(mod => {
 	console.log(mod);
 });
 const a = "a";
 
 exports.test = 30;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/tree-shaking-lazy-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-lazy-import/__snapshots__/treeshaking.snap.txt
@@ -3,9 +3,6 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["lib_js"], {
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _test__rspack_import_0 = __webpack_require__("./test.js");
 
 function myanswer() {
@@ -14,15 +11,20 @@ function myanswer() {
 
 /* export default */ const __rspack_default_export = (myanswer);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 function test() {}
 
 /* export default */ const __rspack_default_export = (test);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
@@ -34,10 +36,11 @@ function test() {}
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  answer: () => (answer)
-});
 const answer = 30;
+
+__webpack_require__.d(__webpack_exports__, [
+  "answer", 0, answer
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/tree-shaking-lazy-import/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/tree-shaking-lazy-import/__snapshots__/treeshaking.snap.txt
@@ -3,6 +3,9 @@
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["lib_js"], {
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _test__rspack_import_0 = __webpack_require__("./test.js");
 
 function myanswer() {
@@ -11,20 +14,15 @@ function myanswer() {
 
 /* export default */ const __rspack_default_export = (myanswer);
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./test.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-function test() {}
-
-/* export default */ const __rspack_default_export = (test);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+function test() {}
+
+/* export default */ const __rspack_default_export = (test);
 
 
 },
@@ -36,11 +34,10 @@ __webpack_require__.d(__webpack_exports__, [
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const answer = 30;
-
 __webpack_require__.d(__webpack_exports__, [
-  "answer", 0, answer
+  "answer", () => (answer)
 ]);
+const answer = 30;
 
 
 },

--- a/tests/rspack-test/treeShakingCases/unused-class-rename/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/unused-class-rename/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  test: () => (test)
-});
 function test() {}
 
 class Cls {
@@ -15,6 +12,10 @@ if (__AAA__) {
 	const __Cls = Cls;
 	__Cls.prototype.aaa = function (a, b) {};
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "test", () => (test)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/unused-class-rename/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/unused-class-rename/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "test", () => (test)
+]);
 function test() {}
 
 class Cls {
@@ -12,10 +15,6 @@ if (__AAA__) {
 	const __Cls = Cls;
 	__Cls.prototype.aaa = function (a, b) {};
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "test", () => (test)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/var-function-expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/var-function-expr/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "app", () => (app)
+]);
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 var app = function () {
@@ -16,10 +19,6 @@ var app4 = (0,_lib__rspack_import_0.something)("app4"),
 
 var app3 = (0,_lib__rspack_import_0.something)("app3");
 
-__webpack_require__.d(__webpack_exports__, [
-  "app", () => (app)
-]);
-
 
 },
 "./index.js"(__unused_rspack_module, __unused_rspack___webpack_exports__, __webpack_require__) {
@@ -30,14 +29,13 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "result", () => (result),
+  "something", () => (something)
+]);
 const secret = "888";
 const result = 20000;
 const something = function () {};
-
-__webpack_require__.d(__webpack_exports__, [
-  "result", 0, result,
-  "something", 0, something
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/var-function-expr/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/var-function-expr/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./app.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  app: () => (app)
-});
 /* import */ var _lib__rspack_import_0 = __webpack_require__("./lib.js");
 
 var app = function () {
@@ -19,6 +16,10 @@ var app4 = (0,_lib__rspack_import_0.something)("app4"),
 
 var app3 = (0,_lib__rspack_import_0.something)("app3");
 
+__webpack_require__.d(__webpack_exports__, [
+  "app", () => (app)
+]);
+
 
 },
 "./index.js"(__unused_rspack_module, __unused_rspack___webpack_exports__, __webpack_require__) {
@@ -29,13 +30,14 @@ var app3 = (0,_lib__rspack_import_0.something)("app3");
 
 },
 "./lib.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (result),
-  something: () => (something)
-});
 const secret = "888";
 const result = 20000;
 const something = function () {};
+
+__webpack_require__.d(__webpack_exports__, [
+  "result", 0, result,
+  "something", 0, something
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-inner-graph-export-default-named/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-inner-graph-export-default-named/__snapshots__/treeshaking.snap.txt
@@ -2,15 +2,16 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (abc)
-});
 /* import */ var _dep_a__rspack_import_0 = __webpack_require__("./dep.js?a");
 
 
 function abc() {
 	return _dep_a__rspack_import_0.x;
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (abc)
+]);
 
 
 },
@@ -37,9 +38,6 @@ abc();
 
 },
 "./d.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (def)
-});
 /* import */ var _dep_d__rspack_import_0 = __webpack_require__("./dep.js?d");
 
 
@@ -49,69 +47,79 @@ class def {
 	}
 }
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (def)
+]);
+
 
 },
 "./dep.js?a"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  x: () => (x)
-});
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", 0, x
+]);
 
 
 },
 "./dep.js?b"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 const x = "x";
 
 /* export default */ const __rspack_default_export = (false);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },
 "./dep.js?c"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  x: () => (x)
-});
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", 0, x
+]);
 
 
 },
 "./dep.js?d"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  x: () => (x)
-});
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", 0, x
+]);
 
 
 },
 "./dep.js?e"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 const x = "x";
 
 /* export default */ const __rspack_default_export = (false);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./dep.js?f"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  x: () => (x)
-});
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", 0, x
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-inner-graph-export-default-named/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-inner-graph-export-default-named/__snapshots__/treeshaking.snap.txt
@@ -2,16 +2,15 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (abc)
+]);
 /* import */ var _dep_a__rspack_import_0 = __webpack_require__("./dep.js?a");
 
 
 function abc() {
 	return _dep_a__rspack_import_0.x;
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (abc)
-]);
 
 
 },
@@ -38,6 +37,9 @@ abc();
 
 },
 "./d.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (def)
+]);
 /* import */ var _dep_d__rspack_import_0 = __webpack_require__("./dep.js?d");
 
 
@@ -47,79 +49,69 @@ class def {
 	}
 }
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (def)
-]);
-
 
 },
 "./dep.js?a"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", () => (x)
+]);
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "x", 0, x
-]);
 
 
 },
 "./dep.js?b"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const x = "x";
-
-/* export default */ const __rspack_default_export = (false);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+const x = "x";
+
+/* export default */ const __rspack_default_export = (false);
 
 
 },
 "./dep.js?c"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", () => (x)
+]);
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "x", 0, x
-]);
 
 
 },
 "./dep.js?d"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", () => (x)
+]);
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "x", 0, x
-]);
 
 
 },
 "./dep.js?e"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 const x = "x";
 
 /* export default */ const __rspack_default_export = (false);
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./dep.js?f"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "x", () => (x)
+]);
 const x = "x";
 
 /* export default */ const __rspack_default_export = (true);
-
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "x", 0, x
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-inner-graph-switch/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-inner-graph-switch/__snapshots__/treeshaking.snap.txt
@@ -15,9 +15,6 @@ __webpack_require__.r(__webpack_exports__);
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./import-module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  test: () => (test)
-});
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 
 
@@ -26,6 +23,10 @@ function test() {
 		type: "inline"
 	});
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "test", () => (test)
+]);
 
 
 },
@@ -39,9 +40,6 @@ it("should generate correct code when pure expressions are in dead branches", ()
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _some_module__rspack_import_0 = __webpack_require__("./some-module.js");
 
 
@@ -85,16 +83,15 @@ function useDocument(obj) {
 
 /* export default */ const __rspack_default_export = (doSomething);
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "./some-module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  Block: () => (Block),
-  Document: () => (Document),
-  Inline: () => (Inline)
-});
 class Block {
 	static doSomething() {}
 }
@@ -108,6 +105,12 @@ class Document {
 }
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "Block", () => (Block),
+  "Document", () => (Document),
+  "Inline", () => (Inline)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-inner-graph-switch/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-inner-graph-switch/__snapshots__/treeshaking.snap.txt
@@ -15,6 +15,9 @@ __webpack_require__.r(__webpack_exports__);
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./import-module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "test", () => (test)
+]);
 /* import */ var _module__rspack_import_0 = __webpack_require__("./module.js");
 
 
@@ -23,10 +26,6 @@ function test() {
 		type: "inline"
 	});
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "test", () => (test)
-]);
 
 
 },
@@ -40,6 +39,9 @@ it("should generate correct code when pure expressions are in dead branches", ()
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _some_module__rspack_import_0 = __webpack_require__("./some-module.js");
 
 
@@ -83,15 +85,16 @@ function useDocument(obj) {
 
 /* export default */ const __rspack_default_export = (doSomething);
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "./some-module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "Block", () => (Block),
+  "Document", () => (Document),
+  "Inline", () => (Inline)
+]);
 class Block {
 	static doSomething() {}
 }
@@ -105,12 +108,6 @@ class Document {
 }
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "Block", () => (Block),
-  "Document", () => (Document),
-  "Inline", () => (Inline)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-circular/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-circular/__snapshots__/treeshaking.snap.txt
@@ -34,13 +34,6 @@ it("export should be unused when only unused functions use it", () => {
 
 },
 "./inner.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  A: () => (A),
-  B: () => (B),
-  exportAUsed: () => (exportAUsed),
-  exportBUsed: () => (exportBUsed),
-  exportCUsed: () => (exportCUsed)
-});
 function A(s) {
 	return s + "A";
 }
@@ -55,12 +48,17 @@ const exportAUsed = true;
 const exportBUsed = true;
 const exportCUsed = false;
 
+__webpack_require__.d(__webpack_exports__, [
+  "A", () => (A),
+  "B", () => (B),
+  "exportAUsed", 0, exportAUsed,
+  "exportBUsed", 0, exportBUsed,
+  "exportCUsed", 0, exportCUsed
+]);
+
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  y: () => (y)
-});
 /* import */ var _inner__rspack_import_0 = __webpack_require__("./inner.js");
 
 
@@ -98,6 +96,10 @@ function withC(v) {
 }
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "y", () => (y)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-circular/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-circular/__snapshots__/treeshaking.snap.txt
@@ -34,6 +34,13 @@ it("export should be unused when only unused functions use it", () => {
 
 },
 "./inner.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "A", () => (A),
+  "B", () => (B),
+  "exportAUsed", () => (exportAUsed),
+  "exportBUsed", () => (exportBUsed),
+  "exportCUsed", () => (exportCUsed)
+]);
 function A(s) {
 	return s + "A";
 }
@@ -48,17 +55,12 @@ const exportAUsed = true;
 const exportBUsed = true;
 const exportCUsed = false;
 
-__webpack_require__.d(__webpack_exports__, [
-  "A", () => (A),
-  "B", () => (B),
-  "exportAUsed", 0, exportAUsed,
-  "exportBUsed", 0, exportBUsed,
-  "exportCUsed", 0, exportCUsed
-]);
-
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "y", () => (y)
+]);
 /* import */ var _inner__rspack_import_0 = __webpack_require__("./inner.js");
 
 
@@ -96,10 +98,6 @@ function withC(v) {
 }
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "y", () => (y)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-circular2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-circular2/__snapshots__/treeshaking.snap.txt
@@ -21,6 +21,13 @@ it("should be able to handle circular referenced", () => {
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a),
+  "f3", () => (f3),
+  "x", () => (x),
+  "y", () => (y),
+  "z", () => (z)
+]);
 function x() {
 	return [y, z];
 }
@@ -70,14 +77,6 @@ function f4() {
 }
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", () => (a),
-  "f3", () => (f3),
-  "x", () => (x),
-  "y", () => (y),
-  "z", () => (z)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-circular2/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-circular2/__snapshots__/treeshaking.snap.txt
@@ -21,13 +21,6 @@ it("should be able to handle circular referenced", () => {
 
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a),
-  f3: () => (f3),
-  x: () => (x),
-  y: () => (y),
-  z: () => (z)
-});
 function x() {
 	return [y, z];
 }
@@ -77,6 +70,14 @@ function f4() {
 }
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a),
+  "f3", () => (f3),
+  "x", () => (x),
+  "y", () => (y),
+  "z", () => (z)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-no-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-no-side-effects/__snapshots__/treeshaking.snap.txt
@@ -10,6 +10,10 @@ it("should be able to load package without side effects where modules are unused
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "test", () => (test)
+]);
 /* import */ var _package__rspack_import_0 = __webpack_require__("./package/index.js");
 
 
@@ -17,15 +21,13 @@ __webpack_require__.r(__webpack_exports__);
 
 function test() {}
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "test", () => (test)
-]);
-
 
 },
 "./package/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 
 
 function a() {
@@ -35,10 +37,6 @@ function a() {
 function b() {
 	return value;
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "a", () => (a)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-no-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-no-side-effects/__snapshots__/treeshaking.snap.txt
@@ -10,10 +10,6 @@ it("should be able to load package without side effects where modules are unused
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  test: () => (test)
-});
 /* import */ var _package__rspack_import_0 = __webpack_require__("./package/index.js");
 
 
@@ -21,13 +17,15 @@ __webpack_require__.d(__webpack_exports__, {
 
 function test() {}
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "test", () => (test)
+]);
+
 
 },
 "./package/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 
 
 function a() {
@@ -37,6 +35,10 @@ function a() {
 function b() {
 	return value;
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-try-globals/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-try-globals/__snapshots__/treeshaking.snap.txt
@@ -20,6 +20,10 @@ it("should not threat globals as pure", () => {
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
+__webpack_require__.d(__webpack_exports__, [
+  "ok", () => (ok),
+  "ok2", () => (ok2)
+]);
 try {
 	var x = NOT_DEFINED;
 	var y = x;
@@ -40,11 +44,6 @@ try {
 }
 
 
-
-__webpack_require__.d(__webpack_exports__, [
-  "ok", () => (ok),
-  "ok2", () => (ok2)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-innergraph-try-globals/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-innergraph-try-globals/__snapshots__/treeshaking.snap.txt
@@ -20,10 +20,6 @@ it("should not threat globals as pure", () => {
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.d(__webpack_exports__, {
-  ok: () => (ok),
-  ok2: () => (ok2)
-});
 try {
 	var x = NOT_DEFINED;
 	var y = x;
@@ -44,6 +40,11 @@ try {
 }
 
 
+
+__webpack_require__.d(__webpack_exports__, [
+  "ok", () => (ok),
+  "ok2", () => (ok2)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-reexport-namespace-and-default/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-reexport-namespace-and-default/__snapshots__/treeshaking.snap.txt
@@ -28,6 +28,9 @@ it("default export should be used", () => {
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, [
+  "mod", () => (mod)
+]);
 /* import */ var _package1_script__rspack_import_0 = __webpack_require__("./package1/script.js");
 /* import */ var _package2_script__rspack_import_1 = __webpack_require__("./package2/script.js");
 
@@ -35,23 +38,18 @@ __webpack_require__.r(__webpack_exports__);
 
 const mod = _package2_script__rspack_import_1["default"];
 
-__webpack_require__.d(__webpack_exports__, [
-  "mod", 0, mod
-]);
-
 
 },
 "./package1/script.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "exportDefaultUsed", () => (exportDefaultUsed)
+]);
 /* import */ var _script1__rspack_import_0 = __webpack_require__("./package1/script1.js");
 
 /* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (mod)));
 
 
 const exportDefaultUsed = false;
-
-__webpack_require__.d(__webpack_exports__, [
-  "exportDefaultUsed", 0, exportDefaultUsed
-]);
 
 
 },
@@ -63,6 +61,9 @@ __webpack_require__.d(__webpack_exports__, [
 
 },
 "./package1/script2.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "exportDefaultUsed", () => (exportDefaultUsed)
+]);
 
 /* export default */ function __rspack_default_export() {
 	return mod;
@@ -71,13 +72,13 @@ __webpack_require__.d(__webpack_exports__, [
 
 const exportDefaultUsed = false;
 
-__webpack_require__.d(__webpack_exports__, [
-  "exportDefaultUsed", 0, exportDefaultUsed
-]);
-
 
 },
 "./package2/script.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "exportDefaultUsed", () => (exportDefaultUsed)
+]);
 /* import */ var _script1__rspack_import_0 = __webpack_require__("./package2/script1.js");
 
 /* export default */ const __rspack_default_export = (_script1__rspack_import_0["default"]);
@@ -85,19 +86,13 @@ __webpack_require__.d(__webpack_exports__, [
 
 const exportDefaultUsed = true;
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export),
-  "exportDefaultUsed", 0, exportDefaultUsed
-]);
-
 
 },
 "./package2/script1.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-/* export default */ const __rspack_default_export = (1);
-
 __webpack_require__.d(__webpack_exports__, [
   "default", () => (__rspack_default_export)
 ]);
+/* export default */ const __rspack_default_export = (1);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-reexport-namespace-and-default/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-reexport-namespace-and-default/__snapshots__/treeshaking.snap.txt
@@ -28,9 +28,6 @@ it("default export should be used", () => {
 },
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  mod: () => (mod)
-});
 /* import */ var _package1_script__rspack_import_0 = __webpack_require__("./package1/script.js");
 /* import */ var _package2_script__rspack_import_1 = __webpack_require__("./package2/script.js");
 
@@ -38,18 +35,23 @@ __webpack_require__.d(__webpack_exports__, {
 
 const mod = _package2_script__rspack_import_1["default"];
 
+__webpack_require__.d(__webpack_exports__, [
+  "mod", 0, mod
+]);
+
 
 },
 "./package1/script.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  exportDefaultUsed: () => (exportDefaultUsed)
-});
 /* import */ var _script1__rspack_import_0 = __webpack_require__("./package1/script1.js");
 
 /* unused export default */ var __rspack_default_export = ((/* unused pure expression or super */ null && (mod)));
 
 
 const exportDefaultUsed = false;
+
+__webpack_require__.d(__webpack_exports__, [
+  "exportDefaultUsed", 0, exportDefaultUsed
+]);
 
 
 },
@@ -61,9 +63,6 @@ const exportDefaultUsed = false;
 
 },
 "./package1/script2.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  exportDefaultUsed: () => (exportDefaultUsed)
-});
 
 /* export default */ function __rspack_default_export() {
 	return mod;
@@ -72,13 +71,13 @@ __webpack_require__.d(__webpack_exports__, {
 
 const exportDefaultUsed = false;
 
+__webpack_require__.d(__webpack_exports__, [
+  "exportDefaultUsed", 0, exportDefaultUsed
+]);
+
 
 },
 "./package2/script.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export),
-  exportDefaultUsed: () => (exportDefaultUsed)
-});
 /* import */ var _script1__rspack_import_0 = __webpack_require__("./package2/script1.js");
 
 /* export default */ const __rspack_default_export = (_script1__rspack_import_0["default"]);
@@ -86,13 +85,19 @@ __webpack_require__.d(__webpack_exports__, {
 
 const exportDefaultUsed = true;
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export),
+  "exportDefaultUsed", 0, exportDefaultUsed
+]);
+
 
 },
 "./package2/script1.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* export default */ const __rspack_default_export = (1);
+
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-side-effects-all-used/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-side-effects-all-used/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "../node_modules/pmodule/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var a = "a";
 var b = "b";
@@ -15,12 +12,13 @@ var c = "c";
 
 (0,_tracker__rspack_import_0.track)("a.js");
 
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
+
 
 },
 "../node_modules/pmodule/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  x: () => (x)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var x = "x";
 var y = "y";
@@ -31,12 +29,13 @@ var y = "y";
 
 (0,_tracker__rspack_import_0.track)("b.js");
 
+__webpack_require__.d(__webpack_exports__, [
+  "x", () => (x)
+]);
+
 
 },
 "../node_modules/pmodule/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  z: () => (z)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var z = "z";
 
@@ -45,12 +44,13 @@ var z = "z";
 
 (0,_tracker__rspack_import_0.track)("c.js");
 
+__webpack_require__.d(__webpack_exports__, [
+  "z", () => (z)
+]);
+
 
 },
 "../node_modules/pmodule/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 
 
@@ -60,13 +60,13 @@ __webpack_require__.d(__webpack_exports__, {
 
 /* export default */ const __rspack_default_export = ("def");
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "../node_modules/pmodule/tracker.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  log: () => (log),
-  track: () => (track)
-});
 function track(file) {
 	log.push(file);
 	log.sort();
@@ -77,6 +77,11 @@ var log = [];
 function reset() {
 	log.length = 0;
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "log", () => (log),
+  "track", () => (track)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-side-effects-all-used/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-side-effects-all-used/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "../node_modules/pmodule/a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "a", () => (a)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var a = "a";
 var b = "b";
@@ -12,13 +15,12 @@ var c = "c";
 
 (0,_tracker__rspack_import_0.track)("a.js");
 
-__webpack_require__.d(__webpack_exports__, [
-  "a", () => (a)
-]);
-
 
 },
 "../node_modules/pmodule/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "x", () => (x)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var x = "x";
 var y = "y";
@@ -29,13 +31,12 @@ var y = "y";
 
 (0,_tracker__rspack_import_0.track)("b.js");
 
-__webpack_require__.d(__webpack_exports__, [
-  "x", () => (x)
-]);
-
 
 },
 "../node_modules/pmodule/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "z", () => (z)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var z = "z";
 
@@ -44,13 +45,12 @@ var z = "z";
 
 (0,_tracker__rspack_import_0.track)("c.js");
 
-__webpack_require__.d(__webpack_exports__, [
-  "z", () => (z)
-]);
-
 
 },
 "../node_modules/pmodule/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 
 
@@ -60,13 +60,13 @@ __webpack_require__.d(__webpack_exports__, [
 
 /* export default */ const __rspack_default_export = ("def");
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "../node_modules/pmodule/tracker.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "log", () => (log),
+  "track", () => (track)
+]);
 function track(file) {
 	log.push(file);
 	log.sort();
@@ -77,11 +77,6 @@ var log = [];
 function reset() {
 	log.length = 0;
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "log", () => (log),
-  "track", () => (track)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-side-effects-simple-unused/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-side-effects-simple-unused/__snapshots__/treeshaking.snap.txt
@@ -2,6 +2,9 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "../node_modules/pmodule/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "x", () => (x)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var x = "x";
 var y = "y";
@@ -12,13 +15,12 @@ var y = "y";
 
 (0,_tracker__rspack_import_0.track)("b.js");
 
-__webpack_require__.d(__webpack_exports__, [
-  "x", () => (x)
-]);
-
 
 },
 "../node_modules/pmodule/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "z", () => (z)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var z = "z";
 
@@ -27,13 +29,12 @@ var z = "z";
 
 (0,_tracker__rspack_import_0.track)("c.js");
 
-__webpack_require__.d(__webpack_exports__, [
-  "z", () => (z)
-]);
-
 
 },
 "../node_modules/pmodule/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 
 
@@ -43,13 +44,13 @@ __webpack_require__.d(__webpack_exports__, [
 
 /* export default */ const __rspack_default_export = ("def");
 
-__webpack_require__.d(__webpack_exports__, [
-  "default", () => (__rspack_default_export)
-]);
-
 
 },
 "../node_modules/pmodule/tracker.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, [
+  "log", () => (log),
+  "track", () => (track)
+]);
 function track(file) {
 	log.push(file);
 	log.sort();
@@ -60,11 +61,6 @@ var log = [];
 function reset() {
 	log.length = 0;
 }
-
-__webpack_require__.d(__webpack_exports__, [
-  "log", () => (log),
-  "track", () => (track)
-]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/webpack-side-effects-simple-unused/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/webpack-side-effects-simple-unused/__snapshots__/treeshaking.snap.txt
@@ -2,9 +2,6 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "../node_modules/pmodule/b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  x: () => (x)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var x = "x";
 var y = "y";
@@ -15,12 +12,13 @@ var y = "y";
 
 (0,_tracker__rspack_import_0.track)("b.js");
 
+__webpack_require__.d(__webpack_exports__, [
+  "x", () => (x)
+]);
+
 
 },
 "../node_modules/pmodule/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  z: () => (z)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 var z = "z";
 
@@ -29,12 +27,13 @@ var z = "z";
 
 (0,_tracker__rspack_import_0.track)("c.js");
 
+__webpack_require__.d(__webpack_exports__, [
+  "z", () => (z)
+]);
+
 
 },
 "../node_modules/pmodule/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 /* import */ var _tracker__rspack_import_0 = __webpack_require__("../node_modules/pmodule/tracker.js");
 
 
@@ -44,13 +43,13 @@ __webpack_require__.d(__webpack_exports__, {
 
 /* export default */ const __rspack_default_export = ("def");
 
+__webpack_require__.d(__webpack_exports__, [
+  "default", () => (__rspack_default_export)
+]);
+
 
 },
 "../node_modules/pmodule/tracker.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  log: () => (log),
-  track: () => (track)
-});
 function track(file) {
 	log.push(file);
 	log.sort();
@@ -61,6 +60,11 @@ var log = [];
 function reset() {
 	log.length = 0;
 }
+
+__webpack_require__.d(__webpack_exports__, [
+  "log", () => (log),
+  "track", () => (track)
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/with-assets/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/with-assets/__snapshots__/treeshaking.snap.txt
@@ -2,10 +2,11 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (a)
-});
 const a = 3;
+
+__webpack_require__.d(__webpack_exports__, [
+  "a", 0, a
+]);
 
 
 },

--- a/tests/rspack-test/treeShakingCases/with-assets/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/with-assets/__snapshots__/treeshaking.snap.txt
@@ -2,11 +2,10 @@
 "use strict";
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-const a = 3;
-
 __webpack_require__.d(__webpack_exports__, [
-  "a", 0, a
+  "a", () => (a)
 ]);
+const a = 3;
 
 
 },

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -1227,7 +1227,7 @@ async fn run_optimize_dependencies_hook(compilation: &mut Compilation) -> Result
 
 async fn run_optimize_modules_hook(compilation: &mut Compilation) -> Result<()> {
   let mut diagnostics = vec![];
-  let mut circular_modules = IdentifierSet::default();
+  let mut circular_modules = None;
   while matches!(
     compilation
       .plugin_driver


### PR DESCRIPTION
## Summary

- Optimize ESM `export const` codegen by emitting value bindings in `__webpack_require__.d` instead of generated getter functions when circular-module information is available and the current module is not circular.
- Keep getter bindings for non-const exports and circular modules, and place circular modules' `__webpack_require__.d` calls at the top while non-circular modules emit them at the end of the module body.
- Update the `__webpack_require__.d` runtime binding format to support flat definitions like `'name', 0, value` for value exports and `'name', () => value` for getter exports.
- Enable `CircularModulesInfoPlugin` only for production/default-production mode, and store circular-module info as `Option<IdentifierSet>` so an empty set still means the plugin ran and the optimization can apply.
- Update related runtime interop handling and snapshots for the new export-definition format.

## Related links

- Inspired by https://github.com/vercel/next.js/pull/82760

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
