### PR TITLE
fix: disable swc concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6368,7 +6368,6 @@ dependencies = [
  "indexmap",
  "once_cell",
  "par-core",
- "par-iter",
  "phf",
  "rustc-hash",
  "serde",

--- a/crates/rspack_javascript_compiler/Cargo.toml
+++ b/crates/rspack_javascript_compiler/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hash          = { workspace = true }
 serde               = { workspace = true, features = ["derive"] }
 swc_config          = { workspace = true }
 swc_core            = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "__parser", "ecma_ast", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "ecma_parser_unstable", "swc_ecma_codegen", "swc_ecma_visit"] }
-swc_ecma_minifier   = { workspace = true, features = ["concurrent"] }
+swc_ecma_minifier   = { workspace = true }
 swc_error_reporters = { workspace = true }
 swc_typescript      = { workspace = true }
 url                 = { workspace = true }

--- a/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_js_minimizer/Cargo.toml
@@ -24,7 +24,7 @@ rspack_util                = { workspace = true }
 serde_json                 = { workspace = true }
 swc_config                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__parser", "__utils", "common_sourcemap", "ecma_preset_env", "ecma_transforms_optimization", "ecma_transforms_module", "ecma_transforms_compat", "ecma_transforms_typescript", "ecma_quote"] }
-swc_ecma_minifier          = { workspace = true, features = ["concurrent"] }
+swc_ecma_minifier          = { workspace = true }
 thread_local               = { workspace = true }
 tracing                    = { workspace = true }
 


### PR DESCRIPTION
## Summary

 Disable the `concurrent` feature of `swc_ecma_minifier`.

Rspack already parallelizes JS minification at the asset level. Enabling SWC's internal concurrent minifier introduces nested Rayon work inside each asset minify task. Some SWC concurrent paths do not explicitly propagate `GLOBALS`, while minification relies on SWC hygiene state such as `Mark`/`SyntaxContext`. This can make mangled output scheduling-dependent.

## Related

  Fixes #14089

  ## Testing

  - `cargo check -p rspack_plugin_swc_js_minimizer`