### PR TITLE
fix(swc): enable stack guard in release builds

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/parse.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/parse.rs
@@ -171,16 +171,18 @@ fn parse_with_lexer(
     }
   };
 
-  // TODO: add stacker to avoid stack overflow
-  #[cfg(all(debug_assertions, not(target_family = "wasm")))]
+  // SWC's recursive-descent parser can blow the default thread stack on
+  // sufficiently deep source. `stacker` grows the stack on demand and has
+  // near-zero overhead on the common path, so apply it for release too —
+  // not only debug builds. WASM has no stacker support.
+  #[cfg(not(target_family = "wasm"))]
   {
-    // Adjust stack to avoid stack overflow.
     stacker::maybe_grow(
       2 * 1024 * 1024, /* 2mb */
       4 * 1024 * 1024, /* 4mb */
       inner,
     )
   }
-  #[cfg(any(not(debug_assertions), target_family = "wasm"))]
+  #[cfg(target_family = "wasm")]
   inner()
 }

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -293,16 +293,18 @@ impl Loader<RunnerContext> for SwcLoader {
   async fn run(&self, loader_context: &mut LoaderContext<RunnerContext>) -> Result<()> {
     #[allow(unused_mut)]
     let mut inner = || self.loader_impl(loader_context);
-    #[cfg(all(debug_assertions, not(target_family = "wasm")))]
+    // SWC's transform pipeline is deeply recursive; grow the stack on demand
+    // so release builds don't crash on attacker-deep input. WASM omitted
+    // because `stacker` has no support there.
+    #[cfg(not(target_family = "wasm"))]
     {
-      // Adjust stack to avoid stack overflow.
       stacker::maybe_grow(
         2 * 1024 * 1024, /* 2mb */
         4 * 1024 * 1024, /* 4mb */
         inner,
       )
     }
-    #[cfg(any(not(debug_assertions), target_family = "wasm"))]
+    #[cfg(target_family = "wasm")]
     inner()
   }
 }


### PR DESCRIPTION
## Why

`stacker::maybe_grow` was gated behind `#[cfg(debug_assertions)]` in both the JavaScript parser and the SWC loader, so released `.node` bindings ran the recursive SWC pipeline without on-demand stack growth — the production path was missing the protection the debug path already had.

## What

- `crates/rspack_javascript_compiler/src/compiler/parse.rs`
- `crates/rspack_loader_swc/src/lib.rs`

Drop the `debug_assertions` gate so release builds also grow the stack on demand. The 2 MB red-zone / 4 MB grow allocation has near-zero overhead on normal inputs. WASM still falls back to a bare call because `stacker` has no support there.

`cargo check` passes for both crates under dev and release profiles.

## Credits

Reported privately via responsible disclosure by the security research team from the University of Sydney, focusing on detecting open source software vulnerabilities:

- Liyi Zhou — https://lzhou1110.github.io/
- Ziyue Wang — https://zyy0530.github.io/
- Strick — https://str1ckl4nd.github.io/
- Maurice — https://maurice.busystar.org/
- Chenchen Yu — https://7thparkk.github.io/

Thanks for the careful write-up and the heads-up before public disclosure.