### PR TITLE
fix(rstest): support legacy define property getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,17 +4844,20 @@ dependencies = [
 name = "rspack_plugin_rstest"
 version = "0.100.4"
 dependencies = [
+ "async-trait",
  "camino",
  "regex",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
  "rspack_error",
+ "rspack_hash",
  "rspack_hook",
  "rspack_plugin_javascript",
  "rspack_util",
  "rustc-hash",
  "swc_core",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2933,6 +2933,7 @@ export interface RawRstestPluginOptions {
   manualMockRoot: string
   preserveNewUrl?: Array<string>
   globals?: boolean
+  definePropertyGettersCompat?: boolean
 injectDynamicImportOrigin?: boolean | { functionName?: string }
 }
 

--- a/crates/rspack_binding_api/src/rstest.rs
+++ b/crates/rspack_binding_api/src/rstest.rs
@@ -29,6 +29,9 @@ pub struct RawRstestPluginOptions {
   // Whether to handle global `rs` and `rstest` variables.
   // When false, only ESM imported variables are processed. Default is true.
   pub globals: Option<bool>,
+  // Whether to support legacy __webpack_require__.d(exports, { key: getter }) calls.
+  // Default is true.
+  pub define_property_getters_compat: Option<bool>,
   // When enabled, rewrite non-string-literal `import()` calls (template
   // literals, variables) to the configured callee and append the source
   // module's absolute path as an extra argument. The runtime uses it as the
@@ -57,6 +60,7 @@ impl From<RawRstestPluginOptions> for RstestPluginOptions {
       manual_mock_root: value.manual_mock_root,
       preserve_new_url: value.preserve_new_url.unwrap_or_default(),
       globals: value.globals.unwrap_or(true),
+      define_property_getters_compat: value.define_property_getters_compat.unwrap_or(true),
       inject_dynamic_import_origin,
     }
   }

--- a/crates/rspack_plugin_rstest/Cargo.toml
+++ b/crates/rspack_plugin_rstest/Cargo.toml
@@ -8,21 +8,24 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait              = { workspace = true }
 camino                   = { workspace = true }
 regex                    = { workspace = true }
 rspack_cacheable         = { workspace = true }
 rspack_collections       = { workspace = true }
 rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
+rspack_hash              = { workspace = true }
 rspack_hook              = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_util              = { workspace = true }
 rustc-hash               = { workspace = true }
 swc_core                 = { workspace = true }
+tokio                    = { workspace = true }
 tracing                  = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["tracing"]
+ignored = ["tracing", "rspack_hash", "tokio"]
 
 [lints]
 workspace = true

--- a/crates/rspack_plugin_rstest/src/define_property_getters_compat.rs
+++ b/crates/rspack_plugin_rstest/src/define_property_getters_compat.rs
@@ -1,0 +1,60 @@
+use rspack_core::{
+  RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeModuleStage, RuntimeTemplate,
+  impl_runtime_module,
+};
+
+#[impl_runtime_module]
+#[derive(Debug)]
+pub struct DefinePropertyGettersCompatRuntimeModule {}
+
+impl DefinePropertyGettersCompatRuntimeModule {
+  pub fn new(runtime_template: &RuntimeTemplate) -> Self {
+    Self::with_default(runtime_template)
+  }
+}
+
+#[async_trait::async_trait]
+impl RuntimeModule for DefinePropertyGettersCompatRuntimeModule {
+  fn stage(&self) -> RuntimeModuleStage {
+    RuntimeModuleStage::Attach
+  }
+
+  async fn generate(
+    &self,
+    context: &RuntimeModuleGenerateContext<'_>,
+  ) -> rspack_error::Result<String> {
+    let require = context
+      .runtime_template
+      .render_runtime_globals(&RuntimeGlobals::REQUIRE);
+    let define_property_getters = context
+      .runtime_template
+      .render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
+
+    Ok(format!(
+      r#"{require}.rstest_define_property_getters = {define_property_getters};
+{define_property_getters} = function(exports, definition) {{
+	// Rstest injected runtime code may still call d(exports, {{ key: getter }}),
+	// while Rspack's optimized runtime expects d(exports, [key, getter]).
+	if(definition && typeof definition === "object" && !Array.isArray(definition)) {{
+		var normalizedDefinition = [];
+		for(var key in definition) {{
+			if({require}.o(definition, key)) {{
+				normalizedDefinition.push(key, definition[key]);
+			}}
+		}}
+		definition = normalizedDefinition;
+	}}
+	return {require}.rstest_define_property_getters(exports, definition);
+}};"#
+    ))
+  }
+
+  fn additional_runtime_requirements(
+    &self,
+    _compilation: &rspack_core::Compilation,
+  ) -> RuntimeGlobals {
+    RuntimeGlobals::REQUIRE
+      .union(RuntimeGlobals::DEFINE_PROPERTY_GETTERS)
+      .union(RuntimeGlobals::HAS_OWN_PROPERTY)
+  }
+}

--- a/crates/rspack_plugin_rstest/src/define_property_getters_compat.rs
+++ b/crates/rspack_plugin_rstest/src/define_property_getters_compat.rs
@@ -31,21 +31,23 @@ impl RuntimeModule for DefinePropertyGettersCompatRuntimeModule {
       .render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
 
     Ok(format!(
-      r#"{require}.rstest_define_property_getters = {define_property_getters};
-{define_property_getters} = function(exports, definition) {{
-	// Rstest injected runtime code may still call d(exports, {{ key: getter }}),
-	// while Rspack's optimized runtime expects d(exports, [key, getter]).
-	if(definition && typeof definition === "object" && !Array.isArray(definition)) {{
-		var normalizedDefinition = [];
-		for(var key in definition) {{
-			if({require}.o(definition, key)) {{
-				normalizedDefinition.push(key, definition[key]);
+      r#"if(!{require}.rstest_define_property_getters) {{
+	{require}.rstest_define_property_getters = {define_property_getters};
+	{define_property_getters} = function(exports, definition) {{
+		// Rstest injected runtime code may still call d(exports, {{ key: getter }}),
+		// while Rspack's optimized runtime expects d(exports, [key, getter]).
+		if(definition && typeof definition === "object" && !Array.isArray(definition)) {{
+			var normalizedDefinition = [];
+			for(var key in definition) {{
+				if({require}.o(definition, key)) {{
+					normalizedDefinition.push(key, definition[key]);
+				}}
 			}}
+			definition = normalizedDefinition;
 		}}
-		definition = normalizedDefinition;
-	}}
-	return {require}.rstest_define_property_getters(exports, definition);
-}};"#
+		return {require}.rstest_define_property_getters(exports, definition);
+	}};
+}}"#
     ))
   }
 

--- a/crates/rspack_plugin_rstest/src/lib.rs
+++ b/crates/rspack_plugin_rstest/src/lib.rs
@@ -1,3 +1,4 @@
+mod define_property_getters_compat;
 mod dynamic_import_origin_dependency;
 mod esm_import_dependency;
 mod import_dependency;

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -7,11 +7,12 @@ use camino::{Utf8Path, Utf8PathBuf};
 use regex::Regex;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  Compilation, CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
+  ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
+  CompilationOptimizeDependencies, CompilationParams, CompilationProcessAssets,
   CompilerCompilation, DependencyType, ExportsInfoArtifact, FactoryMeta, ModuleFactoryCreateData,
   ModuleType, NormalModuleFactoryBeforeResolve, NormalModuleFactoryParser, ParserAndGenerator,
-  ParserOptions, Plugin, ResolveOptionsWithDependencyType, ResolveResult,
-  SideEffectsOptimizeArtifact,
+  ParserOptions, Plugin, ResolveOptionsWithDependencyType, ResolveResult, RuntimeGlobals,
+  RuntimeModule, RuntimeModuleExt, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   module_declared_side_effect_free,
   rspack_sources::{BoxSource, ReplaceSource, SourceExt},
@@ -29,6 +30,7 @@ static RSTEST_FLAG_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 use crate::{
+  define_property_getters_compat::DefinePropertyGettersCompatRuntimeModule,
   dynamic_import_origin_dependency::RstestDynamicImportOriginDependencyTemplate,
   esm_import_dependency::{
     RstestESMImportSideEffectDependencyTemplate, RstestESMImportSpecifierDependencyTemplate,
@@ -49,6 +51,7 @@ pub struct RstestPluginOptions {
   pub manual_mock_root: String,
   pub preserve_new_url: Vec<String>,
   pub globals: bool,
+  pub define_property_getters_compat: bool,
   pub inject_dynamic_import_origin: Option<RstestDynamicImportOriginOptions>,
 }
 
@@ -445,6 +448,25 @@ async fn optimize_dependencies(
   Ok(None)
 }
 
+#[plugin_hook(CompilationAdditionalTreeRuntimeRequirements for RstestPlugin)]
+async fn additional_tree_runtime_requirements(
+  &self,
+  compilation: &Compilation,
+  _chunk_ukey: &ChunkUkey,
+  runtime_requirements: &mut RuntimeGlobals,
+  runtime_modules: &mut Vec<Box<dyn RuntimeModule>>,
+) -> Result<()> {
+  if !self.options.define_property_getters_compat {
+    return Ok(());
+  }
+
+  runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
+  runtime_modules
+    .push(DefinePropertyGettersCompatRuntimeModule::new(&compilation.runtime_template).boxed());
+
+  Ok(())
+}
+
 impl Plugin for RstestPlugin {
   fn name(&self) -> &'static str {
     "rstest"
@@ -491,6 +513,11 @@ impl Plugin for RstestPlugin {
       .compilation_hooks
       .optimize_dependencies
       .tap(optimize_dependencies::new(self));
+
+    ctx
+      .compilation_hooks
+      .additional_tree_runtime_requirements
+      .tap(additional_tree_runtime_requirements::new(self));
 
     if self.options.hoist_mock_module {
       ctx

--- a/tests/rspack-test/configCases/rstest/define-property-getters-compat/disabled.js
+++ b/tests/rspack-test/configCases/rstest/define-property-getters-compat/disabled.js
@@ -1,0 +1,4 @@
+it('should allow disabling define property getters compatibility', () => {
+  expect(__webpack_require__.d).toBeDefined();
+  expect(__webpack_require__.rstest_define_property_getters).toBeUndefined();
+});

--- a/tests/rspack-test/configCases/rstest/define-property-getters-compat/index.js
+++ b/tests/rspack-test/configCases/rstest/define-property-getters-compat/index.js
@@ -1,0 +1,11 @@
+it('should keep legacy define property getters calls compatible by default', () => {
+  expect(__webpack_require__.d).toBeDefined();
+  expect(__webpack_require__.rstest_define_property_getters).toBeDefined();
+
+  const exports = {};
+  __webpack_require__.d(exports, {
+    answer: () => 42,
+  });
+
+  expect(exports.answer).toBe(42);
+});

--- a/tests/rspack-test/configCases/rstest/define-property-getters-compat/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/define-property-getters-compat/rspack.config.js
@@ -1,0 +1,28 @@
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+const createConfig = (entry, filename, rstestOptions = {}) => ({
+  entry,
+  target: 'node',
+  output: {
+    filename,
+  },
+  plugins: [
+    new RstestPlugin({
+      injectModulePathName: false,
+      hoistMockModule: false,
+      importMetaPathName: false,
+      manualMockRoot: __dirname,
+      ...rstestOptions,
+    }),
+  ],
+});
+
+/** @type {import('@rspack/core').Configuration[]} */
+module.exports = [
+  createConfig('./index.js', 'enabled.js'),
+  createConfig('./disabled.js', 'disabled.js', {
+    definePropertyGettersCompat: false,
+  }),
+];

--- a/tests/rspack-test/configCases/rstest/mock/mockFactoryPrimitive.js
+++ b/tests/rspack-test/configCases/rstest/mock/mockFactoryPrimitive.js
@@ -1,0 +1,7 @@
+import foo from './src/foo';
+
+rs.mock('./src/foo', () => 42);
+
+it('should support primitive mock factory values', () => {
+  expect(foo).toBe(42);
+});

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -92,7 +92,10 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
             [key]: () => res[key],
           });
         }
-        if (!res.__esModule && !('default' in res)) {
+        if (
+          !res?.__esModule &&
+          !(res != null && (typeof res === 'object' || typeof res === 'function') && 'default' in res)
+        ) {
           __webpack_require__.d(__webpack_exports__, {
             default: () => res,
           });

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -88,9 +88,14 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
         __webpack_require__.r(__webpack_exports__);
         const res = modFactory();
         for (const key in res) {
-          __webpack_require__.d(__webpack_exports__, [
-            key, () => res[key],
-          ]);
+          __webpack_require__.d(__webpack_exports__, {
+            [key]: () => res[key],
+          });
+        }
+        if (!res.__esModule && !('default' in res)) {
+          __webpack_require__.d(__webpack_exports__, {
+            default: () => res,
+          });
         }
       };
 


### PR DESCRIPTION
## Summary

- Add an Rstest runtime shim for legacy `__webpack_require__.d(exports, { key: getter })` calls.
- Add `definePropertyGettersCompat`, enabled by default, to allow disabling the shim.
- Update the Rstest mock fixture and add coverage for enabled/disabled compatibility behavior.

## Related links

[None.](https://github.com/web-infra-dev/rspack/pull/14045)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).