### PR TITLE
fix: isolate persistent cache by compiler id

### DIFF
--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -10,7 +10,7 @@ use rspack_fs::{IntermediateFileSystem, ReadableFileSystem};
 use self::{
   disable::DisableCache, memory::MemoryCache, mixed::MixedCache, persistent::PersistentCache,
 };
-use crate::{CacheOptions, Compilation, CompilationLogging, CompilerOptions};
+use crate::{CacheOptions, Compilation, CompilationLogging, CompilerId, CompilerOptions};
 
 /// Cache trait
 ///
@@ -100,6 +100,7 @@ pub trait Cache: Debug + Send + Sync {
 }
 
 pub fn new_cache(
+  compiler_id: CompilerId,
   compiler_path: &str,
   compiler_option: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn ReadableFileSystem>,
@@ -111,6 +112,7 @@ pub fn new_cache(
     CacheOptions::Memory { .. } => Box::<MemoryCache>::default(),
     CacheOptions::Persistent(option) => {
       let persistent = PersistentCache::new(
+        compiler_id,
         compiler_path,
         option,
         compiler_option.clone(),

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -27,7 +27,9 @@ use self::{
   storage::{StorageOptions, create_storage},
 };
 use super::Cache;
-use crate::{Compilation, CompilationLogger, CompilationLogging, CompilerOptions, Logger};
+use crate::{
+  Compilation, CompilationLogger, CompilationLogging, CompilerId, CompilerOptions, Logger,
+};
 
 const LOGGER_NAME: &str = "rspack.persistentCache";
 
@@ -60,6 +62,7 @@ pub struct PersistentCache {
 
 impl PersistentCache {
   pub fn new(
+    compiler_id: CompilerId,
     compiler_path: &str,
     option: &PersistentCacheOptions,
     compiler_options: Arc<CompilerOptions>,
@@ -83,6 +86,7 @@ impl PersistentCache {
       compiler_path.hash(&mut hasher);
       option_bytes.hash(&mut hasher);
       rspack_pkg_version!().hash(&mut hasher);
+      compiler_id.hash(&mut hasher);
       compiler_options.name.hash(&mut hasher);
       compiler_options.mode.hash(&mut hasher);
       hex::encode(hasher.finish().to_ne_bytes())

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -154,7 +154,9 @@ impl Compiler {
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
+    let id = CompilerId::new();
     let cache = new_cache(
+      id,
       &compiler_path,
       options.clone(),
       input_filesystem.clone(),
@@ -164,7 +166,6 @@ impl Compiler {
     let incremental = Incremental::new_cold(options.incremental);
     let module_executor = ModuleExecutor::default();
 
-    let id = CompilerId::new();
     let compiler_context = compiler_context.unwrap_or_else(|| Arc::new(CompilerContext::new()));
     Self {
       id,


### PR DESCRIPTION
## Summary

- include `compiler_id` in the persistent cache computed version hash
- keep different compilers in a multi-compiler build in separate persistent cache version directories
- restore the transaction temp directory behavior so each cache version still uses the existing `.temp` path

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo fmt --check -p rspack_core`
- `git diff --check`
- `cargo check -p rspack_core --lib`