### PR TITLE
perf: extend release opt-level s for cold-path crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,6 +405,69 @@ opt-level = "s"
 [profile.release.package."wasi-common"]
 opt-level = "s"
 
+[profile.release.package."cranelift-assembler-x64"]
+opt-level = "s"
+
+[profile.release.package."cranelift-frontend"]
+opt-level = "s"
+
+[profile.release.package."wasmtime-environ"]
+opt-level = "s"
+
+[profile.release.package."wasmtime-internal-cranelift"]
+opt-level = "s"
+
+[profile.release.package.browserslist-rs]
+opt-level = "s"
+
+[profile.release.package.napi]
+opt-level = "s"
+
+[profile.release.package.notify]
+opt-level = "s"
+
+[profile.release.package.parcel_sourcemap]
+opt-level = "s"
+
+[profile.release.package."regex-automata"]
+opt-level = "s"
+
+[profile.release.package.rspack_napi]
+opt-level = "s"
+
+[profile.release.package.rspack_plugin_esm_library]
+opt-level = "s"
+
+[profile.release.package.rspack_plugin_html]
+opt-level = "s"
+
+[profile.release.package.rspack_plugin_mf]
+opt-level = "s"
+
+[profile.release.package.swc_html]
+opt-level = "s"
+
+[profile.release.package.swc_html_ast]
+opt-level = "s"
+
+[profile.release.package.swc_html_codegen]
+opt-level = "s"
+
+[profile.release.package.swc_html_minifier]
+opt-level = "s"
+
+[profile.release.package.swc_html_parser]
+opt-level = "s"
+
+[profile.release.package.swc_html_utils]
+opt-level = "s"
+
+[profile.release.package.swc_html_visit]
+opt-level = "s"
+
+[profile.release.package.tracing-subscriber]
+opt-level = "s"
+
 # This is for CI build based on release but with faster build time
 [profile.ci]
 codegen-units = 256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -417,22 +417,10 @@ opt-level = "s"
 [profile.release.package."wasmtime-internal-cranelift"]
 opt-level = "s"
 
-[profile.release.package.browserslist-rs]
-opt-level = "s"
-
-[profile.release.package.napi]
-opt-level = "s"
-
 [profile.release.package.notify]
 opt-level = "s"
 
 [profile.release.package.parcel_sourcemap]
-opt-level = "s"
-
-[profile.release.package."regex-automata"]
-opt-level = "s"
-
-[profile.release.package.rspack_napi]
 opt-level = "s"
 
 [profile.release.package.rspack_plugin_esm_library]


### PR DESCRIPTION
## Summary

Extend `[profile.release.package.*]` with `opt-level = "s"` for ~21 additional cold-path crates (HTML/SWC plugins, wasmtime/cranelift helpers, regex, tracing, etc.) so the native binding release binary is smaller on Linux (~2.4% in prior measurements) without changing hot compile paths.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).