### PR TITLE
fix(rstest): inject require.resolve origin

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2934,6 +2934,11 @@ export interface RawRstestPluginOptions {
   preserveNewUrl?: Array<string>
   globals?: boolean
 injectDynamicImportOrigin?: boolean | { functionName?: string }
+injectRequireResolveOrigin?: boolean | { functionName?: string }
+}
+
+export interface RawRstestRequireResolveOriginOptions {
+  functionName?: string
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_api/src/rstest.rs
+++ b/crates/rspack_binding_api/src/rstest.rs
@@ -1,6 +1,16 @@
 use derive_more::Debug;
 use napi::Either;
-use rspack_plugin_rstest::{RstestDynamicImportOriginOptions, RstestPluginOptions};
+use rspack_plugin_rstest::{
+  RstestDynamicImportOriginOptions, RstestPluginOptions, RstestRequireResolveOriginOptions,
+};
+
+#[derive(Debug)]
+#[napi(object, object_to_js = false)]
+pub struct RawRstestRequireResolveOriginOptions {
+  // Override the callee that replaces `require.resolve` in the rewrite.
+  // When omitted, rstest uses `__rstest_require_resolve__`.
+  pub function_name: Option<String>,
+}
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -39,6 +49,17 @@ pub struct RawRstestPluginOptions {
   // or pass an object with `functionName` to override the callee independently.
   #[napi(ts_type = "boolean | { functionName?: string }")]
   pub inject_dynamic_import_origin: Option<Either<bool, RawRstestDynamicImportOriginOptions>>,
+
+  // When enabled, rewrite `require.resolve()` calls to the configured callee
+  // and append the source module's absolute path as an extra argument. The
+  // runtime uses it as the base for relative specifier resolution so paths
+  // inside bundled deps resolve to the source file's directory rather than
+  // the test entry's.
+  //
+  // Pass `true` to enable with the default `__rstest_require_resolve__` callee,
+  // or pass an object with `functionName` to override the callee independently.
+  #[napi(ts_type = "boolean | { functionName?: string }")]
+  pub inject_require_resolve_origin: Option<Either<bool, RawRstestRequireResolveOriginOptions>>,
 }
 
 impl From<RawRstestPluginOptions> for RstestPluginOptions {
@@ -50,6 +71,14 @@ impl From<RawRstestPluginOptions> for RstestPluginOptions {
         function_name: opts.function_name,
       }),
     };
+
+    let inject_require_resolve_origin = match value.inject_require_resolve_origin {
+      None | Some(Either::A(false)) => None,
+      Some(Either::A(true)) => Some(RstestRequireResolveOriginOptions::default()),
+      Some(Either::B(opts)) => Some(RstestRequireResolveOriginOptions {
+        function_name: opts.function_name,
+      }),
+    };
     Self {
       module_path_name: value.inject_module_path_name,
       hoist_mock_module: value.hoist_mock_module,
@@ -58,6 +87,7 @@ impl From<RawRstestPluginOptions> for RstestPluginOptions {
       preserve_new_url: value.preserve_new_url.unwrap_or_default(),
       globals: value.globals.unwrap_or(true),
       inject_dynamic_import_origin,
+      inject_require_resolve_origin,
     }
   }
 }

