### PR TITLE
perf: reduce release binding size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,6 +278,9 @@ strip    = "none"
 
 [profile.release.package]
 
+[profile.release.package.lightningcss]
+opt-level = "s"
+
 [profile.release.package.regex-syntax]
 opt-level = "s"
 


### PR DESCRIPTION
## Summary

- Set the release profile for `lightningcss` to `opt-level = "s"` to shrink the Linux release binding.
- Let CodSpeed inherit the release package override, so benchmark builds stay aligned with release for this crate.
- Local release binding size changed from `46,566,808` to `45,838,104` bytes, saving `728,704` bytes.

## Related links

- https://github.com/web-infra-dev/rspack/issues/13908

## Validation

- `RUST_TARGET=x86_64-unknown-linux-gnu pnpm run build:binding:release`
- `pnpm run build:bench`
- `cargo build --profile codspeed -p rspack_benchmark --bench benches -Zunstable-options --unit-graph` confirmed `lightningcss` resolves to CodSpeed `opt_level=s`
- `cargo build --profile release -p rspack_node --target x86_64-unknown-linux-gnu --no-default-features --features plugin,info-level --config "target.'cfg(all())'.rustflags = [\"-Zlocation-detail=none\",\"-Cforce-unwind-tables=no\"]" -Zbuild-std=panic_abort,std -Zunstable-options --unit-graph` confirmed `lightningcss` resolves to release `opt_level=s`
- `git diff --check`
- `pnpm exec taplo format --check Cargo.toml`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
