### PR TITLE
perf: set location-detail=none for release build

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -88,6 +88,7 @@ async function build() {
 		}
 		if (values.profile === "release") {
 			features.push("info-level");
+			rustflags.push("-Zlocation-detail=none");
 			if (process.env.RUST_TARGET && !process.env.RUST_TARGET.includes("windows-msvc")) {
 				rustflags.push("-Cforce-unwind-tables=no");
 			}


### PR DESCRIPTION
## What Changed

Adds `-Zlocation-detail=none` to the release binding build rustflags. This asks rustc to omit caller-location file/line/column details from release builds.
The canary size reduced from [47.4M unzip](https://github.com/web-infra-dev/rspack/actions/runs/26180378705) to [46.6M unzip](https://github.com/web-infra-dev/rspack/actions/runs/26202004071)
it remove the file location info when panic
* before:
<img width="1792" height="344" alt="image" src="https://github.com/user-attachments/assets/eda462a6-28aa-4f70-ab26-725c2574c5ca" />

* after:
<img width="1773" height="469" alt="image" src="https://github.com/user-attachments/assets/ec0686f0-ec97-4d46-be2e-71ac282e382f" />

## Why

The release native binding was carrying panic caller-location metadata that is useful for diagnostics but expensive in the stripped user-facing binary. Release builds already optimize for shipped artifact size and abort on panic, so this is a targeted build-profile size reduction.

## Impact

The measured `librspack_node.so` size decreased from `47,451,800` bytes to `46,575,256` bytes, a reduction of `876,544` bytes. There is no expected runtime hot-path change; the tradeoff is less detailed panic location metadata in release builds.

## Performance Evidence

Local CodSpeed simulation benchmark runs against the baseline and modified release artifacts both reported `No impact detected`.

Baseline run: https://codspeed.io/web-infra-dev/rspack/runs/6a0e106330c09108bb84d49a
Modified run: https://codspeed.io/web-infra-dev/rspack/runs/6a0e109130c09108bb84d4a9

Checks run locally:

- `pnpm run build:js`
- `pnpm run bench:prepare`
- `pnpm exec prettier --check crates/node_binding/scripts/build.js`
- `git diff --check`
- commit hook: `lint-staged` with `prettier` and `pnpm run lint:js`