### PR TITLE
fix(watcher): re-send updated file deps to native watcher (#12904)

### DIFF
--- a/crates/rspack_binding_api/src/compilation/dependencies.rs
+++ b/crates/rspack_binding_api/src/compilation/dependencies.rs
@@ -23,12 +23,18 @@ impl JsDependencies {
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
+  // `added_*_dependencies` merges `added` with `updated` so the JS-side
+  // native watcher protocol (incremental `(added, removed)` deltas) re-sees
+  // paths that went through a remove+add cycle in this build — for example,
+  // a lazy-compiled module whose owning dependency was revoked and
+  // re-factorized. PathTracker.add is idempotent on the native side, so
+  // re-adding tracked paths is safe; without this, FSEvents on those paths
+  // would be silently dropped by DependencyFinder. See #12904.
   #[napi(getter)]
   pub fn added_file_dependencies(&self) -> Vec<String> {
-    self
-      .compilation
-      .file_dependencies()
-      .1
+    let (_, added, updated, _) = self.compilation.file_dependencies();
+    added
+      .chain(updated)
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
@@ -53,10 +59,9 @@ impl JsDependencies {
   }
   #[napi(getter)]
   pub fn added_context_dependencies(&self) -> Vec<String> {
-    self
-      .compilation
-      .context_dependencies()
-      .1
+    let (_, added, updated, _) = self.compilation.context_dependencies();
+    added
+      .chain(updated)
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
@@ -81,10 +86,9 @@ impl JsDependencies {
   }
   #[napi(getter)]
   pub fn added_missing_dependencies(&self) -> Vec<String> {
-    self
-      .compilation
-      .missing_dependencies()
-      .1
+    let (_, added, updated, _) = self.compilation.missing_dependencies();
+    added
+      .chain(updated)
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
@@ -109,10 +113,9 @@ impl JsDependencies {
   }
   #[napi(getter)]
   pub fn added_build_dependencies(&self) -> Vec<String> {
-    self
-      .compilation
-      .build_dependencies()
-      .1
+    let (_, added, updated, _) = self.compilation.build_dependencies();
+    added
+      .chain(updated)
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -473,6 +473,12 @@ impl Compilation {
     impl Iterator<Item = &ArcPath>,
     impl Iterator<Item = &ArcPath>,
   ) {
+    // `added_files` chains `updated_files` so consumers that need to learn about
+    // every still-tracked path (e.g. the native watcher's incremental update
+    // protocol) also see paths that went through a remove+add cycle in this
+    // build — for example, a lazy-compiled module whose owning dependency was
+    // revoked and re-factorized. Without this, the native watcher would have
+    // missed registering such paths and silently drop later FSEvents on them.
     let all_files = self
       .build_module_graph_artifact
       .file_dependencies
@@ -482,6 +488,12 @@ impl Compilation {
       .build_module_graph_artifact
       .file_dependencies
       .added_files()
+      .chain(
+        self
+          .build_module_graph_artifact
+          .file_dependencies
+          .updated_files(),
+      )
       .chain(&self.file_dependencies);
     let updated_files = self
       .build_module_graph_artifact
@@ -511,7 +523,13 @@ impl Compilation {
       .build_module_graph_artifact
       .context_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(
+        self
+          .build_module_graph_artifact
+          .context_dependencies
+          .updated_files(),
+      )
+      .chain(&self.context_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .context_dependencies
@@ -540,7 +558,13 @@ impl Compilation {
       .build_module_graph_artifact
       .missing_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(
+        self
+          .build_module_graph_artifact
+          .missing_dependencies
+          .updated_files(),
+      )
+      .chain(&self.missing_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .missing_dependencies
@@ -569,7 +593,13 @@ impl Compilation {
       .build_module_graph_artifact
       .build_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(
+        self
+          .build_module_graph_artifact
+          .build_dependencies
+          .updated_files(),
+      )
+      .chain(&self.build_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .build_dependencies

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -473,12 +473,6 @@ impl Compilation {
     impl Iterator<Item = &ArcPath>,
     impl Iterator<Item = &ArcPath>,
   ) {
-    // `added_files` chains `updated_files` so consumers that need to learn about
-    // every still-tracked path (e.g. the native watcher's incremental update
-    // protocol) also see paths that went through a remove+add cycle in this
-    // build — for example, a lazy-compiled module whose owning dependency was
-    // revoked and re-factorized. Without this, the native watcher would have
-    // missed registering such paths and silently drop later FSEvents on them.
     let all_files = self
       .build_module_graph_artifact
       .file_dependencies
@@ -488,12 +482,6 @@ impl Compilation {
       .build_module_graph_artifact
       .file_dependencies
       .added_files()
-      .chain(
-        self
-          .build_module_graph_artifact
-          .file_dependencies
-          .updated_files(),
-      )
       .chain(&self.file_dependencies);
     let updated_files = self
       .build_module_graph_artifact
@@ -523,12 +511,6 @@ impl Compilation {
       .build_module_graph_artifact
       .context_dependencies
       .added_files()
-      .chain(
-        self
-          .build_module_graph_artifact
-          .context_dependencies
-          .updated_files(),
-      )
       .chain(&self.context_dependencies);
     let updated_files = self
       .build_module_graph_artifact
@@ -558,12 +540,6 @@ impl Compilation {
       .build_module_graph_artifact
       .missing_dependencies
       .added_files()
-      .chain(
-        self
-          .build_module_graph_artifact
-          .missing_dependencies
-          .updated_files(),
-      )
       .chain(&self.missing_dependencies);
     let updated_files = self
       .build_module_graph_artifact
@@ -593,12 +569,6 @@ impl Compilation {
       .build_module_graph_artifact
       .build_dependencies
       .added_files()
-      .chain(
-        self
-          .build_module_graph_artifact
-          .build_dependencies
-          .updated_files(),
-      )
       .chain(&self.build_dependencies);
     let updated_files = self
       .build_module_graph_artifact

--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -242,6 +242,39 @@ mod test {
   }
 
   #[test]
+  fn file_counter_remove_then_add_in_same_window_marks_as_updated() {
+    // Models the lazy-compilation rebuild cycle: a parent dep is revoked
+    // (remove) and then re-factorized (add) within the same incremental
+    // window, with the same path now also referenced by the newly created
+    // lazy dependency. `added_files()` is intentionally empty (it lists
+    // truly-new paths only); consumers that need every still-tracked path
+    // must read `updated_files()` and merge — see issue #12904.
+    let mut counter = FileCounter::default();
+    let file = ArcPath::from(std::path::PathBuf::from("/a"));
+    let file_list = {
+      let mut list = ArcPathSet::default();
+      list.insert(file.clone());
+      list
+    };
+    let parent_dep = ResourceId::Dependency(DependencyId::from(1));
+    let lazy_dep = ResourceId::Dependency(DependencyId::from(2));
+
+    // Initial: add via parent dep, then commit so subsequent ops show the cycle.
+    counter.add_files(&parent_dep, &file_list);
+    counter.reset_incremental_info();
+
+    // Rebuild: revoke parent dep (path leaves the counter), then re-factorize
+    // (path returns under a new resource id).
+    counter.remove_files(&parent_dep, &file_list);
+    counter.add_files(&lazy_dep, &file_list);
+
+    assert_eq!(counter.added_files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
+    assert_eq!(counter.updated_files().count(), 1);
+    assert_eq!(counter.updated_files().next().unwrap(), &file);
+  }
+
+  #[test]
   fn file_counter_tracks_modules_and_dependencies_separately() {
     let mut counter = FileCounter::default();
     let file = ArcPath::from(std::path::PathBuf::from("/a"));


### PR DESCRIPTION
Closes #12904.

## Why

After lazy compilation activates a module, the proxy is force-revoked and re-factorized within one build cycle. The lazy module's source path ends up in `IncrementalInfo.updated` (removed then re-added), which is filtered out of `addedFileDependencies`. The native watcher's incremental update protocol never sees it, and subsequent FSEvents are silently dropped by `DependencyFinder`.

## What

- **JsDependencies (binding)** — `added_file_dependencies` / `added_context_dependencies` / `added_missing_dependencies` / `added_build_dependencies` now merge `updated` into `added` so the JS-side native watcher's incremental `(added, removed)` protocol re-sees paths that went through a remove+add cycle. `PathTracker.add` is idempotent on the native side, so re-emitting tracked paths is safe.
- **Compilation::*_dependencies** — tuple entries stay disjoint (added/updated/removed). Persistent cache (`PersistentCache::after_compile`) already does `file_added.chain(file_updated)` and is unaffected — no double snapshot work.
- Fix three pre-existing copy-paste bugs in `context_dependencies()` / `missing_dependencies()` / `build_dependencies()` where the per-cycle additions were chaining `&self.file_dependencies` instead of the matching collection.
- Add a unit test in `file_counter` documenting the remove+add cycle that triggered the bug.

## Notes

Minimal local reproduction was not achievable (tried current main + v1.6.6 with concurrent trigger+modify, parent-rebuild, warm persistent cache, burst patterns — all PASS). This patch is the most plausible fix based on tracing the FileCounter / PathTracker flow that the user's instrumentation pointed at. Verification via canary in the reporter's project.