### PR TITLE
perf: reduce module rules matcher overhead

### DIFF
--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -23,7 +23,7 @@ use rspack_core::{
   JavascriptParserOptions, JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions,
   JsonParserOptions, ModuleNoParseRule, ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions,
   ModuleRule, ModuleRuleEffect, ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader,
-  OverrideStrict, ParseOption, ParserOptions, ParserOptionsMap, TypeReexportPresenceMode,
+  OverrideStrict, ParseOption, ParserOptions, ParserOptionsMap, TypeReexportPresenceMode, With,
 };
 use rspack_error::error;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
@@ -954,7 +954,7 @@ impl TryFrom<RawModuleRule> for ModuleRule {
       .map(|data| {
         data
           .into_iter()
-          .map(|(k, v)| Ok((k, v.try_into()?)))
+          .map(|(k, v)| Ok((k.into(), v.try_into()?)))
           .collect::<rspack_error::Result<DescriptionData>>()
       })
       .transpose()?;
@@ -965,7 +965,7 @@ impl TryFrom<RawModuleRule> for ModuleRule {
         data
           .into_iter()
           .map(|(k, v)| Ok((k, v.try_into()?)))
-          .collect::<rspack_error::Result<DescriptionData>>()
+          .collect::<rspack_error::Result<With>>()
       })
       .transpose()?;
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -187,6 +187,89 @@ fn merge_parser_options_with_local(
   }
 }
 
+struct CollectedModuleRuleEffects {
+  module_type: ModuleType,
+  module_layer: Option<ModuleLayer>,
+  resolve: Option<Resolve>,
+  parser: Option<ParserOptions>,
+  generator: Option<GeneratorOptions>,
+  side_effects: Option<bool>,
+  extract_source_map: Option<bool>,
+}
+
+fn collect_module_rule_effects(
+  module_rules: &[&ModuleRuleEffect],
+  matched_module_type: Option<ModuleType>,
+  issuer_layer: Option<&ModuleLayer>,
+) -> CollectedModuleRuleEffects {
+  let mut collected = CollectedModuleRuleEffects {
+    module_type: matched_module_type.unwrap_or(ModuleType::JsAuto),
+    module_layer: issuer_layer.cloned(),
+    resolve: None,
+    parser: None,
+    generator: None,
+    side_effects: None,
+    extract_source_map: None,
+  };
+
+  for rule in module_rules {
+    if let Some(module_type) = rule.r#type {
+      collected.module_type = module_type;
+    }
+    if let Some(module_layer) = &rule.layer {
+      collected.module_layer = Some(module_layer.clone());
+    }
+    if let Some(rule_resolve) = &rule.resolve {
+      collected.resolve = Some(if let Some(resolve) = collected.resolve.take() {
+        resolve.merge(rule_resolve.to_owned())
+      } else {
+        rule_resolve.to_owned()
+      });
+    }
+    collected.parser = collected.parser.merge_from(&rule.parser);
+    collected.generator = collected.generator.merge_from(&rule.generator);
+    if rule.side_effects.is_some() {
+      collected.side_effects = rule.side_effects;
+    }
+    if rule.extract_source_map.is_some() {
+      collected.extract_source_map = rule.extract_source_map;
+    }
+  }
+
+  collected
+}
+
+#[cfg(test)]
+mod module_rule_effect_collection_tests {
+  use super::*;
+
+  #[test]
+  fn collects_rule_effects_in_match_order_with_last_wins_fields() {
+    let first = ModuleRuleEffect {
+      r#type: Some(ModuleType::Asset),
+      layer: Some("first".to_owned()),
+      side_effects: Some(true),
+      extract_source_map: Some(false),
+      ..Default::default()
+    };
+    let second = ModuleRuleEffect {
+      r#type: Some(ModuleType::Json),
+      layer: Some("second".to_owned()),
+      side_effects: Some(false),
+      extract_source_map: Some(true),
+      ..Default::default()
+    };
+    let rules = [&first, &second];
+
+    let collected = collect_module_rule_effects(&rules, Some(ModuleType::JsAuto), None);
+
+    assert_eq!(collected.module_type, ModuleType::Json);
+    assert_eq!(collected.module_layer.as_deref(), Some("second"));
+    assert_eq!(collected.side_effects, Some(false));
+    assert_eq!(collected.extract_source_map, Some(true));
+  }
+}
+
 #[derive(Debug, Default)]
 pub struct NormalModuleFactoryHooks {
   pub before_resolve: NormalModuleFactoryBeforeResolveHook,
@@ -718,22 +801,23 @@ module.exports = "data:,";
       resource_data.resource().to_owned()
     };
 
