### PR TITLE
docs(plugin-api): document module factory hooks

### DIFF
--- a/website/docs/en/api/plugin-api/context-module-factory-hooks.mdx
+++ b/website/docs/en/api/plugin-api/context-module-factory-hooks.mdx
@@ -10,7 +10,7 @@ The `ContextModuleFactory` module is used by the `Compiler` to generate dependen
 
 ## `beforeResolve`
 
-`AsyncSeriesBailHook<[BeforeResolveResult]>`
+`AsyncSeriesWaterfallHook<[BeforeResolveResult]>`
 
 Called before resolving the requested directory. The request can be ignored by returning `false`.
 
@@ -37,7 +37,7 @@ export type BeforeResolveResult =
 
 ## `afterResolve`
 
-`AsyncSeriesBailHook<[AfterResolveResult]>`
+`AsyncSeriesWaterfallHook<[AfterResolveResult]>`
 
 Called after the requested directory resolved.
 
@@ -49,7 +49,7 @@ Called after the requested directory resolved.
   >
 ```ts
 type AfterResolveData = {
-  resource: number;
+  resource: string;
   context: string;
   request: string;
   regExp: RegExp | undefined;

--- a/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
@@ -143,6 +143,24 @@ compiler.hooks.compilation.tap(
   </CollapsePanel>
 </Collapse>
 
+## `createModule`
+
+`AsyncSeriesBailHook<[NormalModuleCreateData, {}]>`
+
+Called after a request has been resolved and before Rspack creates the normal module instance. Return `undefined` to continue with the default module creation flow.
+
+```js
+compiler.hooks.compilation.tap(
+  'MyPlugin',
+  (compilation, { normalModuleFactory }) => {
+    normalModuleFactory.hooks.createModule.tap('MyPlugin', (createData) => {
+      // inspect module creation data
+      console.log(createData.resourceResolveData.resource);
+    });
+  },
+);
+```
+
 ## `resolveForScheme`
 
 `AsyncSeriesBailHook<[ResourceDataWithData]>`

--- a/website/docs/zh/api/plugin-api/context-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/context-module-factory-hooks.mdx
@@ -10,7 +10,7 @@ import { Collapse, CollapsePanel } from '@components/Collapse';
 
 ## `beforeResolve`
 
-`AsyncSeriesBailHook<[BeforeResolveResult]>`
+`AsyncSeriesWaterfallHook<[BeforeResolveResult]>`
 
 在解析请求的目录之前调用。通过返回 `false` 可以忽略该请求。
 
@@ -37,7 +37,7 @@ export type BeforeResolveResult =
 
 ## `afterResolve`
 
-`AsyncSeriesBailHook<[AfterResolveResult]>`
+`AsyncSeriesWaterfallHook<[AfterResolveResult]>`
 
 在请求的目录解析后调用。
 
@@ -49,7 +49,7 @@ export type BeforeResolveResult =
   >
 ```ts
 type AfterResolveData = {
-  resource: number;
+  resource: string;
   context: string;
   request: string;
   regExp: RegExp | undefined;

--- a/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
@@ -143,6 +143,24 @@ compiler.hooks.compilation.tap(
   </CollapsePanel>
 </Collapse>
 
+## `createModule`
+
+`AsyncSeriesBailHook<[NormalModuleCreateData, {}]>`
+
+在请求解析完成后、Rspack 创建 normal module 实例之前调用。返回 `undefined` 表示继续默认的模块创建流程。
+
+```js
+compiler.hooks.compilation.tap(
+  'MyPlugin',
+  (compilation, { normalModuleFactory }) => {
+    normalModuleFactory.hooks.createModule.tap('MyPlugin', (createData) => {
+      // 查看模块创建数据
+      console.log(createData.resourceResolveData.resource);
+    });
+  },
+);
+```
+
 ## `resolveForScheme`
 
 `AsyncSeriesBailHook<[ResourceDataWithData]>`


### PR DESCRIPTION
## Summary

This PR updates the plugin API docs so the module factory hook references match the current hook signatures. It corrects the ContextModuleFactory beforeResolve and afterResolve hook types, fixes the documented AfterResolveData.resource type, and documents NormalModuleFactory.createModule in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).