### PR TITLE
perf: content into_string_lossy

### DIFF
--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -34,7 +34,7 @@ impl Content {
   pub fn into_string_lossy(self) -> String {
     match self {
       Content::String(s) => s,
-      Content::Buffer(b) => String::from_utf8_lossy(&b).into_owned(),
+      Content::Buffer(b) => String::from_utf8_lossy_owned(b),
     }
   }
 

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -1,4 +1,5 @@
 use std::{
+  borrow::Cow,
   fmt::Debug,
   path::{Path, PathBuf},
   sync::Arc,
@@ -34,7 +35,18 @@ impl Content {
   pub fn into_string_lossy(self) -> String {
     match self {
       Content::String(s) => s,
-      Content::Buffer(b) => String::from_utf8_lossy_owned(b),
+      Content::Buffer(b) => {
+        if let Cow::Owned(string) = String::from_utf8_lossy(&b) {
+          string
+        } else {
+          // SAFETY: `String::from_utf8_lossy`'s contract ensures that if
+          // it returns a `Cow::Borrowed`, it is a valid UTF-8 string.
+          // Otherwise, it returns a new allocation of an owned `String`, with
+          // replacement characters for invalid sequences, which is returned
+          // above.
+          unsafe { String::from_utf8_unchecked(b) }
+        }
+      }
     }
   }
 

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -1,5 +1,4 @@
 use std::{
-  borrow::Cow,
   fmt::Debug,
   path::{Path, PathBuf},
   sync::Arc,
@@ -35,18 +34,7 @@ impl Content {
   pub fn into_string_lossy(self) -> String {
     match self {
       Content::String(s) => s,
-      Content::Buffer(b) => {
-        if let Cow::Owned(string) = String::from_utf8_lossy(&b) {
-          string
-        } else {
-          // SAFETY: `String::from_utf8_lossy`'s contract ensures that if
-          // it returns a `Cow::Borrowed`, it is a valid UTF-8 string.
-          // Otherwise, it returns a new allocation of an owned `String`, with
-          // replacement characters for invalid sequences, which is returned
-          // above.
-          unsafe { String::from_utf8_unchecked(b) }
-        }
-      }
+      Content::Buffer(b) => String::from_utf8_lossy_owned(b),
     }
   }
 

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(string_from_utf8_lossy_owned)]
+
 mod content;
 mod context;
 mod loader;


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Optimize `Content::into_string_lossy` for `Content::Buffer` when the buffer already contains valid UTF-8.

Previously, `String::from_utf8_lossy(&b).into_owned()` always produced an owned `String`, which copied valid UTF-8 buffers into a new allocation. This PR keeps the existing lossy behavior for invalid UTF-8, but for the common valid UTF-8 path it reuses the original `Vec<u8>` via `String::from_utf8_unchecked` after `from_utf8_lossy` has already validated the bytes.

This avoids an unnecessary copy/allocation in a shared content conversion path while preserving the current output semantics.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
