### PR TITLE
refactor: move build info to module graph

### DIFF
--- a/crates/rspack_binding_api/src/build_info.rs
+++ b/crates/rspack_binding_api/src/build_info.rs
@@ -86,12 +86,12 @@ impl KnownBuildInfo {
 
   pub fn with_ref<T>(
     &mut self,
-    f: impl FnOnce(&dyn rspack_core::Module) -> napi::Result<T>,
+    f: impl FnOnce(&rspack_core::BuildInfo) -> napi::Result<T>,
   ) -> napi::Result<T> {
     match self.module_reference.get_mut() {
       Some(reference) => {
-        let (_, module) = reference.as_ref()?;
-        f(module)
+        let build_info = reference.build_info_ref()?;
+        f(build_info)
       }
       None => Err(napi::Error::from_reason(
         "Unable to access buildInfo. The Module has been garbage collected by JavaScript."
@@ -102,12 +102,12 @@ impl KnownBuildInfo {
 
   pub fn with_mut<T>(
     &mut self,
-    f: impl FnOnce(&mut dyn rspack_core::Module) -> napi::Result<T>,
+    f: impl FnOnce(&mut rspack_core::BuildInfo) -> napi::Result<T>,
   ) -> napi::Result<T> {
     match self.module_reference.get_mut() {
       Some(reference) => {
-        let module = reference.as_mut()?;
-        f(module)
+        let build_info = reference.build_info_mut()?;
+        f(build_info)
       }
       None => Err(napi::Error::from_reason(
         "Unable to access buildInfo. The Module has been garbage collected by JavaScript."
@@ -135,12 +135,12 @@ impl BuildInfo {
 
   fn with_ref<T>(
     &mut self,
-    f: impl FnOnce(&dyn rspack_core::Module) -> napi::Result<T>,
+    f: impl FnOnce(&rspack_core::BuildInfo) -> napi::Result<T>,
   ) -> napi::Result<T> {
     match self.module_reference.get_mut() {
       Some(reference) => {
-        let (_, module) = reference.as_ref()?;
-        f(module)
+        let build_info = reference.build_info_ref()?;
+        f(build_info)
       }
       None => Err(napi::Error::from_reason(
         "Unable to access buildInfo. The Module has been garbage collected by JavaScript."
@@ -159,7 +159,7 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
         .with_name(env, symbol)?
         .with_getter_closure(|env, this| {
           let wrapped_value = unsafe { KnownBuildInfo::from_napi_mut_ref(env.raw(), this.raw())? };
-          wrapped_value.with_ref(|module| Ok(module.build_info().assets.reflector()))
+          wrapped_value.with_ref(|build_info| Ok(build_info.assets.reflector()))
         })
         .with_property_attributes(PropertyAttributes::Configurable),
     );
@@ -175,9 +175,8 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
         .with_getter_closure(|env, this| {
           let wrapped_value = unsafe { KnownBuildInfo::from_napi_mut_ref(env.raw(), this.raw())? };
           let env_ref = &env;
-          let result = wrapped_value.with_ref(|module| {
-            module
-              .build_info()
+          let result = wrapped_value.with_ref(|build_info| {
+            build_info
               .file_dependencies
               .iter()
               .map(|dependency| env_ref.create_string(dependency.to_string_lossy().as_ref()))
@@ -199,9 +198,8 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
         .with_getter_closure(|env, this| {
           let wrapped_value = unsafe { KnownBuildInfo::from_napi_mut_ref(env.raw(), this.raw())? };
           let env_ref = &env;
-          let result = wrapped_value.with_ref(|module| {
-            module
-              .build_info()
+          let result = wrapped_value.with_ref(|build_info| {
+            build_info
               .context_dependencies
               .iter()
               .map(|dependency| env_ref.create_string(dependency.to_string_lossy().as_ref()))
@@ -223,9 +221,8 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
         .with_getter_closure(|env, this| {
           let wrapped_value = unsafe { KnownBuildInfo::from_napi_mut_ref(env.raw(), this.raw())? };
           let env_ref = &env;
-          let result = wrapped_value.with_ref(|module| {
-            module
-              .build_info()
+          let result = wrapped_value.with_ref(|build_info| {
+            build_info
               .missing_dependencies
               .iter()
               .map(|dependency| env_ref.create_string(dependency.to_string_lossy().as_ref()))
@@ -247,9 +244,8 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
         .with_getter_closure(|env, this| {
           let wrapped_value = unsafe { KnownBuildInfo::from_napi_mut_ref(env.raw(), this.raw())? };
           let env_ref = &env;
-          let result = wrapped_value.with_ref(|module| {
-            module
-              .build_info()
+          let result = wrapped_value.with_ref(|build_info| {
+            build_info
               .build_dependencies
               .iter()
               .map(|dependency| env_ref.create_string(dependency.to_string_lossy().as_ref()))
@@ -293,7 +289,7 @@ impl ToNapiValue for BuildInfo {
             let this: &mut KnownBuildInfo =
               FromNapiMutRef::from_napi_mut_ref(env.raw(), object.raw())?;
 
-            this.with_mut(|module| {
+            this.with_mut(|build_info| {
               let mut extras = serde_json::Map::new();
               let names = Array::from_unknown(object.get_property_names()?.to_unknown())?;
               for index in 0..names.len() {
@@ -307,14 +303,14 @@ impl ToNapiValue for BuildInfo {
                 }
               }
 
-              module.build_info_mut().extras = extras;
+              build_info.extras = extras;
 
               Ok(())
             })
           })?;
 
-        val.with_ref(|module| {
-          let extras = &module.build_info().extras;
+        val.with_ref(|build_info| {
+          let extras = &build_info.extras;
           properties.reserve(extras.len() + 1);
           for (key, value) in extras {
             let napi_val = ToNapiValue::to_napi_value(env, value)?;

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -76,6 +76,7 @@ thread_local! {
 pub struct Module {
   pub(crate) identifier: ModuleIdentifier,
   ptr: Option<NonNull<dyn rspack_core::Module>>,
+  build_info_ptr: Option<NonNull<rspack_core::BuildInfo>>,
   compiler_id: CompilerId,
   compiler_reference: WeakReference<JsCompiler>,
   pub(crate) build_info_ref: Option<WeakRef>,
@@ -324,6 +325,46 @@ impl Module {
       ))),
     }
   }
+
+  pub(crate) fn build_info_ref(&mut self) -> napi::Result<&rspack_core::BuildInfo> {
+    if let Some(ptr) = self.build_info_ptr {
+      // SAFETY:
+      // The pointer is only installed for the duration of synchronous hooks/loader calls.
+      return Ok(unsafe { ptr.as_ref() });
+    }
+    match self.compiler_reference.get() {
+      Some(this) => {
+        let compilation = &this.compiler.compilation;
+        compilation
+          .get_module_graph()
+          .build_info_by_identifier(&self.identifier)
+          .ok_or_else(|| {
+            napi::Error::from_reason(format!(
+              "Unable to access buildInfo for module with id = {} now. The module has been removed on the Rust side.",
+              self.identifier
+            ))
+          })
+      }
+      None => Err(napi::Error::from_reason(format!(
+        "Unable to access buildInfo for module with id = {} now. The Compiler has been garbage collected by JavaScript.",
+        self.identifier
+      ))),
+    }
+  }
+
+  pub(crate) fn build_info_mut(&mut self) -> napi::Result<&'static mut rspack_core::BuildInfo> {
+    match self.build_info_ptr.as_mut() {
+      Some(ptr) => {
+        // SAFETY:
+        // The pointer is only installed for the duration of synchronous hooks/loader calls.
+        Ok(unsafe { ptr.as_mut() })
+      }
+      None => Err(napi::Error::from_reason(format!(
+        "Unable to modify buildInfo for module with id = {}. Currently, you can only modify buildInfo while the module is being built.",
+        self.identifier
+      ))),
+    }
+  }
 }
 
 #[napi]
@@ -443,7 +484,7 @@ impl Module {
     source: JsSourceFromJs,
     object: Option<Object>,
   ) -> napi::Result<()> {
-    let module = self.as_mut()?;
+    let build_info = self.build_info_mut()?;
 
     let asset_info = match object {
       Some(object) => {
@@ -457,7 +498,7 @@ impl Module {
       None => Default::default(),
     };
 
-    module.build_info_mut().assets.insert(
+    build_info.assets.insert(
       filename,
       rspack_core::CompilationAsset {
         source: Some(source.try_into()?),
@@ -509,6 +550,7 @@ pub struct ModuleObject {
   type_id: TypeId,
   identifier: ModuleIdentifier,
   ptr: Option<NonNull<dyn rspack_core::Module>>,
+  build_info_ptr: Option<NonNull<rspack_core::BuildInfo>>,
   compiler_id: CompilerId,
 }
 
@@ -521,6 +563,7 @@ impl ModuleObject {
       type_id: module.as_any().type_id(),
       identifier: module.identifier(),
       ptr: None,
+      build_info_ptr: None,
       compiler_id,
     }
   }
@@ -532,6 +575,23 @@ impl ModuleObject {
       type_id: module.as_any().type_id(),
       identifier: module.identifier(),
       ptr: Some(module_ptr),
+      build_info_ptr: None,
+      compiler_id,
+    }
+  }
+
+  pub fn with_ptr_and_build_info(
+    module_ptr: NonNull<dyn rspack_core::Module>,
+    build_info_ptr: NonNull<rspack_core::BuildInfo>,
+    compiler_id: CompilerId,
+  ) -> Self {
+    let module = unsafe { module_ptr.as_ref() };
+
+    Self {
+      type_id: module.as_any().type_id(),
+      identifier: module.identifier(),
+      ptr: Some(module_ptr),
+      build_info_ptr: Some(build_info_ptr),
       compiler_id,
     }
   }
@@ -554,12 +614,44 @@ impl ModuleObject {
           && let Some(r) = refs.remove(module_identifier)
         {
           match r {
-            Either5::A(mut normal_module) => normal_module.module.ptr = None,
-            Either5::B(mut concatenated_module) => concatenated_module.module.ptr = None,
-            Either5::C(mut context_module) => context_module.module.ptr = None,
-            Either5::D(mut external_module) => external_module.module.ptr = None,
-            Either5::E(mut module) => module.ptr = None,
+            Either5::A(mut normal_module) => {
+              normal_module.module.ptr = None;
+              normal_module.module.build_info_ptr = None;
+            }
+            Either5::B(mut concatenated_module) => {
+              concatenated_module.module.ptr = None;
+              concatenated_module.module.build_info_ptr = None;
+            }
+            Either5::C(mut context_module) => {
+              context_module.module.ptr = None;
+              context_module.module.build_info_ptr = None;
+            }
+            Either5::D(mut external_module) => {
+              external_module.module.ptr = None;
+              external_module.module.build_info_ptr = None;
+            }
+            Either5::E(mut module) => {
+              module.ptr = None;
+              module.build_info_ptr = None;
+            }
           }
+        }
+      }
+    });
+  }
+
+  pub fn cleanup_build_info_ptr(compiler_id: &CompilerId, module_identifier: &ModuleIdentifier) {
+    MODULE_INSTANCE_REFS.with(|refs| {
+      let mut refs_by_compiler_id = refs.borrow_mut();
+      if let Some(refs) = refs_by_compiler_id.get_mut(compiler_id)
+        && let Some(r) = refs.get_mut(module_identifier)
+      {
+        match r {
+          Either5::A(normal_module) => normal_module.module.build_info_ptr = None,
+          Either5::B(concatenated_module) => concatenated_module.module.build_info_ptr = None,
+          Either5::C(context_module) => context_module.module.build_info_ptr = None,
+          Either5::D(external_module) => external_module.module.build_info_ptr = None,
+          Either5::E(module) => module.build_info_ptr = None,
         }
       }
     });
@@ -595,6 +687,7 @@ impl ToNapiValue for ModuleObject {
             Either5::E(module) => &mut **module,
           };
           instance.ptr = val.ptr;
+          instance.build_info_ptr = val.build_info_ptr;
           match instance_ref {
             Either5::A(r) => ToNapiValue::to_napi_value(env, r),
             Either5::B(r) => ToNapiValue::to_napi_value(env, r),
@@ -613,6 +706,7 @@ impl ToNapiValue for ModuleObject {
                 identifier: val.identifier,
                 compiler_id: val.compiler_id,
                 ptr: val.ptr,
+                build_info_ptr: val.build_info_ptr,
                 compiler_reference,
                 build_info_ref: Default::default(),
               };
@@ -666,30 +760,35 @@ impl FromNapiValue for ModuleObject {
           type_id: TypeId::of::<rspack_core::NormalModule>(),
           identifier: normal_module.module.identifier,
           ptr: normal_module.module.ptr,
+          build_info_ptr: normal_module.module.build_info_ptr,
           compiler_id: normal_module.module.compiler_id,
         },
         Either5::B(concatenated_module) => Self {
           type_id: TypeId::of::<rspack_core::ConcatenatedModule>(),
           identifier: concatenated_module.module.identifier,
           ptr: concatenated_module.module.ptr,
+          build_info_ptr: concatenated_module.module.build_info_ptr,
           compiler_id: concatenated_module.module.compiler_id,
         },
         Either5::C(context_module) => Self {
           type_id: TypeId::of::<rspack_core::ContextModule>(),
           identifier: context_module.module.identifier,
           ptr: context_module.module.ptr,
+          build_info_ptr: context_module.module.build_info_ptr,
           compiler_id: context_module.module.compiler_id,
         },
         Either5::D(external_module) => Self {
           type_id: TypeId::of::<rspack_core::ExternalModule>(),
           identifier: external_module.module.identifier,
           ptr: external_module.module.ptr,
+          build_info_ptr: external_module.module.build_info_ptr,
           compiler_id: external_module.module.compiler_id,
         },
         Either5::E(module) => Self {
           type_id: TypeId::of::<dyn rspack_core::Module>(),
           identifier: module.identifier,
           ptr: module.ptr,
+          build_info_ptr: module.build_info_ptr,
           compiler_id: module.compiler_id,
         },
       })

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1167,15 +1167,19 @@ impl CompilationBuildModule for CompilationBuildModuleTap {
     compiler_id: CompilerId,
     _compilation_id: CompilationId,
     module: &mut BoxModule,
+    build_info: &mut rspack_core::BuildInfo,
   ) -> rspack_error::Result<()> {
     #[allow(clippy::unwrap_used)]
-    let _ = self
+    let result = self
       .function
-      .call_with_sync(ModuleObject::with_ptr(
+      .call_with_sync(ModuleObject::with_ptr_and_build_info(
         NonNull::new(module.as_mut() as *const dyn Module as *mut dyn Module).unwrap(),
+        NonNull::new(build_info as *mut rspack_core::BuildInfo).unwrap(),
         compiler_id,
       ))
-      .await?;
+      .await;
+    ModuleObject::cleanup_build_info_ptr(&compiler_id, &module.identifier());
+    let _ = result?;
     Ok(())
   }
 
@@ -1191,15 +1195,19 @@ impl CompilationStillValidModule for CompilationStillValidModuleTap {
     compiler_id: CompilerId,
     _compilation_id: CompilationId,
     module: &mut BoxModule,
+    build_info: &mut rspack_core::BuildInfo,
   ) -> rspack_error::Result<()> {
     #[allow(clippy::unwrap_used)]
-    let _ = self
+    let result = self
       .function
-      .call_with_sync(ModuleObject::with_ptr(
+      .call_with_sync(ModuleObject::with_ptr_and_build_info(
         NonNull::new(module.as_mut() as *const dyn Module as *mut dyn Module).unwrap(),
+        NonNull::new(build_info as *mut rspack_core::BuildInfo).unwrap(),
         compiler_id,
       ))
-      .await?;
+      .await;
+    ModuleObject::cleanup_build_info_ptr(&compiler_id, &module.identifier());
+    let _ = result?;
     Ok(())
   }
 
@@ -1215,15 +1223,19 @@ impl CompilationSucceedModule for CompilationSucceedModuleTap {
     compiler_id: CompilerId,
     _compilation_id: CompilationId,
     module: &mut BoxModule,
+    build_info: &mut rspack_core::BuildInfo,
   ) -> rspack_error::Result<()> {
     #[allow(clippy::unwrap_used)]
-    let _ = self
+    let result = self
       .function
-      .call_with_sync(ModuleObject::with_ptr(
+      .call_with_sync(ModuleObject::with_ptr_and_build_info(
         NonNull::new(module.as_mut() as *const dyn Module as *mut dyn Module).unwrap(),
+        NonNull::new(build_info as *mut rspack_core::BuildInfo).unwrap(),
         compiler_id,
       ))
-      .await?;
+      .await;
+    ModuleObject::cleanup_build_info_ptr(&compiler_id, &module.identifier());
+    let _ = result?;
     Ok(())
   }
 

--- a/crates/rspack_binding_api/src/plugins/js_loader/context.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/context.rs
@@ -127,13 +127,18 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
   fn try_from(
     cx: &mut rspack_core::LoaderContext<RunnerContext>,
   ) -> std::result::Result<Self, Self::Error> {
-    let module = &cx.context.module;
-
     #[allow(clippy::unwrap_used)]
+    let build_info_ptr =
+      NonNull::new(cx.context.build_info_mut() as *mut rspack_core::BuildInfo).unwrap();
+    let module = &mut cx.context.module;
+    #[allow(clippy::unwrap_used)]
+    let module_ptr = NonNull::new(module.as_ref() as *const dyn Module as *mut dyn Module).unwrap();
+
     Ok(JsLoaderContext {
       resource: cx.resource_data.resource().to_owned(),
-      module: ModuleObject::with_ptr(
-        NonNull::new(module.as_ref() as *const dyn Module as *mut dyn Module).unwrap(),
+      module: ModuleObject::with_ptr_and_build_info(
+        module_ptr,
+        build_info_ptr,
         cx.context.compiler_id,
       ),
       hot: cx.hot,

--- a/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
@@ -8,6 +8,7 @@ use rspack_hook::plugin_hook;
 use rspack_loader_runner::State as LoaderState;
 
 use super::{JsLoaderContext, JsLoaderRspackPlugin, JsLoaderRspackPluginInner};
+use crate::module::ModuleObject;
 
 impl JsLoaderRspackPlugin {
   async fn update_loaders_without_pitch(&self, list: Vec<String>) {
@@ -61,12 +62,19 @@ pub(crate) async fn loader_yield(
     .await
     .to_rspack_result()?;
 
-  let new_cx = runner
-    .call_async(loader_context.try_into()?)
+  let js_loader_context: JsLoaderContext = loader_context.try_into()?;
+  let module_identifier = *js_loader_context.module.identifier();
+  let compiler_id = loader_context.context.compiler_id;
+  let new_cx_result = match runner
+    .call_async(js_loader_context)
     .await
-    .to_rspack_result()?
-    .await
-    .to_rspack_result()?;
+    .to_rspack_result()
+  {
+    Ok(promise) => promise.await.to_rspack_result(),
+    Err(error) => Err(error),
+  };
+  ModuleObject::cleanup_build_info_ptr(&compiler_id, &module_identifier);
+  let new_cx = new_cx_result?;
 
   if loader_context.state() == LoaderState::Pitching {
     let list = collect_loaders_without_pitch(loader_context, &new_cx);

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -96,11 +96,10 @@ impl BuildModuleGraphArtifact {
   /// This function will update index on MakeArtifact.
   pub fn revoke_module(&mut self, module_identifier: &ModuleIdentifier) -> Vec<BuildDependency> {
     let mg = &mut self.module_graph;
-    let module = mg
-      .module_by_identifier(module_identifier)
-      .expect("should have module");
     // clean module build info
-    let build_info = module.build_info();
+    let build_info = mg
+      .build_info_by_identifier(module_identifier)
+      .expect("should have module build info");
     let resource_id = ResourceId::from(module_identifier);
     self
       .file_dependencies

--- a/crates/rspack_core/src/cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/alternatives/module.rs
@@ -18,7 +18,6 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct TempModule {
   id: ModuleIdentifier,
-  build_info: BuildInfo,
   build_meta: BuildMeta,
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
@@ -29,7 +28,6 @@ impl TempModule {
     let m = module.as_ref();
     OwnedOrRef::Owned(BoxModule::new(Box::new(Self {
       id: m.identifier(),
-      build_info: m.build_info().clone(),
       build_meta: m.build_meta().clone(),
       dependencies: m.get_dependencies().to_vec(),
       // clean all of blocks
@@ -61,14 +59,6 @@ impl Module for TempModule {
     unreachable!()
   }
 
-  fn build_info(&self) -> &BuildInfo {
-    &self.build_info
-  }
-
-  fn build_info_mut(&mut self) -> &mut BuildInfo {
-    &mut self.build_info
-  }
-
   fn build_meta(&self) -> &BuildMeta {
     &self.build_meta
   }
@@ -97,7 +87,11 @@ impl Module for TempModule {
     unreachable!()
   }
 
-  fn need_build(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build(
+    &self,
+    _build_info: &BuildInfo,
+    _value_cache_versions: &ValueCacheVersions,
+  ) -> bool {
     // return true to make sure this module always rebuild
     true
   }
@@ -123,6 +117,7 @@ impl Module for TempModule {
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
     Ok(BuildResult {
+      build_info: Box::new(BuildInfo::default()),
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -98,7 +98,9 @@ impl Occasion for MakeOccasion {
     let mut missing_dep = FileCounter::default();
     let mut build_dep = FileCounter::default();
     for (mid, module) in mg.modules() {
-      let build_info = module.build_info();
+      let build_info = mg
+        .build_info_by_identifier(mid)
+        .expect("should have module build info");
       let resource_id = ResourceId::from(*mid);
       file_dep.add_files(&resource_id, &build_info.file_dependencies);
       context_dep.add_files(&resource_id, &build_info.context_dependencies);

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -8,9 +8,9 @@ use rustc_hash::FxHashSet;
 
 use super::alternatives::{TempDependency, TempModule};
 use crate::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, Dependency,
-  DependencyId, DependencyParents, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
-  ModuleIdentifier, RayonConsumer,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildInfo,
+  Dependency, DependencyId, DependencyParents, ModuleGraph, ModuleGraphConnection,
+  ModuleGraphModule, ModuleIdentifier, RayonConsumer,
   cache::persistent::{codec::CacheCodec, storage::Storage},
   compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
 };
@@ -21,6 +21,7 @@ pub const SCOPE: &str = "occasion_make_module_graph";
 #[cacheable]
 struct Node<'a> {
   pub mgm: OwnedOrRef<'a, ModuleGraphModule>,
+  pub build_info: OwnedOrRef<'a, BuildInfo>,
   pub module: OwnedOrRef<'a, BoxModule>,
   pub dependencies: Vec<(
     OwnedOrRef<'a, BoxDependency>,
@@ -55,6 +56,7 @@ pub fn save_module_graph(
       let module = mg
         .module_by_identifier(identifier)
         .expect("should have module");
+      let build_info = mg.build_info(identifier);
       let blocks = module
         .get_blocks()
         .par_iter()
@@ -84,6 +86,7 @@ pub fn save_module_graph(
         .map(|lazy_deps| lazy_deps.into());
       let mut node = Node {
         mgm: mgm.into(),
+        build_info: build_info.into(),
         module: module.into(),
         dependencies,
         connections,
@@ -141,6 +144,7 @@ pub async fn recovery_module_graph(
     .with_max_len(1)
     .consume(|node| {
       let mgm = node.mgm.into_owned();
+      let build_info = node.build_info.into_owned();
       let module = node.module.into_owned();
       for (index_in_block, (dep, parent_block)) in node.dependencies.into_iter().enumerate() {
         let dep = dep.into_owned();
@@ -167,7 +171,9 @@ pub async fn recovery_module_graph(
         module_to_lazy_make
           .update_module_lazy_dependencies(module.identifier(), Some(lazy_info.into_owned()));
       }
+      let module_identifier = module.identifier();
       mg.add_module_graph_module(mgm);
+      mg.set_build_info(module_identifier, build_info);
       mg.add_module(module);
     });
   // recovery incoming connections

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -50,8 +50,11 @@ impl Cutout {
           clean_entry_dependencies = true;
         }
         UpdateParam::CheckNeedBuild => {
-          force_build_modules.extend(module_graph.modules().filter_map(|(_, module)| {
-            if module.need_build(&compilation.value_cache_versions) {
+          force_build_modules.extend(module_graph.modules().filter_map(|(identifier, module)| {
+            if module.need_build(
+              module_graph.build_info(identifier),
+              &compilation.value_cache_versions,
+            ) {
               Some(module.identifier())
             } else {
               None

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -48,15 +48,22 @@ impl Task<TaskContext> for BuildTask {
       forwarded_ids,
     } = *self;
 
+    let mut build_info = module.take_build_info();
     plugin_driver
       .compilation_hooks
       .build_module
-      .call(compiler_id, compilation_id, &mut module)
+      .call(
+        compiler_id,
+        compilation_id,
+        &mut module,
+        build_info.as_mut(),
+      )
       .await?;
 
     let result = module
       .build(
         BuildContext {
+          build_info,
           compiler_id,
           compilation_id,
           compiler_options: compiler_options.clone(),
@@ -98,14 +105,18 @@ impl Task<TaskContext> for BuildResultTask {
       mut forwarded_ids,
     } = *self;
     let mut module = build_result.module;
+    let mut build_info = build_result.build_info;
 
     plugin_driver
       .compilation_hooks
       .succeed_module
-      .call(context.compiler_id, context.compilation_id, &mut module)
+      .call(
+        context.compiler_id,
+        context.compilation_id,
+        &mut module,
+        build_info.as_mut(),
+      )
       .await?;
-
-    let build_info = module.build_info();
 
     if !module.diagnostics().is_empty() {
       context
@@ -186,6 +197,7 @@ impl Task<TaskContext> for BuildResultTask {
     }
 
     let module_identifier = module.identifier();
+    module_graph.set_build_info_box(module_identifier, build_info);
 
     module_graph.add_module(module);
 

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -145,7 +145,9 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
         continue;
       }
       let module = mg.module_by_identifier(&m).expect("should have module");
-      let build_info = module.build_info();
+      let build_info = mg
+        .build_info_by_identifier(&m)
+        .expect("should have module build info");
       execute_result
         .file_dependencies
         .extend(build_info.file_dependencies.iter().cloned());

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/mod.rs
@@ -144,8 +144,13 @@ impl ModuleExecutor {
     let module_assets = std::mem::take(&mut self.module_assets);
     for (original_module_identifier, assets) in module_assets {
       // recursive import module may not exist the module, just skip it
-      if let Some(module) = mg.module_by_identifier_mut(&original_module_identifier) {
-        module.build_info_mut().assets.extend(assets);
+      if mg
+        .module_by_identifier(&original_module_identifier)
+        .is_some()
+      {
+        mg.build_info_mut_by_identifier(&original_module_identifier)
+          .assets
+          .extend(assets);
       }
     }
 

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -26,8 +26,11 @@ pub async fn create_module_assets(
   let mut chunk_asset_map = vec![];
   let mut module_assets = vec![];
   let mg = compilation.get_module_graph();
-  for (identifier, module) in mg.modules() {
-    let assets = &module.build_info().assets;
+  for (identifier, _) in mg.modules() {
+    let assets = &mg
+      .build_info_by_identifier(identifier)
+      .expect("should have module build info")
+      .assets;
     if assets.is_empty() {
       continue;
     }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -69,13 +69,13 @@ pub use self::{
   runtime_requirements::RuntimeRequirementsPass,
 };
 use crate::{
-  AsyncModulesArtifact, BindingCell, BoxDependency, BoxModule, BuildChunkGraphArtifact, CacheCount,
-  CacheOptions, CgcRuntimeRequirementsArtifact, CgmHashArtifact, CgmRuntimeRequirementsArtifact,
-  Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey,
-  ChunkHashesArtifact, ChunkKind, ChunkNamedIdArtifact, ChunkRenderArtifact,
-  ChunkRenderCacheArtifact, ChunkRenderResult, ChunkUkey, CodeGenerateCacheArtifact,
-  CodeGenerationJob, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
-  CompilationLogging, CompilerOptions, CompilerPlatform, ConcatenationScope,
+  AsyncModulesArtifact, BindingCell, BoxDependency, BoxModule, BuildChunkGraphArtifact, BuildInfo,
+  CacheCount, CacheOptions, CgcRuntimeRequirementsArtifact, CgmHashArtifact,
+  CgmRuntimeRequirementsArtifact, Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph,
+  ChunkGroupByUkey, ChunkGroupUkey, ChunkHashesArtifact, ChunkKind, ChunkNamedIdArtifact,
+  ChunkRenderArtifact, ChunkRenderCacheArtifact, ChunkRenderResult, ChunkUkey,
+  CodeGenerateCacheArtifact, CodeGenerationJob, CodeGenerationResult, CodeGenerationResults,
+  CompilationLogger, CompilationLogging, CompilerOptions, CompilerPlatform, ConcatenationScope,
   DependenciesDiagnosticsArtifact, DependencyId, DependencyTemplate, DependencyTemplateType,
   DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId,
   ExportsInfoArtifact, ExtendedReferencedExport, Filename, ImportPhase, ImportVarMap,
@@ -96,10 +96,10 @@ use crate::{
 };
 
 define_hook!(CompilationAddEntry: Series(entry_name: Option<&str>, options: &mut EntryOptions));
-define_hook!(CompilationBuildModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule),tracing=false);
+define_hook!(CompilationBuildModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule, build_info: &mut BuildInfo),tracing=false);
 define_hook!(CompilationRevokedModules: Series(compilation: &Compilation, revoked_modules: &IdentifierSet));
-define_hook!(CompilationStillValidModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule));
-define_hook!(CompilationSucceedModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule),tracing=false);
+define_hook!(CompilationStillValidModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule, build_info: &mut BuildInfo));
+define_hook!(CompilationSucceedModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule, build_info: &mut BuildInfo),tracing=false);
 define_hook!(CompilationExecuteModule:
   Series(module: &ModuleIdentifier, runtime_modules: &IdentifierSet, code_generation_results: &BindingCell<CodeGenerationResults>, execute_module_id: &ExecuteModuleId));
 define_hook!(CompilationFinishModules: Series(compilation: &Compilation, async_modules_artifact: &mut AsyncModulesArtifact, exports_info_artifact: &mut ExportsInfoArtifact, side_effects_state_artifact: &mut SideEffectsStateArtifact));

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -811,20 +811,16 @@ impl Module for ConcatenatedModule {
     self.root_module_ctxt.factory_meta = Some(v);
   }
 
-  fn build_info(&self) -> &BuildInfo {
-    &self.build_info
-  }
-
-  fn build_info_mut(&mut self) -> &mut BuildInfo {
-    &mut self.build_info
-  }
-
   fn build_meta(&self) -> &BuildMeta {
     &self.root_module_ctxt.build_meta
   }
 
   fn build_meta_mut(&mut self) -> &mut BuildMeta {
     &mut self.root_module_ctxt.build_meta
+  }
+
+  fn take_build_info(&mut self) -> Box<BuildInfo> {
+    Box::new(std::mem::take(&mut self.build_info))
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -865,20 +861,19 @@ impl Module for ConcatenatedModule {
   /// the compilation is asserted to be `Some(Compilation)`, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ModuleConcatenationPlugin.js#L394-L418
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let compilation = compilation.expect("should pass compilation");
 
     let module_graph = compilation.get_module_graph();
     let modules: IdentifierSet = self.modules.iter().map(|item| item.id).collect();
 
-    let root_module = module_graph
-      .module_by_identifier(&self.root_module_ctxt.id)
-      .expect("should have root module");
-
     // populate root inline_exports
-    self.build_info.inline_exports = root_module.build_info().inline_exports;
+    self.build_info.inline_exports = module_graph
+      .build_info(&self.root_module_ctxt.id)
+      .inline_exports;
 
     let dependency_parts = self
       .modules
@@ -909,7 +904,7 @@ impl Module for ConcatenatedModule {
       let module = module_graph
         .module_by_identifier(&m.id)
         .expect("should have module");
-      let cur_build_info = module.build_info();
+      let cur_build_info = module_graph.build_info(&m.id);
 
       // populate cacheable
       if !cur_build_info.cacheable {
@@ -924,7 +919,7 @@ impl Module for ConcatenatedModule {
       self.diagnostics.extend(module.diagnostics().into_owned());
 
       // populate topLevelDeclarations
-      let module_build_info = module.build_info();
+      let module_build_info = module_graph.build_info(&m.id);
       if let Some(decls) = &module_build_info.top_level_declarations
         && let Some(top_level_declarations) = &mut self.build_info.top_level_declarations
       {
@@ -945,6 +940,7 @@ impl Module for ConcatenatedModule {
     }
     // return a dummy result is enough, since we don't build the ConcatenatedModule in make phase
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
@@ -1636,7 +1632,10 @@ impl Module for ConcatenatedModule {
         })
         .collect();
 
-      let exports_argument = self.get_exports_argument();
+      let exports_argument = compilation
+        .get_module_graph()
+        .build_info(&self.id)
+        .exports_argument;
 
       let should_skip_render_definitions = compilation
         .plugin_driver
@@ -1655,7 +1654,7 @@ impl Module for ConcatenatedModule {
         if should_add_esm_flag {
           result.add(RawStringSource::from_static("// ESM COMPAT FLAG\n"));
           result.add(RawStringSource::from(
-            runtime_template.define_es_module_flag_statement(self.get_exports_argument()),
+            runtime_template.define_es_module_flag_statement(exports_argument),
           ));
         }
 

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1373,9 +1373,10 @@ impl Module for ContextModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let resolve_dependencies = &self.resolve_dependencies;
     let context_element_dependencies = resolve_dependencies(self.options.clone()).await?;
 
@@ -1467,6 +1468,7 @@ impl Module for ContextModule {
     }
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks,

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -107,7 +107,10 @@ impl Dependency for ContextElementDependency {
       create_referenced_exports_by_referenced_specifiers(
         referenced_specifiers,
         exports_type,
-        imported_module.build_info().json_data.is_some(),
+        module_graph
+          .build_info(&imported_module.identifier())
+          .json_data
+          .is_some(),
       )
     } else {
       create_exports_object_referenced()

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1072,6 +1072,7 @@ impl Module for ExternalModule {
     build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     self.build_info.module = build_context.compiler_options.output.module;
     let resolved_external_type = self.resolve_external_type();
     let request = match &self.request {
@@ -1116,6 +1117,7 @@ impl Module for ExternalModule {
     }
     self.build_meta.exports_type = exports_type;
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies: vec![Box::new(StaticExportsDependency::new(
         StaticExportsSpec::True,

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 pub use rspack_loader_runner::{Content, Loader, LoaderContext, run_loaders};
 use rspack_util::source_map::SourceMapKind;
 
-use crate::{CompilationId, CompilerId, CompilerOptions, NormalModule, ResolverFactory};
+use crate::{BuildInfo, CompilationId, CompilerId, CompilerOptions, NormalModule, ResolverFactory};
 
 #[derive(Debug)]
 pub struct RunnerContext {
@@ -13,6 +13,16 @@ pub struct RunnerContext {
   pub resolver_factory: Arc<ResolverFactory>,
   pub module: Box<NormalModule>,
   pub source_map_kind: SourceMapKind,
+}
+
+impl RunnerContext {
+  pub fn build_info(&self) -> &BuildInfo {
+    self.module.build_info()
+  }
+
+  pub fn build_info_mut(&mut self) -> &mut BuildInfo {
+    self.module.build_info_mut()
+  }
 }
 
 pub type BoxLoader = Arc<dyn for<'a> Loader<RunnerContext>>;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -42,6 +42,7 @@ use crate::{
 };
 
 pub struct BuildContext {
+  pub build_info: Box<BuildInfo>,
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub compiler_options: Arc<CompilerOptions>,
@@ -304,6 +305,7 @@ pub struct BuildMeta {
 #[derive(Debug)]
 pub struct BuildResult {
   pub module: BoxModule,
+  pub build_info: Box<BuildInfo>,
   /// Whether the result is cacheable, i.e shared between builds.
   pub dependencies: Vec<BoxDependency>,
   pub blocks: Vec<Box<AsyncDependenciesBlock>>,
@@ -369,20 +371,20 @@ pub trait Module:
 
   fn set_factory_meta(&mut self, factory_meta: FactoryMeta);
 
-  fn build_info(&self) -> &BuildInfo;
-
-  fn build_info_mut(&mut self) -> &mut BuildInfo;
-
   fn build_meta(&self) -> &BuildMeta;
 
   fn build_meta_mut(&mut self) -> &mut BuildMeta;
 
-  fn get_exports_argument(&self) -> ExportsArgument {
-    self.build_info().exports_argument
+  fn take_build_info(&mut self) -> Box<BuildInfo> {
+    Box::default()
   }
 
-  fn get_module_argument(&self) -> ModuleArgument {
-    self.build_info().module_argument
+  fn get_exports_argument(&self, module_graph: &ModuleGraph) -> ExportsArgument {
+    module_graph.build_info(&self.identifier()).exports_argument
+  }
+
+  fn get_module_argument(&self, module_graph: &ModuleGraph) -> ModuleArgument {
+    module_graph.build_info(&self.identifier()).module_argument
   }
 
   fn get_exports_type(
@@ -495,8 +497,7 @@ pub trait Module:
     ConnectionState::Active(true)
   }
 
-  fn need_build(&self, value_cache_version: &ValueCacheVersions) -> bool {
-    let build_info = self.build_info();
+  fn need_build(&self, build_info: &BuildInfo, value_cache_version: &ValueCacheVersions) -> bool {
     !build_info.cacheable
       || value_cache_version.has_diff(&build_info.value_dependencies)
       || self.diagnostics().iter().any(|item| item.is_error())
@@ -744,20 +745,16 @@ macro_rules! impl_module_meta_info {
       self.factory_meta = Some(v);
     }
 
-    fn build_info(&self) -> &$crate::BuildInfo {
-      &self.build_info
-    }
-
-    fn build_info_mut(&mut self) -> &mut $crate::BuildInfo {
-      &mut self.build_info
-    }
-
     fn build_meta(&self) -> &$crate::BuildMeta {
       &self.build_meta
     }
 
     fn build_meta_mut(&mut self) -> &mut $crate::BuildMeta {
       &mut self.build_meta
+    }
+
+    fn take_build_info(&mut self) -> Box<$crate::BuildInfo> {
+      Box::new(std::mem::take(&mut self.build_info))
     }
   };
 }
@@ -916,14 +913,6 @@ mod test {
         }
 
         fn factory_meta(&self) -> Option<&crate::FactoryMeta> {
-          unreachable!()
-        }
-
-        fn build_info(&self) -> &crate::BuildInfo {
-          unreachable!()
-        }
-
-        fn build_info_mut(&mut self) -> &mut crate::BuildInfo {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -23,7 +23,7 @@ mod connection;
 pub use connection::*;
 
 use crate::{
-  BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportsInfoArtifact,
+  BoxDependency, BoxModule, BuildInfo, DependencyCondition, DependencyId, ExportsInfoArtifact,
   ModuleIdentifier,
 };
 
@@ -373,10 +373,24 @@ impl ModuleGraph {
   }
 
   pub fn add_module_graph_module(&mut self, module_graph_module: ModuleGraphModule) {
+    let module_identifier = module_graph_module.module_identifier;
     self
       .inner
       .module_graph_modules
-      .insert(module_graph_module.module_identifier, module_graph_module);
+      .insert(module_identifier, module_graph_module);
+  }
+
+  pub fn set_build_info(&mut self, identifier: ModuleIdentifier, build_info: BuildInfo) {
+    self.set_build_info_box(identifier, Box::new(build_info));
+  }
+
+  pub fn set_build_info_box(&mut self, identifier: ModuleIdentifier, build_info: Box<BuildInfo>) {
+    self
+      .inner
+      .module_graph_modules
+      .get_mut(&identifier)
+      .unwrap_or_else(|| panic!("ModuleGraphModule with identifier {identifier:?} not found"))
+      .set_build_info(build_info);
   }
 
   /// Make sure both source and target module are exists in module graph
@@ -773,6 +787,18 @@ impl ModuleGraph {
     self.inner.module_graph_modules.get(identifier)
   }
 
+  pub fn build_info_by_identifier(&self, identifier: &ModuleIdentifier) -> Option<&BuildInfo> {
+    self
+      .module_graph_module_by_identifier(identifier)
+      .and_then(ModuleGraphModule::build_info)
+  }
+
+  pub fn build_info(&self, identifier: &ModuleIdentifier) -> &BuildInfo {
+    self
+      .build_info_by_identifier(identifier)
+      .unwrap_or_else(|| panic!("BuildInfo with identifier {identifier:?} not found"))
+  }
+
   /// Get a mutable module graph module by identifier, panicking if not found.
   ///
   /// **PREFERRED METHOD**: Use this for all internal code where the module graph module
@@ -788,6 +814,17 @@ impl ModuleGraph {
       .module_graph_modules
       .get_mut(identifier)
       .unwrap_or_else(|| panic!("ModuleGraphModule with identifier {identifier:?} not found"))
+  }
+
+  pub fn build_info_mut_by_identifier(&mut self, identifier: &ModuleIdentifier) -> &mut BuildInfo {
+    let mgm = self.module_graph_module_by_identifier_mut(identifier);
+    if mgm.build_info().is_none() {
+      mgm.set_build_info(Box::new(BuildInfo::default()));
+    }
+
+    mgm
+      .build_info_mut()
+      .unwrap_or_else(|| panic!("BuildInfo with identifier {identifier:?} not found"))
   }
 
   pub fn get_ordered_outgoing_connections(
@@ -960,8 +997,8 @@ impl ModuleGraph {
 
   pub fn get_module_hash(&self, module_id: &ModuleIdentifier) -> Option<&RspackHashDigest> {
     self
-      .module_by_identifier(module_id)
-      .and_then(|m| m.build_info().hash.as_ref())
+      .build_info_by_identifier(module_id)
+      .and_then(|info| info.hash.as_ref())
   }
 
   /// We can't insert all sort of things into one hashmap like javascript, so we create different

--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use rspack_cacheable::{cacheable, with::Skip};
 use rustc_hash::FxHashSet;
 
-use crate::{DependencyId, ModuleIdentifier, ModuleIssuer};
+use crate::{BuildInfo, DependencyId, ModuleIdentifier, ModuleIssuer};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -54,6 +54,8 @@ pub struct ModuleGraphModule {
   pub post_order_index: Option<u32>,
   pub depth: Option<usize>,
   pub optimization_bailout: Vec<OptimizationBailoutItem>,
+  #[cacheable(with=Skip)]
+  pub(crate) build_info: Option<Box<BuildInfo>>,
 }
 
 impl ModuleGraphModule {
@@ -69,6 +71,7 @@ impl ModuleGraphModule {
       post_order_index: None,
       depth: None,
       optimization_bailout: vec![],
+      build_info: None,
     }
   }
 
@@ -120,5 +123,17 @@ impl ModuleGraphModule {
 
   pub(crate) fn optimization_bailout_mut(&mut self) -> &mut Vec<OptimizationBailoutItem> {
     &mut self.optimization_bailout
+  }
+
+  pub(crate) fn build_info(&self) -> Option<&BuildInfo> {
+    self.build_info.as_deref()
+  }
+
+  pub(crate) fn build_info_mut(&mut self) -> Option<&mut BuildInfo> {
+    self.build_info.as_deref_mut()
+  }
+
+  pub(crate) fn set_build_info(&mut self, build_info: Box<BuildInfo>) {
+    self.build_info = Some(build_info);
   }
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -147,7 +147,7 @@ pub struct NormalModule {
   presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
 
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
+  build_info: Option<Box<BuildInfo>>,
   build_meta: BuildMeta,
   parsed: bool,
 
@@ -216,7 +216,7 @@ impl NormalModule {
       code_generation_dependencies: None,
       presentational_dependencies: None,
       factory_meta: None,
-      build_info: Default::default(),
+      build_info: None,
       build_meta: Default::default(),
       parsed: false,
       source_map_kind: SourceMapKind::empty(),
@@ -237,6 +237,17 @@ impl NormalModule {
 
   pub fn resource_resolved_data(&self) -> &Arc<ResourceData> {
     &self.resource_data
+  }
+
+  pub(crate) fn build_info(&self) -> &BuildInfo {
+    self
+      .build_info
+      .as_deref()
+      .expect("NormalModule BuildInfo should be available while building")
+  }
+
+  pub(crate) fn build_info_mut(&mut self) -> &mut BuildInfo {
+    self.build_info.get_or_insert_with(Box::default).as_mut()
   }
 
   pub fn request(&self) -> &str {
@@ -362,17 +373,32 @@ impl Module for NormalModule {
     Cow::Owned(context.shorten(&self.user_request))
   }
 
-  fn size(&self, source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
+  fn size(&self, source_type: Option<&SourceType>, compilation: Option<&Compilation>) -> f64 {
+    let build_info = compilation.and_then(|compilation| {
+      compilation
+        .get_module_graph()
+        .build_info_by_identifier(&self.id)
+    });
     if let Some(source_type) = source_type {
       // Fast-path: lock-free builtin slots / tiny fallback map for custom source types.
       if let Some(size) = self.cached_source_sizes.get(source_type) {
         return size;
       }
 
-      let size = f64::max(1.0, self.parser_and_generator.size(self, Some(source_type)));
+      let size = f64::max(
+        1.0,
+        self
+          .parser_and_generator
+          .size(self, build_info, Some(source_type)),
+      );
       self.cached_source_sizes.get_or_insert(source_type, size)
     } else {
-      f64::max(1.0, self.parser_and_generator.size(self, source_type))
+      f64::max(
+        1.0,
+        self
+          .parser_and_generator
+          .size(self, build_info, source_type),
+      )
     }
   }
 
@@ -390,6 +416,7 @@ impl Module for NormalModule {
   ) -> Result<BuildResult> {
     // so does webpack
     self.parsed = true;
+    self.build_info = Some(build_context.build_info);
 
     let no_parse = if let Some(no_parse) = build_context.compiler_options.module.no_parse.as_ref() {
       no_parse.try_match(self.request.as_str()).await?
@@ -433,27 +460,30 @@ impl Module for NormalModule {
     self = loader_result.context.module;
 
     if let Some(err) = err {
-      self.build_info.cacheable = loader_result.cacheable;
-      self.build_info.file_dependencies = loader_result
-        .file_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
-      self.build_info.context_dependencies = loader_result
-        .context_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
-      self.build_info.missing_dependencies = loader_result
-        .missing_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
-      self.build_info.build_dependencies = loader_result
-        .build_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
+      {
+        let build_info = self.build_info_mut();
+        build_info.cacheable = loader_result.cacheable;
+        build_info.file_dependencies = loader_result
+          .file_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+        build_info.context_dependencies = loader_result
+          .context_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+        build_info.missing_dependencies = loader_result
+          .missing_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+        build_info.build_dependencies = loader_result
+          .build_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+      }
 
       self.source = None;
 
@@ -469,9 +499,11 @@ impl Module for NormalModule {
       )));
       self.diagnostics.push(diagnostic);
 
-      self.build_info.hash =
-        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
+      let hash = self.init_build_hash(&build_context.compiler_options.output, &self.build_meta);
+      self.build_info_mut().hash = Some(hash);
+      let build_info = self.take_build_info();
       return Ok(BuildResult {
+        build_info,
         module: BoxModule::new(self),
         dependencies: Vec::new(),
         blocks: Vec::new(),
@@ -505,27 +537,30 @@ impl Module for NormalModule {
     };
     let source = self.create_source(content, loader_result.source_map)?;
 
-    self.build_info.cacheable = loader_result.cacheable;
-    self.build_info.file_dependencies = loader_result
-      .file_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    self.build_info.context_dependencies = loader_result
-      .context_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    self.build_info.missing_dependencies = loader_result
-      .missing_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    self.build_info.build_dependencies = loader_result
-      .build_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
+    {
+      let build_info = self.build_info_mut();
+      build_info.cacheable = loader_result.cacheable;
+      build_info.file_dependencies = loader_result
+        .file_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+      build_info.context_dependencies = loader_result
+        .context_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+      build_info.missing_dependencies = loader_result
+        .missing_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+      build_info.build_dependencies = loader_result
+        .build_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    }
 
     if no_parse {
       self.parsed = false;
@@ -533,10 +568,12 @@ impl Module for NormalModule {
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
-      self.build_info.hash =
-        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
+      let hash = self.init_build_hash(&build_context.compiler_options.output, &self.build_meta);
+      self.build_info_mut().hash = Some(hash);
 
+      let build_info = self.take_build_info();
       return Ok(BuildResult {
+        build_info,
         module: BoxModule::new(self),
         dependencies: vec![],
         blocks: vec![],
@@ -571,7 +608,10 @@ impl Module for NormalModule {
         compiler_options: &build_context.compiler_options,
         additional_data: loader_result.additional_data,
         factory_meta: self.factory_meta.as_ref(),
-        build_info: &mut self.build_info,
+        build_info: self
+          .build_info
+          .as_deref_mut()
+          .expect("NormalModule BuildInfo should be available while parsing"),
         build_meta: &mut self.build_meta,
         parse_meta: loader_result.parse_meta,
         runtime_template: &build_context.runtime_template,
@@ -600,10 +640,12 @@ impl Module for NormalModule {
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
 
-    self.build_info.hash =
-      Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
+    let hash = self.init_build_hash(&build_context.compiler_options.output, &self.build_meta);
+    self.build_info_mut().hash = Some(hash);
 
+    let build_info = self.take_build_info();
     Ok(BuildResult {
+      build_info,
       module: BoxModule::new(self),
       dependencies,
       blocks,
@@ -685,7 +727,17 @@ impl Module for NormalModule {
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
-    self.build_info.hash.dyn_hash(&mut hasher);
+    compilation
+      .get_module_graph()
+      .build_info_by_identifier(&self.id)
+      .and_then(|build_info| build_info.hash.as_ref())
+      .or(
+        self
+          .build_info
+          .as_ref()
+          .and_then(|build_info| build_info.hash.as_ref()),
+      )
+      .dyn_hash(&mut hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
     if self.source.is_some() {
       self
@@ -824,20 +876,16 @@ impl Module for NormalModule {
     self.factory_meta = Some(factory_meta);
   }
 
-  fn build_info(&self) -> &BuildInfo {
-    &self.build_info
-  }
-
-  fn build_info_mut(&mut self) -> &mut BuildInfo {
-    &mut self.build_info
-  }
-
   fn build_meta(&self) -> &BuildMeta {
     &self.build_meta
   }
 
   fn build_meta_mut(&mut self) -> &mut BuildMeta {
     &mut self.build_meta
+  }
+
+  fn take_build_info(&mut self) -> Box<BuildInfo> {
+    self.build_info.take().unwrap_or_default()
   }
 }
 

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -133,7 +133,12 @@ pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>>;
   /// Size of the original source
-  fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64;
+  fn size(
+    &self,
+    module: &dyn Module,
+    build_info: Option<&BuildInfo>,
+    source_type: Option<&SourceType>,
+  ) -> f64;
   /// Generate source or AST based on the built source or AST
   async fn generate(
     &self,

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -169,11 +169,13 @@ impl Module for RawModule {
   }
 
   async fn build(
-    self: Box<Self>,
-    _build_context: BuildContext,
+    mut self: Box<Self>,
+    build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -130,11 +130,13 @@ impl Module for SelfModule {
   }
 
   async fn build(
-    self: Box<Self>,
-    _build_context: BuildContext,
+    mut self: Box<Self>,
+    build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1278,7 +1278,7 @@ impl Stats<'_> {
       stats.name_for_condition = module.name_for_condition().map(|n| n.to_string());
       stats.pre_order_index = module_graph.get_pre_order_index(&identifier);
       stats.post_order_index = module_graph.get_post_order_index(&identifier);
-      stats.cacheable = Some(module.build_info().cacheable);
+      stats.cacheable = Some(module_graph.build_info(&identifier).cacheable);
       let side_effects_state_artifact = &build_module_graph_artifact.side_effects_state_artifact;
       stats.optional = Some(module_graph.is_optional(
         &identifier,
@@ -1335,11 +1335,8 @@ impl Stats<'_> {
       stats.assets = if executed {
         None
       } else {
-        let module = module_graph
-          .module_by_identifier(&identifier)
-          .expect("should have module");
-        let mut assets = module
-          .build_info()
+        let mut assets = module_graph
+          .build_info(&identifier)
           .assets
           .keys()
           .map(|s| s.as_str())

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -160,10 +160,10 @@ pub fn get_module_hashbang(
       // For concatenated modules, get the root module's build_info
       let root_module_id = concatenated_module.get_root();
       module_graph
-        .module_by_identifier(&root_module_id)
-        .map_or_else(|| module.build_info(), |m| m.build_info())
+        .build_info_by_identifier(&root_module_id)
+        .unwrap_or_else(|| module_graph.build_info(module_id))
     } else {
-      module.build_info()
+      module_graph.build_info(module_id)
     };
 
   build_info
@@ -187,10 +187,10 @@ pub fn get_module_directives(
       // For concatenated modules, get the root module's build_info
       let root_module_id = concatenated_module.get_root();
       module_graph
-        .module_by_identifier(&root_module_id)
-        .map_or_else(|| module.build_info(), |m| m.build_info())
+        .build_info_by_identifier(&root_module_id)
+        .unwrap_or_else(|| module_graph.build_info(module_id))
     } else {
-      module.build_info()
+      module_graph.build_info(module_id)
     };
 
   build_info

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -14,7 +14,7 @@ use options::SwcCompilerOptionsWithAdditional;
 pub use options::SwcLoaderJsOptions;
 pub use plugin::SwcLoaderPlugin;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_core::{COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, Mode, Module, RscMeta, RunnerContext};
+use rspack_core::{COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, Mode, RscMeta, RunnerContext};
 use rspack_error::{Diagnostic, Error, Result, SerdeResultToRspackResultExt};
 use rspack_javascript_compiler::{JavaScriptCompiler, TransformOutput};
 use rspack_loader_runner::{Identifier, Loader, LoaderContext};
@@ -64,7 +64,7 @@ impl SwcLoader {
       .resource_path()
       .map(|p| p.to_path_buf())
       .unwrap_or_default();
-    loader_context.context.module.build_info_mut().isolated_dts = None;
+    loader_context.context.build_info_mut().isolated_dts = None;
     let Some(content) = loader_context.take_content() else {
       return Ok(());
     };
@@ -221,19 +221,22 @@ impl SwcLoader {
     if let Some(isolated_dts) = isolated_dts? {
       handle_isolated_dts_diagnostics(isolated_dts.diagnostics)?;
 
+      let compiler_context = loader_context.context.options.context.clone();
       set_build_info(
-        loader_context.context.module.build_info_mut(),
+        loader_context.context.build_info_mut(),
         resource_path.as_path(),
-        loader_context.context.options.context.as_path(),
+        compiler_context.as_path(),
         isolated_dts.code,
         isolated_dts.references,
       );
     }
 
     if let Some(rsc) = rsc_meta.borrow_mut().take() {
-      let module = &mut loader_context.context.module;
-      module.build_info_mut().rsc = Some(rsc);
-      if let Some(code) = to_server_entry(module)? {
+      loader_context.context.build_info_mut().rsc = Some(rsc);
+      if let Some(code) = to_server_entry(
+        &loader_context.context.module,
+        loader_context.context.build_info(),
+      )? {
         loader_context.finish_with(code);
         return Ok(());
       }

--- a/crates/rspack_loader_swc/src/rsc_transforms/to_server_entry.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/to_server_entry.rs
@@ -1,5 +1,5 @@
 use indoc::formatdoc;
-use rspack_core::{Module as RspackCoreModule, NormalModule, RscModuleType};
+use rspack_core::{BuildInfo, Module as RspackCoreModule, NormalModule, RscModuleType};
 use rspack_error::Result;
 use rspack_util::json_stringify_str;
 use swc::atoms::Wtf8Atom;
@@ -82,7 +82,7 @@ fn to_esm_server_entry(resource: &str, server_refs: &[Wtf8Atom]) -> Result<Strin
   Ok(esm_source)
 }
 
-pub fn to_server_entry(module: &NormalModule) -> Result<Option<String>> {
+pub fn to_server_entry(module: &NormalModule, build_info: &BuildInfo) -> Result<Option<String>> {
   if module
     .get_layer()
     .is_none_or(|layer| layer != "react-server-components")
@@ -90,7 +90,7 @@ pub fn to_server_entry(module: &NormalModule) -> Result<Option<String>> {
     return Ok(None);
   }
 
-  let Some(rsc) = module.build_info().rsc.as_ref() else {
+  let Some(rsc) = build_info.rsc.as_ref() else {
     return Ok(None);
   };
 

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -201,14 +201,6 @@ pub fn impl_runtime_module(
 
       fn set_factory_meta(&mut self, v: ::rspack_core::FactoryMeta) {}
 
-      fn build_info(&self) -> &::rspack_core::BuildInfo {
-        unreachable!()
-      }
-
-      fn build_info_mut(&mut self) -> &mut ::rspack_core::BuildInfo {
-        unreachable!()
-      }
-
       fn build_meta(&self) -> &::rspack_core::BuildMeta {
         unreachable!()
       }
@@ -251,6 +243,7 @@ pub fn impl_runtime_module(
         _compilation: Option<&::rspack_core::Compilation>,
       ) -> ::rspack_error::Result<::rspack_core::BuildResult> {
         Ok(::rspack_core::BuildResult {
+          build_info: Default::default(),
           module: ::rspack_core::BoxModule::new(self),
           dependencies: vec![],
           blocks: vec![],

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -348,8 +348,8 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       )
       .is_ok_and(|x| x.is_preserve());
 
-    if module
-      .build_info()
+    if module_graph
+      .build_info(&(module as &dyn Module).identifier())
       .asset_data_url
       .as_ref()
       .is_some_and(|x| x.is_source() || x.is_inline() || x.is_bytes())
@@ -389,7 +389,12 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     }
   }
 
-  fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64 {
+  fn size(
+    &self,
+    module: &dyn Module,
+    build_info: Option<&rspack_core::BuildInfo>,
+    source_type: Option<&SourceType>,
+  ) -> f64 {
     let original_source_size = module.source().map_or(0, |source| source.size()) as f64;
     match source_type.unwrap_or(&SourceType::Asset) {
       SourceType::Asset => original_source_size,
@@ -398,27 +403,29 @@ impl ParserAndGenerator for AssetParserAndGenerator {
           return 0.0;
         }
 
-        let parsed_size = module.build_info().asset_data_url.as_ref().map(|config| {
-          match config {
-            CanonicalizedDataUrlOption::Source | CanonicalizedDataUrlOption::Bytes => {
-              original_source_size
-            }
-            CanonicalizedDataUrlOption::Asset(is_inline) => {
-              if *is_inline {
-                // copied from webpack's AssetGenerator
-                // roughly for data url
-                // Example: m.exports="data:image/png;base64,ag82/f+2=="
-                // 4/3 = base64 encoding
-                // 34 = ~ data url header + footer + rounding
-                original_source_size * 1.34 + 36.0
-              } else {
-                // copied from webpack's AssetGenerator
-                // roughly for url
-                // Example: m.exports=r.p+"0123456789012345678901.ext"
-                42.0
+        let parsed_size = build_info.and_then(|build_info| {
+          build_info.asset_data_url.as_ref().map(|config| {
+            match config {
+              CanonicalizedDataUrlOption::Source | CanonicalizedDataUrlOption::Bytes => {
+                original_source_size
+              }
+              CanonicalizedDataUrlOption::Asset(is_inline) => {
+                if *is_inline {
+                  // copied from webpack's AssetGenerator
+                  // roughly for data url
+                  // Example: m.exports="data:image/png;base64,ag82/f+2=="
+                  // 4/3 = base64 encoding
+                  // 34 = ~ data url header + footer + rounding
+                  original_source_size * 1.34 + 36.0
+                } else {
+                  // copied from webpack's AssetGenerator
+                  // roughly for url
+                  // Example: m.exports=r.p+"0123456789012345678901.ext"
+                  42.0
+                }
               }
             }
-          }
+          })
         });
 
         parsed_size.unwrap_or_default()
@@ -491,8 +498,9 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     generate_context: &mut GenerateContext,
   ) -> Result<BoxSource> {
     let compilation = generate_context.compilation;
-    let parsed_asset_config = module
-      .build_info()
+    let parsed_asset_config = compilation
+      .get_module_graph()
+      .build_info(&(module as &dyn Module).identifier())
       .asset_data_url
       .as_ref()
       .expect("should have parsed_asset_config in generate phase");
@@ -753,8 +761,9 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
-    let parsed_asset_config = module
-      .build_info()
+    let parsed_asset_config = compilation
+      .get_module_graph()
+      .build_info(&(module as &dyn Module).identifier())
       .asset_data_url
       .as_ref()
       .expect("should have parsed_asset_config in generate phase");

--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -72,7 +72,11 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
 
   fn generate_js_exports(&mut self) -> Result<()> {
     let module = self.module;
-    let build_info = module.build_info();
+    let build_info = self
+      .generate_context
+      .compilation
+      .get_module_graph()
+      .build_info(&module.identifier());
 
     if self.generate_context.concatenation_scope.is_some() {
       if let Some(ref exports) = build_info.css_exports {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -187,7 +187,12 @@ impl ParserAndGenerator for CssParserAndGenerator {
     }
   }
 
-  fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64 {
+  fn size(
+    &self,
+    module: &dyn Module,
+    _build_info: Option<&rspack_core::BuildInfo>,
+    source_type: Option<&SourceType>,
+  ) -> f64 {
     match source_type.unwrap_or(&SourceType::Css) {
       SourceType::JavaScript => 42.0,
       SourceType::Css => module.source().map_or(0, |source| source.size()) as f64,

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
@@ -31,6 +31,7 @@ async fn build_module(
   _compiler_id: CompilerId,
   _compilation_id: CompilationId,
   module: &mut BoxModule,
+  _build_info: &mut rspack_core::BuildInfo,
 ) -> Result<()> {
   if self.module {
     module.set_source_map_kind(SourceMapKind::SourceMap);

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -79,9 +79,10 @@ impl Module for DllModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let dependencies = self
       .entries
       .clone()
@@ -91,6 +92,7 @@ impl Module for DllModule {
       .collect::<Vec<_>>();
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks: vec![],
@@ -118,7 +120,11 @@ impl Module for DllModule {
     Ok(code_generation_result)
   }
 
-  fn need_build(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build(
+    &self,
+    _build_info: &BuildInfo,
+    _value_cache_versions: &ValueCacheVersions,
+  ) -> bool {
     false
   }
 

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -93,9 +93,10 @@ impl Module for DelegatedModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let dependencies = vec![
       Box::new(DelegatedSourceDependency::new(self.source_request.clone())),
       Box::new(StaticExportsDependency::new(
@@ -111,6 +112,7 @@ impl Module for DelegatedModule {
     ];
     self.build_meta = self.delegate_data.build_meta.clone();
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks: vec![],
@@ -184,7 +186,11 @@ impl Module for DelegatedModule {
     Ok(code_generation_result)
   }
 
-  fn need_build(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build(
+    &self,
+    _build_info: &BuildInfo,
+    _value_cache_versions: &ValueCacheVersions,
+  ) -> bool {
     false
   }
 

--- a/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
+++ b/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
@@ -78,6 +78,7 @@ async fn build_module(
   _compiler_id: CompilerId,
   _compilation_id: CompilationId,
   module: &mut BoxModule,
+  build_info: &mut rspack_core::BuildInfo,
 ) -> Result<()> {
   // set all modules have effects. To avoid any module remove by tree shaking.
   // see: https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/FlagAllModulesAsUsedPlugin.js#L43-L47
@@ -86,7 +87,6 @@ async fn build_module(
   });
 
   let module_identifier = module.identifier();
-  let build_info = module.build_info_mut();
   if build_info.module_concatenation_bailout.is_none() {
     // webpack avoid those modules be concatenated using add a virtual module_graph_connection.
     // see: https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/FlagAllModulesAsUsedPlugin.js#L42

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -171,8 +171,10 @@ impl Module for CssModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     self.build_info.hash = Some(self.compute_hash(&build_context.compiler_options));
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
@@ -195,7 +197,12 @@ impl Module for CssModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
-    self.build_info.hash.dyn_hash(&mut hasher);
+    let identifier = self.identifier();
+    compilation
+      .get_module_graph()
+      .build_info(&identifier)
+      .hash
+      .dyn_hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -457,8 +457,8 @@ impl DependencyTemplate for CommonJsExportRequireDependencyTemplate {
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
-    let exports_argument = module.get_exports_argument();
-    let module_argument = module.get_module_argument();
+    let exports_argument = module.get_exports_argument(mg);
+    let module_argument = module.get_module_argument(mg);
 
     let exports_info = compilation
       .exports_info_artifact

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -179,8 +179,8 @@ impl DependencyTemplate for CommonJsExportsDependencyTemplate {
       .get_exports_info_data(&module.identifier());
     let used = exports_info.get_used_name(&compilation.exports_info_artifact, *runtime, &dep.names);
 
-    let exports_argument = module.get_exports_argument();
-    let module_argument = module.get_module_argument();
+    let exports_argument = module.get_exports_argument(module_graph);
+    let module_argument = module.get_module_argument(module_graph);
 
     let base = if dep.base.is_exports() {
       runtime_template.render_exports_argument(exports_argument)

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -102,7 +102,10 @@ impl Dependency for CommonJsFullRequireDependency {
     if matches!(
       exports_type,
       ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
-    ) && module.build_info().json_data.is_some()
+    ) && module_graph
+      .build_info(&module.identifier())
+      .json_data
+      .is_some()
     {
       namespace_object_as_context = true;
     }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -104,7 +104,10 @@ impl Dependency for CommonJsRequireDependency {
       create_referenced_exports_by_referenced_specifiers(
         referenced_specifiers,
         exports_type,
-        module.build_info().json_data.is_some(),
+        module_graph
+          .build_info(&module.identifier())
+          .json_data
+          .is_some(),
       )
     } else {
       create_exports_object_referenced()

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -161,8 +161,8 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
       UsedName::Normal(dep.names.clone())
     };
 
-    let exports_argument = module.get_exports_argument();
-    let module_argument = module.get_module_argument();
+    let exports_argument = module.get_exports_argument(module_graph);
+    let module_argument = module.get_module_argument(module_graph);
 
     let base = if dep.base.is_exports() {
       runtime_template.render_exports_argument(exports_argument)

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -141,7 +141,8 @@ impl DependencyTemplate for ModuleDecoratorDependencyTemplate {
     init_fragments.push(Box::new(NormalInitFragment::new(
       format!(
         "/* module decorator */ {module} = {decorator}({module});\n",
-        module = runtime_template.render_module_argument(module.get_module_argument()),
+        module = runtime_template
+          .render_module_argument(module.get_module_argument(compilation.get_module_graph())),
         decorator = runtime_template.render_runtime_globals(&dep.decorator),
       ),
       InitFragmentStage::StageProvides,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -64,7 +64,8 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
         format!(
           "{}({});\n",
           runtime_template.render_runtime_globals(&RuntimeGlobals::MAKE_NAMESPACE_OBJECT),
-          runtime_template.render_exports_argument(module.get_exports_argument()),
+          runtime_template
+            .render_exports_argument(module.get_exports_argument(compilation.get_module_graph())),
         ),
         InitFragmentStage::StageESMExports,
         0,
@@ -82,7 +83,7 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
             module_graph
               .module_by_identifier(&module.identifier())
               .expect("should have mgm")
-              .get_module_argument()
+              .get_module_argument(module_graph)
           ),
         ),
         InitFragmentStage::StageAsyncBoundary,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -198,7 +198,7 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
         && let UsedName::Normal(used) = used
       {
         init_fragments.push(Box::new(ESMExportInitFragment::new(
-          module.get_exports_argument(),
+          module.get_exports_argument(compilation.get_module_graph()),
           vec![(
             used
               .iter()
@@ -241,7 +241,7 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
         if let UsedName::Normal(used) = used {
           if supports_const {
             init_fragments.push(Box::new(ESMExportInitFragment::new(
-              module.get_exports_argument(),
+              module.get_exports_argument(compilation.get_module_graph()),
               vec![(
                 used
                   .iter()
@@ -257,7 +257,9 @@ impl DependencyTemplate for ESMExportExpressionDependencyTemplate {
           } else {
             format!(
               r#"/* export default */ {}{} = "#,
-              runtime_template.render_exports_argument(module.get_exports_argument()),
+              runtime_template.render_exports_argument(
+                module.get_exports_argument(compilation.get_module_graph())
+              ),
               property_access(used, 0)
             )
           }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -98,11 +98,10 @@ impl ESMExportImportedSpecifierDependency {
 
   // Because it is shared by multiply ESMExportImportedSpecifierDependency, so put it to `BuildInfo`
   pub fn active_exports<'a>(&self, module_graph: &'a ModuleGraph) -> &'a HashSet<Atom> {
-    let build_info = module_graph
+    let parent_module = module_graph
       .get_parent_module(&self.id)
-      .and_then(|ident| module_graph.module_by_identifier(ident))
-      .expect("should have mgm")
-      .build_info();
+      .expect("should have parent module");
+    let build_info = module_graph.build_info(parent_module);
     &build_info.esm_named_exports
   }
 
@@ -111,13 +110,11 @@ impl ESMExportImportedSpecifierDependency {
     &self,
     module_graph: &'a ModuleGraph,
   ) -> Option<(ModuleIdentifier, &'a Vec<DependencyId>)> {
-    let module = module_graph
-      .get_parent_module(&self.id)
-      .and_then(|ident| module_graph.module_by_identifier(ident));
+    let parent_module = module_graph.get_parent_module(&self.id);
 
-    if let Some(module) = module {
-      let build_info = module.build_info();
-      Some((module.identifier(), &build_info.all_star_exports))
+    if let Some(module_identifier) = parent_module {
+      let build_info = module_graph.build_info(module_identifier);
+      Some((*module_identifier, &build_info.all_star_exports))
     } else {
       None
     }
@@ -799,7 +796,7 @@ impl ESMExportImportedSpecifierDependency {
         let module = mg
           .module_by_identifier(&module.identifier())
           .expect("should have module graph module");
-        let exports_name = module.get_exports_argument();
+        let exports_name = module.get_exports_argument(compilation.get_module_graph());
         let is_async =
           ModuleGraph::is_async(&compilation.async_modules_artifact, &module.identifier());
         ctxt.init_fragments.push(
@@ -864,7 +861,7 @@ impl ESMExportImportedSpecifierDependency {
         None,
       ),
       ESMExportInitFragment::new(
-        module.get_exports_argument(),
+        module.get_exports_argument(compilation.get_module_graph()),
         export_map,
         is_circular_module,
       ),
@@ -890,7 +887,9 @@ impl ESMExportImportedSpecifierDependency {
       ESMExportBinding::Getter(format!("/* {comment} */ {return_value}").into()),
     )];
     ESMExportInitFragment::new(
-      ctxt.module.get_exports_argument(),
+      ctxt
+        .module
+        .get_exports_argument(ctxt.compilation.get_module_graph()),
       export_map,
       is_circular_module,
     )
@@ -934,7 +933,7 @@ impl ESMExportImportedSpecifierDependency {
         None,
       ),
       ESMExportInitFragment::new(
-        module.get_exports_argument(),
+        module.get_exports_argument(compilation.get_module_graph()),
         export_map,
         is_circular_module,
       ),
@@ -967,12 +966,13 @@ impl ESMExportImportedSpecifierDependency {
       return "/* unused export */\n".to_string();
     }
     let TemplateContext {
+      compilation,
       module,
       runtime_template,
       ..
     } = ctxt;
     let return_value = Self::get_return_value(name.clone(), value_key);
-    let exports_name = module.get_exports_argument();
+    let exports_name = module.get_exports_argument(compilation.get_module_graph());
     format!(
       "if({}({}, {})) {}({}, {{ {}: function() {{ return {}; }} }});\n",
       runtime_template.render_runtime_globals(&RuntimeGlobals::HAS_OWN_PROPERTY),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -222,7 +222,7 @@ impl DependencyTemplate for ESMExportSpecifierDependencyTemplate {
       ESMExportBinding::Getter(dep.value.clone())
     };
     init_fragments.push(Box::new(ESMExportInitFragment::new(
-      module.get_exports_argument(),
+      module.get_exports_argument(compilation.get_module_graph()),
       vec![(used_name, binding)],
       is_circular_module,
     )));

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -362,8 +362,8 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       if !matches!(
         type_reexports_presence,
         TypeReexportPresenceMode::NoTolerant
-      ) && parent_module
-        .build_info()
+      ) && module_graph
+        .build_info(parent_module_identifier)
         .collected_typescript_info
         .is_some()
         && ids.len() == 1
@@ -473,7 +473,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
         )
         // Ignore the JSON named exports warning: this doesn't follow the standards
         // but it's widely used by the community, other bundlers also ignore the warning.
-        && imported_module.build_info().json_data.is_none()
+        && module_graph.build_info(&imported_module.identifier()).json_data.is_none()
       {
         let msg = format!(
           "Should not import the named export {} {} from default-exporting module (only default export is available soon)",
@@ -499,13 +499,10 @@ fn find_type_exports_from_outgoings(
   visited: &mut IdentifierSet,
 ) -> bool {
   visited.insert(*module_identifier);
-  let module = mg
-    .module_by_identifier(module_identifier)
-    .expect("should have module");
   // bailout the check of this export chain if there is a module that not transpiled from
   // typescript, we only support that the export chain is all transpiled typescript, if not
   // the check will be very slow especially when big javascript npm package exists.
-  let Some(info) = &module.build_info().collected_typescript_info else {
+  let Some(info) = &mg.build_info(module_identifier).collected_typescript_info else {
     return false;
   };
   if info.type_exports.contains(export_name) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -292,7 +292,10 @@ impl Dependency for ESMImportSpecifierDependency {
     if matches!(
       exports_type,
       ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
-    ) && module.build_info().json_data.is_some()
+    ) && module_graph
+      .build_info(&module.identifier())
+      .json_data
+      .is_some()
     {
       namespace_object_as_context = true;
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -129,7 +129,10 @@ impl Dependency for ImportDependency {
       create_referenced_exports_by_referenced_specifiers(
         referenced_specifiers,
         exports_type,
-        module.build_info().json_data.is_some(),
+        module_graph
+          .build_info(&module.identifier())
+          .json_data
+          .is_some(),
       )
     } else {
       create_exports_object_referenced()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -112,7 +112,10 @@ impl Dependency for ImportEagerDependency {
       create_referenced_exports_by_referenced_specifiers(
         referenced_specifiers,
         exports_type,
-        module.build_info().json_data.is_some(),
+        module_graph
+          .build_info(&module.identifier())
+          .json_data
+          .is_some(),
       )
     } else {
       create_exports_object_referenced()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
@@ -117,7 +117,10 @@ impl Dependency for ImportWeakDependency {
       create_referenced_exports_by_referenced_specifiers(
         referenced_specifiers,
         exports_type,
-        module.build_info().json_data.is_some(),
+        module_graph
+          .build_info(&module.identifier())
+          .json_data
+          .is_some(),
       )
     } else {
       create_exports_object_referenced()

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -74,7 +74,7 @@ impl DependencyTemplate for ModuleArgumentDependencyTemplate {
         .get_module_graph()
         .module_by_identifier(&module.identifier())
         .expect("should have mgm")
-        .get_module_argument(),
+        .get_module_argument(compilation.get_module_graph()),
     );
 
     let content = if let Some(id) = &dep.id {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -166,7 +166,12 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     SOURCE_TYPES
   }
 
-  fn size(&self, module: &dyn Module, _source_type: Option<&SourceType>) -> f64 {
+  fn size(
+    &self,
+    module: &dyn Module,
+    _build_info: Option<&rspack_core::BuildInfo>,
+    _source_type: Option<&SourceType>,
+  ) -> f64 {
     module.source().map_or(0, |source| source.size()) as f64
   }
 
@@ -407,7 +412,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
   fn get_concatenation_bailout_reason(
     &self,
     module: &dyn rspack_core::Module,
-    _mg: &ModuleGraph,
+    mg: &ModuleGraph,
     _cg: &ChunkGraph,
   ) -> Option<Cow<'static, str>> {
     // Only ES modules are valid for optimization
@@ -429,7 +434,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       return Some("Module is not an ECMAScript module".into());
     }
 
-    if let Some(bailout) = module.build_info().module_concatenation_bailout.as_deref() {
+    if let Some(bailout) = mg
+      .build_info(&module.identifier())
+      .module_concatenation_bailout
+      .as_deref()
+    {
       return Some(format!("Module uses {bailout}").into());
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -48,10 +48,10 @@ pub(crate) fn has_impure_deferred_pure_checks(
         (*ref_module, deferred_check.atom.clone())
       };
 
-      let Some(ref_module) = module_graph.module_by_identifier(&ref_module_id) else {
+      let Some(build_info) = module_graph.build_info_by_identifier(&ref_module_id) else {
         return true;
       };
-      let Some(side_effects_free) = &ref_module.build_info().side_effects_free else {
+      let Some(side_effects_free) = &build_info.side_effects_free else {
         return true;
       };
 

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -37,7 +37,11 @@ async fn render_module_content(
   init_fragments: &mut ChunkInitFragments,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
-  if module.build_info().need_create_require {
+  if compilation
+    .get_module_graph()
+    .build_info(&module.identifier())
+    .need_create_require
+  {
     let need_prefix = compilation
       .options
       .output

--- a/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inline_exports_plugin.rs
@@ -14,10 +14,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::dependency::{ESMExportImportedSpecifierDependency, ESMImportSpecifierDependency};
 
 fn inline_enabled(dependency_id: &DependencyId, mg: &ModuleGraph) -> bool {
-  let module = mg
-    .get_module_by_dependency_id(dependency_id)
+  let module_identifier = mg
+    .module_identifier_by_dependency_id(dependency_id)
     .expect("should have target module");
-  module.build_info().inline_exports
+  mg.build_info(module_identifier).inline_exports
 }
 
 pub fn is_export_inlined(

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -458,8 +458,8 @@ var {} = {{}};
               .map(|d| d.inner())
               .or_else(|| {
                 module_graph
-                  .module_by_identifier(module)
-                  .and_then(|m| m.build_info().top_level_declarations.as_ref())
+                  .build_info_by_identifier(module)
+                  .and_then(|info| info.top_level_declarations.as_ref())
               });
             top_level_decls.is_none()
           } {
@@ -724,7 +724,11 @@ var {} = {{}};
         "(function() {\n"
       }));
     }
-    if !all_strict && all_modules.iter().all(|m| m.build_info().strict) {
+    if !all_strict
+      && all_modules
+        .iter()
+        .all(|m| module_graph.build_info(&m.identifier()).strict)
+    {
       if let Some(strict_bailout) = hooks
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)
@@ -852,13 +856,13 @@ var {} = {{}};
 
         chunk_init_fragments.extend(fragments);
         chunk_init_fragments.extend(additional_fragments);
-        let inner_strict = !all_strict && m.build_info().strict;
+        let inner_strict = !all_strict && module_graph.build_info(m_identifier).strict;
         let module_runtime_requirements =
           ChunkGraph::get_module_runtime_requirements(compilation, *m_identifier, chunk.runtime());
         let exports = module_runtime_requirements
           .map(|r| r.contains(RuntimeGlobals::EXPORTS))
           .unwrap_or_default();
-        let exports_argument = m.get_exports_argument();
+        let exports_argument = m.get_exports_argument(module_graph);
         let rspack_exports_argument = matches!(exports_argument, ExportsArgument::RspackExports);
         let rspack_exports = exports && rspack_exports_argument;
         let iife: Option<Cow<str>> = if inner_strict {
@@ -1012,7 +1016,11 @@ var {} = {{}};
     hooks: &JavascriptModulesPluginHooks,
     runtime_template: &RuntimeCodeTemplate<'_>,
   ) -> Result<Option<IdentifierMap<Arc<dyn Source>>>> {
-    let inner_strict = !all_strict && all_modules.iter().all(|m| m.build_info().strict);
+    let module_graph = compilation.get_module_graph();
+    let inner_strict = !all_strict
+      && all_modules
+        .iter()
+        .all(|m| module_graph.build_info(&m.identifier()).strict);
     let is_multiple_entries = inlined_modules.len() > 1;
     let single_entry_with_modules = inlined_modules.len() == 1 && has_chunk_modules_result;
 
@@ -1102,7 +1110,7 @@ var {} = {{}};
               if let Some(ident_info_with_hash) =
                 self.rename_module_cache.get_inlined_info(&m.identifier())
                 && let (Some(hash_current), Some(hash_cache)) = (
-                  m.build_info().hash.as_ref(),
+                  module_graph.build_info(&m.identifier()).hash.as_ref(),
                   ident_info_with_hash.hash.as_ref(),
                 )
                 && *hash_current == *hash_cache
@@ -1114,8 +1122,10 @@ var {} = {{}};
             } else if let Some(idents_with_hash) = self
               .rename_module_cache
               .get_non_inlined_idents(&m.identifier())
-              && let (Some(hash_current), Some(hash_cache)) =
-                (m.build_info().hash.as_ref(), idents_with_hash.hash.as_ref())
+              && let (Some(hash_current), Some(hash_cache)) = (
+                module_graph.build_info(&m.identifier()).hash.as_ref(),
+                idents_with_hash.hash.as_ref(),
+              )
               && *hash_current == *hash_cache
             {
               acc
@@ -1380,7 +1390,11 @@ var {} = {{}};
       .chunk_graph
       .get_chunk_modules_by_source_type(chunk_ukey, SourceType::JavaScript, module_graph);
     let mut sources = ConcatSource::default();
-    if !all_strict && chunk_modules.iter().all(|m| m.build_info().strict) {
+    if !all_strict
+      && chunk_modules
+        .iter()
+        .all(|m| module_graph.build_info(&m.identifier()).strict)
+    {
       if let Some(strict_bailout) = hooks
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -6,7 +6,7 @@ use rspack_collections::{
   Identifiable, IdentifierDashMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_core::{
-  BoxDependency, BoxModule, Compilation, CompilationOptimizeChunkModules, DependencyId,
+  BoxDependency, BoxModule, BuildInfo, Compilation, CompilationOptimizeChunkModules, DependencyId,
   DependencyType, ExportProvided, ExportsInfoArtifact, ExtendedReferencedExport, GetTargetResult,
   ImportedByDeferModulesArtifact, LibIdentOptions, Logger, ModuleGraph, ModuleGraphCacheArtifact,
   ModuleGraphConnection, ModuleGraphModule, ModuleIdentifier, OptimizationBailoutItem, Plugin,
@@ -735,7 +735,7 @@ impl ModuleConcatenationPlugin {
           return (false, false, module_id, bailout_reason);
         }
 
-        if !m.build_info().strict {
+        if !module_graph.build_info(&module_id).strict {
           bailout_reason.push("Module is not in strict mode".into());
           return (false, false, module_id, bailout_reason);
         }
@@ -1210,7 +1210,7 @@ impl ModuleConcatenationPlugin {
         let s = unsafe { token.used(&*compilation) };
         s.spawn(move |compilation| async move {
           let modules_set = config.get_modules();
-          let new_module = create_concatenated_module(compilation, &config).await?;
+          let (new_module, build_info) = create_concatenated_module(compilation, &config).await?;
           let new_module_id = new_module.identifier();
           let connections = prepare_concatenated_module_connections(
             compilation,
@@ -1244,6 +1244,7 @@ impl ModuleConcatenationPlugin {
             connections,
             root_outgoings,
             root_incomings,
+            build_info,
             config,
           ))
         });
@@ -1260,10 +1261,10 @@ impl ModuleConcatenationPlugin {
     let mut remove_connection_tasks = vec![];
 
     for res in new_modules {
-      let (new_module, outgoings, root_outgoings, root_incomings, config) = res?;
+      let (new_module, outgoings, root_outgoings, root_incomings, build_info, config) = res?;
       let new_module_id = new_module.identifier();
       let root_module_id = config.root_module;
-      add_concatenated_module(compilation, new_module, config);
+      add_concatenated_module(compilation, new_module, build_info, config);
 
       for connection in outgoings.iter().chain(root_outgoings.iter()) {
         set_original_mid_tasks.push((*connection, new_module_id));
@@ -1351,7 +1352,7 @@ pub struct NoRuntimeModuleCache {
 async fn create_concatenated_module(
   compilation: &Compilation,
   config: &ConcatConfiguration,
-) -> Result<BoxModule> {
+) -> Result<(BoxModule, BuildInfo)> {
   let module_graph = compilation.get_module_graph();
   let root_module_id = config.root_module;
   let modules_set = config.get_modules();
@@ -1394,8 +1395,8 @@ async fn create_concatenated_module(
     ),
     factory_meta: root_module.factory_meta().cloned(),
     build_meta: root_module.build_meta().clone(),
-    module_argument: root_module.get_module_argument(),
-    exports_argument: root_module.get_exports_argument(),
+    module_argument: root_module.get_module_argument(module_graph),
+    exports_argument: root_module.get_exports_argument(module_graph),
   };
   let modules = modules_set
     .iter()
@@ -1426,9 +1427,11 @@ async fn create_concatenated_module(
     config.runtime.clone(),
     compilation,
   )));
+  let build_info = new_module.take_build_info();
   let build_result = new_module
     .build(
       rspack_core::BuildContext {
+        build_info,
         compiler_id: compilation.compiler_id(),
         compilation_id: compilation.id(),
         resolver_factory: compilation.resolver_factory.clone(),
@@ -1442,7 +1445,7 @@ async fn create_concatenated_module(
     .await?;
   new_module = build_result.module;
 
-  Ok(new_module)
+  Ok((new_module, *build_result.build_info))
 }
 
 fn prepare_concatenated_module_connections<F>(
@@ -1536,6 +1539,7 @@ where
 fn add_concatenated_module(
   compilation: &mut Compilation,
   new_module: BoxModule,
+  build_info: BuildInfo,
   config: ConcatConfiguration,
 ) {
   let root_module_id = config.root_module;
@@ -1551,8 +1555,10 @@ fn add_concatenated_module(
   let mut chunk_graph = std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_graph);
   let module_graph = compilation.get_module_graph_mut();
 
-  let module_graph_module = ModuleGraphModule::new(new_module.identifier());
+  let module_identifier = new_module.identifier();
+  let module_graph_module = ModuleGraphModule::new(module_identifier);
   module_graph.add_module_graph_module(module_graph_module);
+  module_graph.set_build_info(module_identifier, build_info);
   ModuleGraph::clone_module_attributes(compilation, &root_module_id, &new_module.identifier());
   // integrate
 

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -188,7 +188,7 @@ async fn finish_modules(
       continue;
     };
 
-    let build_info = module.build_info();
+    let build_info = module_graph.build_info(module_identifier);
     if !self.analyze_side_effects_free || build_info.deferred_pure_checks.is_empty() {
       continue;
     }
@@ -234,11 +234,7 @@ async fn finish_modules(
             (*ref_module, deferred_check.atom.clone())
           };
 
-          let ref_module = module_graph
-            .module_by_identifier(&ref_module_id)
-            .expect("should have module");
-
-          let Some(side_effects_free) = &ref_module.build_info().side_effects_free else {
+          let Some(side_effects_free) = &module_graph.build_info(&ref_module_id).side_effects_free else {
             return true;
           };
           !side_effects_free.contains(&atom)

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -208,8 +208,10 @@ pub async fn render_module(
       });
 
       let mut args = Vec::new();
+      let module_graph = compilation.get_module_graph();
       if need_module || need_exports || need_require {
-        let module_argument = runtime_template.render_module_argument(module.get_module_argument());
+        let module_argument =
+          runtime_template.render_module_argument(module.get_module_argument(module_graph));
         args.push(if need_module {
           module_argument
         } else {
@@ -219,7 +221,7 @@ pub async fn render_module(
 
       if need_exports || need_require {
         let exports_argument =
-          runtime_template.render_exports_argument(module.get_exports_argument());
+          runtime_template.render_exports_argument(module.get_exports_argument(module_graph));
         args.push(if need_exports {
           exports_argument
         } else {
@@ -240,7 +242,12 @@ pub async fn render_module(
           args.join(", ")
         )));
       }
-      if module.build_info().strict && !all_strict {
+      if compilation
+        .get_module_graph()
+        .build_info(&module.identifier())
+        .strict
+        && !all_strict
+      {
         container_sources.add(RawStringSource::from_static("\"use strict\";\n"));
       }
       container_sources.add(render_source.source);

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -40,12 +40,20 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     &[SourceType::JavaScript]
   }
 
-  fn size(&self, module: &dyn Module, _source_type: Option<&SourceType>) -> f64 {
-    module
-      .build_info()
-      .json_data
-      .as_ref()
-      .map_or(0.0, |data| stringify(data.clone()).len() as f64)
+  fn size(
+    &self,
+    module: &dyn Module,
+    build_info: Option<&rspack_core::BuildInfo>,
+    _source_type: Option<&SourceType>,
+  ) -> f64 {
+    build_info
+      .and_then(|build_info| {
+        build_info
+          .json_data
+          .as_ref()
+          .map(|data| stringify(data.clone()).len() as f64)
+      })
+      .unwrap_or_else(|| module.source().map_or(0.0, |source| source.size() as f64))
   }
 
   async fn parse<'a>(
@@ -179,17 +187,15 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     let module_graph = compilation.get_module_graph();
     match generate_context.requested_source_type {
       SourceType::JavaScript => {
-        let module = module_graph
-          .module_by_identifier(&module.identifier())
-          .expect("should have module identifier");
-        let json_data = module
-          .build_info()
+        let module_identifier = module.identifier();
+        let json_data = module_graph
+          .build_info(&module_identifier)
           .json_data
           .as_ref()
           .expect("should have json data");
         let exports_info = compilation
           .exports_info_artifact
-          .get_exports_info_data(&module.identifier());
+          .get_exports_info_data(&module_identifier);
 
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -148,7 +148,7 @@ impl Module for LazyCompilationProxyModule {
     self.lib_ident.as_ref().map(|s| Cow::Borrowed(s.as_str()))
   }
 
-  fn need_build(&self, value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build(&self, _build_info: &BuildInfo, value_cache_versions: &ValueCacheVersions) -> bool {
     if self.need_build {
       return true;
     }
@@ -165,9 +165,10 @@ impl Module for LazyCompilationProxyModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let client_dep = CommonJsRequireDependency::new(
       self.client.clone(),
       DependencyRange::new(0, 0),
@@ -194,6 +195,7 @@ impl Module for LazyCompilationProxyModule {
     }
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks,

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -399,7 +399,13 @@ async fn embed_in_runtime_bailout(
     .data
     .get::<CodeGenerationDataTopLevelDeclarations>()
     .map(|d| d.inner())
-    .or_else(|| module.build_info().top_level_declarations.as_ref());
+    .or_else(|| {
+      compilation
+        .get_module_graph()
+        .build_info(&module.identifier())
+        .top_level_declarations
+        .as_ref()
+    });
   if let Some(top_level_decls) = top_level_decls {
     let full_name = self
       .get_resolved_full_name(&options, compilation, chunk)

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -89,7 +89,7 @@ async fn render_startup(
     module_graph,
     &compilation.module_graph_cache_artifact,
     &compilation.exports_info_artifact,
-    boxed_module.build_info().strict,
+    module_graph.build_info(module).strict,
   );
   for export_info in exports_info.exports().values() {
     if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -185,9 +185,10 @@ impl Module for ContainerEntryModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let mut blocks = vec![];
     let mut dependencies: Vec<BoxDependency> = vec![];
 
@@ -235,6 +236,7 @@ impl Module for ContainerEntryModule {
     // I will add `name` field to struct.
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks,

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -132,15 +132,17 @@ impl Module for FallbackModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let mut dependencies: Vec<BoxDependency> = Vec::new();
     for request in &self.requests {
       dependencies.push(Box::new(FallbackItemDependency::new(request.clone())))
     }
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks: vec![],

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -156,6 +156,7 @@ impl Module for RemoteModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let mut dependencies: Vec<BoxDependency> = Vec::new();
 
     if self.external_requests.len() == 1 {
@@ -189,6 +190,7 @@ impl Module for RemoteModule {
     }
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks: vec![],

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -171,9 +171,10 @@ impl Module for ConsumeSharedModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let mut blocks = vec![];
     let mut dependencies = vec![];
     if let Some(fallback) = &self.options.import {
@@ -187,6 +188,7 @@ impl Module for ConsumeSharedModule {
     }
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks,

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -153,9 +153,10 @@ impl Module for ProvideSharedModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     let mut blocks = vec![];
     let mut dependencies = vec![];
     let dep = Box::new(ProvideForSharedDependency::new(self.request.clone()));
@@ -167,6 +168,7 @@ impl Module for ProvideSharedModule {
     }
 
     Ok(BuildResult {
+      build_info: Box::new(std::mem::take(&mut self.build_info)),
       module: BoxModule::new(self),
       dependencies,
       blocks,

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -360,6 +360,7 @@ async fn build_module(
   _compiler_id: CompilerId,
   _compilation_id: CompilationId,
   module: &mut BoxModule,
+  _build_info: &mut rspack_core::BuildInfo,
 ) -> Result<()> {
   self
     .active_modules
@@ -387,6 +388,7 @@ async fn succeed_module(
   _compiler_id: CompilerId,
   _compilation_id: CompilationId,
   module: &mut BoxModule,
+  _build_info: &mut rspack_core::BuildInfo,
 ) -> Result<()> {
   self.modules_done.fetch_add(1, Relaxed);
   self

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -407,7 +407,12 @@ fn collect_actions(
   }
   visited_modules.insert(*module_identifier);
 
-  if let Some(action_ids) = module.build_info().rsc.as_ref().map(|rsc| &rsc.action_ids) {
+  if let Some(action_ids) = module_graph
+    .build_info(module_identifier)
+    .rsc
+    .as_ref()
+    .map(|rsc| &rsc.action_ids)
+  {
     let pairs = action_ids
       .into_iter()
       .map(|(id, exported_name)| (id.clone(), exported_name.clone()))

--- a/crates/rspack_plugin_rsc/src/component_info.rs
+++ b/crates/rspack_plugin_rsc/src/component_info.rs
@@ -101,13 +101,14 @@ fn traverse_module(
   if resource.is_empty() {
     return;
   }
+  let module_graph = compilation.get_module_graph();
 
   // A nested `use server-entry` starts an independent ownership scope.
   // CSS below it belongs to the nested entry, not to its parent entry.
-  let server_entry = is_server_entry_module(module).then(|| resource.to_string());
+  let server_entry = is_server_entry_module(module_graph, module).then(|| resource.to_string());
   let current_server_entry = server_entry.as_deref().or(current_server_entry);
 
-  if get_module_rsc_information(module).is_some_and(|rsc| rsc.import_meta_rsc)
+  if get_module_rsc_information(module_graph, module).is_some_and(|rsc| rsc.import_meta_rsc)
     && let Some(server_entry) = current_server_entry
   {
     component_info
@@ -130,8 +131,9 @@ fn traverse_module(
   }
 
   let is_first_visit_client_module = visited_client_modules.insert(module.identifier());
-  if is_client_component_entry_module(module) {
+  if is_client_component_entry_module(module_graph, module) {
     record_client_component_import(
+      module_graph,
       module,
       resource.as_ref(),
       imported_identifiers,
@@ -153,10 +155,9 @@ fn traverse_module(
   }
 
   if is_first_visit_client_module {
-    collect_once_per_module(module, resource.as_ref(), component_info);
+    collect_once_per_module(module_graph, module, resource.as_ref(), component_info);
   }
 
-  let module_graph = compilation.get_module_graph();
   for dependency_id in module_graph.get_outgoing_deps_in_order(&module.identifier()) {
     let Some(connection) = module_graph.connection_by_dependency_id(dependency_id) else {
       continue;
@@ -225,6 +226,7 @@ fn record_css_import(
 }
 
 fn record_client_component_import(
+  module_graph: &ModuleGraph,
   module: &dyn Module,
   resource: &str,
   imported_identifiers: &[Atom],
@@ -240,12 +242,14 @@ fn record_client_component_import(
   {
     if is_under_server_dynamic_import {
       add_client_import_to_scope(
+        module_graph,
         module,
         resource,
         imported_identifiers,
         &mut component_info.client_component_imports,
       );
       add_client_import_to_scope(
+        module_graph,
         module,
         resource,
         imported_identifiers,
@@ -255,6 +259,7 @@ fn record_client_component_import(
     }
 
     add_client_import_for_server_entry(
+      module_graph,
       module,
       resource,
       imported_identifiers,
@@ -265,6 +270,7 @@ fn record_client_component_import(
 }
 
 fn collect_once_per_module(
+  module_graph: &ModuleGraph,
   module: &dyn Module,
   resource: &str,
   component_info: &mut ComponentInfo,
@@ -277,7 +283,7 @@ fn collect_once_per_module(
     component_info.should_inject_ssr_modules = true;
   }
 
-  let actions = get_actions_from_build_info(module);
+  let actions = get_actions_from_build_info(module_graph, module);
   if let Some(actions) = actions {
     component_info.action_imports.push((
       resource.to_string(),
@@ -310,6 +316,7 @@ fn get_imported_ids(module_graph: &ModuleGraph, dependency_id: &DependencyId) ->
 }
 
 fn add_client_import_for_server_entry(
+  module_graph: &ModuleGraph,
   module: &dyn Module,
   resource: &str,
   imported_identifiers: &[Atom],
@@ -317,6 +324,7 @@ fn add_client_import_for_server_entry(
   component_info: &mut ComponentInfo,
 ) {
   add_client_import_to_scope(
+    module_graph,
     module,
     resource,
     imported_identifiers,
@@ -325,6 +333,7 @@ fn add_client_import_for_server_entry(
 
   let Some(server_entry) = current_server_entry else {
     add_client_import_to_scope(
+      module_graph,
       module,
       resource,
       imported_identifiers,
@@ -338,6 +347,7 @@ fn add_client_import_for_server_entry(
     .entry(server_entry.to_string())
     .or_default();
   add_client_import_to_scope(
+    module_graph,
     module,
     resource,
     imported_identifiers,
@@ -346,6 +356,7 @@ fn add_client_import_for_server_entry(
 }
 
 fn add_client_import_to_scope(
+  module_graph: &ModuleGraph,
   module: &dyn Module,
   mod_request: &str,
   imported_identifiers: &[Atom],
@@ -356,6 +367,7 @@ fn add_client_import_to_scope(
     client_component_imports.insert(mod_request.to_string(), Default::default());
   }
   add_client_import(
+    module_graph,
     module,
     mod_request,
     imported_identifiers,
@@ -365,16 +377,20 @@ fn add_client_import_to_scope(
 }
 
 fn add_client_import(
+  module_graph: &ModuleGraph,
   module: &dyn Module,
   mod_request: &str,
   imported_identifiers: &[Atom],
   is_first_visit_module: bool,
   client_component_imports: &mut ClientComponentImports,
 ) {
-  let rsc = get_module_rsc_information(module);
+  let rsc = get_module_rsc_information(module_graph, module);
   let is_cjs_module = rsc.as_ref().is_some_and(|rsc| rsc.is_cjs);
-  let assumed_source_type =
-    get_assumed_source_type(module, if is_cjs_module { "commonjs" } else { "auto" });
+  let assumed_source_type = get_assumed_source_type(
+    module_graph,
+    module,
+    if is_cjs_module { "commonjs" } else { "auto" },
+  );
 
   let client_imports_set: &mut FxIndexSet<Atom> = client_component_imports
     .entry(mod_request.to_string())
@@ -415,19 +431,25 @@ fn add_client_import(
 }
 
 // Gives { id: name } record of actions from the build info.
-fn get_actions_from_build_info(module: &dyn Module) -> Option<&FxIndexMap<Atom, Atom>> {
-  let rsc = get_module_rsc_information(module)?;
+fn get_actions_from_build_info<'a>(
+  module_graph: &'a ModuleGraph,
+  module: &dyn Module,
+) -> Option<&'a FxIndexMap<Atom, Atom>> {
+  let rsc = get_module_rsc_information(module_graph, module)?;
   Some(&rsc.action_ids)
 }
 
-fn get_module_rsc_information(module: &dyn Module) -> Option<&RscMeta> {
-  module.build_info().rsc.as_ref()
+fn get_module_rsc_information<'a>(
+  module_graph: &'a ModuleGraph,
+  module: &dyn Module,
+) -> Option<&'a RscMeta> {
+  module_graph.build_info(&module.identifier()).rsc.as_ref()
 }
 
-fn is_client_component_entry_module(module: &dyn Module) -> bool {
-  let rsc = get_module_rsc_information(module);
+fn is_client_component_entry_module(module_graph: &ModuleGraph, module: &dyn Module) -> bool {
+  let rsc = get_module_rsc_information(module_graph, module);
   let has_client_directive = matches!(rsc, Some(rsc) if rsc.module_type == RscModuleType::Client);
-  let is_action_layer_entry = is_action_client_layer_module(module);
+  let is_action_layer_entry = is_action_client_layer_module(module_graph, module);
   let is_image = if let Some(module) = module.as_normal_module() {
     IMAGE_REGEX.is_match(module.resource_resolved_data().resource())
   } else {
@@ -436,20 +458,24 @@ fn is_client_component_entry_module(module: &dyn Module) -> bool {
   has_client_directive || is_action_layer_entry || is_image
 }
 
-fn is_server_entry_module(module: &dyn Module) -> bool {
-  get_module_rsc_information(module)
+fn is_server_entry_module(module_graph: &ModuleGraph, module: &dyn Module) -> bool {
+  get_module_rsc_information(module_graph, module)
     .is_some_and(|rsc| rsc.module_type == RscModuleType::ServerEntry)
 }
 
 // Determine if the whole module is client action, 'use server' in nested closure in the client module
-fn is_action_client_layer_module(module: &dyn Module) -> bool {
-  let rsc = get_module_rsc_information(module);
+fn is_action_client_layer_module(module_graph: &ModuleGraph, module: &dyn Module) -> bool {
+  let rsc = get_module_rsc_information(module_graph, module);
   matches!(&rsc, Some(rsc) if !rsc.action_ids.is_empty())
     && matches!(&rsc, Some(rsc) if rsc.module_type == RscModuleType::Client)
 }
 
-fn get_assumed_source_type<'a>(module: &dyn Module, source_type: &'a str) -> &'a str {
-  let rsc = get_module_rsc_information(module);
+fn get_assumed_source_type<'a>(
+  module_graph: &ModuleGraph,
+  module: &dyn Module,
+  source_type: &'a str,
+) -> &'a str {
+  let rsc = get_module_rsc_information(module_graph, module);
   let is_cjs = rsc.as_ref().is_some_and(|rsc| rsc.is_cjs);
   let client_refs: &[Wtf8Atom] = rsc
     .as_ref()

--- a/crates/rspack_plugin_rsc/src/hot_reloader.rs
+++ b/crates/rspack_plugin_rsc/src/hot_reloader.rs
@@ -69,7 +69,7 @@ fn collect_changed_server_components(
   }
   visited_modules.insert(module_identifier);
 
-  if let Some(rsc) = module.build_info().rsc.as_ref()
+  if let Some(rsc) = module_graph.build_info(&module_identifier).rsc.as_ref()
     && rsc.module_type == RscModuleType::Client
   {
     return;

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -252,9 +252,10 @@ impl Module for RscEntryModule {
 
   async fn build(
     mut self: Box<Self>,
-    _build_context: BuildContext,
+    build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.build_info = *build_context.build_info;
     if self.is_server_side_rendering {
       // Eager: no code-split points; use ImportEagerDependency (CSS filtering done at call site).
       let all_client_modules = self.all_client_modules();
@@ -271,6 +272,7 @@ impl Module for RscEntryModule {
         dependencies.push(Box::new(dep));
       }
       Ok(BuildResult {
+        build_info: Box::new(std::mem::take(&mut self.build_info)),
         module: BoxModule::new(self),
         dependencies,
         blocks: vec![],
@@ -376,6 +378,7 @@ impl Module for RscEntryModule {
       }
 
       Ok(BuildResult {
+        build_info: Box::new(std::mem::take(&mut self.build_info)),
         module: BoxModule::new(self),
         dependencies,
         blocks,

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 pub fn collect_json_module_sizes(
+  module_graph: &ModuleGraph,
   modules: &IdentifierMap<&BoxModule>,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> RsdoctorJsonModuleSizes {
@@ -30,7 +31,7 @@ pub fn collect_json_module_sizes(
       continue;
     }
 
-    let Some(json_data) = module.build_info().json_data.as_ref() else {
+    let Some(json_data) = module_graph.build_info(module_id).json_data.as_ref() else {
       continue;
     };
 

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -276,7 +276,8 @@ async fn collect_json_sizes(&self, compilation: &mut Compilation) -> Result<Opti
     .map(|(id, module)| (*id, module))
     .collect::<IdentifierMap<_>>();
 
-  let json_sizes = collect_json_module_sizes(&modules, &compilation.exports_info_artifact);
+  let json_sizes =
+    collect_json_module_sizes(module_graph, &modules, &compilation.exports_info_artifact);
 
   JSON_MODULE_SIZE_MAP.insert(compilation.id(), json_sizes);
 

--- a/crates/rspack_plugin_rslib/src/asset.rs
+++ b/crates/rspack_plugin_rslib/src/asset.rs
@@ -32,8 +32,8 @@ impl ParserAndGenerator for RslibAssetParserAndGenerator {
 
     // entry resource
     if source_types.is_empty()
-      && module
-        .build_info()
+      && module_graph
+        .build_info(&module.identifier())
         .asset_data_url
         .as_ref()
         .is_some_and(|config| !config.is_inline() && !config.is_source())
@@ -51,8 +51,13 @@ impl ParserAndGenerator for RslibAssetParserAndGenerator {
     self.0.parse(parse_context).await
   }
 
-  fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64 {
-    self.0.size(module, source_type)
+  fn size(
+    &self,
+    module: &dyn Module,
+    build_info: Option<&rspack_core::BuildInfo>,
+    source_type: Option<&SourceType>,
+  ) -> f64 {
+    self.0.size(module, build_info, source_type)
   }
 
   async fn generate(

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -352,9 +352,13 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let mut dts_outputs = Vec::new();
   let mut module_resources = Vec::new();
   let module_graph = compilation.get_module_graph();
-  for (_, module) in module_graph.modules() {
+  for (module_identifier, module) in module_graph.modules() {
     let module = module.as_ref();
-    if let Some(isolated_dts) = module.build_info().isolated_dts.as_deref() {
+    if let Some(isolated_dts) = module_graph
+      .build_info(module_identifier)
+      .isolated_dts
+      .as_deref()
+    {
       dts_outputs.push(isolated_dts.clone());
     }
     if let Some(normal_module) = module.as_normal_module()

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -109,7 +109,12 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
     )
   }
 
-  fn size(&self, module: &dyn Module, source_type: Option<&SourceType>) -> f64 {
+  fn size(
+    &self,
+    module: &dyn Module,
+    _build_info: Option<&rspack_core::BuildInfo>,
+    source_type: Option<&SourceType>,
+  ) -> f64 {
     match source_type.unwrap_or(&SourceType::Wasm) {
       SourceType::JavaScript => {
         40.0
@@ -135,8 +140,9 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
       runtime_template,
       ..
     } = generate_context;
-    let hash = module
-      .build_info()
+    let hash = compilation
+      .get_module_graph()
+      .build_info(&module.identifier())
       .hash
       .as_ref()
       .map(|hash| hash.rendered(16))

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -66,7 +66,11 @@ async fn render_manifest(
     let module_id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, m.identifier())
       .map(|s| PathData::prepare_id(s.as_str()));
     let mut path_data = PathData::default().module_id_optional(module_id.as_deref());
-    if let Some(hash) = &m.build_info().hash {
+    if let Some(hash) = &compilation
+      .get_module_graph()
+      .build_info(&m.identifier())
+      .hash
+    {
       let hash = hash.rendered(16);
       path_data = path_data.content_hash(hash).hash(hash);
     }

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -106,13 +106,10 @@ impl<'a> ArtifactComparator<'a> {
     }
 
     // Second pass: Compare BuildInfo using the DependencyId mapping
-    for (module_id, module1) in modules1 {
-      let module2 = modules2
-        .get(&module_id)
-        .expect("module should exist in both graphs");
+    for (module_id, _) in modules1 {
       let module_debug_info = debug_info.with_field("module", &format!("{module_id:?}"));
 
-      self.compare_module_build_info(module1, module2, &module_debug_info, &dep_id_map)?;
+      self.compare_module_build_info(&module_id, &module_debug_info, &dep_id_map)?;
     }
 
     Ok(())
@@ -230,13 +227,12 @@ impl<'a> ArtifactComparator<'a> {
   /// and serialize the rest for direct comparison.
   fn compare_module_build_info(
     &self,
-    module1: &rspack_core::BoxModule,
-    module2: &rspack_core::BoxModule,
+    module_id: &rspack_core::ModuleIdentifier,
     debug_info: &DebugInfo,
     dep_id_map: &HashMap<DependencyId, DependencyId>,
   ) -> Result<()> {
-    let build_info1 = module1.build_info();
-    let build_info2 = module2.build_info();
+    let build_info1 = self.mg1.build_info(module_id);
+    let build_info2 = self.mg2.build_info(module_id);
 
     // Compare all_star_exports using the DependencyId mapping
     self.compare_all_star_exports(

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -1516,10 +1516,10 @@ fn chunk_asset_totals(compilation: &Compilation) -> (usize, usize, usize) {
 }
 
 fn count_module_assets(compilation: &Compilation) -> usize {
-  compilation
-    .get_module_graph()
+  let module_graph = compilation.get_module_graph();
+  module_graph
     .modules()
-    .map(|(_, module)| module.build_info().assets.len())
+    .map(|(module_identifier, _)| module_graph.build_info(module_identifier).assets.len())
     .sum()
 }
 
@@ -1578,11 +1578,10 @@ fn seed_module_assets(compilation: &mut Compilation) -> usize {
   module_identifiers.truncate(MODULE_ASSET_SEED_COUNT);
 
   for (asset_index, module_identifier) in module_identifiers.iter().copied().enumerate() {
-    let module = compilation
+    let build_info = compilation
       .get_module_graph_mut()
-      .module_by_identifier_mut(&module_identifier)
-      .expect("seeded module should exist");
-    module.build_info_mut().assets.insert(
+      .build_info_mut_by_identifier(&module_identifier);
+    build_info.assets.insert(
       format!("module-assets/module-{asset_index}.txt"),
       CompilationAsset::new(
         Some(RawStringSource::from(format!("module asset fixture {asset_index}")).boxed()),


### PR DESCRIPTION
## Summary

Move `BuildInfo` ownership from concrete module instances into `ModuleGraphModule`, and thread mutable build info through build contexts, loader execution, JS hooks, code generation, stats, persistent cache comparison, and benchmark helpers.

This keeps build-time metadata associated with module graph state, while preserving temporary build-info access for JS/NAPI module objects during loader and plugin hooks.

## Related links

N/A

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run build:cli:dev:browser`
- `pnpm run test:rs`
- `pnpm run test:type`
- `pnpm run test:unit`
- `pnpm run test:hot`
- `pnpm --filter "e2e-test" exec playwright test --workers=4`
- `pnpm --filter "e2e-browser-test" exec playwright test --workers=4`
- `RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed build -p rspack_benchmark --bench benches -m simulation`
- `pnpm run bench:ci`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).