### PR TITLE
perf(javascript): cache inherited scope info lookups

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/location_advancer.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/location_advancer.rs
@@ -16,6 +16,15 @@ impl DependencyLocationAdvancer {
     Self::default()
   }
 
+  #[inline]
+  fn utf16_len(segment: &str) -> usize {
+    if segment.is_ascii() {
+      segment.len()
+    } else {
+      segment.encode_utf16().count()
+    }
+  }
+
   /// Advance a source position from one byte offset to another, counting newlines and UTF-16 columns.
   /// Optimized with ASCII fast-paths and SIMD reverse searching.
   fn advance_pos(
@@ -41,10 +50,10 @@ impl DependencyLocationAdvancer {
         .line
         .checked_add(u32::try_from(newline_count).ok()?)?;
       let after_newline = &segment[last_idx + 1..];
-      let column = u32::try_from(after_newline.encode_utf16().count() + 1).ok()?; // 1-based column
+      let column = u32::try_from(Self::utf16_len(after_newline) + 1).ok()?; // 1-based column
       Some(SourcePosition { line, column })
     } else {
-      let column_advance = u32::try_from(segment.encode_utf16().count()).ok()?;
+      let column_advance = u32::try_from(Self::utf16_len(segment)).ok()?;
       Some(SourcePosition {
         line: from_pos.line,
         column: from_pos.column.checked_add(column_advance)?,

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -74,7 +74,7 @@ impl ScopeInfoDB {
     let info = ScopeInfo {
       is_strict,
       parent,
-      map: Default::default(),
+      map: FxHashMap::with_capacity_and_hasher(8, Default::default()),
     };
     self.map.insert(info)
   }

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -125,35 +125,43 @@ impl ScopeInfoDB {
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
+  fn normalize_variable_info_id(id: VariableInfoId) -> Option<VariableInfoId> {
+    if id == VariableInfoId::tombstone() || id == VariableInfoId::undefined() {
+      None
+    } else {
+      Some(id)
+    }
+  }
+
   pub fn get(&mut self, id: ScopeInfoId, key: &Atom) -> Option<VariableInfoId> {
     let definitions = self.expect_get_scope(id);
     if let Some(&top_value) = definitions.map.get(key) {
-      if top_value == VariableInfoId::tombstone() || top_value == VariableInfoId::undefined() {
-        None
-      } else {
-        Some(top_value)
-      }
-    } else if let Some(parent) = definitions.parent {
-      let mut current = Some(parent);
-      while let Some(current_id) = current {
-        let scope = self.expect_get_scope(current_id);
-        if let Some(&value) = scope.map.get(key) {
-          if value == VariableInfoId::tombstone() || value == VariableInfoId::undefined() {
-            return None;
-          } else {
-            return Some(value);
-          }
-        }
-        current = scope.parent;
-      }
-      let definitions = self.expect_get_mut_scope(id);
-      definitions
-        .map
-        .insert(key.clone(), VariableInfoId::tombstone());
-      None
-    } else {
-      None
+      return Self::normalize_variable_info_id(top_value);
     }
+
+    let mut current = definitions.parent;
+    if current.is_none() {
+      return None;
+    }
+
+    while let Some(current_id) = current {
+      let scope = self.expect_get_scope(current_id);
+      if let Some(&value) = scope.map.get(key) {
+        let result = Self::normalize_variable_info_id(value);
+        self.expect_get_mut_scope(id).map.insert(
+          key.clone(),
+          result.unwrap_or_else(VariableInfoId::tombstone),
+        );
+        return result;
+      }
+      current = scope.parent;
+    }
+
+    self
+      .expect_get_mut_scope(id)
+      .map
+      .insert(key.clone(), VariableInfoId::tombstone());
+    None
   }
 
   pub fn set(&mut self, id: ScopeInfoId, key: Atom, variable_info_id: VariableInfoId) {
@@ -311,5 +319,42 @@ impl ScopeInfo {
       .iter()
       .filter(|&(_, &info_id)| info_id != VariableInfoId::tombstone())
       .map(|(name, info_id)| (name.as_str(), info_id))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn get_caches_inherited_variable_on_current_scope() {
+    let mut db = ScopeInfoDB::new();
+    let root = db.create();
+    let child = db.create_child(root);
+    let name = Atom::from("value");
+    let value = VariableInfo::create(&mut db, root, None, VariableInfoFlags::NORMAL, None);
+    db.set(root, name.clone(), value);
+
+    assert!(!db.expect_get_scope(child).map.contains_key(&name));
+    assert_eq!(db.get(child, &name), Some(value));
+    assert_eq!(db.expect_get_scope(child).map.get(&name), Some(&value));
+  }
+
+  #[test]
+  fn get_caches_inherited_tombstone_on_current_scope() {
+    let mut db = ScopeInfoDB::new();
+    let root = db.create();
+    let child = db.create_child(root);
+    let grandchild = db.create_child(child);
+    let name = Atom::from("value");
+    let value = VariableInfo::create(&mut db, root, None, VariableInfoFlags::NORMAL, None);
+    db.set(root, name.clone(), value);
+    db.delete(child, &name);
+
+    assert_eq!(db.get(grandchild, &name), None);
+    assert_eq!(
+      db.expect_get_scope(grandchild).map.get(&name),
+      Some(&VariableInfoId::tombstone())
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -139,12 +139,9 @@ impl ScopeInfoDB {
       return Self::normalize_variable_info_id(top_value);
     }
 
-    let mut current = definitions.parent;
-    if current.is_none() {
-      return None;
-    }
+    let mut current_id = definitions.parent?;
 
-    while let Some(current_id) = current {
+    loop {
       let scope = self.expect_get_scope(current_id);
       if let Some(&value) = scope.map.get(key) {
         let result = Self::normalize_variable_info_id(value);
@@ -154,7 +151,10 @@ impl ScopeInfoDB {
         );
         return result;
       }
-      current = scope.parent;
+      let Some(parent) = scope.parent else {
+        break;
+      };
+      current_id = parent;
     }
 
     self


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cache inherited `ScopeInfoDB::get` lookup results on the current scope, preallocate small scope maps for the existing scan-dependencies benchmark, and add an ASCII fast path for dependency location UTF-16 column calculation.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfaaf118-9e80-4a0c-a874-0a1ca0ded4f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfaaf118-9e80-4a0c-a874-0a1ca0ded4f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

