### PR TITLE
revert: "revert: "feat: optimize generated getter for const export""

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1296,7 +1296,7 @@ impl CompilationOptimizeModules for CompilationOptimizeModulesTap {
   async fn run(
     &self,
     _compilation: &Compilation,
-    _circular_modules: &mut IdentifierSet,
+    _circular_modules: &mut Option<IdentifierSet>,
     _diagnostics: &mut Vec<rspack_error::Diagnostic>,
   ) -> rspack_error::Result<Option<bool>> {
     self.function.call_with_sync(()).await

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -114,7 +114,7 @@ define_hook!(CompilationDependencyReferencedExports: Sync(
 define_hook!(CompilationConcatenationScope: SeriesBail(compilation: &Compilation, curr_module: ModuleIdentifier) -> ConcatenationScope);
 define_hook!(CompilationOptimizeDependencies: SeriesBail(compilation: &Compilation, side_effects_optimize_artifact: &mut SideEffectsOptimizeArtifact,  build_module_graph_artifact: &mut BuildModuleGraphArtifact, exports_info_artifact: &mut ExportsInfoArtifact,
  diagnostics: &mut Vec<Diagnostic>) -> bool);
-define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, circular_modules: &mut IdentifierSet, diagnostics: &mut Vec<Diagnostic>) -> bool);
+define_hook!(CompilationOptimizeModules: SeriesBail(compilation: &Compilation, circular_modules: &mut Option<IdentifierSet>, diagnostics: &mut Vec<Diagnostic>) -> bool);
 define_hook!(CompilationAfterOptimizeModules: Series(compilation: &Compilation));
 define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeTree: Series(compilation: &Compilation));
@@ -272,7 +272,7 @@ pub struct Compilation {
 
   pub minimize_persistent_cache_artifact: Option<MinimizePersistentCacheArtifact>,
 
-  pub circular_modules: StealCell<IdentifierSet>,
+  pub circular_modules: StealCell<Option<IdentifierSet>>,
   pub code_generated_modules: IdentifierSet,
   pub build_time_executed_modules: IdentifierSet,
   pub build_chunk_graph_artifact: BuildChunkGraphArtifact,
@@ -378,7 +378,7 @@ impl Compilation {
 
       async_modules_artifact: StealCell::new(AsyncModulesArtifact::default()),
       imported_by_defer_modules_artifact: StealCell::new(Default::default()),
-      circular_modules: StealCell::new(Default::default()),
+      circular_modules: StealCell::new(None),
       dependencies_diagnostics_artifact: StealCell::new(DependenciesDiagnosticsArtifact::default()),
       exports_info_artifact: StealCell::new(ExportsInfoArtifact::default()),
       side_effects_optimize_artifact: StealCell::new(Default::default()),

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -403,7 +403,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
       content.push_str(": ");
       content.push_str(&runtime_template.returning_function(getter, ""));
     }
-    while let Some((key, getter)) = getters.next() {
+    for (key, getter) in getters {
       content.push_str(",\n  ");
       content.push_str(&property_name(key)?);
       content.push_str(": ");
@@ -425,7 +425,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
       values_content.push_str(": ");
       values_content.push_str(value);
     }
-    while let Some((key, value)) = values.next() {
+    for (key, value) in values {
       values_content.push_str(",\n  ");
       values_content.push_str(&property_name(key)?);
       values_content.push_str(": ");

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -85,7 +85,7 @@ impl InitFragmentKey {
         res
       }
       InitFragmentKey::ESMExports => {
-        let mut export_map: Vec<(Atom, Atom)> = vec![];
+        let mut export_map: Vec<(Atom, ESMExportBinding)> = vec![];
         let mut iter = fragments.into_iter();
         let first = iter
           .next()
@@ -95,15 +95,17 @@ impl InitFragmentKey {
           .downcast::<ESMExportInitFragment>()
           .expect("fragment of InitFragmentKey::ESMExports should be a ESMExportInitFragment");
         let export_argument = first.exports_argument;
+        let is_circular_module = first.is_circular_module;
         export_map.extend(first.export_map);
         for fragment in iter {
           let fragment = fragment
             .into_any()
             .downcast::<ESMExportInitFragment>()
             .expect("fragment of InitFragmentKey::ESMExports should be a ESMExportInitFragment");
+          debug_assert_eq!(is_circular_module, fragment.is_circular_module);
           export_map.extend(fragment.export_map);
         }
-        ESMExportInitFragment::new(export_argument, export_map).boxed()
+        ESMExportInitFragment::new(export_argument, export_map, is_circular_module).boxed()
       }
       InitFragmentKey::AwaitDependencies => {
         let promises = fragments.into_iter().map(|f| f.into_any().downcast::<AwaitDependenciesInitFragment>().expect("fragment of InitFragmentKey::AwaitDependencies should be a AwaitDependenciesInitFragment")).flat_map(|f| f.promises).collect();
@@ -349,17 +351,29 @@ impl<C> InitFragment<C> for NormalInitFragment {
 }
 
 #[derive(Debug, Clone, Hash)]
+pub enum ESMExportBinding {
+  Getter(Atom),
+  Value(Atom),
+}
+
+#[derive(Debug, Clone, Hash)]
 pub struct ESMExportInitFragment {
   exports_argument: ExportsArgument,
   // TODO: should be a map
-  export_map: Vec<(Atom, Atom)>,
+  export_map: Vec<(Atom, ESMExportBinding)>,
+  is_circular_module: Option<bool>,
 }
 
 impl ESMExportInitFragment {
-  pub fn new(exports_argument: ExportsArgument, export_map: Vec<(Atom, Atom)>) -> Self {
+  pub fn new(
+    exports_argument: ExportsArgument,
+    export_map: Vec<(Atom, ESMExportBinding)>,
+    is_circular_module: Option<bool>,
+  ) -> Self {
     Self {
       exports_argument,
       export_map,
+      is_circular_module,
     }
   }
 }
@@ -369,31 +383,73 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
     let runtime_template = context.runtime_template();
 
     self.export_map.sort_by(|a, b| a.0.cmp(&b.0));
-    let exports = format!(
-      "{{\n  {}\n}}",
-      self
-        .export_map
-        .iter()
-        .map(|s| {
-          let prop = property_name(&s.0)?;
-          Ok(format!(
-            "{}: {}",
-            prop,
-            runtime_template.returning_function(&s.1, "")
-          ))
-        })
-        .collect::<Result<Vec<_>>>()?
-        .join(",\n  ")
-    );
 
-    let res = InitFragmentContents {
-      start: format!(
-        "{}({}, {});\n",
-        runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
-        runtime_template.render_exports_argument(self.exports_argument),
-        exports
-      ),
-      end: None,
+    let mut content =
+      runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
+    content.push('(');
+    content.push_str(&runtime_template.render_exports_argument(self.exports_argument));
+    content.push_str(", {");
+
+    let mut getters = self
+      .export_map
+      .iter()
+      .filter_map(|(key, value)| match value {
+        ESMExportBinding::Getter(getter) => Some((key, getter)),
+        _ => None,
+      });
+    if let Some((key, getter)) = getters.next() {
+      content.push_str("\n  ");
+      content.push_str(&property_name(key)?);
+      content.push_str(": ");
+      content.push_str(&runtime_template.returning_function(getter, ""));
+    }
+    while let Some((key, getter)) = getters.next() {
+      content.push_str(",\n  ");
+      content.push_str(&property_name(key)?);
+      content.push_str(": ");
+      content.push_str(&runtime_template.returning_function(getter, ""));
+    }
+    content.push_str("\n}");
+
+    let mut values_content = String::new();
+    let mut values = self
+      .export_map
+      .iter()
+      .filter_map(|(key, value)| match value {
+        ESMExportBinding::Value(value) => Some((key, value)),
+        _ => None,
+      });
+    if let Some((key, value)) = values.next() {
+      values_content.push_str("\n  ");
+      values_content.push_str(&property_name(key)?);
+      values_content.push_str(": ");
+      values_content.push_str(value);
+    }
+    while let Some((key, value)) = values.next() {
+      values_content.push_str(",\n  ");
+      values_content.push_str(&property_name(key)?);
+      values_content.push_str(": ");
+      values_content.push_str(value);
+    }
+
+    if values_content.is_empty() {
+      content.push_str(");\n");
+    } else {
+      content.push_str(", {");
+      content.push_str(&values_content);
+      content.push_str("\n});\n");
+    }
+
+    let res = if matches!(self.is_circular_module, None | Some(true)) {
+      InitFragmentContents {
+        start: content,
+        end: None,
+      }
+    } else {
+      InitFragmentContents {
+        start: String::new(),
+        end: Some(format!("\n{content}")),
+      }
     };
     Ok(res)
   }

--- a/crates/rspack_plugin_circular_dependencies/src/circular_dependency_rspack_plugin.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/circular_dependency_rspack_plugin.rs
@@ -362,7 +362,7 @@ impl CircularDependencyRspackPlugin {
 async fn optimize_modules(
   &self,
   compilation: &Compilation,
-  _circular_modules: &mut IdentifierSet,
+  _circular_modules: &mut Option<IdentifierSet>,
   diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   if let Some(on_start) = &self.options.on_start {

--- a/crates/rspack_plugin_circular_dependencies/src/circular_modules_info_plugin.rs
+++ b/crates/rspack_plugin_circular_dependencies/src/circular_modules_info_plugin.rs
@@ -301,12 +301,12 @@ fn should_ignore_dependency_type(ty: DependencyType) -> bool {
 async fn optimize_modules(
   &self,
   compilation: &Compilation,
-  circular_modules: &mut IdentifierSet,
+  circular_modules: &mut Option<IdentifierSet>,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   let module_graph = compilation.get_module_graph();
   let graph = CycleGraph::build(module_graph);
-  *circular_modules = CycleDetector::new(&graph).find_circular_modules();
+  *circular_modules = Some(CycleDetector::new(&graph).find_circular_modules());
   Ok(None)
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -4,7 +4,7 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, DEFAULT_EXPORT, Dependency, DependencyCodeGeneration,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, ESMExportInitFragment, ExportNameOrSpec, ExportsInfoArtifact,
+  DependencyType, ESMExportBinding, ESMExportInitFragment, ExportNameOrSpec, ExportsInfoArtifact,
   ExportsOfExportsSpec, ExportsSpec, ForwardId, ModuleGraph, ModuleGraphCacheArtifact,
   SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedName, property_access,
   rspack_sources::ReplacementEnforce,
@@ -166,6 +166,10 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
     } = code_generatable_context;
 
     let module_identifier = module.identifier();
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module_identifier));
 
     if let Some(declaration) = &dep.declaration {
       let name = match declaration {
@@ -202,8 +206,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
               .collect_vec()
               .join("")
               .into(),
-            Atom::from(format!("/* export default binding */ {name}")),
+            ESMExportBinding::Getter(Atom::from(format!("/* export default binding */ {name}"))),
           )],
+          is_circular_module,
         )));
       } else {
         // do nothing for unused or inlined
@@ -244,8 +249,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
                   .collect_vec()
                   .join("")
                   .into(),
-                DEFAULT_EXPORT.into(),
+                ESMExportBinding::Getter(DEFAULT_EXPORT.into()),
               )],
+              is_circular_module,
             )));
             format!("/* export default */ const {DEFAULT_EXPORT} = ")
           } else {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -10,8 +10,8 @@ use rspack_core::{
   AsContextDependency, ChunkGraph, ConditionalInitFragment, ConnectionState, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyCondition, DependencyConditionFn,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, DetermineExportAssignmentsKey, ESMExportInitFragment, ExportMode,
-  ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
+  DependencyType, DetermineExportAssignmentsKey, ESMExportBinding, ESMExportInitFragment,
+  ExportMode, ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
   ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
   ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
@@ -840,11 +840,19 @@ impl ESMExportImportedSpecifierDependency {
       runtime_template,
       ..
     } = ctxt;
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module.identifier()));
     let module_id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, target_module);
     let mode = render_make_deferred_namespace_mode_from_exports_type(exports_type);
