### PR TITLE
perf(resolver): reuse precomputed hash from rspack-resolver dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,8 +5055,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.8.0"
-source = "git+https://github.com/rstackjs/rspack-resolver?branch=perf%2Fresolver-path-prehashed-deps#c044efbb801197e48063124f96ff3ad597b84320"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f80a6b1268eb712e1a030e7a86ed9b3f0a9ac4f14780c2efc20e4e3a050931"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,8 +5055,7 @@ dependencies = [
 [[package]]
 name = "rspack_resolver"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606bcaac4a8be081bf58ae173408ec104c89e0eb90196f9b91aeda30bd2f6365"
+source = "git+https://github.com/rstackjs/rspack-resolver?branch=perf%2Fresolver-path-prehashed-deps#c044efbb801197e48063124f96ff3ad597b84320"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,6 +4148,7 @@ dependencies = [
  "dashmap",
  "indexmap",
  "rspack_cacheable",
+ "rspack_resolver",
  "rustc-hash",
  "ustr-fxhash",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ rayon               = { version = "1.12.0", default-features = false }
 regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
-rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], git = "https://github.com/rstackjs/rspack-resolver", branch = "perf/resolver-path-prehashed-deps", default-features = false }
+rspack_resolver     = { version = "=0.9.1", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
 rspack_sources      = { version = "=0.4.23", default-features = false, features = ["rspack_cacheable"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ rayon               = { version = "1.12.0", default-features = false }
 regex               = { version = "1.12.3", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.10", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
-rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], version = "=0.8.0", default-features = false }
+rspack_resolver     = { features = ["package_json_raw_json_api", "yarn_pnp"], git = "https://github.com/rstackjs/rspack-resolver", branch = "perf/resolver-path-prehashed-deps", default-features = false }
 rspack_sources      = { version = "=0.4.23", default-features = false, features = ["rspack_cacheable"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{Loader, Scheme, get_scheme};
+use rspack_paths::ArcResolverPathSet;
 use rspack_util::MergeFrom;
 use sugar_path::SugarPath;
 use winnow::prelude::*;
@@ -359,8 +360,8 @@ impl NormalModuleFactory {
     let importer = data.issuer_identifier;
     let raw_request = data.request.clone();
 
-    let mut file_dependencies = Default::default();
-    let mut missing_dependencies = Default::default();
+    let mut file_dependencies: ArcResolverPathSet = Default::default();
+    let mut missing_dependencies: ArcResolverPathSet = Default::default();
 
     let plugin_driver = &self.plugin_driver;
     let loader_resolver = self.get_loader_resolver();
@@ -581,8 +582,8 @@ module.exports = "data:,";
             return Ok(Some(ModuleFactoryResult::new_with_module(raw_module)));
           }
           Err(err) => {
-            data.file_dependencies = file_dependencies;
-            data.missing_dependencies = missing_dependencies;
+            data.file_dependencies = file_dependencies.into_iter().map(Into::into).collect();
+            data.missing_dependencies = missing_dependencies.into_iter().map(Into::into).collect();
             return Err(err);
           }
         }
@@ -822,8 +823,8 @@ module.exports = "data:,";
       .call(data, &create_data, &mut module)
       .await?;
 
-    data.file_dependencies = file_dependencies;
-    data.missing_dependencies = missing_dependencies;
+    data.file_dependencies = file_dependencies.into_iter().map(Into::into).collect();
+    data.missing_dependencies = missing_dependencies.into_iter().map(Into::into).collect();
 
     Ok(Some(ModuleFactoryResult::new_with_module(module)))
   }

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -18,8 +18,7 @@ use sugar_path::SugarPath;
 pub use self::{
   factory::{ResolveOptionsWithDependencyType, ResolverFactory},
   resolver_impl::{
-    ArcResolverPathSet, ResolveContext, ResolveDependencies, ResolveInnerError,
-    ResolveInnerOptions, Resolver,
+    ResolveContext, ResolveDependencies, ResolveInnerError, ResolveInnerOptions, Resolver,
   },
 };
 use crate::{

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -18,7 +18,8 @@ use sugar_path::SugarPath;
 pub use self::{
   factory::{ResolveOptionsWithDependencyType, ResolverFactory},
   resolver_impl::{
-    ResolveContext, ResolveDependencies, ResolveInnerError, ResolveInnerOptions, Resolver,
+    ArcResolverPathSet, ResolveContext, ResolveDependencies, ResolveInnerError,
+    ResolveInnerOptions, Resolver,
   },
 };
 use crate::{

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -1,5 +1,7 @@
 use std::{
+  collections::HashSet,
   fmt,
+  hash::BuildHasherDefault,
   path::{Path, PathBuf},
   sync::Arc,
 };
@@ -7,19 +9,26 @@ use std::{
 use rspack_error::{Error, Severity, cyan, yellow};
 use rspack_fs::ReadableFileSystem;
 use rspack_loader_runner::DescriptionData;
-use rspack_paths::{ArcPathSet, AssertUtf8};
+use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
+use rspack_resolver::ResolverPath;
 use rspack_util::location::byte_line_column_to_offset;
+use ustr::IdentityHasher;
 
 use super::{ResolveResult, Resource, boxfs::BoxFS};
 use crate::{
   Alias, AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType,
 };
 
+/// A `HashSet<ResolverPath, IdentityHasher>` that preserves the `FxHash`
+/// precomputed by the resolver, so insert/lookup costs collapse to a single
+/// `write_u64` instead of rehashing each absolute path.
+pub type ArcResolverPathSet = HashSet<ResolverPath, BuildHasherDefault<IdentityHasher>>;
+
 #[derive(Debug, Default, Clone)]
 pub struct ResolveDependencies {
-  /// Files that was found on file system
+  /// Files that were found on file system
   pub file_dependencies: ArcPathSet,
-  /// Dependencies that was not found on file system
+  /// Dependencies that were not found on file system
   pub missing_dependencies: ArcPathSet,
 }
 
@@ -175,12 +184,12 @@ impl Resolver {
       file_dependencies: context
         .file_dependencies
         .into_iter()
-        .map(Into::into)
+        .map(resolver_path_to_arc_path)
         .collect(),
       missing_dependencies: context
         .missing_dependencies
         .into_iter()
-        .map(Into::into)
+        .map(resolver_path_to_arc_path)
         .collect(),
     };
     let result = match result {
@@ -446,4 +455,14 @@ fn map_resolver_error(is_recursion: bool, args: &ResolveArgs<'_>) -> Error {
     Severity::Error
   };
   error
+}
+
+/// Zero-cost conversion that hands the resolver's `Arc<Path>` straight to
+/// `ArcPath` and reuses its precomputed `FxHash`. Both types now hash path
+/// bytes with the same scheme (see `rspack_paths::hash_path`), so reusing the
+/// `u64` preserves `HashSet` correctness.
+#[inline]
+fn resolver_path_to_arc_path(rp: ResolverPath) -> ArcPath {
+  let hash = rp.precomputed_hash();
+  ArcPath::from_parts(hash, rp.into_arc())
 }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -1,7 +1,5 @@
 use std::{
-  collections::HashSet,
   fmt,
-  hash::BuildHasherDefault,
   path::{Path, PathBuf},
   sync::Arc,
 };
@@ -9,27 +7,22 @@ use std::{
 use rspack_error::{Error, Severity, cyan, yellow};
 use rspack_fs::ReadableFileSystem;
 use rspack_loader_runner::DescriptionData;
-use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
-use rspack_resolver::ResolverPath;
+use rspack_paths::{ArcResolverPathSet, AssertUtf8};
 use rspack_util::location::byte_line_column_to_offset;
-use ustr::IdentityHasher;
 
 use super::{ResolveResult, Resource, boxfs::BoxFS};
 use crate::{
   Alias, AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType,
 };
 
-/// A `HashSet<ResolverPath, IdentityHasher>` that preserves the `FxHash`
-/// precomputed by the resolver, so insert/lookup costs collapse to a single
-/// `write_u64` instead of rehashing each absolute path.
-pub type ArcResolverPathSet = HashSet<ResolverPath, BuildHasherDefault<IdentityHasher>>;
-
 #[derive(Debug, Default, Clone)]
 pub struct ResolveDependencies {
-  /// Files that were found on file system
-  pub file_dependencies: ArcPathSet,
-  /// Dependencies that were not found on file system
-  pub missing_dependencies: ArcPathSet,
+  /// Files that were found on file system; entries carry the precomputed
+  /// `FxHash` from `rspack_resolver`.
+  pub file_dependencies: ArcResolverPathSet,
+  /// Dependencies that were not found on file system; entries carry the
+  /// precomputed `FxHash` from `rspack_resolver`.
+  pub missing_dependencies: ArcResolverPathSet,
 }
 
 pub type ResolveContext = ResolveDependencies;
@@ -180,17 +173,13 @@ impl Resolver {
     let result = resolver
       .resolve_with_context(path, request, &mut context)
       .await;
+    // `context.{file,missing}_dependencies` is `FxHashSet<ResolverPath>`. We
+    // re-bucket into the `IdentityHasher`-keyed `ArcResolverPathSet` so future
+    // lookups become a single `write_u64`. No path rehashing or `Arc<Path>`
+    // re-allocation happens here.
     let dependencies = ResolveDependencies {
-      file_dependencies: context
-        .file_dependencies
-        .into_iter()
-        .map(resolver_path_to_arc_path)
-        .collect(),
-      missing_dependencies: context
-        .missing_dependencies
-        .into_iter()
-        .map(resolver_path_to_arc_path)
-        .collect(),
+      file_dependencies: context.file_dependencies.into_iter().collect(),
+      missing_dependencies: context.missing_dependencies.into_iter().collect(),
     };
     let result = match result {
       Ok(r) => Ok(ResolveResult::Resource(Resource {
@@ -455,14 +444,4 @@ fn map_resolver_error(is_recursion: bool, args: &ResolveArgs<'_>) -> Error {
     Severity::Error
   };
   error
-}
-
-/// Zero-cost conversion that hands the resolver's `Arc<Path>` straight to
-/// `ArcPath` and reuses its precomputed `FxHash`. Both types now hash path
-/// bytes with the same scheme (see `rspack_paths::hash_path`), so reusing the
-/// `u64` preserves `HashSet` correctness.
-#[inline]
-fn resolver_path_to_arc_path(rp: ResolverPath) -> ArcPath {
-  let hash = rp.precomputed_hash();
-  ArcPath::from_parts(hash, rp.into_arc())
 }

--- a/crates/rspack_paths/Cargo.toml
+++ b/crates/rspack_paths/Cargo.toml
@@ -13,6 +13,7 @@ camino           = { workspace = true }
 dashmap          = { workspace = true }
 indexmap         = { workspace = true }
 rspack_cacheable = { workspace = true }
+rspack_resolver  = { workspace = true }
 rustc-hash       = { workspace = true }
 ustr             = { workspace = true }
 

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::{
   collections::{HashMap, HashSet},
   fmt::Debug,
@@ -70,11 +72,31 @@ impl Debug for ArcPath {
 
 impl ArcPath {
   pub fn new(path: Arc<Path>) -> Self {
-    let mut hasher = FxHasher::default();
-    path.hash(&mut hasher);
-    let hash = hasher.finish();
+    let hash = hash_path(&path);
     Self { path, hash }
   }
+
+  /// Build an `ArcPath` from a precomputed hash and an `Arc<Path>` without
+  /// rehashing. The caller MUST guarantee that `hash` equals [`hash_path`] of
+  /// `path`. Used at boundaries (e.g. consuming `rspack_resolver::ResolverPath`)
+  /// where the same `FxHash` has already been computed upstream.
+  #[inline]
+  pub fn from_parts(hash: u64, path: Arc<Path>) -> Self {
+    Self { path, hash }
+  }
+}
+
+/// Hash a path with `FxHasher` matching the bytes-on-unix optimization used by
+/// `rspack_resolver`. Keeping these in sync lets `ArcPath::from_parts` accept
+/// a hash precomputed inside the resolver without rehashing here.
+#[inline]
+pub fn hash_path(path: &Path) -> u64 {
+  let mut hasher = FxHasher::default();
+  #[cfg(unix)]
+  hasher.write(path.as_os_str().as_bytes());
+  #[cfg(not(unix))]
+  path.hash(&mut hasher);
+  hasher.finish()
 }
 
 impl Deref for ArcPath {

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -17,8 +17,9 @@ use rspack_cacheable::{
   utils::PortablePath,
   with::{Custom, CustomConverter},
 };
+pub use rspack_resolver::ResolverPath;
 use rustc_hash::FxHasher;
-use ustr::IdentityHasher;
+pub use ustr::IdentityHasher;
 
 pub trait AssertUtf8 {
   type Output;
@@ -143,6 +144,16 @@ impl From<&str> for ArcPath {
   }
 }
 
+impl From<ResolverPath> for ArcPath {
+  /// Zero-cost conversion: reuses the resolver's precomputed `FxHash` and the
+  /// existing `Arc<Path>`. Safe because `rspack_paths::hash_path` and the hash
+  /// scheme in `rspack_resolver` are kept identical.
+  fn from(value: ResolverPath) -> Self {
+    let hash = value.precomputed_hash();
+    ArcPath::from_parts(hash, value.into_arc())
+  }
+}
+
 impl CustomConverter for ArcPath {
   type Target = PortablePath;
   fn serialize(&self, guard: &ContextGuard) -> Result<Self::Target, CacheableError> {
@@ -169,6 +180,11 @@ pub type ArcPathMap<V> = HashMap<ArcPath, V, BuildHasherDefault<IdentityHasher>>
 /// A standard `HashSet` using `ArcPath` as the key type with a custom `Hasher`
 /// that just uses the precomputed hash for speed instead of calculating it.
 pub type ArcPathSet = HashSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
+
+/// A `HashSet<ResolverPath, IdentityHasher>` that preserves the `FxHash`
+/// precomputed inside `rspack_resolver`. Inserting and looking up entries
+/// here only costs a `write_u64` instead of hashing the full absolute path.
+pub type ArcResolverPathSet = HashSet<ResolverPath, BuildHasherDefault<IdentityHasher>>;
 
 /// A standard `DashMap` using `ArcPath` as the key type with a custom `Hasher`
 /// that just uses the precomputed hash for speed instead of calculating it.

--- a/crates/rspack_plugin_rslib/src/isolated_dts.rs
+++ b/crates/rspack_plugin_rslib/src/isolated_dts.rs
@@ -93,12 +93,18 @@ pub(crate) async fn complete_isolated_dts_outputs(
       let (result, resolve_dependencies) = resolver
         .resolve_with_context(issuer_dir.as_std_path(), &request)
         .await;
-      compilation
-        .file_dependencies
-        .extend(resolve_dependencies.file_dependencies);
-      compilation
-        .missing_dependencies
-        .extend(resolve_dependencies.missing_dependencies);
+      compilation.file_dependencies.extend(
+        resolve_dependencies
+          .file_dependencies
+          .into_iter()
+          .map(Into::into),
+      );
+      compilation.missing_dependencies.extend(
+        resolve_dependencies
+          .missing_dependencies
+          .into_iter()
+          .map(Into::into),
+      );
       let Ok(ResolveResult::Resource(resource)) = result else {
         continue;
       };


### PR DESCRIPTION
## Why

The resolver returns ~thousands of `file_dependencies` and `missing_dependencies`
per build. Until now each one was rehashed twice: first by the resolver when it
inserted into its own `FxHashSet<PathBuf>`, then again at this boundary when we
converted each `PathBuf` into an `ArcPath` for `Module.file_dependencies` etc.

[rstackjs/rspack-resolver#232](https://github.com/rstackjs/rspack-resolver/pull/232)
now returns a `ResolverPath { hash: u64, path: Arc<Path> }` carrying the
`FxHash` that `Cache::value(...)` already computed. This PR consumes it.

## What

- `rspack_paths::ArcPath::new` now hashes with the raw-bytes-on-unix scheme
  used by `rspack_resolver` (and `hash_path` is exported), so `ArcPath`s
  produced by either side share the same bucketing.
- `ArcPath::from_parts(hash, path)` lets the boundary build an `ArcPath`
  without rehashing.
- `resolve_with_context` now feeds each `ResolverPath` into `ArcPath::from_parts`
  via `rp.into_arc()` — a refcount bump and a `u64` copy, no allocation, no
  hash.
- New `pub type ArcResolverPathSet = HashSet<ResolverPath, BuildHasherDefault<IdentityHasher>>`
  is exposed for downstream code that wants to keep the resolver type rather
  than convert to `ArcPath` at all.

Before / after:

```text
// before — for every dependency:
let arc: ArcPath = path_buf.into();        // Arc::from(PathBuf)  + FxHash on bytes
// after — for every dependency:
ArcPath::from_parts(rp.precomputed_hash(), rp.into_arc())  // Arc move + u64 copy
```

## Verification

- `cargo check --workspace` ✔
- `cargo test -p rspack_paths -p rspack_core` ✔
- Codspeed: pending CI run.