### PR TITLE
feat: support import option for import.meta.glob

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -35,7 +35,7 @@ use crate::{
   ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleId, ModuleIdsArtifact,
   ModuleLayer, ModuleType, RealDependencyLocation, ReferencedSpecifier, Resolve, RuntimeGlobals,
   RuntimeSpec, SourceType, contextify, get_exports_type_with_strict, get_outgoing_async_modules,
-  impl_module_meta_info, module_update_hash, to_path,
+  impl_module_meta_info, module_update_hash, property_access, to_path,
 };
 
 static CHUNK_NAME_INDEX_PLACEHOLDER: &str = "[index]";
@@ -188,6 +188,7 @@ pub struct ContextOptions {
   pub end: u32,
   #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
   pub referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
+  pub glob_import: Option<String>,
   pub attributes: Option<ImportAttributes>,
   pub phase: Option<ImportPhase>,
 }
@@ -209,6 +210,7 @@ impl Default for ContextOptions {
       start: 0,
       end: 0,
       referenced_specifiers: None,
+      glob_import: None,
       attributes: None,
       phase: None,
     }
@@ -555,6 +557,15 @@ impl ContextModule {
     )
   }
 
+  fn get_glob_import_property_access(&self) -> Option<String> {
+    self
+      .options
+      .context_options
+      .glob_import
+      .as_ref()
+      .map(|import| property_access([import.as_str()], 0))
+  }
+
   fn get_sorted_context_block_info(&self, compilation: &Compilation) -> Vec<ContextBlockInfo> {
     let module_graph = compilation.get_module_graph();
     let mut block_info: Vec<_> = self
@@ -597,7 +608,7 @@ impl ContextModule {
 
         let mut entries = String::with_capacity(block_info.len() * 96);
         for (i, info) in block_info.iter().enumerate() {
-          let import_promise = runtime_template.module_namespace_promise(
+          let mut import_promise = runtime_template.module_namespace_promise(
             compilation,
             self.identifier,
             &info.dep_id,
@@ -607,6 +618,14 @@ impl ContextModule {
             false,
             self.options.context_options.phase.unwrap_or_default(),
           );
+          if let Some(access) = self.get_glob_import_property_access() {
+            import_promise = concat_string!(
+              import_promise,
+              ".then(function(m) { return m",
+              access,
+              "; })"
+            );
+          }
           Self::append_glob_map_entry(
             &mut entries,
             i,
@@ -633,12 +652,17 @@ impl ContextModule {
         );
 
         let mut entries = String::with_capacity(map.len() * 64);
+        let glob_import_access = self.get_glob_import_property_access();
         for (i, (user_request, module_id)) in map.iter().enumerate() {
           let module_id_expr = if let Some(id) = module_id {
-            format!(
+            let mut module_expr = format!(
               "function() {{ var id = {}; return {return_module_object}; }}()",
               json_stringify(id)
-            )
+            );
+            if let Some(access) = &glob_import_access {
+              module_expr.push_str(access);
+            }
+            module_expr
           } else {
             concat_string!("undefined /* ", json_stringify(user_request), " */")
           };
@@ -1334,6 +1358,10 @@ impl Module for ContextModule {
         })
         .join(", ");
     }
+    if let Some(import) = &self.options.context_options.glob_import {
+      id += " globImport: ";
+      id += import;
+    }
     Some(Cow::Owned(id))
   }
 
@@ -1536,6 +1564,10 @@ fn create_identifier(options: &ContextModuleOptions, resource: Option<&str>) -> 
         }
       })
       .join(", ");
+  }
+  if let Some(import) = &options.context_options.glob_import {
+    id += "|globImport: ";
+    id += import;
   }
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.context_options.group_options {

--- a/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
@@ -72,6 +72,11 @@ fn create_resource_identifier_for_context_dependency(
         .join(", ")
     })
     .unwrap_or_default();