-    let resolved_module_type =
-      self.calculate_module_type(match_module_type, &resolved_module_rules);
-    let resolved_module_layer =
-      self.calculate_module_layer(data.issuer_layer.as_ref(), &resolved_module_rules);
+    let resolved_module_rule_effects = collect_module_rule_effects(
+      &resolved_module_rules,
+      match_module_type,
+      data.issuer_layer.as_ref(),
+    );
+    let resolved_module_type = resolved_module_rule_effects.module_type;
+    let resolved_module_layer = resolved_module_rule_effects.module_layer;
 
-    let resolved_resolve_options = self.calculate_resolve_options(&resolved_module_rules);
-    let (resolved_parser_options, resolved_generator_options) =
-      self.calculate_parser_and_generator_options(&resolved_module_rules);
+    let resolved_resolve_options = resolved_module_rule_effects.resolve.map(Arc::new);
     let (resolved_parser_options, resolved_generator_options) = self
       .merge_global_parser_and_generator_options(
         &resolved_module_type,
-        resolved_parser_options,
-        resolved_generator_options,
+        resolved_module_rule_effects.parser,
+        resolved_module_rule_effects.generator,
       );
-    let resolved_side_effects = self.calculate_side_effects(&resolved_module_rules);
-    let resolved_extract_source_map = self.calculate_extract_source_map(&resolved_module_rules);
+    let resolved_side_effects = resolved_module_rule_effects.side_effects;
+    let resolved_extract_source_map = resolved_module_rule_effects.extract_source_map;
     let mut resolved_parser_and_generator = self
       .plugin_driver
       .registered_parser_and_generator_builder
@@ -849,57 +933,6 @@ module.exports = "data:,";
     Ok(rules)
   }
 
-  fn calculate_resolve_options(&self, module_rules: &[&ModuleRuleEffect]) -> Option<Arc<Resolve>> {
-    let mut resolved: Option<Resolve> = None;
-    for rule in module_rules {
-      if let Some(rule_resolve) = &rule.resolve {
-        if let Some(r) = resolved {
-          resolved = Some(r.merge(rule_resolve.to_owned()));
-        } else {
-          resolved = Some(rule_resolve.to_owned());
-        }
-      }
-    }
-    resolved.map(Arc::new)
-  }
-
-  fn calculate_side_effects(&self, module_rules: &[&ModuleRuleEffect]) -> Option<bool> {
-    let mut side_effect_res = None;
-    // side_effects from module rule has higher priority
-    for rule in module_rules.iter() {
-      if rule.side_effects.is_some() {
-        side_effect_res = rule.side_effects;
-      }
-    }
-    side_effect_res
-  }
-
-  fn calculate_extract_source_map(&self, module_rules: &[&ModuleRuleEffect]) -> Option<bool> {
-    let mut extract_source_map_res = None;
-    // extract_source_map from module rule has higher priority
-    for rule in module_rules.iter() {
-      if rule.extract_source_map.is_some() {
-        extract_source_map_res = rule.extract_source_map;
-      }
-    }
-    extract_source_map_res
-  }
-
-  fn calculate_parser_and_generator_options(
-    &self,
-    module_rules: &[&ModuleRuleEffect],
-  ) -> (Option<ParserOptions>, Option<GeneratorOptions>) {
-    let mut resolved_parser = None;
-    let mut resolved_generator = None;
-
-    for rule in module_rules {
-      resolved_parser = resolved_parser.merge_from(&rule.parser);
-      resolved_generator = resolved_generator.merge_from(&rule.generator);
-    }
-
-    (resolved_parser, resolved_generator)
-  }
-
   fn merge_global_parser_and_generator_options(
     &self,
     module_type: &ModuleType,
@@ -975,36 +1008,6 @@ module.exports = "data:,";
       },
     );
     (parser, generator)
-  }
-
-  fn calculate_module_type(
-    &self,
-    matched_module_type: Option<ModuleType>,
-    module_rules: &[&ModuleRuleEffect],
-  ) -> ModuleType {
-    let mut resolved_module_type = matched_module_type.unwrap_or(ModuleType::JsAuto);
-    for module_rule in module_rules.iter() {
-      if let Some(module_type) = module_rule.r#type {
-        resolved_module_type = module_type;
-      };
-    }
-
-    resolved_module_type
-  }
-
-  fn calculate_module_layer(
-    &self,
-    issuer_layer: Option<&ModuleLayer>,
-    module_rules: &[&ModuleRuleEffect],
-  ) -> Option<ModuleLayer> {
-    let mut resolved_module_layer = issuer_layer;
-    for module_rule in module_rules.iter() {
-      if let Some(module_layer) = &module_rule.layer {
-        resolved_module_layer = Some(module_layer);
-      };
-    }
-
-    resolved_module_layer.cloned()
   }
 
   async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<ModuleFactoryResult> {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -863,11 +863,73 @@ impl Default for CssExportsConvention {
   }
 }
 