--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -136,6 +136,7 @@ pub enum DependencyType {
   RstestMockModuleId,
   RstestHoistMock,
   RstestDynamicImportOrigin,
+  RstestRequireResolveOrigin,
   /// RSC entry that aggregates all "use client" and CSS modules for one Rspack entry
   RscEntry,
   /// RSC client reference to an individual "use client" or CSS module, not subject to lazy compilation
@@ -227,6 +228,7 @@ impl DependencyType {
       DependencyType::RstestMockModuleId => "rstest mock module id",
       DependencyType::RstestHoistMock => "rstest hoist mock",
       DependencyType::RstestDynamicImportOrigin => "rstest dynamic import origin",
+      DependencyType::RstestRequireResolveOrigin => "rstest require.resolve origin",
       DependencyType::RscEntry => "rsc entry",
       DependencyType::RscClientReference => "rsc client reference",
       DependencyType::ImportMetaRsc => "import.meta.rspackRsc",

--- a/crates/rspack_plugin_rstest/src/lib.rs
+++ b/crates/rspack_plugin_rstest/src/lib.rs
@@ -6,6 +6,7 @@ mod mock_module_id_dependency;
 mod module_path_name_dependency;
 mod parser_plugin;
 mod plugin;
+mod require_resolve_origin_dependency;
 mod url_dependency;
 
 pub use plugin::*;

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -10,7 +10,7 @@ use rspack_plugin_javascript::{
     self,
     eval::{self},
   },
-  visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error},
+  visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error, expr_name},
 };
 use rspack_util::{SpanExt, atom::Atom, json_stringify_str, swc::get_swc_comments};
 use swc_core::{
@@ -25,6 +25,7 @@ use crate::{
   mock_method_dependency::{MockMethod, MockMethodDependency},
   mock_module_id_dependency::MockModuleIdDependency,
   module_path_name_dependency::{ModulePathNameDependency, NameType},
+  require_resolve_origin_dependency::RstestRequireResolveOriginDependency,
 };
 
 const DIR_NAME: &str = "__dirname";
@@ -52,6 +53,8 @@ pub struct RstestParserPluginOptions {
   /// Pre-resolved at plugin construction — false here covers both "feature
   /// disabled" and "callee resolved to default `import`".
   pub inject_dynamic_import_origin: bool,
+  /// Whether to rewrite `require.resolve()` calls with origin info.
+  pub inject_require_resolve_origin: bool,
 }
 
 impl Default for RstestParserPluginOptions {
@@ -63,6 +66,7 @@ impl Default for RstestParserPluginOptions {
       manual_mock_root: String::new(),
       globals: true,
       inject_dynamic_import_origin: false,
+      inject_require_resolve_origin: false,
     }
   }
 }
