### PR TITLE
fix(rsc): skip manifest runtime for worker entries

### DIFF
--- a/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
+++ b/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
@@ -59,13 +59,11 @@ impl RuntimeModule for RscManifestRuntimeModule {
       )
     })?;
 
-    let entry_state = plugin_state.entries.get(&entry_name).ok_or_else(|| {
-      rspack_error::error!(
-        "RSC entry state not found for entry {:?} (compiler ID: {}).",
-        entry_name,
-        server_compiler_id.as_u32()
-      )
-    })?;
+    let Some(entry_state) = plugin_state.entries.get(&entry_name) else {
+      // Worker entries are represented as named entrypoints in the chunk graph,
+      // but they are not top-level RSC compilation entries.
+      return Ok(String::new());
+    };
     let server_manifest = &entry_state.server_actions;
     let client_manifest = &entry_state.client_modules;
     let server_consumer_module_map = entry_state.server_consumer_module_map.as_ref();

--- a/tests/rspack-test/configCases/rsc-plugin/worker/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/rspack.config.js
@@ -1,0 +1,104 @@
+const path = require('node:path');
+const { experiments } = require('@rspack/core');
+
+const { createPlugins, Layers } = experiments.rsc;
+const { ServerPlugin, ClientPlugin } = createPlugins();
+
+const ssrEntry = path.join(__dirname, 'src/framework/entry.ssr.js');
+const rscEntry = path.join(__dirname, 'src/framework/entry.rsc.js');
+
+const swcLoaderRule = {
+  test: /\.jsx?$/,
+  use: [
+    {
+      loader: 'builtin:swc-loader',
+      options: {
+        detectSyntax: 'auto',
+        jsc: {
+          transform: {
+            react: {
+              runtime: 'automatic',
+            },
+          },
+        },
+        rspackExperiments: {
+          reactServerComponents: true,
+        },
+      },
+    },
+  ],
+};
+
+module.exports = [
+  {
+    name: 'server',
+    mode: 'production',
+    target: 'node',
+    entry: {
+      main: {
+        import: ssrEntry,
+      },
+    },
+    output: {
+      filename: '[name].js',
+    },
+    resolve: {
+      extensions: ['...', '.jsx'],
+    },
+    module: {
+      rules: [
+        swcLoaderRule,
+        {
+          resource: ssrEntry,
+          layer: Layers.ssr,
+        },
+        {
+          resource: rscEntry,
+          layer: Layers.rsc,
+          resolve: {
+            conditionNames: ['react-server', '...'],
+          },
+        },
+        {
+          issuerLayer: Layers.rsc,
+          resolve: {
+            conditionNames: ['react-server', '...'],
+          },
+        },
+      ],
+    },
+    plugins: [new ServerPlugin()],
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+        minSize: 0,
+        cacheGroups: {
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendor',
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'client',
+    mode: 'production',
+    target: 'web',
+    entry: {
+      main: {
+        import: './src/framework/entry.client.js',
+      },
+    },
+    output: {
+      filename: 'client.js',
+    },
+    resolve: {
+      extensions: ['...', '.jsx'],
+    },
+    module: {
+      rules: [swcLoaderRule],
+    },
+    plugins: [new ClientPlugin()],
+  },
+];

--- a/tests/rspack-test/configCases/rsc-plugin/worker/src/App.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/src/App.js
@@ -1,0 +1,7 @@
+"use server-entry";
+
+import { Client } from './Client';
+
+export const App = () => {
+  return <Client />;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/worker/src/Client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/src/Client.js
@@ -1,0 +1,15 @@
+"use client";
+
+export const Client = () => {
+  const createWorker = () => {
+    new Worker(
+      /* webpackChunkName: "my-worker" */ new URL(
+        './worker.js',
+        import.meta.url,
+      ),
+      { type: 'module' },
+    );
+  };
+
+  return <button onClick={createWorker}>spawn worker</button>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/worker/src/framework/entry.client.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/src/framework/entry.client.js
@@ -1,0 +1,1 @@
+// Client entry for the RSC worker-entry test.

--- a/tests/rspack-test/configCases/rsc-plugin/worker/src/framework/entry.rsc.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/src/framework/entry.rsc.js
@@ -1,0 +1,6 @@
+import { renderToReadableStream } from 'react-server-dom-rspack/server';
+import { App } from '../App';
+
+export const renderRscStream = () => {
+  return renderToReadableStream(<App />);
+};

--- a/tests/rspack-test/configCases/rsc-plugin/worker/src/framework/entry.ssr.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/src/framework/entry.ssr.js
@@ -1,0 +1,7 @@
+import { createFromReadableStream } from 'react-server-dom-rspack/client';
+import { renderRscStream } from './entry.rsc';
+
+export const renderHTML = async () => {
+  const rscStream = await renderRscStream();
+  return createFromReadableStream(rscStream);
+};

--- a/tests/rspack-test/configCases/rsc-plugin/worker/src/worker.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/src/worker.js
@@ -1,0 +1,5 @@
+import { camelCase } from 'lodash-es';
+
+self.onmessage = event => {
+  self.postMessage(camelCase(event.data));
+};

--- a/tests/rspack-test/configCases/rsc-plugin/worker/test.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/worker/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+  findBundle() {
+    return [];
+  },
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Skip generating the RSC manifest runtime for worker entries, since they can appear as named entrypoints in the chunk graph but are not top-level RSC compilation entries.
- Fix the `RSC entry state not found` failure when an RSC client component creates a module worker.
- Add a regression config case covering an RSC server/client build with a client-created worker entry.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
