### PR TITLE
fix(cli): block prototype-pollution payloads in --env parsing

### DIFF
--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -125,9 +125,10 @@ function setBuiltinEnvArg(
   value: unknown,
 ) {
   const envName = `RSPACK_${envNameSuffix}`;
-  // `Object.hasOwn` (not `in`) so that a polluted `Object.prototype` cannot
-  // hide a legitimate write of the reserved RSPACK_* flag.
-  if (!Object.hasOwn(env, envName)) {
+  // `hasOwnProperty.call` (not `in`) so that a polluted `Object.prototype`
+  // cannot hide a legitimate write of the reserved RSPACK_* flag.
+  // (`Object.hasOwn` would be cleaner but requires ES2022.)
+  if (!Object.prototype.hasOwnProperty.call(env, envName)) {
     env[envName] = value;
   }
 }
@@ -160,9 +161,7 @@ function normalizeEnvToObject(options: CommonOptions) {
       }
 
       if (!prevRef[someKey] || typeof prevRef[someKey] === 'string') {
-        // Null-prototype intermediates so lookups never reach `Object.prototype`,
-        // even if a future contributor reintroduces a dangerous key.
-        prevRef[someKey] = Object.create(null);
+        prevRef[someKey] = {};
       }
 
       if (index === splitKeys.length - 1) {
@@ -179,10 +178,7 @@ function normalizeEnvToObject(options: CommonOptions) {
     return previous;
   }
 
-  return ((options.env as string[]) ?? []).reduce(
-    parseValue,
-    Object.create(null) as Record<string, unknown>,
-  );
+  return ((options.env as string[]) ?? []).reduce(parseValue, {});
 }
 
 export function setDefaultNodeEnv(

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -125,17 +125,13 @@ function setBuiltinEnvArg(
   value: unknown,
 ) {
   const envName = `RSPACK_${envNameSuffix}`;
-  // `hasOwnProperty.call` (not `in`) so that a polluted `Object.prototype`
-  // cannot hide a legitimate write of the reserved RSPACK_* flag.
-  // (`Object.hasOwn` would be cleaner but requires ES2022.)
+  // `hasOwnProperty.call` so a polluted prototype can't mask the write.
   if (!Object.prototype.hasOwnProperty.call(env, envName)) {
     env[envName] = value;
   }
 }
 
-// Keys that would mutate `Object.prototype` (or escape via the constructor) if
-// allowed to appear in a dotted `--env` path. Aligned with lodash `_.set`
-// hardening (CVE-2020-8203).
+// Reject these segments in dotted `--env` paths to avoid prototype pollution.
 const DANGEROUS_ENV_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function normalizeEnvToObject(options: CommonOptions) {

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -125,15 +125,26 @@ function setBuiltinEnvArg(
   value: unknown,
 ) {
   const envName = `RSPACK_${envNameSuffix}`;
-  if (!(envName in env)) {
+  // `Object.hasOwn` (not `in`) so that a polluted `Object.prototype` cannot
+  // hide a legitimate write of the reserved RSPACK_* flag.
+  if (!Object.hasOwn(env, envName)) {
     env[envName] = value;
   }
 }
+
+// Keys that would mutate `Object.prototype` (or escape via the constructor) if
+// allowed to appear in a dotted `--env` path. Aligned with lodash `_.set`
+// hardening (CVE-2020-8203).
+const DANGEROUS_ENV_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function normalizeEnvToObject(options: CommonOptions) {
   function parseValue(previous: Record<string, unknown>, value: string) {
     const [allKeys, val] = value.split(/=(.+)/, 2);
     const splitKeys = allKeys.split(/\.(?!$)/);
+
+    if (splitKeys.some((k) => DANGEROUS_ENV_KEYS.has(k.replace(/=$/, '')))) {
+      return previous;
+    }
 
     let prevRef = previous;
 
@@ -149,7 +160,9 @@ function normalizeEnvToObject(options: CommonOptions) {
       }
 
       if (!prevRef[someKey] || typeof prevRef[someKey] === 'string') {
-        prevRef[someKey] = {};
+        // Null-prototype intermediates so lookups never reach `Object.prototype`,
+        // even if a future contributor reintroduces a dangerous key.
+        prevRef[someKey] = Object.create(null);
       }
 
       if (index === splitKeys.length - 1) {
@@ -166,7 +179,10 @@ function normalizeEnvToObject(options: CommonOptions) {
     return previous;
   }
 
-  return ((options.env as string[]) ?? []).reduce(parseValue, {});
+  return ((options.env as string[]) ?? []).reduce(
+    parseValue,
+    Object.create(null) as Record<string, unknown>,
+  );
 }
 
 export function setDefaultNodeEnv(

--- a/packages/rspack-cli/tests/utils/options.test.ts
+++ b/packages/rspack-cli/tests/utils/options.test.ts
@@ -16,6 +16,15 @@ describe('normalizeCommonOptions --env parsing', () => {
     expect(opts.env.RSPACK_BUNDLE).toBe(true);
   });
 
+  it('keeps env as a plain object so config functions can call Object methods', () => {
+    const opts: any = { env: ['app.name=demo', 'flag=true'] };
+    normalizeCommonOptions(opts, 'build');
+    // User configs commonly do `env.hasOwnProperty(...)` or `env instanceof Object`.
+    expect(opts.env instanceof Object).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(opts.env, 'flag')).toBe(true);
+    expect(opts.env.hasOwnProperty('app')).toBe(true);
+  });
+
   describe('prototype-pollution hardening', () => {
     afterEach(() => {
       // Defensive cleanup so a regression in this file cannot leak pollution

--- a/packages/rspack-cli/tests/utils/options.test.ts
+++ b/packages/rspack-cli/tests/utils/options.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@rstest/core';
+import { normalizeCommonOptions } from '../../src/utils/options';
+
+describe('normalizeCommonOptions --env parsing', () => {
+  it('builds a nested object from dotted keys', () => {
+    const opts: any = { env: ['app.name=demo', 'app.debug=true'] };
+    normalizeCommonOptions(opts, 'build');
+    expect(opts.env.app.name).toBe('demo');
+    expect(opts.env.app.debug).toBe('true');
+  });
+
+  it('sets RSPACK_BUILD and RSPACK_BUNDLE on build action', () => {
+    const opts: any = { env: [] };
+    normalizeCommonOptions(opts, 'build');
+    expect(opts.env.RSPACK_BUILD).toBe(true);
+    expect(opts.env.RSPACK_BUNDLE).toBe(true);
+  });
+
+  describe('prototype-pollution hardening', () => {
+    afterEach(() => {
+      // Defensive cleanup so a regression in this file cannot leak pollution
+      // into sibling test files in the same worker.
+      delete (Object.prototype as any).RSPACK_BUILD;
+      delete (Object.prototype as any).polluted;
+      delete (Object.prototype as any).injected;
+    });
+
+    it('rejects __proto__ in dotted env path without polluting Object.prototype', () => {
+      const opts: any = {
+        env: ['__proto__.polluted=yes', '__proto__.RSPACK_BUILD=owned'],
+      };
+      normalizeCommonOptions(opts, 'build');
+
+      expect(({} as any).polluted).toBeUndefined();
+      expect(({} as any).RSPACK_BUILD).toBeUndefined();
+    });
+
+    it('rejects constructor.prototype.x payloads', () => {
+      const opts: any = { env: ['constructor.prototype.injected=1'] };
+      normalizeCommonOptions(opts, 'build');
+      expect(({} as any).injected).toBeUndefined();
+    });
+
+    it('does not allow attacker to spoof reserved RSPACK_BUILD via prototype', () => {
+      const opts: any = { env: ['__proto__.RSPACK_BUILD=owned'] };
+      normalizeCommonOptions(opts, 'build');
+      // Legitimate write must win — not the attacker-controlled "owned" string.
+      expect(opts.env.RSPACK_BUILD).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Harden `rspack-cli` `--env` parsing against prototype-pollution-style key paths so that:

- malicious dotted keys cannot mutate `Object.prototype` (and from there leak into every plain object created later in the build)
- reserved `RSPACK_*` build flags written by the CLI can't be overridden through the prototype chain

## What

`packages/rspack-cli/src/utils/options.ts`

- Block dotted `--env` paths whose segments hit a small dangerous-key denylist (lodash `_.set` hardening pattern).
- `setBuiltinEnvArg` now uses `Object.prototype.hasOwnProperty.call` instead of `in`, so a polluted prototype can't mask a legitimate write.

`packages/rspack-cli/tests/utils/options.test.ts` (new)

- Regression coverage for the hardened parser plus the existing nested-key and plain-object-shape happy paths.

Single-package change, no public API impact — the `env` object passed to user config functions keeps its plain `{}` shape.

## Credits

Reported privately via responsible disclosure by the security research team from the University of Sydney, focusing on detecting open source software vulnerabilities:

- Liyi Zhou — https://lzhou1110.github.io/
- Ziyue Wang — https://zyy0530.github.io/
- Strick — https://str1ckl4nd.github.io/
- Maurice — https://maurice.busystar.org/
- Chenchen Yu — https://7thparkk.github.io/

Thanks for the careful write-up and the heads-up before public disclosure.