### PR TITLE
perf(javascript): reduce rayon overhead in dependency optimization passes

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -32,6 +32,7 @@ impl<'a> FlagDependencyExportsState<'a> {
   }
 
   pub fn apply(&mut self, modules: IdentifierSet) {
+    let use_parallel = rayon::current_num_threads() > 1;
     // initialize the exports info data and their provided info for all modules
     for module_id in &modules {
       let exports_type_unset = self
@@ -70,19 +71,35 @@ impl<'a> FlagDependencyExportsState<'a> {
       let modules = std::mem::take(&mut batch);
 
       // collect the exports specs from modules by calling `dependency.get_exports`
-      let module_exports_specs = modules
-        .into_par_iter()
-        .map(|module_id| {
-          let exports_specs = collect_module_exports_specs(
-            &module_id,
-            self.mg,
-            self.mg_cache,
-            self.exports_info_artifact,
-          )
-          .unwrap_or_default();
-          (module_id, exports_specs)
-        })
-        .collect::<Vec<_>>();
+      let module_exports_specs = if use_parallel && modules.len() > 32 {
+        modules
+          .into_par_iter()
+          .map(|module_id| {
+            let exports_specs = collect_module_exports_specs(
+              &module_id,
+              self.mg,
+              self.mg_cache,
+              self.exports_info_artifact,
+            )
+            .unwrap_or_default();
+            (module_id, exports_specs)
+          })
+          .collect::<Vec<_>>()
+      } else {
+        modules
+          .into_iter()
+          .map(|module_id| {
+            let exports_specs = collect_module_exports_specs(
+              &module_id,
+              self.mg,
+              self.mg_cache,
+              self.exports_info_artifact,
+            )
+            .unwrap_or_default();
+            (module_id, exports_specs)
+          })
+          .collect::<Vec<_>>()
+      };
 
       let mut changed_modules =
         IdentifierSet::with_capacity_and_hasher(module_exports_specs.len(), Default::default());
@@ -107,30 +124,57 @@ impl<'a> FlagDependencyExportsState<'a> {
         });
 
       // parallelize the merging of exports specs to exports info data
-      let non_nested_tasks = non_nested_specs
-        .into_par_iter()
-        .map(|(module_id, (exports_specs, _))| {
-          let mut changed = false;
-          let mut exports_info = self
-            .exports_info_artifact
-            .get_exports_info_data(&module_id)
-            .clone();
-          let mut dependencies = Vec::with_capacity(exports_specs.len());
-          for (dep_id, exports_spec) in exports_specs {
-            let (is_changed, changed_dependencies) = process_exports_spec_without_nested(
-              self.mg,
-              self.exports_info_artifact,
-              &module_id,
-              dep_id,
-              &exports_spec,
-              &mut exports_info,
-            );
-            changed |= is_changed;
-            dependencies.extend(changed_dependencies);
-          }
-          (module_id, changed, dependencies, exports_info)
-        })
-        .collect::<Vec<_>>();
+      let non_nested_tasks = if use_parallel && non_nested_specs.len() > 32 {
+        non_nested_specs
+          .into_par_iter()
+          .map(|(module_id, (exports_specs, _))| {
+            let mut changed = false;
+            let mut exports_info = self
+              .exports_info_artifact
+              .get_exports_info_data(&module_id)
+              .clone();
+            let mut dependencies = Vec::with_capacity(exports_specs.len());
+            for (dep_id, exports_spec) in exports_specs {
+              let (is_changed, changed_dependencies) = process_exports_spec_without_nested(
+                self.mg,
+                self.exports_info_artifact,
+                &module_id,
+                dep_id,
+                &exports_spec,
+                &mut exports_info,
+              );
+              changed |= is_changed;
+              dependencies.extend(changed_dependencies);
+            }
+            (module_id, changed, dependencies, exports_info)
+          })
+          .collect::<Vec<_>>()
+      } else {
+        non_nested_specs
+          .into_iter()
+          .map(|(module_id, (exports_specs, _))| {
+            let mut changed = false;
+            let mut exports_info = self
+              .exports_info_artifact
+              .get_exports_info_data(&module_id)
+              .clone();
+            let mut dependencies = Vec::with_capacity(exports_specs.len());
+            for (dep_id, exports_spec) in exports_specs {
+              let (is_changed, changed_dependencies) = process_exports_spec_without_nested(
+                self.mg,
+                self.exports_info_artifact,
+                &module_id,
+                dep_id,
+                &exports_spec,
+                &mut exports_info,
+              );
+              changed |= is_changed;
+              dependencies.extend(changed_dependencies);
+            }
+            (module_id, changed, dependencies, exports_info)
+          })
+          .collect::<Vec<_>>()
+      };
 
       // handle collected side effects and apply the merged exports info data to module graph
       for (module_id, changed, changed_dependencies, exports_info) in non_nested_tasks {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -57,6 +57,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
   }
 
   async fn apply(&mut self) {
+    let use_parallel = rayon::current_num_threads() > 1;
     let side_effects_state_artifact = self
       .build_module_graph_artifact
       .side_effects_state_artifact
@@ -136,25 +137,47 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
 
       // collect referenced exports from modules by calling `dependency.get_referenced_exports`
       // and also added referenced modules to queue for further processing
-      let batch_res = batch
-        .into_par_iter()
-        .map(|(block_id, runtime, force_side_effects)| {
-          let (referenced_exports, module_tasks) = self.process_module(
-            module_graph,
-            &side_effects_state_artifact,
-            block_id,
-            runtime.as_ref(),
-            force_side_effects,
-            self.global,
-          );
-          (
-            runtime,
-            force_side_effects,
-            referenced_exports,
-            module_tasks,
-          )
-        })
-        .collect::<Vec<_>>();
+      let batch_res = if use_parallel && batch.len() > 32 {
+        batch
+          .into_par_iter()
+          .map(|(block_id, runtime, force_side_effects)| {
+            let (referenced_exports, module_tasks) = self.process_module(
+              module_graph,
+              &side_effects_state_artifact,
+              block_id,
+              runtime.as_ref(),
+              force_side_effects,
+              self.global,
+            );
+            (
+              runtime,
+              force_side_effects,
+              referenced_exports,
+              module_tasks,
+            )
+          })
+          .collect::<Vec<_>>()
+      } else {
+        batch
+          .into_iter()
+          .map(|(block_id, runtime, force_side_effects)| {
+            let (referenced_exports, module_tasks) = self.process_module(
+              module_graph,
+              &side_effects_state_artifact,
+              block_id,
+              runtime.as_ref(),
+              force_side_effects,
+              self.global,
+            );
+            (
+              runtime,
+              force_side_effects,
+              referenced_exports,
+              module_tasks,
+            )
+          })
+          .collect::<Vec<_>>()
+      };
 
       let mut nested_tasks = vec![];
       let mut non_nested_tasks: IdentifierMap<Vec<NonNestedTask>> =
@@ -167,35 +190,67 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
 
         let mg = self.build_module_graph_artifact.get_module_graph();
 
-        let collected = batch_res
-          .into_par_iter()
-          .map(
-            |(runtime, force_side_effects, referenced_exports, module_tasks)| {
-              let mut nested_tasks = Vec::with_capacity(referenced_exports.len());
-              let mut non_nested_tasks = Vec::with_capacity(referenced_exports.len());
-              for (module_id, exports) in referenced_exports {
-                let exports_info = self.exports_info_artifact.get_exports_info_data(&module_id);
-                let has_nested = exports.iter().any(|e| match e {
-                  ExtendedReferencedExport::Array(arr) => arr.len() > 1,
-                  ExtendedReferencedExport::Export(export) => export.name.len() > 1,
-                });
-                if has_nested {
-                  nested_tasks.push((
-                    runtime.clone(),
-                    force_side_effects,
-                    module_id,
-                    exports_info.id(),
-                    exports,
-                  ));
-                } else {
-                  non_nested_tasks
-                    .push((module_id, (runtime.clone(), force_side_effects, exports)));
+        let collected = if use_parallel && batch_res.len() > 32 {
+          batch_res
+            .into_par_iter()
+            .map(
+              |(runtime, force_side_effects, referenced_exports, module_tasks)| {
+                let mut nested_tasks = Vec::with_capacity(referenced_exports.len());
+                let mut non_nested_tasks = Vec::with_capacity(referenced_exports.len());
+                for (module_id, exports) in referenced_exports {
+                  let exports_info = self.exports_info_artifact.get_exports_info_data(&module_id);
+                  let has_nested = exports.iter().any(|e| match e {
+                    ExtendedReferencedExport::Array(arr) => arr.len() > 1,
+                    ExtendedReferencedExport::Export(export) => export.name.len() > 1,
+                  });
+                  if has_nested {
+                    nested_tasks.push((
+                      runtime.clone(),
+                      force_side_effects,
+                      module_id,
+                      exports_info.id(),
+                      exports,
+                    ));
+                  } else {
+                    non_nested_tasks
+                      .push((module_id, (runtime.clone(), force_side_effects, exports)));
+                  }
                 }
-              }
-              (nested_tasks, non_nested_tasks, module_tasks)
-            },
-          )
-          .collect::<Vec<_>>();
+                (nested_tasks, non_nested_tasks, module_tasks)
+              },
+            )
+            .collect::<Vec<_>>()
+        } else {
+          batch_res
+            .into_iter()
+            .map(
+              |(runtime, force_side_effects, referenced_exports, module_tasks)| {
+                let mut nested_tasks = Vec::with_capacity(referenced_exports.len());
+                let mut non_nested_tasks = Vec::with_capacity(referenced_exports.len());
+                for (module_id, exports) in referenced_exports {
+                  let exports_info = self.exports_info_artifact.get_exports_info_data(&module_id);
+                  let has_nested = exports.iter().any(|e| match e {
+                    ExtendedReferencedExport::Array(arr) => arr.len() > 1,
+                    ExtendedReferencedExport::Export(export) => export.name.len() > 1,
+                  });
+                  if has_nested {
+                    nested_tasks.push((
+                      runtime.clone(),
+                      force_side_effects,
+                      module_id,
+                      exports_info.id(),
+                      exports,
+                    ));
+                  } else {
+                    non_nested_tasks
+                      .push((module_id, (runtime.clone(), force_side_effects, exports)));
+                  }
+                }
+                (nested_tasks, non_nested_tasks, module_tasks)
+              },
+            )
+            .collect::<Vec<_>>()
+        };
 
         for (module_nested_tasks, module_non_nested_tasks, module_tasks) in collected {
           for i in module_tasks {
@@ -212,39 +267,75 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       // so we can process these non-nested tasks parallelly by cloning the exports info data
       let non_nested_res = {
         let mg = self.build_module_graph_artifact.get_module_graph();
-        non_nested_tasks
-          .into_par_iter()
-          .map(|(module_id, tasks)| {
-            let mut exports_info: ExportsInfoData = self
-              .exports_info_artifact
-              .get_exports_info_data(&module_id)
-              .clone();
-            let module = mg
-              .module_by_identifier(&module_id)
-              .expect("should have module");
-            let is_exports_type_unset = matches!(
-              module.build_meta().exports_type,
-              BuildMetaExportsType::Unset
-            );
-            let is_side_effect_free =
-              module_declared_side_effect_free(module.as_ref()).unwrap_or_default();
-
-            let mut res = vec![];
-            for (runtime, force_side_effects, exports) in tasks {
-              let module_res = process_referenced_module_without_nested(
-                module_id,
-                is_exports_type_unset,
-                is_side_effect_free,
-                &mut exports_info,
-                exports,
-                runtime,
-                force_side_effects,
+        if use_parallel && non_nested_tasks.len() > 32 {
+          non_nested_tasks
+            .into_par_iter()
+            .map(|(module_id, tasks)| {
+              let mut exports_info: ExportsInfoData = self
+                .exports_info_artifact
+                .get_exports_info_data(&module_id)
+                .clone();
+              let module = mg
+                .module_by_identifier(&module_id)
+                .expect("should have module");
+              let is_exports_type_unset = matches!(
+                module.build_meta().exports_type,
+                BuildMetaExportsType::Unset
               );
-              res.extend(module_res);
-            }
-            (exports_info, res)
-          })
-          .collect::<Vec<_>>()
+              let is_side_effect_free =
+                module_declared_side_effect_free(module.as_ref()).unwrap_or_default();
+
+              let mut res = vec![];
+              for (runtime, force_side_effects, exports) in tasks {
+                let module_res = process_referenced_module_without_nested(
+                  module_id,
+                  is_exports_type_unset,
+                  is_side_effect_free,
+                  &mut exports_info,
+                  exports,
+                  runtime,
+                  force_side_effects,
+                );
+                res.extend(module_res);
+              }
+              (exports_info, res)
+            })
+            .collect::<Vec<_>>()
+        } else {
+          non_nested_tasks
+            .into_iter()
+            .map(|(module_id, tasks)| {
+              let mut exports_info: ExportsInfoData = self
+                .exports_info_artifact
+                .get_exports_info_data(&module_id)
+                .clone();
+              let module = mg
+                .module_by_identifier(&module_id)
+                .expect("should have module");
+              let is_exports_type_unset = matches!(
+                module.build_meta().exports_type,
+                BuildMetaExportsType::Unset
+              );
+              let is_side_effect_free =
+                module_declared_side_effect_free(module.as_ref()).unwrap_or_default();
+
+              let mut res = vec![];
+              for (runtime, force_side_effects, exports) in tasks {
+                let module_res = process_referenced_module_without_nested(
+                  module_id,
+                  is_exports_type_unset,
+                  is_side_effect_free,
+                  &mut exports_info,
+                  exports,
+                  runtime,
+                  force_side_effects,
+                );
+                res.extend(module_res);
+              }
+              (exports_info, res)
+            })
+            .collect::<Vec<_>>()
+        }
       };
 
       {

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -284,6 +284,7 @@ async fn optimize_dependencies(
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   let logger = compilation.get_logger("rspack.SideEffectsFlagPlugin");
+  let use_parallel = rayon::current_num_threads() > 1;
   let start = logger.time("update connections");
 
   let side_effects_state_map: IdentifierMap<ConnectionState> = {
@@ -388,26 +389,49 @@ async fn optimize_dependencies(
   logger.time_end(inner_start);
 
   let inner_start = logger.time("find optimizable connections");
-  let mut optimized_connections = modules
-    .par_iter()
-    .filter(|module| side_effects_state_map[module] == ConnectionState::Active(false))
-    .flat_map(|module| {
-      module_graph
-        .get_incoming_connections(module)
-        .collect::<Vec<_>>()
-    })
-    .map(|connection| {
-      (
-        connection.dependency_id,
-        can_optimize_connection(
-          connection,
-          &side_effects_state_map,
-          module_graph,
-          exports_info_artifact,
-        ),
-      )
-    })
-    .collect::<Vec<_>>();
+  let mut optimized_connections = if use_parallel && modules.len() > 32 {
+    modules
+      .par_iter()
+      .filter(|module| side_effects_state_map[module] == ConnectionState::Active(false))
+      .flat_map(|module| {
+        module_graph
+          .get_incoming_connections(module)
+          .collect::<Vec<_>>()
+      })
+      .map(|connection| {
+        (
+          connection.dependency_id,
+          can_optimize_connection(
+            connection,
+            &side_effects_state_map,
+            module_graph,
+            exports_info_artifact,
+          ),
+        )
+      })
+      .collect::<Vec<_>>()
+  } else {
+    modules
+      .iter()
+      .filter(|module| side_effects_state_map[module] == ConnectionState::Active(false))
+      .flat_map(|module| {
+        module_graph
+          .get_incoming_connections(module)
+          .collect::<Vec<_>>()
+      })
+      .map(|connection| {
+        (
+          connection.dependency_id,
+          can_optimize_connection(
+            connection,
+            &side_effects_state_map,
+            module_graph,
+            exports_info_artifact,
+          ),
+        )
+      })
+      .collect::<Vec<_>>()
+  };
   optimized_connections.sort_unstable_by_key(|(dep_id, _)| *dep_id);
   for (dep_id, can_optimize) in optimized_connections {
     if let Some(do_optimize) = can_optimize {
@@ -439,20 +463,37 @@ async fn optimize_dependencies(
       .collect();
 
     let module_graph = build_module_graph_artifact.get_module_graph();
-    do_optimizes = new_connections
-      .into_par_iter()
-      .filter(|(_, module)| side_effects_state_map[module] == ConnectionState::Active(false))
-      .filter_map(|(connection, _)| module_graph.connection_by_dependency_id(&connection))
-      .filter_map(|connection| {
-        can_optimize_connection(
-          connection,
-          &side_effects_state_map,
-          module_graph,
-          exports_info_artifact,
-        )
-        .map(|i| (connection.dependency_id, i))
-      })
-      .collect();
+    do_optimizes = if use_parallel && new_connections.len() > 32 {
+      new_connections
+        .into_par_iter()
+        .filter(|(_, module)| side_effects_state_map[module] == ConnectionState::Active(false))
+        .filter_map(|(connection, _)| module_graph.connection_by_dependency_id(&connection))
+        .filter_map(|connection| {
+          can_optimize_connection(
+            connection,
+            &side_effects_state_map,
+            module_graph,
+            exports_info_artifact,
+          )
+          .map(|i| (connection.dependency_id, i))
+        })
+        .collect()
+    } else {
+      new_connections
+        .into_iter()
+        .filter(|(_, module)| side_effects_state_map[module] == ConnectionState::Active(false))
+        .filter_map(|(connection, _)| module_graph.connection_by_dependency_id(&connection))
+        .filter_map(|connection| {
+          can_optimize_connection(
+            connection,
+            &side_effects_state_map,
+            module_graph,
+            exports_info_artifact,
+          )
+          .map(|i| (connection.dependency_id, i))
+        })
+        .collect()
+    };
     do_optimizes.sort_unstable_by_key(|(dependency, _)| *dependency);
   }
   logger.time_end(inner_start);


### PR DESCRIPTION
## Summary
- Gate several rayon-heavy loops behind a runtime heuristic so we avoid parallel scheduling overhead when the effective rayon thread count is 1 (or work is small).
- Keep existing parallel behavior for larger/multi-thread workloads.
- Touches:
  - `FlagDependencyUsagePluginProxy::apply`
  - `FlagDependencyExportsState::apply`
  - `SideEffectsFlagPlugin::optimize_dependencies`

## Why
CodSpeed profiling for `bundle@threejs-production-sourcemap` showed large time in rayon/crossbeam work-stealing internals. This change keeps semantics intact while removing unnecessary rayon orchestration in low-parallelism/small-batch paths.

## Benchmark (CodSpeed simulation)
Command:
`RAYON_NUM_THREADS=1 RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases codspeed run -m simulation -- cargo codspeed run -m simulation 'bundle@threejs-production-sourcemap'`

| Run | Time | Impact | Report |
| --- | ---: | ---: | --- |
| baseline (HEAD before this patch) | 418.14 ms | -8% | https://codspeed.io/web-infra-dev/rspack/runs/6a0ba620dd07fbfbff1d3cc9 |
| candidate | 312.68 ms | +23% | https://codspeed.io/web-infra-dev/rspack/runs/6a0ba7ec80d40a9d0e63e186 |
| candidate recheck | 312.67 ms | +23% | https://codspeed.io/web-infra-dev/rspack/runs/6a0ba81c80d40a9d0e63e18c |
| accidental re-run (same patch) | 312.68 ms | +23% | https://codspeed.io/web-infra-dev/rspack/runs/6a0ba88280d40a9d0e63e191 |

## Related links
- Goal thread: micro-optimize `bundle@threejs-production-sourcemap` by 10%+

## Checklist
- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).