-    let mut export_map = vec![];
-    export_map.push((key.into(), format!("/* reexport deferred namespace object */ {name}_deferred_namespace_cache || ({name}_deferred_namespace_cache = {}({}, {}))", runtime_template
-                .render_runtime_globals(&RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT), json_stringify(&module_id), mode).into()));
+    let value = format!(
+      "/* reexport deferred namespace object */ {name}_deferred_namespace_cache || ({name}_deferred_namespace_cache = {}({}, {}))",
+      runtime_template.render_runtime_globals(&RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT),
+      json_stringify(&module_id),
+      mode
+    );
+    let export_map = vec![(key.into(), ESMExportBinding::Getter(value.into()))];
     let cache_var = format!("var {name}_deferred_namespace_cache;\n");
 
     (
@@ -855,7 +863,11 @@ impl ESMExportImportedSpecifierDependency {
         InitFragmentKey::ESMDeferImportNamespaceObjectFragment(cache_var),
         None,
       ),
-      ESMExportInitFragment::new(module.get_exports_argument(), export_map),
+      ESMExportInitFragment::new(
+        module.get_exports_argument(),
+        export_map,
+        is_circular_module,
+      ),
     )
   }
 
@@ -868,9 +880,20 @@ impl ESMExportImportedSpecifierDependency {
     value_key: ValueKey,
   ) -> ESMExportInitFragment {
     let return_value = Self::get_return_value(name.to_owned(), value_key);
-    let mut export_map = vec![];
-    export_map.push((key.into(), format!("/* {comment} */ {return_value}").into()));
-    ESMExportInitFragment::new(ctxt.module.get_exports_argument(), export_map)
+    let is_circular_module = ctxt
+      .compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&ctxt.module.identifier()));
+    let export_map = vec![(
+      key.into(),
+      ESMExportBinding::Getter(format!("/* {comment} */ {return_value}").into()),
+    )];
+    ESMExportInitFragment::new(
+      ctxt.module.get_exports_argument(),
+      export_map,
+      is_circular_module,
+    )
   }
 
   fn get_reexport_fake_namespace_object_fragments(
@@ -882,10 +905,14 @@ impl ESMExportImportedSpecifierDependency {
   ) -> (NormalInitFragment, ESMExportInitFragment) {
     let TemplateContext {
       module,
+      compilation,
       runtime_template,
       ..
     } = ctxt;
-    let mut export_map = vec![];
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module.identifier()));
     let value = format!(
       r"/* reexport fake namespace object from non-ESM */ {name}_namespace_cache || ({name}_namespace_cache = {}({name}{}))",
       runtime_template.render_runtime_globals(&RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT),
@@ -895,7 +922,7 @@ impl ESMExportImportedSpecifierDependency {
         format!(", {fake_type}")
       }
     );
-    export_map.push((key.into(), value.into()));
+    let export_map = vec![(key.into(), ESMExportBinding::Getter(value.into()))];
     let cache_var = format!("var {name}_namespace_cache;\n");
 
     (
@@ -906,7 +933,11 @@ impl ESMExportImportedSpecifierDependency {
         InitFragmentKey::ESMFakeNamespaceObjectFragment(cache_var),
         None,
       ),
-      ESMExportInitFragment::new(module.get_exports_argument(), export_map),
+      ESMExportInitFragment::new(
+        module.get_exports_argument(),
+        export_map,
+        is_circular_module,
+      ),
     )
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -3,14 +3,14 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ESMExportInitFragment, EvaluatedInlinableValue,
+  DependencyTemplateType, DependencyType, ESMExportBinding, ESMExportInitFragment,
   ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, LazyUntil,
   ModuleGraph, ModuleGraphCacheArtifact, SideEffectsStateArtifact, TSEnumValue, TemplateContext,
   TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::Atom;
 
-use crate::is_export_inlined;
+use crate::{ConstValue, is_export_inlined};
 
 // Create _webpack_require__.d(__webpack_exports__, {}) for each export.
 #[cacheable]
@@ -23,7 +23,7 @@ pub struct ESMExportSpecifierDependency {
   name: Atom,
   #[cacheable(with=AsPreset)]
   value: Atom, // id
-  inline: Option<EvaluatedInlinableValue>,
+  const_value: Option<ConstValue>,
   enum_value: Option<TSEnumValue>,
 }
 
