### PR TITLE
fix: update peer dependency of @swc/helpers to ^0.5.23

### DIFF
--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -41,7 +41,7 @@
     "webpack-sources": "3.3.4"
   },
   "peerDependencies": {
-    "@swc/helpers": ">=0.5.1"
+    "@swc/helpers": "^0.5.23"
   },
   "peerDependenciesMeta": {
     "@swc/helpers": {

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0",
-    "@swc/helpers": ">=0.5.1"
+    "@swc/helpers": "^0.5.23"
   },
   "peerDependenciesMeta": {
     "@module-federation/runtime-tools": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,8 +549,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@rspack/core@packages+rspack)(react-refresh@0.18.0)
       '@swc/helpers':
-        specifier: 0.5.21
-        version: 0.5.21
+        specifier: 0.5.23
+        version: 0.5.23
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
@@ -651,8 +651,8 @@ importers:
         specifier: ^0.9.10
         version: 0.9.10(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(jsdom@26.1.0)
       '@swc/helpers':
-        specifier: 0.5.21
-        version: 0.5.21
+        specifier: 0.5.23
+        version: 0.5.23
       '@swc/plugin-remove-console':
         specifier: ^12.9.0
         version: 12.9.0
@@ -3044,6 +3044,9 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/plugin-remove-console@12.9.0':
     resolution: {integrity: sha512-Ve64fWHghdhMHMYAmKlIdyV0aIbj8PX6mlUwXyf1dJXsBirkDm3HYtGw+XIpyNtIUfg1Rojyqc+TXATrqgRdhg==}
@@ -8953,8 +8956,8 @@ snapshots:
 
   '@rsbuild/core@2.0.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
-      '@swc/helpers': 0.5.21
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
     optionalDependencies:
       core-js: 3.49.0
     transitivePeerDependencies:
@@ -9121,6 +9124,13 @@ snapshots:
       '@module-federation/runtime-tools': 2.5.0
       '@swc/helpers': 0.5.21
 
+  '@rspack/core@2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.4
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.0
+      '@swc/helpers': 0.5.23
+
   '@rspack/dev-middleware@2.0.1(@rspack/core@packages+rspack)':
     optionalDependencies:
       '@rspack/core': link:packages/rspack
@@ -9141,7 +9151,7 @@ snapshots:
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   '@rspack/plugin-react-refresh@2.0.0(@rspack/core@packages+rspack)(react-refresh@0.18.0)':
     dependencies:
@@ -9349,6 +9359,10 @@ snapshots:
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -16,7 +16,7 @@
     "@rspack/dev-server": "^2.0.1",
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@module-federation/runtime-tools": "2.5.0",
-    "@swc/helpers": "0.5.21",
+    "@swc/helpers": "0.5.23",
     "@types/fs-extra": "11.0.4",
     "babel-loader": "^10.1.1",
     "fs-extra": "^11.3.5",

--- a/tests/rspack-test/package.json
+++ b/tests/rspack-test/package.json
@@ -25,7 +25,7 @@
     "@rspack/plugin-react-refresh": "^2.0.0",
     "@rspack/test-tools": "workspace:*",
     "@rstest/core": "^0.9.10",
-    "@swc/helpers": "0.5.21",
+    "@swc/helpers": "0.5.23",
     "@swc/plugin-remove-console": "^12.9.0",
     "@types/babel__generator": "7.27.0",
     "@types/babel__traverse": "7.28.0",


### PR DESCRIPTION
## What

Update the optional `@swc/helpers` peer dependency range for `@rspack/core` and `@rspack/browser` to `^0.5.23`.

Also update the workspace test dependencies and `pnpm-lock.yaml` to resolve `@swc/helpers@0.5.23`.

## Why

`@swc/helpers@0.5.22` contains a decorator helper regression in `_apply_decs_2203_r`. The fixed helper version has been released as `0.5.23`, so Rspack should require users to resolve at least that version for the current SWC decorator output.

## How

- Changed the optional peer range from `>=0.5.1` to `^0.5.23` in `packages/rspack` and `packages/rspack-browser`.
- Updated test workspace helper dependencies to `0.5.23`.
- Regenerated the lockfile entry for `@swc/helpers@0.5.23`.

## Checks

- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --config.minimumReleaseAge=0`
- `pnpm run check-dependency-version`
- `git diff --check`