### PR TITLE
fix: derive modern-module require external type from target

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2262,6 +2262,7 @@ export interface RawExternalItemFnResult {
 
 export interface RawExternalsPluginOptions {
   type: string
+  fallbackType?: string
   externals: (string | RegExp | Record<string, string | boolean | string[] | Record<string, string[]>> | ((...args: any[]) => any))[]
   placeInInitial: boolean
 }

--- a/crates/rspack/src/builder/builder_context.rs
+++ b/crates/rspack/src/builder/builder_context.rs
@@ -12,7 +12,7 @@ use rspack_core::{
 #[repr(u8)]
 pub(super) enum BuiltinPluginOptions {
   // External handling plugins
-  ExternalsPlugin((ExternalType, Vec<ExternalItem>, bool)),
+  ExternalsPlugin((ExternalType, Vec<ExternalItem>, bool, ExternalType)),
   NodeTargetPlugin,
   CssHttpExternalsRspackPlugin,
   ElectronTargetPlugin(rspack_plugin_externals::ElectronTargetContext),
@@ -119,10 +119,20 @@ impl BuilderContext {
     let mut plugins = Vec::new();
     self.plugins.drain(..).for_each(|plugin| match plugin {
       // External handling plugins
-      BuiltinPluginOptions::ExternalsPlugin((external_type, externals, place_in_initial)) => {
+      BuiltinPluginOptions::ExternalsPlugin((
+        external_type,
+        externals,
+        place_in_initial,
+        fallback_type,
+      )) => {
         plugins.push(
-          rspack_plugin_externals::ExternalsPlugin::new(external_type, externals, place_in_initial)
-            .boxed(),
+          rspack_plugin_externals::ExternalsPlugin::new_with_options(
+            external_type,
+            externals,
+            place_in_initial,
+            fallback_type,
+          )
+          .boxed(),
         );
       }
       BuiltinPluginOptions::NodeTargetPlugin => {

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1090,12 +1090,18 @@ impl CompilerOptionsBuilder {
     if let Some(externals) = &mut self.externals {
       let externals = std::mem::take(externals);
       let externals_type = expect!(self.externals_type.clone());
+      let fallback_type = if target_properties.node_builtins() {
+        "node-commonjs".to_string()
+      } else {
+        "commonjs".to_string()
+      };
       builder_context
         .plugins
         .push(BuiltinPluginOptions::ExternalsPlugin((
           externals_type,
           externals,
           false,
+          fallback_type,
         )));
     }
 
@@ -1151,6 +1157,7 @@ impl CompilerOptionsBuilder {
           "node-commonjs".to_string(),
           vec!["nw.gui".to_string().into()],
           false,
+          "commonjs".to_string(),
         )));
     }
 

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -396,10 +396,13 @@ impl<'a> BuiltinPlugin<'a> {
           .map(|e| RawExternalItemWrapper(e).try_into())
           .collect::<Result<Vec<_>>>()
           .map_err(|report| napi::Error::from_reason(report.to_string()))?;
-        let plugin = ExternalsPlugin::new(
+        let plugin = ExternalsPlugin::new_with_options(
           plugin_options.r#type,
           externals,
           plugin_options.place_in_initial,
+          plugin_options
+            .fallback_type
+            .unwrap_or_else(|| "commonjs".to_string()),
         )
         .boxed();
         plugins.push(plugin);

--- a/crates/rspack_binding_api/src/raw_options/raw_external.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_external.rs
@@ -31,6 +31,7 @@ pub struct RawHttpExternalsRspackPluginOptions {
 #[napi(object, object_to_js = false)]
 pub struct RawExternalsPluginOptions {
   pub r#type: String,
+  pub fallback_type: Option<String>,
   #[napi(
     ts_type = "(string | RegExp | Record<string, string | boolean | string[] | Record<string, string[]>> | ((...args: any[]) => any))[]"
   )]

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -378,12 +378,7 @@ fn resolve_external_type<'a>(
         match external_type {
           ExternalTypeEnum::Import => "import",
           ExternalTypeEnum::Module => "module",
-          // `modern-module` currently collapses require-style CommonJS
-          // externals to node-commonjs in ESM output. This preserves a
-          // distinct identity from plain commonjs externals, but it also means
-          // we don't yet support selecting other CJS render variants such as
-          // preserving a bare require(...).
-          ExternalTypeEnum::CommonJs => "node-commonjs",
+          ExternalTypeEnum::CommonJs(external_type) => external_type.as_str(),
         }
       } else {
         "module"
@@ -417,7 +412,7 @@ pub struct ExternalModule {
 pub enum ExternalTypeEnum {
   Import,
   Module,
-  CommonJs,
+  CommonJs(ExternalType),
 }
 
 pub type MetaExternalType = Option<ExternalTypeEnum>;

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -23,11 +23,21 @@ pub struct ExternalsPlugin {
   externals: Vec<ExternalItem>,
   r#type: ExternalType,
   place_in_initial: bool,
+  fallback_type: ExternalType,
 }
 
 impl ExternalsPlugin {
   pub fn new(r#type: ExternalType, externals: Vec<ExternalItem>, place_in_initial: bool) -> Self {
-    Self::new_inner(externals, r#type, place_in_initial)
+    Self::new_with_options(r#type, externals, place_in_initial, "commonjs".to_string())
+  }
+
+  pub fn new_with_options(
+    r#type: ExternalType,
+    externals: Vec<ExternalItem>,
+    place_in_initial: bool,
+    fallback_type: ExternalType,
+  ) -> Self {
+    Self::new_inner(externals, r#type, place_in_initial, fallback_type)
   }
 
   fn handle_external(
@@ -155,7 +165,7 @@ impl ExternalsPlugin {
           | DependencyType::RequireResolveContext
       )
     {
-      dependency_meta.external_type = Some(ExternalTypeEnum::CommonJs);
+      dependency_meta.external_type = Some(ExternalTypeEnum::CommonJs(self.fallback_type.clone()));
     }
 
     Some(ExternalModule::new(

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -20,6 +20,7 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
     private type: string,
     private externals: Externals,
     private placeInInitial?: boolean,
+    private fallbackType?: string,
   ) {
     super();
   }
@@ -29,6 +30,7 @@ export class ExternalsPlugin extends RspackBuiltinPlugin {
     const externals = this.externals;
     const raw: RawExternalsPluginOptions = {
       type,
+      fallbackType: this.fallbackType,
       externals: (Array.isArray(externals) ? externals : [externals])
         .filter(Boolean)
         .map((item) => this.#getRawExternalItem(item)),

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -102,6 +102,7 @@ export class RspackOptionsApply {
         options.externalsType,
         options.externals,
         false,
+        getModernModuleCjsExternalType(options),
       ).apply(compiler);
     }
 
@@ -436,4 +437,18 @@ export class RspackOptionsApply {
 
     compiler.hooks.afterResolvers.call(compiler);
   }
+}
+
+function getModernModuleCjsExternalType(
+  options: RspackOptionsNormalized,
+): 'commonjs' | 'node-commonjs' {
+  const presets = options.externalsPresets;
+  return presets.node ||
+    presets.electron ||
+    presets.electronMain ||
+    presets.electronPreload ||
+    presets.electronRenderer ||
+    presets.nwjs
+    ? 'node-commonjs'
+    : 'commonjs';
 }

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-explicit-web/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-explicit-web/test.config.js
@@ -21,9 +21,7 @@ module.exports = {
 
 		expect(source).toMatch(/import\s*\{\s*resolve\s*\}\s*from\s*["']path["']/);
 		expect(source).toMatch(/import\s*\(\s*["']os["']\s*\)/);
-		expect(source).toMatch(/createRequire\s+as\s+__rspack_createRequire/);
-		expect(source).toMatch(
-			/__rspack_createRequire_require\s*\(\s*["']fs["']\s*\)/
-		);
+		expect(source).toMatch(/require\s*\(\s*["']fs["']\s*\)/);
+		expect(source).not.toContain("createRequire");
 	}
 };

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -562,9 +562,7 @@ For compatibility, Rspack does not enable this automatically when [`output.libra
 
 For static ESM imports, Rspack renders the external like [`'module'`](#externalstypemodule), using a static `import` statement. For dynamic `import()`, Rspack renders the external like [`'module-import'`](#externalstypemodule-import), using `import()`.
 
-For CommonJS `require()`, Rspack currently renders the external like [`'node-commonjs'`](#externalstypenode-commonjs) and creates a `require` function with `createRequire` in the generated ESM output.
-
-This means `modern-module` does not yet distinguish CommonJS external variants for `require()` dependencies. In particular, it does not currently provide a variant that preserves a bare `require()` call in the generated ESM output.
+For CommonJS `require()`, Rspack chooses the CommonJS external variant from the target. Node-like targets render the external like [`'node-commonjs'`](#externalstypenode-commonjs) and create a `require` function with `createRequire` in the generated ESM output. Other targets render it like [`'commonjs'`](#externalstypecommonjs), preserving a bare `require()` call.
 
 **Example**
 
@@ -597,7 +595,7 @@ export default {
 };
 ```
 
-The generated ESM output keeps the static import as an `import` statement, keeps the dynamic import as `import()`, and renders the `require()` external through `createRequire`:
+Because this example targets Node.js, the generated ESM output keeps the static import as an `import` statement, keeps the dynamic import as `import()`, and renders the `require()` external through `createRequire`:
 
 ```js
 import { createRequire as __rspack_createRequire } from 'node:module';

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -561,9 +561,7 @@ export default {
 
 对于静态 ESM import，Rspack 会像 [`'module'`](#externalstypemodule) 一样渲染 external，生成静态 `import` 语句。对于动态 `import()`，Rspack 会像 [`'module-import'`](#externalstypemodule-import) 一样渲染 external，生成 `import()`。
 
-对于 CommonJS `require()`，Rspack 当前会像 [`'node-commonjs'`](#externalstypenode-commonjs) 一样渲染 external，在生成的 ESM 产物中通过 `createRequire` 构造 `require` 函数。
-
-这意味着 `modern-module` 暂时不会为 `require()` 依赖区分不同的 CommonJS external 变体。特别是，当前还没有提供在生成的 ESM 产物中保留裸 `require()` 调用的变体。
+对于 CommonJS `require()`，Rspack 会根据 target 选择 CommonJS external 变体。Node-like target 会像 [`'node-commonjs'`](#externalstypenode-commonjs) 一样渲染 external，在生成的 ESM 产物中通过 `createRequire` 构造 `require` 函数。其他 target 会像 [`'commonjs'`](#externalstypecommonjs) 一样渲染 external，保留裸 `require()` 调用。
 
 **示例**
 
@@ -596,7 +594,7 @@ export default {
 };
 ```
 
-生成的 ESM 产物会保留静态 import 为 `import` 语句，保留动态 import 为 `import()`，并通过 `createRequire` 渲染 `require()` external：
+因为这个示例的 target 是 Node.js，生成的 ESM 产物会保留静态 import 为 `import` 语句，保留动态 import 为 `import()`，并通过 `createRequire` 渲染 `require()` external：
 
 ```js
 import { createRequire as __rspack_createRequire } from 'node:module';


### PR DESCRIPTION
## What

- Thread a `fallbackType` option through `ExternalsPlugin` so `externalsType: 'modern-module'` can choose the final CommonJS external variant before rendering.
- Use `node-commonjs` for Node-like targets and `commonjs` for other targets when a `modern-module` external is reached through CommonJS `require()`.
- Update the web modern-module external test and EN/ZH externals docs to describe the target-dependent behavior.

## Why

`modern-module` already resolves static ESM imports as `module` and dynamic imports as `module-import`, but require-style dependencies were collapsed to one CommonJS rendering path. That made web-like targets emit `createRequire`, even though the target decision is known earlier from the normalized target presets.

## How

- Store the resolved CommonJS fallback type in dependency metadata as `ExternalTypeEnum::CommonJs(ExternalType)`.
- Choose the fallback in the JS options apply path from `externalsPresets`, and in the Rust builder path from target properties.
- Keep rendering logic simple: `ExternalModule::resolve_external_type()` only consumes the already-resolved fallback type.

## Validation

- `corepack pnpm run build:binding:dev`
- `corepack pnpm run build:js`
- `corepack pnpm --dir tests/rspack-test run test -- -t modern-module-explicit-web`
- `corepack pnpm --dir tests/rspack-test run test -- -t modern-module-explicit-node`
- `corepack pnpm --dir tests/rspack-test exec rstest esm`
- `cargo check -p rspack`
- `cargo fmt --all --check`
- `git diff --check`