### PR TITLE
perf(parser): reduce parser walk and hook dispatch overhead

### DIFF
--- a/crates/rspack_macros/src/javascript_parser_plugin_hooks.rs
+++ b/crates/rspack_macros/src/javascript_parser_plugin_hooks.rs
@@ -54,6 +54,9 @@ fn expand_impl(input: &mut ItemImpl) -> Result<()> {
         "remove manual hook metadata; this attribute generates it automatically",
       ));
     }
+    if normalized_name == "hook_name_filter" {
+      continue;
+    }
 
     hook_variants.push(hook_variant_ident(&func.sig.ident)?);
   }

--- a/crates/rspack_plugin_extract_css/src/parser_plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/parser_plugin.rs
@@ -26,7 +26,7 @@ pub struct PluginCssExtractParserPlugin {
 #[rspack_plugin_javascript::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for PluginCssExtractParserPlugin {
   fn finish(&self, parser: &mut JavascriptParser) -> Option<bool> {
-    let deps = if let Some(data_str) = parser.parse_meta.remove(PLUGIN_NAME)
+    if let Some(data_str) = parser.parse_meta.remove(PLUGIN_NAME)
       && let Ok(data_str) = (data_str as Box<dyn std::any::Any>)
         .downcast::<String>()
         .map(|i| *i)
@@ -37,13 +37,13 @@ impl JavascriptParserPlugin for PluginCssExtractParserPlugin {
         self.cache.insert(data_str, data.clone());
         data
       } else {
-        vec![]
+        return None;
       };
       if data.is_empty() {
-        vec![]
+        return None;
       } else {
         parser.build_info.strict = true;
-        data
+        let deps = data
           .iter()
           .enumerate()
           .map(
@@ -79,12 +79,10 @@ impl JavascriptParserPlugin for PluginCssExtractParserPlugin {
               )) as BoxDependency
             },
           )
-          .collect::<Vec<_>>()
+          .collect::<Vec<_>>();
+        parser.add_dependencies(deps);
       }
