### PR TITLE
perf: optimize mangle exports plugin

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -1,8 +1,7 @@
-use std::{borrow::Cow, sync::LazyLock};
+use std::borrow::Cow;
 
 use itertools::Itertools;
 use rayon::prelude::*;
-use regex::Regex;
 use rspack_core::{
   BuildMetaExportsType, Compilation, CompilationOptimizeCodeGeneration, ExportInfo, ExportProvided,
   ExportsInfo, ExportsInfoArtifact, ExportsInfoData, Plugin, UsageState, UsedNameItem,
@@ -18,17 +17,34 @@ use crate::utils::mangle_exports::{
   NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS, NUMBER_OF_IDENTIFIER_START_CHARS, number_to_identifier,
 };
 
-fn can_mangle(exports_info: &ExportsInfoData) -> bool {
+fn get_mangleable_state(
+  exports_info: &ExportsInfoData,
+  deterministic: bool,
+  is_namespace: bool,
+) -> Option<bool> {
   if exports_info.other_exports_info().get_used(None) != UsageState::Unused {
-    return false;
+    return None;
   }
-  let mut has_something_to_mangle = false;
+
+  let mut has_mangleable_export = false;
+  let mut avoid_mangle_non_provided = !is_namespace;
+  let check_non_provided = deterministic && !avoid_mangle_non_provided;
   for export_info in exports_info.exports().values() {
     if export_info.can_mangle() == Some(true) {
-      has_something_to_mangle = true;
+      has_mangleable_export = true;
+      if !check_non_provided || avoid_mangle_non_provided {
+        break;
+      }
+    }
+    if check_non_provided && !matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
+      avoid_mangle_non_provided = true;
+      if has_mangleable_export {
+        break;
+      }
     }
   }
-  has_something_to_mangle
+
+  has_mangleable_export.then_some(avoid_mangle_non_provided)
 }
 
 /// Struct to represent the mangle exports plugin.
@@ -62,8 +78,12 @@ struct PreparedMangleableExports<'a> {
   changes: Vec<(ExportInfo, UsedNameItem)>,
   nested_exports: Vec<ExportsInfo>,
   used_names: FxHashSet<Cow<'a, str>>,
-  mangleable_exports: Vec<ExportInfo>,
-  mangleable_export_names: FxHashMap<ExportInfo, &'a Atom>,
+  mangleable_exports: Vec<MangleableExport<'a>>,
+}
+
+struct MangleableExport<'a> {
+  id: ExportInfo,
+  name: &'a Atom,
 }
 
 fn prepare_mangleable_exports<'a>(
@@ -73,7 +93,6 @@ fn prepare_mangleable_exports<'a>(
   let mut nested_exports = vec![];
   let mut used_names = FxHashSet::default();
   let mut mangleable_exports = Vec::new();
-  let mut mangleable_export_names = FxHashMap::default();
 
   for export_info in export_list {
     match &export_info.can_mangle {
@@ -82,8 +101,10 @@ fn prepare_mangleable_exports<'a>(
         used_names.insert(Cow::Borrowed(name.as_str()));
       }
       Manglable::CanMangle(name) => {
-        mangleable_export_names.insert(export_info.id.clone(), name);
-        mangleable_exports.push(export_info.id.clone());
+        mangleable_exports.push(MangleableExport {
+          id: export_info.id.clone(),
+          name,
+        });
       }
       Manglable::Mangled => {}
     }
@@ -98,7 +119,6 @@ fn prepare_mangleable_exports<'a>(
     nested_exports,
     used_names,
     mangleable_exports,
-    mangleable_export_names,
   }
 }
 
