### PR TITLE
fix(lazy-compilation): clean up stale entry proxies on dynamic entry removal

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -90,6 +90,29 @@ impl Cutout {
       .fix_build_meta
       .analyze_force_build_modules(artifact, &force_build_modules);
 
+    // Snapshot the targets of entry-like dependencies before they get revoked.
+    // For entry deps (no parent module, no parent block) the connection is the
+    // only edge back to their target module. After `revoke_dependency(force=false)`
+    // below removes that connection, later `BuildEntryAndClean` can no longer
+    // find the target via the module graph, so it would miss running an orphan
+    // check on the target. Add those targets to `need_check_modules` up-front
+    // so `fix_issuers` can revoke them if they end up without any incoming.
+    {
+      let module_graph = artifact.get_module_graph();
+      for dep_id in &force_build_deps {
+        if module_graph.get_parent_module(dep_id).is_some()
+          || module_graph.get_parent_block(dep_id).is_some()
+        {
+          continue;
+        }
+        if let Some(con) = module_graph.connection_by_dependency_id(dep_id) {
+          self
+            .fix_issuers
+            .add_need_check_module(*con.module_identifier());
+        }
+      }
+    }
+
     let mut build_deps = HashSet::default();
 
     // do revoke dependencies and collect deps

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -90,13 +90,9 @@ impl Cutout {
       .fix_build_meta
       .analyze_force_build_modules(artifact, &force_build_modules);
 
-    // Snapshot the targets of entry-like dependencies before they get revoked.
-    // For entry deps (no parent module, no parent block) the connection is the
-    // only edge back to their target module. After `revoke_dependency(force=false)`
-    // below removes that connection, later `BuildEntryAndClean` can no longer
-    // find the target via the module graph, so it would miss running an orphan
-    // check on the target. Add those targets to `need_check_modules` up-front
-    // so `fix_issuers` can revoke them if they end up without any incoming.
+    // Entry deps have no parent — their connection is the only edge back to
+    // the target. Snapshot those targets before revoke deletes the edge, so
+    // `fix_issuers` can still orphan-check them.
     {
       let module_graph = artifact.get_module_graph();
       for dep_id in &force_build_deps {

--- a/crates/rspack_plugin_dynamic_entry/src/lib.rs
+++ b/crates/rspack_plugin_dynamic_entry/src/lib.rs
@@ -100,12 +100,9 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
 
     *imported_dependencies = next_imported_dependencies;
   } else {
-    // On a non-incremental run (e.g. the very first compile, before state
-    // becomes Hot) we still need to seed `imported_dependencies` so that the
-    // next incremental rebuild can reuse these dep ids instead of allocating
-    // fresh ones. Without this, the next compilation would see all entry
-    // deps as "new" and lose the dep -> proxy/module connection that other
-    // plugins (LazyCompilationPlugin, incremental cleanup) rely on.
+    // Cold branch must still seed `imported_dependencies` — otherwise the
+    // next Hot rebuild reallocates dep ids and breaks every downstream
+    // lookup that relies on dep id continuity across compiles.
     let mut imported_dependencies = self.imported_dependencies.borrow_mut();
     let mut next_imported_dependencies: FxHashMap<Arc<str>, FxHashMap<EntryOptions, DependencyId>> =
       Default::default();

--- a/crates/rspack_plugin_dynamic_entry/src/lib.rs
+++ b/crates/rspack_plugin_dynamic_entry/src/lib.rs
@@ -100,6 +100,15 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
 
     *imported_dependencies = next_imported_dependencies;
   } else {
+    // On a non-incremental run (e.g. the very first compile, before state
+    // becomes Hot) we still need to seed `imported_dependencies` so that the
+    // next incremental rebuild can reuse these dep ids instead of allocating
+    // fresh ones. Without this, the next compilation would see all entry
+    // deps as "new" and lose the dep -> proxy/module connection that other
+    // plugins (LazyCompilationPlugin, incremental cleanup) rely on.
+    let mut imported_dependencies = self.imported_dependencies.borrow_mut();
+    let mut next_imported_dependencies: FxHashMap<Arc<str>, FxHashMap<EntryOptions, DependencyId>> =
+      Default::default();
     for EntryDynamicResult { import, options } in decs {
       for entry in import {
         let entry_dependency: BoxDependency = Box::new(EntryDependency::new(
@@ -108,11 +117,16 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
           options.layer.clone(),
           false,
         ));
+        next_imported_dependencies
+          .entry(entry.clone().into())
+          .or_default()
+          .insert(options.clone(), *entry_dependency.id());
         compilation
           .add_entry(entry_dependency, options.clone())
           .await?;
       }
     }
+    *imported_dependencies = next_imported_dependencies;
   }
 
   Ok(())

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -49,7 +49,6 @@ pub(crate) struct LazyCompilationProxyModule {
   dep_options: DependencyOptions,
   resource: String,
   active: bool,
-  is_entry: bool,
   client: String,
   need_build: bool,
 }
@@ -73,7 +72,6 @@ impl LazyCompilationProxyModule {
     create_data: &ModuleFactoryCreateData,
     resource: String,
     active: bool,
-    is_entry: bool,
     client: String,
   ) -> Self {
     let lib_ident = lib_ident.map(|s| format!("{s}!lazy-compilation-proxy"));
@@ -101,14 +99,9 @@ impl LazyCompilationProxyModule {
       dep_options,
       resource,
       active,
-      is_entry,
       client,
       need_build: false,
     }
-  }
-
-  pub(crate) fn is_entry(&self) -> bool {
-    self.is_entry
   }
 
   pub fn invalid(&mut self) {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -49,6 +49,7 @@ pub(crate) struct LazyCompilationProxyModule {
   dep_options: DependencyOptions,
   resource: String,
   active: bool,
+  is_entry: bool,
   client: String,
   need_build: bool,
 }
@@ -72,6 +73,7 @@ impl LazyCompilationProxyModule {
     create_data: &ModuleFactoryCreateData,
     resource: String,
     active: bool,
+    is_entry: bool,
     client: String,
   ) -> Self {
     let lib_ident = lib_ident.map(|s| format!("{s}!lazy-compilation-proxy"));
@@ -99,9 +101,14 @@ impl LazyCompilationProxyModule {
       dep_options,
       resource,
       active,
+      is_entry,
       client,
       need_build: false,
     }
+  }
+
+  pub(crate) fn is_entry(&self) -> bool {
+    self.is_entry
   }
 
   pub fn invalid(&mut self) {

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -219,6 +219,7 @@ async fn normal_module_factory_module(
     module_factory_create_data,
     create_data.resource_resolve_data.resource().to_owned(),
     active,
+    is_entries,
     self.client.clone(),
   )
   .boxed();
@@ -229,9 +230,34 @@ async fn normal_module_factory_module(
 #[plugin_hook(CompilerMake for LazyCompilationPlugin<T: Backend, F: LazyCompilationTestCheck>)]
 async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
   let active_modules = self.backend.lock().await.current_active_modules().await?;
+
+  // Proxy modules that current entries point to in this compilation.
+  // A previously-active entry proxy whose entry has been removed (e.g. by a
+  // dynamic entry function) must NOT be force-rebuilt here — its underlying
+  // resource may no longer exist, and the orphan will be cleaned up later by
+  // `BuildEntryAndClean` in `finish_module_graph`. The dep -> module lookup
+  // works because incremental mode preserves the connection across builds;
+  // entries whose deps haven't been factorized yet (first build, freshly
+  // added entry) simply won't appear in this set, which is fine — we only
+  // use it to *prove* stale-ness, never to drop ids we're unsure about.
+  let current_entry_proxy_ids: IdentifierSet = {
+    let mg = compilation.build_module_graph_artifact.get_module_graph();
+    compilation
+      .entries
+      .values()
+      .flat_map(|e| e.all_dependencies())
+      .filter_map(|dep_id| mg.module_identifier_by_dependency_id(dep_id).copied())
+      .collect()
+  };
+
   let module_graph = compilation
     .build_module_graph_artifact
     .get_module_graph_mut();
+  // Start from the full backend snapshot. Ids whose proxies haven't been
+  // factorized yet (first build, new entry, non-incremental) must stay so
+  // that `normal_module_factory_module`'s `active` check sees them later.
+  // Only drop ids that we positively identify as stale entry proxies.
+  let mut next_active_modules: IdentifierSet = active_modules.iter().copied().collect();
   for module_id in &active_modules {
     let Some(active_module) = module_graph.module_by_identifier_mut(module_id) else {
       continue;
@@ -240,10 +266,15 @@ async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
       continue;
     };
 
+    if active_module.is_entry() && !current_entry_proxy_ids.contains(module_id) {
+      next_active_modules.remove(module_id);
+      continue;
+    }
+
     active_module.invalid();
   }
 
-  *self.active_modules.write().await = active_modules.into_iter().collect();
+  *self.active_modules.write().await = next_active_modules;
 
   Ok(())
 }

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -231,15 +231,11 @@ async fn normal_module_factory_module(
 async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
   let active_modules = self.backend.lock().await.current_active_modules().await?;
 
-  // Proxy modules that current entries point to in this compilation.
-  // A previously-active entry proxy whose entry has been removed (e.g. by a
-  // dynamic entry function) must NOT be force-rebuilt here — its underlying
-  // resource may no longer exist, and the orphan will be cleaned up later by
-  // `BuildEntryAndClean` in `finish_module_graph`. The dep -> module lookup
-  // works because incremental mode preserves the connection across builds;
-  // entries whose deps haven't been factorized yet (first build, freshly
-  // added entry) simply won't appear in this set, which is fine — we only
-  // use it to *prove* stale-ness, never to drop ids we're unsure about.
+  // Entry proxies whose entry was removed must NOT be force-rebuilt — the
+  // source may no longer exist on disk. `BuildEntryAndClean` will clean
+  // them up later. Use this set only to prove stale-ness, never to drop
+  // ids we're unsure about (a freshly-added entry's dep may not be
+  // factorized yet and won't appear here).
   let current_entry_proxy_ids: IdentifierSet = {
     let mg = compilation.build_module_graph_artifact.get_module_graph();
     compilation
@@ -250,28 +246,52 @@ async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
       .collect()
   };
 
+  // Seed from the backend snapshot — not-yet-factorized ids must survive
+  // so the later `active` check in `normal_module_factory_module` sees them.
+  let mut next_active_modules: IdentifierSet = active_modules.iter().copied().collect();
+  let mut to_invalidate: IdentifierSet = IdentifierSet::default();
+  {
+    let module_graph = compilation.build_module_graph_artifact.get_module_graph();
+    for module_id in &active_modules {
+      let Some(active_module) = module_graph.module_by_identifier(module_id) else {
+        continue;
+      };
+      let Some(active_module) = active_module.downcast_ref::<LazyCompilationProxyModule>() else {
+        continue;
+      };
+
+      if active_module.is_entry() && !current_entry_proxy_ids.contains(module_id) {
+        // proxy identifier doesn't encode dep kind, so the same resource may
+        // be both an entry and a lazy `import()` target. Only drop if no
+        // non-entry incoming connection still references it.
+        let still_referenced_by_import =
+          module_graph.get_incoming_connections(module_id).any(|con| {
+            !matches!(
+              module_graph
+                .dependency_by_id(&con.dependency_id)
+                .dependency_type(),
+              DependencyType::Entry
+            )
+          });
+        if !still_referenced_by_import {
+          next_active_modules.remove(module_id);
+          continue;
+        }
+      }
+
+      to_invalidate.insert(*module_id);
+    }
+  }
+
   let module_graph = compilation
     .build_module_graph_artifact
     .get_module_graph_mut();
-  // Start from the full backend snapshot. Ids whose proxies haven't been
-  // factorized yet (first build, new entry, non-incremental) must stay so
-  // that `normal_module_factory_module`'s `active` check sees them later.
-  // Only drop ids that we positively identify as stale entry proxies.
-  let mut next_active_modules: IdentifierSet = active_modules.iter().copied().collect();
-  for module_id in &active_modules {
-    let Some(active_module) = module_graph.module_by_identifier_mut(module_id) else {
-      continue;
-    };
-    let Some(active_module) = active_module.downcast_mut::<LazyCompilationProxyModule>() else {
-      continue;
-    };
-
-    if active_module.is_entry() && !current_entry_proxy_ids.contains(module_id) {
-      next_active_modules.remove(module_id);
-      continue;
+  for module_id in &to_invalidate {
+    if let Some(active_module) = module_graph.module_by_identifier_mut(module_id)
+      && let Some(active_module) = active_module.downcast_mut::<LazyCompilationProxyModule>()
+    {
+      active_module.invalid();
     }
-
-    active_module.invalid();
   }
 
   *self.active_modules.write().await = next_active_modules;

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -6,13 +6,14 @@ use std::{
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   BoxModule, Compilation, CompilationId, CompilationParams, CompilerCompilation, CompilerId,
-  CompilerMake, DependencyType, EntryDependency, LibIdentOptions, Module, ModuleExt, ModuleFactory,
-  ModuleFactoryCreateData, ModuleIdentifier, NormalModuleCreateData, NormalModuleFactoryModule,
-  Plugin,
+  CompilerMake, DependencyId, DependencyType, EntryDependency, LibIdentOptions, Module, ModuleExt,
+  ModuleFactory, ModuleFactoryCreateData, ModuleIdentifier, NormalModuleCreateData,
+  NormalModuleFactoryModule, Plugin,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_regex::RspackRegex;
+use rspack_util::fx_hash::FxHashSet;
 use tokio::sync::{Mutex, RwLock};
 
 use crate::{
@@ -219,7 +220,6 @@ async fn normal_module_factory_module(
     module_factory_create_data,
     create_data.resource_resolve_data.resource().to_owned(),
     active,
-    is_entries,
     self.client.clone(),
   )
   .boxed();
@@ -231,20 +231,15 @@ async fn normal_module_factory_module(
 async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
   let active_modules = self.backend.lock().await.current_active_modules().await?;
 
-  // Entry proxies whose entry was removed must NOT be force-rebuilt — the
-  // source may no longer exist on disk. `BuildEntryAndClean` will clean
-  // them up later. Use this set only to prove stale-ness, never to drop
-  // ids we're unsure about (a freshly-added entry's dep may not be
-  // factorized yet and won't appear here).
-  let current_entry_proxy_ids: IdentifierSet = {
-    let mg = compilation.build_module_graph_artifact.get_module_graph();
-    compilation
-      .entries
-      .values()
-      .flat_map(|e| e.all_dependencies())
-      .filter_map(|dep_id| mg.module_identifier_by_dependency_id(dep_id).copied())
-      .collect()
-  };
+  // Dep ids of every entry dependency the current compilation knows about.
+  // Used below to detect an entry proxy whose only remaining edge points to
+  // an entry dep that has just been dropped.
+  let current_entry_dep_ids: FxHashSet<DependencyId> = compilation
+    .entries
+    .values()
+    .flat_map(|e| e.all_dependencies())
+    .copied()
+    .collect();
 
   // Seed from the backend snapshot — not-yet-factorized ids must survive
   // so the later `active` check in `normal_module_factory_module` sees them.
@@ -256,27 +251,32 @@ async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
       let Some(active_module) = module_graph.module_by_identifier(module_id) else {
         continue;
       };
-      let Some(active_module) = active_module.downcast_ref::<LazyCompilationProxyModule>() else {
+      if active_module
+        .downcast_ref::<LazyCompilationProxyModule>()
+        .is_none()
+      {
         continue;
-      };
+      }
 
-      if active_module.is_entry() && !current_entry_proxy_ids.contains(module_id) {
-        // proxy identifier doesn't encode dep kind, so the same resource may
-        // be both an entry and a lazy `import()` target. Only drop if no
-        // non-entry incoming connection still references it.
-        let still_referenced_by_import =
-          module_graph.get_incoming_connections(module_id).any(|con| {
-            !matches!(
-              module_graph
-                .dependency_by_id(&con.dependency_id)
-                .dependency_type(),
-              DependencyType::Entry
-            )
-          });
-        if !still_referenced_by_import {
-          next_active_modules.remove(module_id);
-          continue;
-        }
+      // Drop the proxy only when its sole incoming edge is an entry dep
+      // that no longer belongs to any current entry. Any other shape
+      // (multiple incomings, non-entry dep, or still-current entry dep)
+      // keeps the proxy active.
+      let mut incoming = module_graph.get_incoming_connections(module_id);
+      let only = incoming.next();
+      let is_stale = incoming.next().is_none()
+        && only.is_some_and(|con| {
+          matches!(
+            module_graph
+              .dependency_by_id(&con.dependency_id)
+              .dependency_type(),
+            DependencyType::Entry
+          ) && !current_entry_dep_ids.contains(&con.dependency_id)
+        });
+
+      if is_stale {
+        next_active_modules.remove(module_id);
+        continue;
       }
 
       to_invalidate.insert(*module_id);

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/index.test.ts
@@ -16,17 +16,28 @@ test('shared file as both import() and entry — remove import() first, then ent
   // Stage 1: activate via import(). main.js triggers import('./shared.js'),
   // which factorizes shared as DynamicImport — proxy.is_entry = false.
   await page.goto(`http://localhost:${rspack.devServer.options.port}/`);
-  await expect(page.locator('#shared')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(
+    () => document.body.dataset.sharedFromImport === '1',
+    null,
+    { timeout: 30000 },
+  );
 
   // Stage 2: activate the same proxy via the entry route.
   await page.goto(
     `http://localhost:${rspack.devServer.options.port}/shared.html`,
   );
-  await expect(page.locator('#shared')).toBeVisible({ timeout: 30000 });
+  await page.waitForFunction(
+    () => document.body.dataset.sharedAsEntry === '1',
+    null,
+    { timeout: 30000 },
+  );
 
   // Stage 3: remove only the import() — entry to shared.js remains.
-  fileAction.updateFile('src/main.js', (content) =>
-    content.replace(/^.*import\(['"]\.\/shared\.js['"]\);?.*$/m, ''),
+  // Overwrite main.js entirely; tweaking with regex is brittle because
+  // `import().then(...)` spans multiple lines.
+  fileAction.updateFile(
+    'src/main.js',
+    () => "document.body.dataset.main = '1';\n",
   );
   await rspack.waitingForBuild();
   await new Promise((r) => setTimeout(r, 500));

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/index.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@/fixtures';
+
+// shared.js is referenced two ways at the same time:
+//   - via import() from main.js  -> proxy factorized with is_entry = false
+//   - as a dynamic entry          -> proxy reused, is_entry stays false
+//
+// Then we remove the import() first, then remove the entry. Both stages
+// must complete without compile errors — the proxy must stay active while
+// the import() is gone but entry remains, and must be cleaned up only
+// after the entry is also gone.
+test('shared file as both import() and entry — remove import() first, then entry', async ({
+  page,
+  fileAction,
+  rspack,
+}) => {
+  // Stage 1: activate via import(). main.js triggers import('./shared.js'),
+  // which factorizes shared as DynamicImport — proxy.is_entry = false.
+  await page.goto(`http://localhost:${rspack.devServer.options.port}/`);
+  await expect(page.locator('#shared')).toBeVisible({ timeout: 30000 });
+
+  // Stage 2: activate the same proxy via the entry route.
+  await page.goto(
+    `http://localhost:${rspack.devServer.options.port}/shared.html`,
+  );
+  await expect(page.locator('#shared')).toBeVisible({ timeout: 30000 });
+
+  // Stage 3: remove only the import() — entry to shared.js remains.
+  fileAction.updateFile('src/main.js', (content) =>
+    content.replace(/^.*import\(['"]\.\/shared\.js['"]\);?.*$/m, ''),
+  );
+  await rspack.waitingForBuild();
+  await new Promise((r) => setTimeout(r, 500));
+  await rspack.waitingForBuild();
+
+  let stats = rspack.compiler._lastCompilation
+    ?.getStats()
+    .toJson({ all: false, errors: true });
+  expect(stats?.errors ?? []).toEqual([]);
+
+  // Stage 4: delete shared.js — entry to shared.js disappears, watcher
+  // reports RemovedFiles. The proxy must be cleaned up cleanly.
+  fileAction.deleteFile('src/shared.js');
+  await rspack.waitingForBuild();
+  await new Promise((r) => setTimeout(r, 500));
+  await rspack.waitingForBuild();
+
+  stats = rspack.compiler._lastCompilation
+    ?.getStats()
+    .toJson({ all: false, errors: true });
+  expect(stats?.errors ?? []).toEqual([]);
+});

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/rspack.config.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const fs = require('fs');
+const rspack = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: async () => {
+    const context = path.resolve(__dirname, 'src');
+    const files = await fs.promises.readdir(context);
+    const result = {};
+    for (const f of files) {
+      if (f.endsWith('.js')) {
+        result[path.basename(f, '.js')] = path.resolve(context, f);
+      }
+    }
+    return result;
+  },
+  context: __dirname,
+  mode: 'development',
+  plugins: [
+    new rspack.HtmlRspackPlugin({ chunks: ['main'], filename: 'index.html' }),
+    new rspack.HtmlRspackPlugin({
+      chunks: ['shared'],
+      filename: 'shared.html',
+    }),
+  ],
+  devServer: {
+    hot: true,
+  },
+  lazyCompilation: {
+    entries: true,
+    imports: true,
+  },
+};

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/main.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/main.js
@@ -1,4 +1,6 @@
-document.body.id = 'main';
+document.body.dataset.main = '1';
 // `shared.js` is also a dynamic entry, but we hit it first via import() —
 // so the proxy is factorized with `is_entry = false` on the import path.
-import('./shared.js');
+import('./shared.js').then(() => {
+  document.body.dataset.sharedFromImport = '1';
+});

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/main.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/main.js
@@ -1,0 +1,4 @@
+document.body.id = 'main';
+// `shared.js` is also a dynamic entry, but we hit it first via import() —
+// so the proxy is factorized with `is_entry = false` on the import path.
+import('./shared.js');

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/shared.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/shared.js
@@ -1,0 +1,1 @@
+document.body.id = 'shared';

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/shared.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/src/shared.js
@@ -1,1 +1,1 @@
-document.body.id = 'shared';
+document.body.dataset.sharedAsEntry = '1';

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/index.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@/fixtures';
+
+test('removing a dynamic entry should not produce compile errors', async ({
+  page,
+  fileAction,
+  rspack,
+}) => {
+  // Activate both entry proxies first so the backend has them in active_modules.
+  await page.goto(`http://localhost:${rspack.devServer.options.port}/`);
+  await expect(page.locator('#index1')).toBeVisible({ timeout: 30000 });
+  await page.goto(
+    `http://localhost:${rspack.devServer.options.port}/index2.html`,
+  );
+  await expect(page.locator('#index2')).toBeVisible({ timeout: 30000 });
+
+  // Remove index2 entry source while index1 stays.
+  fileAction.deleteFile('src/index2.js');
+
+  // Wait for the rebuild triggered by file removal to settle.
+  await rspack.waitingForBuild();
+  // The watcher may schedule a follow-up rebuild for the HMR update; let it run too.
+  await new Promise((r) => setTimeout(r, 500));
+  await rspack.waitingForBuild();
+
+  const stats = rspack.compiler._lastCompilation
+    ?.getStats()
+    .toJson({ all: false, errors: true });
+  expect(stats?.errors ?? []).toEqual([]);
+});

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/rspack.config.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const fs = require('fs');
+const rspack = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: async () => {
+    const context = path.resolve(__dirname, 'src');
+    const files = await fs.promises.readdir(context);
+    let entries = files.filter((f) => f.startsWith('index'));
+    entries.sort();
+    return entries.reduce((acc, e, i) => {
+      acc[`index${i + 1}`] = path.resolve(context, e);
+      return acc;
+    }, {});
+  },
+  context: __dirname,
+  mode: 'development',
+  plugins: [
+    new rspack.HtmlRspackPlugin({ chunks: ['index1'], filename: 'index.html' }),
+    new rspack.HtmlRspackPlugin({
+      chunks: ['index2'],
+      filename: 'index2.html',
+    }),
+  ],
+  devServer: {
+    hot: true,
+  },
+  lazyCompilation: {
+    entries: true,
+  },
+};

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/src/index1.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/src/index1.js
@@ -1,0 +1,6 @@
+Promise.resolve().then(() => {
+  const div = document.createElement('div');
+  div.innerText = 'index1';
+  div.id = 'index1';
+  document.body.appendChild(div);
+});

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/src/index2.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/src/index2.js
@@ -1,0 +1,4 @@
+const div = document.createElement('div');
+div.innerText = 'index2';
+div.id = 'index2';
+document.body.appendChild(div);

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/index.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@/fixtures';
+
+// shared.js is referenced two ways at the same time:
+//   - as a dynamic entry (controlled by marker.js)
+//   - via import() from main.js
+//
+// We remove the dynamic entry while the import() is still alive, and
+// then prove the proxy stays active by reloading the main page so the
+// lazy-compilation client requests `shared` again. Without the
+// non-entry-incoming check on `compiler_make`, `shared`'s active state
+// would be dropped after the entry removal, breaking subsequent
+// import() activations.
+test('removing dynamic entry must keep proxy active when import() still references it', async ({
+  page,
+  fileAction,
+  rspack,
+}) => {
+  // Stage 1: activate via the entry route first.
+  await page.goto(
+    `http://localhost:${rspack.devServer.options.port}/shared.html`,
+  );
+  await page.waitForFunction(() => document.body.dataset.shared === '1', null, {
+    timeout: 30000,
+  });
+
+  // Stage 2: activate via the import() route too.
+  await page.goto(`http://localhost:${rspack.devServer.options.port}/`);
+  await page.waitForFunction(
+    () => document.body.dataset.sharedLoaded === '1',
+    null,
+    { timeout: 30000 },
+  );
+
+  // Stage 3: remove the dynamic-entry marker so the entry function no longer
+  // emits `shared`. Touch main.js to make the watcher notice and rerun the
+  // entry function (marker.js itself is not in the dep graph).
+  fileAction.deleteFile('src/marker.js');
+  fileAction.updateFile('src/main.js', (content) => `${content}\n`);
+  await rspack.waitingForBuild();
+  await new Promise((r) => setTimeout(r, 500));
+  await rspack.waitingForBuild();
+
+  const stats = rspack.compiler._lastCompilation
+    ?.getStats()
+    .toJson({ all: false, errors: true });
+  expect(stats?.errors ?? []).toEqual([]);
+
+  // Stage 4: reload main page — the import() must still resolve, proving
+  // the proxy stayed active despite the entry removal.
+  await page.goto(`http://localhost:${rspack.devServer.options.port}/`);
+  await page.waitForFunction(
+    () => document.body.dataset.sharedLoaded === '1',
+    null,
+    { timeout: 30000 },
+  );
+});

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/rspack.config.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const fs = require('fs');
+const rspack = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: async () => {
+    const context = path.resolve(__dirname, 'src');
+    const entries = { main: './src/main.js' };
+    try {
+      await fs.promises.stat(path.join(context, 'marker.js'));
+      entries.shared = './src/shared.js';
+    } catch {}
+    return entries;
+  },
+  context: __dirname,
+  mode: 'development',
+  plugins: [
+    new rspack.HtmlRspackPlugin({ chunks: ['main'], filename: 'index.html' }),
+    new rspack.HtmlRspackPlugin({
+      chunks: ['shared'],
+      filename: 'shared.html',
+    }),
+  ],
+  devServer: {
+    hot: true,
+  },
+  lazyCompilation: {
+    entries: true,
+    imports: true,
+  },
+};

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/src/main.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/src/main.js
@@ -1,0 +1,4 @@
+document.body.id = 'main';
+import('./shared.js').then(() => {
+  document.body.dataset.sharedLoaded = '1';
+});

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/src/marker.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/src/marker.js
@@ -1,0 +1,3 @@
+// Presence of this file makes the dynamic entry function emit `shared`
+// as an entry. Removing it triggers BuildEntryAndClean to revoke that
+// entry dep, but the import() in main.js still references shared.js.

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/src/shared.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/src/shared.js
@@ -1,0 +1,1 @@
+document.body.dataset.shared = '1';


### PR DESCRIPTION
## Why

`lazyCompilation.entries: true` together with a dynamic `entry` function crashes the incremental rebuild with `Module not found` when one of the entries is removed (issue #12444).

The failure looks like one bug but is three independent issues across three crates that only compound on this code path:

- `LazyCompilationPlugin::compiler_make` called `invalid()` on every active proxy each compile — including proxies whose underlying entry source had been deleted on disk. The follow-up force-rebuild then fails to resolve the deleted file.
- `DynamicEntryPlugin::make` only seeded `imported_dependencies` on the Hot (incremental) branch. The first compile is always Cold, so the next compile saw every entry dep as new and reallocated dep ids — breaking the dep → module connection that other plugins rely on.
- `cutout`'s `RemovedFiles` branch revoked the entry dep's connection before `BuildEntryAndClean` could read it. For entry deps the connection is the only edge back to the target module, so the orphan proxy was never cleaned up and a failed `LazyCompilationDependency` stayed stuck in `make_failed_dependencies`.

All three fixes are required for the cleanup chain to run end-to-end.

## What

### Core fixes
- `rspack_plugin_lazy_compilation/src/plugin.rs` — `compiler_make` decides stale purely from the live module_graph: drop the proxy from `active_modules` **only when its sole incoming edge is an entry dep that no longer belongs to any current entry**. Any other shape (multiple incomings, non-entry dep, or still-current entry dep) keeps the proxy active.
- `rspack_plugin_lazy_compilation/src/module.rs` — `is_entry` field, accessor and constructor parameter removed; the dep kind is no longer cached on the proxy because the proxy identifier doesn't encode it (the same resource can be both an entry and a lazy `import()` target).
- `rspack_plugin_dynamic_entry/src/lib.rs` — also seed `imported_dependencies` on the Cold branch so subsequent Hot rebuilds reuse the same dep ids.
- `rspack_core/.../cutout/mod.rs` — snapshot the targets of orphan-style entry deps into `fix_issuers.need_check_modules` **before** `revoke_dependency` deletes the connection. The snapshot/revoke order is load-bearing; a comment in the source warns future refactors not to reorder it.

### Test plan

Three e2e cases under `tests/e2e/cases/lazy-compilation/`:

| case | scenario |
|---|---|
| `dynamic-entry-remove` | two entries on separate HTML pages, delete one entry source, assert `stats.errors == []` |
| `dynamic-entry-import-shared` | shared file factorized as `import()` first then also referenced as a dynamic entry; remove the import(), then remove the entry — both stages must finish cleanly |
| `dynamic-entry-removed-with-import-alive` | shared file is both an entry and an `import()` target; remove only the dynamic entry, then prove the proxy stays active by reloading main and watching the import() resolve again |

Existing `cases/lazy-compilation/*` and `cases/make/remove-dynamic-entry` continue to pass. Reverting any one of the three rust fixes individually reproduces the original failure, confirming each fix is load-bearing.

Refs #12444