### PR TITLE
docs: add CSS module parser options

### DIFF
--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -576,8 +576,6 @@ export default {
 
 Generator options for `css/auto` modules.
 
-The `css/auto`, `css/global`, and `css/module` module types share the same generator options. The examples in this section use `css/auto`; replace it with `css/global` or `css/module` to configure those module types.
-
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -843,7 +841,133 @@ export default {
 };
 ```
 
-Same generator options as [`module.generator["css/auto"]`](#modulegeneratorcssauto).
+### module.generator["css/global"].exportsConvention
+
+Same as [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        exportsConvention: 'camel-case',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].exportsOnly
+
+Same as [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        exportsOnly: false,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentName
+
+Same as [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentName: '[local]-[hash:base64:6]',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashDigest
+
+Same as [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashDigest: 'hex',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashDigestLength
+
+Same as [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashDigestLength: 8,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashFunction
+
+Same as [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashFunction: 'xxhash64',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashSalt
+
+Same as [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashSalt: 'my-salt',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].esModule
+
+Same as [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        esModule: true,
+      },
+    },
+  },
+};
+```
 
 ### module.generator["css/module"]
 
@@ -861,7 +985,133 @@ export default {
 };
 ```
 
-Same generator options as [`module.generator["css/auto"]`](#modulegeneratorcssauto).
+### module.generator["css/module"].exportsConvention
+
+Same as [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        exportsConvention: 'camel-case',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].exportsOnly
+
+Same as [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        exportsOnly: false,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentName
+
+Same as [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentName: '[local]-[hash:base64:6]',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashDigest
+
+Same as [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashDigest: 'hex',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashDigestLength
+
+Same as [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashDigestLength: 8,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashFunction
+
+Same as [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashFunction: 'xxhash64',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashSalt
+
+Same as [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashSalt: 'my-salt',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].esModule
+
+Same as [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        esModule: true,
+      },
+    },
+  },
+};
+```
 
 ### module.generator.json.JSONParse
 
@@ -949,22 +1199,14 @@ export default {
       // Parser options for CSS modules
       css: {
         namedExports: true,
-        import: true,
       },
       // Parser options for css/auto modules
       'css/auto': {
         namedExports: true,
-        import: true,
-      },
-      // Parser options for css/global modules
-      'css/global': {
-        namedExports: true,
-        import: true,
       },
       // Parser options for css/module modules
       'css/module': {
         namedExports: true,
-        import: true,
       },
     },
   },
@@ -1870,8 +2112,6 @@ export default {
 
 Parser options for `css/auto` modules.
 
-The `css/auto`, `css/global`, and `css/module` module types share the same parser options. The examples in this section use `css/auto`; replace it with `css/global` or `css/module` to configure those module types.
-
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -1942,39 +2182,17 @@ import classes, { class1, class2 } from './index.module.css';
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to handle CSS `url()` functions.
+Allow to enable/disables handling the CSS functions url.
 
-When using `url: true`, Rspack will resolve the path in `url()` as an asset dependency.
-When using `url: false`, Rspack will keep `url()` unchanged.
+When using `url: true`, Rspack will resolve the path in `url` function, the resolve file will be treated as an asset.
+When using `url: false`, Rspack will ignore the path in the `url` function, keep the content unchanged.
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
-      'css/auto': {
+      css: {
         url: true,
-      },
-    },
-  },
-};
-```
-
-### module.parser["css/auto"].import
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Whether to handle CSS `@import` rules.
-
-When using `import: true`, Rspack will resolve `@import` rules as dependencies.
-When using `import: false`, Rspack will keep `@import` rules unchanged.
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/auto': {
-        import: true,
       },
     },
   },
@@ -2008,12 +2226,34 @@ export default {
 };
 ```
 
