### PR TITLE
fix: resolve external type in esm rendering

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -701,8 +701,7 @@ impl EsmLibraryPlugin {
                   if let Some(ext) = module_graph
                     .module_by_identifier(&symbol_binding.module)
                     .and_then(|m| m.as_external_module())
-                    && (ext.get_external_type().as_str().starts_with("module")
-                      || ext.resolve_external_type() == "module")
+                    && ext.resolve_external_type() == "module"
                   {
                     let Some((raw_import_source, import_binding)) = concate_modules_map
                       .get(&symbol_binding.module)

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -757,6 +757,8 @@ async fn after_factorize(
   // Check if this is an external module using the existing downcast helper
   if let Some(external_module) = module.as_external_module_mut()
     && external_module.resolve_external_type() == "module"
+    && (external_module.get_external_type() != "modern-module"
+      || data.dependencies.first().is_some_and(is_esm_dep_like))
   {
     // If there's an issuer, append it to the module id
     if let Some(issuer_identifier) = &data.issuer_identifier {

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -756,9 +756,7 @@ async fn after_factorize(
 ) -> Result<()> {
   // Check if this is an external module using the existing downcast helper
   if let Some(external_module) = module.as_external_module_mut()
-    && (external_module.get_external_type().starts_with("module")
-      || (external_module.get_external_type() == "modern-module"
-        && data.dependencies.first().is_some_and(is_esm_dep_like)))
+    && external_module.resolve_external_type() == "module"
   {
     // If there's an issuer, append it to the module id
     if let Some(issuer_identifier) = &data.issuer_identifier {

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -45,8 +45,7 @@ pub fn cutout_star_re_export_externals(
       let Some(external_module) = module.as_external_module() else {
         continue;
       };
-      let external_type = external_module.get_external_type().as_str();
-      if !external_type.starts_with("module") {
+      if external_module.resolve_external_type() != "module" {
         continue;
       }
 
@@ -268,7 +267,8 @@ impl DependencyTemplate for ExportImportedDependencyTemplate {
       && let Some(module) = module
         .and_then(|mid| mg.module_by_identifier(mid))
         .and_then(|m| {
-          m.as_external_module().filter(|&m| m.get_external_type().starts_with("module"))
+          m.as_external_module()
+            .filter(|&m| m.resolve_external_type() == "module")
         })
       // TODO: should cache calculate results for this
       && code_generatable_context

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/__snapshots__/esm.snap.txt
@@ -1,0 +1,8 @@
+```mjs title=main.mjs
+export * from "externals";
+// ./index.js
+
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/index.js
@@ -1,0 +1,1 @@
+export * from "externals";

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/rspack.config.js
@@ -1,0 +1,11 @@
+const {
+  experiments: { RslibPlugin },
+} = require('@rspack/core');
+
+module.exports = {
+  externalsType: 'modern-module',
+  externals: {
+    externals: 'externals',
+  },
+  plugins: [new RslibPlugin()],
+};

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-star-reexport-rslib/test.config.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const path = require("path");
+
+function readOutput(options) {
+  return fs
+    .readdirSync(options.output.path)
+    .filter(file => file.endsWith(".mjs"))
+    .map(file => fs.readFileSync(path.join(options.output.path, file), "utf-8"))
+    .join("\n");
+}
+
+module.exports = {
+  findBundle() {
+    return [];
+  },
+  afterExecute(options) {
+    const source = readOutput(options);
+
+    expect(source).toContain('export * from "externals";');
+    expect(source).not.toContain("__webpack_require__");
+  },
+};

--- a/tests/rspack-test/esmOutputCases/externals/namespace-name-collision-across-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/namespace-name-collision-across-modules/__snapshots__/esm.snap.txt
@@ -1,5 +1,5 @@
 ```mjs title=fs.mjs
-// fs?a6ed
+// fs?78e7
 const external_fs_namespaceObject = import("fs").then(function(module) { return module; });
 var readFile = external_fs_namespaceObject.readFile;
 var readFileSync = external_fs_namespaceObject.readFileSync;
@@ -47,7 +47,7 @@ export { readFile, readFileSync } from "fs";
 ```
 
 ```mjs title=path.mjs
-// path?3687
+// path?5fdd
 const external_path_namespaceObject = import("path").then(function(module) { return module; });
 var join = external_path_namespaceObject.join;
 var sep = external_path_namespaceObject.sep;


### PR DESCRIPTION
## What

Use `resolve_external_type()` when ESM library and Rslib external rendering need to decide whether an external should be treated as a module external.

This updates the ESM library issuer disambiguation path, the ESM link import path, and Rslib's star re-export external cutout/render path. It also adds an ESM output regression case for `export * from "externals"` with `externalsType: "modern-module"` and `RslibPlugin`.

## Why

`get_external_type()` only reflects the configured external type, so `modern-module` and `module-import` can be classified incorrectly without considering the actual dependency kind. Static ESM externals should resolve to `module`, while dynamic imports and CommonJS dependencies should keep their resolved behavior.

## How

- Replace module-like checks based on `get_external_type().starts_with("module")` with `resolve_external_type() == "module"`.
- Add `esmOutputCases/externals/modern-module-star-reexport-rslib` to verify the output preserves `export * from "externals"`.
- Refresh the affected `module-import` namespace collision snapshot after the resolved-type behavior changes the async chunk query hash.

## Validation

- `cargo fmt --all --check`
- `corepack pnpm run build:binding:dev`
- `corepack pnpm --dir tests/rspack-test run test -t "modern-module-star-reexport-rslib"`
- `corepack pnpm --dir tests/rspack-test run test -t "esmOutputCases/externals"`