### PR TITLE
perf(swc): skip wasmtime when no wasm plugins are configured

### DIFF
--- a/crates/rspack_binding_api/src/swc.rs
+++ b/crates/rspack_binding_api/src/swc.rs
@@ -48,9 +48,7 @@ fn _transform(source: String, options: String) -> napi::Result<TransformOutput> 
 
   #[cfg(feature = "plugin")]
   {
-    options.runtime_options = options.runtime_options.plugin_runtime(std::sync::Arc::new(
-      rspack_util::swc::runtime::WasmtimeRuntime,
-    ));
+    rspack_util::swc::configure_wasm_plugin_runtime_if_needed(&mut options);
   }
 
   let compiler = JavaScriptCompiler::new();

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -111,12 +111,7 @@ impl SwcLoader {
 
       #[cfg(feature = "plugin")]
       {
-        swc_options.runtime_options =
-          swc_options
-            .runtime_options
-            .plugin_runtime(std::sync::Arc::new(
-              rspack_util::swc::runtime::WasmtimeRuntime,
-            ));
+        rspack_util::swc::configure_wasm_plugin_runtime_if_needed(&mut swc_options);
       }
 
       swc_options

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -45,7 +45,7 @@ signal-hook  = { workspace = true, optional = true }
 
 [features]
 debug_tool = ["signal-hook"]                                                         # only used for local debug and  should not be enabled in production release
-plugin     = ["anyhow", "once_cell", "wasmtime", "wasi-common", "swc_plugin_runner"]
+plugin     = ["anyhow", "once_cell", "wasmtime", "wasi-common", "swc_core/__plugin_transform_host", "swc_plugin_runner"]
 
 [lints]
 workspace = true

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -44,7 +44,7 @@ rspack_regex = { workspace = true }
 signal-hook  = { workspace = true, optional = true }
 
 [features]
-debug_tool = ["signal-hook"]                                                         # only used for local debug and  should not be enabled in production release
+debug_tool = ["signal-hook"]                                                                                             # only used for local debug and  should not be enabled in production release
 plugin     = ["anyhow", "once_cell", "wasmtime", "wasi-common", "swc_core/__plugin_transform_host", "swc_plugin_runner"]
 
 [lints]

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -28,9 +28,9 @@ pub fn has_wasm_plugins(jsc: &JscConfig) -> bool {
 #[cfg(feature = "plugin")]
 pub fn configure_wasm_plugin_runtime_if_needed(options: &mut Options) {
   if has_wasm_plugins(&options.config.jsc) {
-    options.runtime_options = options
-      .runtime_options
-      .plugin_runtime(std::sync::Arc::new(crate::swc::runtime::WasmtimeRuntime));
+    let runtime_options = std::mem::take(&mut options.runtime_options);
+    options.runtime_options =
+      runtime_options.plugin_runtime(std::sync::Arc::new(crate::swc::runtime::WasmtimeRuntime));
   }
 }
 

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -5,12 +5,30 @@ use rustc_hash::FxHashSet;
 use swc_config::types::BoolOr;
 use swc_core::{
   atoms::Atom,
-  base::config::JsMinifyCommentOption,
+  base::config::{JscConfig, JsMinifyCommentOption, Options},
   common::{
     BytePos,
     comments::{Comment, CommentKind, Comments, SingleThreadedComments},
   },
 };
+
+/// Returns true when `jsc.experimental.plugins` contains at least one wasm plugin.
+pub fn has_wasm_plugins(jsc: &JscConfig) -> bool {
+  jsc.experimental
+    .plugins
+    .as_ref()
+    .is_some_and(|plugins| !plugins.is_empty())
+}
+
+/// Registers wasmtime as the SWC plugin runtime only when wasm plugins are configured.
+#[cfg(feature = "plugin")]
+pub fn configure_wasm_plugin_runtime_if_needed(options: &mut Options) {
+  if has_wasm_plugins(&options.config.jsc) {
+    options.runtime_options = options.runtime_options.plugin_runtime(std::sync::Arc::new(
+      crate::swc::runtime::WasmtimeRuntime,
+    ));
+  }
+}
 
 pub fn normalize_custom_filename(source: &str) -> &str {
   if source.starts_with('<') && source.ends_with('>') {

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -24,13 +24,16 @@ pub fn has_wasm_plugins(jsc: &JscConfig) -> bool {
     .is_some_and(|plugins| !plugins.is_empty())
 }
 
-/// Registers wasmtime as the SWC plugin runtime only when wasm plugins are configured.
+/// Registers wasmtime only when wasm plugins are configured.
 #[cfg(feature = "plugin")]
 pub fn configure_wasm_plugin_runtime_if_needed(options: &mut Options) {
+  let runtime_options = std::mem::take(&mut options.runtime_options);
   if has_wasm_plugins(&options.config.jsc) {
-    let runtime_options = std::mem::take(&mut options.runtime_options);
     options.runtime_options =
       runtime_options.plugin_runtime(std::sync::Arc::new(crate::swc::runtime::WasmtimeRuntime));
+  } else {
+    options.runtime_options =
+      runtime_options.plugin_runtime(std::sync::Arc::new(crate::swc::runtime::UnsupportedRuntime));
   }
 }
 

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet;
 use swc_config::types::BoolOr;
 use swc_core::{
   atoms::Atom,
-  base::config::{JscConfig, JsMinifyCommentOption, Options},
+  base::config::{JsMinifyCommentOption, JscConfig, Options},
   common::{
     BytePos,
     comments::{Comment, CommentKind, Comments, SingleThreadedComments},
@@ -14,7 +14,8 @@ use swc_core::{
 
 /// Returns true when `jsc.experimental.plugins` contains at least one wasm plugin.
 pub fn has_wasm_plugins(jsc: &JscConfig) -> bool {
-  jsc.experimental
+  jsc
+    .experimental
     .plugins
     .as_ref()
     .is_some_and(|plugins| !plugins.is_empty())
@@ -24,9 +25,9 @@ pub fn has_wasm_plugins(jsc: &JscConfig) -> bool {
 #[cfg(feature = "plugin")]
 pub fn configure_wasm_plugin_runtime_if_needed(options: &mut Options) {
   if has_wasm_plugins(&options.config.jsc) {
-    options.runtime_options = options.runtime_options.plugin_runtime(std::sync::Arc::new(
-      crate::swc::runtime::WasmtimeRuntime,
-    ));
+    options.runtime_options = options
+      .runtime_options
+      .plugin_runtime(std::sync::Arc::new(crate::swc::runtime::WasmtimeRuntime));
   }
 }
 

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -3,9 +3,11 @@ pub mod runtime;
 
 use rustc_hash::FxHashSet;
 use swc_config::types::BoolOr;
+#[cfg(feature = "plugin")]
+use swc_core::base::config::{JscConfig, Options};
 use swc_core::{
   atoms::Atom,
-  base::config::{JsMinifyCommentOption, JscConfig, Options},
+  base::config::JsMinifyCommentOption,
   common::{
     BytePos,
     comments::{Comment, CommentKind, Comments, SingleThreadedComments},
@@ -13,6 +15,7 @@ use swc_core::{
 };
 
 /// Returns true when `jsc.experimental.plugins` contains at least one wasm plugin.
+#[cfg(feature = "plugin")]
 pub fn has_wasm_plugins(jsc: &JscConfig) -> bool {
   jsc
     .experimental

--- a/crates/rspack_util/src/swc/runtime.rs
+++ b/crates/rspack_util/src/swc/runtime.rs
@@ -16,6 +16,9 @@ static ENGINE: OnceCell<wasmtime::Engine> = OnceCell::new();
 #[derive(Clone, Copy, Debug)]
 pub struct WasmtimeRuntime;
 
+#[derive(Clone, Copy, Debug)]
+pub struct UnsupportedRuntime;
+
 struct WasmtimeCache(wasmtime::Module);
 
 struct WasmtimeTable {
@@ -53,6 +56,30 @@ struct WasmtimeCallerRef<'a> {
 fn init_engine() -> anyhow::Result<wasmtime::Engine> {
   let config = wasmtime::Config::default();
   wasmtime::Engine::new(&config)
+}
+
+impl runtime::Runtime for UnsupportedRuntime {
+  fn identifier(&self) -> &'static str {
+    "unsupported"
+  }
+
+  fn prepare_module(&self, _bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
+    Err(anyhow::format_err!(
+      "SWC wasm plugin runtime is not enabled"
+    ))
+  }
+
+  fn init(
+    &self,
+    _name: &str,
+    _imports: Vec<(String, runtime::Func)>,
+    _envs: Vec<(String, String)>,
+    _module: runtime::Module,
+  ) -> anyhow::Result<Box<dyn runtime::Instance>> {
+    Err(anyhow::format_err!(
+      "SWC wasm plugin runtime is not enabled"
+    ))
+  }
 }
 
 impl runtime::Runtime for WasmtimeRuntime {


### PR DESCRIPTION
## Summary

- Only register `WasmtimeRuntime` for `builtin:swc-loader` and the binding `transform` APIs when `jsc.experimental.plugins` is non-empty.
- Avoids initializing wasmtime on builds that do not use SWC wasm plugins.

## Test plan

- [ ] Ecosystem benchmark (triggered manually)
- [ ] Existing `builtin-swc-loader/swc-plugin` config case still passes with wasm plugins configured