### PR TITLE
perf: optimize named id assignment

### DIFF
--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -14,6 +14,14 @@ use crate::id_helpers::{
   NaturalChunkCompareCache, compare_chunks_natural, get_long_chunk_name, get_short_chunk_name,
 };
 
+fn is_chunk_id_reserved(
+  id: &ChunkId,
+  used_ids: &ChunkIdMap<ChunkUkey>,
+  name_to_items_keys: Option<&ChunkIdSet>,
+) -> bool {
+  used_ids.contains_key(id) || name_to_items_keys.is_some_and(|keys| keys.contains(id))
+}
+
 #[tracing::instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
 fn assign_named_chunk_ids(
@@ -171,11 +179,7 @@ fn assign_named_chunk_ids(
       for item in items {
         let mut i_buffer = itoa::Buffer::new();
         let mut formatted_name = ChunkId::from(format!("{name}{}", i_buffer.format(i)));
-        while name_to_items_keys
-          .as_ref()
-          .is_some_and(|keys| keys.contains(&formatted_name))
-          && used_ids.contains_key(&formatted_name)
-        {
+        while is_chunk_id_reserved(&formatted_name, used_ids, name_to_items_keys.as_ref()) {
           i += 1;
           let mut i_buffer = itoa::Buffer::new();
           formatted_name = ChunkId::from(format!("{name}{}", i_buffer.format(i)));

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -59,9 +59,16 @@ fn assign_named_chunk_ids(
       (item, ChunkId::from(name))
     })
     .collect();
-  named_chunk_ids_artifact
-    .chunk_short_names
-    .reserve(chunks_len.saturating_sub(named_chunk_ids_artifact.chunk_short_names.len()));
+  named_chunk_ids_artifact.chunk_short_names.reserve(
+    item_name_pair
+      .iter()
+      .filter(|(item, _)| {
+        !named_chunk_ids_artifact
+          .chunk_short_names
+          .contains_key(item)
+      })
+      .count(),
+  );
   let mut name_to_items: ChunkIdMap<FxIndexSet<ChunkUkey>> =
     ChunkIdMap::with_capacity_and_hasher(chunks_len, Default::default());
   let mut invalid_and_repeat_names = ChunkIdSet::with_capacity_and_hasher(1, Default::default());
@@ -120,8 +127,9 @@ fn assign_named_chunk_ids(
 
   named_chunk_ids_artifact.chunk_long_names.reserve(
     item_name_pair
-      .len()
-      .saturating_sub(named_chunk_ids_artifact.chunk_long_names.len()),
+      .iter()
+      .filter(|(item, _)| !named_chunk_ids_artifact.chunk_long_names.contains_key(item))
+      .count(),
   );
   for (item, name) in item_name_pair {
     named_chunk_ids_artifact
@@ -362,8 +370,13 @@ async fn chunk_ids(
   // store chunk id map to the artifact
   named_chunk_ids_artifact.chunk_ids.reserve(
     chunk_by_ukey
-      .len()
-      .saturating_sub(named_chunk_ids_artifact.chunk_ids.len()),
+      .values()
+      .filter(|chunk| {
+        !named_chunk_ids_artifact
+          .chunk_ids
+          .contains_key(&chunk.ukey())
+      })
+      .count(),
   );
   chunk_by_ukey.values().for_each(|chunk| {
     named_chunk_ids_artifact

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -142,11 +142,12 @@ fn assign_named_chunk_ids(
       needs_name_to_items_keys = true;
     }
     // Also rename the conflicting chunks in used_ids
-    if let Some(item) = used_ids.get(&name)
-    // Unless the chunk is explicitly using chunk name as id
-      && matches!(chunk_by_ukey.expect_get(item).name(), Some(chunk_name) if chunk_name != name.as_str())
-    {
-      items.insert(*item);
+    if let Some(item) = used_ids.get(&name) {
+      // Unless the chunk is explicitly using chunk name as id
+      if matches!(chunk_by_ukey.expect_get(item).name(), Some(chunk_name) if chunk_name != name.as_str())
+      {
+        items.insert(*item);
+      }
       needs_name_to_items_keys = true;
     }
   }

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -14,14 +14,6 @@ use crate::id_helpers::{
   NaturalChunkCompareCache, compare_chunks_natural, get_long_chunk_name, get_short_chunk_name,
 };
 
-fn is_chunk_id_reserved(
-  id: &ChunkId,
-  used_ids: &ChunkIdMap<ChunkUkey>,
-  name_to_items_keys: Option<&ChunkIdSet>,
-) -> bool {
-  used_ids.contains_key(id) || name_to_items_keys.is_some_and(|keys| keys.contains(id))
-}
-
 #[tracing::instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
 fn assign_named_chunk_ids(
@@ -69,6 +61,9 @@ fn assign_named_chunk_ids(
       })
       .count(),
   );
+  // name_to_items keeps the current id candidates grouped by name.
+  // invalid_and_repeat_names tracks short names that need long-name fallback.
+  // name_to_items_keys is built lazily only when suffixed ids must avoid other pending names.
   let mut name_to_items: ChunkIdMap<FxIndexSet<ChunkUkey>> =
     ChunkIdMap::with_capacity_and_hasher(chunks_len, Default::default());
   let mut invalid_and_repeat_names = ChunkIdSet::with_capacity_and_hasher(1, Default::default());
@@ -193,7 +188,11 @@ fn assign_named_chunk_ids(
       for item in items {
         let mut i_buffer = itoa::Buffer::new();
         let mut formatted_name = ChunkId::from(format!("{name}{}", i_buffer.format(i)));
-        while is_chunk_id_reserved(&formatted_name, used_ids, name_to_items_keys.as_ref()) {
+        while used_ids.contains_key(&formatted_name)
+          || name_to_items_keys
+            .as_ref()
+            .is_some_and(|keys| keys.contains(&formatted_name))
+        {
           i += 1;
           let mut i_buffer = itoa::Buffer::new();
           formatted_name = ChunkId::from(format!("{name}{}", i_buffer.format(i)));

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -32,6 +32,7 @@ fn assign_named_chunk_ids(
   named_chunk_ids_artifact: &mut ChunkNamedIdArtifact,
   mutations: &mut Option<Mutations>,
 ) -> Vec<ChunkUkey> {
+  let chunks_len = chunks.len();
   let item_name_pair: Vec<_> = chunks
     .into_par_iter()
     .map(|item| {
@@ -50,9 +51,14 @@ fn assign_named_chunk_ids(
       (item, ChunkId::from(name))
     })
     .collect();
-  let mut name_to_items: ChunkIdMap<FxIndexSet<ChunkUkey>> = ChunkIdMap::default();
-  let mut invalid_and_repeat_names: ChunkIdSet =
-    std::iter::once(ChunkId::from(String::new())).collect();
+  named_chunk_ids_artifact
+    .chunk_short_names
+    .reserve(chunks_len);
+  let mut name_to_items: ChunkIdMap<FxIndexSet<ChunkUkey>> =
+    ChunkIdMap::with_capacity_and_hasher(chunks_len, Default::default());
+  let mut invalid_and_repeat_names = ChunkIdSet::with_capacity_and_hasher(1, Default::default());
+  invalid_and_repeat_names.insert(ChunkId::from(String::new()));
+  let mut needs_name_to_items_keys = false;
   for (item, name) in item_name_pair {
     named_chunk_ids_artifact
       .chunk_short_names
@@ -101,6 +107,9 @@ fn assign_named_chunk_ids(
     })
     .collect();
 
+  named_chunk_ids_artifact
+    .chunk_long_names
+    .reserve(item_name_pair.len());
   for (item, name) in item_name_pair {
     named_chunk_ids_artifact
       .chunk_long_names
@@ -108,16 +117,21 @@ fn assign_named_chunk_ids(
 
     let items = name_to_items.entry(name.clone()).or_default();
     items.insert(item);
+    if items.len() > 1 {
+      needs_name_to_items_keys = true;
+    }
     // Also rename the conflicting chunks in used_ids
     if let Some(item) = used_ids.get(&name)
     // Unless the chunk is explicitly using chunk name as id
       && matches!(chunk_by_ukey.expect_get(item).name(), Some(chunk_name) if chunk_name != name.as_str())
     {
       items.insert(*item);
+      needs_name_to_items_keys = true;
     }
   }
 
-  let name_to_items_keys = name_to_items.keys().cloned().collect::<ChunkIdSet>();
+  let name_to_items_keys =
+    needs_name_to_items_keys.then(|| name_to_items.keys().cloned().collect::<ChunkIdSet>());
   let mut unnamed_items = vec![];
 
   let mut chunk_compare_cache = NaturalChunkCompareCache::default();
@@ -157,7 +171,10 @@ fn assign_named_chunk_ids(
       for item in items {
         let mut i_buffer = itoa::Buffer::new();
         let mut formatted_name = ChunkId::from(format!("{name}{}", i_buffer.format(i)));
-        while name_to_items_keys.contains(&formatted_name) && used_ids.contains_key(&formatted_name)
+        while name_to_items_keys
+          .as_ref()
+          .is_some_and(|keys| keys.contains(&formatted_name))
+          && used_ids.contains_key(&formatted_name)
         {
           i += 1;
           let mut i_buffer = itoa::Buffer::new();
@@ -334,6 +351,9 @@ async fn chunk_ids(
   }
 
   // store chunk id map to the artifact
+  named_chunk_ids_artifact
+    .chunk_ids
+    .reserve(chunk_by_ukey.len());
   chunk_by_ukey.values().for_each(|chunk| {
     named_chunk_ids_artifact
       .chunk_ids

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -61,7 +61,7 @@ fn assign_named_chunk_ids(
     .collect();
   named_chunk_ids_artifact
     .chunk_short_names
-    .reserve(chunks_len);
+    .reserve(chunks_len.saturating_sub(named_chunk_ids_artifact.chunk_short_names.len()));
   let mut name_to_items: ChunkIdMap<FxIndexSet<ChunkUkey>> =
     ChunkIdMap::with_capacity_and_hasher(chunks_len, Default::default());
   let mut invalid_and_repeat_names = ChunkIdSet::with_capacity_and_hasher(1, Default::default());
@@ -79,12 +79,15 @@ fn assign_named_chunk_ids(
       invalid_and_repeat_names.insert(name);
     }
     // Also rename the conflicting chunks in used_ids
-    else if let Some(item) = used_ids.get(&name)
-    // Unless the chunk is explicitly using chunk name as id
-      && matches!(chunk_by_ukey.expect_get(item).name(), Some(chunk_name) if chunk_name != name.as_str())
-    {
-      items.insert(*item);
-      invalid_and_repeat_names.insert(name);
+    else if let Some(item) = used_ids.get(&name) {
+      // Unless the chunk is explicitly using chunk name as id
+      if matches!(chunk_by_ukey.expect_get(item).name(), Some(chunk_name) if chunk_name != name.as_str())
+      {
+        items.insert(*item);
+        invalid_and_repeat_names.insert(name);
+      } else {
+        needs_name_to_items_keys = true;
+      }
     }
   }
 
@@ -115,9 +118,11 @@ fn assign_named_chunk_ids(
     })
     .collect();
 
-  named_chunk_ids_artifact
-    .chunk_long_names
-    .reserve(item_name_pair.len());
+  named_chunk_ids_artifact.chunk_long_names.reserve(
+    item_name_pair
+      .len()
+      .saturating_sub(named_chunk_ids_artifact.chunk_long_names.len()),
+  );
   for (item, name) in item_name_pair {
     named_chunk_ids_artifact
       .chunk_long_names
@@ -355,9 +360,11 @@ async fn chunk_ids(
   }
 
   // store chunk id map to the artifact
-  named_chunk_ids_artifact
-    .chunk_ids
-    .reserve(chunk_by_ukey.len());
+  named_chunk_ids_artifact.chunk_ids.reserve(
+    chunk_by_ukey
+      .len()
+      .saturating_sub(named_chunk_ids_artifact.chunk_ids.len()),
+  );
   chunk_by_ukey.values().for_each(|chunk| {
     named_chunk_ids_artifact
       .chunk_ids

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -27,14 +27,6 @@ fn add_conflicted_module_name(
   conflict_name_to_items.entry(name).or_default().insert(item);
 }
 
-fn is_module_id_reserved(
-  id: &ModuleId,
-  used_ids: &ModuleIdMap<ModuleIdentifier>,
-  name_to_items_keys: Option<&ModuleIdSet>,
-) -> bool {
-  used_ids.contains_key(id) || name_to_items_keys.is_some_and(|keys| keys.contains(id))
-}
-
 #[tracing::instrument(skip_all)]
 fn assign_named_module_ids(
   modules: IdentifierSet,
@@ -54,6 +46,9 @@ fn assign_named_module_ids(
       (item, name)
     })
     .collect();
+  // name_to_item keeps the common unique-name path allocation-light.
+  // conflict_name_to_items stores only names that need long-name or suffix fallback.
+  // name_to_items_keys is built lazily only when suffixed ids must avoid other pending names.
   let mut name_to_item: ModuleIdMap<ModuleIdentifier> = ModuleIdMap::default();
   let mut conflict_name_to_items: ModuleIdMap<IdentifierIndexSet> = ModuleIdMap::default();
   let mut needs_name_to_items_keys = false;
@@ -160,7 +155,13 @@ fn assign_named_module_ids(
       for item in items {
         let mut i_buffer = itoa::Buffer::new();
         let mut formatted_name = ModuleId::from(format!("{name}{}", i_buffer.format(i)));
-        while is_module_id_reserved(&formatted_name, used_ids, name_to_items_keys.as_ref()) {
+        // Suffixed ids must skip both ids already assigned and ids that are pending
+        // as natural names for another module.
+        while used_ids.contains_key(&formatted_name)
+          || name_to_items_keys
+            .as_ref()
+            .is_some_and(|keys| keys.contains(&formatted_name))
+        {
           i += 1;
           let mut i_buffer = itoa::Buffer::new();
           formatted_name = ModuleId::from(format!("{name}{}", i_buffer.format(i)));

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -12,6 +12,21 @@ use rspack_util::{comparators::compare_ids, itoa};
 
 use crate::id_helpers::{get_long_module_name, get_short_module_name};
 
+fn add_conflicted_module_name(
+  name_to_item: &mut ModuleIdMap<ModuleIdentifier>,
+  conflict_name_to_items: &mut ModuleIdMap<IdentifierIndexSet>,
+  name: ModuleId,
+  item: ModuleIdentifier,
+) {
+  if let Some(existing) = name_to_item.remove(&name) {
+    conflict_name_to_items
+      .entry(name.clone())
+      .or_default()
+      .insert(existing);
+  }
+  conflict_name_to_items.entry(name).or_default().insert(item);
+}
+
 #[tracing::instrument(skip_all)]
 fn assign_named_module_ids(
   modules: IdentifierSet,
@@ -31,33 +46,41 @@ fn assign_named_module_ids(
       (item, name)
     })
     .collect();
-  let mut name_to_items: ModuleIdMap<IdentifierIndexSet> = ModuleIdMap::default();
-  let mut invalid_and_repeat_names = ModuleIdSet::default();
-  invalid_and_repeat_names.insert(ModuleId::from(String::new()));
+  let mut name_to_item: ModuleIdMap<ModuleIdentifier> = ModuleIdMap::default();
+  let mut conflict_name_to_items: ModuleIdMap<IdentifierIndexSet> = ModuleIdMap::default();
   let mut needs_name_to_items_keys = false;
   for (item, name) in item_name_pair {
-    let items = name_to_items.entry(name.clone()).or_default();
-    items.insert(item);
-    // If the short module id is conflict, then we need to rename all the conflicting modules to long module id
-    if items.len() > 1 {
-      invalid_and_repeat_names.insert(name);
-    }
-    // Also rename the conflicting modules in used_ids
-    else if let Some(item) = used_ids.get(&name) {
-      items.insert(*item);
-      invalid_and_repeat_names.insert(name);
+    if name.as_str().is_empty() {
+      add_conflicted_module_name(&mut name_to_item, &mut conflict_name_to_items, name, item);
+    } else if let Some(used_item) = used_ids.get(&name) {
+      add_conflicted_module_name(
+        &mut name_to_item,
+        &mut conflict_name_to_items,
+        name.clone(),
+        item,
+      );
+      add_conflicted_module_name(
+        &mut name_to_item,
+        &mut conflict_name_to_items,
+        name,
+        *used_item,
+      );
+    } else if conflict_name_to_items.contains_key(&name) {
+      add_conflicted_module_name(&mut name_to_item, &mut conflict_name_to_items, name, item);
+    } else if let Some(existing) = name_to_item.insert(name.clone(), item) {
+      add_conflicted_module_name(
+        &mut name_to_item,
+        &mut conflict_name_to_items,
+        name.clone(),
+        existing,
+      );
+      add_conflicted_module_name(&mut name_to_item, &mut conflict_name_to_items, name, item);
     }
   }
 
-  let item_name_pair: Vec<_> = invalid_and_repeat_names
-    .iter()
-    .flat_map(|name| {
-      let mut res = vec![];
-      for item in name_to_items.remove(name).unwrap_or_default() {
-        res.push((name.clone(), item));
-      }
-      res
-    })
+  let item_name_pair: Vec<_> = conflict_name_to_items
+    .into_iter()
+    .flat_map(|(name, items)| items.into_iter().map(move |item| (name.clone(), item)))
     .par_bridge()
     .map(|(name, item)| {
       let module = module_graph
@@ -67,36 +90,59 @@ fn assign_named_module_ids(
       (item, long_name)
     })
     .collect();
+  let mut conflict_name_to_items: ModuleIdMap<IdentifierIndexSet> = ModuleIdMap::default();
   for (item, name) in item_name_pair {
-    let items = name_to_items.entry(name.clone()).or_default();
-    items.insert(item);
-    if items.len() > 1 {
+    if let Some(used_item) = used_ids.get(&name) {
+      add_conflicted_module_name(
+        &mut name_to_item,
+        &mut conflict_name_to_items,
+        name.clone(),
+        item,
+      );
+      add_conflicted_module_name(
+        &mut name_to_item,
+        &mut conflict_name_to_items,
+        name,
+        *used_item,
+      );
       needs_name_to_items_keys = true;
-    }
-    // Also rename the conflicting modules in used_ids
-    if let Some(item) = used_ids.get(&name) {
-      items.insert(*item);
+    } else if conflict_name_to_items.contains_key(&name) {
+      add_conflicted_module_name(&mut name_to_item, &mut conflict_name_to_items, name, item);
+      needs_name_to_items_keys = true;
+    } else if let Some(existing) = name_to_item.insert(name.clone(), item) {
+      add_conflicted_module_name(
+        &mut name_to_item,
+        &mut conflict_name_to_items,
+        name.clone(),
+        existing,
+      );
+      add_conflicted_module_name(&mut name_to_item, &mut conflict_name_to_items, name, item);
       needs_name_to_items_keys = true;
     }
   }
 
   let name_to_items_keys =
-    needs_name_to_items_keys.then(|| name_to_items.keys().cloned().collect::<ModuleIdSet>());
+    needs_name_to_items_keys.then(|| name_to_item.keys().cloned().collect::<ModuleIdSet>());
   let mut unnamed_items = vec![];
 
-  for (name, mut items) in name_to_items {
+  for (name, item) in name_to_item {
     if name.as_str().is_empty() {
-      for item in items {
-        unnamed_items.push(item)
-      }
-    } else if items.len() == 1 && !used_ids.contains_key(&name) {
-      let item = items[0];
+      unnamed_items.push(item)
+    } else {
       if ChunkGraph::set_module_id(module_ids, item, name.clone())
         && let Some(mutations) = mutations
       {
         mutations.add(Mutation::ModuleSetId { module: item });
       }
       used_ids.insert(name, item);
+    }
+  }
+
+  for (name, mut items) in conflict_name_to_items {
+    if name.as_str().is_empty() {
+      for item in items {
+        unnamed_items.push(item)
+      }
     } else {
       items.sort_unstable_by(|a, b| compare_ids(a, b));
       let mut i = 0;

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -27,6 +27,14 @@ fn add_conflicted_module_name(
   conflict_name_to_items.entry(name).or_default().insert(item);
 }
 
+fn is_module_id_reserved(
+  id: &ModuleId,
+  used_ids: &ModuleIdMap<ModuleIdentifier>,
+  name_to_items_keys: Option<&ModuleIdSet>,
+) -> bool {
+  used_ids.contains_key(id) || name_to_items_keys.is_some_and(|keys| keys.contains(id))
+}
+
 #[tracing::instrument(skip_all)]
 fn assign_named_module_ids(
   modules: IdentifierSet,
@@ -121,8 +129,11 @@ fn assign_named_module_ids(
     }
   }
 
-  let name_to_items_keys =
-    needs_name_to_items_keys.then(|| name_to_item.keys().cloned().collect::<ModuleIdSet>());
+  let name_to_items_keys = needs_name_to_items_keys.then(|| {
+    let mut keys = name_to_item.keys().cloned().collect::<ModuleIdSet>();
+    keys.extend(conflict_name_to_items.keys().cloned());
+    keys
+  });
   let mut unnamed_items = vec![];
 
   for (name, item) in name_to_item {
@@ -149,11 +160,7 @@ fn assign_named_module_ids(
       for item in items {
         let mut i_buffer = itoa::Buffer::new();
         let mut formatted_name = ModuleId::from(format!("{name}{}", i_buffer.format(i)));
-        while name_to_items_keys
-          .as_ref()
-          .is_some_and(|keys| keys.contains(&formatted_name))
-          && used_ids.contains_key(&formatted_name)
-        {
+        while is_module_id_reserved(&formatted_name, used_ids, name_to_items_keys.as_ref()) {
           i += 1;
           let mut i_buffer = itoa::Buffer::new();
           formatted_name = ModuleId::from(format!("{name}{}", i_buffer.format(i)));

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -32,8 +32,9 @@ fn assign_named_module_ids(
     })
     .collect();
   let mut name_to_items: ModuleIdMap<IdentifierIndexSet> = ModuleIdMap::default();
-  let mut invalid_and_repeat_names: ModuleIdSet =
-    std::iter::once(ModuleId::from(String::new())).collect();
+  let mut invalid_and_repeat_names = ModuleIdSet::default();
+  invalid_and_repeat_names.insert(ModuleId::from(String::new()));
+  let mut needs_name_to_items_keys = false;
   for (item, name) in item_name_pair {
     let items = name_to_items.entry(name.clone()).or_default();
     items.insert(item);
@@ -69,13 +70,18 @@ fn assign_named_module_ids(
   for (item, name) in item_name_pair {
     let items = name_to_items.entry(name.clone()).or_default();
     items.insert(item);
+    if items.len() > 1 {
+      needs_name_to_items_keys = true;
+    }
     // Also rename the conflicting modules in used_ids
     if let Some(item) = used_ids.get(&name) {
       items.insert(*item);
+      needs_name_to_items_keys = true;
     }
   }
 
-  let name_to_items_keys = name_to_items.keys().cloned().collect::<ModuleIdSet>();
+  let name_to_items_keys =
+    needs_name_to_items_keys.then(|| name_to_items.keys().cloned().collect::<ModuleIdSet>());
   let mut unnamed_items = vec![];
 
   for (name, mut items) in name_to_items {
@@ -97,7 +103,10 @@ fn assign_named_module_ids(
       for item in items {
         let mut i_buffer = itoa::Buffer::new();
         let mut formatted_name = ModuleId::from(format!("{name}{}", i_buffer.format(i)));
-        while name_to_items_keys.contains(&formatted_name) && used_ids.contains_key(&formatted_name)
+        while name_to_items_keys
+          .as_ref()
+          .is_some_and(|keys| keys.contains(&formatted_name))
+          && used_ids.contains_key(&formatted_name)
         {
           i += 1;
           let mut i_buffer = itoa::Buffer::new();


### PR DESCRIPTION
## Summary

- Optimize named module id assignment by splitting the common unique-name path from conflict handling.
- Build the named-id key set lazily only when suffix fallback ids are needed, while keeping suffix assignment collision-safe.
- Optimize named chunk id assignment by reserving artifact maps only for keys missing from retained incremental artifacts.
- Tighten suffix collision handling for named module and chunk ids so generated fallback ids skip both already-used ids and pending natural ids.

## Named module ids

Before this change, named module id assignment stored every short-name candidate in `ModuleIdMap<IdentifierIndexSet>`. Even when a module name was unique, the hot path still had to create or update an index set. After collecting conflicts, it always cloned the full set of candidate names into `name_to_items_keys` before suffix assignment.

After this change, unique names stay in `ModuleIdMap<ModuleIdentifier>` and are assigned directly. A name is promoted into `conflict_name_to_items` only when it is empty, duplicated, collides with an existing used id, or later collides again after long-name fallback. This keeps the no-conflict path smaller and reserves `IdentifierIndexSet` work for actual conflicts.

The suffix fallback check now treats either condition as reserved: the candidate id is already assigned in `used_ids`, or it is a pending natural name in `name_to_items_keys`. This is intentionally `||`, not the previous `&&`, because either side alone would produce an unstable or duplicate assignment: `used_ids` protects already assigned ids, while `name_to_items_keys` prevents a suffixed fallback such as `foo0` from stealing another module's natural `foo0` id.

## Why this is faster

Most modules have unique named ids. Keeping those entries as direct `ModuleIdentifier` values avoids per-module `IdentifierIndexSet` insertion and reduces the `IndexMap::insert_full` cost seen in the named module ids benchmark. Only names that actually need long-name or suffix fallback pay the set/grouping cost.

The full key set used by suffix fallback is also no longer built unconditionally. Non-conflicting builds avoid cloning every candidate id into a second set, while conflicting builds still build the set when it is needed to preserve deterministic and unique assignment.

For named chunk ids, the artifact maps are retained across incremental rebuilds. Reserving by the number of missing keys avoids doubling capacity for maps that are mostly overwrites, while still preallocating for genuinely new chunk names and ids.