### PR TITLE
docs: clarify module parser and generator options

### DIFF
--- a/website/docs/en/config/module-generator.mdx
+++ b/website/docs/en/config/module-generator.mdx
@@ -8,18 +8,20 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # Module generator
 
+`module.generator` controls how Rspack turns parsed modules into output code or emitted assets. It affects output-related behavior such as asset filenames, public paths, CSS Modules exports, and other generation settings for each module type.
+
 ## generator
 
 - **Type:** `Object`
 - **Default:** `{}`
 
-Configure all generators' options in one place with `module.generator`.
+Use `module.generator` to define output generation options for each module type.
 
 Available generator option groups:
 
-- [Asset generator options](#asset)
-- [CSS generator options](#cssauto)
-- [JSON generator options](#jsonjsonparse)
+- `asset`, `asset/inline`, `asset/resource`: [Asset generator options](#asset)
+- `css`, `css/auto`, `css/global`, `css/module`: [CSS generator options](#cssauto)
+- `json`: [JSON generator options](#jsonjsonparse)
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -10,19 +10,21 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # Module parser
 
+`module.parser` controls how Rspack reads modules after they are resolved. It affects how dependencies are collected, how syntax such as `import.meta` and dynamic `import()` is interpreted, and other parsing behavior for each module type.
+
 ## parser
 
 - **Type:** `Object`
 - **Default:** `{}`
 
-Configure all parsers' options in one place with `module.parser`.
+Use `module.parser` to define parser options for each module type.
 
 Available parser option groups:
 
-- [Asset parser options](#asset)
-- [JavaScript parser options](#javascript)
-- [JSON parser options](#json)
-- [CSS parser options](#cssauto)
+- `asset`: [Asset parser options](#asset)
+- `javascript`, `javascript/auto`, `javascript/dynamic`, `javascript/esm`: [JavaScript parser options](#javascript)
+- `json`: [JSON parser options](#json)
+- `css`, `css/auto`, `css/global`, `css/module`: [CSS parser options](#cssauto)
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -58,7 +58,7 @@ See the [source code](https://github.com/web-infra-dev/rspack/blob/main/packages
 - **Type:** `Object`
 - **Default:** `{}`
 
-Configure global generator options for different module types. See [Module Generator](/config/module-generator) for details.
+Use `module.generator` to define output generation options for each module type, such as asset filenames, public paths, and CSS Modules exports. See [Module Generator](/config/module-generator) for details.
 
 ## module.noParse
 
@@ -104,7 +104,7 @@ export default {
 - **Type:** `Object`
 - **Default:** `{}`
 
-Configure global parser options for different module types. See [Module Parser](/config/module-parser) for details.
+Use `module.parser` to define parser options for each module type, such as dependency collection and how module syntax is interpreted. See [Module Parser](/config/module-parser) for details.
 
 ## module.rules
 

--- a/website/docs/zh/config/module-generator.mdx
+++ b/website/docs/zh/config/module-generator.mdx
@@ -8,18 +8,20 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # Module generator
 
+`module.generator` 用于控制 Rspack 在模块解析完成后如何生成最终代码或资源。它会影响资源文件名、publicPath、CSS Modules 导出形式等按模块类型决定的输出行为。
+
 ## generator
 
 - **类型：** `Object`
 - **默认值：** `{}`
 
-使用 `module.generator` 在一个地方配置所有生成器选项。
+使用 `module.generator` 可以按模块类型配置输出生成选项。
 
-查看按模块类型拆分的详细页面：
+可配置的 generator 选项分组包括：
 
-- [Asset generator 选项](/config/module-generator#asset)
-- [CSS generator 选项](/config/module-generator#cssauto)
-- [JSON generator 选项](/config/module-generator#jsonjsonparse)
+- `asset`, `asset/inline`, `asset/resource`: [Asset generator 选项](/config/module-generator#asset)
+- `css`, `css/auto`, `css/global`, `css/module`: [CSS generator 选项](/config/module-generator#cssauto)
+- `json`: [JSON generator 选项](/config/module-generator#jsonjsonparse)
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -10,19 +10,21 @@ import WebpackLicense from '@components/WebpackLicense';
 
 # Module parser
 
+`module.parser` 用于控制 Rspack 如何解析不同类型的模块。它会影响依赖收集、`import.meta` 和动态 `import()` 等语法的识别，以及各类模块自己的解析行为。
+
 ## parser
 
 - **类型：** `Object`
 - **默认值：** `{}`
 
-使用 `module.parser` 在一个地方配置所有解析器选项。
+使用 `module.parser` 可以按模块类型配置解析器选项。
 
-查看按模块类型拆分的详细页面：
+可配置的 parser 选项分组包括：
 
-- [Asset parser 选项](/config/module-parser#asset)
-- [JavaScript parser 选项](/config/module-parser#javascript)
-- [JSON parser 选项](/config/module-parser#json)
-- [CSS parser 选项](/config/module-parser#cssauto)
+- `asset`: [Asset parser 选项](/config/module-parser#asset)
+- `javascript`, `javascript/auto`, `javascript/dynamic`, `javascript/esm`: [JavaScript parser 选项](/config/module-parser#javascript)
+- `json`: [JSON parser 选项](/config/module-parser#json)
+- `css`, `css/auto`, `css/global`, `css/module`: [CSS parser 选项](/config/module-parser#cssauto)
 
 ```js title="rspack.config.mjs"
 export default {
@@ -909,7 +911,7 @@ export default {
 
 <ApiMeta addedVersion="1.2.0" />
 
-`json` 模块的解析器选项
+`json` 模块的解析器选项。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -58,7 +58,7 @@ export default {
 - **类型：** `Object`
 - **默认值：** `{}`
 
-用于配置不同模块类型的全局 generator 选项。查看 [Module Generator](/config/module-generator) 了解详情。
+使用 `module.generator` 可以按模块类型配置输出生成选项，例如资源文件名、publicPath 和 CSS Modules 导出形式。查看 [Module Generator](/config/module-generator) 了解详情。
 
 ## module.noParse
 
@@ -104,7 +104,7 @@ export default {
 - **类型：** `Object`
 - **默认值：** `{}`
 
-用于配置不同模块类型的全局 parser 选项。查看 [Module Parser](/config/module-parser) 了解详情。
+使用 `module.parser` 可以按模块类型配置解析器选项，例如依赖收集以及模块语法的解析方式。查看 [Module Parser](/config/module-parser) 了解详情。
 
 ## module.rules
 


### PR DESCRIPTION
## Summary

This PR clarifies the module parser and generator docs so users can understand what each option controls before reading the detailed option tables. It adds short introductions, rewrites vague global option descriptions, and lists the supported module type keys next to the parser and generator option group links in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