-    } else {
-      vec![]
-    };
-    parser.add_dependencies(deps);
+    }
     None
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -16,7 +16,7 @@ use swc_core::{
 };
 
 use crate::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   dependency::{
     AMDRequireContextDependency,
     amd_define_dependency::AMDDefineDependency,
@@ -31,6 +31,8 @@ use crate::{
 };
 
 pub struct AMDDefineDependencyParserPlugin;
+
+const AMD_DEFINE_CALL_NAMES: &[&str] = &["define"];
 
 fn is_unbound_function_expression(expr: &Expr) -> bool {
   expr.is_fn_expr() || expr.is_arrow()
@@ -589,6 +591,13 @@ impl AMDDefineDependencyParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for AMDDefineDependencyParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Call => Some(AMD_DEFINE_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn call(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
@@ -6,7 +6,7 @@ use swc_core::{
 };
 
 use crate::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   utils::eval::{BasicEvaluatedExpression, evaluate_to_identifier, evaluate_to_string},
   visitors::JavascriptParser,
 };
@@ -17,9 +17,34 @@ const DEFINE: &str = "define";
 const REQUIRE: &str = "require";
 const DEFINE_AMD: &str = "define.amd";
 const REQUIRE_AMD: &str = "require.amd";
+const AMD_CALL_NAMES: &[&str] = &["require.config", "requirejs.config"];
+const AMD_MEMBER_NAMES: &[&str] = &[
+  "require.version",
+  "requirejs.onError",
+  DEFINE_AMD,
+  REQUIRE_AMD,
+];
+const AMD_TYPEOF_NAMES: &[&str] = &[DEFINE, REQUIRE, DEFINE_AMD, REQUIRE_AMD];
+const AMD_IDENTIFIER_NAMES: &[&str] = &[DEFINE];
+const AMD_EVALUATE_IDENTIFIER_NAMES: &[&str] = &[DEFINE_AMD, REQUIRE_AMD];
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for AMDParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Call => Some(AMD_CALL_NAMES),
+      JavascriptParserPluginHook::Member => Some(AMD_MEMBER_NAMES),
+      JavascriptParserPluginHook::Typeof | JavascriptParserPluginHook::EvaluateTypeof => {
+        Some(AMD_TYPEOF_NAMES)
+      }
+      JavascriptParserPluginHook::Identifier
+      | JavascriptParserPluginHook::CanRename
+      | JavascriptParserPluginHook::Rename => Some(AMD_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::EvaluateIdentifier => Some(AMD_EVALUATE_IDENTIFIER_NAMES),
+      _ => None,
+    }
+  }
+
   fn call(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -15,7 +15,7 @@ use swc_core::{
 };
 
 use crate::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   dependency::{
     AMDRequireContextDependency,
     amd_require_array_dependency::{AMDRequireArrayDependency, AMDRequireArrayItem},
@@ -40,8 +40,17 @@ fn is_reserved_param(pat: &Pat) -> bool {
 
 pub struct AMDRequireDependenciesBlockParserPlugin;
 
+const AMD_REQUIRE_CALL_NAMES: &[&str] = &["require"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for AMDRequireDependenciesBlockParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Call => Some(AMD_REQUIRE_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn call(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -8,7 +8,7 @@ use swc_core::{
 
 use crate::{
   dependency::{ModuleArgumentDependency, RequireMainDependency},
-  parser_plugin::JavascriptParserPlugin,
+  parser_plugin::{JavascriptParserPlugin, JavascriptParserPluginHook},
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error},
 };
@@ -55,6 +55,68 @@ const API_GET_SCRIPT_FILENAME: &str = "__webpack_get_script_filename__";
 const API_VERSION: &str = "__rspack_version__";
 const API_UNIQUE_ID: &str = "__rspack_unique_id__";
 const API_RSC_MANIFEST: &str = "__rspack_rsc_manifest__";
+const API_IDENTIFIER_NAMES: &[&str] = &[
+  API_REQUIRE,
+  API_HASH,
+  API_LAYER,
+  API_PUBLIC_PATH,
+  API_MODULES,
+  API_CHUNK_LOAD,
+  API_MODULE,
+  API_BASE_URI,
+  API_NON_REQUIRE,
+  API_SYSTEM_CONTEXT,
+  API_SHARE_SCOPES,
+  API_INIT_SHARING,
+  API_NONCE,
+  API_CHUNK_NAME,
+  API_RUNTIME_ID,
+  API_GET_SCRIPT_FILENAME,
+  API_VERSION,
+  API_UNIQUE_ID,
+  API_RSC_MANIFEST,
+];
+const API_EVALUATE_TYPEOF_NAMES: &[&str] = &[
+  API_REQUIRE,
+  API_HASH,
+  API_LAYER,
+  API_PUBLIC_PATH,
+  API_MODULES,
+  API_MODULE,
+  API_CHUNK_LOAD,
+  API_BASE_URI,
+  API_NON_REQUIRE,
+  API_SYSTEM_CONTEXT,
+  API_SHARE_SCOPES,
+  API_INIT_SHARING,
+  API_NONCE,
+  API_CHUNK_NAME,
+  API_RUNTIME_ID,
+  API_GET_SCRIPT_FILENAME,
+  API_VERSION,
+  API_UNIQUE_ID,
+  API_RSC_MANIFEST,
+];
+const API_EVALUATE_IDENTIFIER_NAMES: &[&str] = &[API_LAYER];
+const API_MEMBER_NAMES: &[&str] = &[
+  "require.extensions",
+  "require.config",
+  "require.version",
+  "require.include",
+  "require.onError",
+  "require.main.require",
+  "module.parent.require",
+  "require.cache",
+  "require.main",
+  "__webpack_module__.id",
+];
+const API_CALL_NAMES: &[&str] = &[
+  "require.config",
+  "require.include",
+  "require.onError",
+  "require.main.require",
+  "module.parent.require",
+];
 
 pub struct APIPluginOptions {
   module: bool,
@@ -97,6 +159,17 @@ fn get_typeof_evaluate_of_api(sym: &str) -> Option<&str> {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for APIPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier => Some(API_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::EvaluateIdentifier => Some(API_EVALUATE_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::EvaluateTypeof => Some(API_EVALUATE_TYPEOF_NAMES),
+      JavascriptParserPluginHook::Member => Some(API_MEMBER_NAMES),
+      JavascriptParserPluginHook::Call => Some(API_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_typeof<'a>(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -9,7 +9,7 @@ use swc_core::{
   },
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::{
     CommonJsExportRequireDependency, CommonJsExportsDependency, CommonJsSelfReferenceDependency,
@@ -259,6 +259,12 @@ pub struct CommonJsExportsParserPlugin {
   skip_in_esm: bool,
 }
 
+const COMMONJS_EXPORTS_ROOT_NAMES: &[&str] = &["exports", "module", "this"];
+const COMMONJS_EXPORTS_CALL_NAMES: &[&str] = &["Object.defineProperty"];
+const COMMONJS_EXPORTS_IDENTIFIER_NAMES: &[&str] = &["module", "exports"];
+const COMMONJS_EXPORTS_MEMBER_NAMES: &[&str] = &["module.exports"];
+const COMMONJS_EXPORTS_TYPEOF_NAMES: &[&str] = &["module", "exports"];
+
 impl CommonJsExportsParserPlugin {
   pub fn new(skip_in_esm: bool) -> Self {
     Self { skip_in_esm }
@@ -271,6 +277,19 @@ impl CommonJsExportsParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::AssignMemberChain
+      | JavascriptParserPluginHook::MemberChain
+      | JavascriptParserPluginHook::CallMemberChain => Some(COMMONJS_EXPORTS_ROOT_NAMES),
+      JavascriptParserPluginHook::Call => Some(COMMONJS_EXPORTS_CALL_NAMES),
+      JavascriptParserPluginHook::Identifier => Some(COMMONJS_EXPORTS_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::Member => Some(COMMONJS_EXPORTS_MEMBER_NAMES),
+      JavascriptParserPluginHook::EvaluateTypeof => Some(COMMONJS_EXPORTS_TYPEOF_NAMES),
+      _ => None,
+    }
+  }
+
   fn assign_member_chain(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -13,7 +13,7 @@ use swc_core::{
   },
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::{
     CommonJsFullRequireDependency, CommonJsRequireContextDependency, CommonJsRequireDependency,
@@ -30,6 +30,22 @@ use crate::{
 };
 
 const COMMONJS_REQUIRE_TAG: &str = "commonjs require";
+const COMMONJS_REQUIRE_TAG_NAMES: &[&str] = &[COMMONJS_REQUIRE_TAG];
+const COMMONJS_REQUIRE_IDENTIFIER_NAMES: &[&str] = &[COMMONJS_REQUIRE_TAG, expr_name::REQUIRE];
+const COMMONJS_REQUIRE_NAMES: &[&str] = &[expr_name::REQUIRE];
+const COMMONJS_REQUIRE_TYPEOF_NAMES: &[&str] = &[
+  expr_name::REQUIRE,
+  expr_name::REQUIRE_RESOLVE,
+  expr_name::REQUIRE_RESOLVE_WEAK,
+];
+const COMMONJS_REQUIRE_CALL_NAMES: &[&str] = &[
+  expr_name::REQUIRE,
+  expr_name::MODULE_REQUIRE,
+  expr_name::REQUIRE_RESOLVE,
+  expr_name::REQUIRE_RESOLVE_WEAK,
+];
+const COMMONJS_REQUIRE_CALL_OR_NEW_NAMES: &[&str] =
+  &[expr_name::REQUIRE, expr_name::MODULE_REQUIRE];
 
 #[derive(Debug, Default)]
 pub struct RequireReferencesState {
@@ -624,6 +640,28 @@ impl CommonJsImportsParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier => Some(COMMONJS_REQUIRE_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::MemberChain | JavascriptParserPluginHook::CallMemberChain => {
+        Some(COMMONJS_REQUIRE_TAG_NAMES)
+      }
+      JavascriptParserPluginHook::CanRename
+      | JavascriptParserPluginHook::Rename
+      | JavascriptParserPluginHook::Assign => Some(COMMONJS_REQUIRE_NAMES),
+      JavascriptParserPluginHook::EvaluateTypeof
+      | JavascriptParserPluginHook::EvaluateIdentifier
+      | JavascriptParserPluginHook::Typeof => Some(COMMONJS_REQUIRE_TYPEOF_NAMES),
+      JavascriptParserPluginHook::Call => Some(COMMONJS_REQUIRE_CALL_NAMES),
+      JavascriptParserPluginHook::NewExpression
+      | JavascriptParserPluginHook::MemberChainOfCallMemberChain
+      | JavascriptParserPluginHook::CallMemberChainOfCallMemberChain => {
+        Some(COMMONJS_REQUIRE_CALL_OR_NEW_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn can_collect_destructuring_assignment_properties(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -97,6 +97,13 @@ struct RequireTagData {
   require_span: Span,
 }
 
+fn current_require_tag_span(parser: &JavascriptParser) -> Option<Span> {
+  let tag_info = parser
+    .definitions_db
+    .expect_get_tag_info(parser.current_tag_info?);
+  Some(RequireTagData::downcast_ref(tag_info.data.as_deref()?).require_span)
+}
+
 fn tag_commonjs_require_referenced(
   parser: &mut JavascriptParser,
   require_call: &CallExpr,
@@ -665,10 +672,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     for_name: &str,
   ) -> Option<bool> {
     if for_name == COMMONJS_REQUIRE_TAG {
-      let tag_info = parser
-        .definitions_db
-        .expect_get_tag_info(parser.current_tag_info?);
-      let data = RequireTagData::downcast(tag_info.data.clone()?);
+      let require_span = current_require_tag_span(parser)?;
       if let Some(keys) = parser
         .destructuring_assignment_properties
         .get(&ident.span())
@@ -680,13 +684,13 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
         for ids in refs {
           parser
             .common_js_require_references
-            .get_require_mut_expect(&data.require_span)
+            .get_require_mut_expect(&require_span)
             .add_reference(ids);
         }
       } else {
         parser
           .common_js_require_references
-          .get_require_mut_expect(&data.require_span)
+          .get_require_mut_expect(&require_span)
           .add_reference(vec![]);
       }
       return Some(true);
@@ -711,14 +715,11 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     if for_name != COMMONJS_REQUIRE_TAG {
       return None;
     }
-    let tag_info = parser
-      .definitions_db
-      .expect_get_tag_info(parser.current_tag_info?);
-    let data = RequireTagData::downcast(tag_info.data.clone()?);
+    let require_span = current_require_tag_span(parser)?;
     let ids = get_non_optional_part(members, members_optionals);
     parser
       .common_js_require_references
-      .get_require_mut_expect(&data.require_span)
+      .get_require_mut_expect(&require_span)
       .add_reference(ids.to_vec());
     Some(true)
   }
@@ -735,15 +736,12 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     if for_name != COMMONJS_REQUIRE_TAG {
       return None;
     }
-    let tag_info = parser
-      .definitions_db
-      .expect_get_tag_info(parser.current_tag_info?);
-    let data = RequireTagData::downcast(tag_info.data.clone()?);
+    let require_span = current_require_tag_span(parser)?;
     let ids = get_non_optional_part(members, members_optionals);
     let direct_import = members.is_empty();
     parser
       .common_js_require_references
-      .get_require_mut_expect(&data.require_span)
+      .get_require_mut_expect(&require_span)
       .add_call_reference(
         ids.to_vec(),
         parser

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
@@ -1,7 +1,7 @@
 use rspack_core::{ConstDependency, RuntimeGlobals, RuntimeRequirementsDependency};
 use swc_core::ecma::ast::MemberExpr;
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   utils::eval::{BasicEvaluatedExpression, evaluate_to_identifier},
   visitors::{JavascriptParser, expr_name},
@@ -9,8 +9,21 @@ use crate::{
 
 pub struct CommonJsPlugin;
 
+const COMMON_JS_EVALUATE_IDENTIFIER_NAMES: &[&str] = &[expr_name::MODULE_HOT];
+const COMMON_JS_TYPEOF_NAMES: &[&str] = &[expr_name::MODULE];
+const COMMON_JS_MEMBER_NAMES: &[&str] = &["module.id", "module.loaded"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for CommonJsPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateIdentifier => Some(COMMON_JS_EVALUATE_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::Typeof => Some(COMMON_JS_TYPEOF_NAMES),
+      JavascriptParserPluginHook::Member => Some(COMMON_JS_MEMBER_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_identifier(
     &self,
     _parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -6,13 +6,15 @@ use swc_core::{
   ecma::ast::{CallExpr, VarDeclarator},
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::CommonJsRequireContextDependency,
   visitors::{JavascriptParser, Statement, TagInfoData, VariableDeclaration, expr_name},
 };
 
 pub const NESTED_IDENTIFIER_TAG: &str = "_identifier__nested_rspack_identifier__";
+const NESTED_IDENTIFIER_TAG_NAMES: &[&str] = &[NESTED_IDENTIFIER_TAG];
+const REQUIRE_NAMES: &[&str] = &[expr_name::REQUIRE];
 
 #[derive(Debug, Clone)]
 pub struct NestedRequireData {
@@ -76,6 +78,14 @@ impl CompatibilityPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for CompatibilityPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier => Some(NESTED_IDENTIFIER_TAG_NAMES),
+      JavascriptParserPluginHook::Call => Some(REQUIRE_NAMES),
+      _ => None,
+    }
+  }
+
   fn program(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/mod.rs
@@ -6,7 +6,7 @@ use rspack_util::SpanExt;
 use swc_core::common::Spanned;
 
 pub use self::logic_expr::is_logic_op;
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   utils::eval::evaluate_to_string,
   visitors::{JavascriptParser, Statement},
@@ -16,9 +16,19 @@ pub struct ConstPlugin;
 
 const RESOURCE_FRAGMENT: &str = "__resourceFragment";
 const RESOURCE_QUERY: &str = "__resourceQuery";
+const CONST_IDENTIFIER_NAMES: &[&str] = &[RESOURCE_FRAGMENT, RESOURCE_QUERY];
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ConstPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier | JavascriptParserPluginHook::EvaluateIdentifier => {
+        Some(CONST_IDENTIFIER_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn expression_logical_operator(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashMap;
 use swc_core::{
   atoms::Atom,
   common::Span,
@@ -25,6 +26,8 @@ pub struct JavaScriptParserPluginDrive {
   // Each bit stores whether the plugin at the same index implements the hook.
   // This keeps hook dispatch allocation-free for the common case while preserving plugin order.
   plugins_by_hook: [u64; JavascriptParserPluginHook::COUNT],
+  name_filtered_plugins_by_hook: [FxHashMap<&'static str, u64>; JavascriptParserPluginHook::COUNT],
+  unfiltered_plugins_by_hook: [u64; JavascriptParserPluginHook::COUNT],
 }
 
 struct PluginBitmaskIter<'a> {
@@ -54,6 +57,9 @@ impl JavaScriptParserPluginDrive {
     );
 
     let mut plugins_by_hook = [0; JavascriptParserPluginHook::COUNT];
+    let mut name_filtered_plugins_by_hook =
+      std::array::from_fn(|_| FxHashMap::<&'static str, u64>::default());
+    let mut unfiltered_plugins_by_hook = [0; JavascriptParserPluginHook::COUNT];
 
     for (idx, plugin) in plugins.iter().enumerate() {
       let plugin_bit = 1u64 << idx;
@@ -64,12 +70,24 @@ impl JavaScriptParserPluginDrive {
         implemented_hooks &= implemented_hooks - 1;
 
         plugins_by_hook[hook_idx] |= plugin_bit;
+        let hook = JavascriptParserPluginHook::ALL[hook_idx];
+        if let Some(names) = plugin.hook_name_filter(hook) {
+          for name in names {
+            *name_filtered_plugins_by_hook[hook_idx]
+              .entry(*name)
+              .or_default() |= plugin_bit;
+          }
+        } else {
+          unfiltered_plugins_by_hook[hook_idx] |= plugin_bit;
+        }
       }
     }
 
     Self {
       plugins,
       plugins_by_hook,
+      name_filtered_plugins_by_hook,
+      unfiltered_plugins_by_hook,
     }
   }
 
@@ -79,6 +97,29 @@ impl JavaScriptParserPluginDrive {
     PluginBitmaskIter {
       plugins: &self.plugins,
       plugin_bitmask: unsafe { *self.plugins_by_hook.get_unchecked(hook_idx) },
+    }
+  }
+
+  #[inline]
+  fn plugins_for_name(
+    &self,
+    hook: JavascriptParserPluginHook,
+    name: &str,
+  ) -> PluginBitmaskIter<'_> {
+    let hook_idx = hook as usize;
+    let unfiltered_plugin_bitmask =
+      unsafe { *self.unfiltered_plugins_by_hook.get_unchecked(hook_idx) };
+    let filtered_plugin_bitmask = unsafe {
+      self
+        .name_filtered_plugins_by_hook
+        .get_unchecked(hook_idx)
+        .get(name)
+        .copied()
+        .unwrap_or_default()
+    };
+    PluginBitmaskIter {
+      plugins: &self.plugins,
+      plugin_bitmask: unfiltered_plugin_bitmask | filtered_plugin_bitmask,
     }
   }
 }
@@ -163,7 +204,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   }
 
   fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, name: &str) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Call) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Call, name) {
       let res = plugin.call(parser, expr, name);
       // `SyncBailHook`
       if res.is_some() {
@@ -179,7 +220,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &swc_core::ecma::ast::MemberExpr,
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Member) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Member, for_name) {
       let res = plugin.member(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -198,7 +239,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     members_optionals: &[bool],
     member_ranges: &[Span],
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::MemberChain) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::MemberChain, for_name) {
       let res = plugin.member_chain(
         parser,
         expr,
@@ -225,7 +266,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     member_ranges: &[Span],
   ) -> Option<bool> {
     assert!(matches!(expr.callee, Callee::Expr(_)));
-    for plugin in self.plugins_for(JavascriptParserPluginHook::CallMemberChain) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::CallMemberChain, for_name) {
       let res = plugin.call_member_chain(
         parser,
         expr,
@@ -263,7 +304,10 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::MemberChainOfCallMemberChain) {
+    for plugin in self.plugins_for_name(
+      JavascriptParserPluginHook::MemberChainOfCallMemberChain,
+      for_name,
+    ) {
       let res = plugin.member_chain_of_call_member_chain(
         parser,
         member_expr,
@@ -291,7 +335,10 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::CallMemberChainOfCallMemberChain) {
+    for plugin in self.plugins_for_name(
+      JavascriptParserPluginHook::CallMemberChainOfCallMemberChain,
+      for_name,
+    ) {
       let res = plugin.call_member_chain_of_call_member_chain(
         parser,
         call_expr,
@@ -315,7 +362,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &AssignExpr,
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Assign) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Assign, for_name) {
       let res = plugin.assign(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -332,7 +379,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     members: &[Atom],
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::AssignMemberChain) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::AssignMemberChain, for_name) {
       let res = plugin.assign_member_chain(parser, expr, members, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -349,7 +396,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     for_name: &str,
   ) -> Option<bool> {
     assert!(expr.op == UnaryOp::TypeOf);
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Typeof) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Typeof, for_name) {
       let res = plugin.r#typeof(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -442,7 +489,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &swc_core::ecma::ast::NewExpr,
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::NewExpression) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::NewExpression, for_name) {
       let res = plugin.new_expression(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -458,7 +505,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &swc_core::ecma::ast::Ident,
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Identifier) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Identifier, for_name) {
       let res = plugin.identifier(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -523,7 +570,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &swc_core::ecma::ast::ThisExpr,
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::This) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::This, for_name) {
       let res = plugin.this(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -554,7 +601,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &'a UnaryExpr,
     for_name: &str,
   ) -> Option<BasicEvaluatedExpression<'a>> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::EvaluateTypeof) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::EvaluateTypeof, for_name) {
       let res = plugin.evaluate_typeof(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -570,7 +617,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     name: &str,
     expr: &'a CallExpr,
   ) -> Option<BasicEvaluatedExpression<'a>> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::EvaluateCallExpression) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::EvaluateCallExpression, name) {
       let res = plugin.evaluate_call_expression(parser, name, expr);
       if res.is_some() {
         return res;
@@ -586,7 +633,10 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     expr: &'a CallExpr,
     param: BasicEvaluatedExpression<'a>,
   ) -> Option<BasicEvaluatedExpression<'a>> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::EvaluateCallExpressionMember) {
+    for plugin in self.plugins_for_name(
+      JavascriptParserPluginHook::EvaluateCallExpressionMember,
+      property,
+    ) {
       let res = plugin.evaluate_call_expression_member(parser, property, expr, param.clone());
       // `SyncBailHook`
       if res.is_some() {
@@ -603,7 +653,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'static>> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::EvaluateIdentifier) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::EvaluateIdentifier, for_name) {
       let res = plugin.evaluate_identifier(parser, for_name, start, end);
       // `SyncBailHook`
       if res.is_some() {
@@ -636,7 +686,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     ident: &swc_core::ecma::ast::Ident,
     for_name: &str,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Pattern) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Pattern, for_name) {
       let res = plugin.pattern(parser, ident, for_name);
       // `SyncBailHook`
       if res.is_some() {
@@ -663,7 +713,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   }
 
   fn can_rename(&self, parser: &mut JavascriptParser, str: &str) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::CanRename) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::CanRename, str) {
       let res = plugin.can_rename(parser, str);
       // `SyncBailHook`
       if res.is_some() {
@@ -674,7 +724,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   }
 
   fn rename(&self, parser: &mut JavascriptParser, expr: &Expr, str: &str) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::Rename) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::Rename, str) {
       let res = plugin.rename(parser, expr, str);
       // `SyncBailHook`
       if res.is_some() {
@@ -730,7 +780,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     root_name: &swc_core::atoms::Atom,
     span: Span,
   ) -> Option<bool> {
-    for plugin in self.plugins_for(JavascriptParserPluginHook::MetaProperty) {
+    for plugin in self.plugins_for_name(JavascriptParserPluginHook::MetaProperty, root_name) {
       let res = plugin.meta_property(parser, root_name, span);
       // `SyncBailHook`
       if res.is_some() {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -7,7 +7,7 @@ use swc_core::{
   ecma::ast::{Ident, ModuleItem, Program, UnaryExpr},
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::ESMCompatibilityDependency,
   utils::eval::BasicEvaluatedExpression,
@@ -47,9 +47,21 @@ fn is_non_esm_identifier(name: &str) -> bool {
   name == "exports" || name == "define"
 }
 
+const NON_ESM_IDENTIFIER_NAMES: &[&str] = &["exports", "define"];
+
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/HarmonyDetectionParserPlugin.js
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ESMDetectionParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateTypeof
+      | JavascriptParserPluginHook::Typeof
+      | JavascriptParserPluginHook::Identifier
+      | JavascriptParserPluginHook::Call => Some(NON_ESM_IDENTIFIER_NAMES),
+      _ => None,
+    }
+  }
+
   fn program(&self, parser: &mut JavascriptParser, ast: &Program) -> Option<bool> {
     let is_strict_esm = matches!(parser.module_type, ModuleType::JsEsm);
     let is_esm = is_strict_esm

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -9,7 +9,8 @@ use swc_core::{
 };
 
 use super::{
-  InnerGraphParserPlugin, JavascriptParserPlugin, inner_graph::state::InnerGraphUsageOperation,
+  InnerGraphParserPlugin, JavascriptParserPlugin, JavascriptParserPluginHook,
+  inner_graph::state::InnerGraphUsageOperation,
 };
 use crate::{
   dependency::{ESMImportSideEffectDependency, ESMImportSpecifierDependency},
@@ -24,6 +25,7 @@ use crate::{
 pub struct ESMImportDependencyParserPlugin;
 
 pub const ESM_SPECIFIER_TAG: &str = "_identifier__esm_specifier_tag__";
+const ESM_SPECIFIER_TAG_NAMES: &[&str] = &[ESM_SPECIFIER_TAG];
 
 #[derive(Debug, Clone)]
 pub struct ESMSpecifierData {
@@ -38,6 +40,15 @@ pub struct ESMSpecifierData {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier
+      | JavascriptParserPluginHook::MemberChain
+      | JavascriptParserPluginHook::CallMemberChain => Some(ESM_SPECIFIER_TAG_NAMES),
+      _ => None,
+    }
+  }
+
   fn import(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_top_level_this_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_top_level_this_plugin.rs
@@ -1,12 +1,21 @@
 use rspack_core::ConstDependency;
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::visitors::JavascriptParser;
 
 pub struct ESMTopLevelThisParserPlugin;
 
+const THIS_NAMES: &[&str] = &["this"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ESMTopLevelThisParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::This => Some(THIS_NAMES),
+      _ => None,
+    }
+  }
+
   fn this(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/exports_info_api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/exports_info_api_plugin.rs
@@ -6,15 +6,26 @@ use swc_core::{
   ecma::ast::{Ident, MemberExpr},
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{dependency::ExportInfoDependency, visitors::JavascriptParser};
 
 const EXPORTS_INFO: &str = "__webpack_exports_info__";
 
 pub struct ExportsInfoApiPlugin;
 
+const EXPORTS_INFO_NAMES: &[&str] = &[EXPORTS_INFO];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ExportsInfoApiPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::MemberChain | JavascriptParserPluginHook::Identifier => {
+        Some(EXPORTS_INFO_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn member_chain(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -11,7 +11,7 @@ use crate::{
     ModuleArgumentDependency, ModuleHotAcceptDependency, ModuleHotDeclineDependency,
     import_emitted_runtime,
   },
-  parser_plugin::JavascriptParserPlugin,
+  parser_plugin::{JavascriptParserPlugin, JavascriptParserPluginHook},
   utils::eval,
   visitors::{JavascriptParser, expr_name},
 };
@@ -124,6 +124,10 @@ pub struct ModuleHotReplacementParserPlugin {
   _private: (),
 }
 
+const MODULE_HOT_EVALUATE_OR_MEMBER_NAMES: &[&str] = &[expr_name::MODULE_HOT];
+const MODULE_HOT_CALL_NAMES: &[&str] =
+  &[expr_name::MODULE_HOT_ACCEPT, expr_name::MODULE_HOT_DECLINE];
+
 impl ModuleHotReplacementParserPlugin {
   #[allow(clippy::new_without_default)]
   pub fn new() -> Self {
@@ -134,6 +138,16 @@ impl ModuleHotReplacementParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ModuleHotReplacementParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateIdentifier | JavascriptParserPluginHook::Member => {
+        Some(MODULE_HOT_EVALUATE_OR_MEMBER_NAMES)
+      }
+      JavascriptParserPluginHook::Call => Some(MODULE_HOT_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_identifier(
     &self,
     _parser: &mut JavascriptParser,
@@ -192,6 +206,12 @@ pub struct ImportMetaHotReplacementParserPlugin {
   _private: (),
 }
 
+const IMPORT_META_HOT_EVALUATE_OR_MEMBER_NAMES: &[&str] = &[expr_name::IMPORT_META_HOT];
+const IMPORT_META_HOT_CALL_NAMES: &[&str] = &[
+  expr_name::IMPORT_META_HOT_ACCEPT,
+  expr_name::IMPORT_META_HOT_DECLINE,
+];
+
 impl ImportMetaHotReplacementParserPlugin {
   #[allow(clippy::new_without_default)]
   pub fn new() -> Self {
@@ -202,6 +222,16 @@ impl ImportMetaHotReplacementParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ImportMetaHotReplacementParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateIdentifier | JavascriptParserPluginHook::Member => {
+        Some(IMPORT_META_HOT_EVALUATE_OR_MEMBER_NAMES)
+      }
+      JavascriptParserPluginHook::Call => Some(IMPORT_META_HOT_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_identifier(
     &self,
     _parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -6,7 +6,7 @@ use swc_core::{
   ecma::ast::{CallExpr, Lit},
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::ImportMetaContextDependency,
   utils::{
@@ -108,8 +108,19 @@ fn create_import_meta_context_dependency(
 
 pub struct ImportMetaContextDependencyParserPlugin;
 
+const IMPORT_META_CONTEXT_NAMES: &[&str] = &[expr_name::IMPORT_META_CONTEXT];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ImportMetaContextDependencyParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateIdentifier | JavascriptParserPluginHook::Call => {
+        Some(IMPORT_META_CONTEXT_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn evaluate_identifier(
     &self,
     _parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -12,7 +12,7 @@ use swc_core::{
 };
 use url::Url;
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::{
     IMPORT_META_RSC_BINDING, ImportMetaResolveContextDependency, ImportMetaResolveDependency,
@@ -58,6 +58,28 @@ fn create_import_meta_resolve_context_dependency(
 }
 
 pub struct ImportMetaPlugin(pub(crate) ImportMeta);
+
+const IMPORT_META_ROOT_NAMES: &[&str] = &[expr_name::IMPORT_META];
+const IMPORT_META_TYPEOF_NAMES: &[&str] = &[
+  expr_name::IMPORT_META,
+  expr_name::IMPORT_META_URL,
+  expr_name::IMPORT_META_RESOLVE,
+  expr_name::IMPORT_META_VERSION,
+  expr_name::IMPORT_META_MAIN,
+  expr_name::IMPORT_META_RSPACK_RSC,
+];
+const IMPORT_META_EVALUATE_IDENTIFIER_NAMES: &[&str] = &[
+  expr_name::IMPORT_META_VERSION,
+  expr_name::IMPORT_META_URL,
+  expr_name::IMPORT_META_RESOLVE,
+];
+const IMPORT_META_MEMBER_NAMES: &[&str] = &[
+  expr_name::IMPORT_META_URL,
+  expr_name::IMPORT_META_VERSION,
+  expr_name::IMPORT_META_MAIN,
+  expr_name::IMPORT_META_RSPACK_RSC,
+];
+const IMPORT_META_CALL_NAMES: &[&str] = &[expr_name::IMPORT_META_RESOLVE];
 
 impl ImportMetaPlugin {
   fn import_meta_url(&self, parser: &JavascriptParser) -> String {
@@ -214,6 +236,20 @@ fn mark_import_meta_rsc_used(parser: &mut JavascriptParser) {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ImportMetaPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateTypeof | JavascriptParserPluginHook::Typeof => {
+        Some(IMPORT_META_TYPEOF_NAMES)
+      }
+      JavascriptParserPluginHook::EvaluateIdentifier => Some(IMPORT_META_EVALUATE_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::MetaProperty
+      | JavascriptParserPluginHook::UnhandledExpressionMemberChain => Some(IMPORT_META_ROOT_NAMES),
+      JavascriptParserPluginHook::Member => Some(IMPORT_META_MEMBER_NAMES),
+      JavascriptParserPluginHook::Call => Some(IMPORT_META_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_typeof<'a>(
     &self,
     parser: &mut JavascriptParser,
@@ -569,6 +605,13 @@ pub struct ImportMetaDisabledPlugin;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ImportMetaDisabledPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::MetaProperty => Some(IMPORT_META_ROOT_NAMES),
+      _ => None,
+    }
+  }
+
   fn meta_property(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -122,6 +122,13 @@ struct ImportTagData {
   import_span: Span,
 }
 
+fn current_import_tag_span(parser: &JavascriptParser) -> Option<Span> {
+  let tag_info = parser
+    .definitions_db
+    .expect_get_tag_info(parser.current_tag_info?);
+  Some(ImportTagData::downcast_ref(tag_info.data.as_deref()?).import_span)
+}
+
 pub struct ImportParserPlugin;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
@@ -177,10 +184,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     if for_name != DYNAMIC_IMPORT_TAG {
       return None;
     }
-    let tag_info = parser
-      .definitions_db
-      .expect_get_tag_info(parser.current_tag_info?);
-    let data = ImportTagData::downcast(tag_info.data.clone()?);
+    let import_span = current_import_tag_span(parser)?;
     if let Some(keys) = parser
       .destructuring_assignment_properties
       .get(&ident.span())
@@ -192,13 +196,13 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       for ids in refs {
         parser
           .dynamic_import_references
-          .get_import_mut_expect(&data.import_span)
+          .get_import_mut_expect(&import_span)
           .add_reference(ids);
       }
     } else {
       parser
         .dynamic_import_references
-        .get_import_mut_expect(&data.import_span)
+        .get_import_mut_expect(&import_span)
         .add_reference(vec![]);
     }
     Some(true)
@@ -216,14 +220,11 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     if for_name != DYNAMIC_IMPORT_TAG {
       return None;
     }
-    let tag_info = parser
-      .definitions_db
-      .expect_get_tag_info(parser.current_tag_info?);
-    let data = ImportTagData::downcast(tag_info.data.clone()?);
+    let import_span = current_import_tag_span(parser)?;
     let ids = get_non_optional_part(members, members_optionals);
     parser
       .dynamic_import_references
-      .get_import_mut_expect(&data.import_span)
+      .get_import_mut_expect(&import_span)
       .add_reference(ids.to_vec());
     Some(true)
   }
@@ -240,15 +241,12 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     if for_name != DYNAMIC_IMPORT_TAG {
       return None;
     }
-    let tag_info = parser
-      .definitions_db
-      .expect_get_tag_info(parser.current_tag_info?);
-    let data = ImportTagData::downcast(tag_info.data.clone()?);
+    let import_span = current_import_tag_span(parser)?;
     let ids = get_non_optional_part(members, members_optionals);
     let direct_import = members.is_empty();
     parser
       .dynamic_import_references
-      .get_import_mut_expect(&data.import_span)
+      .get_import_mut_expect(&import_span)
       .add_call_reference(
         ids.to_vec(),
         parser

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -16,7 +16,7 @@ use swc_core::{
   },
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::{
     ImportContextDependency, ImportDependency, ImportEagerDependency, ImportWeakDependency,
@@ -31,6 +31,7 @@ use crate::{
 };
 
 const DYNAMIC_IMPORT_TAG: &str = "dynamic import";
+const DYNAMIC_IMPORT_TAG_NAMES: &[&str] = &[DYNAMIC_IMPORT_TAG];
 
 fn tag_dynamic_import_referenced(
   parser: &mut JavascriptParser,
@@ -133,6 +134,15 @@ pub struct ImportParserPlugin;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for ImportParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier
+      | JavascriptParserPluginHook::MemberChain
+      | JavascriptParserPluginHook::CallMemberChain => Some(DYNAMIC_IMPORT_TAG_NAMES),
+      _ => None,
+    }
+  }
+
   fn can_collect_destructuring_assignment_properties(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
@@ -4,7 +4,7 @@ use cow_utils::CowUtils;
 use rspack_util::SpanExt;
 use swc_core::ecma::ast::CallExpr;
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{utils::eval::BasicEvaluatedExpression, visitors::JavascriptParser};
 
 const SLICE_METHOD_NAME: &str = "slice";
@@ -14,11 +14,31 @@ const INDEXOF_METHOD_NAME: &str = "indexOf";
 const SPLIT_METHOD_NAME: &str = "split";
 const SUBSTR_METHOD_NAME: &str = "substr";
 const SUBSTRING_METHOD_NAME: &str = "substring";
+const EVALUATE_CALL_EXPRESSION_NAMES: &[&str] = &["String", "Number", "Boolean"];
+const EVALUATE_CALL_EXPRESSION_MEMBER_NAMES: &[&str] = &[
+  SLICE_METHOD_NAME,
+  REPLACE_METHOD_NAME,
+  CONCAT_METHOD_NAME,
+  INDEXOF_METHOD_NAME,
+  SPLIT_METHOD_NAME,
+  SUBSTR_METHOD_NAME,
+  SUBSTRING_METHOD_NAME,
+];
 
 pub struct InitializeEvaluating;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for InitializeEvaluating {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateCallExpression => Some(EVALUATE_CALL_EXPRESSION_NAMES),
+      JavascriptParserPluginHook::EvaluateCallExpressionMember => {
+        Some(EVALUATE_CALL_EXPRESSION_MEMBER_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn evaluate_call_expression<'a>(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -2,7 +2,7 @@ use rspack_core::EvaluatedInlinableValue;
 use rspack_util::ryu_js;
 use swc_core::ecma::ast::VarDeclarator;
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   utils::eval::{
     BasicEvaluatedExpression, evaluate_to_boolean, evaluate_to_null, evaluate_to_number,
@@ -15,6 +15,7 @@ use crate::{
 };
 
 pub const INLINABLE_CONST_TAG: &str = "inlinable const";
+const INLINABLE_CONST_TAG_NAMES: &[&str] = &[INLINABLE_CONST_TAG];
 
 #[derive(Debug, Clone)]
 pub struct InlinableConstData {
@@ -26,6 +27,13 @@ pub struct InlineConstPlugin;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for InlineConstPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateIdentifier => Some(INLINABLE_CONST_TAG_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_identifier(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -19,7 +19,7 @@ use super::state::{
 use crate::{
   ClassExt,
   dependency::{ESMImportSpecifierDependency, PureExpressionDependency, URLDependency},
-  parser_plugin::{DEFAULT_STAR_JS_WORD, JavascriptParserPlugin},
+  parser_plugin::{DEFAULT_STAR_JS_WORD, JavascriptParserPlugin, JavascriptParserPluginHook},
   side_effects_parser_plugin::{
     is_pure_class, is_pure_class_member, is_pure_expression, is_pure_function,
   },
@@ -36,6 +36,7 @@ pub struct InnerGraphParserPlugin {
 }
 
 pub static TOP_LEVEL_SYMBOL: &str = "inner graph top level symbol";
+const TOP_LEVEL_SYMBOL_NAMES: &[&str] = &[TOP_LEVEL_SYMBOL];
 
 impl InnerGraphParserPlugin {
   pub fn new(unresolved_mark: Mark, analyze_pure_annotation: bool) -> Self {
@@ -361,6 +362,16 @@ impl InnerGraphParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for InnerGraphParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Member
+      | JavascriptParserPluginHook::Assign
+      | JavascriptParserPluginHook::Identifier
+      | JavascriptParserPluginHook::This => Some(TOP_LEVEL_SYMBOL_NAMES),
+      _ => None,
+    }
+  }
+
   fn program(
     &self,
     parser: &mut crate::visitors::JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/is_included_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/is_included_plugin.rs
@@ -5,15 +5,26 @@ use swc_core::{
   ecma::ast::{CallExpr, UnaryExpr},
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{dependency::IsIncludeDependency, visitors::JavascriptParser};
 
 const IS_INCLUDED: &str = "__webpack_is_included__";
 
 pub struct IsIncludedPlugin;
 
+const IS_INCLUDED_NAMES: &[&str] = &[IS_INCLUDED];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for IsIncludedPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Call | JavascriptParserPluginHook::Typeof => {
+        Some(IS_INCLUDED_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, name: &str) -> Option<bool> {
     if name != IS_INCLUDED || expr.args.len() != 1 || expr.args[0].spread.is_some() {
       return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -2,15 +2,24 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
 
 use super::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   inner_graph::state::{InnerGraphMapUsage, TopLevelSymbol},
 };
 use crate::visitors::JavascriptParser;
 
 pub struct JavascriptMetaInfoPlugin;
 
+const JAVASCRIPT_META_CALL_NAMES: &[&str] = &["eval"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Call => Some(JAVASCRIPT_META_CALL_NAMES),
+      _ => None,
+    }
+  }
+
   fn call(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -9,10 +9,10 @@ use swc_core::{common::Spanned, ecma::ast::Expr};
 use url::Url;
 
 use crate::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   dependency::ExternalModuleDependency,
   utils::eval,
-  visitors::{DestructuringAssignmentProperty, JavascriptParser},
+  visitors::{DestructuringAssignmentProperty, JavascriptParser, expr_name},
 };
 
 const DIRNAME: &str = "__dirname";
@@ -22,6 +22,28 @@ const IMPORT_META_FILENAME: &str = "import.meta.filename";
 const GLOBAL: &str = "global";
 const MOCK_DIRNAME: &str = "/";
 const MOCK_FILENAME: &str = "/index.js";
+const NODE_IDENTIFIER_NAMES: &[&str] = &[DIRNAME, FILENAME, GLOBAL];
+const NODE_RENAME_NAMES: &[&str] = &[GLOBAL];
+const NODE_TYPEOF_NAMES: &[&str] = &[
+  DIRNAME,
+  FILENAME,
+  expr_name::IMPORT_META_DIRNAME,
+  expr_name::IMPORT_META_FILENAME,
+];
+const NODE_EVALUATE_TYPEOF_NAMES: &[&str] = &[
+  expr_name::IMPORT_META_DIRNAME,
+  expr_name::IMPORT_META_FILENAME,
+];
+const NODE_EVALUATE_IDENTIFIER_NAMES: &[&str] = &[
+  DIRNAME,
+  FILENAME,
+  expr_name::IMPORT_META_DIRNAME,
+  expr_name::IMPORT_META_FILENAME,
+];
+const NODE_MEMBER_NAMES: &[&str] = &[
+  expr_name::IMPORT_META_DIRNAME,
+  expr_name::IMPORT_META_FILENAME,
+];
 
 /// Represents the type of import.meta property being handled (filename or dirname)
 #[derive(Clone, Copy)]
@@ -398,6 +420,18 @@ impl NodeStuffPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for NodeStuffPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier => Some(NODE_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::Rename => Some(NODE_RENAME_NAMES),
+      JavascriptParserPluginHook::Typeof => Some(NODE_TYPEOF_NAMES),
+      JavascriptParserPluginHook::EvaluateTypeof => Some(NODE_EVALUATE_TYPEOF_NAMES),
+      JavascriptParserPluginHook::EvaluateIdentifier => Some(NODE_EVALUATE_IDENTIFIER_NAMES),
+      JavascriptParserPluginHook::Member => Some(NODE_MEMBER_NAMES),
+      _ => None,
+    }
+  }
+
   fn identifier(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -5,7 +5,7 @@ use rspack_regex::RspackRegex;
 use rspack_util::SpanExt;
 use swc_core::{common::Spanned, ecma::ast::CallExpr};
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::RequireContextDependency,
   visitors::{JavascriptParser, clean_regexp_in_context_module, default_context_reg_exp},
@@ -13,8 +13,17 @@ use crate::{
 
 pub struct RequireContextDependencyParserPlugin;
 
+const REQUIRE_CONTEXT_NAMES: &[&str] = &["require.context"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for RequireContextDependencyParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Call => Some(REQUIRE_CONTEXT_NAMES),
+      _ => None,
+    }
+  }
+
   fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, for_name: &str) -> Option<bool> {
     if for_name != "require.context" {
       return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -11,7 +11,7 @@ use swc_core::{
   ecma::ast::{ArrowExpr, BlockStmtOrExpr, CallExpr, Expr, FnExpr, UnaryExpr},
 };
 
-use super::JavascriptParserPlugin;
+use super::{JavascriptParserPlugin, JavascriptParserPluginHook};
 use crate::{
   dependency::{RequireEnsureDependency, RequireEnsureItemDependency},
   utils::eval::{self, BasicEvaluatedExpression},
@@ -20,8 +20,19 @@ use crate::{
 
 pub struct RequireEnsureDependenciesBlockParserPlugin;
 
+const REQUIRE_ENSURE_NAMES: &[&str] = &["require.ensure"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for RequireEnsureDependenciesBlockParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::EvaluateTypeof
+      | JavascriptParserPluginHook::Typeof
+      | JavascriptParserPluginHook::Call => Some(REQUIRE_ENSURE_NAMES),
+      _ => None,
+    }
+  }
+
   fn evaluate_typeof<'a>(
     &self,
     _parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -217,6 +217,14 @@ Please annotate your `impl JavascriptParserPlugin for ...` block with `#[rspack_
     JavascriptParserPluginHooks::all()
   }
 
+  /// Optional static name filter for name-based parser hooks.
+  ///
+  /// Returning `Some(names)` lets the parser drive skip this plugin before
+  /// virtual dispatch when the current hook name is not in `names`.
+  fn hook_name_filter(&self, _hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    None
+  }
+
   /// Return:
   /// - `Some(true)` signifies the termination of the current
   ///   statement's visit during the pre-walk phase.

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -12,7 +12,9 @@ use swc_core::{
 };
 use url::Url;
 
-use super::{JavascriptParserPlugin, inner_graph::state::InnerGraphUsageOperation};
+use super::{
+  JavascriptParserPlugin, JavascriptParserPluginHook, inner_graph::state::InnerGraphUsageOperation,
+};
 use crate::{
   InnerGraphParserPlugin,
   dependency::{URLContextDependency, URLDependency},
@@ -102,8 +104,19 @@ pub struct URLPlugin {
   pub mode: Option<JavascriptParserUrl>,
 }
 
+const URL_NAMES: &[&str] = &["URL"];
+
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for URLPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::CanRename | JavascriptParserPluginHook::NewExpression => {
+        Some(URL_NAMES)
+      }
+      _ => None,
+    }
+  }
+
   fn can_rename(&self, _parser: &mut JavascriptParser, for_name: &str) -> Option<bool> {
     (for_name == "URL").then_some(true)
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -3,7 +3,6 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, EntryOptions, GroupOptions,
 };
@@ -27,7 +26,7 @@ use crate::{
   magic_comment::try_extract_magic_comment,
   parser_plugin::url_plugin::is_meta_url,
   utils::object_properties::get_literal_str_by_obj_prop,
-  visitors::{JavascriptParser, TagInfoData, VariableDeclaration},
+  visitors::{AtomMembers, JavascriptParser, TagInfoData, VariableDeclaration},
 };
 
 #[derive(Debug)]
@@ -238,9 +237,9 @@ fn handle_worker<'a>(
 struct WorkerPluginInner {
   new_syntax: FxHashSet<String>,
   call_syntax: FxHashSet<String>,
-  from_new_syntax: FxHashSet<(String, String)>,
-  from_call_syntax: FxHashSet<(String, String)>,
-  pattern_syntax: FxHashMap<String, FxHashSet<String>>,
+  from_new_syntax: FxHashSet<(AtomMembers, Atom)>,
+  from_call_syntax: FxHashSet<(AtomMembers, Atom)>,
+  pattern_syntax: FxHashMap<String, FxHashSet<AtomMembers>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -306,11 +305,11 @@ impl WorkerPluginInner {
       let pattern = &syntax[0..first_dot];
       let members = &syntax[first_dot + 1..];
       if let Some(value) = self.pattern_syntax.get_mut(pattern) {
-        value.insert(members.to_string());
+        value.insert(worker_syntax_members(members));
       } else {
         self.pattern_syntax.insert(
           pattern.to_string(),
-          FxHashSet::from_iter([members.to_string()]),
+          FxHashSet::from_iter([worker_syntax_members(members)]),
         );
       }
     } else if let Some(syntax) = syntax.strip_suffix("()") {
@@ -319,16 +318,24 @@ impl WorkerPluginInner {
       if is_call {
         self
           .from_call_syntax
-          .insert((ids.to_string(), source.to_string()));
+          .insert((worker_syntax_members(ids), Atom::from(source)));
       } else {
         self
           .from_new_syntax
-          .insert((ids.to_string(), source.to_string()));
+          .insert((worker_syntax_members(ids), Atom::from(source)));
       }
     } else {
       self.new_syntax.insert(syntax.to_string());
     }
   }
+}
+
+fn worker_syntax_members(ids: &str) -> AtomMembers {
+  ids.split('.').map(Atom::from).collect()
+}
+
+fn worker_members(members: &[Atom]) -> AtomMembers {
+  members.iter().cloned().collect()
 }
 
 impl WorkerPlugin {
@@ -407,7 +414,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
       .expect_get_tag_info(parser.current_tag_info?);
     let data = WorkerSpecifierData::downcast(tag_info.data.clone()?);
     if let Some(value) = self.inner.pattern_syntax.get(data.key.as_str())
-      && value.contains(&members.iter().map(|id| id.as_str()).join("."))
+      && value.contains(&worker_members(members))
     {
       return handle_worker(parser, &call_expr.args, call_expr.span).map(
         |(parsed_path, parsed_options, first_arg, need_new_url)| {
@@ -443,11 +450,10 @@ impl JavascriptParserPlugin for WorkerPlugin {
         .definitions_db
         .expect_get_tag_info(parser.current_tag_info?);
       let settings = ESMSpecifierData::downcast(tag_info.data.clone()?);
-      let ids = settings.ids.iter().map(|id| id.as_str()).join(".");
       if self
         .inner
         .from_call_syntax
-        .contains(&(ids, settings.source.to_string()))
+        .contains(&(settings.ids, settings.source))
       {
         return handle_worker(parser, &call_expr.args, call_expr.span).map(
           |(parsed_path, parsed_options, first_arg, need_new_url)| {
@@ -506,11 +512,10 @@ impl JavascriptParserPlugin for WorkerPlugin {
         .definitions_db
         .expect_get_tag_info(parser.current_tag_info?);
       let settings = ESMSpecifierData::downcast(tag_info.data.clone()?);
-      let ids = settings.ids.iter().map(|id| id.as_str()).join(".");
       if self
         .inner
         .from_new_syntax
-        .contains(&(ids, settings.source.to_string()))
+        .contains(&(settings.ids, settings.source))
       {
         return new_expr
           .args

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -17,7 +17,7 @@ use swc_core::{
 use url::Url;
 
 use super::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   esm_import_dependency_parser_plugin::{ESM_SPECIFIER_TAG, ESMSpecifierData},
   url_plugin::get_url_request,
 };
@@ -248,6 +248,7 @@ pub struct WorkerPlugin {
 }
 
 const WORKER_SPECIFIER_TAG: &str = "_identifier__worker_specifier_tag__";
+const WORKER_SPECIFIER_TAG_NAMES: &[&str] = &[WORKER_SPECIFIER_TAG];
 const DEFAULT_SYNTAX: [&str; 4] = [
   "Worker",
   "SharedWorker",
@@ -362,6 +363,13 @@ impl WorkerPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for WorkerPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::CallMemberChain => Some(WORKER_SPECIFIER_TAG_NAMES),
+      _ => None,
+    }
+  }
+
   fn pre_declarator(
     &self,
     parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -29,7 +29,7 @@ pub fn eval_member_expression<'a>(
         let mut eval =
           BasicEvaluatedExpression::with_range(member.span.real_lo(), member.span.real_hi());
         eval.set_identifier(
-          info.name.into(),
+          info.name,
           info.root_info,
           Some(info.members.into_vec()),
           Some(info.members_optionals.into_vec()),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
@@ -1,6 +1,6 @@
 use swc_core::{
   atoms::Atom,
-  ecma::ast::{Expr, MemberExpr, OptChainExpr},
+  ecma::ast::{MemberExpr, OptChainExpr},
 };
 
 use super::{AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo};
@@ -90,11 +90,8 @@ impl CallHooksName for OptChainExpr {
   where
     F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
-    let Some(MemberExpressionInfo::Expression(expr_name)) = parser
-      .get_member_expression_info_from_expr(
-        &Expr::OptChain(self.to_owned()),
-        AllowedMemberTypes::Expression,
-      )
+    let Some(MemberExpressionInfo::Expression(expr_name)) =
+      parser.get_member_expression_info(ExprRef::OptChain(self), AllowedMemberTypes::Expression)
     else {
       return None;
     };

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -130,7 +130,7 @@ pub struct CallExpressionInfo<'ast> {
 
 #[derive(Debug)]
 pub struct ExpressionExpressionInfo {
-  pub name: String,
+  pub name: Atom,
   pub root_info: ExportedVariableInfo,
   pub members: AtomMembers,
   pub members_optionals: OptionalMembers,
@@ -143,7 +143,11 @@ pub enum ExportedVariableInfo {
   VariableInfo(VariableInfoId),
 }
 
-fn object_and_members_to_name(object: &Atom, members_reversed: &[impl AsRef<str>]) -> String {
+fn object_and_members_to_name(object: &Atom, members_reversed: &[impl AsRef<str>]) -> Atom {
+  if members_reversed.is_empty() {
+    return object.clone();
+  }
+
   let total_len = object.len()
     + members_reversed.len()
     + members_reversed
@@ -158,7 +162,7 @@ fn object_and_members_to_name(object: &Atom, members_reversed: &[impl AsRef<str>
     name.push('.');
     name.push_str(member.as_ref());
   }
-  name
+  name.into()
 }
 
 pub trait RootName {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1313,31 +1313,15 @@ impl JavascriptParser<'_> {
           let mut params = expr.args.iter().map(|arg| &*arg.expr);
           let this = params.next();
           self._walk_iife(&member_expr.obj, params, this)
-        } else if let Expr::Member(member_expr) = &**callee
-          && let Expr::Fn(fn_expr) = &*member_expr.obj
-          && let MemberProp::Ident(ident) = &member_expr.prop
-          && (ident.sym == "call" || ident.sym == "bind")
-          && !expr.args.is_empty()
-          && is_simple_function(&fn_expr.function.params)
-        {
-          // (function(…) { }.call(…))
-          let mut params = expr.args.iter().map(|arg| &*arg.expr);
-          let this = params.next();
-          self._walk_iife(&member_expr.obj, params, this)
         } else if let Expr::Fn(fn_expr) = &**callee
           && is_simple_function(&fn_expr.function.params)
         {
           // (function(…) { })(…)
           self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
-        } else if let Expr::Fn(fn_expr) = &**callee
-          && is_simple_function(&fn_expr.function.params)
-        {
-          // ((…) => { }(…))
-          self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
         } else if let Expr::Arrow(arrow_expr) = &**callee
           && arrow_expr.params.iter().all(|p| p.as_ident().is_some())
         {
-          // (function(…) { }(…))
+          // ((…) => { })(…)
           self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
         } else {
           if let Expr::Member(member) = &**callee {

--- a/crates/rspack_plugin_rslib/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/parser_plugin.rs
@@ -1,4 +1,6 @@
-use rspack_plugin_javascript::{JavascriptParserPlugin, visitors::JavascriptParser};
+use rspack_plugin_javascript::{
+  JavascriptParserPlugin, JavascriptParserPluginHook, visitors::JavascriptParser,
+};
 use swc_core::ecma::ast::MemberExpr;
 
 #[derive(PartialEq, Debug, Default)]
@@ -14,8 +16,26 @@ impl RslibParserPlugin {
   }
 }
 
+const RSLIB_MEMBER_NAMES: &[&str] = &[
+  "require.cache",
+  "require.extensions",
+  "require.config",
+  "require.version",
+  "require.include",
+  "require.onError",
+];
+const RSLIB_TYPEOF_NAMES: &[&str] = &["module"];
+
 #[rspack_plugin_javascript::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for RslibParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Member => Some(RSLIB_MEMBER_NAMES),
+      JavascriptParserPluginHook::Typeof => Some(RSLIB_TYPEOF_NAMES),
+      _ => None,
+    }
+  }
+
   fn member(
     &self,
     _parser: &mut JavascriptParser,

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -686,6 +686,10 @@ impl JavascriptParserPlugin for RstestParserPlugin {
   }
 
   fn statement(&self, parser: &mut JavascriptParser, stmt: Statement) -> Option<bool> {
+    if !self.options.hoist_mock_module {
+      return None;
+    }
+
     let call_expr = match stmt {
       Statement::Expr(expr_stmt) if expr_stmt.expr.as_call().is_some() => expr_stmt
         .expr
@@ -693,10 +697,6 @@ impl JavascriptParserPlugin for RstestParserPlugin {
         .expect("call expression should exist after checking with is_some()"),
       _ => return None,
     };
-
-    if !self.options.hoist_mock_module {
-      return None;
-    }
 
     if let Some(callee_expr) = call_expr.callee.as_expr()
       && let Some(member_expr) = callee_expr.as_member()

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, ImportAttributes, ImportPhase,
 };
 use rspack_plugin_javascript::{
-  JavascriptParserPlugin,
+  JavascriptParserPlugin, JavascriptParserPluginHook,
   dependency::{CommonJsRequireDependency, ImportDependency, RequireHeaderDependency},
   try_extract_magic_comment,
   utils::{
@@ -32,6 +32,8 @@ const FILE_NAME: &str = "__filename";
 const IMPORT_META_DIRNAME: &str = "import.meta.dirname";
 const IMPORT_META_FILENAME: &str = "import.meta.filename";
 pub(crate) const MOCK_TARGET_REQUEST_PREFIX: &str = "\0rstest_mock_target:\0";
+const MODULE_PATH_NAMES: &[&str] = &[DIR_NAME, FILE_NAME];
+const IMPORT_META_PATH_NAMES: &[&str] = &[IMPORT_META_DIRNAME, IMPORT_META_FILENAME];
 
 #[derive(PartialEq)]
 enum ModulePathType {
@@ -650,6 +652,17 @@ impl RstestParserPlugin {
 
 #[rspack_plugin_javascript::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for RstestParserPlugin {
+  fn hook_name_filter(&self, hook: JavascriptParserPluginHook) -> Option<&'static [&'static str]> {
+    match hook {
+      JavascriptParserPluginHook::Identifier => Some(MODULE_PATH_NAMES),
+      JavascriptParserPluginHook::EvaluateTypeof
+      | JavascriptParserPluginHook::EvaluateIdentifier
+      | JavascriptParserPluginHook::Typeof
+      | JavascriptParserPluginHook::Member => Some(IMPORT_META_PATH_NAMES),
+      _ => None,
+    }
+  }
+
   fn declarator(
     &self,
     parser: &mut JavascriptParser,


### PR DESCRIPTION
### What changed

- Added name-aware parser hook dispatch in `JavaScriptParserPluginDrive`: for high-frequency name-based hooks, plugins can now declare static names and the drive skips unrelated plugins before virtual dispatch.
- Audited all `JavascriptParserPlugin` implementations and added static filters across CommonJS, ESM import/export tags, AMD, API, import.meta, HMR, node stuff, URL, inline const, inner graph, rstest, and rslib parser plugins.
- Kept dynamic-name plugins such as DefinePlugin, ProvidePlugin, and configurable worker syntax on the unfiltered path to avoid duplicating large per-config name maps for every parser instance.
- Kept the earlier parser walk allocation reductions: root-only member names reuse `Atom`, composed names are rendered only when needed, and duplicate IIFE call-shape checks were removed.

### Why

Parser walk calls identifier/member/call/typeof/evaluate hooks for many AST nodes. Before this change, every plugin implementing a hook was invoked for every name and most plugins immediately returned after a string comparison. The new dispatch table moves those comparisons into one shared lookup and avoids irrelevant plugin calls across the whole ParserPlugin set, not only JavaScriptParser internals.

### Expected benefit

Lower hot-path dispatch overhead in dependency scanning and parser walk, especially for common identifiers and member chains that do not match webpack/Rspack magic names. The allocation reductions also reduce pressure while constructing member-expression info.

### Validation

- `cargo check -p rspack_plugin_javascript -p rspack_plugin_rslib -p rspack_plugin_rstest`
- `cargo clippy -p rspack_plugin_javascript -p rspack_plugin_rslib -p rspack_plugin_rstest --all-targets --all-features`
- `PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" pnpm run build:cli:dev`
- `PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" pnpm run test:unit`
- `PATH="$HOME/.nvm/versions/node/v20.19.3/bin:$PATH" pnpm run format:js`
- `pnpm run format:rs`
- `RSPACK_BENCHCASES_DIR="$PWD/.bench/rspack-benchcases" cargo codspeed run -m simulation -p rspack_benchmark --bench benches scan_dependencies`

`cargo clippy --workspace --all-targets --all-features` still fails in `rspack_cacheable` because the workspace currently pulls both rkyv 0.7 and 0.8 and `PortablePath` does not satisfy the expected rkyv 0.8 `Archive` bound; this is unrelated to the parser changes.
