### PR TITLE
experimental: remove forced inline annotations

### DIFF
--- a/crates/rspack_napi/src/errors.rs
+++ b/crates/rspack_napi/src/errors.rs
@@ -24,7 +24,6 @@ const fn get_backtrace() -> Option<String> {
 
 /// Extract stack or message from a native Node error object,
 /// otherwise we try to format the error from the given `Error` object that indicates which was created on the Rust side.
-#[inline(always)]
 fn extract_stack_or_message_from_napi_error(
   env: &Env,
   err: Error,

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -120,7 +120,6 @@ fn handle_strict_equality_comparison<'a>(
 }
 
 /// `eql` is `true` for `==` and `false` for `!=`
-#[inline(always)]
 fn handle_abstract_equality_comparison<'a>(
   eql: bool,
   left: BasicEvaluatedExpression<'a>,
@@ -149,7 +148,6 @@ fn handle_abstract_equality_comparison<'a>(
   }
 }
 
-#[inline(always)]
 fn handle_nullish_coalescing<'a>(
   left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr,
@@ -174,7 +172,6 @@ fn handle_nullish_coalescing<'a>(
   }
 }
 
-#[inline(always)]
 fn handle_logical_or<'a>(
   left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr,
@@ -209,7 +206,6 @@ fn handle_logical_or<'a>(
   }
 }
 
-#[inline(always)]
 fn handle_logical_and<'a>(
   left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr,
@@ -244,7 +240,6 @@ fn handle_logical_and<'a>(
   }
 }
 
-#[inline(always)]
 fn handle_add<'a>(
   left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr,
@@ -376,7 +371,6 @@ fn handle_add<'a>(
   Some(res)
 }
 
-#[inline(always)]
 pub fn handle_const_operation<'a>(
   left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr,

--- a/crates/rspack_plugin_schemes/src/http_uri/http_cache.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/http_cache.rs
@@ -57,7 +57,6 @@ pub struct ContentFetchResult {
 }
 
 impl ContentFetchResult {
-  #[inline(always)]
   pub fn content(&self) -> &[u8] {
     match &self.content {
       BufferOrBytes::Buffer(buffer) => buffer.as_ref(),


### PR DESCRIPTION
## Summary
- remove all #[inline(always)] annotations currently present in the repository
- leave normal compiler inlining decisions to rustc for this experiment

## Validation
- rg for inline(always) / force_inline / always_inline returned no matches
- cargo fmt --all --check
- cargo check -p rspack_plugin_javascript -p rspack_plugin_schemes -p rspack_napi

---
_by OpenAI Codex_