### PR TITLE
docs: update runtime plugin hooks

### DIFF
--- a/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
@@ -40,7 +40,7 @@ As in the following code, the `crossorigin` attribute can be added to the `<scri
 hooks.createScript.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    script.crossorigin = 'anonymous';
+    script.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -48,8 +48,8 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"
-    header="CreateScript.ts"
-    key="CreateScript"
+    header="Chunk.ts"
+    key="Chunk"
   >
     <ChunkType />
   </CollapsePanel>
@@ -65,7 +65,7 @@ Can modify the code executed when creating a generic `<link>` tag.
 hooks.createLink.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    link.crossorigin = 'anonymous';
+    link.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -88,7 +88,7 @@ As in the following code, the `crossorigin` attribute can be added to the `<link
 hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    link.crossorigin = 'anonymous';
+    link.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -96,8 +96,8 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"
-    header="CreateScript.ts"
-    key="CreateScript"
+    header="Chunk.ts"
+    key="Chunk"
   >
     <ChunkType />
   </CollapsePanel>
@@ -115,7 +115,7 @@ As in the following code, the `crossorigin` attribute can be added to the `<link
 hooks.linkPreload.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    link.crossorigin = 'anonymous';
+    link.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -123,8 +123,8 @@ hooks.linkPreload.tap('MyPlugin', (code, chunk) => {
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"
-    header="CreateScript.ts"
-    key="CreateScript"
+    header="Chunk.ts"
+    key="Chunk"
   >
     <ChunkType />
   </CollapsePanel>

--- a/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
@@ -46,11 +46,7 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
 ```
 
 <Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Chunk.ts"
-    key="Chunk"
-  >
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
     <ChunkType />
   </CollapsePanel>
 </Collapse>
@@ -94,11 +90,7 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 ```
 
 <Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Chunk.ts"
-    key="Chunk"
-  >
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
     <ChunkType />
   </CollapsePanel>
 </Collapse>
@@ -121,11 +113,7 @@ hooks.linkPreload.tap('MyPlugin', (code, chunk) => {
 ```
 
 <Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Chunk.ts"
-    key="Chunk"
-  >
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
     <ChunkType />
   </CollapsePanel>
 </Collapse>

