### PR TITLE
docs: document loader peer dependencies

### DIFF
--- a/website/docs/en/api/loader-api/writing-loaders.mdx
+++ b/website/docs/en/api/loader-api/writing-loaders.mdx
@@ -143,11 +143,9 @@ For example, with the following configuration:
 
 ```js title="rspack.config.mjs"
 export default {
-  //...
   module: {
     rules: [
       {
-        //...
         use: ['a-loader', 'b-loader', 'c-loader'],
       },
     ],
@@ -327,6 +325,46 @@ export default async function myLoader(source, inputSourceMap) {
     }
   } catch (err) {
     callback(err);
+  }
+}
+```
+
+## Publishing loaders
+
+### Declaring peer dependencies
+
+When publishing a loader as an npm package, declare the bundler packages it integrates with as optional peer dependencies. This documents the supported host bundlers without requiring users who only use one bundler to install the other.
+
+If the loader is designed only for Rspack, declare `@rspack/core` as an optional peer dependency. Set the version range according to the APIs the loader relies on. For example, if the loader uses an API introduced in a newer Rspack release, set that release as the minimum supported version.
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  }
+}
+```
+
+If the loader is designed to work with both Rspack and webpack, declare both `@rspack/core` and `webpack` as optional peer dependencies:
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0",
+    "webpack": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   }
 }
 ```

--- a/website/docs/zh/api/loader-api/writing-loaders.mdx
+++ b/website/docs/zh/api/loader-api/writing-loaders.mdx
@@ -144,11 +144,9 @@ Raw Loader 在处理图片压缩、二进制资源转换、文件编码等场景
 
 ```js title="rspack.config.mjs"
 export default {
-  //...
   module: {
     rules: [
       {
-        //...
         use: ['a-loader', 'b-loader', 'c-loader'],
       },
     ],
@@ -329,6 +327,44 @@ export default async function myLoader(source, inputSourceMap) {
     }
   } catch (err) {
     callback(err);
+  }
+}
+```
+
+## 发布 loader
+
+### 声明 peer dependencies
+
+将 loader 发布为 npm 包时，如果这个 loader 仅面向 Rspack，将 `@rspack/core` 声明为 optional peer dependency 即可。版本范围应根据 loader 实际依赖的 API 来决定；如果使用了某个 Rspack 新版本引入的 API，需要将最低版本限制为该版本。
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  }
+}
+```
+
+如果这个 loader 同时适配 Rspack 和 webpack，则将 `@rspack/core` 和 `webpack` 都声明为 optional peer dependencies：
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0",
+    "webpack": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary

This PR updates the loader authoring docs to explain how loaders published as npm packages should declare optional peer dependencies for Rspack-only packages and loaders that support both Rspack and webpack.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).