### PR TITLE
chore(deps): bump rstack ecosystem ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@1345990b3128d94ee37afbb7607f9ddc9feadb49 # v0.3.0
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ca8d345a115158ea5ab3807378357f2162be7467 # v0.3.1
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@1345990b3128d94ee37afbb7607f9ddc9feadb49 # v0.3.0
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ca8d345a115158ea5ab3807378357f2162be7467 # v0.3.1
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev


### PR DESCRIPTION
## Summary

This PR updates the two `rstackjs/rstack-ecosystem-ci` composite action pins used by Rspack's Ecosystem CI workflows from `v0.3.0` to the `v0.3.1` release commit `ca8d345a115158ea5ab3807378357f2162be7467`. This keeps the workflows pinned to a full-length SHA while tracking the released `v0.3.1` tag.

## Related links

- https://github.com/rstackjs/rstack-ecosystem-ci/releases/tag/v0.3.1
- https://github.com/web-infra-dev/rsbuild/pull/7688
- https://github.com/rstackjs/rstack-ecosystem-ci/pull/41

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).