+### module.parser["css/auto"].import
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to handle CSS `@import` at-rules.
+
+- `true`: resolve and process `@import` rules (default).
+- `false`: leave `@import` rules unchanged in the generated CSS.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        import: true,
+      },
+    },
+  },
+};
+```
+
 ### module.parser["css/auto"].animation
 
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to rename `@keyframes` and animation names in CSS Modules.
+Enable or disable renaming local `@keyframes` identifiers and their `animation` or `animation-name` usages.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -2032,14 +2272,14 @@ export default {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to rename custom identifiers in CSS Modules, such as `@counter-style` and `@font-palette-values`.
+Enable or disable renaming custom identifiers, such as local `@counter-style` and `@font-palette-values` names.
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
       'css/auto': {
-        customIdents: false,
+        customIdents: true,
       },
     },
   },
@@ -2051,14 +2291,14 @@ export default {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to rename dashed identifiers in CSS Modules, such as CSS custom properties.
+Enable or disable renaming dashed identifiers, such as CSS custom properties and `@property` declarations.
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
       'css/auto': {
-        dashedIdents: false,
+        dashedIdents: true,
       },
     },
   },
@@ -2131,6 +2371,70 @@ export default {
 };
 ```
 
+### module.parser.css.import
+
+Same as [`module.parser["css/auto"].import`](#moduleparsercssautoimport).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        import: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.css.animation
+
+Same as [`module.parser["css/auto"].animation`](#moduleparsercssautoanimation).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.css.customIdents
+
+Same as [`module.parser["css/auto"].customIdents`](#moduleparsercssautocustomidents).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        customIdents: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.css.dashedIdents
+
+Same as [`module.parser["css/auto"].dashedIdents`](#moduleparsercssautodashedidents).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        dashedIdents: true,
+      },
+    },
+  },
+};
+```
+
 ### module.parser["css/global"]
 
 Parser options for `css/global` modules.
@@ -2147,7 +2451,119 @@ export default {
 };
 ```
 
