### PR TITLE
perf: store ArcPath as hstr atom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,6 +4146,7 @@ version = "0.100.3"
 dependencies = [
  "camino",
  "dashmap",
+ "hstr",
  "indexmap",
  "rspack_cacheable",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4149,7 +4149,6 @@ dependencies = [
  "hstr",
  "indexmap",
  "rspack_cacheable",
- "rustc-hash",
  "ustr-fxhash",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ futures             = { version = "0.3.32", default-features = false, features =
 hashlink            = { version = "0.11.0", default-features = false }
 heck                = { version = "0.5.0", default-features = false }
 hex                 = { version = "0.4.3", default-features = false, features = ["std"] }
+hstr                = { version = "3.0.5", default-features = false }
 indexmap            = { version = "2.14.0", default-features = false }
 indicatif           = { version = "0.18.4", default-features = false }
 indoc               = { version = "2.0.7", default-features = false }

--- a/crates/rspack_cacheable/src/utils/portable_path.rs
+++ b/crates/rspack_cacheable/src/utils/portable_path.rs
@@ -53,10 +53,11 @@ impl PortablePath {
       return self
         .path
         .absolutize_with(project_root)
+        .normalize()
         .to_string_lossy()
         .into_owned();
     }
-    self.path
+    self.path.normalize().to_string_lossy().into_owned()
   }
 }
 
@@ -73,5 +74,45 @@ where
 
   fn deserialize(self, guard: &ContextGuard) -> Result<T> {
     Ok(T::from(self.into_path_string(guard.project_root())))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::PortablePath;
+
+  #[test]
+  fn should_normalize_untransformed_path_on_deserialize() {
+    let path = PortablePath {
+      path: "a//b/../c.js".to_string(),
+      transformed: false,
+    };
+
+    assert_eq!(path.into_path_string(None), "a/c.js");
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn should_normalize_windows_separators_on_deserialize() {
+    let path = PortablePath {
+      path: "C:/project/src/file.js".to_string(),
+      transformed: false,
+    };
+
+    assert_eq!(path.into_path_string(None), r"C:\project\src\file.js");
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn should_normalize_transformed_windows_path_on_deserialize() {
+    let path = PortablePath {
+      path: "src/file.js".to_string(),
+      transformed: true,
+    };
+
+    assert_eq!(
+      path.into_path_string(Some(std::path::Path::new(r"C:\project"))),
+      r"C:\project\src\file.js"
+    );
   }
 }

--- a/crates/rspack_cacheable/src/utils/portable_path.rs
+++ b/crates/rspack_cacheable/src/utils/portable_path.rs
@@ -57,7 +57,12 @@ impl PortablePath {
         .to_string_lossy()
         .into_owned();
     }
-    self.path.normalize().to_string_lossy().into_owned()
+
+    let path = Path::new(&self.path);
+    if path.is_absolute() {
+      return path.normalize().to_string_lossy().into_owned();
+    }
+    self.path
   }
 }
 
@@ -82,13 +87,13 @@ mod tests {
   use super::PortablePath;
 
   #[test]
-  fn should_normalize_untransformed_path_on_deserialize() {
+  fn should_preserve_untransformed_relative_path_on_deserialize() {
     let path = PortablePath {
-      path: "a//b/../c.js".to_string(),
+      path: "./src".to_string(),
       transformed: false,
     };
 
-    assert_eq!(path.into_path_string(None), "a/c.js");
+    assert_eq!(path.into_path_string(None), "./src");
   }
 
   #[cfg(windows)]

--- a/crates/rspack_paths/Cargo.toml
+++ b/crates/rspack_paths/Cargo.toml
@@ -14,7 +14,6 @@ dashmap          = { workspace = true }
 hstr             = { workspace = true }
 indexmap         = { workspace = true }
 rspack_cacheable = { workspace = true }
-rustc-hash       = { workspace = true }
 ustr             = { workspace = true }
 
 [lints]

--- a/crates/rspack_paths/Cargo.toml
+++ b/crates/rspack_paths/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [dependencies]
 camino           = { workspace = true }
 dashmap          = { workspace = true }
+hstr             = { workspace = true }
 indexmap         = { workspace = true }
 rspack_cacheable = { workspace = true }
 rustc-hash       = { workspace = true }

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
   hash::{BuildHasherDefault, Hash},
   ops::Deref,
   path::{Path, PathBuf},
-  sync::Arc,
 };
 
 pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
@@ -66,10 +65,6 @@ impl Debug for ArcPath {
 }
 
 impl ArcPath {
-  pub fn new(path: Arc<Path>) -> Self {
-    Self::from_path(&path)
-  }
-
   fn from_path(path: &Path) -> Self {
     let path = path.to_str().unwrap_or_else(|| {
       panic!("expected UTF-8 path, got: {}", path.display());

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
   collections::{HashMap, HashSet},
   fmt::Debug,
-  hash::{BuildHasherDefault, Hash, Hasher},
+  hash::{BuildHasherDefault, Hash},
   ops::Deref,
   path::{Path, PathBuf},
   sync::Arc,
@@ -9,13 +9,13 @@ use std::{
 
 pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
 use dashmap::{DashMap, DashSet};
+use hstr::Atom;
 use indexmap::IndexSet;
 use rspack_cacheable::{
   ContextGuard, Error as CacheableError, cacheable,
   utils::PortablePath,
   with::{Custom, CustomConverter},
 };
-use rustc_hash::FxHasher;
 use ustr::IdentityHasher;
 
 pub trait AssertUtf8 {
@@ -54,58 +54,61 @@ impl<'a> AssertUtf8 for &'a Path {
 }
 
 #[cacheable(with=Custom)]
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ArcPath {
-  path: Arc<Path>,
-  // Pre-calculating and caching the hash value upon creation, making hashing operations
-  // in collections virtually free.
-  hash: u64,
+  inner: Atom,
 }
 
 impl Debug for ArcPath {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    self.path.fmt(f)
+    self.as_ref().fmt(f)
   }
 }
 
 impl ArcPath {
   pub fn new(path: Arc<Path>) -> Self {
-    let mut hasher = FxHasher::default();
-    path.hash(&mut hasher);
-    let hash = hasher.finish();
-    Self { path, hash }
+    Self::from_path(&path)
+  }
+
+  fn from_path(path: &Path) -> Self {
+    let path = path.to_str().unwrap_or_else(|| {
+      panic!("expected UTF-8 path, got: {}", path.display());
+    });
+    Self {
+      inner: Atom::from(path),
+    }
   }
 }
 
 impl Deref for ArcPath {
-  type Target = Arc<Path>;
+  type Target = Path;
 
   fn deref(&self) -> &Self::Target {
-    &self.path
+    self.as_ref()
   }
 }
 
 impl AsRef<Path> for ArcPath {
   fn as_ref(&self) -> &Path {
-    &self.path
+    Path::new(self.inner.as_ref())
   }
 }
 
 impl From<PathBuf> for ArcPath {
   fn from(value: PathBuf) -> Self {
-    ArcPath::new(value.into())
+    ArcPath::from_path(&value)
   }
 }
 
 impl From<&Path> for ArcPath {
   fn from(value: &Path) -> Self {
-    ArcPath::new(value.into())
+    ArcPath::from_path(value)
   }
 }
 
 impl From<&Utf8Path> for ArcPath {
   fn from(value: &Utf8Path) -> Self {
-    ArcPath::new(value.as_std_path().into())
+    ArcPath::from_path(value.as_std_path())
   }
 }
 
@@ -117,14 +120,16 @@ impl From<&ArcPath> for ArcPath {
 
 impl From<&str> for ArcPath {
   fn from(value: &str) -> Self {
-    ArcPath::new(<str as std::convert::AsRef<Path>>::as_ref(value).into())
+    Self {
+      inner: Atom::from(value),
+    }
   }
 }
 
 impl CustomConverter for ArcPath {
   type Target = PortablePath;
   fn serialize(&self, guard: &ContextGuard) -> Result<Self::Target, CacheableError> {
-    Ok(PortablePath::new(&self.path, guard.project_root()))
+    Ok(PortablePath::new(self.as_ref(), guard.project_root()))
   }
   fn deserialize(data: Self::Target, guard: &ContextGuard) -> Result<Self, CacheableError> {
     Ok(Self::from(PathBuf::from(
@@ -133,29 +138,22 @@ impl CustomConverter for ArcPath {
   }
 }
 
-impl Hash for ArcPath {
-  #[inline]
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    state.write_u64(self.hash);
-  }
-}
-
 /// A standard `HashMap` using `ArcPath` as the key type with a custom `Hasher`
-/// that just uses the precomputed hash for speed instead of calculating it.
+/// that just uses the `hstr` hash for speed instead of calculating it.
 pub type ArcPathMap<V> = HashMap<ArcPath, V, BuildHasherDefault<IdentityHasher>>;
 
 /// A standard `HashSet` using `ArcPath` as the key type with a custom `Hasher`
-/// that just uses the precomputed hash for speed instead of calculating it.
+/// that just uses the `hstr` hash for speed instead of calculating it.
 pub type ArcPathSet = HashSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
 
 /// A standard `DashMap` using `ArcPath` as the key type with a custom `Hasher`
-/// that just uses the precomputed hash for speed instead of calculating it.
+/// that just uses the `hstr` hash for speed instead of calculating it.
 pub type ArcPathDashMap<V> = DashMap<ArcPath, V, BuildHasherDefault<IdentityHasher>>;
 
 /// A standard `DashSet` using `ArcPath` as the key type with a custom `Hasher`
-/// that just uses the precomputed hash for speed instead of calculating it.
+/// that just uses the `hstr` hash for speed instead of calculating it.
 pub type ArcPathDashSet = DashSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
 
 /// A standard `IndexSet` using `ArcPath` as the key type with a custom `Hasher`
-/// that just uses the precomputed hash for speed instead of calculating it.
+/// that just uses the `hstr` hash for speed instead of calculating it.
 pub type ArcPathIndexSet = IndexSet<ArcPath, BuildHasherDefault<IdentityHasher>>;


### PR DESCRIPTION
## Summary

Store `ArcPath` as an `hstr::Atom` instead of `Arc<Path>` plus a separately cached `FxHasher` value.

This keeps the path-facing API (`AsRef<Path>`, `Deref<Target = Path>`, cache serialization) while letting `PartialEq`, `Eq`, and `Hash` delegate directly to `hstr`.

This should reduce the hot watch/dependency path key size and avoid maintaining a duplicate hash field for high-cardinality path sets such as file, context, missing, and build dependencies. The expected benefit is lower per-key memory footprint and cheaper clone/equality/hash behavior in `ArcPathSet`, `ArcPathDashSet`, and related maps.

Local checks run:

- `cargo check -p rspack_paths`
- `cargo check -p rspack_watcher -p rspack_core -p rspack_binding_api -p rspack_plugin_extract_css -p rspack_plugin_lazy_compilation`
- `pnpm run format:rs`
- `pnpm run build:binding:dev`
- `pnpm run test:rs`
- `pnpm run build:cli:dev`
- `pnpm run test:unit` initially hit local inotify `max_user_instances=128`; reran `@rspack/tests` with `--pool.maxWorkers=1`, passing 6,190 tests
- `cargo clippy -p rspack_paths -p rspack_watcher -p rspack_core -p rspack_binding_api -p rspack_plugin_extract_css -p rspack_plugin_lazy_compilation --all-targets`
- `pnpm run format:js`

`cargo clippy --workspace --all-targets --all-features` currently fails before this change in `rspack_cacheable` with existing rkyv 0.7/0.8 trait conflicts.

## CodSpeed attribution

CodSpeed compared PR head `81e6166` against `main` `556d466` in Simulation/Callgrind mode. Raw artifacts inspected:

- Head CI run: `26183108670`, artifact `codspeed-valgrind-tmp-x86_64-unknown-linux-gnu`
- Base CI run: `26160801668`, artifact `codspeed-valgrind-tmp-x86_64-unknown-linux-gnu`

Regressed cases:

- `rust@persistent_cache_restore@basic-react-development`: direct regression from restored portable-path normalization. `PortablePath::into_path_string` inclusive work increased from about `4.9k Ir` to about `431k Ir` for the same `194` calls, mainly through `sugar_path::normalize`, UTF-8/lossy string conversion, and `memchr` paths. This is from the Windows cache-path fix path, not from `hstr` equality/hash itself.
- `rust@create_module_hashes`: no direct `rspack_paths` / `PortablePath` hotspot in the measured part. The delta is mostly old code paths and allocator/table behavior (`mimalloc`, `hashbrown`, `NormalModule::get_runtime_hash`, module graph hash paths). Classified as indirect layout/allocator noise unless repeated runs show a stable direct hotspot.
- `rust@create_named_chunk_ids`: similarly no direct `rspack_paths` / `PortablePath` hotspot. The increase is concentrated in existing allocation, `hashbrown`, graph-root/chunk-id paths. Classified as indirect layout/allocator noise.

The same report also shows improvements in related stage benchmarks such as `create_full_hash`, `mangle_exports`, `runtime_requirements`, and `create_chunk_ids`, so the only clear actionable attribution is the persistent-cache restore normalization cost.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).