### PR TITLE
docs: update config option types

### DIFF
--- a/website/docs/en/config/devtool.mdx
+++ b/website/docs/en/config/devtool.mdx
@@ -15,7 +15,7 @@ Use the [SourceMapDevToolPlugin](/plugins/webpack/source-map-dev-tool-plugin) or
 - **Type:**
 
 ```ts
-type Devtool = 'string' | false;
+type Devtool = string | false;
 ```
 
 - **Default:** `cheap-module-source-map` in development mode and `false` in production mode
@@ -65,7 +65,7 @@ Functional modifiers, to control source map generation, usually used in **produc
 | nosources | source map is created without the `sourcesContent` in it                                                                                     |
 | debugids  | source map is created with the `debugId` in it                                                                                               |
 
-We expect a certain pattern when validate devtool name, pay attention and don't mix up the sequence of devtool string. The pattern is: `[inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids]`.
+Rspack validates the `devtool` string with a fixed modifier order. The pattern is: `[inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids]`.
 
 ## Recommended configurations
 

--- a/website/docs/en/config/node.mdx
+++ b/website/docs/en/config/node.mdx
@@ -10,6 +10,10 @@ import WebpackLicense from '@components/WebpackLicense';
 
 The following Node.js options configure whether to polyfill or mock certain [Node.js globals](https://nodejs.org/docs/latest/api/globals.html).
 
+- **Type:** `false | object`
+
+Set `node` to `false` to disable all Node.js global polyfills and mocks. Otherwise, configure the individual options below.
+
 ## node.global
 
 - **Type:** `boolean | 'warn'`
@@ -39,7 +43,7 @@ export default {
 
 ## node.\_\_filename
 
-- **Type:** `boolean | 'mock' | 'warn-mock' | 'eval-only'`
+- **Type:** `boolean | 'mock' | 'warn-mock' | 'eval-only' | 'node-module'`
 - **Default:**
   - If `target` does not include `node`, defaults to `'warn-mock'`.
   - If `target` includes `node`, uses `'node-module'` if [output.module](/config/output#outputmodule) is enabled, otherwise `'eval-only'`.
@@ -83,7 +87,7 @@ export default {
 
 ## node.\_\_dirname
 
-- **Type:** `boolean | 'mock' | 'warn-mock' | 'eval-only'`
+- **Type:** `boolean | 'mock' | 'warn-mock' | 'eval-only' | 'node-module'`
 - **Default:**
   - If `target` does not include `node`, defaults to `'warn-mock'`.
   - If `target` includes `node`, uses `'node-module'` if [output.module](/config/output#outputmodule) is enabled, otherwise `'eval-only'`.

--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -10,7 +10,7 @@ import WebpackLicense from '@components/WebpackLicense';
 
 Used to configure the target environment of Rspack output and the ECMAScript version of Rspack runtime code.
 
-- **Type:** `string | string[]`
+- **Type:** `false | string | string[]`
 - **Default:** `browserslist` if the current project has a browserslist config, otherwise `web`.
 
 ## string

--- a/website/docs/zh/config/devtool.mdx
+++ b/website/docs/zh/config/devtool.mdx
@@ -15,7 +15,7 @@ import WebpackLicense from '@components/WebpackLicense';
 - **类型：**
 
 ```ts
-type Devtool = 'string' | false;
+type Devtool = string | false;
 ```
 
 - **默认值：** development 模式为 `cheap-module-source-map`，production 模式 为 `false`
@@ -65,7 +65,7 @@ type Devtool = 'string' | false;
 | nosources | 创建的 source map 不包含 `sourcesContent`（源代码内容）                                                 |
 | debugids  | 创建的 source map 增加 `debugId` 字段                                                                   |
 
-验证 `devtool` 的配置时，我们期望的格式是 `[inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids]`.
+验证 `devtool` 的配置时，Rspack 期望的格式是 `[inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map[-debugids]`.
 
 ## 推荐配置
 

--- a/website/docs/zh/config/node.mdx
+++ b/website/docs/zh/config/node.mdx
@@ -10,6 +10,10 @@ import WebpackLicense from '@components/WebpackLicense';
 
 全局变量：该选项可以配置是否 polyfill 或 mock 某些 [Node.js 全局变量](https://nodejs.org/docs/latest/api/globals.html)。
 
+- **类型：** `false | object`
+
+将 `node` 设置为 `false` 可以禁用所有 Node.js 全局变量的 polyfill 和 mock。否则，可以使用下面的选项分别配置。
+
 ## node.global
 
 - **类型：** `boolean | 'warn'`
@@ -39,7 +43,7 @@ export default {
 
 ## node.\_\_filename
 
-- **类型：** `boolean | 'mock' | 'warn-mock' | 'eval-only'`
+- **类型：** `boolean | 'mock' | 'warn-mock' | 'eval-only' | 'node-module'`
 - **默认值：**
   - 当 `target` 不包含 `node` 时，默认值为 `'warn-mock'`。
   - 当 `target` 包含 `node` 时，启用 [output.module](/config/output#outputmodule) 则为 `'node-module'`，否则为 `'eval-only'`
@@ -83,7 +87,7 @@ export default {
 
 ## node.\_\_dirname
 
-- **类型：** `boolean | 'mock' | 'warn-mock' | 'eval-only'`
+- **类型：** `boolean | 'mock' | 'warn-mock' | 'eval-only' | 'node-module'`
 - **默认值：**
   - 当 `target` 不包含 `node` 时，默认值为 `'warn-mock'`。
   - 当 `target` 包含 `node` 时，启用 [output.module](/config/output#outputmodule) 则为 `'node-module'`，否则为 `'eval-only'`

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -10,7 +10,7 @@ import WebpackLicense from '@components/WebpackLicense';
 
 目标环境与兼容性：该选项用于配置 Rspack 输出产物的目标环境和 Rspack runtime 代码的 ECMAScript 版本。
 
-- **类型：** `string | string[]`
+- **类型：** `false | string | string[]`
 - **默认值：** 如果当前项目中存在 `browserslist` 配置，则为 `browserslist`，否则为 `web`。
 
 ## string


### PR DESCRIPTION
## Summary

This PR updates the config documentation to better match the supported option types for `devtool`, `node`, and `target` in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