@@ -75,6 +79,68 @@ pub struct RstestParserPlugin {
 impl RstestParserPlugin {
   pub fn new(options: RstestParserPluginOptions) -> Self {
     Self { options }
+  }
+
+  fn has_ignore_comment(
+    &self,
+    parser: &mut JavascriptParser,
+    error_span: Span,
+    span: Span,
+  ) -> bool {
+    try_extract_magic_comment(parser, error_span, span)
+      .get_ignore()
+      .unwrap_or_default()
+  }
+
+  fn process_require_resolve_origin(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: &CallExpr,
+  ) -> Option<bool> {
+    let callee_expr = call_expr.callee.as_expr()?;
+    let member_expr = callee_expr.as_member()?;
+    let require_ident = member_expr.obj.as_ident()?;
+
+    if parser.get_variable_info(&require_ident.sym).is_some() {
+      return None;
+    }
+
+    if !(1..=2).contains(&call_expr.args.len()) {
+      return None;
+    }
+
+    let first_arg = call_expr.args.first()?;
+    if first_arg.spread.is_some()
+      || self.has_ignore_comment(parser, call_expr.span, first_arg.span())
+    {
+      return None;
+    }
+
+    if call_expr
+      .args
+      .get(1)
+      .is_some_and(|arg| arg.spread.is_some())
+    {
+      return None;
+    }
+
+    let resource_path = parser.resource_data.path()?;
+    let origin_path = resource_path.as_str().to_string();
+
+    let last_arg = call_expr
+      .args
+      .last()
+      .expect("call_expr.args has at least one element");
+    parser.add_presentational_dependency(Box::new(RstestRequireResolveOriginDependency::new(
+      call_expr.callee.span().into(),
+      last_arg.span().real_hi(),
+      origin_path,
+    )));
+
+    // Returning `Some(true)` short-circuits the default walker for this call,
+    // so preserve dependency collection for nested expressions in arguments.
+    parser.walk_expr_or_spread(&call_expr.args);
+    Some(true)
   }
 
   fn process_require_actual(
@@ -709,6 +775,19 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     None
   }
 
+  fn call(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: &CallExpr,
+    for_name: &str,
+  ) -> Option<bool> {
+    if self.options.inject_require_resolve_origin && for_name == "require.resolve" {
+      return self.process_require_resolve_origin(parser, call_expr);
+    }
+
+    None
+  }
+
   fn import_call(
     &self,
     parser: &mut JavascriptParser,
@@ -885,6 +964,16 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     start: u32,
     end: u32,
   ) -> Option<eval::BasicEvaluatedExpression<'static>> {
+    if self.options.inject_require_resolve_origin && for_name == expr_name::REQUIRE_RESOLVE {
+      return Some(eval::evaluate_to_identifier(
+        expr_name::REQUIRE_RESOLVE.into(),
+        expr_name::REQUIRE_RESOLVE.into(),
+        Some(true),
+        start,
+        end,
+      ));
+    }
+
     if self.options.import_meta_path_name {
       if for_name == IMPORT_META_DIRNAME {
         return Some(eval::evaluate_to_string(

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -55,6 +55,8 @@ pub struct RstestParserPluginOptions {
   pub inject_dynamic_import_origin: bool,
   /// Whether to rewrite `require.resolve()` calls with origin info.
   pub inject_require_resolve_origin: bool,
+  /// Whether to respect `/* webpackIgnore: true */` in CommonJS calls.
+  pub commonjs_magic_comments: bool,
 }
 
 impl Default for RstestParserPluginOptions {
@@ -67,6 +69,7 @@ impl Default for RstestParserPluginOptions {
       globals: true,
       inject_dynamic_import_origin: false,
       inject_require_resolve_origin: false,
+      commonjs_magic_comments: false,
     }
   }
 }
@@ -87,6 +90,10 @@ impl RstestParserPlugin {
     error_span: Span,
     span: Span,
   ) -> bool {
+    if !self.options.commonjs_magic_comments {
+      return false;
+    }
+
     try_extract_magic_comment(parser, error_span, span)
       .get_ignore()
       .unwrap_or_default()

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -250,7 +250,7 @@ async fn nmf_parser(
   &self,
   module_type: &ModuleType,
   parser: &mut Box<dyn ParserAndGenerator>,
-  _parser_options: Option<&ParserOptions>,
+  parser_options: Option<&ParserOptions>,
 ) -> Result<()> {
   if module_type.is_js_like()
     && let Some(parser) = parser.downcast_mut::<JavaScriptParserAndGenerator>()
@@ -263,6 +263,10 @@ async fn nmf_parser(
       .require_resolve_origin_callee
       .get()
       .is_some_and(|c| c.is_some());
+    let commonjs_magic_comments = parser_options
+      .and_then(|options| options.get_javascript())
+      .and_then(|options| options.commonjs_magic_comments)
+      .unwrap_or(false);
 
     parser.add_parser_plugin(Box::new(RstestParserPlugin::new(
       crate::parser_plugin::RstestParserPluginOptions {
@@ -273,6 +277,7 @@ async fn nmf_parser(
         globals: self.options.globals,
         inject_dynamic_import_origin,
         inject_require_resolve_origin,
+        commonjs_magic_comments,
       },
     )) as BoxJavascriptParserPlugin);
   }

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -38,6 +38,7 @@ use crate::{
   mock_module_id_dependency::{MockModuleIdDependency, MockModuleIdDependencyTemplate},
   module_path_name_dependency::ModulePathNameDependencyTemplate,
   parser_plugin::{MOCK_TARGET_REQUEST_PREFIX, RstestParserPlugin},
+  require_resolve_origin_dependency::RstestRequireResolveOriginDependencyTemplate,
   url_dependency::RstestUrlDependencyTemplate,
 };
 
@@ -50,12 +51,20 @@ pub struct RstestPluginOptions {
   pub preserve_new_url: Vec<String>,
   pub globals: bool,
   pub inject_dynamic_import_origin: Option<RstestDynamicImportOriginOptions>,
+  pub inject_require_resolve_origin: Option<RstestRequireResolveOriginOptions>,
 }
 
 #[derive(Debug, Default)]
 pub struct RstestDynamicImportOriginOptions {
   /// Overrides the rewrite callee. When `None`, falls back to
   /// `output.importFunctionName`.
+  pub function_name: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct RstestRequireResolveOriginOptions {
+  /// Overrides the rewrite callee. When `None`, defaults to
+  /// `__rstest_require_resolve__`.
   pub function_name: Option<String>,
 }
 
@@ -74,11 +83,12 @@ pub struct RstestPlugin {
   /// covers both "feature disabled" and "callee resolved to default `import`"
   /// (incompatible with native syntax — rewriting would yield a SyntaxError).
   dynamic_import_origin_callee: OnceLock<Option<Arc<str>>>,
+  require_resolve_origin_callee: OnceLock<Option<Arc<str>>>,
 }
 
 impl RstestPlugin {
   pub fn new(options: RstestPluginOptions) -> Self {
-    Self::new_inner(options, OnceLock::new())
+    Self::new_inner(options, OnceLock::new(), OnceLock::new())
   }
 
   fn calc_default_mocked_target(&self, value: &str) -> Utf8PathBuf {
@@ -249,6 +259,10 @@ async fn nmf_parser(
       .dynamic_import_origin_callee
       .get()
       .is_some_and(|c| c.is_some());
+    let inject_require_resolve_origin = self
+      .require_resolve_origin_callee
+      .get()
+      .is_some_and(|c| c.is_some());
 
     parser.add_parser_plugin(Box::new(RstestParserPlugin::new(
       crate::parser_plugin::RstestParserPluginOptions {
@@ -258,6 +272,7 @@ async fn nmf_parser(
         manual_mock_root: self.options.manual_mock_root.clone(),
         globals: self.options.globals,
         inject_dynamic_import_origin,
+        inject_require_resolve_origin,
       },
     )) as BoxJavascriptParserPlugin);
   }
@@ -290,6 +305,15 @@ async fn compilation(
     compilation.set_dependency_template(
       RstestDynamicImportOriginDependencyTemplate::template_type(),
       Arc::new(RstestDynamicImportOriginDependencyTemplate::new(
+        callee.to_string(),
+      )),
+    );
+  }
+
+  if let Some(Some(callee)) = self.require_resolve_origin_callee.get() {
+    compilation.set_dependency_template(
+      RstestRequireResolveOriginDependencyTemplate::template_type(),
+      Arc::new(RstestRequireResolveOriginDependencyTemplate::new(
         callee.to_string(),
       )),
     );
@@ -468,6 +492,23 @@ impl Plugin for RstestPlugin {
       });
     let _ = self.dynamic_import_origin_callee.set(resolved_callee);
 
+    let resolved_require_resolve_callee =
+      self
+        .options
+        .inject_require_resolve_origin
+        .as_ref()
+        .map(|cfg| {
+          Arc::<str>::from(
+            cfg
+              .function_name
+              .as_deref()
+              .unwrap_or("__rstest_require_resolve__"),
+          )
+        });
+    let _ = self
+      .require_resolve_origin_callee
+      .set(resolved_require_resolve_callee);
+
     ctx.compiler_hooks.compilation.tap(compilation::new(self));
 
     ctx
@@ -480,7 +521,10 @@ impl Plugin for RstestPlugin {
       .compilation
       .tap(compilation_stage_9999::new(self));
 
-    if self.options.module_path_name || self.options.inject_dynamic_import_origin.is_some() {
+    if self.options.module_path_name
+      || self.options.inject_dynamic_import_origin.is_some()
+      || self.options.inject_require_resolve_origin.is_some()
+    {
       ctx
         .normal_module_factory_hooks
         .parser

--- a/crates/rspack_plugin_rstest/src/require_resolve_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/require_resolve_origin_dependency.rs
@@ -1,0 +1,82 @@
+use rspack_cacheable::{cacheable, cacheable_dyn};
+use rspack_core::{
+  AsContextDependency, AsModuleDependency, DependencyCodeGeneration, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, TemplateContext,
+  TemplateReplaceSource,
+};
+use rspack_util::json_stringify_str;
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct RstestRequireResolveOriginDependency {
+  callee_range: DependencyRange,
+  args_end: u32,
+  origin_path: String,
+}
+
+impl RstestRequireResolveOriginDependency {
+  pub fn new(callee_range: DependencyRange, args_end: u32, origin_path: String) -> Self {
+    Self {
+      callee_range,
+      args_end,
+      origin_path,
+    }
+  }
+}
+
+#[cacheable_dyn]
+impl DependencyCodeGeneration for RstestRequireResolveOriginDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
+    Some(RstestRequireResolveOriginDependencyTemplate::template_type())
+  }
+}
+
+impl AsModuleDependency for RstestRequireResolveOriginDependency {}
+impl AsContextDependency for RstestRequireResolveOriginDependency {}
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct RstestRequireResolveOriginDependencyTemplate {
+  function_name: String,
+}
+
+impl RstestRequireResolveOriginDependencyTemplate {
+  pub fn new(function_name: String) -> Self {
+    Self { function_name }
+  }
+
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Dependency(DependencyType::RstestRequireResolveOrigin)
+  }
+}
+
+impl DependencyTemplate for RstestRequireResolveOriginDependencyTemplate {
+  fn render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    _code_generatable_context: &mut TemplateContext,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<RstestRequireResolveOriginDependency>()
+      .expect(
+        "RstestRequireResolveOriginDependencyTemplate can only be applied to \
+         RstestRequireResolveOriginDependency",
+      );
+
+    source.replace(
+      dep.callee_range.start,
+      dep.callee_range.end,
+      self.function_name.clone(),
+      None,
+    );
+
+    source.replace(
+      dep.args_end,
+      dep.args_end,
+      format!(", {}", json_stringify_str(&dep.origin_path)),
+      None,
+    );
+  }
+}

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/index.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/index.js
@@ -25,12 +25,14 @@ it('rewrites require.resolve calls with source module origin', () => {
 	expect(content).toContain("module.exports = { name: './target' }");
 
 	// Nested require.resolve calls inside arguments should still be rewritten, while
-	// webpackIgnore and shadowed require must not be rewritten.
+	// `webpackIgnore` only affects require.resolve when commonjsMagicComments is
+	// enabled, and shadowed require must not be rewritten.
 	expect(content).toContain(
 		`${helper}((__webpack_require__(161)/* .name */.name), ${originLiteral})`,
 	);
-	expect(content).toContain("require.resolve(/* webpackIgnore: true */ './ignored')");
-	expect(content).not.toContain(`${helper}('./ignored', ${originLiteral})`);
+	expect(content).toContain(
+		`${helper}(/* webpackIgnore: true */ './ignored', ${originLiteral})`,
+	);
 	expect(content).toContain("require.resolve('./shadowed')");
 });
 
@@ -50,4 +52,18 @@ it('rewrites require.resolve calls with `functionName` override', () => {
 	expect(content).not.toContain(
 		`__rstest_require_resolve__('./target', ${originLiteral})`,
 	);
+});
+
+it('respects webpackIgnore when commonjsMagicComments is enabled', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'requireResolveOriginMagicComments.js'),
+		'utf-8',
+	);
+
+	const helper = '__rstest_require_resolve__';
+	const originLiteral = JSON.stringify(sourceFile);
+
+	expect(content).toContain(`${helper}('./target', ${originLiteral})`);
+	expect(content).toContain("require.resolve(/* webpackIgnore: true */ './ignored')");
+	expect(content).not.toContain(`${helper}('./ignored', ${originLiteral})`);
 });

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/index.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/index.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+const sourceFile = path.resolve(
+	__dirname,
+	'../../../../configCases/rstest/require-resolve-origin/src/index.js',
+);
+
+it('rewrites require.resolve calls with source module origin', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'requireResolveOrigin.js'),
+		'utf-8',
+	);
+
+	const helper = '__rstest_require_resolve__';
+	const originLiteral = JSON.stringify(sourceFile);
+
+	expect(content).toContain(`${helper}('./target', ${originLiteral})`);
+	expect(content).toContain(`${helper}(name, ${originLiteral})`);
+	expect(content).toContain(
+		`${helper}('./target', { paths: [__dirname] }, ${originLiteral})`,
+	);
+
+	// Nested require inside the argument must still be collected as a dependency.
+	expect(content).toContain("module.exports = { name: './target' }");
+
+	// Nested require.resolve calls inside arguments should still be rewritten, while
+	// webpackIgnore and shadowed require must not be rewritten.
+	expect(content).toContain(
+		`${helper}((__webpack_require__(161)/* .name */.name), ${originLiteral})`,
+	);
+	expect(content).toContain("require.resolve(/* webpackIgnore: true */ './ignored')");
+	expect(content).not.toContain(`${helper}('./ignored', ${originLiteral})`);
+	expect(content).toContain("require.resolve('./shadowed')");
+});
+
+it('rewrites require.resolve calls with `functionName` override', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'requireResolveOriginFunctionName.js'),
+		'utf-8',
+	);
+
+	const helper = 'globalThis.__custom_require_resolve__';
+	const originLiteral = JSON.stringify(sourceFile);
+
+	expect(content).toContain(`${helper}('./target', ${originLiteral})`);
+	expect(content).toContain(
+		`${helper}('./target', { paths: [__dirname] }, ${originLiteral})`,
+	);
+	expect(content).not.toContain(
+		`__rstest_require_resolve__('./target', ${originLiteral})`,
+	);
+});

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/rspack.config.js
@@ -1,0 +1,79 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+  {
+    entry: './src/index.js',
+    target: 'node',
+    output: {
+      filename: 'requireResolveOrigin.js',
+    },
+    module: {
+      parser: {
+        javascript: {
+          requireResolve: false,
+          requireAsExpression: false,
+          commonjsMagicComments: true,
+        },
+      },
+    },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: false,
+        hoistMockModule: false,
+        importMetaPathName: false,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+        injectRequireResolveOrigin: true,
+      }),
+    ],
+  },
+  {
+    entry: './src/index.js',
+    target: 'node',
+    output: {
+      filename: 'requireResolveOriginFunctionName.js',
+    },
+    module: {
+      parser: {
+        javascript: {
+          requireResolve: false,
+          requireAsExpression: false,
+          commonjsMagicComments: true,
+        },
+      },
+    },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: false,
+        hoistMockModule: false,
+        importMetaPathName: false,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+        injectRequireResolveOrigin: {
+          functionName: 'globalThis.__custom_require_resolve__',
+        },
+      }),
+    ],
+  },
+  {
+    entry: {
+      main: './index.js',
+    },
+    output: {
+      filename: '[name].js',
+    },
+    externalsPresets: {
+      node: true,
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/rspack.config.js
@@ -11,15 +11,6 @@ module.exports = [
     output: {
       filename: 'requireResolveOrigin.js',
     },
-    module: {
-      parser: {
-        javascript: {
-          requireResolve: false,
-          requireAsExpression: false,
-          commonjsMagicComments: true,
-        },
-      },
-    },
     optimization: {
       concatenateModules: false,
       minimize: false,
@@ -40,11 +31,31 @@ module.exports = [
     output: {
       filename: 'requireResolveOriginFunctionName.js',
     },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: false,
+        hoistMockModule: false,
+        importMetaPathName: false,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+        injectRequireResolveOrigin: {
+          functionName: 'globalThis.__custom_require_resolve__',
+        },
+      }),
+    ],
+  },
+  {
+    entry: './src/index.js',
+    target: 'node',
+    output: {
+      filename: 'requireResolveOriginMagicComments.js',
+    },
     module: {
       parser: {
         javascript: {
-          requireResolve: false,
-          requireAsExpression: false,
           commonjsMagicComments: true,
         },
       },
@@ -59,9 +70,7 @@ module.exports = [
         hoistMockModule: false,
         importMetaPathName: false,
         manualMockRoot: path.resolve(__dirname, '__mocks__'),
-        injectRequireResolveOrigin: {
-          functionName: 'globalThis.__custom_require_resolve__',
-        },
+        injectRequireResolveOrigin: true,
       }),
     ],
   },

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/src/ignored.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/src/ignored.js
@@ -1,0 +1,1 @@
+module.exports = './ignored';

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/src/index.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/src/index.js
@@ -1,0 +1,13 @@
+const name = './target';
+
+const a = require.resolve('./target');
+const b = require.resolve(name);
+const c = require.resolve('./target', { paths: [__dirname] });
+const d = require.resolve(require('./nested').name);
+const e = require.resolve(/* webpackIgnore: true */ './ignored');
+
+function shadowed(require) {
+  return require.resolve('./shadowed');
+}
+
+console.log(a, b, c, d, e, shadowed);

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/src/nested.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/src/nested.js
@@ -1,0 +1,1 @@
+module.exports = { name: './target' };

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/src/target.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/src/target.js
@@ -1,0 +1,1 @@
+module.exports = 'target';

--- a/tests/rspack-test/configCases/rstest/require-resolve-origin/test.config.js
+++ b/tests/rspack-test/configCases/rstest/require-resolve-origin/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: function () {
+		return ['main.js'];
+	},
+};


### PR DESCRIPTION
## Summary

This PR adds `RstestPlugin` support for rewriting `require.resolve()` calls with the source module origin, so Rstest can resolve relative specifiers from the module that produced the call instead of the test entry. It also preserves the native two-argument `require.resolve(request, options)` form and adds a config case covering default and custom helper names.

## Related links

- https://github.com/web-infra-dev/rstest/issues/848
- https://github.com/web-infra-dev/rspack/pull/13849
- https://github.com/web-infra-dev/rspack/pull/13930

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).