-pub type DescriptionData = HashMap<String, RuleSetConditionWithEmpty>;
+pub type DescriptionData = HashMap<DescriptionDataMatcherKey, RuleSetConditionWithEmpty>;
 pub type With = HashMap<String, RuleSetConditionWithEmpty>;
 
 pub type RuleSetConditionFnMatcher =
   Box<dyn Fn(DataRef) -> BoxFuture<'static, Result<bool>> + Sync + Send>;
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct DescriptionDataMatcherKey {
+  original: String,
+  path: Box<[String]>,
+}
+
+impl DescriptionDataMatcherKey {
+  pub fn get<'a>(&self, description: &'a serde_json::Value) -> Option<&'a serde_json::Value> {
+    self
+      .path
+      .iter()
+      .try_fold(description, |acc, key| acc.get(key))
+  }
+}
+
+impl From<String> for DescriptionDataMatcherKey {
+  fn from(value: String) -> Self {
+    let path = value.split('.').map(str::to_owned).collect();
+    Self {
+      original: value,
+      path,
+    }
+  }
+}
+
+impl From<&str> for DescriptionDataMatcherKey {
+  fn from(value: &str) -> Self {
+    value.to_owned().into()
+  }
+}
+
+impl fmt::Debug for DescriptionDataMatcherKey {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.original.fmt(f)
+  }
+}
+
+#[cfg(test)]
+mod description_data_matcher_key_tests {
+  use serde_json::json;
+
+  use super::DescriptionDataMatcherKey;
+
+  #[test]
+  fn precomputes_dot_path_lookup_without_changing_debug_shape() {
+    let key = DescriptionDataMatcherKey::from("exports.browser.import".to_owned());
+    let description = json!({
+      "exports": {
+        "browser": {
+          "import": "browser-entry"
+        }
+      }
+    });
+
+    assert_eq!(
+      key.get(&description).and_then(|value| value.as_str()),
+      Some("browser-entry")
+    );
+    assert_eq!(format!("{key:?}"), "\"exports.browser.import\"");
+  }
+}
 
 pub enum RuleSetCondition {
   String(String),

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -261,9 +261,7 @@ fn module_rule_matcher_sync<'a>(
       for (k, matcher) in description_data {
         ensure_sync_matched!(check_optional_sync(
           matcher,
-          k.split('.')
-            .try_fold(resource_description.json(), |acc, key| acc.get(key))
-            .map(Into::into),
+          k.get(resource_description.json()).map(Into::into),
         ));
       }
     } else {
@@ -435,13 +433,8 @@ async fn module_rule_matcher_async<'a>(
   if let Some(description_data) = &module_rule.description_data {
     if let Some(resource_description) = resource_data.description() {
       for (k, matcher) in description_data {
-        if !check_optional_async(
-          matcher,
-          k.split('.')
-            .try_fold(resource_description.json(), |acc, key| acc.get(key))
-            .map(Into::into),
-        )
-        .await?
+        if !check_optional_async(matcher, k.get(resource_description.json()).map(Into::into))
+          .await?
         {
           return Ok(false);
         }


### PR DESCRIPTION
## What changed

- Precompute `descriptionData` matcher dot-path keys when module rules are built, then reuse those path segments during module rule matching.
- Collapse matched module rule effect post-processing in `NormalModuleFactory` into a single pass that collects module type, layer, resolve, parser, generator, side effects, and source map flags together.

## Why this should improve performance

Module rule matching runs during module factorization, so its cost scales with the number of modules multiplied by the rule tree size. `descriptionData` matchers previously split dot-path keys on each match attempt; this moves that stable work to rule construction time. The downstream effect handling previously scanned the matched rule effects several times per module; this now scans them once.

## Hot path and cardinality risk

The hot path is `module_rules_matcher` and its downstream `NormalModuleFactory` rule effect resolution. The risky cardinality is modules times matched rules, with additional nested rule checks for `rules` and `oneOf`. Avoiding repeated per-module string splitting and repeated scans keeps work proportional to the rule checks themselves instead of adding extra passes over the same matched effects.

## Expected benefit

Expected CPU benefit comes from less repeated string work for `descriptionData` and fewer iterations over matched rule effects. Expected allocation benefit is modest but positive because dot-path segment allocation moves out of the per-module matching path and into one-time rule construction.