+  let glob_import = options
+    .glob_import
+    .as_ref()
+    .map(|import| format!("globImport: {import}"))
+    .unwrap_or_default();
   let mut group_options = String::new();
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.group_options {
@@ -92,7 +97,7 @@ fn create_resource_identifier_for_context_dependency(
   }
 
   let id = format!(
-    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports}",
+    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import}",
   );
   id.into()
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -1,11 +1,12 @@
 use rspack_core::{
   ContextMode, ContextModulePattern, ContextNameSpaceObject, ContextOptions, DependencyCategory,
-  extract_glob_base_dir, get_context, normalize_path_separators,
+  ReferencedSpecifier, extract_glob_base_dir, get_context, normalize_path_separators,
 };
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_regex::RspackRegex;
 use rspack_util::{SpanExt, node_path::NodePath};
 use swc_core::{
+  atoms::Atom,
   common::Spanned,
   ecma::ast::{CallExpr, Expr},
 };
@@ -202,17 +203,20 @@ fn create_import_meta_glob_dependency(
   let base_dir = common_glob_base_dir(&resolved_glob_patterns, context.as_str());
   let recursive = glob_patterns_are_recursive(&resolved_glob_patterns, &base_dir);
 
-  let mode = node
-    .args
-    .get(1)
-    .and_then(|arg| arg.expr.as_object())
-    .map_or(ContextMode::Lazy, |obj| {
-      if get_bool_by_obj_prop(obj, "eager").is_some_and(|b| b.value) {
-        ContextMode::Sync
-      } else {
-        ContextMode::Lazy
-      }
-    });
+  let glob_options = node.args.get(1).and_then(|arg| arg.expr.as_object());
+  let mode = glob_options.map_or(ContextMode::Lazy, |obj| {
+    if get_bool_by_obj_prop(obj, "eager").is_some_and(|b| b.value) {
+      ContextMode::Sync
+    } else {
+      ContextMode::Lazy
+    }
+  });
+  let glob_import = glob_options
+    .and_then(|obj| get_literal_str_by_obj_prop(obj, "import"))
+    .map(|s| s.value.to_string_lossy().into_owned());
+  let referenced_specifiers = glob_import
+    .as_ref()
+    .map(|import| vec![ReferencedSpecifier::new(vec![Atom::from(import.as_str())])]);
   let namespace_object = if parser.build_meta.strict_esm_module {
     ContextNameSpaceObject::Strict
   } else {
@@ -229,6 +233,8 @@ fn create_import_meta_glob_dependency(
     mode,
     start: node.span().real_lo(),
     end: node.span().real_hi(),
+    referenced_specifiers,
+    glob_import,
     ..Default::default()
   };
   Some(ImportMetaContextDependency::new_glob(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -494,6 +494,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
           start: import_call_span.real_lo(),
           end: import_call_span.real_hi(),
           referenced_specifiers: exports,
+          glob_import: None,
           attributes,
           phase: Some(phase),
         },

--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -172,6 +172,10 @@ declare namespace Rspack {
   }
 
   type ImportMetaGlobPattern = string | readonly string[];
+  type ImportMetaGlobOptions<Eager extends boolean = boolean> = {
+    eager?: Eager;
+    import?: string;
+  };
 
   interface Module {
     exports: any;
@@ -246,16 +250,12 @@ interface ImportMeta {
   glob: {
     <T = unknown>(
       pattern: Rspack.ImportMetaGlobPattern,
-      options: {
-        eager: true;
-      },
-    ): Record<string, T>;
+      options?: Rspack.ImportMetaGlobOptions<false>,
+    ): Record<string, () => Promise<T>>;
     <T = unknown>(
       pattern: Rspack.ImportMetaGlobPattern,
-      options?: {
-        eager?: false;
-      },
-    ): Record<string, () => Promise<T>>;
+      options: Rspack.ImportMetaGlobOptions<true>,
+    ): Record<string, T>;
   };
 }
 

--- a/tests/rspack-test/normalCases/context/import-meta-glob/dir/bar.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/dir/bar.js
@@ -1,1 +1,2 @@
 export default 'bar';
+export const named = 'bar named';

--- a/tests/rspack-test/normalCases/context/import-meta-glob/dir/foo.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/dir/foo.js
@@ -1,1 +1,2 @@
 export default 'foo';
+export const named = 'foo named';

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -9,6 +9,8 @@ const dotfileModules = import.meta.glob('./dot/.*.js')
 const filteredModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], { eager: true })
 const multiModules = import.meta.glob(['./dir/*.js', './other/*.js'], { eager: true })
 const lazyMultiModules = import.meta.glob(['./dir/*.js', './other/*.js'])
