### PR TITLE
perf: remove unused graph roots edge sorting

### DIFF
--- a/crates/rspack_core/src/utils/find_graph_roots.rs
+++ b/crates/rspack_core/src/utils/find_graph_roots.rs
@@ -186,14 +186,6 @@ pub fn find_graph_roots<
 
         // Are there still edges unprocessed in the current node?
         if !stack[top_of_stack_idx].open_edges.is_empty() {
-          let mut edges = stack[top_of_stack_idx]
-            .open_edges
-            .iter()
-            .map(|edge| expect_get(&db, edge))
-            .collect::<Vec<_>>();
-
-          edges.sort_by_key(|a| a.item);
-
           // Process one dependency
           let dependency = stack[top_of_stack_idx]
             .open_edges


### PR DESCRIPTION
## Description

This branch #13998 constantly slows down `find_graph_roots` by 13%, result in a constant 6% overall slowdown.

Although the new import.meta.glob code is on a cold path and is not covered by this benchmark, it still changes the final Rust binary: code size, function layout, symbol order, codegen units, and potentially LLVM inlining decisions.

find_graph_roots already had dead work in its hot loop: it repeatedly collected open_edges into a temporary Vec and sorted it, but never used the sorted result. My branch likely did not make this code execute more often. Instead, it changed the binary/code layout enough that this existing unnecessary allocation and sorting became slightly more expensive under CodSpeed/Valgrind simulation.

So this is probably not a semantic regression in import.meta.glob, nor a graph-shape change. It is more likely a stable measurement/code-layout effect exposing pre-existing dead work in find_graph_roots.

## Related links

https://github.com/web-infra-dev/rspack/pull/13998#issuecomment-4497570754

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
