### PR TITLE
perf(cli): lazy load json stream helpers

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -28,10 +28,10 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
   let createJsonStringifyStream: ((value: unknown) => Readable) | undefined;
 
   if (options.json) {
-    const [stream, jsonExt] = await Promise.all([
-      import('node:stream'),
-      import(/* webpackChunkName: "json-ext" */ '@discoveryjs/json-ext'),
-    ]);
+    const stream = await import('node:stream');
+    const jsonExt = await import(
+      /* webpackChunkName: "json-ext" */ '@discoveryjs/json-ext'
+    );
     createJsonStringifyStream = (value) =>
       stream.Readable.from(jsonExt.stringifyChunked(value));
   }

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import type {
   MultiStats,
   MultiStatsOptions,
@@ -28,11 +28,12 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
   let createJsonStringifyStream: ((value: unknown) => Readable) | undefined;
 
   if (options.json) {
-    const jsonExt = await import(
-      /* webpackChunkName: "json-ext" */ '@discoveryjs/json-ext'
-    );
+    const [stream, jsonExt] = await Promise.all([
+      import('node:stream'),
+      import(/* webpackChunkName: "json-ext" */ '@discoveryjs/json-ext'),
+    ]);
     createJsonStringifyStream = (value) =>
-      Readable.from(jsonExt.stringifyChunked(value));
+      stream.Readable.from(jsonExt.stringifyChunked(value));
   }
 
   const errorHandler = (


### PR DESCRIPTION
## Summary

This PR keeps the default `rspack build` path from loading Node stream helpers that are only needed for `--json` output. JSON stats output still loads `node:stream` and `@discoveryjs/json-ext` only when requested, preserving the existing behavior for both stdout and file output.

## Benchmark

Local benchmark on `build-tools-performance/cases/react-1k`:

```sh
hyperfine --warmup 5 --runs 30 --prepare 'rm -rf ./node_modules/.cache' \
  'node ../../node_modules/@rspack/cli/bin/rspack.js build'
```

- Before lazy `node:stream`: `531.1 ms ± 7.6 ms`
- After lazy `node:stream`: `529.1 ms ± 6.5 ms`
- Mean improvement: `2.0 ms`

This was measured as the incremental lazy stream step during the Node-side startup performance investigation.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
