### PR TITLE
[codex] fix: tree shake json optional chaining access

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -43,6 +43,9 @@ pub struct ESMImportSpecifierDependency {
   range: DependencyRange,
   #[cacheable(with=AsVec<AsPreset>)]
   ids: Vec<Atom>,
+  #[cacheable(with=AsOption<AsVec<AsPreset>>)]
+  json_safe_ids: Option<Vec<Atom>>,
+  json_safe_range: Option<DependencyRange>,
   call: bool,
   direct_import: bool,
   used_by_exports: Option<UsedByExports>,
@@ -91,6 +94,8 @@ impl ESMImportSpecifierDependency {
       asi_safe,
       range,
       ids,
+      json_safe_ids: None,
+      json_safe_range: None,
       call,
       direct_import,
       export_presence_mode,
@@ -111,6 +116,31 @@ impl ESMImportSpecifierDependency {
   pub fn get_ids<'a>(&'a self, mg: &'a ModuleGraph) -> &'a [Atom] {
     mg.get_dep_meta_if_existing(&self.id)
       .map_or_else(|| self.ids.as_slice(), |meta| meta.ids.as_slice())
+  }
+
+  pub fn set_json_safe_ids(&mut self, ids: Vec<Atom>, range: DependencyRange) {
+    self.json_safe_ids = Some(ids);
+    self.json_safe_range = Some(range);
+  }
+
+  fn get_json_safe_ids<'a>(
+    &'a self,
+    module_graph: &'a ModuleGraph,
+  ) -> Option<(&'a [Atom], DependencyRange)> {
+    let module = module_graph.get_module_by_dependency_id(&self.id)?;
+    if module
+      .build_info()
+      .json_data
+      .as_ref()
+      .is_some_and(|data| data.is_object() || data.is_array())
+    {
+      Some((
+        self.json_safe_ids.as_deref()?,
+        self.json_safe_range.expect("should have json safe range"),
+      ))
+    } else {
+      None
+    }
   }
 
   pub fn name(&self) -> &Atom {
@@ -295,6 +325,10 @@ impl Dependency for ESMImportSpecifierDependency {
     ) && module.build_info().json_data.is_some()
     {
       namespace_object_as_context = true;
+    }
+
+    if let Some((json_safe_ids, _)) = self.get_json_safe_ids(module_graph) {
+      ids = json_safe_ids;
     }
 
     if let Some(id) = ids.first()
@@ -609,7 +643,10 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
     let compilation = code_generatable_context.compilation;
     let runtime = code_generatable_context.runtime;
     let module_graph = compilation.get_module_graph();
-    let ids = dep.get_ids(module_graph);
+    let json_safe_ids = dep.get_json_safe_ids(module_graph);
+    let ids = json_safe_ids
+      .map(|(ids, _)| ids)
+      .unwrap_or_else(|| dep.get_ids(module_graph));
     let connection = module_graph.connection_by_dependency_id(&dep.id);
     // Early return if target is not active and export is not inlined
     if let Some(con) = connection
@@ -643,11 +680,12 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
     }
 
     let export_expr = self.get_code_for_ids(ids, dep, connection, code_generatable_context);
+    let range = json_safe_ids.map(|(_, range)| range).unwrap_or(dep.range);
 
     if dep.shorthand {
-      source.insert(dep.range.end, format!(": {export_expr}"), None);
+      source.insert(range.end, format!(": {export_expr}"), None);
     } else {
-      source.replace(dep.range.start, dep.range.end, export_expr, None);
+      source.replace(range.start, range.end, export_expr, None);
     }
 
     let module_graph = code_generatable_context.compilation.get_module_graph();

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -644,9 +644,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
     let runtime = code_generatable_context.runtime;
     let module_graph = compilation.get_module_graph();
     let json_safe_ids = dep.get_json_safe_ids(module_graph);
-    let ids = json_safe_ids
-      .map(|(ids, _)| ids)
-      .unwrap_or_else(|| dep.get_ids(module_graph));
+    let ids = json_safe_ids.map_or_else(|| dep.get_ids(module_graph), |(ids, _)| ids);
     let connection = module_graph.connection_by_dependency_id(&dep.id);
     // Early return if target is not active and export is not inlined
     if let Some(con) = connection
@@ -680,7 +678,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
     }
 
     let export_expr = self.get_code_for_ids(ids, dep, connection, code_generatable_context);
-    let range = json_safe_ids.map(|(_, range)| range).unwrap_or(dep.range);
+    let range = json_safe_ids.map_or(dep.range, |(_, range)| range);
 
     if dep.shorthand {
       source.insert(range.end, format!(": {export_expr}"), None);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -25,6 +25,12 @@ pub struct ESMImportDependencyParserPlugin;
 
 pub const ESM_SPECIFIER_TAG: &str = "_identifier__esm_specifier_tag__";
 
+fn is_json_safe_optional_chain(members: &[Atom], members_optionals: &[bool]) -> bool {
+  !members.is_empty()
+    && matches!(members_optionals.first(), Some(true))
+    && members_optionals.iter().skip(1).all(|optional| !*optional)
+}
+
 #[derive(Debug, Clone)]
 pub struct ESMSpecifierData {
   pub name: Atom,
@@ -341,6 +347,8 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
     } else {
       member_expr.span()
     };
+    let mut json_safe_ids = settings.ids.clone();
+    json_safe_ids.extend(members.iter().cloned());
     let mut ids = settings.ids;
     ids.extend(non_optional_members.iter().cloned());
     let ns_access = settings.namespace_import && !ids.is_empty();
@@ -348,7 +356,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       .destructuring_assignment_properties
       .get(&member_expr.span())
       .cloned();
-    let dep = ESMImportSpecifierDependency::new(
+    let mut dep = ESMImportSpecifierDependency::new(
       settings.source,
       settings.name,
       settings.source_order,
@@ -365,6 +373,9 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       settings.attributes,
       parser.to_dependency_location(DependencyRange::from(span)),
     );
+    if is_json_safe_optional_chain(members, members_optionals) {
+      dep.set_json_safe_ids(json_safe_ids.into_vec(), member_expr.span.into());
+    }
     let dep_idx = parser.next_dependency_idx();
     parser.add_dependency(Box::new(dep));
 

--- a/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/index.js
@@ -1,0 +1,9 @@
+import pkg from "./package.json";
+
+it("should tree shake json properties used through optional chaining", () => {
+	expect(pkg?.version).toBe("1.0.0");
+
+	const source = __non_webpack_require__("fs").readFileSync(__filename, "utf-8");
+	const unused = ["should", "be", "shaken"].join("-");
+	expect(source).not.toContain(unused);
+});

--- a/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/package.json
+++ b/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "should-be-shaken",
+	"version": "1.0.0",
+	"bin": {
+		"rspack-json-optional-chain": "should-be-shaken"
+	}
+}

--- a/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/rspack.config.js
@@ -1,9 +1,9 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	mode: "production",
-	context: __dirname,
-	optimization: {
-		moduleIds: "named",
-		minimize: false
-	}
+  mode: 'production',
+  context: __dirname,
+  optimization: {
+    moduleIds: 'named',
+    minimize: false,
+  },
 };

--- a/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/json-optional-chaining/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "production",
+	context: __dirname,
+	optimization: {
+		moduleIds: "named",
+		minimize: false
+	}
+};


### PR DESCRIPTION
## Summary

- Preserve full JSON export usage for root optional-chain property reads such as `import pkg from "./package.json"; pkg?.version`.
- Keep the existing non-optional import replacement path for normal ESM optional chains, and only use the full access when the target module is a JSON object or array.
- Add a config case that verifies `pkg?.version` works and unused JSON fields are removed from the generated bundle.

## Validation

- `cargo check -p rspack_plugin_javascript`
- `cargo fmt --all`
- `pnpm run build:binding:dev`
- `pnpm exec rstest Config.part3.test.js -t "configCases/tree-shaking/json-optional-chaining"`
- `pnpm exec rstest Config.part3.test.js -t "configCases/tree-shaking/import-by-name-json"`

Notes: `pnpm run build:js` produced the JS dist but failed during d.ts generation because this local install is missing `@typescript/native-preview/package.json`. The broad `pnpm run test -t ...` form also loads unrelated Normal test files and hit a stale local `@rspack/test-tools` dist export; the targeted Config tests above passed.