--- a/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/en/api/plugin-api/runtime-plugin-hooks.mdx
@@ -30,7 +30,7 @@ export default {
 
 ## `createScript`
 
-`SyncWaterallHook<[string, chunk]>`
+`SyncWaterfallHook<[string, Chunk]>`
 
 Can modify the code executed when creating the `<script>` tag.
 
@@ -55,9 +55,30 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
   </CollapsePanel>
 </Collapse>
 
+## `createLink`
+
+`SyncWaterfallHook<[string, Chunk]>`
+
+Can modify the code executed when creating a generic `<link>` tag.
+
+```js
+hooks.createLink.tap('MyPlugin', (code, chunk) => {
+  return `
+    ${code}
+    link.crossorigin = 'anonymous';
+  `;
+});
+```
+
+<Collapse>
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
+    <ChunkType />
+  </CollapsePanel>
+</Collapse>
+
 ## `linkPrefetch`
 
-`SyncWaterallHook<[string, chunk]>`
+`SyncWaterfallHook<[string, Chunk]>`
 
 Can modify the code executed when creating the [prefetch](/guide/optimization/code-splitting#prefetchingpreloading-modules) `<link rel="prefetch">` tag.
 
@@ -84,7 +105,7 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 
 ## `linkPreload`
 
-`SyncWaterallHook<[string, chunk]>`
+`SyncWaterfallHook<[string, Chunk]>`
 
 Can modify the code executed when creating the [preload](/guide/optimization/code-splitting#prefetchingpreloading-modules) `<link rel="preload">` tag.
 

--- a/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
@@ -29,7 +29,7 @@ export default {
 
 ## `createScript`
 
-`SyncWaterallHook<[string, chunk]>`
+`SyncWaterfallHook<[string, Chunk]>`
 
 可修改创建 `<script>` 标签时所执行的代码。
 
@@ -54,13 +54,34 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
   </CollapsePanel>
 </Collapse>
 
+## `createLink`
+
+`SyncWaterfallHook<[string, Chunk]>`
+
+可修改创建通用 `<link>` 标签时所执行的代码。
+
+```js
+hooks.createLink.tap('MyPlugin', (code, chunk) => {
+  return `
+    ${code}
+    link.crossorigin = 'anonymous';
+  `;
+});
+```
+
+<Collapse>
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
+    <ChunkType />
+  </CollapsePanel>
+</Collapse>
+
 ## `linkPrefetch`
 
-`SyncWaterallHook<[string, chunk]>`
+`SyncWaterfallHook<[string, Chunk]>`
 
-可修改创建[预载](/guide/optimization/code-splitting#prefetchingpreloading-modules)的 `<link rel="prefetch">` 标签时所执行的代码。
+可修改创建[预取](/guide/optimization/code-splitting#prefetchingpreloading-modules)的 `<link rel="prefetch">` 标签时所执行的代码。
 
-如以下代码，可给用于预载的 `<link>` 标签添加 `crossorigin` 属性：
+如以下代码，可给用于预取的 `<link>` 标签添加 `crossorigin` 属性：
 
 ```js
 hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
@@ -83,11 +104,11 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 
 ## `linkPreload`
 
-`SyncWaterallHook<[string, chunk]>`
+`SyncWaterfallHook<[string, Chunk]>`
 
-可修改创建[预取](/guide/optimization/code-splitting#prefetchingpreloading-modules)的 `<link rel="preload">` 标签时所执行的代码。
+可修改创建[预加载](/guide/optimization/code-splitting#prefetchingpreloading-modules)的 `<link rel="preload">` 标签时所执行的代码。
 
-如以下代码，可给用于预取的 `<link>` 标签添加 `crossorigin` 属性：
+如以下代码，可给用于预加载的 `<link>` 标签添加 `crossorigin` 属性：
 
 ```js
 hooks.linkPreload.tap('MyPlugin', (code, chunk) => {

--- a/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
@@ -45,11 +45,7 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
 ```
 
 <Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Chunk.ts"
-    key="Chunk"
-  >
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
     <ChunkType />
   </CollapsePanel>
 </Collapse>
@@ -93,11 +89,7 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 ```
 
 <Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Chunk.ts"
-    key="Chunk"
-  >
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
     <ChunkType />
   </CollapsePanel>
 </Collapse>
@@ -120,11 +112,7 @@ hooks.linkPreload.tap('MyPlugin', (code, chunk) => {
 ```
 
 <Collapse>
-  <CollapsePanel
-    className="collapse-code-panel"
-    header="Chunk.ts"
-    key="Chunk"
-  >
+  <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
     <ChunkType />
   </CollapsePanel>
 </Collapse>

--- a/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/runtime-plugin-hooks.mdx
@@ -39,7 +39,7 @@ export default {
 hooks.createScript.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    script.crossorigin = 'anonymous';
+    script.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -47,8 +47,8 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"
-    header="CreateScript.ts"
-    key="CreateScript"
+    header="Chunk.ts"
+    key="Chunk"
   >
     <ChunkType />
   </CollapsePanel>
@@ -64,7 +64,7 @@ hooks.createScript.tap('MyPlugin', (code, chunk) => {
 hooks.createLink.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    link.crossorigin = 'anonymous';
+    link.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -87,7 +87,7 @@ hooks.createLink.tap('MyPlugin', (code, chunk) => {
 hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    link.crossorigin = 'anonymous';
+    link.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -95,8 +95,8 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"
-    header="CreateScript.ts"
-    key="CreateScript"
+    header="Chunk.ts"
+    key="Chunk"
   >
     <ChunkType />
   </CollapsePanel>
@@ -114,7 +114,7 @@ hooks.linkPrefetch.tap('MyPlugin', (code, chunk) => {
 hooks.linkPreload.tap('MyPlugin', (code, chunk) => {
   return `
     ${code}
-    link.crossorigin = 'anonymous';
+    link.crossOrigin = 'anonymous';
   `;
 });
 ```
@@ -122,8 +122,8 @@ hooks.linkPreload.tap('MyPlugin', (code, chunk) => {
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"
-    header="CreateScript.ts"
-    key="CreateScript"
+    header="Chunk.ts"
+    key="Chunk"
   >
     <ChunkType />
   </CollapsePanel>


### PR DESCRIPTION
## Summary

This PR updates the runtime plugin hook docs to cover `createLink`, which lets plugins customize generic `<link>` tag creation. It also fixes the hook type spelling/casing and corrects the Chinese prefetch/preload wording.

## Related links

https://github.com/web-infra-dev/rspack/pull/12237

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).