### PR TITLE
chore(security): replace issues helper action

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  contents: read
-
 jobs:
   issue-close-require:
     permissions:
@@ -14,29 +11,32 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'web-infra-dev'
     steps:
-      - name: need reproduce
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+      - name: Close inactive need reproduction issues
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          actions: 'close-issues'
-          labels: 'need reproduction'
-          inactive-day: 14
-          body: |
+          days-before-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-close: 14
+          stale-issue-label: 'need reproduction'
+          close-issue-message: |
             Since the issue was labeled with `need reproduction`, but no response in 14 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions.
 
-      - name: need more info
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+      - name: Close inactive need more info issues
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          actions: 'close-issues'
-          labels: 'need more info'
-          inactive-day: 14
-          body: |
+          days-before-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-close: 14
+          stale-issue-label: 'need more info'
+          close-issue-message: |
             Since the issue was labeled with `need more info`, but no response in 14 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions.
 
-      - name: awaiting feedback
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+      - name: Close inactive awaiting feedback issues
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          actions: 'close-issues'
-          labels: 'awaiting more feedback'
-          inactive-day: 14
-          body: |
+          days-before-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-close: 14
+          stale-issue-label: 'awaiting more feedback'
+          close-issue-message: |
             Since the issue was labeled with `awaiting more feedback`, but no response in 14 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions.

--- a/.github/workflows/label-auto-comment.yml
+++ b/.github/workflows/label-auto-comment.yml
@@ -6,32 +6,25 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  contents: read
-  # for `actions-cool/issues-helper` to update issues
-  issues: write
-  # for `actions-cool/issues-helper` to update PRs
-  pull-requests: write
-
 jobs:
   issue-labeled:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: 🤔 Need Reproduce
         if: github.event.label.name == 'need reproduction'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: |
             Hello @${{ github.event.issue.user.login }}, sorry we can't investigate the problem further without reproduction demo, please provide a repro demo by forking [rspack-repro](https://github.com/web-infra-dev/rspack-repro), or provide a minimal GitHub repository by yourself. Issues labeled by `need reproduction` will be closed if no activities in 14 days.
+        run: gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"
       - name: invalid
         if: github.event.label.name == 'invalid'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3.8.0
-        with:
-          actions: 'create-comment,close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: |
             Hello @${{ github.event.issue.user.login }}, your issue has been closed because it does not conform to our issue requirements. Please use our [issue template](https://github.com/web-infra-dev/rspack/issues/new/choose) to create an issue, thank you!
+        run: gh issue close "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --comment "$COMMENT_BODY"


### PR DESCRIPTION
## Summary

Replace the third-party `actions-cool/issues-helper` usage in issue-management workflows after the action was reported compromised.

The previous workflows referenced a pinned commit SHA, so this repository was not affected by the compromised tags.

The label reply workflow now uses GitHub CLI directly, and the inactive issue close workflow uses the official `actions/stale` action pinned to a commit SHA with minimal `issues: write` permissions.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/7683
- https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials
- https://docs.github.com/en/actions/tutorials/manage-your-work/add-comments-with-labels
- https://docs.github.com/en/actions/tutorials/manage-your-work/close-inactive-issues

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
