### PR TITLE
chore(deps): upgrade swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5868,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "66.0.2"
+version = "66.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dba809fb900d93b02fb821fe19c48c76433f5dfb3a76bdb28068851e2a6307"
+checksum = "458fe6f4767653597b5d1c7ae2194c56bf0cb0929b6e4e45325402275d2436ff"
 dependencies = [
  "par-core",
  "swc",
@@ -5918,9 +5918,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "26.0.1"
+version = "26.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbcdd29cc03b0c04860bb0143e781e13a4e2dac03eb8747df520f602e0aa94"
+checksum = "39230b073d1d785ac7a905354161e21970d15956e348f46a85deb0da0d4d5132"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6174,9 +6174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "53.0.0"
+version = "53.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c9d429baf26f3e5efb0f98fd5f16425ae14becc2f82cd78e39512f1fd68a5e"
+checksum = "42b8a26a135d998592f2e73ba0b177a0faf3607c56c3b5584c88df4ef18ed03a"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,8 @@ rkyv      = { version = "=0.8.16", default-features = false, features = ["std", 
 pnp                 = { version = "0.12.9", default-features = false }
 swc                 = { version = "64.0.0", default-features = false }
 swc_config          = { version = "5.0.0", default-features = false }
-swc_core            = { version = "66.0.2", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "53.0.0", default-features = false }
+swc_core            = { version = "66.0.3", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "53.0.1", default-features = false }
 swc_error_reporters = { version = "23.0.0", default-features = false }
 swc_html            = { version = "33.0.0", default-features = false }
 swc_html_minifier   = { version = "53.0.0", default-features = false }

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "66.0.2"
+  "66.0.3"
 }
 
 /// The version of the JavaScript `@rspack/core` package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -663,8 +663,8 @@ importers:
         specifier: 0.5.21
         version: 0.5.21
       '@swc/plugin-remove-console':
-        specifier: ^12.9.0
-        version: 12.9.0
+        specifier: ^12.10.0
+        version: 12.10.0
       '@types/babel__generator':
         specifier: 7.27.0
         version: 7.27.0
@@ -3240,8 +3240,8 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
-  '@swc/plugin-remove-console@12.9.0':
-    resolution: {integrity: sha512-Ve64fWHghdhMHMYAmKlIdyV0aIbj8PX6mlUwXyf1dJXsBirkDm3HYtGw+XIpyNtIUfg1Rojyqc+TXATrqgRdhg==}
+  '@swc/plugin-remove-console@12.10.0':
+    resolution: {integrity: sha512-paeQ2oIB8k7oBHrZSF68QZZuXu/My2JhTtv3hDgTWvHPkOkWYTaiCNA8s9j2+To3cAy75uQFTMbhvfx7kEAAPA==}
 
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
@@ -10053,7 +10053,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/plugin-remove-console@12.9.0':
+  '@swc/plugin-remove-console@12.10.0':
     dependencies:
       '@swc/counter': 0.1.3
 

--- a/tests/rspack-test/package.json
+++ b/tests/rspack-test/package.json
@@ -24,7 +24,7 @@
     "@rspack/test-tools": "workspace:*",
     "@rstest/core": "^0.9.10",
     "@swc/helpers": "0.5.21",
-    "@swc/plugin-remove-console": "^12.9.0",
+    "@swc/plugin-remove-console": "^12.10.0",
     "@types/babel__generator": "7.27.0",
     "@types/babel__traverse": "7.28.0",
     "@types/fs-extra": "11.0.4",


### PR DESCRIPTION
## Summary

- upgrade `swc_core` to `66.0.3` and `swc_ecma_minifier` to `53.0.1`
- refresh `Cargo.lock`, generated workspace metadata, and `@swc/plugin-remove-console` to `12.10.0`

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- `cargo codegen`
- `cargo check --workspace --all-targets --locked`
- `cargo deny --all-features check license bans`
- `cargo xtask deny-ext`
- `pnpm install --frozen-lockfile --lockfile-only`
- `pnpm run check-dependency-version`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm --filter @rspack/core run prepare`
- `pnpm --dir tests/rspack-test run test --project base -t swc-api`