### PR TITLE
fix(cli): include close time in build stats

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -5,6 +5,7 @@ import type {
   MultiStatsOptions,
   Stats,
   StatsOptions,
+  StatsValue,
 } from '@rspack/core';
 import type { RspackCLI } from '../cli';
 import type { RspackCommand } from '../types';
@@ -20,23 +21,59 @@ type BuildOptions = CommonOptionsForBuildAndServe & {
   json?: boolean | string;
 };
 
-function updateStatsEndTime(
-  stats: Stats | MultiStats | undefined,
+type StatsFormatOptions = StatsValue | MultiStatsOptions | undefined;
+
+const isMultiStats = (stats: Stats | MultiStats): stats is MultiStats =>
+  'stats' in stats;
+
+// Only adjust the StatsFactory result used for CLI text output. The original
+// Stats/Compilation data and `--json` output stay unchanged.
+const applyCliReportedTime = (stat: Stats, endTime: number) => {
+  let enabled = true;
+  const { compilation } = stat;
+  compilation.hooks.statsFactory.tap('RspackCLIStatsTime', (statsFactory) => {
+    statsFactory.hooks.result
+      .for('compilation')
+      .tap('RspackCLIStatsTime', (statsCompilation, context) => {
+        const compilationStats = statsCompilation as { time?: number };
+        if (
+          enabled &&
+          context.compilation === compilation &&
+          compilationStats.time !== undefined
+        ) {
+          compilationStats.time = endTime - stat.startTime;
+        }
+        return statsCompilation;
+      });
+  });
+
+  return () => {
+    enabled = false;
+  };
+};
+
+const statsToStringWithEndTime = (
+  stats: Stats | MultiStats,
+  options: StatsFormatOptions,
   endTime: number,
-) {
-  if (!stats) {
-    return;
-  }
-
-  if ('stats' in stats) {
+) => {
+  const cleanup: (() => void)[] = [];
+  if (isMultiStats(stats)) {
     for (const stat of stats.stats) {
-      stat.compilation.endTime = endTime;
+      cleanup.push(applyCliReportedTime(stat, endTime));
     }
-    return;
+  } else {
+    cleanup.push(applyCliReportedTime(stats, endTime));
   }
 
-  stats.compilation.endTime = endTime;
-}
+  try {
+    return stats.toString(options as StatsOptions);
+  } finally {
+    for (const fn of cleanup) {
+      fn();
+    }
+  }
+};
 
 async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
   setDefaultNodeEnv(options, 'production');
@@ -57,6 +94,7 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
   const errorHandler = (
     error: Error | null,
     stats: Stats | MultiStats | undefined,
+    cliReportedEndTime?: number,
   ) => {
     if (error) {
       logger.error(error);
@@ -82,7 +120,7 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
       return compiler.options?.stats;
     };
 
-    const statsOptions = getStatsOptions() as StatsOptions;
+    const statsOptions = getStatsOptions() as StatsFormatOptions;
 
     if (options.json && createJsonStringifyStream) {
       const handleWriteError = (error: Error) => {
@@ -90,13 +128,13 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
         process.exit(2);
       };
       if (options.json === true) {
-        createJsonStringifyStream(stats.toJson(statsOptions))
+        createJsonStringifyStream(stats.toJson(statsOptions as StatsOptions))
           .on('error', handleWriteError)
           .pipe(process.stdout)
           .on('error', handleWriteError)
           .on('close', () => process.stdout.write('\n'));
       } else if (typeof options.json === 'string') {
-        createJsonStringifyStream(stats.toJson(statsOptions))
+        createJsonStringifyStream(stats.toJson(statsOptions as StatsOptions))
           .on('error', handleWriteError)
           .pipe(fs.createWriteStream(options.json))
           .on('error', handleWriteError)
@@ -110,7 +148,10 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
           });
       }
     } else {
-      const printedStats = stats.toString(statsOptions);
+      const printedStats =
+        cliReportedEndTime === undefined
+          ? stats.toString(statsOptions as StatsOptions)
+          : statsToStringWithEndTime(stats, statsOptions, cliReportedEndTime);
       // Avoid extra empty line when `stats: 'none'`
       if (printedStats) {
         logger.raw(printedStats);
@@ -127,13 +168,11 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
 
   compiler.run((error: Error | null, stats: Stats | MultiStats | undefined) => {
     compiler.close((closeErr) => {
-      // The build command prints stats after close, so its timing should cover
-      // close-time work such as persistent cache flushing.
-      updateStatsEndTime(stats, Date.now());
+      const cliReportedEndTime = Date.now();
       if (closeErr) {
         logger.error(closeErr);
       }
-      errorHandler(error, stats);
+      errorHandler(error, stats, cliReportedEndTime);
     });
   });
 }

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -20,6 +20,24 @@ type BuildOptions = CommonOptionsForBuildAndServe & {
   json?: boolean | string;
 };
 
+function updateStatsEndTime(
+  stats: Stats | MultiStats | undefined,
+  endTime: number,
+) {
+  if (!stats) {
+    return;
+  }
+
+  if ('stats' in stats) {
+    for (const stat of stats.stats) {
+      stat.compilation.endTime = endTime;
+    }
+    return;
+  }
+
+  stats.compilation.endTime = endTime;
+}
+
 async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
   setDefaultNodeEnv(options, 'production');
   normalizeCommonOptions(options, 'build');
@@ -109,6 +127,9 @@ async function runBuild(cli: RspackCLI, options: BuildOptions): Promise<void> {
 
   compiler.run((error: Error | null, stats: Stats | MultiStats | undefined) => {
     compiler.close((closeErr) => {
+      // The build command prints stats after close, so its timing should cover
+      // close-time work such as persistent cache flushing.
+      updateStatsEndTime(stats, Date.now());
       if (closeErr) {
         logger.error(closeErr);
       }

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -100,6 +100,25 @@ describe('build command', () => {
     const durationMs = Number(value) * (unit === 's' ? 1000 : 1);
     expect(durationMs).toBeGreaterThanOrEqual(1000);
   });
+  it('should not include close duration in stats json time', async () => {
+    const { exitCode, stderr, stdout } = await run(
+      __dirname,
+      ['--config', './entry.close-time.js', '--json'],
+      {},
+      {},
+      true,
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+
+    const doneStats = JSON.parse(
+      await readFile(
+        resolve(__dirname, 'dist/close-time/done-time.json'),
+        'utf-8',
+      ),
+    );
+    expect(JSON.parse(stdout).time).toBe(doneStats.time);
+  });
   it.concurrent('should work with mjs configuration ', async () => {
     const { exitCode, stderr, stdout } = await run(
       __dirname,

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from 'node:util';
 import { resolve } from 'path';
 import { readFile, run, runWatch } from '../../utils/test-utils';
 
@@ -79,6 +80,25 @@ describe('build command', () => {
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
     expect(stdout).toBeTruthy();
+  });
+  it('should include close duration in printed build time', async () => {
+    const { exitCode, stderr, stdout } = await run(
+      __dirname,
+      ['--config', './entry.close-time.js'],
+      {},
+      {},
+      true,
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+
+    const output = stripVTControlCharacters(stdout);
+    const match = output.match(/compiled successfully in ([\d.]+) (ms|s)/i);
+    expect(match).toBeTruthy();
+
+    const [, value, unit] = match!;
+    const durationMs = Number(value) * (unit === 's' ? 1000 : 1);
+    expect(durationMs).toBeGreaterThanOrEqual(1000);
   });
   it.concurrent('should work with mjs configuration ', async () => {
     const { exitCode, stderr, stdout } = await run(

--- a/packages/rspack-cli/tests/build/basic/entry.close-time.js
+++ b/packages/rspack-cli/tests/build/basic/entry.close-time.js
@@ -1,14 +1,25 @@
+const fs = require('fs');
 const path = require('path');
+
+const outputPath = path.resolve(__dirname, 'dist/close-time');
+const doneTimePath = path.resolve(outputPath, 'done-time.json');
 
 module.exports = {
   mode: 'development',
   entry: './src/entry.js',
   output: {
-    path: path.resolve(__dirname, 'dist/close-time'),
+    path: outputPath,
   },
   plugins: [
     {
       apply(compiler) {
+        compiler.hooks.done.tap('RecordStatsTimePlugin', (stats) => {
+          fs.mkdirSync(outputPath, { recursive: true });
+          fs.writeFileSync(
+            doneTimePath,
+            JSON.stringify(stats.toJson({ all: false, timings: true })),
+          );
+        });
         compiler.hooks.shutdown.tapAsync(
           'SlowShutdownForStatsTimePlugin',
           (callback) => setTimeout(callback, 1200),

--- a/packages/rspack-cli/tests/build/basic/entry.close-time.js
+++ b/packages/rspack-cli/tests/build/basic/entry.close-time.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'development',
+  entry: './src/entry.js',
+  output: {
+    path: path.resolve(__dirname, 'dist/close-time'),
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.shutdown.tapAsync(
+          'SlowShutdownForStatsTimePlugin',
+          (callback) => setTimeout(callback, 1200),
+        );
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- Update one-shot `rspack build` stats end time after `compiler.close()` resolves so printed/JSON timings include close-time work such as persistent cache flushing.
- Add a CLI regression test that delays the shutdown hook and verifies the printed build time includes that delay.

## Related links

Fixes #14102

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation:

- `git diff --check`
- `pnpm run build:js` (blocked: `node_modules` missing, `rslib` not found)
- `pnpm --filter @rspack/cli test -- build/basic/basic.test.ts` (blocked: `node_modules` missing, `rstest` not found)
