### PR TITLE
fix: mark json parse output as pure

### DIFF
--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -212,7 +212,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
         let json_str = utils::escape_json(&final_json_string);
         let json_expr = if self.json_parse && is_js_object && json_str.len() > 20 {
           Cow::Owned(format!(
-            "JSON.parse('{}')",
+            "/*#__PURE__*/JSON.parse('{}')",
             json_str.cow_replace('\\', r"\\").cow_replace('\'', r"\'")
           ))
         } else {

--- a/tests/rspack-test/builtinCases/plugin-json/simple/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-json/simple/__snapshots__/output.snap.txt
@@ -12,7 +12,7 @@ console.log(_json_json__rspack_import_0,_string_json__rspack_import_1)
 
 },
 "./json.json"(module) {
-module.exports = JSON.parse('{"hello":"world is better \'","b":"\\\\"}')
+module.exports = /*#__PURE__*/JSON.parse('{"hello":"world is better \'","b":"\\\\"}')
 
 },
 "./string.json"(module) {

--- a/tests/rspack-test/builtinCases/plugin-rsdoctor/json-size-tree-shaking/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-rsdoctor/json-size-tree-shaking/__snapshots__/output.snap.txt
@@ -29,7 +29,7 @@ it("should tree-shake unused JSON properties", () => {
 
 },
 "./data.json"(module) {
-module.exports = JSON.parse('{"user":{"name":"Alice","age":25,"email":"alice@example.com","profile":{"bio":"Software Engineer","avatar":"https://example.com/avatar.jpg","social":{"twitter":"@alice","github":"alice"}}}}')
+module.exports = /*#__PURE__*/JSON.parse('{"user":{"name":"Alice","age":25,"email":"alice@example.com","profile":{"bio":"Software Engineer","avatar":"https://example.com/avatar.jpg","social":{"twitter":"@alice","github":"alice"}}}}')
 
 },
 


### PR DESCRIPTION
## Summary

- Mark generated JSON module `JSON.parse(...)` calls with `/*#__PURE__*/`.
- Update JSON module output snapshots that exercise the `JSON.parse` path.

## Root Cause

Rspack's JSON module generator emitted `JSON.parse(...)` directly for larger object/array JSON payloads, while webpack marks that generated call as pure. Without the annotation, downstream minimizers have less information for dead-code elimination.

## Testing

- `PATH="$HOME/.nvm/versions/node/v22.21.1/bin:$PATH" pnpm run build:binding:dev`
- `PATH="$HOME/.nvm/versions/node/v22.21.1/bin:$PATH" pnpm --dir tests/rspack-test run test:base -t "plugin-json/simple"`
- `PATH="$HOME/.nvm/versions/node/v22.21.1/bin:$PATH" pnpm --dir tests/rspack-test run test:base -t "plugin-rsdoctor/json-size-tree-shaking"`
- `git diff --check`
