### PR TITLE
perf(javascript): reduce parser allocations

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -419,8 +419,8 @@ impl<'parser> JavascriptParser<'parser> {
     parse_meta: ParseMeta,
     parser_runtime_requirements: &'parser ParserRuntimeRequirementsData,
   ) -> Self {
-    let warning_diagnostics: Vec<Diagnostic> = Vec::with_capacity(4);
-    let errors = Vec::with_capacity(4);
+    let warning_diagnostics: Vec<Diagnostic> = Vec::new();
+    let errors = Vec::new();
     let dependencies = Vec::with_capacity(64);
     let blocks = Vec::with_capacity(64);
     let presentational_dependencies = Vec::with_capacity(64);


### PR DESCRIPTION
## Summary
most module don't have errors and warnings, so eagerly allocation for errors and warnings is not necessary.
- Replace eager diagnostic-vector allocation in `JavaScriptParser::new` with empty vectors for parser warnings and errors.
- Keep dependency, block, presentational dependency, and parser plugin vector preallocation unchanged.

## Why

Valgrind DHAT analysis of the `build_module_graph` benchmark showed `JavaScriptParser::new` runs on a high-cardinality module parsing path. Warning and error vectors are usually empty on successful parses, so allocating them lazily avoids unnecessary per-module heap allocation.

## Expected impact

This should slightly reduce build-module-graph heap allocation on successful parser paths without changing parser behavior or emitted output.

Checked with `cargo check -p rspack_plugin_javascript`.