### PR TITLE
revert: upgrade swc_core from 66 to 67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5703,9 +5703,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "65.0.0"
+version = "64.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71961ff67d721c26d4eb65b09bd2dcfe59a0845f727af2f46bf32b272a8d73d2"
+checksum = "b84c09355c735beb8534d629b06468dd7f536e5f3920aeebeae7920c5c442202"
 dependencies = [
  "anyhow",
  "base64",
@@ -5782,9 +5782,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "22.0.0"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162109f5780051aba388a3451c916096af5d47f530e68dc1f4999cfcb7633371"
+checksum = "da38f2cee8e659bf0ec7f51ec5b37ec58c9127de755d3fe0b2c2353ec9474b09"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -5813,9 +5813,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "57.0.0"
+version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43d8d85f3d304a7bc5f0c38a3829162aa53bf665188cf083ce0c31657a71483"
+checksum = "f6537a4d89b8689d8e085e3b0f58f8032da63e2dd0fd9415470a4a4eeb2f5145"
 dependencies = [
  "anyhow",
  "base64",
@@ -5872,9 +5872,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "67.0.1"
+version = "66.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596430882e5edc8eb266963700c291e02aade3947fbd1d01eaa03fe6e06c83b7"
+checksum = "96dba809fb900d93b02fb821fe19c48c76433f5dfb3a76bdb28068851e2a6307"
 dependencies = [
  "par-core",
  "swc",
@@ -5901,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "24.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9a622ffc0c3364da3a276154b30271319e9aa5fb95a1b111a2e99ace0ac3c4"
+checksum = "550ee54eab536fe357090fec6d42d083c28cf44cc9bcfa93b1ea5e1606f3b2f7"
 dependencies = [
  "bitflags 2.11.1",
  "cbor4ii",
@@ -5922,9 +5922,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "27.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbce091d854f467dd4dac339a25cadd867fc7a976fba4043ed6df46dafdc2e2a"
+checksum = "fafbcdd29cc03b0c04860bb0143e781e13a4e2dac03eb8747df520f602e0aa94"
 dependencies = [
  "ascii",
  "compact_str",
@@ -5956,9 +5956,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "49.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b3c6ed1eb5d1c6f928843a11e7e0386a12d2d2de332cef34c477a4a05ed2ae"
+checksum = "18c83464946e2263439b6826e673075114a621418085933d0975059f98405d2d"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -5974,9 +5974,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "39.0.0"
+version = "38.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9a0ad4a6aa736ab18fdda8bb24c646b313769d8f19660f93f5776d752b96e6"
+checksum = "b8119b1753c18a4fe7a8947bf0afe4e6666c9e2facd7e73134b976643d4b9738"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -5986,9 +5986,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "48.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0677f866b6276c1e642b0448984614ed6e775b9a6547ae039be1bbca65827c"
+checksum = "207d9015a9a9c036735eaa18810a99c1372c4e877d76f28ce5a4b640b0847918"
 dependencies = [
  "arrayvec",
  "indexmap",
@@ -6014,9 +6014,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "44.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb37dca1fb547882dd041357642fc391c2124b2b9a314aec4b486898ac91d9d5"
+checksum = "c63e2fda7259b25b6bab5ee86b5aa78955c92c7874ad0721a308e48aebfbabf0"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_transformer",
@@ -6027,9 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "44.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23259557653278d4ac22f58232f25e0898644a67af48e57dcc6ec8c30b46d86c"
+checksum = "8a358aa832bb4137a8eddd952f6d670c304514a0a558706bd489a12bdc48cdcb"
 dependencies = [
  "serde",
  "swc_common",
@@ -6042,9 +6042,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "45.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc56177c581df3344e2a6ce3a7e8cac9740f9af7cf2ad5a90ff13139140aaac0"
+checksum = "c556df42cc18645a1b3b85305f9870788dd3dffcbbce11d5195dfa8e38e3fb40"
 dependencies = [
  "serde",
  "swc_ecma_ast",
@@ -6056,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "44.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05d7935884edb0496a3f9fa1947a218e01b0f79f7de0c40672ac0c71bb2678a"
+checksum = "1cc56b01664bed45eefc0316847d7e439f05587dcb7285fcfc3c62e89e90c288"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6070,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "46.0.0"
+version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2302c97ccf9ff21b41a29d9bd5397d3d53130ec113998aba61d130d9334b8069"
+checksum = "2f57606cbd07a019079ec9b9cfeb32a5141c97a71441fc97c2cada52500e030e"
 dependencies = [
  "serde",
  "swc_common",
@@ -6087,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "44.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb72e3cb4a93c4f53233b50f06b07845240d0b5f6de8d1505e132fceedb303f"
+checksum = "d7dca6ddcfe2cabd285163b70b4b04b16232ca08cba448390b492512190f24f3"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_transformer",
@@ -6100,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "46.0.0"
+version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135cde07359a7f92d57a7f6db8c1bef03b22d9fda5cf9d07d9acd9e2d93294f9"
+checksum = "7e4d44d6c7317a8e1189785e8aa5c82ab3b491722db46c82a9b82bc70f892b27"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6120,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_regexp"
-version = "5.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2049351cda0d2939f159d2a2e797d8c70cf588fc99e7f564c586b3fea27bfcfe"
+checksum = "bf01bca3c32928c9cbc436f05efce56b5007ace2b3ac870eb710211b0fffa570"
 dependencies = [
  "icu_properties",
  "swc_ecma_regexp_ast",
@@ -6131,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "30.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "846562b1d258a7fc3f75f6f0c8100c03a1d754b4f770e17e90d2d6280d8e01ea"
+checksum = "b81ca56fdd7170e23194ab05e6be528de490432eeadfa4b9a287be231017d46b"
 dependencies = [
  "phf",
  "swc_common",
@@ -6144,9 +6144,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_hooks"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577bdd0de044c14c8b5daef87c87c5cbb8c4495ea1acf0363cf61023fc05f38e"
+checksum = "ee7662517362f6726b0e107a3caec2b4cc7d629f9bf702958948e9350722e52f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6156,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "23.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb92b16fea4820aec5e418e6e6114a241eb6efce32a469805a73825c6b87f8d"
+checksum = "562c983a163ca2a016626d03f037390a9c1de8f004605ecf44f4fa92a292ae42"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6178,9 +6178,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "54.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc5ab5a95da345e6088cc728fe7adcf13dfce8c3abda7e926b20d135caa3475"
+checksum = "76c9d429baf26f3e5efb0f98fd5f16425ae14becc2f82cd78e39512f1fd68a5e"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -6214,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "40.0.0"
+version = "39.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5311f6c93d5790b28df4ea5bcf9c1785c6bbda90f9e647de3fe5c535bd7140"
+checksum = "76e6934ad1cf59a947528f034943be40d06fb3332def0d71db29ba6ad8181283"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6234,9 +6234,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "55.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810c2810a15bde9189943e49b2091120db06ecc75616a81cebae20ae7577f38e"
+checksum = "c4a2b1cfbb23db2bcd002b86aa28c4e7bd2645ea778d8a4a4d410c9196e1cd1f"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
@@ -6259,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "40.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203299bca3c8d0190486f9519ae61c470bc8a1c7df619af9688e3fa9cb9ad875"
+checksum = "54e4d28106d86d9c45d187687688d03bab7064bd8480d8bc783df9ff2a5d5a9a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6277,9 +6277,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_regexp"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0022056a36b0f074bcb6cbbdc51bb7425f27c9953a48799d541176c168b78542"
+checksum = "4afafa422a0c86bde3e7cc3d3d1073f13ea05047c5c08bcc15df6f9b470de1eb"
 dependencies = [
  "phf",
  "rustc-hash",
@@ -6293,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_regexp_ast"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3df4664d15402a4af626e38c5b4e9d39c27fca860dd27b4b8f4a9ac11d07b83"
+checksum = "5e01fc6155c5fcdce85f253c96fe764877ebaa1dc50ab0639b383dafb46a6427"
 dependencies = [
  "bitflags 2.11.1",
  "is-macro",
@@ -6312,9 +6312,9 @@ checksum = "0a0a09a9e4dc09c97f07273695bd4b58e46b99dbb0cb788ce0dad2a181eb1e94"
 
 [[package]]
 name = "swc_ecma_regexp_visit"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15349ef50a2eb97d2bd71f9a1c47d29c0e2e6c257839a59c68b3002e97df5aa"
+checksum = "73317054bba9a6fed553ce2c830702b8602fc5f5c08d9328bd3ab9d8489ce827"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6325,9 +6325,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transformer"
-version = "15.0.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5ae57bb5a6523d55f44b62addcceb7cbe53886ffa67dd7fa3355e740c0f19f"
+checksum = "54f5623374970e628160f83784af5e4f3e1fd75f79393f270df421439a3920b3"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6344,9 +6344,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "54.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1077428549fe7a7489587fccaffcfea905496248f2cebfc655eb8f88d0a07ea"
+checksum = "2a0269f4ccf7a83a1a3bef7bde5257143e6794d2523db1fa6c5b03a6ab9fb430"
 dependencies = [
  "par-core",
  "swc_common",
@@ -6363,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "43.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6abfa3cde48dcaf5a513d5110e6b8fb0fdfc285a5e39e6123a7ded797902bd"
+checksum = "1f0c8ee943a8f9099391cecef5b3eafc98aba64dfa5f6f7cd336a32989d92d1a"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -6386,9 +6386,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8186a91e387ffae65012f6eb252c535a9b290d6de97da45e035b7ac1c61c18"
+checksum = "136e114c3d98aafbdbe6800ff40299a9661fd8bd3902fffb248fd9fe8194e3fd"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6399,9 +6399,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "50.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9740568170f288ccf3beeeb2782f8ff462c901cdecc303b17fbf703f98935a02"
+checksum = "9739057661ec031d05deb8588b5b90025212bf080e060cb82ed4c7095618dc2d"
 dependencies = [
  "indexmap",
  "par-core",
@@ -6439,9 +6439,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "48.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4daae858596f92fe2a1eecef570d9919616e91b85492a9ab8f8851b31e0997b3"
+checksum = "50f4bed3e69e05890ea326df97035412071a37da59d6fc0a6488c3cf200c6f08"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6467,9 +6467,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "46.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6a90476f1356ce065119a9be3e046810cb883ad2f4b40c0e898f9af75e6000"
+checksum = "b462cdbe5561316a2b15898fa2d8536c363d337285f78fc31a2f2a39b62ce99d"
 dependencies = [
  "bytes-str",
  "dashmap",
@@ -6491,9 +6491,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf798347ccf610faf4e45cec18b449731dd4f201b5cde3e6cc231eb6013ac26"
+checksum = "369f6af2a00c85232aaa60c085ff5d63c34e48996723e6bceabba33dabb71228"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6509,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "48.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb32d1ce7608f36839958f11df1b40335917946c2ccf7f9df35e18dddaa0e6e"
+checksum = "8989e4d64e0d219f1c471c4ecd2190bab717a15ad48c4ce3ba603f6501fc551d"
 dependencies = [
  "base64",
  "bytes-str",
@@ -6534,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "48.0.0"
+version = "47.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b6813f841b2ecd4eaf2840d772165ab12ee4cd610014a31f0499f5989b561"
+checksum = "ae0e18e9b19ff547a187b5fd5706a85fcd23ad472b9056202918ac0126a3aa06"
 dependencies = [
  "bytes-str",
  "rustc-hash",
@@ -6552,9 +6552,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "30.0.0"
+version = "29.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf58c53435892e6faba97ee2c8d178f2a737e93f8c97b1ddf46fa3f7972995"
+checksum = "3d69b480aa02b5ff2ab951478d8e7633eeda42940aeb5fe0386eebc19dd3b1e4"
 dependencies = [
  "dragonbox_ecma",
  "indexmap",
@@ -6571,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "24.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc8718c20a595dda55d316a802dfa82fc0287312259e3e68c2adba29b110431"
+checksum = "ad65d392ed427dc9e94f16a3d802b02e27722c21227639c8d5f45f19757b447b"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -6597,9 +6597,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "24.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e352ca9b8cd8f0e42ff18b2d4ef4aeb51ec7519a3049522cf4b7c57a0649fc04"
+checksum = "a901e41bea44b4ec8237b1cde1d2e7ae0a3b5c87c6d1100103de45caf440f972"
 dependencies = [
  "anyhow",
  "miette",
@@ -6621,9 +6621,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_ast"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71d7acd55b802d966c83403d268789ffdfd1f99025702317255dd5876fbc1d4"
+checksum = "078f89faf183e8af0817206ed39008c765e35c80a3656c0a0e1dab47f15bd947"
 dependencies = [
  "hashbrown 0.16.1",
  "num-bigint",
@@ -6635,9 +6635,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_parser"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464bcea1c7322106f79dc65919eb97618674cb01f11fcaa3f8ddd66369ecb60b"
+checksum = "8beae6cf921cb8f0cef7433320aeb9cbf9ff877b7bc8bcd35c3a20b8f848c721"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6652,9 +6652,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_semantic"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357b0350ebba2a2bd2948c5bf966a234dea030ae1c705af8aee035422201d40"
+checksum = "be35c4858ca13e17d372a8a847eaccffa4caf4a139109a6369aa368986b78d06"
 dependencies = [
  "oxc_index",
  "rustc-hash",
@@ -6674,9 +6674,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "34.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bedf6a36ec009e5f32b25b65a155c1734f7b4762cd504fabcd431742ea68f8"
+checksum = "0e774a110a297eb12b50aeb0c4047a718c087d00432392ca79dfc2cb8e291aa8"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -6686,9 +6686,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_ast"
-version = "22.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cedf1cac7e9a8085946fea1fe3c599e0e2bd06453f9dfb6898e0d860705fd9"
+checksum = "e457b067b8ad2056d39ce0ff2b7d03a51af18be40d71e568973359b7cf46ed44"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -6698,9 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_codegen"
-version = "23.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e999b46408c19cc627a4b2d5700976c83b2ca2482ec76d988b30d98caf36bf"
+checksum = "2c80902f6bcef80b089d5c19efab02ccd61e3a88f036d5c2ba75ef75a04a50f7"
 dependencies = [
  "auto_impl",
  "bitflags 2.11.1",
@@ -6724,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "54.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403e5f3e55391ae74e460cacbcd6c3e3d84e9217235f029053ac418d9a16aab5"
+checksum = "101d3ac04372eefb0e61a26f7af8fa2466557c0ce7494bc3df3dc1383cded409"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -6750,9 +6750,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_parser"
-version = "22.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e754ccab8ab6211c81719a58acb4dfa435d0358ad92a86059c8e8a2de4008aca"
+checksum = "9d48d4af23e6500970d63af1cc0ac9e911c5166e3fb1ed333fa60276516140d4"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6776,9 +6776,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_visit"
-version = "22.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ca02c3ca25584547be88ac0d308fe8799a63794dde4d3cd50ea7b058a419af"
+checksum = "3f3876621f4f084d08a55f0f78fab408dac3d8dc32afc580fcb24ff0f3eaff84"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6800,9 +6800,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "23.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60b8529ef91d558bdd70823bb31562b2bfcc2df5322cdd0df6155abba6fe1f9"
+checksum = "2fa52abc79bfc58486c79581c869dbadaa99fa2fc1f6b3ab9ca30c0af9aa09a3"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -6812,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "24.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49be3ff3d08e81604160b5585d46bd06b76f4ea79fd6a67ff06067dd4fa6c1ff"
+checksum = "dbfc8183fc43f5617a6bf5e6af0869dd634f3df469070f61b6f98d7cbd300d5a"
 dependencies = [
  "better_scoped_tls",
  "cbor4ii",
@@ -6827,9 +6827,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "28.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58036e2a403e74cd742f31f5ac3c63a8c0814f2477d5ee92a25efc3abc4e7db3"
+checksum = "ff8883348391cfcf1911454282a8c664cf4727b79f6c0d81457f7add873e64fb"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6886,9 +6886,9 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "16.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768a88c26bb362f9f89e3e7a2b57c2e9ad257f0aa3d5e08af55af262471b1f76"
+checksum = "fbf6619f4691d3934610de7d0acf4807634161f395bf44d695810ebae9e405d2"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash",
@@ -6898,9 +6898,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "29.0.0"
+version = "28.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0329dcafd83c32f93d663647ef8bc8fb92decd6503ca5b5f0d5de1f2fc9dc"
+checksum = "a86cf04561e92a19f5f37b7fcfdb442e749b9e360bc2796f731599967dfcb8cd"
 dependencies = [
  "bitflags 2.11.1",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,19 +129,19 @@ rkyv      = { version = "=0.8.16", default-features = false, features = ["std", 
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.9", default-features = false }
-swc                 = { version = "65.0.0", default-features = false }
+swc                 = { version = "64.0.0", default-features = false }
 swc_config          = { version = "5.0.0", default-features = false }
-swc_core            = { version = "67.0.1", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "54.0.0", default-features = false }
-swc_error_reporters = { version = "24.0.0", default-features = false }
-swc_html            = { version = "34.0.0", default-features = false }
-swc_html_minifier   = { version = "54.0.0", default-features = false }
-swc_plugin_runner   = { version = "28.0.0", default-features = false }
-swc_typescript      = { version = "29.0.0", default-features = false }
+swc_core            = { version = "66.0.2", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "53.0.0", default-features = false }
+swc_error_reporters = { version = "23.0.0", default-features = false }
+swc_html            = { version = "33.0.0", default-features = false }
+swc_html_minifier   = { version = "53.0.0", default-features = false }
+swc_plugin_runner   = { version = "27.0.0", default-features = false }
+swc_typescript      = { version = "28.0.2", default-features = false }
 
-swc_experimental_ecma_ast      = { version = "0.6.8", default-features = false }
-swc_experimental_ecma_parser   = { version = "0.6.8", default-features = false }
-swc_experimental_ecma_semantic = { version = "0.6.8", default-features = false }
+swc_experimental_ecma_ast      = { version = "0.6.7", default-features = false }
+swc_experimental_ecma_parser   = { version = "0.6.7", default-features = false }
+swc_experimental_ecma_semantic = { version = "0.6.7", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "67.0.1"
+  "66.0.2"
 }
 
 /// The version of the JavaScript `@rspack/core` package.


### PR DESCRIPTION
## Summary

- Revert `chore: upgrade swc_core from 66 to 67 (#14135)`.
- Restore the SWC dependency set to the previous `swc_core 66` versions.
- Regenerate the workspace SWC version constant back to `66.0.2`.

## Why

The `swc_core 67` upgrade changed decorator helper output for 2022-03 decorators. Downstream ecosystem projects can still resolve `@swc/helpers@0.5.21` from their existing lockfiles, which is incompatible with the generated `_apply_decs_2203_r` helper import and keeps Ecosystem CI failing even after raising Rspack's peer dependency minimum.

This revert unblocks the release while downstream lockfiles / helper version handling are updated separately.

## Validation

- `git diff --check`
- `cargo check -p rspack_plugin_javascript`