### PR TITLE
docs(cli): update cli option descriptions

### DIFF
--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -94,7 +94,7 @@ export const commonOptionsForBuildAndServe = (command: Command): Command => {
   return command
     .option(
       '-d, --devtool <value>',
-      'specify a developer tool for debugging. Defaults to `cheap-module-source-map` in development and `source-map` in production.',
+      'set source map style for debugging. Use `false` to disable source maps.',
     )
     .option('--entry <entry>', 'entry file', {
       type: [String],

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -32,7 +32,7 @@ Rspack CLI provides several common flags that can be used with all commands:
 | -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
 | --configLoader       | Specify the loader to load the config file, can be `auto`, `jiti` or `native`, defaults to `auto`                                             |
 | --configName         | Specify the name of the configuration to use.                                                                                                 |
-| --env <env>          | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
+| --env &lt;env&gt;    | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
 | --nodeEnv            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
 | -h, --help           | Show help information                                                                                                                         |
 | -v, --version        | Show version number                                                                                                                           |

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -32,6 +32,7 @@ Rspack CLI provides several common flags that can be used with all commands:
 | -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
 | --configLoader       | Specify the loader to load the config file, can be `auto`, `jiti` or `native`, defaults to `auto`                                             |
 | --configName         | Specify the name of the configuration to use.                                                                                                 |
+| --env                | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
 | --nodeEnv            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
 | -h, --help           | Show help information                                                                                                                         |
 | -v, --version        | Show version number                                                                                                                           |
@@ -71,8 +72,8 @@ Options:
   -m, --mode           mode                                             [string]
   -w, --watch          watch                          [boolean] [default: false]
       --env            env passed to config function                     [array]
-  -d, --devtool        devtool                        [boolean] [default: false]
-      --json           emit stats json
+  -d, --devtool        set source map style for debugging                [string]
+      --json [path]    emit stats json, optionally to the specified path
 ```
 
 ## rspack dev
@@ -121,7 +122,7 @@ Options:
   -m, --mode           mode                                             [string]
   -w, --watch          watch                          [boolean] [default: false]
       --env            env passed to config function                     [array]
-  -d, --devtool        devtool                        [boolean] [default: false]
+  -d, --devtool        set source map style for debugging                [string]
       --hot            enables hot module replacement
       --port           allows to specify a port to use                  [number]
       --host           allows to specify a hostname to use              [string]

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -32,7 +32,7 @@ Rspack CLI provides several common flags that can be used with all commands:
 | -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
 | --configLoader       | Specify the loader to load the config file, can be `auto`, `jiti` or `native`, defaults to `auto`                                             |
 | --configName         | Specify the name of the configuration to use.                                                                                                 |
-| --env &lt;env&gt;    | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
+| `--env <env>`        | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
 | --nodeEnv            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
 | -h, --help           | Show help information                                                                                                                         |
 | -v, --version        | Show version number                                                                                                                           |

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -27,15 +27,15 @@ npx rspack -h
 
 Rspack CLI provides several common flags that can be used with all commands:
 
-| Flag                 | Description                                                                                                                                   |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
-| --configLoader       | Specify the loader to load the config file, can be `auto`, `jiti` or `native`, defaults to `auto`                                             |
-| --configName         | Specify the name of the configuration to use.                                                                                                 |
-| `--env <env>`        | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
-| --nodeEnv            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
-| -h, --help           | Show help information                                                                                                                         |
-| -v, --version        | Show version number                                                                                                                           |
+| Flag                   | Description                                                                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-c, --config [value]` | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
+| `--configLoader`       | Specify the loader to load the config file, can be `auto`, `jiti` or `native`, defaults to `auto`                                             |
+| `--configName`         | Specify the name of the configuration to use.                                                                                                 |
+| `--env <env>`          | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
+| `--nodeEnv`            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
+| `-h, --help`           | Show help information                                                                                                                         |
+| `-v, --version`        | Show version number                                                                                                                           |
 
 :::tip
 All flags in Rspack CLI support the `camelCase` and `kebab-case`, for example, both `--configLoader` and `--config-loader` are valid.

--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -32,7 +32,7 @@ Rspack CLI provides several common flags that can be used with all commands:
 | -c, --config [value] | Specify the path to the configuration file, see [Specify the configuration file](/config/index#specify-the-configuration-file)                |
 | --configLoader       | Specify the loader to load the config file, can be `auto`, `jiti` or `native`, defaults to `auto`                                             |
 | --configName         | Specify the name of the configuration to use.                                                                                                 |
-| --env                | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
+| --env <env>          | Pass environment values to a configuration function. For example, `--env production --env foo=bar`                                            |
 | --nodeEnv            | Set the value of `process.env.NODE_ENV`, defaults to `development` for `rspack dev`, and `production` for `rspack build` and `rspack preview` |
 | -h, --help           | Show help information                                                                                                                         |
 | -v, --version        | Show version number                                                                                                                           |

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -32,7 +32,7 @@ Rspack CLI 提供了一些公共选项，可以用于所有命令：
 | -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
 | --configLoader       | 指定配置文件加载器，可以是 `auto`、`jiti` 或 `native`，默认是 `auto`                                                        |
 | --configName         | 指定配置文件名称                                                                                                            |
-| --env <env>          | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
+| --env &lt;env&gt;    | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
 | --nodeEnv            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
 | -h, --help           | 显示帮助信息                                                                                                                |
 | -v, --version        | 显示版本号                                                                                                                  |

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -32,7 +32,7 @@ Rspack CLI 提供了一些公共选项，可以用于所有命令：
 | -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
 | --configLoader       | 指定配置文件加载器，可以是 `auto`、`jiti` 或 `native`，默认是 `auto`                                                        |
 | --configName         | 指定配置文件名称                                                                                                            |
-| --env &lt;env&gt;    | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
+| `--env <env>`        | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
 | --nodeEnv            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
 | -h, --help           | 显示帮助信息                                                                                                                |
 | -v, --version        | 显示版本号                                                                                                                  |

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -27,15 +27,15 @@ npx rspack -h
 
 Rspack CLI 提供了一些公共选项，可以用于所有命令：
 
-| 选项                 | 描述                                                                                                                        |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
-| --configLoader       | 指定配置文件加载器，可以是 `auto`、`jiti` 或 `native`，默认是 `auto`                                                        |
-| --configName         | 指定配置文件名称                                                                                                            |
-| `--env <env>`        | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
-| --nodeEnv            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
-| -h, --help           | 显示帮助信息                                                                                                                |
-| -v, --version        | 显示版本号                                                                                                                  |
+| 选项                   | 描述                                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `-c, --config [value]` | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
+| `--configLoader`       | 指定配置文件加载器，可以是 `auto`、`jiti` 或 `native`，默认是 `auto`                                                        |
+| `--configName`         | 指定配置文件名称                                                                                                            |
+| `--env <env>`          | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
+| `--nodeEnv`            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
+| `-h, --help`           | 显示帮助信息                                                                                                                |
+| `-v, --version`        | 显示版本号                                                                                                                  |
 
 :::tip
 Rspack CLI 的所有选项都支持使用 `camelCase`（驼峰命名）和 `kebab-case`（短横线命名），例如 `--configLoader` 和 `--config-loader` 都是有效的。

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -32,7 +32,7 @@ Rspack CLI 提供了一些公共选项，可以用于所有命令：
 | -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
 | --configLoader       | 指定配置文件加载器，可以是 `auto`、`jiti` 或 `native`，默认是 `auto`                                                        |
 | --configName         | 指定配置文件名称                                                                                                            |
-| --env                | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
+| --env <env>          | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
 | --nodeEnv            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
 | -h, --help           | 显示帮助信息                                                                                                                |
 | -v, --version        | 显示版本号                                                                                                                  |

--- a/website/docs/zh/api/cli.mdx
+++ b/website/docs/zh/api/cli.mdx
@@ -32,6 +32,7 @@ Rspack CLI 提供了一些公共选项，可以用于所有命令：
 | -c, --config [value] | 指定配置文件路径，详见 [指定配置文件](/config/index#指定配置文件)                                                           |
 | --configLoader       | 指定配置文件加载器，可以是 `auto`、`jiti` 或 `native`，默认是 `auto`                                                        |
 | --configName         | 指定配置文件名称                                                                                                            |
+| --env                | 传递给配置函数的环境变量，例如 `--env production --env foo=bar`                                                             |
 | --nodeEnv            | 设置 `process.env.NODE_ENV` 的值，`rspack dev` 默认是 `development`，`rspack build` 和 `rspack preview` 默认是 `production` |
 | -h, --help           | 显示帮助信息                                                                                                                |
 | -v, --version        | 显示版本号                                                                                                                  |
@@ -71,8 +72,8 @@ Options:
   -m, --mode         mode                                               [string]
   -w, --watch        watch                            [boolean] [default: false]
       --env          env passed to config function                       [array]
-  -d, --devtool      devtool                          [boolean] [default: false]
-      --json         emit stats json
+  -d, --devtool      set source map style for debugging                  [string]
+      --json [path]  emit stats json, optionally to the specified path
 ```
 
 ## rspack dev
@@ -122,7 +123,7 @@ Options:
   -m, --mode         mode                                               [string]
   -w, --watch        watch                            [boolean] [default: false]
       --env          env passed to config function                       [array]
-  -d, --devtool      devtool                          [boolean] [default: false]
+  -d, --devtool      set source map style for debugging                  [string]
       --hot          enables hot module replacement
       --port         allows to specify a port to use                    [number]
       --host         allows to specify a hostname to use                [string]


### PR DESCRIPTION
## Summary

This PR updates CLI option descriptions so `--devtool` is documented as the source map style option instead of a boolean flag. It also documents `--env` in the common CLI options table and clarifies that `--json` can optionally write stats to a specified path.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).