### PR TITLE
fix: keep buildHttp imports bundled for node target

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -603,6 +603,7 @@ export declare enum BuiltinPluginName {
   DllReferenceAgencyPlugin = 'DllReferenceAgencyPlugin',
   LibManifestPlugin = 'LibManifestPlugin',
   FlagAllModulesAsUsedPlugin = 'FlagAllModulesAsUsedPlugin',
+  CssHttpExternalsRspackPlugin = 'CssHttpExternalsRspackPlugin',
   HttpExternalsRspackPlugin = 'HttpExternalsRspackPlugin',
   CopyRspackPlugin = 'CopyRspackPlugin',
   HtmlRspackPlugin = 'HtmlRspackPlugin',
@@ -2346,7 +2347,6 @@ export interface RawHtmlRspackPluginOptions {
 }
 
 export interface RawHttpExternalsRspackPluginOptions {
-  css: boolean
   webAsync: boolean
 }
 

--- a/crates/rspack/src/builder/builder_context.rs
+++ b/crates/rspack/src/builder/builder_context.rs
@@ -14,8 +14,9 @@ pub(super) enum BuiltinPluginOptions {
   // External handling plugins
   ExternalsPlugin((ExternalType, Vec<ExternalItem>, bool)),
   NodeTargetPlugin,
+  CssHttpExternalsRspackPlugin,
   ElectronTargetPlugin(rspack_plugin_externals::ElectronTargetContext),
-  HttpExternalsRspackPlugin((bool /* css */, bool /* web_async */)),
+  HttpExternalsRspackPlugin(bool /* web_async */),
 
   // Chunk format and loading plugins
   ChunkPrefetchPreloadPlugin,
@@ -130,9 +131,12 @@ impl BuilderContext {
       BuiltinPluginOptions::ElectronTargetPlugin(context) => {
         rspack_plugin_externals::electron_target_plugin(context, &mut plugins)
       }
-      BuiltinPluginOptions::HttpExternalsRspackPlugin((css, web_async)) => {
+      BuiltinPluginOptions::CssHttpExternalsRspackPlugin => {
+        plugins.push(rspack_plugin_externals::css_http_externals_rspack_plugin())
+      }
+      BuiltinPluginOptions::HttpExternalsRspackPlugin(web_async) => {
         plugins.push(rspack_plugin_externals::http_externals_rspack_plugin(
-          css, web_async,
+          web_async,
         ));
       }
 

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1104,6 +1104,9 @@ impl CompilerOptionsBuilder {
       builder_context
         .plugins
         .push(BuiltinPluginOptions::NodeTargetPlugin);
+      builder_context
+        .plugins
+        .push(BuiltinPluginOptions::CssHttpExternalsRspackPlugin);
     }
 
     use rspack_plugin_externals::ElectronTargetContext;
@@ -1151,14 +1154,12 @@ impl CompilerOptionsBuilder {
         )));
     }
 
-    if externals_presets.web() || externals_presets.web_async() || (externals_presets.node() && css)
-    {
+    if externals_presets.web() || externals_presets.web_async() {
       builder_context
         .plugins
-        .push(BuiltinPluginOptions::HttpExternalsRspackPlugin((
-          css,
+        .push(BuiltinPluginOptions::HttpExternalsRspackPlugin(
           externals_presets.web_async(),
-        )));
+        ));
     }
 
     // apply node defaults

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -66,8 +66,8 @@ use rspack_plugin_ensure_chunk_conditions::EnsureChunkConditionsPlugin;
 use rspack_plugin_entry::EntryPlugin;
 use rspack_plugin_esm_library::EsmLibraryPlugin;
 use rspack_plugin_externals::{
-  EsmNodeTargetPlugin, ExternalsPlugin, electron_target_plugin, http_externals_rspack_plugin,
-  node_target_plugin,
+  EsmNodeTargetPlugin, ExternalsPlugin, css_http_externals_rspack_plugin, electron_target_plugin,
+  http_externals_rspack_plugin, node_target_plugin,
 };
 use rspack_plugin_hmr::HotModuleReplacementPlugin;
 use rspack_plugin_html::HtmlRspackPlugin;
@@ -232,6 +232,7 @@ pub enum BuiltinPluginName {
 
   // rspack specific plugins
   // naming format follow XxxRspackPlugin
+  CssHttpExternalsRspackPlugin,
   HttpExternalsRspackPlugin,
   CopyRspackPlugin,
   HtmlRspackPlugin,
@@ -715,10 +716,13 @@ impl<'a> BuiltinPlugin<'a> {
       }
 
       // rspack specific plugins
+      BuiltinPluginName::CssHttpExternalsRspackPlugin => {
+        plugins.push(css_http_externals_rspack_plugin());
+      }
       BuiltinPluginName::HttpExternalsRspackPlugin => {
         let plugin_options = downcast_into::<RawHttpExternalsRspackPluginOptions>(self.options)
           .map_err(|report| napi::Error::from_reason(report.to_string()))?;
-        let plugin = http_externals_rspack_plugin(plugin_options.css, plugin_options.web_async);
+        let plugin = http_externals_rspack_plugin(plugin_options.web_async);
         plugins.push(plugin);
       }
       BuiltinPluginName::SwcJsMinimizerRspackPlugin => {

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -25,7 +25,6 @@ use crate::{
 
 #[napi(object)]
 pub struct RawHttpExternalsRspackPluginOptions {
-  pub css: bool,
   pub web_async: bool,
 }
 

--- a/crates/rspack_plugin_externals/src/http_externals_plugin.rs
+++ b/crates/rspack_plugin_externals/src/http_externals_plugin.rs
@@ -4,25 +4,48 @@ use rspack_core::{
 
 use crate::ExternalsPlugin;
 
-pub fn http_externals_rspack_plugin(css: bool, web_async: bool) -> BoxPlugin {
+pub fn http_externals_rspack_plugin(web_async: bool) -> BoxPlugin {
   if web_async {
     ExternalsPlugin::new(
       "import".to_owned(),
-      vec![http_external_item_web_async(css)],
+      vec![http_external_item_web_async()],
       false,
     )
     .boxed()
   } else {
-    ExternalsPlugin::new(
-      "module".to_owned(),
-      vec![http_external_item_web(css)],
-      false,
-    )
-    .boxed()
+    ExternalsPlugin::new("module".to_owned(), vec![http_external_item_web()], false).boxed()
   }
 }
 
-fn http_external_item_web(css: bool) -> ExternalItem {
+pub fn css_http_externals_rspack_plugin() -> BoxPlugin {
+  ExternalsPlugin::new("module".to_owned(), vec![css_http_external_item()], false).boxed()
+}
+
+fn css_http_external_item() -> ExternalItem {
+  ExternalItem::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
+    Box::pin(async move {
+      if is_css_issuer(&ctx.context_info.issuer) && is_external_http_request(&ctx.request) {
+        if ctx.dependency_type == "url" {
+          return Ok(ExternalItemFnResult {
+            external_type: Some("asset".to_owned()),
+            result: Some(ExternalItemValue::String(ctx.request)),
+          });
+        } else if is_external_css_import_dependency(&ctx.dependency_type) {
+          return Ok(ExternalItemFnResult {
+            external_type: Some("css-import".to_owned()),
+            result: Some(ExternalItemValue::String(ctx.request)),
+          });
+        }
+      }
+      Ok(ExternalItemFnResult {
+        external_type: None,
+        result: None,
+      })
+    })
+  }))
+}
+
+fn http_external_item_web() -> ExternalItem {
   ExternalItem::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
     Box::pin(async move {
       if ctx.dependency_type == "url" {
@@ -32,7 +55,7 @@ fn http_external_item_web(css: bool) -> ExternalItem {
             result: Some(ExternalItemValue::String(ctx.request)),
           });
         }
-      } else if css && ctx.dependency_type == "css-import" {
+      } else if is_external_css_import_dependency(&ctx.dependency_type) {
         if is_external_http_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
@@ -40,7 +63,7 @@ fn http_external_item_web(css: bool) -> ExternalItem {
           });
         }
       } else if is_external_http_std_request(&ctx.request) {
-        if css && is_external_css_request(&ctx.request) {
+        if is_external_css_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
@@ -60,7 +83,7 @@ fn http_external_item_web(css: bool) -> ExternalItem {
   }))
 }
 
-fn http_external_item_web_async(css: bool) -> ExternalItem {
+fn http_external_item_web_async() -> ExternalItem {
   ExternalItem::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
     Box::pin(async move {
       if ctx.dependency_type == "url" {
@@ -70,7 +93,7 @@ fn http_external_item_web_async(css: bool) -> ExternalItem {
             result: Some(ExternalItemValue::String(ctx.request)),
           });
         }
-      } else if css && ctx.dependency_type == "css-import" {
+      } else if is_external_css_import_dependency(&ctx.dependency_type) {
         if is_external_http_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
@@ -78,7 +101,7 @@ fn http_external_item_web_async(css: bool) -> ExternalItem {
           });
         }
       } else if is_external_http_std_request(&ctx.request) {
-        if css && is_external_css_request(&ctx.request) {
+        if is_external_css_request(&ctx.request) {
           return Ok(ExternalItemFnResult {
             external_type: Some("css-import".to_owned()),
             result: Some(ExternalItemValue::String(ctx.request)),
@@ -114,4 +137,15 @@ fn is_external_http_std_request(input: &str) -> bool {
 
 fn is_external_css_request(input: &str) -> bool {
   input == ".css" || input.starts_with(".css?")
+}
+
+fn is_external_css_import_dependency(input: &str) -> bool {
+  matches!(
+    input,
+    "css-import" | "css-import-local-module" | "css-import-global-module"
+  )
+}
+
+fn is_css_issuer(input: &str) -> bool {
+  input.ends_with(".css") || input.contains(".css?")
 }

--- a/crates/rspack_plugin_externals/src/lib.rs
+++ b/crates/rspack_plugin_externals/src/lib.rs
@@ -7,6 +7,6 @@ mod plugin;
 
 pub use electron_target_plugin::{ElectronTargetContext, electron_target_plugin};
 pub use esm_node_target_plugin::EsmNodeTargetPlugin;
-pub use http_externals_plugin::http_externals_rspack_plugin;
+pub use http_externals_plugin::{css_http_externals_rspack_plugin, http_externals_rspack_plugin};
 pub use node_target_plugin::node_target_plugin;
 pub use plugin::ExternalsPlugin;

--- a/packages/rspack/src/builtin-plugin/CssHttpExternalsRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CssHttpExternalsRspackPlugin.ts
@@ -1,0 +1,8 @@
+import { BuiltinPluginName } from '@rspack/binding';
+
+import { create } from './base';
+
+export const CssHttpExternalsRspackPlugin = create(
+  BuiltinPluginName.CssHttpExternalsRspackPlugin,
+  () => undefined,
+);

--- a/packages/rspack/src/builtin-plugin/HttpExternalsRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HttpExternalsRspackPlugin.ts
@@ -7,9 +7,8 @@ import { create } from './base';
 
 export const HttpExternalsRspackPlugin = create(
   BuiltinPluginName.HttpExternalsRspackPlugin,
-  (css: boolean, webAsync: boolean): RawHttpExternalsRspackPluginOptions => {
+  (webAsync: boolean): RawHttpExternalsRspackPluginOptions => {
     return {
-      css,
       webAsync,
     };
   },

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -13,6 +13,7 @@ export * from './CommonJsChunkFormatPlugin';
 export * from './ContextReplacementPlugin';
 export * from './CopyRspackPlugin';
 export * from './CssChunkingPlugin';
+export * from './CssHttpExternalsRspackPlugin';
 export * from './CssModulesPlugin';
 export * from './css-extract/index';
 export * from './DataUriPlugin';

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -23,6 +23,7 @@ import {
   BundlerInfoRspackPlugin,
   ChunkPrefetchPreloadPlugin,
   CommonJsChunkFormatPlugin,
+  CssHttpExternalsRspackPlugin,
   CssModulesPlugin,
   DataUriPlugin,
   DefinePlugin,
@@ -105,6 +106,7 @@ export class RspackOptionsApply {
 
     if (options.externalsPresets.node) {
       new NodeTargetPlugin().apply(compiler);
+      new CssHttpExternalsRspackPlugin().apply(compiler);
     }
     if (options.externalsPresets.electronMain) {
       new ElectronTargetPlugin('main').apply(compiler);
@@ -126,15 +128,10 @@ export class RspackOptionsApply {
     if (options.externalsPresets.nwjs) {
       new ExternalsPlugin('node-commonjs', 'nw.gui', false).apply(compiler);
     }
-    if (
-      options.externalsPresets.web ||
-      options.externalsPresets.webAsync ||
-      options.externalsPresets.node
-    ) {
-      new HttpExternalsRspackPlugin(
-        true,
-        !!options.externalsPresets.webAsync,
-      ).apply(compiler);
+    if (options.externalsPresets.web || options.externalsPresets.webAsync) {
+      new HttpExternalsRspackPlugin(!!options.externalsPresets.webAsync).apply(
+        compiler,
+      );
     }
 
     new ChunkPrefetchPreloadPlugin().apply(compiler);

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -106,6 +106,10 @@ export class RspackOptionsApply {
 
     if (options.externalsPresets.node) {
       new NodeTargetPlugin().apply(compiler);
+      // Keep this aligned with webpack's node externals preset: CSS HTTP(S)
+      // @import/url() requests are externalized during factorization. This
+      // happens before HttpUriPlugin can fetch buildHttp resources, so buildHttp
+      // does not bundle those CSS requests for node targets.
       new CssHttpExternalsRspackPlugin().apply(compiler);
     }
     if (options.externalsPresets.electronMain) {

--- a/tests/rspack-test/configCases/build-http/node-target/custom-http-client.js
+++ b/tests/rspack-test/configCases/build-http/node-target/custom-http-client.js
@@ -1,0 +1,21 @@
+module.exports = async (url) => {
+  const pathname = new URL(url).pathname;
+
+  if (pathname === "/value.js") {
+    return {
+      status: 200,
+      headers: {
+        "content-type": "application/javascript",
+      },
+      body: Buffer.from("export const named = 42; export default 42;\n"),
+    };
+  }
+
+  return {
+    status: 404,
+    headers: {
+      "content-type": "text/plain",
+    },
+    body: Buffer.from(`Not found: ${pathname}`),
+  };
+};

--- a/tests/rspack-test/configCases/build-http/node-target/index.js
+++ b/tests/rspack-test/configCases/build-http/node-target/index.js
@@ -1,0 +1,6 @@
+import value, { named } from "https://test.rspack.rs/value.js";
+
+it("should bundle https imports for node target with buildHttp", () => {
+	expect(value).toBe(42);
+	expect(named).toBe(42);
+});

--- a/tests/rspack-test/configCases/build-http/node-target/rspack.config.js
+++ b/tests/rspack-test/configCases/build-http/node-target/rspack.config.js
@@ -1,0 +1,21 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const tempDir = path.join(os.tmpdir(), 'rspack-build-http-node-target');
+
+fs.mkdirSync(tempDir, { recursive: true });
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  experiments: {
+    buildHttp: {
+      allowedUris: ['https://test.rspack.rs/'],
+      cacheLocation: false,
+      lockfileLocation: path.join(tempDir, `lock-${process.pid}.json`),
+      httpClient: require('./custom-http-client'),
+    },
+  },
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Add `CssHttpExternalsRspackPlugin` to handle external CSS `@import` and `url()` for node externals presets
- Stop applying regular `HttpExternalsRspackPlugin` for `externalsPresets.node`, so `buildHttp` can bundle `https://` JavaScript imports
- Treat CSS HTTP externals as first-class behavior instead of gating it behind `experiments.css`
- Add a `build-http/node-target` config case covering HTTPS imports with `target: "node"`

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