@@ -139,28 +159,16 @@ async fn optimize_code_generation(
     let batch = items
       .par_iter()
       .filter_map(|(exports_info, is_namespace)| {
-        let mut avoid_mangle_non_provided = !is_namespace;
         let deterministic = self.deterministic;
         let exports_info_data = exports_info.as_data(exports_info_artifact);
-        let export_list = {
-          if !can_mangle(exports_info_data) {
-            return None;
-          }
-          if !avoid_mangle_non_provided && deterministic {
-            for export_info in exports_info_data.exports().values() {
-              if !matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
-                avoid_mangle_non_provided = true;
-                break;
-              }
-            }
-          }
-          exports_info_data.exports().values().collect::<Vec<_>>()
-        };
+        let avoid_mangle_non_provided =
+          get_mangleable_state(exports_info_data, deterministic, *is_namespace)?;
 
         Some((
           *exports_info,
-          export_list
-            .iter()
+          exports_info_data
+            .exports()
+            .values()
             .map(|export_info_data| {
               let can_mangle = if !export_info_data.has_used_name() {
                 let name = export_info_data
@@ -168,10 +176,8 @@ async fn optimize_code_generation(
                   .expect("the name of export_info inserted in exports_info can not be `None`")
                   .clone();
                 let can_not_mangle = export_info_data.can_mangle() != Some(true)
-                  || (name.len() == 1 && MANGLE_NAME_NORMAL_REG.is_match(name.as_str()))
-                  || (deterministic
-                    && name.len() == 2
-                    && MANGLE_NAME_DETERMINISTIC_REG.is_match(name.as_str()))
+                  || is_one_char_mangle_name(name.as_str())
+                  || (deterministic && is_two_char_deterministic_mangle_name(name.as_str()))
                   || (avoid_mangle_non_provided
                     && !matches!(export_info_data.provided(), Some(ExportProvided::Provided)));
 
@@ -259,14 +265,29 @@ impl Plugin for MangleExportsPlugin {
 }
 
 /// Compare function for sorting exports by name.
-fn compare_strings_numeric(a: Option<&Atom>, b: Option<&Atom>) -> std::cmp::Ordering {
-  a.cmp(&b)
+fn compare_strings_numeric(a: &Atom, b: &Atom) -> std::cmp::Ordering {
+  a.cmp(b)
 }
-static MANGLE_NAME_NORMAL_REG: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new("^[a-zA-Z0-9_$]").expect("should construct regex"));
-static MANGLE_NAME_DETERMINISTIC_REG: LazyLock<Regex> = LazyLock::new(|| {
-  Regex::new("^[a-zA-Z_$][a-zA-Z0-9_$]|^[1-9][0-9]").expect("should construct regex")
-});
+
+fn is_identifier_start(byte: u8) -> bool {
+  byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
+fn is_identifier_continuation(byte: u8) -> bool {
+  byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+fn is_one_char_mangle_name(name: &str) -> bool {
+  let bytes = name.as_bytes();
+  bytes.len() == 1 && is_identifier_continuation(bytes[0])
+}
+
+fn is_two_char_deterministic_mangle_name(name: &str) -> bool {
+  let bytes = name.as_bytes();
+  bytes.len() == 2
+    && ((is_identifier_start(bytes[0]) && is_identifier_continuation(bytes[1]))
+      || ((b'1'..=b'9').contains(&bytes[0]) && bytes[1].is_ascii_digit()))
+}
 
 /// Function to mangle exports information.
 fn mangle_exports_info(
@@ -284,7 +305,6 @@ fn mangle_exports_info(
     nested_exports,
     mut used_names,
     mangleable_exports,
-    mangleable_export_names,
   } = prepare_mangleable_exports(export_list);
 
   if deterministic {
@@ -292,20 +312,8 @@ fn mangle_exports_info(
     let mut export_info_used_name = FxHashMap::default();
     assign_deterministic_ids(
       mangleable_exports,
-      |e| {
-        Cow::Borrowed(
-          mangleable_export_names
-            .get(e)
-            .expect("should have name")
-            .as_str(),
-        )
-      },
-      |a, b| {
-        compare_strings_numeric(
-          mangleable_export_names.get(a).copied(),
-          mangleable_export_names.get(b).copied(),
-        )
-      },
+      |e| Cow::Borrowed(e.name.as_str()),
+      |a, b| compare_strings_numeric(a.name, b.name),
       |e, id| {
         let name = number_to_identifier(id as u32);
         let size = used_names.len();
@@ -313,7 +321,7 @@ fn mangle_exports_info(
         if size == used_names.len() {
           false
         } else {
-          export_info_used_name.insert(e.clone(), name);
+          export_info_used_name.insert(e.id.clone(), name);
           true
         }
       },
@@ -333,7 +341,7 @@ fn mangle_exports_info(
     let mut unused_exports = Vec::new();
 
     for export_info in mangleable_exports {
-      let used = export_info.as_data(exports_info_artifact).get_used(None);
+      let used = export_info.id.as_data(exports_info_artifact).get_used(None);
       if used == UsageState::Unused {
         unused_exports.push(export_info);
       } else {
@@ -341,18 +349,8 @@ fn mangle_exports_info(
       }
     }
 
-    used_exports.sort_by(|a, b| {
-      compare_strings_numeric(
-        mangleable_export_names.get(a).copied(),
-        mangleable_export_names.get(b).copied(),
-      )
-    });
-    unused_exports.sort_by(|a, b| {
-      compare_strings_numeric(
-        mangleable_export_names.get(a).copied(),
-        mangleable_export_names.get(b).copied(),
-      )
-    });
+    used_exports.sort_by(|a, b| compare_strings_numeric(a.name, b.name));
+    unused_exports.sort_by(|a, b| compare_strings_numeric(a.name, b.name));
 
     let mut i = 0;
     for list in [used_exports, unused_exports] {
@@ -365,7 +363,7 @@ fn mangle_exports_info(
             break;
           }
         }
-        changes.push((export_info, UsedNameItem::Str(name.into())));
+        changes.push((export_info.id, UsedNameItem::Str(name.into())));
       }
     }
   }

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -17,11 +17,15 @@ use crate::utils::mangle_exports::{
   NUMBER_OF_IDENTIFIER_CONTINUATION_CHARS, NUMBER_OF_IDENTIFIER_START_CHARS, number_to_identifier,
 };
 
+struct MangleableState {
+  avoid_mangle_non_provided: bool,
+}
+
 fn get_mangleable_state(
   exports_info: &ExportsInfoData,
   deterministic: bool,
   is_namespace: bool,
-) -> Option<bool> {
+) -> Option<MangleableState> {
   if exports_info.other_exports_info().get_used(None) != UsageState::Unused {
     return None;
   }
@@ -44,7 +48,9 @@ fn get_mangleable_state(
     }
   }
 
-  has_mangleable_export.then_some(avoid_mangle_non_provided)
+  has_mangleable_export.then_some(MangleableState {
+    avoid_mangle_non_provided,
+  })
 }
 
 /// Struct to represent the mangle exports plugin.
@@ -161,7 +167,7 @@ async fn optimize_code_generation(
       .filter_map(|(exports_info, is_namespace)| {
         let deterministic = self.deterministic;
         let exports_info_data = exports_info.as_data(exports_info_artifact);
-        let avoid_mangle_non_provided =
+        let mangleable_state =
           get_mangleable_state(exports_info_data, deterministic, *is_namespace)?;
 
         Some((
@@ -178,7 +184,7 @@ async fn optimize_code_generation(
                 let can_not_mangle = export_info_data.can_mangle() != Some(true)
                   || is_one_char_mangle_name(name.as_str())
                   || (deterministic && is_two_char_deterministic_mangle_name(name.as_str()))
-                  || (avoid_mangle_non_provided
+                  || (mangleable_state.avoid_mangle_non_provided
                     && !matches!(export_info_data.provided(), Some(ExportProvided::Provided)));
 
                 if can_not_mangle {


### PR DESCRIPTION
### What changed

- Collapse the mangleability pre-scan into one export-info pass that also derives whether non-provided exports must be avoided.
- Carry export names directly alongside mangleable export ids so deterministic id assignment and sorting no longer build or query a per-exports-info name map.
- Replace short-name regex checks with direct ASCII byte predicates for generated mangle names.

### Why this should improve performance

`MangleExportsPlugin` runs over exports info, which can be much higher cardinality than chunks, chunk groups, or runtimes. The previous path repeatedly scanned export collections and allocated a temporary name lookup map for every mangled exports info, then performed map lookups inside sorting and deterministic id assignment.

The new path keeps the same observable ordering and assignment behavior while reducing repeated traversal, per-export lookup work, and temporary hash-map allocation on the export-info hot path. The expected benefit is lower CPU time and fewer transient allocations when compilations contain many modules or nested exports with mangleable names.