-Same parser options as [`module.parser["css/auto"]`](#moduleparsercssauto).
+### module.parser["css/global"].namedExports
+
+Same as [`module.parser["css/auto"].namedExports`](#moduleparsercssautonamedexports).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        namedExports: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].url
+
+Same as [`module.parser["css/auto"].url`](#moduleparsercssautourl).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        url: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].resolveImport
+
+Same as [`module.parser["css/auto"].resolveImport`](#moduleparsercssautoresolveimport).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        resolveImport: ({ url }) => {
+          return url.includes('style.css');
+        },
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].import
+
+Same as [`module.parser["css/auto"].import`](#moduleparsercssautoimport).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        import: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].animation
+
+Same as [`module.parser["css/auto"].animation`](#moduleparsercssautoanimation).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].customIdents
+
+Same as [`module.parser["css/auto"].customIdents`](#moduleparsercssautocustomidents).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        customIdents: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].dashedIdents
+
+Same as [`module.parser["css/auto"].dashedIdents`](#moduleparsercssautodashedidents).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        dashedIdents: true,
+      },
+    },
+  },
+};
+```
 
 ### module.parser["css/module"]
 
@@ -2165,7 +2581,119 @@ export default {
 };
 ```
 
-Same parser options as [`module.parser["css/auto"]`](#moduleparsercssauto).
+### module.parser["css/module"].namedExports
+
+Same as [`module.parser["css/auto"].namedExports`](#moduleparsercssautonamedexports).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        namedExports: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].url
+
+Same as [`module.parser["css/auto"].url`](#moduleparsercssautourl).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        url: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].resolveImport
+
+Same as [`module.parser["css/auto"].resolveImport`](#moduleparsercssautoresolveimport).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        resolveImport: ({ url }) => {
+          return url.includes('style.css');
+        },
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].import
+
+Same as [`module.parser["css/auto"].import`](#moduleparsercssautoimport).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        import: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].animation
+
+Same as [`module.parser["css/auto"].animation`](#moduleparsercssautoanimation).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].customIdents
+
+Same as [`module.parser["css/auto"].customIdents`](#moduleparsercssautocustomidents).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        customIdents: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].dashedIdents
+
+Same as [`module.parser["css/auto"].dashedIdents`](#moduleparsercssautodashedidents).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        dashedIdents: true,
+      },
+    },
+  },
+};
+```
 
 ## module.rules
 

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -576,6 +576,8 @@ export default {
 
 Generator options for `css/auto` modules.
 
+The `css/auto`, `css/global`, and `css/module` module types share the same generator options. The examples in this section use `css/auto`; replace it with `css/global` or `css/module` to configure those module types.
+
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -841,133 +843,7 @@ export default {
 };
 ```
 
-### module.generator["css/global"].exportsConvention
-
-Same as [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        exportsConvention: 'camel-case',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].exportsOnly
-
-Same as [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        exportsOnly: false,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentName
-
-Same as [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentName: '[local]-[hash:base64:6]',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashDigest
-
-Same as [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashDigest: 'hex',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashDigestLength
-
-Same as [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashDigestLength: 8,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashFunction
-
-Same as [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashFunction: 'xxhash64',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashSalt
-
-Same as [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashSalt: 'my-salt',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].esModule
-
-Same as [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        esModule: true,
-      },
-    },
-  },
-};
-```
+Same generator options as [`module.generator["css/auto"]`](#modulegeneratorcssauto).
 
 ### module.generator["css/module"]
 
@@ -985,133 +861,7 @@ export default {
 };
 ```
 
-### module.generator["css/module"].exportsConvention
-
-Same as [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        exportsConvention: 'camel-case',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].exportsOnly
-
-Same as [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        exportsOnly: false,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentName
-
-Same as [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentName: '[local]-[hash:base64:6]',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashDigest
-
-Same as [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashDigest: 'hex',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashDigestLength
-
-Same as [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashDigestLength: 8,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashFunction
-
-Same as [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashFunction: 'xxhash64',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashSalt
-
-Same as [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashSalt: 'my-salt',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].esModule
-
-Same as [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        esModule: true,
-      },
-    },
-  },
-};
-```
+Same generator options as [`module.generator["css/auto"]`](#modulegeneratorcssauto).
 
 ### module.generator.json.JSONParse
 
@@ -1199,14 +949,22 @@ export default {
       // Parser options for CSS modules
       css: {
         namedExports: true,
+        import: true,
       },
       // Parser options for css/auto modules
       'css/auto': {
         namedExports: true,
+        import: true,
+      },
+      // Parser options for css/global modules
+      'css/global': {
+        namedExports: true,
+        import: true,
       },
       // Parser options for css/module modules
       'css/module': {
         namedExports: true,
+        import: true,
       },
     },
   },
@@ -2112,6 +1870,8 @@ export default {
 
 Parser options for `css/auto` modules.
 
+The `css/auto`, `css/global`, and `css/module` module types share the same parser options. The examples in this section use `css/auto`; replace it with `css/global` or `css/module` to configure those module types.
+
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -2182,17 +1942,39 @@ import classes, { class1, class2 } from './index.module.css';
 - **Type:** `boolean`
 - **Default:** `true`
 
-Allow to enable/disables handling the CSS functions url.
+Whether to handle CSS `url()` functions.
 
-When using `url: true`, Rspack will resolve the path in `url` function, the resolve file will be treated as an asset.
-When using `url: false`, Rspack will ignore the path in the `url` function, keep the content unchanged.
+When using `url: true`, Rspack will resolve the path in `url()` as an asset dependency.
+When using `url: false`, Rspack will keep `url()` unchanged.
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
-      css: {
+      'css/auto': {
         url: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].import
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to handle CSS `@import` rules.
+
+When using `import: true`, Rspack will resolve `@import` rules as dependencies.
+When using `import: false`, Rspack will keep `@import` rules unchanged.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        import: true,
       },
     },
   },
@@ -2220,6 +2002,63 @@ export default {
         resolveImport: ({ url }) => {
           return url.includes('style.css');
         },
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].animation
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to rename `@keyframes` and animation names in CSS Modules.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].customIdents
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Whether to rename custom identifiers in CSS Modules, such as `@counter-style` and `@font-palette-values`.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        customIdents: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].dashedIdents
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Whether to rename dashed identifiers in CSS Modules, such as CSS custom properties.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        dashedIdents: false,
       },
     },
   },
@@ -2292,6 +2131,24 @@ export default {
 };
 ```
 
+### module.parser["css/global"]
+
+Parser options for `css/global` modules.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        // options
+      },
+    },
+  },
+};
+```
+
+Same parser options as [`module.parser["css/auto"]`](#moduleparsercssauto).
+
 ### module.parser["css/module"]
 
 Parser options for `css/module` modules.
@@ -2308,55 +2165,7 @@ export default {
 };
 ```
 
-### module.parser["css/module"].namedExports
-
-Same as [`module.parser["css/auto"].namedExports`](#moduleparsercssautonamedexports).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/module': {
-        namedExports: true,
-      },
-    },
-  },
-};
-```
-
-### module.parser["css/module"].url
-
-Same as [`module.parser["css/auto"].url`](#moduleparsercssautourl).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/module': {
-        url: true,
-      },
-    },
-  },
-};
-```
-
-### module.parser["css/module"].resolveImport
-
-Same as [`module.parser["css/auto"].resolveImport`](#moduleparsercssautoresolveimport).
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/module': {
-        resolveImport: ({ url }) => {
-          return url.includes('style.css');
-        },
-      },
-    },
-  },
-};
-```
+Same parser options as [`module.parser["css/auto"]`](#moduleparsercssauto).
 
 ## module.rules
 

--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -257,10 +257,14 @@ document.getElementById('element').className = styles.red;
 
 Rspack provides options to customize the parsing and generation of CSS Modules:
 
-- [module.parser.css](/config/module#moduleparsercss): Configure the parsing of CSS Modules.
-- [module.generator["css/auto"]](/config/module#modulegeneratorcssauto): Configure generation for `css/auto` modules.
-- [module.generator["css/global"]](/config/module#modulegeneratorcssglobal): Configure generation for `css/global` modules.
-- [module.generator["css/module"]](/config/module#modulegeneratorcssmodule): Configure generation for `css/module` modules.
+- Parser options:
+  - [module.parser["css/auto"]](/config/module#moduleparsercssauto)
+  - [module.parser["css/global"]](/config/module#moduleparsercssglobal)
+  - [module.parser["css/module"]](/config/module#moduleparsercssmodule)
+- Generator options:
+  - [module.generator["css/auto"]](/config/module#modulegeneratorcssauto)
+  - [module.generator["css/global"]](/config/module#modulegeneratorcssglobal)
+  - [module.generator["css/module"]](/config/module#modulegeneratorcssmodule)
 
 :::
 

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -575,6 +575,8 @@ export default {
 
 `css/auto` 模块的生成器选项。
 
+`css/auto`、`css/global` 和 `css/module` 模块类型使用相同的生成器选项。本节示例使用 `css/auto`，如需配置其他模块类型，可以替换为 `css/global` 或 `css/module`。
+
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -838,133 +840,7 @@ export default {
 };
 ```
 
