### PR TITLE
docs: document plugin peer dependencies

### DIFF
--- a/website/docs/en/guide/features/plugin.mdx
+++ b/website/docs/en/guide/features/plugin.mdx
@@ -171,3 +171,43 @@ export class MyPlugin implements RspackPluginInstance {
   }
 }
 ```
+
+## Publishing plugins
+
+### Declaring peer dependencies
+
+When publishing a plugin as an npm package, declare the bundler packages it integrates with as optional peer dependencies. This documents the supported host bundlers without requiring users who only use one bundler to install the other.
+
+If the plugin is designed only for Rspack, declare `@rspack/core` as an optional peer dependency. Set the version range according to the APIs the plugin relies on. For example, if the plugin uses an API introduced in a newer Rspack release, set that release as the minimum supported version.
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  }
+}
+```
+
+If the plugin is designed to work with both Rspack and webpack, declare both `@rspack/core` and `webpack` as optional peer dependencies:
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0",
+    "webpack": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
+  }
+}
+```

--- a/website/docs/zh/guide/features/plugin.mdx
+++ b/website/docs/zh/guide/features/plugin.mdx
@@ -171,3 +171,41 @@ export class MyPlugin implements RspackPluginInstance {
   }
 }
 ```
+
+## 发布插件
+
+### 声明 peer dependencies
+
+将插件发布为 npm 包时，如果这个插件仅面向 Rspack，将 `@rspack/core` 声明为 optional peer dependency 即可。版本范围应根据插件实际依赖的 API 来决定；如果使用了某个 Rspack 新版本引入的 API，需要将最低版本限制为该版本。
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  }
+}
+```
+
+如果这个插件同时适配 Rspack 和 webpack，则将 `@rspack/core` 和 `webpack` 都声明为 optional peer dependencies：
+
+```json title="package.json"
+{
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0 || ^2.0.0",
+    "webpack": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

This PR updates the plugin guide to explain how plugins published as npm packages should declare optional peer dependencies for Rspack-only packages and plugins that support both Rspack and webpack.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).