### PR TITLE
fix(esm-library): move async runtime split logic

### DIFF
--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -263,7 +263,6 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
 
 /// Ensure that all entry chunks only export the exports used by other chunks,
 /// this requires no other chunks depend on the entry chunk to get exports
-/// or the entry chunk's runtime from async chunks.
 ///
 /// for example entryA -> a -> b => c -> a
 /// entry chunk: a, b
@@ -300,27 +299,6 @@ pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
   }
 
   let dirty_chunks = FxDashSet::default();
-
-  for (entry_chunk_ukey, entrypoint_ukey) in &entrypoint_chunks {
-    let entrypoint = compilation
-      .build_chunk_graph_artifact
-      .chunk_group_by_ukey
-      .expect_get(entrypoint_ukey);
-    if entrypoint.get_runtime_chunk(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
-      != *entry_chunk_ukey
-    {
-      continue;
-    }
-
-    let chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get(entry_chunk_ukey);
-
-    if chunk.has_async_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
-      dirty_chunks.insert(*entry_chunk_ukey);
-    }
-  }
 
   compilation
     .build_chunk_graph_artifact
@@ -436,7 +414,8 @@ pub(crate) fn ensure_entry_exports(compilation: &mut Compilation) {
 }
 
 /// For each entrypoint, if the runtime chunk is the same as the entry chunk
-/// and any initial ChunkGroup containing this chunk has multiple chunks,
+/// and either this chunk has async chunks or any initial ChunkGroup containing
+/// this chunk has multiple chunks,
 /// split the runtime into a separate runtime chunk.
 ///
 /// This must run AFTER SplitChunksPlugin and RemoveDuplicateModulesPlugin
@@ -462,12 +441,16 @@ pub(crate) fn optimize_runtime_chunks(compilation: &mut Compilation) {
         return false;
       }
 
-      // Check if any initial ChunkGroup containing this chunk has multiple chunks
       let chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey
         .expect_get(&runtime_chunk_ukey);
 