-### module.generator["css/global"].exportsConvention
-
-和 [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        exportsConvention: 'camel-case',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].exportsOnly
-
-和 [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        exportsOnly: false,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentName
-
-和 [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentName: '[local]-[hash:base64:6]',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashDigest
-
-和 [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashDigest: 'hex',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashDigestLength
-
-和 [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashDigestLength: 8,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashFunction
-
-和 [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashFunction: 'xxhash64',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].localIdentHashSalt
-
-和 [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        localIdentHashSalt: 'my-salt',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/global"].esModule
-
-和 [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/global': {
-        esModule: true,
-      },
-    },
-  },
-};
-```
+生成器选项和 [`module.generator["css/auto"]`](#modulegeneratorcssauto) 相同。
 
 ### module.generator["css/module"]
 
@@ -982,133 +858,7 @@ export default {
 };
 ```
 
-### module.generator["css/module"].exportsConvention
-
-和 [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        exportsConvention: 'camel-case',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].exportsOnly
-
-和 [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        exportsOnly: false,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentName
-
-和 [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentName: '[local]-[hash:base64:6]',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashDigest
-
-和 [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashDigest: 'hex',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashDigestLength
-
-和 [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashDigestLength: 8,
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashFunction
-
-和 [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashFunction: 'xxhash64',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].localIdentHashSalt
-
-和 [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        localIdentHashSalt: 'my-salt',
-      },
-    },
-  },
-};
-```
-
-### module.generator["css/module"].esModule
-
-和 [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    generator: {
-      'css/module': {
-        esModule: true,
-      },
-    },
-  },
-};
-```
+生成器选项和 [`module.generator["css/auto"]`](#modulegeneratorcssauto) 相同。
 
 ### module.generator.json.JSONParse
 
@@ -1196,14 +946,22 @@ export default {
       // CSS 模块的解析器选项
       css: {
         namedExports: true,
+        import: true,
       },
       // css/auto 模块的解析器选项
       'css/auto': {
         namedExports: true,
+        import: true,
+      },
+      // css/global 模块的解析器选项
+      'css/global': {
+        namedExports: true,
+        import: true,
       },
       // css/module 模块的解析器选项
       'css/module': {
         namedExports: true,
+        import: true,
       },
     },
   },
@@ -2109,6 +1867,8 @@ export default {
 
 `css/auto` 模块的解析器选项。
 
+`css/auto`、`css/global` 和 `css/module` 模块类型使用相同的解析器选项。本节示例使用 `css/auto`，如需配置其他模块类型，可以替换为 `css/global` 或 `css/module`。
+
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -2179,17 +1939,39 @@ import classes, { class1, class2 } from './index.module.css';
 - **类型：** `boolean`
 - **默认值：** `true`
 
-开启或者关闭对 CSS 中的 `url` 的处理。
+配置是否处理 CSS `url()` 函数。
 
-当开启该选项 `url: true`, Rspack 将 `url` 函数中的路径解析成资源路径。
-当关闭该选项 `url: false`, Rspack 忽略 `url` 函数，保持内容不变。
+当使用 `url: true` 时，Rspack 会将 `url()` 中的路径解析为资源依赖。
+当使用 `url: false` 时，Rspack 会保持 `url()` 不变。
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
-      css: {
+      'css/auto': {
         url: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].import
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+配置是否处理 CSS `@import` 规则。
+
+当使用 `import: true` 时，Rspack 会将 `@import` 规则解析为依赖。
+当使用 `import: false` 时，Rspack 会保持 `@import` 规则不变。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        import: true,
       },
     },
   },
@@ -2217,6 +1999,63 @@ export default {
         resolveImport: ({ url }) => {
           return url.includes('style.css');
         },
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].animation
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+配置是否重命名 CSS Modules 中的 `@keyframes` 和动画名称。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].customIdents
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+配置是否重命名 CSS Modules 中的自定义标识符，例如 `@counter-style` 和 `@font-palette-values`。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        customIdents: false,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/auto"].dashedIdents
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+配置是否重命名 CSS Modules 中的短横线标识符，例如 CSS 自定义属性。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        dashedIdents: false,
       },
     },
   },
