### PR TITLE
fix: exclude enhanced rspack federation plugin

### DIFF
--- a/packages/rspack/src/sharing/IndependentSharedPlugin.ts
+++ b/packages/rspack/src/sharing/IndependentSharedPlugin.ts
@@ -38,6 +38,7 @@ const filterPlugin = (plugin: Plugins[0], excludedPlugins: string[] = []) => {
     'TreeShakingSharedPlugin',
     'IndependentSharedPlugin',
     'ModuleFederationPlugin',
+    'RspackModuleFederationPlugin',
     'SharedUsedExportsOptimizerPlugin',
     'HtmlWebpackPlugin',
     'HtmlRspackPlugin',

--- a/tests/rspack-test/configCases/sharing/tree-shaking-shared/rspack.config.js
+++ b/tests/rspack-test/configCases/sharing/tree-shaking-shared/rspack.config.js
@@ -2,6 +2,19 @@ const { container } = require('@rspack/core');
 
 const { ModuleFederationPlugin } = container;
 
+class RspackModuleFederationPlugin {
+  name = 'RspackModuleFederationPlugin';
+
+  apply(compiler) {
+    const outputPath = compiler.options.output?.path || '';
+    if (outputPath.includes('independent-packages')) {
+      throw new Error(
+        'RspackModuleFederationPlugin should not be applied to shared fallback compilers',
+      );
+    }
+  }
+}
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   // entry: './index.js',
@@ -15,6 +28,7 @@ module.exports = {
     chunkFilename: '[id].js',
   },
   plugins: [
+    new RspackModuleFederationPlugin(),
     new ModuleFederationPlugin({
       name: 'tree_shaking_share',
       manifest: true,


### PR DESCRIPTION
## Summary

- Add `RspackModuleFederationPlugin` to the built-in plugin exclusion list used when creating independent shared fallback compilers.
- Extend the existing tree-shaking shared config case with a regression plugin that throws if that plugin name is copied into shared fallback compilers.

## Why

`IndependentSharedPlugin` copies parent compiler plugins into secondary shared fallback compilers, excluding federation-related plugins that should not be applied recursively. The enhanced Module Federation Rspack plugin exposes the name `RspackModuleFederationPlugin`, but that name was not in the default exclusion list.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec prettier --check packages/rspack/src/sharing/IndependentSharedPlugin.ts tests/rspack-test/configCases/sharing/tree-shaking-shared/rspack.config.js`
- `pnpm run lint-ci:js`
- `pnpm --filter @rspack/core build`
- `git diff --check`

I did not run the full config-case runtime suite locally because this checkout does not have native Rspack bindings built; importing the built package fails while resolving the local `@rspack/binding` native module.