@@ -31,7 +31,7 @@ impl ESMExportSpecifierDependency {
   pub fn new(
     name: Atom,
     value: Atom,
-    inline: Option<EvaluatedInlinableValue>,
+    const_value: Option<ConstValue>,
     enum_value: Option<TSEnumValue>,
     range: DependencyRange,
     loc: Option<DependencyLocation>,
@@ -39,7 +39,7 @@ impl ESMExportSpecifierDependency {
     Self {
       name,
       value,
-      inline,
+      const_value,
       enum_value,
       range,
       loc,
@@ -75,7 +75,10 @@ impl Dependency for ESMExportSpecifierDependency {
     Some(ExportsSpec {
       exports: ExportsOfExportsSpec::Names(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
         name: self.name.clone(),
-        inlinable: self.inline.clone(),
+        inlinable: self
+          .const_value
+          .as_ref()
+          .and_then(|const_value| const_value.as_inlinable().cloned()),
         exports: self.enum_value.as_ref().map(|enum_value| {
           enum_value
             .iter()
@@ -209,9 +212,19 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       }
       UsedName::Inlined(_) => return,
     };
+    let is_circular_module = compilation
+      .circular_modules
+      .as_ref()
+      .map(|circular_modules| circular_modules.contains(&module.identifier()));
+    let binding = if matches!(is_circular_module, Some(false)) && dep.const_value.is_some() {
+      ESMExportBinding::Value(dep.value.clone())
+    } else {
+      ESMExportBinding::Getter(dep.value.clone())
+    };
     init_fragments.push(Box::new(ESMExportInitFragment::new(
       module.get_exports_argument(),
-      vec![(used_name, dep.value.clone())],
+      vec![(used_name, binding)],
+      is_circular_module,
     )));
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -12,7 +12,7 @@ use swc_core::{
 use super::{
   DEFAULT_STAR_JS_WORD, JS_DEFAULT_KEYWORD, JavascriptParserPlugin,
   esm_import_dependency_parser_plugin::{ESM_SPECIFIER_TAG, ESMSpecifierData},
-  inline_const::{INLINABLE_CONST_TAG, InlinableConstData},
+  inline_const::{ConstValueData, INLINABLE_CONST_TAG},
   inner_graph::state::InnerGraphMapUsage,
 };
 use crate::{
@@ -177,8 +177,8 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
       }
       Box::new(dep) as BoxDependency
     } else {
-      let inlinable = parser
-        .get_tag_data::<InlinableConstData>(local_id, INLINABLE_CONST_TAG)
+      let const_value = parser
+        .get_tag_data::<ConstValueData>(local_id, INLINABLE_CONST_TAG)
         .map(|data| data.value.clone());
       let enum_value = parser
         .build_info
@@ -198,7 +198,7 @@ impl JavascriptParserPlugin for ESMExportDependencyParserPlugin {
         } else {
           local_id.clone()
         },
-        inlinable,
+        const_value,
         enum_value,
         statement.span().into(),
         loc,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -1,6 +1,10 @@
+use rspack_cacheable::cacheable;
 use rspack_core::EvaluatedInlinableValue;
 use rspack_util::ryu_js;
-use swc_core::ecma::ast::VarDeclarator;
+use swc_core::ecma::{
+  ast::{ObjectPatProp, Pat, VarDeclarator},
+  atoms::Atom,
+};
 
 use super::JavascriptParserPlugin;
 use crate::{
@@ -17,15 +21,39 @@ use crate::{
 pub const INLINABLE_CONST_TAG: &str = "inlinable const";
 
 #[derive(Debug, Clone)]
-pub struct InlinableConstData {
-  pub value: EvaluatedInlinableValue,
+pub struct ConstValueData {
+  pub value: ConstValue,
+}
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub enum ConstValue {
+  NoInlinable,
+  Inlinable(EvaluatedInlinableValue),
+}
+
+impl ConstValue {
+  pub fn as_inlinable(&self) -> Option<&EvaluatedInlinableValue> {
+    match self {
+      ConstValue::Inlinable(v) => Some(v),
+      _ => None,
+    }
+  }
 }
 
 #[derive(Default)]
-pub struct InlineConstPlugin;
+pub struct ConstValuePlugin {
+  inline: bool,
+}
+
+impl ConstValuePlugin {
+  pub fn new(inline: bool) -> Self {
+    Self { inline }
+  }
+}
 
 #[rspack_macros::implemented_javascript_parser_hooks]
-impl JavascriptParserPlugin for InlineConstPlugin {
+impl JavascriptParserPlugin for ConstValuePlugin {
   fn evaluate_identifier(
     &self,
     parser: &mut JavascriptParser,
@@ -41,8 +69,12 @@ impl JavascriptParserPlugin for InlineConstPlugin {
     let tag_info = parser
       .definitions_db
       .expect_get_tag_info(parser.current_tag_info?);
-    let data = InlinableConstData::downcast(tag_info.data.clone()?);
-    Some(match data.value {
+    let data = ConstValueData::downcast(tag_info.data.clone()?);
+    let value = match data.value {
+      ConstValue::NoInlinable => return None,
+      ConstValue::Inlinable(v) => v,
+    };
+    Some(match value {
       EvaluatedInlinableValue::Null => evaluate_to_null(start, end),
       EvaluatedInlinableValue::Undefined => evaluate_to_undefined(start, end),
       EvaluatedInlinableValue::Boolean(v) => evaluate_to_boolean(v, start, end),
@@ -60,21 +92,69 @@ impl JavascriptParserPlugin for InlineConstPlugin {
     if !parser.is_top_level_scope() {
       return None;
     }
-    if matches!(declaration.kind(), VariableDeclarationKind::Const)
-      && let Some(name) = declarator.name.as_ident()
-      && let Some(init) = &declarator.init
-    {
-      let evaluated = parser.evaluate_expression(init);
-      if let Some(inlinable) = to_evaluated_inlinable_value(&evaluated) {
-        parser.tag_variable_with_flags(
-          name.id.sym.clone(),
-          INLINABLE_CONST_TAG,
-          Some(InlinableConstData { value: inlinable }),
-          VariableInfoFlags::NORMAL,
+    if !matches!(declaration.kind(), VariableDeclarationKind::Const) || declarator.init.is_none() {
+      return None;
+    }
+
+    if let Some(name) = declarator.name.as_ident() {
+      let const_value = if self.inline {
+        let evaluated = parser.evaluate_expression(
+          declarator
+            .init
+            .as_ref()
+            .expect("init should exist for const value"),
         );
+        match to_evaluated_inlinable_value(&evaluated) {
+          Some(v) => ConstValue::Inlinable(v),
+          None => ConstValue::NoInlinable,
+        }
+      } else {
+        ConstValue::NoInlinable
+      };
+      tag_const_variable(parser, name.id.sym.clone(), const_value);
+    } else {
+      tag_const_pattern(parser, &declarator.name);
+    }
+
+    None
+  }
+}
+
+fn tag_const_variable(parser: &mut JavascriptParser, name: Atom, value: ConstValue) {
+  parser.tag_variable_with_flags(
+    name,
+    INLINABLE_CONST_TAG,
+    Some(ConstValueData { value }),
+    VariableInfoFlags::NORMAL,
+  );
+}
+
+fn tag_const_pattern(parser: &mut JavascriptParser, pattern: &Pat) {
+  match pattern {
+    Pat::Ident(ident) => {
+      tag_const_variable(parser, ident.id.sym.clone(), ConstValue::NoInlinable);
+    }
+    Pat::Array(array) => {
+      for elem in array.elems.iter().flatten() {
+        tag_const_pattern(parser, elem);
       }
     }
-    None
+    Pat::Assign(assign) => {
+      tag_const_pattern(parser, &assign.left);
+    }
+    Pat::Object(object) => {
+      for prop in &object.props {
+        match prop {
+          ObjectPatProp::KeyValue(prop) => tag_const_pattern(parser, &prop.value),
+          ObjectPatProp::Assign(prop) => {
+            tag_const_variable(parser, prop.key.sym.clone(), ConstValue::NoInlinable);
+          }
+          ObjectPatProp::Rest(rest) => tag_const_pattern(parser, &rest.arg),
+        }
+      }
+    }
+    Pat::Rest(rest) => tag_const_pattern(parser, &rest.arg),
+    Pat::Invalid(_) | Pat::Expr(_) => {}
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -338,14 +338,11 @@ impl InnerGraphParserPlugin {
   ) -> TopLevelSymbol {
     parser.define_variable(name.clone());
 
-    let existing = parser.get_variable_info(name);
-    if let Some(existing) = existing
-      && let Some(tag_info) = existing.tag_info
-      && let tag_info = parser.definitions_db.expect_get_tag_info(tag_info)
-      && tag_info.tag == TOP_LEVEL_SYMBOL
-      && let Some(tag_data) = tag_info.data.as_deref()
+    if let Some(existing) = parser
+      .get_tag_data::<TopLevelSymbol>(name, TOP_LEVEL_SYMBOL)
+      .copied()
     {
-      return *TopLevelSymbol::downcast_ref(tag_data);
+      return existing;
     }
 
     let symbol = parser.inner_graph.new_top_level_symbol(name.clone());

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -57,7 +57,7 @@ pub(crate) use self::{
   import_meta_plugin::{ImportMetaDisabledPlugin, ImportMetaPlugin},
   import_parser_plugin::{ImportParserPlugin, ImportsReferencesState},
   initialize_evaluating::InitializeEvaluating,
-  inline_const::InlineConstPlugin,
+  inline_const::{ConstValue, ConstValuePlugin},
   inner_graph::{connection_active_used_by_exports, plugin::*, runtime_condition_used_by_exports},
   is_included_plugin::IsIncludedPlugin,
   javascript_meta_info_plugin::JavascriptMetaInfoPlugin,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -517,10 +517,13 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(parser_plugin::OverrideStrictPlugin));
     }
 
-    if compiler_options.optimization.inline_exports {
+    let inline_exports = compiler_options.optimization.inline_exports;
+    if inline_exports {
       build_info.inline_exports = true;
-      plugins.push(Box::new(parser_plugin::InlineConstPlugin));
     }
+    plugins.push(Box::new(parser_plugin::ConstValuePlugin::new(
+      inline_exports,
+    )));
     if compiler_options.optimization.inner_graph {
       plugins.push(Box::new(parser_plugin::InnerGraphParserPlugin::new(
         unresolved_mark,

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -471,7 +471,7 @@ async fn optimize_dependencies(
 async fn optimize_modules(
   &self,
   _compilation: &Compilation,
-  _circular_modules: &mut IdentifierSet,
+  _circular_modules: &mut Option<IdentifierSet>,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   self.sealing_hooks_report("optimize modules", 7).await?;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
@@ -1,7 +1,11 @@
-<%- DEFINE_PROPERTY_GETTERS %> = <%- basicFunction("exports, definition") %> {
-	for(var key in definition) {
-        if(<%- HAS_OWN_PROPERTY %>(definition, key) && !<%- HAS_OWN_PROPERTY %>(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+<%- DEFINE_PROPERTY_GETTERS %> = <%- basicFunction("exports, getters, values") %> {
+	var define = <%- basicFunction("defs, kind") %> {
+		for(var key in defs) {
+			if(<%- HAS_OWN_PROPERTY %>(defs, key) && !<%- HAS_OWN_PROPERTY %>(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };

--- a/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
+++ b/packages/rspack-test-tools/src/helper/hot-update/plugin.ts
@@ -170,16 +170,22 @@ export class HotUpdatePlugin {
           if (
             module.constructor.name === 'DefinePropertyGettersRuntimeModule'
           ) {
+            // HMR tests re-execute modules and redefine the same export keys, so
+            // the test-only runtime keeps export descriptors configurable (`configurable: true`).
             module.source.source = Buffer.from(
               `
-										${RuntimeGlobals.definePropertyGetters} = function (exports, definition) {
-												for (var key in definition) {
-														if (${RuntimeGlobals.hasOwnProperty}(definition, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										`,
+${RuntimeGlobals.definePropertyGetters} = function (exports, getters, values) {
+  var define = function (defs, kind) {
+    for(var key in defs) {
+      if(${RuntimeGlobals.hasOwnProperty}(defs, key) && !${RuntimeGlobals.hasOwnProperty}(exports, key)) {
+        Object.defineProperty(exports, key, { configurable: true, enumerable: true, [kind]: defs[key] });
+      }
+    }
+  }
+  define(getters, "get");
+  define(values, "value");
+};
+`,
               'utf-8',
             );
           }

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -22,6 +22,7 @@ import {
   AsyncWebAssemblyModulesPlugin,
   BundlerInfoRspackPlugin,
   ChunkPrefetchPreloadPlugin,
+  CircularModulesInfoPlugin,
   CommonJsChunkFormatPlugin,
   CssHttpExternalsRspackPlugin,
   CssModulesPlugin,
@@ -267,6 +268,9 @@ export class RspackOptionsApply {
     }
     if (options.optimization.providedExports) {
       new FlagDependencyExportsPlugin().apply(compiler);
+    }
+    if (options.mode === 'production') {
+      new CircularModulesInfoPlugin().apply(compiler);
     }
     if (options.optimization.usedExports) {
       new FlagDependencyUsagePlugin(

--- a/tests/rspack-test/configCases/code-generation/import-export-format-2/index.js
+++ b/tests/rspack-test/configCases/code-generation/import-export-format-2/index.js
@@ -33,7 +33,7 @@ it("should use the same accessor syntax for import and export", function () {
 	/*********** DO NOT MATCH BELOW THIS LINE ***********/
 
 	// Checking harmonyexportinitfragment.js formation of standard export fragment
-	expectSourceToContain(source, "bar: () => (bar)");
+	expectSourceToContain(source, "bar: bar");
 
 	// Checking formation of imports
 	expectSourceToMatch(source, `${regexEscape("const { harmonyexport_cjsimport } = (__webpack_require__(")}\\d+${regexEscape(")/* .bar */.bar);")}`);

--- a/tests/rspack-test/configCases/code-generation/import-export-format/index.js
+++ b/tests/rspack-test/configCases/code-generation/import-export-format/index.js
@@ -30,7 +30,7 @@ it("should use the same accessor syntax for import and export", function () {
 	// Note that there are no quotes around the "a" and "b" properties in the following lines.
 
 	// Checking harmonyexportinitfragment.js formation of standard export fragment
-	expectSourceToContain(source, "a: () => (bar)");
+	expectSourceToContain(source, "a: bar");
 
 	// Checking formation of imports
 	expectSourceToContain(source, "harmony_module/* .bar */.a;");

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/const-export.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/const-export.js
@@ -1,0 +1,9 @@
+export const literal = "literal";
+
+const local = "local";
+export { local as renamed };
+
+const source = { destructured: "destructured" };
+export const { destructured } = source;
+
+export const [arrayValue] = ["array"];

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-a.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-a.js
@@ -1,0 +1,7 @@
+import { readCyclicConst } from "./cycle-b";
+
+export const cyclicConst = "cyclic";
+
+export function readFromCycle() {
+	return readCyclicConst();
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-b.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/cycle-b.js
@@ -1,0 +1,5 @@
+import { cyclicConst } from "./cycle-a";
+
+export function readCyclicConst() {
+	return cyclicConst;
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/function-export.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/function-export.js
@@ -1,0 +1,3 @@
+export function fn() {
+	return "fn";
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/index.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/index.js
@@ -1,0 +1,44 @@
+import * as constExports from "./const-export";
+import * as cyclicExports from "./cycle-a";
+import * as functionExports from "./function-export";
+import * as letExports from "./let-export";
+
+it("should bind const exports as readonly values", () => {
+	expectValueDescriptor(constExports, "literal", "literal");
+	expectValueDescriptor(constExports, "renamed", "local");
+	expectValueDescriptor(constExports, "destructured", "destructured");
+	expectValueDescriptor(constExports, "arrayValue", "array");
+});
+
+it("should keep non-const exports as getters", () => {
+	expectGetterDescriptor(letExports, "counter");
+	expectGetterDescriptor(functionExports, "fn");
+});
+
+it("should keep const exports in circular modules as getters", () => {
+	expectGetterDescriptor(cyclicExports, "cyclicConst");
+	expect(cyclicExports.readFromCycle()).toBe("cyclic");
+});
+
+function expectValueDescriptor(ns, key, value) {
+	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
+	expect(descriptor).toEqual(
+		expect.objectContaining({
+			enumerable: true,
+			writable: false,
+			value
+		})
+	);
+	expect(descriptor.get).toBe(undefined);
+}
+
+function expectGetterDescriptor(ns, key) {
+	const descriptor = Object.getOwnPropertyDescriptor(ns, key);
+	expect(descriptor).toEqual(
+		expect.objectContaining({
+			enumerable: true,
+			get: expect.any(Function)
+		})
+	);
+	expect(Object.prototype.hasOwnProperty.call(descriptor, "value")).toBe(false);
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/let-export.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/let-export.js
@@ -1,0 +1,5 @@
+export let counter = 0;
+
+export function setCounter(value) {
+	counter = value;
+}

--- a/tests/rspack-test/configCases/parsing/export-const-value-binding/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/export-const-value-binding/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    concatenateModules: false,
+    inlineExports: false,
+    mangleExports: false,
+  },
+};

--- a/tests/rspack-test/configCases/rsdoctor/assets/rspack.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/assets/rspack.config.js
@@ -37,11 +37,11 @@ module.exports = {
               Array [
                 Object {
                   path: a.js,
-                  size: 4300,
+                  size: 4298,
                 },
                 Object {
                   path: b.js,
-                  size: 4300,
+                  size: 4298,
                 },
                 Object {
                   path: c_js.js,

--- a/tests/rspack-test/configCases/rsdoctor/assets/rspack.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/assets/rspack.config.js
@@ -34,25 +34,25 @@ module.exports = {
             }));
             assetsInfo.sort((a, b) => (a.path > b.path ? 1 : -1));
             expect(assetsInfo).toMatchInlineSnapshot(`
-							Array [
-							  Object {
-							    path: a.js,
-							    size: 4240,
-							  },
-							  Object {
-							    path: b.js,
-							    size: 4240,
-							  },
-							  Object {
-							    path: c_js.js,
-							    size: 221,
-							  },
-							  Object {
-							    path: d_js.js,
-							    size: 221,
-							  },
-							]
-						`);
+              Array [
+                Object {
+                  path: a.js,
+                  size: 4300,
+                },
+                Object {
+                  path: b.js,
+                  size: 4300,
+                },
+                Object {
+                  path: c_js.js,
+                  size: 219,
+                },
+                Object {
+                  path: d_js.js,
+                  size: 219,
+                },
+              ]
+            `);
           });
         });
       },

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -80,22 +80,22 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
   if (typeof modFactory === 'string' || typeof modFactory === 'number') {
     __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
   } else if (typeof modFactory === 'function') {
-          const finalModFactory = function (
-        __unused_webpack_module,
-        __webpack_exports__,
-        __webpack_require__,
-      ) {
-        __webpack_require__.r(__webpack_exports__);
-        const res = modFactory();
-        for (const key in res) {
-          __webpack_require__.d(__webpack_exports__, {
-            [key]: () => res[key],
-          });
-        }
-      };
+    const finalModFactory = function (
+      __unused_webpack_module,
+      __webpack_exports__,
+      __webpack_require__,
+    ) {
+      __webpack_require__.r(__webpack_exports__);
+      const res = modFactory();
+      for (const key in res) {
+        __webpack_require__.d(__webpack_exports__, {
+          [key]: () => res[key],
+        });
+      }
+    };
 
-      __webpack_modules__[id] = finalModFactory;
-      delete __webpack_module_cache__[id];
+    __webpack_modules__[id] = finalModFactory;
+    delete __webpack_module_cache__[id];
   }
 };
 

--- a/tests/rspack-test/esmOutputCases/basic/export-shared-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/export-shared-namespace/__snapshots__/esm.snap.txt
@@ -21,12 +21,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/basic/export-shared-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/export-shared-namespace/__snapshots__/esm.snap.txt
@@ -23,8 +23,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/esm.snap.txt
@@ -103,8 +103,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/esm.snap.txt
@@ -101,12 +101,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_module_decorator

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
@@ -42,8 +42,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/basic/__snapshots__/esm.snap.txt
@@ -40,12 +40,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
@@ -52,12 +52,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-conflict-exports/__snapshots__/esm.snap.txt
@@ -54,8 +54,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
@@ -26,12 +26,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-mixed-chunks/__snapshots__/esm.snap.txt
@@ -28,8 +28,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-module-external-namespace-default-named-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-module-external-namespace-default-named-collision/__snapshots__/esm.snap.txt
@@ -27,12 +27,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-module-external-namespace-default-named-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-module-external-namespace-default-named-collision/__snapshots__/esm.snap.txt
@@ -29,8 +29,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-duplicate-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-duplicate-external/__snapshots__/esm.snap.txt
@@ -20,12 +20,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-duplicate-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-duplicate-external/__snapshots__/esm.snap.txt
@@ -22,8 +22,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-namespace-named-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-namespace-named-external/__snapshots__/esm.snap.txt
@@ -20,12 +20,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-namespace-named-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-multi-module-namespace-named-external/__snapshots__/esm.snap.txt
@@ -22,8 +22,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-three-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-three-modules/__snapshots__/esm.snap.txt
@@ -78,8 +78,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-three-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-three-modules/__snapshots__/esm.snap.txt
@@ -76,12 +76,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-treeshake-real-conflict/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-treeshake-real-conflict/__snapshots__/esm.snap.txt
@@ -24,8 +24,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-treeshake-real-conflict/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/dyn-import-treeshake-real-conflict/__snapshots__/esm.snap.txt
@@ -22,12 +22,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
@@ -105,8 +105,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
@@ -103,12 +103,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
@@ -95,8 +95,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
@@ -93,12 +93,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
@@ -120,12 +120,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs/__snapshots__/esm.snap.txt
@@ -122,8 +122,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/magic-comment/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/magic-comment/__snapshots__/esm.snap.txt
@@ -53,12 +53,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/dynamic-import/magic-comment/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/magic-comment/__snapshots__/esm.snap.txt
@@ -55,8 +55,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/externals/array-request-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/array-request-module/__snapshots__/esm.snap.txt
@@ -37,12 +37,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/externals/array-request-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/array-request-module/__snapshots__/esm.snap.txt
@@ -39,8 +39,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
@@ -43,12 +43,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
@@ -45,8 +45,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module-with-own-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module-with-own-export/__snapshots__/esm.snap.txt
@@ -45,12 +45,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module-with-own-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module-with-own-export/__snapshots__/esm.snap.txt
@@ -47,8 +47,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module/__snapshots__/esm.snap.txt
@@ -38,12 +38,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/reexport-star-as-namespace-via-module/__snapshots__/esm.snap.txt
@@ -40,8 +40,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
@@ -106,8 +106,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/esm.snap.txt
@@ -104,12 +104,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/interop/access-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/access-exports/__snapshots__/esm.snap.txt
@@ -69,8 +69,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/interop/access-exports/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/access-exports/__snapshots__/esm.snap.txt
@@ -67,12 +67,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/interop/access-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/access-module/__snapshots__/esm.snap.txt
@@ -68,12 +68,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/interop/access-module/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/access-module/__snapshots__/esm.snap.txt
@@ -70,8 +70,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/interop/correct-order/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/correct-order/__snapshots__/esm.snap.txt
@@ -80,12 +80,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/interop/correct-order/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/correct-order/__snapshots__/esm.snap.txt
@@ -82,8 +82,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/interop/entry-exports-type-defaut/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/entry-exports-type-defaut/__snapshots__/esm.snap.txt
@@ -89,8 +89,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/interop/entry-exports-type-defaut/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/entry-exports-type-defaut/__snapshots__/esm.snap.txt
@@ -87,12 +87,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
@@ -77,8 +77,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default/__snapshots__/esm.snap.txt
@@ -75,12 +75,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
@@ -53,12 +53,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/namespace-import-asset/__snapshots__/esm.snap.txt
@@ -55,8 +55,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/basic-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-capture/__snapshots__/esm.snap.txt
@@ -31,12 +31,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/basic-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-capture/__snapshots__/esm.snap.txt
@@ -33,8 +33,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/basic-cjs-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-cjs-capture/__snapshots__/esm.snap.txt
@@ -85,12 +85,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/basic-cjs-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-cjs-capture/__snapshots__/esm.snap.txt
@@ -87,8 +87,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/default-only-object/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/default-only-object/__snapshots__/esm.snap.txt
@@ -35,8 +35,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/default-only-object/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/default-only-object/__snapshots__/esm.snap.txt
@@ -33,12 +33,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/empty-modules-default-property/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/empty-modules-default-property/__snapshots__/esm.snap.txt
@@ -84,12 +84,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/empty-modules-default-property/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/empty-modules-default-property/__snapshots__/esm.snap.txt
@@ -86,8 +86,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -86,8 +86,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -84,12 +84,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/export-namespace-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-namespace-as/__snapshots__/esm.snap.txt
@@ -32,12 +32,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/export-namespace-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-namespace-as/__snapshots__/esm.snap.txt
@@ -34,8 +34,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -29,12 +29,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -31,8 +31,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -85,12 +85,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -87,8 +87,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as/__snapshots__/esm.snap.txt
@@ -31,12 +31,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as/__snapshots__/esm.snap.txt
@@ -33,8 +33,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -32,12 +32,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -34,8 +34,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-export-namespace-as-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-export-namespace-as-capture/__snapshots__/esm.snap.txt
@@ -31,12 +31,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-export-namespace-as-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-export-namespace-as-capture/__snapshots__/esm.snap.txt
@@ -33,8 +33,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-export-star-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-export-star-as/__snapshots__/esm.snap.txt
@@ -43,8 +43,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-export-star-as/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-export-star-as/__snapshots__/esm.snap.txt
@@ -41,12 +41,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-re-export-star-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-re-export-star-capture/__snapshots__/esm.snap.txt
@@ -31,12 +31,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/import-of-re-export-star-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-of-re-export-star-capture/__snapshots__/esm.snap.txt
@@ -33,8 +33,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/missing-export-capture/__snapshots__/esm.snap.txt
@@ -29,12 +29,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/missing-export-capture/__snapshots__/esm.snap.txt
@@ -31,8 +31,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/missing-export-cjs-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/missing-export-cjs-capture/__snapshots__/esm.snap.txt
@@ -85,8 +85,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/missing-export-cjs-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/missing-export-cjs-capture/__snapshots__/esm.snap.txt
@@ -83,12 +83,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/no-treeshake-object/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/no-treeshake-object/__snapshots__/esm.snap.txt
@@ -42,8 +42,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/no-treeshake-object/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/no-treeshake-object/__snapshots__/esm.snap.txt
@@ -40,12 +40,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/optimization-in-operator/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/optimization-in-operator/__snapshots__/esm.snap.txt
@@ -45,12 +45,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/optimization-in-operator/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/optimization-in-operator/__snapshots__/esm.snap.txt
@@ -47,8 +47,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/optional-chaining/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/optional-chaining/__snapshots__/esm.snap.txt
@@ -39,8 +39,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/optional-chaining/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/optional-chaining/__snapshots__/esm.snap.txt
@@ -37,12 +37,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-named-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-named-missing-export-capture/__snapshots__/esm.snap.txt
@@ -38,8 +38,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-named-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-named-missing-export-capture/__snapshots__/esm.snap.txt
@@ -36,12 +36,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-namespace-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-namespace-missing-export-capture/__snapshots__/esm.snap.txt
@@ -29,12 +29,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-namespace-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-namespace-missing-export-capture/__snapshots__/esm.snap.txt
@@ -31,8 +31,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -32,12 +32,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-self-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-self-as-namespace/__snapshots__/esm.snap.txt
@@ -34,8 +34,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-self-import-export-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-self-import-export-as-namespace/__snapshots__/esm.snap.txt
@@ -37,8 +37,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-self-import-export-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-self-import-export-as-namespace/__snapshots__/esm.snap.txt
@@ -35,12 +35,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-star-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-star-missing-export-capture/__snapshots__/esm.snap.txt
@@ -29,12 +29,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-star-missing-export-capture/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-star-missing-export-capture/__snapshots__/esm.snap.txt
@@ -31,8 +31,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-star/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-star/__snapshots__/esm.snap.txt
@@ -41,8 +41,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/re-export-star/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/re-export-star/__snapshots__/esm.snap.txt
@@ -39,12 +39,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/reexport-self-cycle/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/reexport-self-cycle/__snapshots__/esm.snap.txt
@@ -38,12 +38,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/reexport-self-cycle/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/reexport-self-cycle/__snapshots__/esm.snap.txt
@@ -40,8 +40,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/self-import-cycle/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/self-import-cycle/__snapshots__/esm.snap.txt
@@ -36,8 +36,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/self-import-cycle/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/self-import-cycle/__snapshots__/esm.snap.txt
@@ -34,12 +34,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/side-effect-free-modules-default-property/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/side-effect-free-modules-default-property/__snapshots__/esm.snap.txt
@@ -84,12 +84,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/side-effect-free-modules-default-property/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/side-effect-free-modules-default-property/__snapshots__/esm.snap.txt
@@ -86,8 +86,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
@@ -91,8 +91,8 @@ __webpack_require__.t = function(value, mode) {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
@@ -89,12 +89,16 @@ __webpack_require__.t = function(value, mode) {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace/__snapshots__/esm.snap.txt
@@ -31,12 +31,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace/__snapshots__/esm.snap.txt
@@ -33,8 +33,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/tostring-inlined-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/tostring-inlined-namespace/__snapshots__/esm.snap.txt
@@ -41,8 +41,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/namespace/tostring-inlined-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/tostring-inlined-namespace/__snapshots__/esm.snap.txt
@@ -39,12 +39,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/tostring-static-resolution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/tostring-static-resolution/__snapshots__/esm.snap.txt
@@ -31,12 +31,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/namespace/tostring-static-resolution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/tostring-static-resolution/__snapshots__/esm.snap.txt
@@ -33,8 +33,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
@@ -100,8 +100,8 @@ __webpack_require__.m = __webpack_modules__;
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
@@ -98,12 +98,16 @@ __webpack_require__.m = __webpack_modules__;
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_module_decorator
@@ -144,15 +148,16 @@ __webpack_require__.add({
   !*** ./src/wrapped.js ***!
   \************************/
 (module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: () => (/* reexport safe */ node_events__rspack_import_0.a),
-  b: () => (/* reexport safe */ node_events__rspack_import_0.b)
-});
 /* import */ var node_events__rspack_import_0 = __webpack_require__(/*! node:events */ "node:events?df85");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
 console.log.bind(module);
+
+__webpack_require__.d(__webpack_exports__, {
+  a: () => (/* reexport safe */ node_events__rspack_import_0.a),
+  b: () => (/* reexport safe */ node_events__rspack_import_0.b)
+});
 
 
 },

--- a/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/__snapshots__/esm.snap.txt
@@ -55,8 +55,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/__snapshots__/esm.snap.txt
@@ -53,12 +53,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/esm.snap.txt
@@ -91,8 +91,8 @@ __webpack_require__.m = __webpack_modules__;
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/esm.snap.txt
@@ -89,12 +89,16 @@ __webpack_require__.m = __webpack_modules__;
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_module_decorator
@@ -135,15 +139,16 @@ __webpack_require__.add({
   !*** ./src/wrapped.js ***!
   \************************/
 (module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  E: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  Z: () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs?2159");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
 console.log.bind(module)
+
+__webpack_require__.d(__webpack_exports__, {
+  E: () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  Z: () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
+});
 
 
 },

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/esm.snap.txt
@@ -109,8 +109,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/esm.snap.txt
@@ -107,12 +107,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_module_decorator
@@ -153,16 +157,17 @@ __webpack_require__.add({
   !*** ./src/wrapped.js ***!
   \************************/
 (module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  E: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  Z: () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 /* import */ var fs__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(fs__rspack_import_0);
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
 console.log.bind(module)
+
+__webpack_require__.d(__webpack_exports__, {
+  E: () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  Z: () => (/* reexport safe */ fs__rspack_import_0.readFileSync)
+});
 
 
 },

--- a/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/esm.snap.txt
@@ -84,8 +84,8 @@ __webpack_require__.m = __webpack_modules__;
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/esm.snap.txt
@@ -17,13 +17,15 @@ exports.bar = 2
   \****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  bar: () => (/* reexport safe */ _bar__rspack_import_0.bar),
-  foo: () => (foo)
-});
 /* import */ var _bar__rspack_import_0 = __webpack_require__(/*! ./bar */ "./bar.js");
 const foo = 1
 
+
+__webpack_require__.d(__webpack_exports__, {
+  bar: () => (/* reexport safe */ _bar__rspack_import_0.bar)
+}, {
+  foo: foo
+});
 
 
 },
@@ -80,12 +82,16 @@ __webpack_require__.m = __webpack_modules__;
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
@@ -52,12 +52,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-export-external/__snapshots__/esm.snap.txt
@@ -54,8 +54,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
@@ -10,9 +10,6 @@ __webpack_require__.add({
   \****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  lib: () => (lib)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 
 /* reexport */ var __rspack_reexport = {};
@@ -29,6 +26,11 @@ __webpack_require__.d(__webpack_exports__, {
 
 const lib = 42
 
+__webpack_require__.d(__webpack_exports__, {
+}, {
+  lib: lib
+});
+
 
 },
 "./lib2.js"
@@ -37,12 +39,6 @@ const lib = 42
   \*****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  fs: () => (/* reexport safe */ _lib3__rspack_import_1.fs),
-  lib2: () => (lib2),
-  lib3: () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */42)),
-  lib4: () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */24))
-});
 /* import */ var path__rspack_import_0 = __webpack_require__(/*! path */ "path");
 
 /* reexport */ var __rspack_reexport = {};
@@ -55,6 +51,14 @@ __webpack_require__.d(__webpack_exports__, {
 
 const lib2 = 42
 
+__webpack_require__.d(__webpack_exports__, {
+  fs: () => (/* reexport safe */ _lib3__rspack_import_1.fs),
+  lib3: () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */42)),
+  lib4: () => (/* reexport safe */ (/* inlined export _lib3__rspack_import_1 */24))
+}, {
+  lib2: lib2
+});
+
 
 },
 "./lib3.js"
@@ -62,9 +66,6 @@ const lib2 = 42
   !*** ./lib3.js ***!
   \*****************/
 (__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  fs: () => (/* reexport module object */ fs__rspack_import_0)
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 const lib3 = 42
 
@@ -72,6 +73,10 @@ const lib_local = 24
 
 
 
+
+__webpack_require__.d(__webpack_exports__, {
+  fs: () => (/* reexport module object */ fs__rspack_import_0)
+});
 
 
 },
@@ -150,12 +155,16 @@ __webpack_require__.m = __webpack_modules__;
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_register_module

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/esm.snap.txt
@@ -157,8 +157,8 @@ __webpack_require__.m = __webpack_modules__;
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/re-exports/default-namespace-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/default-namespace-external/__snapshots__/esm.snap.txt
@@ -38,8 +38,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/re-exports/default-namespace-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/default-namespace-external/__snapshots__/esm.snap.txt
@@ -36,12 +36,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/re-exports/default-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/default-re-export-external/__snapshots__/esm.snap.txt
@@ -38,8 +38,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/re-exports/default-re-export-external/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/default-re-export-external/__snapshots__/esm.snap.txt
@@ -36,12 +36,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/re-exports/string-export-star-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/string-export-star-as-namespace/__snapshots__/esm.snap.txt
@@ -38,8 +38,8 @@ var __webpack_require__ = {};
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/esmOutputCases/re-exports/string-export-star-as-namespace/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/string-export-star-as-namespace/__snapshots__/esm.snap.txt
@@ -36,12 +36,16 @@ var __webpack_require__ = {};
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/esm.snap.txt
@@ -9,13 +9,6 @@ __webpack_require__.add({
   \******************/
 (module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  fs: () => (/* reexport safe */ fs__rspack_import_0["default"]),
-  named: () => (/* reexport safe */ (/* inlined export _lib__rspack_import_1 */42)),
-  r: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  readFile: () => (/* reexport safe */ fs__rspack_import_0.readFile),
-  starExports: () => (/* reexport safe */ (/* inlined export _lib2__rspack_import_2 */42))
-});
 /* import */ var fs__rspack_import_0 = __webpack_require__(/*! fs */ "fs");
 
 /* reexport */ var __rspack_reexport = {};
@@ -44,6 +37,14 @@ it('should compile and import success', async () => {
 	expect(r).toBeDefined()
 	expect(readFile).toBeDefined()
 })
+
+__webpack_require__.d(__webpack_exports__, {
+  fs: () => (/* reexport safe */ fs__rspack_import_0["default"]),
+  named: () => (/* reexport safe */ (/* inlined export _lib__rspack_import_1 */42)),
+  r: () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  readFile: () => (/* reexport safe */ fs__rspack_import_0.readFile),
+  starExports: () => (/* reexport safe */ (/* inlined export _lib2__rspack_import_2 */42))
+});
 
 
 },
@@ -98,12 +99,16 @@ __webpack_require__.m = __webpack_modules__;
 
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/esm_module_decorator

--- a/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/esm.snap.txt
@@ -101,8 +101,8 @@ __webpack_require__.m = __webpack_modules__;
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
@@ -57,8 +57,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
@@ -55,12 +55,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
@@ -52,8 +52,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
@@ -50,12 +50,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
@@ -52,8 +52,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
@@ -50,12 +50,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
@@ -52,8 +52,8 @@ __webpack_require__.n = (module) => {
 (() => {
 __webpack_require__.d = (exports, getters, values) => {
 	var define = (defs, kind) => {
-		for (var key in defs) {
-			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
 				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
 			}
 		}

--- a/tests/rspack-test/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
@@ -50,12 +50,16 @@ __webpack_require__.n = (module) => {
 })();
 // webpack/runtime/define_property_getters
 (() => {
-__webpack_require__.d = (exports, definition) => {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for (var key in defs) {
+			if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
 };
 })();
 // webpack/runtime/has_own_property

--- a/tests/rspack-test/hotCases/concat/reload-compat-flag/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-compat-flag/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 469
+- Update: 889.LAST_HASH.hot-update.js, size: 470
 
 ## Manifest
 
@@ -34,12 +34,13 @@
 self["rspackHotUpdate"](889, {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
 
 
 /* export default */ const __rspack_default_export = ("ok2");
+
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
 
 
 },

--- a/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 458
+- Update: 889.LAST_HASH.hot-update.js, size: 459
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"](889, {
 "./a.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+/* export default */ const __rspack_default_export = (2);
+
 __webpack_require__.d(__webpack_exports__, {
   "default": () => (__rspack_default_export)
 });
-/* export default */ const __rspack_default_export = (2);
 
 
 },

--- a/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/concat/reload-external/__snapshots__/web/2.snap.txt
@@ -7,7 +7,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 459
+- Update: 889.LAST_HASH.hot-update.js, size: 460
 
 ## Manifest
 
@@ -35,10 +35,11 @@
 self["rspackHotUpdate"](889, {
 "./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+/* export default */ const __rspack_default_export = (20);
+
 __webpack_require__.d(__webpack_exports__, {
   "default": () => (__rspack_default_export)
 });
-/* export default */ const __rspack_default_export = (20);
 
 
 },

--- a/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 6024
+- Update: main.hot-update.js, size: 6038
 
 ## Manifest
 
@@ -174,14 +174,18 @@ function cssReload(moduleId, options) {
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, getters, values) {
+  var define = function (defs, kind) {
+    for(var key in defs) {
+      if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+        Object.defineProperty(exports, key, { configurable: true, enumerable: true, [kind]: defs[key] });
+      }
+    }
+  }
+  define(getters, "get");
+  define(values, "value");
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/numeric-ids/production/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/numeric-ids/production/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: [runtime of 889].LAST_HASH.hot-update.json, size: 25
-- Update: 889.LAST_HASH.hot-update.js, size: 396
+- Update: 889.LAST_HASH.hot-update.js, size: 397
 
 ## Manifest
 
@@ -34,10 +34,11 @@
 self["rspackHotUpdate"](889, {
 "./file.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
+var value = 2;
+
 __webpack_require__.d(__webpack_exports__, {
   value: () => (value)
 });
-var value = 2;
 
 
 },

--- a/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-loader-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 912
+- Update: main.LAST_HASH.hot-update.js, size: 926
 
 ## Manifest
 
@@ -47,14 +47,18 @@ __webpack_require__.d(__webpack_exports__, {
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, getters, values) {
+  var define = function (defs, kind) {
+    for(var key in defs) {
+      if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+        Object.defineProperty(exports, key, { configurable: true, enumerable: true, [kind]: defs[key] });
+      }
+    }
+  }
+  define(getters, "get");
+  define(values, "value");
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-parsing-error/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 900
+- Update: main.LAST_HASH.hot-update.js, size: 914
 
 ## Manifest
 
@@ -47,14 +47,18 @@ __webpack_require__.d(__webpack_exports__, {
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, getters, values) {
+  var define = function (defs, kind) {
+    for(var key in defs) {
+      if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+        Object.defineProperty(exports, key, { configurable: true, enumerable: true, [kind]: defs[key] });
+      }
+    }
+  }
+  define(getters, "get");
+  define(values, "value");
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
+++ b/tests/rspack-test/hotCases/recover/recover-after-self-error/__snapshots__/web/3.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 1134
+- Update: main.LAST_HASH.hot-update.js, size: 1148
 
 ## Manifest
 
@@ -53,14 +53,18 @@ const id = module.id;
 // webpack/runtime/define_property_getters
 (() => {
 
-										__webpack_require__.d = function (exports, definition) {
-												for (var key in definition) {
-														if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-																Object.defineProperty(exports, key, { configurable: true, enumerable: true, get: definition[key] });
-														}
-												}
-										};
-										
+__webpack_require__.d = function (exports, getters, values) {
+  var define = function (defs, kind) {
+    for(var key in defs) {
+      if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+        Object.defineProperty(exports, key, { configurable: true, enumerable: true, [kind]: defs[key] });
+      }
+    }
+  }
+  define(getters, "get");
+  define(values, "value");
+};
+
 })();
 // webpack/runtime/get_full_hash
 (() => {

--- a/tests/rspack-test/normalCases/parsing/harmony-duplicate-export/index.js
+++ b/tests/rspack-test/normalCases/parsing/harmony-duplicate-export/index.js
@@ -21,7 +21,8 @@ it("should not overwrite when using star export (known exports)", function () {
 	expect(x4).toBe("b");
 	expect(x5).toBe("c");
 	expect(x6).toBe("a");
-	expect(x7).toBe("b"); // Looks wrong, but is irrelevant as this is an error anyway
+	// Different from webpack, but is irrelevant as this is an error anyway
+	expect(x7).toBeOneOf(["b", "d"]);
 });
 
 it("should not overwrite when using star export (unknown exports)", function () {
@@ -31,5 +32,6 @@ it("should not overwrite when using star export (unknown exports)", function () 
 	expect(y4).toBe("b");
 	expect(y5).toBe("c");
 	expect(y6).toBe("a");
-	expect(y7).toBe("b"); // Looks wrong, but is irrelevant as this is an error anyway
+	// Different from webpack, but is irrelevant as this is an error anyway
+	expect(y7).toBeOneOf(["b", "d"]);
 });

--- a/tests/rspack-test/statsAPICases/additional-chunks.js
+++ b/tests/rspack-test/statsAPICases/additional-chunks.js
@@ -61,10 +61,10 @@ module.exports = {
 			      assets: Array [
 			        Object {
 			          name: entryB.js,
-			          size: 3169,
+			          size: 3210,
 			        },
 			      ],
-			      assetsSize: 3169,
+			      assetsSize: 3210,
 			      auxiliaryAssets: undefined,
 			      auxiliaryAssetsSize: undefined,
 			      childAssets: undefined,

--- a/tests/rspack-test/statsAPICases/assets.js
+++ b/tests/rspack-test/statsAPICases/assets.js
@@ -39,7 +39,7 @@ module.exports = {
 			        related: Object {},
 			      },
 			      name: entryB.js,
-			      size: 3169,
+			      size: 3210,
 			      type: asset,
 			    },
 			    Object {

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -59,7 +59,7 @@ module.exports = {
 			      isOverSizeLimit: false,
 			      name: main.js,
 			      related: Array [],
-			      size: 403,
+			      size: 444,
 			      type: asset,
 			    },
 			  ],
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: ab4d81bf47aea773,
+			      hash: c6228ed378e658dd,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -437,7 +437,7 @@ module.exports = {
 			      size: 192,
 			      sizes: Object {
 			        javascript: 192,
-			        runtime: 647,
+			        runtime: 707,
 			      },
 			      type: chunk,
 			    },
@@ -447,10 +447,10 @@ module.exports = {
 			      assets: Array [
 			        Object {
 			          name: main.js,
-			          size: 403,
+			          size: 444,
 			        },
 			      ],
-			      assetsSize: 403,
+			      assetsSize: 444,
 			      auxiliaryAssets: Array [],
 			      auxiliaryAssetsSize: 0,
 			      childAssets: Object {},
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 48be6dd9fe1e1073,
+			  hash: 4f5def60dc2b0822,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -1106,9 +1106,9 @@ module.exports = {
 			      preOrderIndex: undefined,
 			      providedExports: Array [],
 			      reasons: Array [],
-			      size: 285,
+			      size: 345,
 			      sizes: Object {
-			        runtime: 285,
+			        runtime: 345,
 			      },
 			      type: module,
 			      usedExports: null,
@@ -1204,10 +1204,10 @@ module.exports = {
 			      assets: Array [
 			        Object {
 			          name: main.js,
-			          size: 403,
+			          size: 444,
 			        },
 			      ],
-			      assetsSize: 403,
+			      assetsSize: 444,
 			      auxiliaryAssets: Array [],
 			      auxiliaryAssetsSize: 0,
 			      childAssets: Object {},
@@ -1235,9 +1235,9 @@ module.exports = {
 			builtAt: false,
 			version: false
 		})).toMatchInlineSnapshot(`
-			asset main.js 403 bytes [emitted] (name: main)
+			asset main.js 444 bytes [emitted] (name: main)
 			orphan modules 192 bytes [orphan] 4 modules
-			runtime modules 647 bytes 3 modules
+			runtime modules 707 bytes 3 modules
 			./fixtures/esm/abc.js + 3 modules 192 bytes [code generated]
 			  [no exports]
 			  [no exports used]

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: c6228ed378e658dd,
+			      hash: cdb99ed02c08ea23,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -437,7 +437,7 @@ module.exports = {
 			      size: 192,
 			      sizes: Object {
 			        javascript: 192,
-			        runtime: 707,
+			        runtime: 705,
 			      },
 			      type: chunk,
 			    },
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 4f5def60dc2b0822,
+			  hash: 8231f20d8ffb8e3d,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -1106,9 +1106,9 @@ module.exports = {
 			      preOrderIndex: undefined,
 			      providedExports: Array [],
 			      reasons: Array [],
-			      size: 345,
+			      size: 343,
 			      sizes: Object {
-			        runtime: 345,
+			        runtime: 343,
 			      },
 			      type: module,
 			      usedExports: null,
@@ -1237,7 +1237,7 @@ module.exports = {
 		})).toMatchInlineSnapshot(`
 			asset main.js 444 bytes [emitted] (name: main)
 			orphan modules 192 bytes [orphan] 4 modules
-			runtime modules 707 bytes 3 modules
+			runtime modules 705 bytes 3 modules
 			./fixtures/esm/abc.js + 3 modules 192 bytes [code generated]
 			  [no exports]
 			  [no exports used]

--- a/tests/rspack-test/statsAPICases/nested-modules.js
+++ b/tests/rspack-test/statsAPICases/nested-modules.js
@@ -29,9 +29,9 @@ module.exports = {
 		expect(concatedModule).toBeTruthy();
 		expect(stats?.toString(statsOptions))
 			.toMatchInlineSnapshot(`
-				asset main.js 403 bytes [emitted] (name: main)
+				asset main.js 444 bytes [emitted] (name: main)
 				orphan modules 192 bytes [orphan] 4 modules
-				runtime modules 647 bytes 3 modules
+				runtime modules 707 bytes 3 modules
 				./fixtures/esm/abc.js + 3 modules 192 bytes [code generated]
 				  | orphan modules 192 bytes [orphan] 4 modules
 				Rspack compiled successfully

--- a/tests/rspack-test/statsAPICases/nested-modules.js
+++ b/tests/rspack-test/statsAPICases/nested-modules.js
@@ -31,7 +31,7 @@ module.exports = {
 			.toMatchInlineSnapshot(`
 				asset main.js 444 bytes [emitted] (name: main)
 				orphan modules 192 bytes [orphan] 4 modules
-				runtime modules 707 bytes 3 modules
+				runtime modules 705 bytes 3 modules
 				./fixtures/esm/abc.js + 3 modules 192 bytes [code generated]
 				  | orphan modules 192 bytes [orphan] 4 modules
 				Rspack compiled successfully

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 99bbf509c54b9cc6.js xx KiB [emitted] [immutable] (name: main)
+asset 6cca7f3e8d53f587.js xx KiB [emitted] [immutable] (name: main)
 asset 7b129503d319bd23.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 6cca7f3e8d53f587.js xx KiB [emitted] [immutable] (name: main)
+asset 9eb9c806b81c0408.js xx KiB [emitted] [immutable] (name: main)
 asset 7b129503d319bd23.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -6,11 +6,11 @@ runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset b-runtime~main-5ee5a9d8cad7385e.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset b-runtime~main-e6acfc16a960b892.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset b-main-8680a888f1bf9eb6.js xx bytes [emitted] [immutable] (name: main)
 asset b-all-b_js-9176ed8ced1de96c.js xx bytes [emitted] [immutable] (id hint: all)
 asset b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-5ee5a9d8cad7385e.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-9176ed8ced1de96c.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
+Entrypoint main xx KiB = b-runtime~main-e6acfc16a960b892.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-9176ed8ced1de96c.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -20,10 +20,10 @@ Rspack x.x.x compiled successfully in X s
 assets by chunk xx bytes (id hint: all)
   asset c-all-b_js-0f2306cb10798728.js xx bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-a87e28008385c9d2.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-ea5f7ddc435735fd.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-a87e28008385c9d2.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+Entrypoint main xx KiB = c-runtime~main-ea5f7ddc435735fd.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -6,11 +6,11 @@ runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset b-runtime~main-e6acfc16a960b892.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset b-runtime~main-60e1a9cacb740650.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset b-main-8680a888f1bf9eb6.js xx bytes [emitted] [immutable] (name: main)
 asset b-all-b_js-9176ed8ced1de96c.js xx bytes [emitted] [immutable] (id hint: all)
 asset b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-e6acfc16a960b892.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-9176ed8ced1de96c.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
+Entrypoint main xx KiB = b-runtime~main-60e1a9cacb740650.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-9176ed8ced1de96c.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -20,10 +20,10 @@ Rspack x.x.x compiled successfully in X s
 assets by chunk xx bytes (id hint: all)
   asset c-all-b_js-0f2306cb10798728.js xx bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-ea5f7ddc435735fd.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-52a5240270c0583f.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-ea5f7ddc435735fd.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+Entrypoint main xx KiB = c-runtime~main-52a5240270c0583f.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/side-effects-optimization/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/side-effects-optimization/__snapshots__/stats.txt
@@ -1,5 +1,5 @@
 asset main.js xx KiB [emitted] (name: main)
-runtime modules xx bytes 4 modules
+runtime modules xx KiB 4 modules
 cacheable modules xx KiB
   modules by path ./node_modules/big-module/*.js xx bytes
     ./node_modules/big-module/index.js xx bytes [built] [code generated]
@@ -29,7 +29,7 @@ cacheable modules xx KiB
 Rspack x.x.x compiled successfully in X s
 
 asset main.no-side.js xx KiB [emitted] (name: main)
-runtime modules xx bytes 4 modules
+runtime modules xx KiB 4 modules
 cacheable modules xx KiB
   modules by path ./node_modules/big-module/*.js xx bytes
     ./node_modules/big-module/index.js xx bytes [built] [code generated]

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -1318,7 +1318,7 @@ async fn run_optimize_dependencies_hook(compilation: &mut Compilation) -> Result
 
 async fn run_optimize_modules_hook(compilation: &mut Compilation) -> Result<()> {
   let mut diagnostics = vec![];
-  let mut circular_modules = IdentifierSet::default();
+  let mut circular_modules = None;
   while matches!(
     compilation
       .plugin_driver


### PR DESCRIPTION
Reverts web-infra-dev/rspack#14151

And the only different with https://github.com/web-infra-dev/rspack/pull/14045 is `__webpack_require__.d`:

- in #14045:
    ```js
    __webpack_require__.d(exports, [
      "a", () => a, // getter
      "b", 0, b // const export value
    ]);
    ```
- now:
    ```js
    __webpack_require__.d(exports, {
      a: () => a, // getter
    }, {
      b: b // const export value
    });
    ```
because it's smaller and more compatiable ([rstest will directly use `__webpack_require__.d`](https://github.com/web-infra-dev/rstest/blob/e555fb0875cfbbcdc5d1d80edc645f58664bd6a1/packages/core/src/core/plugins/mockRuntimeCode.js#L52-L60))