@@ -2289,6 +2128,24 @@ export default {
 };
 ```
 
+### module.parser["css/global"]
+
+`css/global` 模块的解析器选项。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        // options
+      },
+    },
+  },
+};
+```
+
+解析器选项和 [`module.parser["css/auto"]`](#moduleparsercssauto) 相同。
+
 ### module.parser["css/module"]
 
 `css/module` 模块的解析器选项。
@@ -2305,55 +2162,7 @@ export default {
 };
 ```
 
-### module.parser["css/module"].namedExports
-
-和 [`module.parser["css/auto"].namedExports`](#moduleparsercssautonamedexports) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/module': {
-        namedExports: true,
-      },
-    },
-  },
-};
-```
-
-### module.parser["css/module"].url
-
-和 [`module.parser["css/auto"].url`](#moduleparsercssautourl) 一样。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      css: {
-        url: true,
-      },
-    },
-  },
-};
-```
-
-### module.parser["css/module"].resolveImport
-
-参考 [`module.parser["css/auto"].resolveImport`](#moduleparsercssautoresolveimport)。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/module': {
-        resolveImport: ({ url }) => {
-          return url.includes('style.css');
-        },
-      },
-    },
-  },
-};
-```
+解析器选项和 [`module.parser["css/auto"]`](#moduleparsercssauto) 相同。
 
 ## module.rules
 

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -575,8 +575,6 @@ export default {
 
 `css/auto` 模块的生成器选项。
 
-`css/auto`、`css/global` 和 `css/module` 模块类型使用相同的生成器选项。本节示例使用 `css/auto`，如需配置其他模块类型，可以替换为 `css/global` 或 `css/module`。
-
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -840,7 +838,133 @@ export default {
 };
 ```
 
-生成器选项和 [`module.generator["css/auto"]`](#modulegeneratorcssauto) 相同。
+### module.generator["css/global"].exportsConvention
+
+和 [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        exportsConvention: 'camel-case',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].exportsOnly
+
+和 [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        exportsOnly: false,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentName
+
+和 [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentName: '[local]-[hash:base64:6]',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashDigest
+
+和 [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashDigest: 'hex',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashDigestLength
+
+和 [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashDigestLength: 8,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashFunction
+
+和 [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashFunction: 'xxhash64',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].localIdentHashSalt
+
+和 [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        localIdentHashSalt: 'my-salt',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/global"].esModule
+
+和 [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/global': {
+        esModule: true,
+      },
+    },
+  },
+};
+```
 
 ### module.generator["css/module"]
 
@@ -858,7 +982,133 @@ export default {
 };
 ```
 
-生成器选项和 [`module.generator["css/auto"]`](#modulegeneratorcssauto) 相同。
+### module.generator["css/module"].exportsConvention
+
+和 [`module.generator["css/auto"].exportsConvention`](#modulegeneratorcssautoexportsconvention) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        exportsConvention: 'camel-case',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].exportsOnly
+
+和 [`module.generator["css/auto"].exportsOnly`](#modulegeneratorcssautoexportsonly) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        exportsOnly: false,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentName
+
+和 [`module.generator["css/auto"].localIdentName`](#modulegeneratorcssautolocalidentname) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentName: '[local]-[hash:base64:6]',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashDigest
+
+和 [`module.generator["css/auto"].localIdentHashDigest`](#modulegeneratorcssautolocalidenthashdigest) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashDigest: 'hex',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashDigestLength
+
+和 [`module.generator["css/auto"].localIdentHashDigestLength`](#modulegeneratorcssautolocalidenthashdigestlength) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashDigestLength: 8,
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashFunction
+
+和 [`module.generator["css/auto"].localIdentHashFunction`](#modulegeneratorcssautolocalidenthashfunction) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashFunction: 'xxhash64',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].localIdentHashSalt
+
+和 [`module.generator["css/auto"].localIdentHashSalt`](#modulegeneratorcssautolocalidenthashsalt) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        localIdentHashSalt: 'my-salt',
+      },
+    },
+  },
+};
+```
+
+### module.generator["css/module"].esModule
+
+和 [`module.generator["css/auto"].esModule`](#modulegeneratorcssautoesmodule) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'css/module': {
+        esModule: true,
+      },
+    },
+  },
+};
+```
 
 ### module.generator.json.JSONParse
 
@@ -946,22 +1196,14 @@ export default {
       // CSS 模块的解析器选项
       css: {
         namedExports: true,
-        import: true,
       },
       // css/auto 模块的解析器选项
       'css/auto': {
         namedExports: true,
-        import: true,
-      },
-      // css/global 模块的解析器选项
-      'css/global': {
-        namedExports: true,
-        import: true,
       },
       // css/module 模块的解析器选项
       'css/module': {
         namedExports: true,
-        import: true,
       },
     },
   },
@@ -1867,8 +2109,6 @@ export default {
 
 `css/auto` 模块的解析器选项。
 
-`css/auto`、`css/global` 和 `css/module` 模块类型使用相同的解析器选项。本节示例使用 `css/auto`，如需配置其他模块类型，可以替换为 `css/global` 或 `css/module`。
-
 ```js title="rspack.config.mjs"
 export default {
   module: {
@@ -1939,39 +2179,17 @@ import classes, { class1, class2 } from './index.module.css';
 - **类型：** `boolean`
 - **默认值：** `true`
 
-配置是否处理 CSS `url()` 函数。
+开启或者关闭对 CSS 中的 `url` 的处理。
 
-当使用 `url: true` 时，Rspack 会将 `url()` 中的路径解析为资源依赖。
-当使用 `url: false` 时，Rspack 会保持 `url()` 不变。
+当开启该选项 `url: true`, Rspack 将 `url` 函数中的路径解析成资源路径。
+当关闭该选项 `url: false`, Rspack 忽略 `url` 函数，保持内容不变。
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
-      'css/auto': {
+      css: {
         url: true,
-      },
-    },
-  },
-};
-```
-
-### module.parser["css/auto"].import
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-配置是否处理 CSS `@import` 规则。
-
-当使用 `import: true` 时，Rspack 会将 `@import` 规则解析为依赖。
-当使用 `import: false` 时，Rspack 会保持 `@import` 规则不变。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      'css/auto': {
-        import: true,
       },
     },
   },
@@ -2005,12 +2223,34 @@ export default {
 };
 ```
 