+      if chunk.has_async_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
+        return true;
+      }
+
+      // Check if any initial ChunkGroup containing this chunk has multiple chunks
       chunk.groups().iter().any(|group_ukey| {
         let group = compilation
           .build_chunk_graph_artifact
@@ -496,6 +479,10 @@ pub(crate) fn optimize_runtime_chunks(compilation: &mut Compilation) {
     if let Some(mut mutation) = compilation.incremental.mutations_write() {
       mutation.add(Mutation::ChunkAdd {
         chunk: new_chunk_ukey,
+      });
+      mutation.add(Mutation::ChunkSplit {
+        from: entry_chunk_ukey,
+        to: new_chunk_ukey,
       });
     }
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
@@ -1,5 +1,5 @@
 ```mjs title=dynamic.mjs
-import { __webpack_require__ } from "./index_js.mjs";
+import { __webpack_require__ } from "./runtime.mjs";
 
 __webpack_require__.add({
 "./dynamic.js"
@@ -33,9 +33,29 @@ export default dynamic_default_0;
 
 ```
 
-```mjs title=index_js.mjs
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+// ./index.js
+it("should split runtime for Promise.all with external and bundled async chunks", async () => {
+	const [stream, mod] = await Promise.all([
+		import("node:stream"),
+		import("./dynamic.mjs").then(__webpack_require__.t.bind(__webpack_require__, /*! ./dynamic */ "./dynamic.js", 19)),
+	]);
+
+	expect(stream.Readable).toBeDefined();
+	expect(mod.value).toBe(42);
+});
+
+// node:stream
+const external_node_stream_namespaceObject = __rspack_createRequire_require("node:stream");
+export {};
+
+```
+
+```mjs title=runtime.mjs
 
 var __webpack_modules__ = {};
 // The module cache
@@ -116,9 +136,6 @@ __webpack_require__.d = (exports, definition) => {
 __webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
 
 })();
-// webpack/runtime/export_webpack_require
-var __webpack_require__temp = __webpack_require__;
-export { __webpack_require__temp as __webpack_require__ };
 // webpack/runtime/has_own_property
 (() => {
 __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
@@ -133,63 +150,7 @@ __webpack_require__.r = (exports) => {
 	Object.defineProperty(exports, '__esModule', { value: true });
 };
 })();
-// webpack/runtime/module_chunk_loading
-(() => {
-// no BaseURI
-      // object to store loaded and loading chunks
-      // undefined = chunk not loaded, null = chunk preloaded/prefetched
-      // [resolve, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = {"index_js": 0,"main": 0,};
-      var installChunk = (data) => {
-    var __rspack_esm_ids = data.__rspack_esm_ids;
-    var __webpack_modules__ = data.__webpack_modules__;
-    var __rspack_esm_runtime = data.__rspack_esm_runtime;
-    // add "modules" to the modules object,
-    // then flag all "ids" as loaded and fire callback
-    var moduleId, chunkId, i = 0;
-    for (moduleId in __webpack_modules__) {
-        if (__webpack_require__.o(__webpack_modules__, moduleId)) {
-            __webpack_require__.m[moduleId] = __webpack_modules__[moduleId];
-        }
-    }
-    if (__rspack_esm_runtime) __rspack_esm_runtime(__webpack_require__);
-    for (; i < __rspack_esm_ids.length; i++) {
-        chunkId = __rspack_esm_ids[i];
-        if (__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
-            installedChunks[chunkId][0]();
-        }
-        installedChunks[__rspack_esm_ids[i]] = 0;
-    }
-    
-};// no chunk on demand loading
 
-        __webpack_require__.C = installChunk;
-        // no on chunks loaded
-// no HMR
-// no HMR manifest
-
-})();
-
-// ./index.js
-it("should split runtime for Promise.all with external and bundled async chunks", async () => {
-	const [stream, mod] = await Promise.all([
-		import("node:stream"),
-		import("./dynamic.mjs").then(__webpack_require__.t.bind(__webpack_require__, /*! ./dynamic */ "./dynamic.js", 19)),
-	]);
-
-	expect(stream.Readable).toBeDefined();
-	expect(mod.value).toBe(42);
-});
-
-// node:stream
-const external_node_stream_namespaceObject = __rspack_createRequire_require("node:stream");
-export * from "node:stream";
-
-```
-
-```mjs title=main.mjs
-import "./index_js.mjs";
-
-export {};
+export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/test.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/test.config.js
@@ -7,16 +7,20 @@ module.exports = {
 			fs.readFileSync(path.join(options.output.path, file), "utf-8");
 
 		const entry = readAsset("main.mjs");
-		const entryImpl = readAsset("index_js.mjs");
 		const dynamic = readAsset("dynamic.mjs");
+		const runtime = readAsset("runtime.mjs");
 
-		expect(entry).toContain('import "./index_js.mjs";');
-		expect(entryImpl).toContain("Promise.all");
-		expect(entryImpl).toContain('import("node:stream")');
-		expect(entryImpl).toContain('import("./dynamic.mjs")');
+		expect(fs.existsSync(path.join(options.output.path, "index_js.mjs"))).toBe(
+			false,
+		);
+		expect(entry).toContain('import { __webpack_require__ } from "./runtime.mjs";');
+		expect(entry).toContain("Promise.all");
+		expect(entry).toContain('import("node:stream")');
+		expect(entry).toContain('import("./dynamic.mjs")');
+		expect(runtime).toContain("export { __webpack_require__");
 		expect(entry).not.toContain("export { __webpack_require__");
 		expect(entry).not.toContain("as __webpack_require__");
 		expect(dynamic).not.toContain('from "./main.mjs"');
-		expect(dynamic).toContain('import { __webpack_require__ } from "./index_js.mjs";');
+		expect(dynamic).toContain('import { __webpack_require__ } from "./runtime.mjs";');
 	},
 };


### PR DESCRIPTION
## Summary

- move the async-chunk runtime splitting trigger out of `ensure_entry_exports`
- handle entrypoints with async chunks in `optimize_runtime_chunks`, alongside the existing automatic runtime chunk split logic
- update the ESM output regression case so `main.mjs` keeps the entry code while async chunks import `__webpack_require__` from `runtime.mjs`

## Validation

- `cargo fmt --package rspack_plugin_esm_library --check`
- `cargo check -p rspack_plugin_esm_library`
- `git diff --check`

Note: the filtered `rstest` case could not run locally because this checkout has no `node_modules`, so `rstest` was not found.