### PR TITLE
fix: respect resolved external type in ESM rendering

### DIFF
--- a/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
+++ b/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
@@ -3,8 +3,9 @@ use std::{borrow::Cow, sync::Arc};
 use atomic_refcell::AtomicRefCell;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  Dependency, DependencyId, DependencyTemplate, ExportsType, FakeNamespaceObjectMode, ModuleGraph,
-  ModuleReferenceOptions, RuntimeGlobals, TemplateContext, get_exports_type,
+  Dependency, DependencyId, DependencyTemplate, ExportsType, ExternalModule,
+  FakeNamespaceObjectMode, ModuleGraph, ModuleReferenceOptions, RuntimeGlobals, TemplateContext,
+  get_exports_type, property_access,
 };
 use rspack_plugin_javascript::dependency::ImportDependency;
 use rspack_plugin_rslib::dyn_import_external::render_dyn_import_external_module;
@@ -95,6 +96,104 @@ fn then_expr(
   appending
 }
 
+fn get_fake_namespace_object_mode(
+  code_generatable_context: &TemplateContext,
+  dep_id: &DependencyId,
+) -> FakeNamespaceObjectMode {
+  let exports_type = get_exports_type(
+    code_generatable_context.compilation.get_module_graph(),
+    &code_generatable_context
+      .compilation
+      .module_graph_cache_artifact,
+    &code_generatable_context.compilation.exports_info_artifact,
+    dep_id,
+    &code_generatable_context.module.identifier(),
+  );
+  let mut fake_type = FakeNamespaceObjectMode::PROMISE_LIKE;
+  if matches!(exports_type, ExportsType::Dynamic) {
+    fake_type |= FakeNamespaceObjectMode::RETURN_VALUE;
+  }
+  if matches!(
+    exports_type,
+    ExportsType::DefaultWithNamed | ExportsType::Dynamic
+  ) {
+    fake_type |= FakeNamespaceObjectMode::MERGE_PROPERTIES;
+  }
+  fake_type
+}
+
+fn render_lazy_require_external_import(
+  create_fake_namespace_object: &str,
+  request_expr: &str,
+  properties: &str,
+  fake_type: FakeNamespaceObjectMode,
+) -> String {
+  format!(
+    "Promise.resolve().then(function() {{ return {create_fake_namespace_object}(require({request_expr}){properties}, {fake_type}) }})"
+  )
+}
+
+fn render_lazy_create_require_external_import(
+  code_generatable_context: &TemplateContext,
+  create_fake_namespace_object: &str,
+  request_expr: &str,
+  properties: &str,
+  fake_type: FakeNamespaceObjectMode,
+) -> String {
+  let need_prefix = code_generatable_context
+    .compilation
+    .options
+    .output
+    .environment
+    .supports_node_prefix_for_core_modules();
+  let import_meta_name = &code_generatable_context
+    .compilation
+    .options
+    .output
+    .import_meta_name;
+  let module_request =
+    rspack_util::json_stringify_str(if need_prefix { "node:module" } else { "module" });
+
+  format!(
+    "import({module_request}).then(function(module) {{ return {create_fake_namespace_object}(module.createRequire({import_meta_name}.url)({request_expr}){properties}, {fake_type}) }})"
+  )
+}
+
+fn render_lazy_commonjs_external_import(
+  code_generatable_context: &mut TemplateContext,
+  external_module: &ExternalModule,
+  fake_type: FakeNamespaceObjectMode,
+) -> Option<String> {
+  let request = external_module.get_request();
+  let request_expr = rspack_util::json_stringify_str(request.primary());
+  let properties = property_access(request.iter(), 1);
+  let create_fake_namespace_object = code_generatable_context
+    .runtime_template
+    .render_runtime_globals(&RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
+
+  match external_module.resolve_external_type() {
+    "commonjs" | "commonjs2" | "commonjs-module" | "commonjs-static" | "node-commonjs" => {
+      if code_generatable_context.compilation.options.output.module {
+        Some(render_lazy_create_require_external_import(
+          code_generatable_context,
+          &create_fake_namespace_object,
+          &request_expr,
+          &properties,
+          fake_type,
+        ))
+      } else {
+        Some(render_lazy_require_external_import(
+          &create_fake_namespace_object,
+          &request_expr,
+          &properties,
+          fake_type,
+        ))
+      }
+    }
+    _ => None,
+  }
+}
+
 #[derive(Debug)]
 pub struct DynamicImportDependencyTemplate {
   /// module_id → namespace export name in the chunk.
@@ -136,9 +235,25 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
       return;
     };
 
-    if let Some(external_module) = ref_module.as_external_module() {
+    if let Some(external_module) = ref_module.as_external_module()
+      && matches!(external_module.resolve_external_type(), "import" | "module")
+    {
       render_dyn_import_external_module(import_dep, external_module, source);
       return;
+    }
+    if let Some(external_module) = ref_module.as_external_module() {
+      let fake_type = get_fake_namespace_object_mode(code_generatable_context, dep_id);
+      if let Some(external_import) =
+        render_lazy_commonjs_external_import(code_generatable_context, external_module, fake_type)
+      {
+        source.replace(
+          import_dep.range.start,
+          import_dep.range.end,
+          external_import,
+          None,
+        );
+        return;
+      }
     }
 
     let ref_chunk_ukey = match EsmLibraryPlugin::get_module_chunk(

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -2132,6 +2132,9 @@ var {} = {{}};
         .expect("should have module")
         .as_external_module()
         .expect("should be external module");
+      if external_module.resolve_external_type() != "module" {
+        continue;
+      }
       entry_chunk_link
         .raw_star_exports
         .entry(external_module.get_request().primary().into())

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -29,6 +29,7 @@ use rspack_plugin_javascript::{
   JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
   dependency::ImportDependencyTemplate, parser_and_generator::JavaScriptParserAndGenerator,
 };
+use rspack_plugin_rslib::dyn_import_external::cutout_dyn_import_externals;
 use rspack_plugin_split_chunks::CacheGroup;
 use rspack_util::{
   atom::Atom,
@@ -874,6 +875,12 @@ async fn optimize_dependencies(
   exports_info_artifact: &mut ExportsInfoArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
+  cutout_dyn_import_externals(
+    false,
+    compilation.options.output.module,
+    build_module_graph_artifact,
+  );
+
   self
     .mark_modules(
       compilation,

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -132,7 +132,11 @@ pub fn cutout_star_re_export_externals(
   }
 }
 
-pub fn cutout_dyn_import_externals(build_module_graph_artifact: &mut BuildModuleGraphArtifact) {
+pub fn cutout_dyn_import_externals(
+  cutout_all_externals: bool,
+  output_module: bool,
+  build_module_graph_artifact: &mut BuildModuleGraphArtifact,
+) {
   let mg = build_module_graph_artifact.get_module_graph();
   let mut connections_to_disable = Vec::new();
   for (_, module) in mg.modules() {
@@ -152,7 +156,24 @@ pub fn cutout_dyn_import_externals(build_module_graph_artifact: &mut BuildModule
               continue;
             };
 
-            if import_module.as_external_module().is_some() {
+            if import_module.as_external_module().is_some_and(|external| {
+              if cutout_all_externals {
+                return true;
+              }
+              if !output_module {
+                return true;
+              }
+              matches!(
+                external.resolve_external_type(),
+                "import"
+                  | "module"
+                  | "commonjs"
+                  | "commonjs2"
+                  | "commonjs-module"
+                  | "commonjs-static"
+                  | "node-commonjs"
+              )
+            }) {
               // remove connection of dyn-import external module
               connections_to_disable.push(*block_dep_id);
             }

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -314,7 +314,11 @@ async fn optimize_dependencies(
   exports_info_artifact: &mut ExportsInfoArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
-  cutout_dyn_import_externals(build_module_graph_artifact);
+  cutout_dyn_import_externals(
+    true,
+    compilation.options.output.module,
+    build_module_graph_artifact,
+  );
   cutout_star_re_export_externals(
     compilation,
     build_module_graph_artifact,

--- a/tests/rspack-test/configCases/library/modern-module-dynamic-import-runtime/rspack.config.js
+++ b/tests/rspack-test/configCases/library/modern-module-dynamic-import-runtime/rspack.config.js
@@ -16,7 +16,7 @@ const basic = {
     angular: 'angular-alias',
     svelte: 'svelte-alias',
     lit: 'lit-alias',
-    solid: 'solid-alias',
+    solid: 'module solid-alias',
     jquery: 'jquery-alias',
   },
   externalsType: 'module-import',

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
@@ -36,12 +36,10 @@ export default dynamic_default_0;
 ```mjs title=main.mjs
 import { __webpack_require__ } from "./runtime.mjs";
 
-import { createRequire as __rspack_createRequire } from "node:module";
-const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 // ./index.js
 it("should split runtime for Promise.all with external and bundled async chunks", async () => {
 	const [stream, mod] = await Promise.all([
-		import("node:stream"),
+		import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("node:stream"), 22) }),
 		import("./dynamic.mjs").then(__webpack_require__.t.bind(__webpack_require__, /*! ./dynamic */ "./dynamic.js", 19)),
 	]);
 
@@ -49,8 +47,6 @@ it("should split runtime for Promise.all with external and bundled async chunks"
 	expect(mod.value).toBe(42);
 });
 
-// node:stream
-const external_node_stream_namespaceObject = __rspack_createRequire_require("node:stream");
 export {};
 
 ```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/test.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/test.config.js
@@ -15,7 +15,9 @@ module.exports = {
 		);
 		expect(entry).toContain('import { __webpack_require__ } from "./runtime.mjs";');
 		expect(entry).toContain("Promise.all");
-		expect(entry).toContain('import("node:stream")');
+		expect(entry).toContain(
+			'__webpack_require__.t(module.createRequire(import.meta.url)("node:stream"), 22)'
+		);
 		expect(entry).toContain('import("./dynamic.mjs")');
 		expect(runtime).toContain("export { __webpack_require__");
 		expect(entry).not.toContain("export { __webpack_require__");

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-external/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-external/index.js
@@ -1,0 +1,10 @@
+export async function loadPlatform() {
+	const os = await import("os");
+	return [os.platform, os.default.platform];
+}
+
+it("should wrap commonjs dynamic external as a namespace object", async () => {
+	const [platform, defaultPlatform] = await loadPlatform();
+
+	expect(platform).toBe(defaultPlatform);
+});

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-external/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-external/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  externals: {
+    os: 'commonjs os',
+  },
+};

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-external/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-external/test.config.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const path = require("path");
+
+function readOutput(options) {
+	return fs
+		.readdirSync(options.output.path)
+		.filter(file => file.endsWith(".mjs"))
+		.map(file => fs.readFileSync(path.join(options.output.path, file), "utf-8"))
+		.join("\n");
+}
+
+module.exports = {
+	findBundle() {
+		return [];
+	},
+	snapshotFileFilter() {
+		return false;
+	},
+	afterExecute(options) {
+		const source = readOutput(options);
+
+		expect(source).not.toMatch(/import\s*\(\s*["']os["']\s*\)/);
+		expect(source).toMatch(/module\.createRequire\(import\.meta\.url\)\(\s*["']os["']\s*\)/);
+		expect(source).not.toContain("external_os_namespaceObject");
+		expect(source).not.toContain("Promise.resolve(external_os_namespaceObject)");
+		expect(source).not.toContain('__webpack_require__.t(require("os"), 22)');
+		expect(source).toContain(
+			'__webpack_require__.t(module.createRequire(import.meta.url)("os"), 22)'
+		);
+	}
+};

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/__snapshots__/esm.snap.txt
@@ -1,31 +1,31 @@
 ```mjs title=main.mjs
-import { resolve } from "path";
 import { __webpack_require__ } from "./runtime.mjs";
 
-// path
-
-// fs
-
 // ./index.js
+const index_require = () => {
+	throw new Error("user require should not be called");
+};
 
+import.meta.__customImport__ = async request => {
+	throw new Error(`custom import should not load ${request}`);
+};
 
+async function loadPlatform(require) {
+	const os = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("os"), 22) });
+	return [typeof os.platform, typeof os.default.platform, require];
+}
 
-it("should externalize node builtins with correct external types", async () => {
-	const main = await import(/* webpackIgnore: true */ "./main.mjs");
-	const nodePath = await import(/* webpackIgnore: true */ "path");
-	const nodeFs = await import(/* webpackIgnore: true */ "fs");
-
-	// esm import should use "module" external type
-	expect(resolve).toBe(nodePath.resolve);
-	// esm re-export should use "module" external type
-	expect(main.readFileSync).toBe(nodeFs.readFileSync);
-
-	// dynamic import should use "import" external type
-	const dynamicOs = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("os"), 22) });
-	expect(dynamicOs.platform).toBeDefined();
+it("should not capture user require for commonjs dynamic external", async () => {
+	expect(await loadPlatform("local-require")).toEqual([
+		"function",
+		"function",
+		"local-require"
+	]);
 });
 
-export { readFileSync } from "fs";
+
+
+export { index_require as userRequire, loadPlatform };
 
 ```
 

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/index.js
@@ -1,0 +1,22 @@
+const require = () => {
+	throw new Error("user require should not be called");
+};
+
+import.meta.__customImport__ = async request => {
+	throw new Error(`custom import should not load ${request}`);
+};
+
+export async function loadPlatform(require) {
+	const os = await import("os");
+	return [typeof os.platform, typeof os.default.platform, require];
+}
+
+it("should not capture user require for commonjs dynamic external", async () => {
+	expect(await loadPlatform("local-require")).toEqual([
+		"function",
+		"function",
+		"local-require"
+	]);
+});
+
+export { require as userRequire };

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/rspack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  output: {
+    importFunctionName: 'import.meta.__customImport__',
+  },
+  externals: {
+    os: 'commonjs os',
+  },
+};

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-commonjs-require-collision/test.config.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	afterExecute(options) {
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8"
+		);
+
+		expect(source).toContain("user require should not be called");
+		expect(source).toContain("async function loadPlatform(require)");
+		expect(source).toContain('import("node:module").then');
+		expect(source).not.toContain('import.meta.__customImport__("node:module")');
+		expect(source).toContain('module.createRequire(import.meta.url)("os")');
+		expect(source).not.toContain('__webpack_require__.t(require("os"), 22)');
+	}
+};

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/__snapshots__/esm.snap.txt
@@ -1,31 +1,30 @@
 ```mjs title=main.mjs
-import { resolve } from "path";
 import { __webpack_require__ } from "./runtime.mjs";
 
-// path
-
-// fs
-
 // ./index.js
+const __rspack_createRequire = "local-createRequire";
+const __rspack_createRequire_require = "local-require";
 
+async function loadFs() {
+	const fs = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("fs"), 22) });
+	return [
+		typeof fs.readFile,
+		typeof fs.default.readFile,
+		__rspack_createRequire,
+		__rspack_createRequire_require
+	];
+}
 
-
-it("should externalize node builtins with correct external types", async () => {
-	const main = await import(/* webpackIgnore: true */ "./main.mjs");
-	const nodePath = await import(/* webpackIgnore: true */ "path");
-	const nodeFs = await import(/* webpackIgnore: true */ "fs");
-
-	// esm import should use "module" external type
-	expect(resolve).toBe(nodePath.resolve);
-	// esm re-export should use "module" external type
-	expect(main.readFileSync).toBe(nodeFs.readFileSync);
-
-	// dynamic import should use "import" external type
-	const dynamicOs = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("os"), 22) });
-	expect(dynamicOs.platform).toBeDefined();
+it("should keep lazy node-commonjs helper names from colliding", async () => {
+	expect(await loadFs()).toEqual([
+		"function",
+		"function",
+		"local-createRequire",
+		"local-require"
+	]);
 });
 
-export { readFileSync } from "fs";
+export { loadFs };
 
 ```
 

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/index.js
@@ -1,0 +1,21 @@
+const __rspack_createRequire = "local-createRequire";
+const __rspack_createRequire_require = "local-require";
+
+export async function loadFs() {
+	const fs = await import("fs");
+	return [
+		typeof fs.readFile,
+		typeof fs.default.readFile,
+		__rspack_createRequire,
+		__rspack_createRequire_require
+	];
+}
+
+it("should keep lazy node-commonjs helper names from colliding", async () => {
+	expect(await loadFs()).toEqual([
+		"function",
+		"function",
+		"local-createRequire",
+		"local-require"
+	]);
+});

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  externals: {
+    fs: 'node-commonjs fs',
+  },
+};

--- a/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/dynamic-import-node-commonjs-helper-collision/test.config.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	afterExecute(options) {
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8"
+		);
+
+		expect(source).toContain('const __rspack_createRequire = "local-createRequire";');
+		expect(source).toContain(
+			'const __rspack_createRequire_require = "local-require";'
+		);
+		expect(source).not.toContain(
+			"import { createRequire as __rspack_createRequire }"
+		);
+		expect(source).toContain('import("node:module").then');
+		expect(source).toContain('module.createRequire(import.meta.url)("fs")');
+	}
+};

--- a/tests/rspack-test/esmOutputCases/externals/namespace-name-collision-across-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/namespace-name-collision-across-modules/__snapshots__/esm.snap.txt
@@ -1,22 +1,12 @@
-```mjs title=fs.mjs
-// fs?78e7
-const external_fs_namespaceObject = import("fs").then(function(module) { return module; });
-var readFile = external_fs_namespaceObject.readFile;
-var readFileSync = external_fs_namespaceObject.readFileSync;
-export { readFile, readFileSync };
-export * from "fs";
-
-```
-
 ```mjs title=main.mjs
 import * as __rspack_external_path from "path";
 
-// fs?bba3
+// fs
 
 // ./named.js
 
 
-// path?6f35
+// path
 
 // ./path-ns.js
 
@@ -43,15 +33,5 @@ it("should deconflict concatenated namespace imports that match generated module
 
 export { __rspack_external_path as pathNs, joinFn };
 export { readFile, readFileSync } from "fs";
-
-```
-
-```mjs title=path.mjs
-// path?5fdd
-const external_path_namespaceObject = import("path").then(function(module) { return module; });
-var join = external_path_namespaceObject.join;
-var sep = external_path_namespaceObject.sep;
-export { join, sep };
-export * from "path";
 
 ```

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-export-namespace-as-with-named/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-export-namespace-as-with-named/__snapshots__/esm.snap.txt
@@ -1,4 +1,6 @@
 ```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 // fs
@@ -9,7 +11,7 @@ const external_fs_namespaceObject = __rspack_createRequire_require("fs");
 
 it("should combine node-commonjs export-star-as and named exports for the same source", async () => {
   const mod = await import(/* webpackIgnore: true */ "./main.mjs");
-  const { createRequire } = await import("node:module");
+  const { createRequire } = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("node:module"), 22) });
   const require = createRequire('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-export-namespace-as-with-named/index.js');
   const fs = require("fs");
 
@@ -19,10 +21,74 @@ it("should combine node-commonjs export-star-as and named exports for the same s
   expect(mod.fsNs.readFileSync).toBe(fs.readFileSync);
 });
 
-// node:module
-const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
 var readFile = external_fs_namespaceObject.readFile;
 var readFileSync = external_fs_namespaceObject.readFileSync;
 export { external_fs_namespaceObject as fsNs, readFile, readFileSync };
+
+```
+
+```mjs title=runtime.mjs
+// The require scope
+var __webpack_require__ = {};
+
+// webpack/runtime/create_fake_namespace_object
+(() => {
+var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+var leafPrototypes;
+// create a fake namespace object
+// mode & 1: value is a module id, require it
+// mode & 2: merge all properties of value into the ns
+// mode & 4: return value when already ns object
+// mode & 16: return value when it's Promise-like
+// mode & 8|1: behave like require
+__webpack_require__.t = function(value, mode) {
+	if(mode & 1) value = this(value);
+	if(mode & 8) return value;
+	if(typeof value === 'object' && value) {
+		if((mode & 4) && value.__esModule) return value;
+		if((mode & 16) && typeof value.then === 'function') return value;
+	}
+	var ns = Object.create(null);
+  __webpack_require__.r(ns);
+	var def = {};
+	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+	}
+	def['default'] = () => (value);
+	__webpack_require__.d(ns, def);
+	return ns;
+};
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-import-namespace-reexport-with-named/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-import-namespace-reexport-with-named/__snapshots__/esm.snap.txt
@@ -1,4 +1,6 @@
 ```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 // fs
@@ -11,7 +13,7 @@ const external_fs_namespaceObject = __rspack_createRequire_require("fs");
 
 it("should re-export an imported node-commonjs namespace alongside named exports from the same source", async () => {
   const mod = await import(/* webpackIgnore: true */ "./main.mjs");
-  const { createRequire } = await import("node:module");
+  const { createRequire } = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("node:module"), 22) });
   const require = createRequire('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-import-namespace-reexport-with-named/index.js');
   const fs = require("fs");
 
@@ -21,10 +23,74 @@ it("should re-export an imported node-commonjs namespace alongside named exports
   expect(mod.fsNs.readFileSync).toBe(fs.readFileSync);
 });
 
-// node:module
-const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
 var readFile = external_fs_namespaceObject.readFile;
 var readFileSync = external_fs_namespaceObject.readFileSync;
 export { external_fs_namespaceObject as fsNs, readFile, readFileSync };
+
+```
+
+```mjs title=runtime.mjs
+// The require scope
+var __webpack_require__ = {};
+
+// webpack/runtime/create_fake_namespace_object
+(() => {
+var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+var leafPrototypes;
+// create a fake namespace object
+// mode & 1: value is a module id, require it
+// mode & 2: merge all properties of value into the ns
+// mode & 4: return value when already ns object
+// mode & 16: return value when it's Promise-like
+// mode & 8|1: behave like require
+__webpack_require__.t = function(value, mode) {
+	if(mode & 1) value = this(value);
+	if(mode & 8) return value;
+	if(typeof value === 'object' && value) {
+		if((mode & 4) && value.__esModule) return value;
+		if((mode & 16) && typeof value.then === 'function') return value;
+	}
+	var ns = Object.create(null);
+  __webpack_require__.r(ns);
+	var def = {};
+	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+	}
+	def['default'] = () => (value);
+	__webpack_require__.d(ns, def);
+	return ns;
+};
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-namespace-name-collision-across-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-namespace-name-collision-across-modules/__snapshots__/esm.snap.txt
@@ -1,4 +1,6 @@
 ```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 // fs
@@ -23,7 +25,7 @@ const joinFn = Reflect.get(external_path_namespaceObject, "join");
 
 it("should deconflict concatenated namespace imports that match generated node-commonjs names", async () => {
   const mod = await import(/* webpackIgnore: true */ "./main.mjs");
-  const { createRequire } = await import("node:module");
+  const { createRequire } = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("node:module"), 22) });
   const require = createRequire('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-namespace-name-collision-across-modules/index.js');
   const fs = require("fs");
   const path = require("path");
@@ -35,10 +37,74 @@ it("should deconflict concatenated namespace imports that match generated node-c
   expect(mod.joinFn).toBe(path.join);
 });
 
-// node:module
-const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
 var readFile = external_fs_namespaceObject.readFile;
 var readFileSync = external_fs_namespaceObject.readFileSync;
 export { external_path_namespaceObject as pathNs, joinFn, readFile, readFileSync };
+
+```
+
+```mjs title=runtime.mjs
+// The require scope
+var __webpack_require__ = {};
+
+// webpack/runtime/create_fake_namespace_object
+(() => {
+var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+var leafPrototypes;
+// create a fake namespace object
+// mode & 1: value is a module id, require it
+// mode & 2: merge all properties of value into the ns
+// mode & 4: return value when already ns object
+// mode & 16: return value when it's Promise-like
+// mode & 8|1: behave like require
+__webpack_require__.t = function(value, mode) {
+	if(mode & 1) value = this(value);
+	if(mode & 8) return value;
+	if(typeof value === 'object' && value) {
+		if((mode & 4) && value.__esModule) return value;
+		if((mode & 16) && typeof value.then === 'function') return value;
+	}
+	var ns = Object.create(null);
+  __webpack_require__.r(ns);
+	var def = {};
+	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+	}
+	def['default'] = () => (value);
+	__webpack_require__.d(ns, def);
+	return ns;
+};
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/__snapshots__/esm.snap.txt
@@ -1,5 +1,6 @@
 ```mjs title=main.mjs
 import { __webpack_require__ } from "./runtime.mjs";
+
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
 // NAMESPACE OBJECT: ./exports.js
@@ -22,7 +23,7 @@ const index_js_namespaceObject = __rspack_createRequire_require("webpack-sources
 
 it("should keep a node-commonjs external wrapper on the require path only", async () => {
   const mod = await import(/* webpackIgnore: true */ "./main.mjs");
-  const { createRequire } = await import("node:module");
+  const { createRequire } = await import("node:module").then(function(module) { return __webpack_require__.t(module.createRequire(import.meta.url)("node:module"), 22) });
   const require = createRequire('<ROOT>/tests/rspack-test/esmOutputCases/externals/node-commonjs-wrapper-namespace-reexport/index.js');
   const sources = require("webpack-sources/lib/index.js");
 
@@ -31,8 +32,6 @@ it("should keep a node-commonjs external wrapper on the require path only", asyn
   expect(mod.exportsNS.sources.RawSource).toBe(mod.sources.RawSource);
 });
 
-// node:module
-const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
 export { exports_namespaceObject as exportsNS, index_js_namespaceObject as sources };
 
 ```
@@ -41,6 +40,35 @@ export { exports_namespaceObject as exportsNS, index_js_namespaceObject as sourc
 // The require scope
 var __webpack_require__ = {};
 
+// webpack/runtime/create_fake_namespace_object
+(() => {
+var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
+var leafPrototypes;
+// create a fake namespace object
+// mode & 1: value is a module id, require it
+// mode & 2: merge all properties of value into the ns
+// mode & 4: return value when already ns object
+// mode & 16: return value when it's Promise-like
+// mode & 8|1: behave like require
+__webpack_require__.t = function(value, mode) {
+	if(mode & 1) value = this(value);
+	if(mode & 8) return value;
+	if(typeof value === 'object' && value) {
+		if((mode & 4) && value.__esModule) return value;
+		if((mode & 16) && typeof value.then === 'function') return value;
+	}
+	var ns = Object.create(null);
+  __webpack_require__.r(ns);
+	var def = {};
+	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
+	}
+	def['default'] = () => (value);
+	__webpack_require__.d(ns, def);
+	return ns;
+};
+})();
 // webpack/runtime/define_property_getters
 (() => {
 __webpack_require__.d = (exports, getters, values) => {

--- a/tests/rspack-test/esmOutputCases/externals/star-reexport-commonjs-external/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/star-reexport-commonjs-external/index.js
@@ -1,0 +1,4 @@
+export * from "fs";
+
+export const value = 42;
+

--- a/tests/rspack-test/esmOutputCases/externals/star-reexport-commonjs-external/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/star-reexport-commonjs-external/rspack.config.js
@@ -1,0 +1,10 @@
+const {
+  experiments: { RslibPlugin },
+} = require('@rspack/core');
+
+module.exports = {
+  externals: {
+    fs: 'commonjs fs',
+  },
+  plugins: [new RslibPlugin()],
+};

--- a/tests/rspack-test/esmOutputCases/externals/star-reexport-commonjs-external/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/star-reexport-commonjs-external/test.config.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+function readOutput(options) {
+	return fs
+		.readdirSync(options.output.path)
+		.filter(file => file.endsWith(".mjs"))
+		.map(file => fs.readFileSync(path.join(options.output.path, file), "utf-8"))
+		.join("\n");
+}
+
+module.exports = {
+	findBundle() {
+		return [];
+	},
+	snapshotFileFilter() {
+		return false;
+	},
+	afterExecute(options) {
+		const source = readOutput(options);
+
+		expect(source).not.toContain('export * from "fs"');
+		expect(source).toContain('require("fs")');
+	}
+};


### PR DESCRIPTION
## What

- Gate ESM dynamic import external passthrough on `ExternalModule::resolve_external_type() == "import"`.
- Keep Rslib dynamic-import external cutout broad for non-ESM output, but in `output.module` only cut out externals that resolve to `import`.
- Prevent ESM link-time raw star re-exports from being emitted for externals that do not resolve to `module`.
- Add ESM output regression coverage for commonjs dynamic import externals and commonjs star re-export externals.

## Why

Raw ESM `import(...)` and `export * from ...` output is only correct for the matching resolved external type. If a user forces a CommonJS-style external, preserving the raw ESM form bypasses the intended CJS external rendering path and can emit the wrong runtime shape.

## How

- Check `resolve_external_type()` before bypassing normal dynamic import rendering.
- Pass `output.module` into Rslib dynamic external cutout so CJS library compact output keeps its existing behavior while ESM output preserves non-`import` externals for normal rendering.
- Filter ESM `raw_star_exports` to resolved `module` externals only.
- Update affected ESM snapshots around module star re-export optimization.

## Checks

- `pnpm run build:binding:dev`
- `cargo fmt --all --check`
- `git diff --check`
- `pnpm --dir tests/rspack-test run test -t "configCases/rslib/compact-external-dynamic-import-runtime"`
- `pnpm --dir tests/rspack-test exec rstest EsmOutput.test.js`