+### module.parser["css/auto"].import
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+配置是否处理 CSS `@import` 规则。
+
+- `true`: 解析并处理 `@import` 规则（默认）。
+- `false`: 在生成的 CSS 中保留 `@import` 规则，不进行解析。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/auto': {
+        import: true,
+      },
+    },
+  },
+};
+```
+
 ### module.parser["css/auto"].animation
 
 - **类型：** `boolean`
 - **默认值：** `true`
 
-配置是否重命名 CSS Modules 中的 `@keyframes` 和动画名称。
+启用或禁用对本地 `@keyframes` 标识符及其 `animation` 或 `animation-name` 使用处的重命名。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -2029,14 +2269,14 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-配置是否重命名 CSS Modules 中的自定义标识符，例如 `@counter-style` 和 `@font-palette-values`。
+启用或禁用对自定义标识符的重命名，例如本地 `@counter-style` 和 `@font-palette-values` 名称。
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
       'css/auto': {
-        customIdents: false,
+        customIdents: true,
       },
     },
   },
@@ -2048,14 +2288,14 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-配置是否重命名 CSS Modules 中的短横线标识符，例如 CSS 自定义属性。
+启用或禁用对 dashed identifiers 的重命名，例如 CSS 自定义属性和 `@property` 声明。
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     parser: {
       'css/auto': {
-        dashedIdents: false,
+        dashedIdents: true,
       },
     },
   },
@@ -2128,6 +2368,70 @@ export default {
 };
 ```
 
