### PR TITLE
fix: annotate generated JSON.parse as pure

### DIFF
--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -212,7 +212,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
         let json_str = utils::escape_json(&final_json_string);
         let json_expr = if self.json_parse && is_js_object && json_str.len() > 20 {
           Cow::Owned(format!(
-            "JSON.parse('{}')",
+            "/*#__PURE__*/JSON.parse('{}')",
             json_str.cow_replace('\\', r"\\").cow_replace('\'', r"\'")
           ))
         } else {

--- a/tests/rspack-test/builtinCases/plugin-json/simple/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-json/simple/__snapshots__/output.snap.txt
@@ -12,7 +12,7 @@ console.log(_json_json__rspack_import_0,_string_json__rspack_import_1)
 
 },
 "./json.json"(module) {
-module.exports = JSON.parse('{"hello":"world is better \'","b":"\\\\"}')
+module.exports = /*#__PURE__*/JSON.parse('{"hello":"world is better \'","b":"\\\\"}')
 
 },
 "./string.json"(module) {

--- a/tests/rspack-test/builtinCases/plugin-rsdoctor/json-size-tree-shaking/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-rsdoctor/json-size-tree-shaking/__snapshots__/output.snap.txt
@@ -29,7 +29,7 @@ it("should tree-shake unused JSON properties", () => {
 
 },
 "./data.json"(module) {
-module.exports = JSON.parse('{"user":{"name":"Alice","age":25,"email":"alice@example.com","profile":{"bio":"Software Engineer","avatar":"https://example.com/avatar.jpg","social":{"twitter":"@alice","github":"alice"}}}}')
+module.exports = /*#__PURE__*/JSON.parse('{"user":{"name":"Alice","age":25,"email":"alice@example.com","profile":{"bio":"Software Engineer","avatar":"https://example.com/avatar.jpg","social":{"twitter":"@alice","github":"alice"}}}}')
 
 },
 

--- a/tests/rspack-test/configCases/json/generator-json-parse-true/index.js
+++ b/tests/rspack-test/configCases/json/generator-json-parse-true/index.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 it("should use JSON.parse", () => {
 	const JSONParse = rstest.spyOn(JSON, 'parse');
 	JSONParse.mockClear();
@@ -11,6 +13,9 @@ it("should use JSON.parse", () => {
 	expect(data3).toMatchObject([{"this is a large JSON object": "that should be converted to JSON.parse by default"}]);
 
 	expect(JSONParse).toHaveBeenCalledTimes(3);
+
+	const source = fs.readFileSync(__filename, 'utf-8').toString();
+	expect((source.match(/\/\*#__PURE__\*\/JSON\.parse/g) || []).length).toBe(3);
 });
 
 it("should not call JSON.parse when resourceQuery is JSONParse=false", () => {


### PR DESCRIPTION
## Summary

- Align the JSON generator with webpack by marking generated `JSON.parse(...)` expressions as `/*#__PURE__*/`.
- Extend the existing JSONParse=true config case to assert the generated bundle contains pure annotations for JSON.parse output.

## Related links

- https://github.com/webpack/webpack/blob/0a6eb4a66adef645924079cb32df64a9bf8880c0/lib/json/JsonGenerator.js#L214

## Tests

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test:base -t "configCases/json/generator-json-parse-true"`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
