### PR TITLE
fix(stats): preserve sub-millisecond precision in logger time entries

### DIFF
--- a/crates/rspack_binding_api/src/stats.rs
+++ b/crates/rspack_binding_api/src/stats.rs
@@ -16,7 +16,7 @@ use rspack_napi::napi::{
   Either,
   bindgen_prelude::{Buffer, Result, SharedReference, ToNapiValue},
 };
-use rspack_util::{atom::Atom, itoa, numeric_id_value};
+use rspack_util::{atom::Atom, itoa, numeric_id_value, ryu_js};
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
@@ -325,8 +325,9 @@ impl<'a> From<(String, rspack_core::LogType)> for JsStatsLogging<'a> {
         secs,
         subsec_nanos,
       } => {
-        let mut time_buffer = itoa::Buffer::new();
-        let time_str = time_buffer.format(secs * 1000 + subsec_nanos as u64 / 1_000_000);
+        let ms = secs as f64 * 1000.0 + subsec_nanos as f64 / 1_000_000.0;
+        let mut time_buffer = ryu_js::Buffer::new();
+        let time_str = time_buffer.format(ms);
         Self {
           name: value.0,
           r#type: "time",


### PR DESCRIPTION
## Why

`stats.toJson({ logging: 'verbose' })` reported every per-phase timing as an integer ms because the napi serializer truncated the nanosecond remainder via `u64` integer division. Short stages like `Compilation.seal` / `optimize tree` / `optimize modules` were always `0 ms` even when they actually took tens of µs.

## What

Compute elapsed ms as `f64` and format with `ryu_js::Buffer`, so messages become e.g. `seal: 0.019542 ms`. The webpack-compat parsing path and existing `[\d.]+ ms` regex consumers already support decimals — nothing else needs to change.