### PR TITLE
perf: optimize flag dependency usage

### DIFF
--- a/crates/rspack_core/src/exports/export_info_setter.rs
+++ b/crates/rspack_core/src/exports/export_info_setter.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 
 use rspack_util::atom::Atom;
 
-use super::{ExportInfoData, ExportInfoTargetValue, UsageFilterFnTy, UsageState};
+use super::{ExportInfoData, ExportInfoTargetValue, UsageState};
 use crate::{CanInlineUse, DependencyId, Nullable, RuntimeSpec};
 
 impl ExportInfoData {
@@ -130,7 +130,7 @@ impl ExportInfoData {
 
   pub fn set_used_conditionally(
     &mut self,
-    condition: UsageFilterFnTy<UsageState>,
+    condition: impl Fn(&UsageState) -> bool,
     new_value: UsageState,
     runtime: Option<&RuntimeSpec>,
   ) -> bool {
@@ -180,7 +180,7 @@ impl ExportInfoData {
     let mut changed = false;
 
     if self.set_used_conditionally(
-      Box::new(|value| value < &UsageState::Unknown),
+      |value| value < &UsageState::Unknown,
       UsageState::Unknown,
       runtime,
     ) {

--- a/crates/rspack_core/src/exports/exports_info_setter.rs
+++ b/crates/rspack_core/src/exports/exports_info_setter.rs
@@ -9,7 +9,7 @@ use crate::{
 impl ExportsInfoData {
   pub fn set_used_for_side_effects_only(&mut self, runtime: Option<&RuntimeSpec>) -> bool {
     self.side_effects_only_info_mut().set_used_conditionally(
-      Box::new(|value| value == &UsageState::Unused),
+      |value| value == &UsageState::Unused,
       UsageState::Used,
       runtime,
     )
@@ -132,7 +132,7 @@ impl ExportsInfoData {
     }
     let other_exports_info = self.other_exports_info_mut();
     if other_exports_info.set_used_conditionally(
-      Box::new(|value| value < &UsageState::Unknown),
+      |value| value < &UsageState::Unknown,
       UsageState::Unknown,
       runtime,
     ) {

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -178,8 +178,6 @@ impl UsageKey {
   }
 }
 
-pub type UsageFilterFnTy<T> = Box<dyn Fn(&T) -> bool>;
-
 #[derive(Debug, PartialEq, Copy, Clone, Default, Hash, PartialOrd, Ord, Eq)]
 pub enum UsageState {
   Unused = 0,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -491,7 +491,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             let last_one = i == len - 1;
             if !last_one && let Some(nested_info) = export_info.exports_info() {
               let changed_flag = export_info.set_used_conditionally(
-                Box::new(|used| used == &UsageState::Unused),
+                |used| used == &UsageState::Unused,
                 UsageState::OnlyPropertiesUsed,
                 runtime.as_ref(),
               );
@@ -517,7 +517,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             }
 
             let changed_flag = export_info.set_used_conditionally(
-              Box::new(|v| v != &UsageState::Used),
+              |v| v != &UsageState::Used,
               UsageState::Used,
               runtime.as_ref(),
             );
@@ -707,7 +707,34 @@ fn collect_active_dependencies(
         (block.get_blocks(), block.get_dependencies())
       }
     };
-    dependencies.extend(block_dependencies);
+    for &dep_id in block_dependencies {
+      let Some(connection) = module_graph.connection_by_dependency_id(&dep_id) else {
+        continue;
+      };
+      let active_state = connection.active_state(
+        module_graph,
+        runtime,
+        module_graph_cache,
+        side_effects_state_artifact,
+        exports_info_artifact,
+      );
+
+      match active_state {
+        ConnectionState::Active(false) => {
+          continue;
+        }
+        ConnectionState::TransitiveOnly => {
+          q.push((
+            ModuleOrAsyncDependenciesBlock::Module(*connection.module_identifier()),
+            runtime.cloned(),
+            false,
+          ));
+          continue;
+        }
+        _ => {}
+      }
+      dependencies.push((dep_id, *connection.module_identifier()));
+    }
     for block_id in blocks {
       let block = module_graph
         .block_by_id(block_id)
@@ -726,36 +753,6 @@ fn collect_active_dependencies(
       }
     }
   }
-
-  let dependencies = dependencies
-    .into_iter()
-    .filter_map(|dep_id| {
-      let connection = module_graph.connection_by_dependency_id(&dep_id)?;
-      let active_state = connection.active_state(
-        module_graph,
-        runtime,
-        module_graph_cache,
-        side_effects_state_artifact,
-        exports_info_artifact,
-      );
-
-      match active_state {
-        ConnectionState::Active(false) => {
-          return None;
-        }
-        ConnectionState::TransitiveOnly => {
-          q.push((
-            ModuleOrAsyncDependenciesBlock::Module(*connection.module_identifier()),
-            runtime.cloned(),
-            false,
-          ));
-          return None;
-        }
-        _ => {}
-      }
-      Some((dep_id, *connection.module_identifier()))
-    })
-    .collect::<Vec<_>>();
 
   (dependencies, q)
 }
@@ -846,7 +843,7 @@ fn process_referenced_module_without_nested(
         }
 
         let changed_flag = export_info.set_used_conditionally(
-          Box::new(|v| v != &UsageState::Used),
+          |v| v != &UsageState::Used,
           UsageState::Used,
           runtime.as_ref(),
         );

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
@@ -297,7 +297,7 @@ async fn optimize_dependencies(
           // Mark used exports
           for export_info in exports_info_data.exports_mut().values_mut() {
             export_info.set_used_conditionally(
-              Box::new(|used| *used == rspack_core::UsageState::Unknown),
+              |used| *used == rspack_core::UsageState::Unknown,
               rspack_core::UsageState::Unused,
               None,
             );


### PR DESCRIPTION
## What changed

- Avoid allocating boxed usage-filter closures when marking export usage by making `set_used_conditionally` generic over the predicate.
- Filter active dependencies while walking dependency blocks in `FlagDependencyUsagePlugin` instead of first materializing all dependency ids and scanning them again.

## Why this should improve performance

`FlagDependencyUsagePlugin` scales with dependencies and export infos, which are among the highest-cardinality structures in compilation. The previous path performed repeated heap allocation for usage predicates and kept an avoidable temporary dependency list before active-state filtering.

The new path keeps the same observable usage propagation while reducing per-export allocation and one dependency traversal/materialization step.

## Expected benefit

- Lower allocation churn during export usage propagation.
- Less temporary memory and CPU work while collecting active dependencies for large dependency blocks.

<img width="1572" height="810" alt="image" src="https://github.com/user-attachments/assets/aaa3eda5-b91a-4c47-88a3-9c2c81603d0d" />