+const lazyDefaultModules = import.meta.glob('./dir/*.js', { import: 'default' })
+const lazyNamedModules = import.meta.glob('./dir/*.js', { import: 'named' })
 
 it('should return a thunk for each matched file in lazy mode', async () => {
   const keys = Object.keys(lazyModules).sort()
@@ -94,8 +96,29 @@ it('should support multiple glob patterns in lazy mode', async () => {
   expect(baz.default).toBe('baz')
 })
 
+it('should expose selected default exports in lazy mode', async () => {
+  const keys = Object.keys(lazyDefaultModules).sort()
+  expect(keys).toEqual(['./dir/bar.js', './dir/foo.js'])
+
+  await expect(lazyDefaultModules['./dir/foo.js']()).resolves.toBe('foo')
+  await expect(lazyDefaultModules['./dir/bar.js']()).resolves.toBe('bar')
+})
+
+it('should expose selected named exports in lazy mode', async () => {
+  await expect(lazyNamedModules['./dir/foo.js']()).resolves.toBe('foo named')
+  await expect(lazyNamedModules['./dir/bar.js']()).resolves.toBe('bar named')
+})
+
 // Eager: each value is the module object directly
 const eagerModules = import.meta.glob('./dir/*.js', { eager: true })
+const eagerDefaultModules = import.meta.glob('./dir/*.js', {
+  eager: true,
+  import: 'default',
+})
+const eagerNamedModules = import.meta.glob('./dir/*.js', {
+  eager: true,
+  import: 'named',
+})
 
 it('should expose module objects directly in eager mode', () => {
   const keys = Object.keys(eagerModules).sort()
@@ -106,4 +129,14 @@ it('should expose module objects directly in eager mode', () => {
 
 it('should expose eager CommonJS matches as dynamic import namespace objects', () => {
   expect(eagerCjsModules['./cjs/value.js'].default.answer).toBe(42)
+})
+
+it('should expose selected default exports in eager mode', () => {
+  expect(eagerDefaultModules['./dir/foo.js']).toBe('foo')
+  expect(eagerDefaultModules['./dir/bar.js']).toBe('bar')
+})
+
+it('should expose selected named exports in eager mode', () => {
+  expect(eagerNamedModules['./dir/foo.js']).toBe('foo named')
+  expect(eagerNamedModules['./dir/bar.js']).toBe('bar named')
 })

--- a/tests/type-tests/resolution-bundler/index.ts
+++ b/tests/type-tests/resolution-bundler/index.ts
@@ -38,6 +38,17 @@ eagerGlobModules['./dir/foo.js'].default.toUpperCase();
 const lazyGlobModules = import.meta.glob<GlobModule>('./dir/*.js');
 lazyGlobModules['./dir/foo.js']().then((mod) => mod.default.toUpperCase());
 
+const eagerDefaultGlobModules = import.meta.glob<string>('./dir/*.js', {
+  eager: true,
+  import: 'default',
+});
+eagerDefaultGlobModules['./dir/foo.js'].toUpperCase();
+
+const lazyDefaultGlobModules = import.meta.glob<string>('./dir/*.js', {
+  import: 'default',
+});
+lazyDefaultGlobModules['./dir/foo.js']().then((mod) => mod.toUpperCase());
+
 const multiGlobModules = import.meta.glob<GlobModule>(
   ['./dir/*.js', '!**/bar.js'] as const,
   {

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -328,24 +328,40 @@ componentsContext.keys().forEach((fileName) => {
 - **Type:**
 
 ```ts
+interface ImportMetaGlobOptions<Eager extends boolean = boolean> {
+  /**
+   * If `true`, modules are loaded synchronously.
+   *
+   * @default false
+   */
+  eager?: Eager;
+  /**
+   * Import only the specific named export. Set to `default` to import the default export.
+   */
+  import?: string;
+}
+
 function glob(
   /**
-   * A glob pattern to match files.
+   * A glob pattern, or an array of glob patterns, to match files.
    */
-  pattern: string,
-  options?: {
-    /**
-     * If `true`, modules are loaded synchronously.
-     * @default false
-     */
-    eager?: boolean;
-  },
-): Record<string, () => Promise<Record<string, any>>>;
+  pattern: string | readonly string[],
+  options?: ImportMetaGlobOptions<false>,
+): Record<string, () => Promise<any>>;
+
+function glob(
+  /**
+   * A glob pattern, or an array of glob patterns, to match files.
+   */
+  pattern: string | readonly string[],
+  options: ImportMetaGlobOptions<true>,
+): Record<string, any>;
 ```
 
 - **Parameters:**
-  - `pattern`: A glob pattern string to match files (e.g., `'./dir/*.js'`). Supports `*`, `?`, `[abc]`, `{a,b}`, and `**` for recursive matching.
+  - `pattern`: A glob pattern string, or an array of glob pattern strings, to match files (e.g., `'./dir/*.js'`). Supports `*`, `?`, `[abc]`, `{a,b}`, and `**` for recursive matching. Array patterns can also include negative patterns such as `'!**/bar.js'`.
   - `options.eager`: When set to `true`, modules are included directly in the bundle and loaded synchronously. By default (`false`), modules are lazily loaded and each value is a thunk function that returns a `Promise` resolving to the module.
+  - `options.import`: Import only the specified export from each matched module. For example, use `'default'` to get default exports, or a named export such as `'setup'`.
 
 - **Example:**
 
@@ -361,12 +377,24 @@ console.log(foo.default);
 const eagerModules = import.meta.glob('./dir/*.js', { eager: true });
 console.log(eagerModules['./dir/foo.js'].default);
 
+// Import only the default export from each matched module
+const defaultModules = import.meta.glob('./dir/*.js', { import: 'default' });
+const fooDefault = await defaultModules['./dir/foo.js']();
+console.log(fooDefault);
+
+// Combine eager loading with import selection
+const eagerDefaultModules = import.meta.glob('./dir/*.js', {
+  eager: true,
+  import: 'default',
+});
+console.log(eagerDefaultModules['./dir/foo.js']);
+
 // Recursive matching with **
 const allModules = import.meta.glob('./components/**/*.js', { eager: true });
 ```
 
 :::tip
-Rspack uses static analysis to parse the parameters of `import.meta.glob()` during compilation. Therefore, the `pattern` parameter must be a string literal, and the `options` parameter must be an object literal. Variables or dynamically constructed values are not supported.
+Rspack uses static analysis to parse the parameters of `import.meta.glob()` during compilation. Therefore, the `pattern` parameter must be a string literal or an array of string literals, and the `options` parameter must be an object literal. Variables or dynamically constructed values are not supported.
 :::
 
 :::warning

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -321,9 +321,9 @@ componentsContext.keys().forEach((fileName) => {
 
 ### import.meta.glob
 
-<ApiMeta specific={['Rspack']} />
+<ApiMeta specific={['Rspack']} addedVersion="2.0.5" />
 
-`import.meta.glob` is a Vite-compatible API that allows you to import multiple modules at once using glob patterns. Rspack will parse and reference the matching modules during the build process.
+`import.meta.glob` allows you to import multiple modules at once using glob patterns. Rspack will parse and reference the matching modules during the build process.
 
 - **Type:**
 

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -321,9 +321,9 @@ componentsContext.keys().forEach((fileName) => {
 
 ### import.meta.glob
 
-<ApiMeta specific={['Rspack']} />
+<ApiMeta specific={['Rspack']} addedVersion="2.0.5" />
 
-`import.meta.glob` 是一个与 Vite 兼容的 API，允许你使用 glob 模式一次导入多个模块。Rspack 将在构建时解析并引用匹配的模块。
+`import.meta.glob` 允许你使用 glob 模式一次导入多个模块。Rspack 将在构建时解析并引用匹配的模块。
 
 - **类型：**
 

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -328,24 +328,40 @@ componentsContext.keys().forEach((fileName) => {
 - **类型：**
 
 ```ts
+interface ImportMetaGlobOptions<Eager extends boolean = boolean> {
+  /**
+   * 如果为 `true`，模块将同步加载
+   *
+   * @default false
+   */
+  eager?: Eager;
+  /**
+   * 只导入指定的具名导出。设置为 `default` 时会导入默认导出。
+   */
+  import?: string;
+}
+
 function glob(
   /**
-   * 匹配文件的 glob 模式
+   * 匹配文件的 glob 模式，或 glob 模式数组
    */
-  pattern: string,
-  options?: {
-    /**
-     * 如果为 `true`，模块将同步加载
-     * @default false
-     */
-    eager?: boolean;
-  },
-): Record<string, () => Promise<Record<string, any>>>;
+  pattern: string | readonly string[],
+  options?: ImportMetaGlobOptions<false>,
+): Record<string, () => Promise<any>>;
+
+function glob(
+  /**
+   * 匹配文件的 glob 模式，或 glob 模式数组
+   */
+  pattern: string | readonly string[],
+  options: ImportMetaGlobOptions<true>,
+): Record<string, any>;
 ```
 
 - **参数：**
-  - `pattern`：匹配文件的 glob 模式字符串（例如 `'./dir/*.js'`）。支持 `*`、`?`、`[abc]`、`{a,b}` 以及 `**`（递归匹配）。
+  - `pattern`：匹配文件的 glob 模式字符串，或 glob 模式字符串数组（例如 `'./dir/*.js'`）。支持 `*`、`?`、`[abc]`、`{a,b}` 以及 `**`（递归匹配）。数组模式也可以包含负向模式，例如 `'!**/bar.js'`。
   - `options.eager`：设置为 `true` 时，模块直接包含在 bundle 中并同步加载。默认为 `false`，模块会延迟加载，每个值是一个返回 `Promise` 的 thunk 函数。
+  - `options.import`：只导入每个匹配模块的指定导出。例如使用 `'default'` 获取默认导出，或使用 `'setup'` 这样的具名导出。
 
 - **示例：**
 
@@ -361,12 +377,24 @@ console.log(foo.default);
 const eagerModules = import.meta.glob('./dir/*.js', { eager: true });
 console.log(eagerModules['./dir/foo.js'].default);
 
+// 只导入每个匹配模块的默认导出
+const defaultModules = import.meta.glob('./dir/*.js', { import: 'default' });
+const fooDefault = await defaultModules['./dir/foo.js']();
+console.log(fooDefault);
+
+// 将同步加载和指定导出结合使用
+const eagerDefaultModules = import.meta.glob('./dir/*.js', {
+  eager: true,
+  import: 'default',
+});
+console.log(eagerDefaultModules['./dir/foo.js']);
+
 // 使用 ** 进行递归匹配
 const allModules = import.meta.glob('./components/**/*.js', { eager: true });
 ```
 
 :::tip
-Rspack 在编译时会通过静态分析来解析 `import.meta.glob()` 的参数，因此 `pattern` 参数必须是字符串字面量，`options` 参数必须是对象字面量。不支持使用变量或动态构造的值。
+Rspack 在编译时会通过静态分析来解析 `import.meta.glob()` 的参数，因此 `pattern` 参数必须是字符串字面量或字符串字面量数组，`options` 参数必须是对象字面量。不支持使用变量或动态构造的值。
 :::
 
 :::warning


### PR DESCRIPTION
## Summary

- Add support for `import.meta.glob(pattern, { import: "xxx" })`
- Return the selected export for both lazy and eager glob modes
- Track referenced exports for the selected glob import
- Add coverage for `import: "default"` and named exports

## Testing

- cargo check -p rspack_core -p rspack_plugin_javascript
- pnpm run build:js
- pnpm run build:binding:dev
- pnpm --filter @rspack/tests test -t "normalCases/context/import-meta-glob"

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
