### PR TITLE
perf: optimize flag dependency exports

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -72,15 +72,14 @@ impl<'a> FlagDependencyExportsState<'a> {
       // collect the exports specs from modules by calling `dependency.get_exports`
       let module_exports_specs = modules
         .into_par_iter()
-        .map(|module_id| {
-          let exports_specs = collect_module_exports_specs(
+        .filter_map(|module_id| {
+          collect_module_exports_specs(
             &module_id,
             self.mg,
             self.mg_cache,
             self.exports_info_artifact,
           )
-          .unwrap_or_default();
-          (module_id, exports_specs)
+          .map(|exports_specs| (module_id, exports_specs))
         })
         .collect::<Vec<_>>();
 
@@ -269,7 +268,11 @@ fn collect_module_exports_specs(
     res.push((id, exports_spec));
   }
   // mg_cache.unfreeze();
-  Some((res, has_nested_exports))
+  if res.is_empty() {
+    None
+  } else {
+    Some((res, has_nested_exports))
+  }
 }
 
 /// Merge exports specs to exports info data
@@ -718,6 +721,10 @@ fn find_target_exports_info(
   exports_info_artifact: &ExportsInfoArtifact,
   export_info: &ExportInfoData,
 ) -> (Option<ExportsInfo>, Option<ModuleIdentifier>) {
+  if !export_info.target_is_set() || export_info.target().is_empty() {
+    return (None, None);
+  }
+
   // Recalculate target exportsInfo
   let target = get_target(
     export_info,


### PR DESCRIPTION
## What changed

- Skip modules that do not produce any export specs before entering the merge phase.
- Return early from target export-info resolution when an export has no target mapping.

## Why this should improve performance

`FlagDependencyExportsPlugin` works at dependency/export-info cardinality, so empty per-module export-spec batches and per-export target lookups can add up quickly on large graphs. The new fast paths avoid scheduling/collecting empty merge work and skip target resolution setup for the common local-export case.

## Expected benefit

This should reduce CPU work and small temporary allocations during `finishModules`, especially in projects with many dependencies that do not contribute export specs and many ordinary non-reexported exports.