### PR TITLE
perf(core): box large NormalModule fields

### DIFF
--- a/crates/rspack_binding_api/src/modules/normal_module.rs
+++ b/crates/rspack_binding_api/src/modules/normal_module.rs
@@ -78,8 +78,9 @@ impl NormalModule {
             query,
             fragment,
           } = parse_resource(&val).expect("Should parse resource");
-          *module.match_resource_mut() =
-            Some(ResourceData::new_with_path(val, path, query, fragment));
+          module.set_match_resource(Some(ResourceData::new_with_path(
+            val, path, query, fragment,
+          )));
         }
         Either::B(_) => {}
       }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -117,7 +117,7 @@ pub struct NormalModule {
   /// Affiliated parser and generator to the module type
   parser_and_generator: Box<dyn ParserAndGenerator>,
   /// Resource matched with inline match resource, (`!=!` syntax)
-  match_resource: Option<ResourceData>,
+  match_resource: Option<Box<ResourceData>>,
   /// Resource data (path, query, fragment etc.)
   resource_data: Arc<ResourceData>,
   /// Loaders for the module
@@ -140,14 +140,14 @@ pub struct NormalModule {
   #[allow(unused)]
   debug_id: usize,
   #[cacheable(with=As<SourceSizeCacheSerde>)]
-  cached_source_sizes: SourceSizeCache,
+  cached_source_sizes: Box<SourceSizeCache>,
   diagnostics: Vec<Diagnostic>,
 
   code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
   presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
 
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
+  build_info: Box<BuildInfo>,
   build_meta: BuildMeta,
   parsed: bool,
 
@@ -203,7 +203,7 @@ impl NormalModule {
       parser_and_generator,
       parser_options,
       generator_options,
-      match_resource,
+      match_resource: match_resource.map(Box::new),
       resource_data,
       resolve_options,
       loaders,
@@ -211,12 +211,12 @@ impl NormalModule {
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,
 
-      cached_source_sizes: SourceSizeCache::default(),
+      cached_source_sizes: Box::default(),
       diagnostics: Default::default(),
       code_generation_dependencies: None,
       presentational_dependencies: None,
       factory_meta: None,
-      build_info: Default::default(),
+      build_info: Box::default(),
       build_meta: Default::default(),
       parsed: false,
       source_map_kind: SourceMapKind::empty(),
@@ -228,11 +228,11 @@ impl NormalModule {
   }
 
   pub fn match_resource(&self) -> Option<&ResourceData> {
-    self.match_resource.as_ref()
+    self.match_resource.as_deref()
   }
 
-  pub fn match_resource_mut(&mut self) -> &mut Option<ResourceData> {
-    &mut self.match_resource
+  pub fn set_match_resource(&mut self, match_resource: Option<ResourceData>) {
+    self.match_resource = match_resource.map(Box::new);
   }
 
   pub fn resource_resolved_data(&self) -> &Arc<ResourceData> {
@@ -564,14 +564,14 @@ impl Module for NormalModule {
         module_type: &self.module_type,
         module_layer: self.layer.as_ref(),
         module_user_request: &self.user_request,
-        module_match_resource: self.match_resource.as_ref(),
+        module_match_resource: self.match_resource.as_deref(),
         module_source_map_kind: self.source_map_kind,
         loaders: &self.loaders,
         resource_data: &self.resource_data,
         compiler_options: &build_context.compiler_options,
         additional_data: loader_result.additional_data,
         factory_meta: self.factory_meta.as_ref(),
-        build_info: &mut self.build_info,
+        build_info: self.build_info.as_mut(),
         build_meta: &mut self.build_meta,
         parse_meta: loader_result.parse_meta,
         runtime_template: &build_context.runtime_template,
@@ -825,11 +825,11 @@ impl Module for NormalModule {
   }
 
   fn build_info(&self) -> &BuildInfo {
-    &self.build_info
+    self.build_info.as_ref()
   }
 
   fn build_info_mut(&mut self) -> &mut BuildInfo {
-    &mut self.build_info
+    self.build_info.as_mut()
   }
 
   fn build_meta(&self) -> &BuildMeta {

--- a/crates/rspack_core/src/utils/source_size_cache.rs
+++ b/crates/rspack_core/src/utils/source_size_cache.rs
@@ -127,3 +127,17 @@ impl AsConverter<SourceSizeCache> for SourceSizeCacheSerde {
     })
   }
 }
+
+impl AsConverter<Box<SourceSizeCache>> for SourceSizeCacheSerde {
+  #[allow(clippy::borrowed_box)]
+  fn serialize(
+    data: &Box<SourceSizeCache>,
+    guard: &rspack_cacheable::ContextGuard,
+  ) -> Result<Self> {
+    <Self as AsConverter<SourceSizeCache>>::serialize(data.as_ref(), guard)
+  }
+
+  fn deserialize(self, guard: &rspack_cacheable::ContextGuard) -> Result<Box<SourceSizeCache>> {
+    <Self as AsConverter<SourceSizeCache>>::deserialize(self, guard).map(Box::new)
+  }
+}


### PR DESCRIPTION
## Summary

Box the largest cold/heavy `NormalModule` fields instead of constructing `NormalModule` with a custom unsafe boxed initializer:

- `build_info: Box<BuildInfo>`
- `match_resource: Option<Box<ResourceData>>`
- `cached_source_sizes: Box<SourceSizeCache>`

This keeps the normal `NormalModule::new(...).boxed()` path while shrinking the inline `NormalModule` layout. Local DWARF size for `NormalModule` drops from 1648 bytes to 488 bytes, so the `Box::new(self)` move copies much less data.

In the local `rust@build_module_graph` Callgrind comparison, memcpy estimated cycles dropped from 277,349,885 to 263,056,346 (-5.15%), and memcpy share dropped from 8.2578% to 7.9334%. The `NormalModule as ModuleExt>::boxed` memcpy caller dropped from 29,735,845 to 5,438,939 estimated cycles (-81.71%).

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Checks used:

- `cargo fmt --all --check`
- `cargo check -p rspack_core`
- `cargo check -p rspack_binding_api`
- `cargo codspeed build -m simulation --profile codspeed -p rspack_benchmark`
- `codspeed run -m simulation -- cargo codspeed run -m simulation -- build_module_graph`