+### module.parser.css.import
+
+和 [`module.parser["css/auto"].import`](#moduleparsercssautoimport) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        import: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.css.animation
+
+和 [`module.parser["css/auto"].animation`](#moduleparsercssautoanimation) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.css.customIdents
+
+和 [`module.parser["css/auto"].customIdents`](#moduleparsercssautocustomidents) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        customIdents: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser.css.dashedIdents
+
+和 [`module.parser["css/auto"].dashedIdents`](#moduleparsercssautodashedidents) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        dashedIdents: true,
+      },
+    },
+  },
+};
+```
+
 ### module.parser["css/global"]
 
 `css/global` 模块的解析器选项。
@@ -2144,7 +2448,119 @@ export default {
 };
 ```
 
-解析器选项和 [`module.parser["css/auto"]`](#moduleparsercssauto) 相同。
+### module.parser["css/global"].namedExports
+
+和 [`module.parser["css/auto"].namedExports`](#moduleparsercssautonamedexports) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        namedExports: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].url
+
+和 [`module.parser["css/auto"].url`](#moduleparsercssautourl) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        url: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].resolveImport
+
+参考 [`module.parser["css/auto"].resolveImport`](#moduleparsercssautoresolveimport)。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        resolveImport: ({ url }) => {
+          return url.includes('style.css');
+        },
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].import
+
+和 [`module.parser["css/auto"].import`](#moduleparsercssautoimport) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        import: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].animation
+
+和 [`module.parser["css/auto"].animation`](#moduleparsercssautoanimation) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].customIdents
+
+和 [`module.parser["css/auto"].customIdents`](#moduleparsercssautocustomidents) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        customIdents: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/global"].dashedIdents
+
+和 [`module.parser["css/auto"].dashedIdents`](#moduleparsercssautodashedidents) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/global': {
+        dashedIdents: true,
+      },
+    },
+  },
+};
+```
 
 ### module.parser["css/module"]
 
@@ -2162,7 +2578,119 @@ export default {
 };
 ```
 
-解析器选项和 [`module.parser["css/auto"]`](#moduleparsercssauto) 相同。
+### module.parser["css/module"].namedExports
+
+和 [`module.parser["css/auto"].namedExports`](#moduleparsercssautonamedexports) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        namedExports: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].url
+
+和 [`module.parser["css/auto"].url`](#moduleparsercssautourl) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      css: {
+        url: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].resolveImport
+
+参考 [`module.parser["css/auto"].resolveImport`](#moduleparsercssautoresolveimport)。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        resolveImport: ({ url }) => {
+          return url.includes('style.css');
+        },
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].import
+
+和 [`module.parser["css/auto"].import`](#moduleparsercssautoimport) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        import: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].animation
+
+和 [`module.parser["css/auto"].animation`](#moduleparsercssautoanimation) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        animation: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].customIdents
+
+和 [`module.parser["css/auto"].customIdents`](#moduleparsercssautocustomidents) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        customIdents: true,
+      },
+    },
+  },
+};
+```
+
+### module.parser["css/module"].dashedIdents
+
+和 [`module.parser["css/auto"].dashedIdents`](#moduleparsercssautodashedidents) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      'css/module': {
+        dashedIdents: true,
+      },
+    },
+  },
+};
+```
 
 ## module.rules
 

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -257,10 +257,14 @@ document.getElementById('element').className = styles.red;
 
 Rspack 提供了选项，允许你自定义 CSS Modules 的解析和生成方式：
 
-- [module.parser.css](/config/module#moduleparsercss)：配置 CSS Modules 的解析方式。
-- [module.generator["css/auto"]](/config/module#modulegeneratorcssauto)：配置 `css/auto` 模块的生成方式。
-- [module.generator["css/global"]](/config/module#modulegeneratorcssglobal)：配置 `css/global` 模块的生成方式。
-- [module.generator["css/module"]](/config/module#modulegeneratorcssmodule)：配置 `css/module` 模块的生成方式。
+- 解析器选项：
+  - [module.parser["css/auto"]](/config/module#moduleparsercssauto)
+  - [module.parser["css/global"]](/config/module#moduleparsercssglobal)
+  - [module.parser["css/module"]](/config/module#moduleparsercssmodule)
+- 生成器选项：
+  - [module.generator["css/auto"]](/config/module#modulegeneratorcssauto)
+  - [module.generator["css/global"]](/config/module#modulegeneratorcssglobal)
+  - [module.generator["css/module"]](/config/module#modulegeneratorcssmodule)
 
 :::
 


### PR DESCRIPTION
## Summary

- Document CSS parser options for import, animation, customIdents, and dashedIdents.
- Add matching English and Chinese docs for css/auto, css, and css/module parser sections.

## Validation

- git diff --check -- website/docs/en/config/module.mdx website/docs/zh/config/module.mdx
- pnpm prettier --write website/docs/en/config/module.mdx website/docs/zh/config/module.mdx (failed: prettier command not found)
- pnpm --filter rspack-website check:case (failed: case-police command not found)

---
_by OpenAI Codex_