### PR TITLE
chore: bump patch of swc_core and swc_typescript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5968,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "66.0.1"
+version = "66.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7732cc0c530a42ddfc03135c8747d8ef0db1d15f18f158fb2345f28ceb10ffb"
+checksum = "96dba809fb900d93b02fb821fe19c48c76433f5dfb3a76bdb28068851e2a6307"
 dependencies = [
  "par-core",
  "swc",
@@ -6994,9 +6994,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "28.0.1"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fb646fa6dc0c0f45cbb8c7acc4b581857a5468e778b3cf51a2db15447d772"
+checksum = "a86cf04561e92a19f5f37b7fcfdb442e749b9e360bc2796f731599967dfcb8cd"
 dependencies = [
  "bitflags 2.11.1",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,13 +132,13 @@ rkyv      = { version = "=0.8.16", default-features = false, features = ["std", 
 pnp                 = { version = "0.12.9", default-features = false }
 swc                 = { version = "64.0.0", default-features = false }
 swc_config          = { version = "5.0.0", default-features = false }
-swc_core            = { version = "66.0.1", default-features = false, features = ["parallel_rayon"] }
+swc_core            = { version = "66.0.2", default-features = false, features = ["parallel_rayon"] }
 swc_ecma_minifier   = { version = "53.0.0", default-features = false }
 swc_error_reporters = { version = "23.0.0", default-features = false }
 swc_html            = { version = "33.0.0", default-features = false }
 swc_html_minifier   = { version = "53.0.0", default-features = false }
 swc_plugin_runner   = { version = "27.0.0", default-features = false }
-swc_typescript      = { version = "28.0.1", default-features = false }
+swc_typescript      = { version = "28.0.2", default-features = false }
 
 swc_experimental_ecma_ast      = { version = "0.6.7", default-features = false }
 swc_experimental_ecma_parser   = { version = "0.6.7", default-features = false }

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "66.0.1"
+  "66.0.2"
 }
 
 /// The version of the JavaScript `@rspack/core` package.


### PR DESCRIPTION
## Summary

Bump swc_core from 66.0.1 to 66.0.2, and swc_typescript from 28.0.1 to 28.0.2

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
