### PR TITLE
refactor: avoid cloning optional calls in parser walk

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use swc_core::{
   common::Spanned,
   ecma::{
-    ast::{BlockStmtOrExpr, CallExpr, Callee, Expr, Lit, Pat},
+    ast::{BlockStmtOrExpr, Callee, Expr, Lit, Pat},
     utils::ExprExt,
   },
 };
@@ -113,7 +113,7 @@ impl AMDDefineDependencyParserPlugin {
   fn process_array(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
     identifiers: &mut FxHashMap<usize, Atom>, // param index => "require" | "module" | "exports"
     named_module: &Option<Atom>,
@@ -168,7 +168,7 @@ impl AMDDefineDependencyParserPlugin {
   fn process_item(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
     named_module: &Option<Atom>,
   ) -> Option<bool> {
@@ -236,7 +236,7 @@ impl AMDDefineDependencyParserPlugin {
   fn process_context(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     let call_span = call_expr.span();
@@ -265,7 +265,7 @@ impl AMDDefineDependencyParserPlugin {
   fn process_call_define(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
   ) -> Option<bool> {
     let mut array: Option<&Expr> = None;
     let mut func: Option<&Expr> = None;
@@ -586,7 +586,7 @@ impl JavascriptParserPlugin for AMDDefineDependencyParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == "define" {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
@@ -2,7 +2,7 @@ use rspack_core::{ConstDependency, RuntimeGlobals, RuntimeRequirementsDependency
 use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
-  ecma::ast::{CallExpr, Expr, MemberExpr, UnaryExpr},
+  ecma::ast::{Expr, MemberExpr, UnaryExpr},
 };
 
 use crate::{
@@ -23,7 +23,7 @@ impl JavascriptParserPlugin for AMDParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == "require.config" || for_name == "requirejs.config" {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -10,7 +10,7 @@ use rspack_error::{Error, Severity};
 use rspack_util::{SpanExt, atom::Atom};
 use swc_core::{
   common::Spanned,
-  ecma::ast::{BlockStmtOrExpr, CallExpr, ExprOrSpread, Pat},
+  ecma::ast::{BlockStmtOrExpr, ExprOrSpread, Pat},
 };
 
 use crate::{
@@ -44,7 +44,7 @@ impl JavascriptParserPlugin for AMDRequireDependenciesBlockParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == "require" {
@@ -60,7 +60,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     block_deps: &mut Vec<BoxDependency>,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     if param.is_array() {
@@ -103,7 +103,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     block_deps: &mut Vec<BoxDependency>,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     if param.is_conditional() {
@@ -166,7 +166,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     block_deps: &mut Vec<BoxDependency>,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     let call_span = call_expr.span();
@@ -273,7 +273,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
   fn process_call_require(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
   ) -> Option<bool> {
     if call_expr.args.is_empty() {
       return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -3,7 +3,7 @@ use rspack_error::{Error, Severity};
 use rspack_util::SpanExt;
 use swc_core::{
   common::{Span, Spanned},
-  ecma::ast::{CallExpr, Ident, Pat, UnaryExpr},
+  ecma::ast::{Ident, Pat, UnaryExpr},
 };
 
 use crate::{
@@ -387,7 +387,7 @@ impl JavascriptParserPlugin for APIPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == "require.config"

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -4,7 +4,7 @@ use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},
   ecma::ast::{
-    AssignExpr, CallExpr, Expr, ExprOrSpread, Ident, Lit, MemberExpr, ObjectLit, Prop, PropName,
+    AssignExpr, Expr, ExprOrSpread, Ident, Lit, MemberExpr, ObjectLit, Prop, PropName,
     PropOrSpread, UnaryExpr, UnaryOp,
   },
 };
@@ -234,7 +234,7 @@ fn handle_access_export(
   remaining: &[Atom],
   remaining_optionals: &[bool],
   base: ExportsBase,
-  call_args: Option<&Vec<ExprOrSpread>>,
+  call_args: Option<&[ExprOrSpread]>,
 ) -> Option<bool> {
   if parser.is_esm {
     return None;
@@ -305,7 +305,7 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if self.should_skip_handler(parser) {
@@ -494,7 +494,7 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
@@ -512,7 +512,7 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
         members,
         members_optionals,
         ExportsBase::Exports,
-        Some(&expr.args),
+        Some(expr.args),
       );
     }
 
@@ -524,7 +524,7 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
         &members[1..],
         &members_optionals[1..],
         ExportsBase::ModuleExports,
-        Some(&expr.args),
+        Some(expr.args),
       );
     }
 
@@ -536,7 +536,7 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
         members,
         members_optionals,
         ExportsBase::This,
-        Some(&expr.args),
+        Some(expr.args),
       );
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -8,8 +8,7 @@ use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},
   ecma::ast::{
-    AssignExpr, CallExpr, Callee, Expr, ExprOrSpread, Ident, MemberExpr, NewExpr, UnaryExpr,
-    VarDeclarator,
+    AssignExpr, CallExpr, Expr, ExprOrSpread, Ident, MemberExpr, NewExpr, UnaryExpr, VarDeclarator,
   },
 };
 
@@ -120,7 +119,7 @@ fn tag_commonjs_require_referenced(
 fn create_commonjs_require_context_dependency(
   parser: &mut JavascriptParser,
   param: &BasicEvaluatedExpression,
-  call_expr: &CallExpr,
+  call_expr: crate::parser_plugin::CallExprRef<'_>,
   arg_expr: &Expr,
   referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
 ) -> CommonJsRequireContextDependency {
@@ -214,21 +213,21 @@ pub(crate) fn is_require_call_expr(parser: &mut JavascriptParser, call: &CallExp
 }
 
 enum CallOrNewExpr<'a> {
-  Call(&'a CallExpr),
+  Call(crate::parser_plugin::CallExprRef<'a>),
   New(&'a NewExpr),
 }
 
 impl CallOrNewExpr<'_> {
   pub fn callee(&self) -> Option<&Expr> {
     match self {
-      CallOrNewExpr::Call(call_expr) => call_expr.callee.as_expr().map(|e| &**e),
+      CallOrNewExpr::Call(call_expr) => call_expr.callee.as_expr(),
       CallOrNewExpr::New(new_expr) => Some(&new_expr.callee),
     }
   }
 
   pub fn args(&self) -> Option<&[ExprOrSpread]> {
     match self {
-      CallOrNewExpr::Call(call_expr) => Some(&call_expr.args),
+      CallOrNewExpr::Call(call_expr) => Some(call_expr.args),
       CallOrNewExpr::New(new_expr) => new_expr.args.as_deref(),
     }
   }
@@ -258,12 +257,15 @@ impl CommonJsImportsParserPlugin {
       .unwrap_or_default()
   }
 
-  fn should_process_resolve(parser: &mut JavascriptParser, call_expr: &CallExpr) -> bool {
-    let Callee::Expr(expr) = &call_expr.callee else {
+  fn should_process_resolve(
+    parser: &mut JavascriptParser,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
+  ) -> bool {
+    let Some(expr) = call_expr.callee.as_expr() else {
       return false;
     };
 
-    let Expr::Member(member_expr) = expr.as_ref() else {
+    let Expr::Member(member_expr) = expr else {
       return false;
     };
 
@@ -278,7 +280,12 @@ impl CommonJsImportsParserPlugin {
     true
   }
 
-  fn process_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr, weak: bool) {
+  fn process_resolve(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
+    weak: bool,
+  ) {
     if call_expr.args.len() != 1 {
       return;
     }
@@ -432,7 +439,7 @@ impl CommonJsImportsParserPlugin {
   fn process_require_context(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     param: &BasicEvaluatedExpression,
   ) -> Option<bool> {
     let Some(argument_expr) = &call_expr.args.first().map(|expr| expr.expr.as_ref()) else {
@@ -707,7 +714,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
@@ -733,7 +740,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
           .unwrap_or(false)
           && !direct_import,
       );
-    parser.walk_expr_or_spread(&expr.args);
+    parser.walk_expr_or_spread(expr.args);
     Some(true)
   }
 
@@ -840,7 +847,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE {
@@ -902,7 +909,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
   fn call_member_chain_of_call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     callee_members: &[Atom],
     inner_call_expr: &CallExpr,
     members: &[Atom],
@@ -916,7 +923,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
       && let Some(dep) = self.chain_handler(parser, member, inner_call_expr, members, true)
     {
       parser.add_dependency(Box::new(dep));
-      parser.walk_expr_or_spread(&call_expr.args);
+      parser.walk_expr_or_spread(call_expr.args);
       return Some(true);
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -1,10 +1,6 @@
 use rspack_core::{BoxDependencyTemplate, ConstDependency, ContextDependency, DependencyRange};
 use rspack_util::{SpanExt, itoa};
-use swc_core::{
-  atoms::Atom,
-  common::Spanned,
-  ecma::ast::{CallExpr, VarDeclarator},
-};
+use swc_core::{atoms::Atom, common::Spanned, ecma::ast::VarDeclarator};
 
 use super::JavascriptParserPlugin;
 use crate::{
@@ -28,7 +24,7 @@ impl CompatibilityPlugin {
   pub fn browserify_require_handler(
     &self,
     parser: &mut JavascriptParser,
-    expr: &CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
   ) -> Option<bool> {
     if expr.args.len() != 2 {
       return None;
@@ -241,7 +237,7 @@ impl JavascriptParserPlugin for CompatibilityPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == expr_name::REQUIRE {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -2,12 +2,14 @@ use swc_core::{
   atoms::Atom,
   common::Span,
   ecma::ast::{
-    AssignExpr, BinExpr, CallExpr, Callee, ClassMember, CondExpr, Expr, IfStmt, MemberExpr,
-    OptChainExpr, UnaryExpr, UnaryOp, VarDeclarator,
+    AssignExpr, BinExpr, CallExpr, ClassMember, CondExpr, Expr, IfStmt, MemberExpr, OptChainExpr,
+    UnaryExpr, UnaryOp, VarDeclarator,
   },
 };
 
-use super::{BoxJavascriptParserPlugin, JavascriptParserPlugin, JavascriptParserPluginHook};
+use super::{
+  BoxJavascriptParserPlugin, CallExprRef, JavascriptParserPlugin, JavascriptParserPluginHook,
+};
 use crate::{
   parser_plugin::r#const::is_logic_op,
   utils::eval::BasicEvaluatedExpression,
@@ -162,7 +164,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     None
   }
 
-  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, name: &str) -> Option<bool> {
+  fn call(&self, parser: &mut JavascriptParser, expr: CallExprRef<'_>, name: &str) -> Option<bool> {
     for plugin in self.plugins_for(JavascriptParserPluginHook::Call) {
       let res = plugin.call(parser, expr, name);
       // `SyncBailHook`
@@ -218,13 +220,13 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &CallExpr,
+    expr: CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
     member_ranges: &[Span],
   ) -> Option<bool> {
-    assert!(matches!(expr.callee, Callee::Expr(_)));
+    assert!(expr.callee().is_expr());
     for plugin in self.plugins_for(JavascriptParserPluginHook::CallMemberChain) {
       let res = plugin.call_member_chain(
         parser,
@@ -284,7 +286,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
   fn call_member_chain_of_call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: CallExprRef<'_>,
     callee_members: &[Atom],
     inner_call_expr: &CallExpr,
     members: &[Atom],
@@ -710,7 +712,7 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     &self,
     parser: &mut JavascriptParser,
     expr: &CallExpr,
-    import_then: Option<&CallExpr>,
+    import_then: Option<CallExprRef<'_>>,
     members: Option<(&[Atom], bool /* is_call */)>,
   ) -> Option<bool> {
     assert!(expr.callee.is_import());

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -125,7 +125,7 @@ impl JavascriptParserPlugin for ESMDetectionParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    _expr: &swc_core::ecma::ast::CallExpr,
+    _expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     (parser.is_esm && is_non_esm_identifier(for_name)).then_some(true)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},
-  ecma::ast::{BinExpr, BinaryOp, Callee, Expr, Ident, ImportDecl},
+  ecma::ast::{BinExpr, BinaryOp, Expr, Ident, ImportDecl},
 };
 
 use super::{
@@ -247,13 +247,13 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &swc_core::ecma::ast::CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
     _member_ranges: &[Span],
   ) -> Option<bool> {
-    let Callee::Expr(callee) = &call_expr.callee else {
+    let Some(callee) = call_expr.callee.as_expr() else {
       unreachable!()
     };
     if for_name != ESM_SPECIFIER_TAG {
@@ -310,7 +310,7 @@ impl JavascriptParserPlugin for ESMImportDependencyParserPlugin {
       InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
     );
 
-    parser.walk_expr_or_spread(&call_expr.args);
+    parser.walk_expr_or_spread(call_expr.args);
     Some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -2,7 +2,7 @@ use rspack_core::{BoxDependency, DependencyRange};
 use rspack_util::SpanExt;
 use swc_core::{
   common::{Span, Spanned},
-  ecma::{ast::CallExpr, atoms::Atom},
+  ecma::atoms::Atom,
 };
 
 use crate::{
@@ -20,7 +20,7 @@ type CreateDependency = fn(Atom, DependencyRange) -> BoxDependency;
 
 fn extract_deps(
   parser: &mut JavascriptParser,
-  call_expr: &CallExpr,
+  call_expr: crate::parser_plugin::CallExprRef<'_>,
   create_dependency: CreateDependency,
 ) -> Vec<BoxDependency> {
   let mut dependencies: Vec<BoxDependency> = vec![];
@@ -63,7 +63,7 @@ impl JavascriptParser<'_> {
 
   fn create_accept_handler(
     &mut self,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     create_dependency: CreateDependency,
   ) -> Option<bool> {
     self.build_info.module_concatenation_bailout = Some(String::from("Hot Module Replacement"));
@@ -97,13 +97,13 @@ impl JavascriptParser<'_> {
       }
       return Some(true);
     }
-    self.walk_expr_or_spread(&call_expr.args);
+    self.walk_expr_or_spread(call_expr.args);
     Some(true)
   }
 
   fn create_decline_handler(
     &mut self,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     create_dependency: CreateDependency,
   ) -> Option<bool> {
     self.build_info.module_concatenation_bailout = Some(String::from("Hot Module Replacement"));
@@ -171,7 +171,7 @@ impl JavascriptParserPlugin for ModuleHotReplacementParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &swc_core::ecma::ast::CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == expr_name::MODULE_HOT_ACCEPT {
@@ -239,7 +239,7 @@ impl JavascriptParserPlugin for ImportMetaHotReplacementParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &swc_core::ecma::ast::CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == expr_name::IMPORT_META_HOT_ACCEPT {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -11,7 +11,7 @@ use sugar_path::SugarPath;
 use swc_core::{
   atoms::Atom,
   common::Spanned,
-  ecma::ast::{CallExpr, Expr, Lit, PropName},
+  ecma::ast::{Expr, Lit, PropName},
 };
 
 use super::JavascriptParserPlugin;
@@ -278,7 +278,7 @@ fn glob_patterns_are_recursive(
 }
 
 fn create_import_meta_context_dependency(
-  node: &CallExpr,
+  node: crate::parser_plugin::CallExprRef<'_>,
   parser: &mut JavascriptParser,
 ) -> Option<ImportMetaContextDependency> {
   assert!(node.callee.is_expr());
@@ -336,7 +336,7 @@ fn create_import_meta_context_dependency(
 }
 
 fn create_import_meta_glob_dependency(
-  node: &CallExpr,
+  node: crate::parser_plugin::CallExprRef<'_>,
   parser: &mut JavascriptParser,
 ) -> Option<ImportMetaContextDependency> {
   assert!(node.callee.is_expr());
@@ -451,7 +451,7 @@ impl JavascriptParserPlugin for ImportMetaContextDependencyParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if expr.args.is_empty() || expr.args.len() > 2 {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -94,7 +94,7 @@ impl ImportMetaPlugin {
   fn process_import_meta_resolve(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &swc_core::ecma::ast::CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
   ) {
     if call_expr.args.len() != 1 {
       return;
@@ -495,7 +495,7 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &swc_core::ecma::ast::CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if parser.javascript_options.import_meta_resolve == Some(true)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -231,7 +231,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    expr: &CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
@@ -257,7 +257,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
           .unwrap_or(false)
           && !direct_import,
       );
-    parser.walk_expr_or_spread(&expr.args);
+    parser.walk_expr_or_spread(expr.args);
     Some(true)
   }
 
@@ -265,7 +265,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     node: &CallExpr,
-    import_then: Option<&CallExpr>,
+    import_then: Option<crate::parser_plugin::CallExprRef<'_>>,
     referenced_in_members: Option<(&[Atom], bool)>,
   ) -> Option<bool> {
     // Skip unreachable dynamic imports that are placed after a terminating
@@ -518,7 +518,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
         walk_import_then_fulfilled_callback(parser, node, &import_then.args[0].expr, ns_obj);
         parser.walk_expr_or_spread(&import_then.args[1..]);
       } else {
-        parser.walk_expr_or_spread(&import_then.args);
+        parser.walk_expr_or_spread(import_then.args);
       }
     }
 
@@ -597,7 +597,9 @@ fn get_attributes_from_call_expr(node: &CallExpr) -> Option<ImportAttributes> {
     .map(get_attributes)
 }
 
-fn get_fulfilled_callback_namespace_obj(import_then: &CallExpr) -> Option<&Pat> {
+fn get_fulfilled_callback_namespace_obj<'a>(
+  import_then: crate::parser_plugin::CallExprRef<'a>,
+) -> Option<&'a Pat> {
   let fulfilled_callback = import_then.args.first()?;
   if fulfilled_callback.spread.is_some() {
     return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/is_included_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/is_included_plugin.rs
@@ -1,9 +1,6 @@
 use rspack_core::ConstDependency;
 use rspack_util::SpanExt;
-use swc_core::{
-  common::Spanned,
-  ecma::ast::{CallExpr, UnaryExpr},
-};
+use swc_core::{common::Spanned, ecma::ast::UnaryExpr};
 
 use super::JavascriptParserPlugin;
 use crate::{dependency::IsIncludeDependency, visitors::JavascriptParser};
@@ -14,7 +11,12 @@ pub struct IsIncludedPlugin;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for IsIncludedPlugin {
-  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, name: &str) -> Option<bool> {
+  fn call(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: crate::parser_plugin::CallExprRef<'_>,
+    name: &str,
+  ) -> Option<bool> {
     if name != IS_INCLUDED || expr.args.len() != 1 || expr.args[0].spread.is_some() {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -14,7 +14,7 @@ impl JavascriptParserPlugin for JavascriptMetaInfoPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    _expr: &swc_core::ecma::ast::CallExpr,
+    _expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == "eval" {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -34,8 +34,8 @@ pub mod provide_plugin;
 pub mod side_effects_parser_plugin;
 
 pub use self::r#trait::{
-  BoxJavascriptParserPlugin, JavascriptParserPlugin, JavascriptParserPluginHook,
-  JavascriptParserPluginHooks,
+  BoxJavascriptParserPlugin, CallCalleeRef, CallExprRef, JavascriptParserPlugin,
+  JavascriptParserPluginHook, JavascriptParserPluginHooks,
 };
 pub(crate) use self::{
   amd::{

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin/parser.rs
@@ -70,12 +70,12 @@ impl JavascriptParserPlugin for ProvideParserPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    expr: &swc_core::ecma::ast::CallExpr,
+    expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if self.add_provide_dep(for_name, expr.callee.span(), parser) {
       // FIXME: webpack use `walk_expression` here
-      parser.walk_expr_or_spread(&expr.args);
+      parser.walk_expr_or_spread(expr.args);
       return Some(true);
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -3,7 +3,7 @@ use rspack_core::{
 };
 use rspack_regex::RspackRegex;
 use rspack_util::SpanExt;
-use swc_core::{common::Spanned, ecma::ast::CallExpr};
+use swc_core::common::Spanned;
 
 use super::JavascriptParserPlugin;
 use crate::{
@@ -15,7 +15,12 @@ pub struct RequireContextDependencyParserPlugin;
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl JavascriptParserPlugin for RequireContextDependencyParserPlugin {
-  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, for_name: &str) -> Option<bool> {
+  fn call(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: crate::parser_plugin::CallExprRef<'_>,
+    for_name: &str,
+  ) -> Option<bool> {
     if for_name != "require.context" {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -8,7 +8,7 @@ use rspack_core::{
 use rspack_util::SpanExt;
 use swc_core::{
   common::Spanned,
-  ecma::ast::{ArrowExpr, BlockStmtOrExpr, CallExpr, Expr, FnExpr, UnaryExpr},
+  ecma::ast::{ArrowExpr, BlockStmtOrExpr, Expr, FnExpr, UnaryExpr},
 };
 
 use super::JavascriptParserPlugin;
@@ -52,7 +52,12 @@ impl JavascriptParserPlugin for RequireEnsureDependenciesBlockParserPlugin {
     })
   }
 
-  fn call(&self, parser: &mut JavascriptParser, expr: &CallExpr, for_name: &str) -> Option<bool> {
+  fn call(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: crate::parser_plugin::CallExprRef<'_>,
+    for_name: &str,
+  ) -> Option<bool> {
     if for_name != "require.ensure" {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -1,12 +1,127 @@
 use swc_core::{
   atoms::Atom,
-  common::Span,
+  common::{Span, Spanned, SyntaxContext},
   ecma::ast::{
-    AssignExpr, AwaitExpr, BinExpr, CallExpr, ClassMember, CondExpr, Expr, ForOfStmt, Ident,
-    IfStmt, ImportDecl, MemberExpr, ModuleDecl, NewExpr, OptChainExpr, Program, ThisExpr,
-    UnaryExpr, VarDeclarator,
+    AssignExpr, AwaitExpr, BinExpr, CallExpr, Callee, ClassMember, CondExpr, Expr, ExprOrSpread,
+    ForOfStmt, Ident, IfStmt, Import, ImportDecl, MemberExpr, ModuleDecl, NewExpr, OptCall,
+    OptChainExpr, Program, Super, ThisExpr, UnaryExpr, VarDeclarator,
   },
 };
+
+#[derive(Clone, Copy)]
+pub enum CallCalleeRef<'a> {
+  Expr(&'a Expr),
+  Super(&'a Super),
+  Import(&'a Import),
+}
+
+impl<'a> CallCalleeRef<'a> {
+  pub fn as_expr(&self) -> Option<&'a Expr> {
+    match self {
+      Self::Expr(expr) => Some(expr),
+      Self::Super(_) | Self::Import(_) => None,
+    }
+  }
+
+  pub fn is_expr(&self) -> bool {
+    matches!(self, Self::Expr(_))
+  }
+
+  pub fn is_import(&self) -> bool {
+    matches!(self, Self::Import(_))
+  }
+
+  pub fn span(&self) -> Span {
+    match self {
+      Self::Expr(expr) => expr.span(),
+      Self::Super(super_) => super_.span,
+      Self::Import(import) => import.span,
+    }
+  }
+}
+
+impl Spanned for CallCalleeRef<'_> {
+  fn span(&self) -> Span {
+    match self {
+      Self::Expr(expr) => expr.span(),
+      Self::Super(super_) => super_.span,
+      Self::Import(import) => import.span,
+    }
+  }
+}
+
+#[derive(Clone, Copy)]
+pub struct CallExprRef<'a> {
+  pub callee: CallCalleeRef<'a>,
+  pub args: &'a [ExprOrSpread],
+  pub span: Span,
+  pub ctxt: SyntaxContext,
+  call_expr: Option<&'a CallExpr>,
+  opt_call: Option<&'a OptCall>,
+}
+
+impl<'a> CallExprRef<'a> {
+  pub fn callee(&self) -> CallCalleeRef<'a> {
+    self.callee
+  }
+
+  pub fn args(&self) -> &'a [ExprOrSpread] {
+    self.args
+  }
+
+  pub fn span(&self) -> Span {
+    self.span
+  }
+
+  pub fn ctxt(&self) -> SyntaxContext {
+    self.ctxt
+  }
+
+  pub fn as_call_expr(&self) -> Option<&'a CallExpr> {
+    self.call_expr
+  }
+
+  pub fn as_opt_call(&self) -> Option<&'a OptCall> {
+    self.opt_call
+  }
+}
+
+impl Spanned for CallExprRef<'_> {
+  fn span(&self) -> Span {
+    self.span
+  }
+}
+
+impl<'a> From<&'a CallExpr> for CallExprRef<'a> {
+  fn from(value: &'a CallExpr) -> Self {
+    let callee = match &value.callee {
+      Callee::Expr(expr) => CallCalleeRef::Expr(expr),
+      Callee::Super(super_) => CallCalleeRef::Super(super_),
+      Callee::Import(import) => CallCalleeRef::Import(import),
+    };
+    Self {
+      callee,
+      args: &value.args,
+      span: value.span,
+      ctxt: value.ctxt,
+      call_expr: Some(value),
+      opt_call: None,
+    }
+  }
+}
+
+impl<'a> From<&'a OptCall> for CallExprRef<'a> {
+  fn from(value: &'a OptCall) -> Self {
+    Self {
+      callee: CallCalleeRef::Expr(&value.callee),
+      args: &value.args,
+      span: value.span,
+      ctxt: value.ctxt,
+      call_expr: None,
+      opt_call: Some(value),
+    }
+  }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -356,7 +471,7 @@ Please annotate your `impl JavascriptParserPlugin for ...` block with `#[rspack_
   fn call(
     &self,
     _parser: &mut JavascriptParser,
-    _expr: &CallExpr,
+    _expr: CallExprRef<'_>,
     _for_name: &str,
   ) -> Option<bool> {
     None
@@ -365,7 +480,7 @@ Please annotate your `impl JavascriptParserPlugin for ...` block with `#[rspack_
   fn call_member_chain(
     &self,
     _parser: &mut JavascriptParser,
-    _expr: &CallExpr,
+    _expr: CallExprRef<'_>,
     _for_name: &str,
     _members: &[Atom],
     _members_optionals: &[bool],
@@ -422,7 +537,7 @@ Please annotate your `impl JavascriptParserPlugin for ...` block with `#[rspack_
   fn call_member_chain_of_call_member_chain(
     &self,
     _parser: &mut JavascriptParser,
-    _call_expr: &CallExpr,
+    _call_expr: CallExprRef<'_>,
     _callee_members: &[Atom],
     _inner_call_expr: &CallExpr,
     _members: &[Atom],
@@ -554,7 +669,7 @@ Please annotate your `impl JavascriptParserPlugin for ...` block with `#[rspack_
     &self,
     _parser: &mut JavascriptParser,
     _expr: &CallExpr,
-    _import_then: Option<&CallExpr>,
+    _import_then: Option<CallExprRef<'_>>,
     _members: Option<(&[Atom], bool)>,
   ) -> Option<bool> {
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -13,7 +13,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
   atoms::Atom,
   common::{Span, Spanned},
-  ecma::ast::{CallExpr, ExprOrSpread, Ident, NewExpr, VarDeclarator},
+  ecma::ast::{ExprOrSpread, Ident, NewExpr, VarDeclarator},
 };
 use url::Url;
 
@@ -393,7 +393,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     _members_optionals: &[bool],
@@ -409,7 +409,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
     if let Some(value) = self.inner.pattern_syntax.get(data.key.as_str())
       && value.contains(&members.iter().map(|id| id.as_str()).join("."))
     {
-      return handle_worker(parser, &call_expr.args, call_expr.span).map(
+      return handle_worker(parser, call_expr.args, call_expr.span).map(
         |(parsed_path, parsed_options, first_arg, need_new_url)| {
           add_dependencies(
             parser,
@@ -435,7 +435,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
   fn call(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: crate::parser_plugin::CallExprRef<'_>,
     for_name: &str,
   ) -> Option<bool> {
     if for_name == ESM_SPECIFIER_TAG {
@@ -449,7 +449,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
         .from_call_syntax
         .contains(&(ids, settings.source.to_string()))
       {
-        return handle_worker(parser, &call_expr.args, call_expr.span).map(
+        return handle_worker(parser, call_expr.args, call_expr.span).map(
           |(parsed_path, parsed_options, first_arg, need_new_url)| {
             add_dependencies(
               parser,
@@ -474,7 +474,7 @@ impl JavascriptParserPlugin for WorkerPlugin {
     if !self.inner.call_syntax.contains(for_name) {
       return None;
     }
-    handle_worker(parser, &call_expr.args, call_expr.span).map(
+    handle_worker(parser, call_expr.args, call_expr.span).map(
       |(parsed_path, parsed_options, first_arg, need_new_url)| {
         add_dependencies(
           parser,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::{
   dependency::{DependencyBranchGuard, ESMImportSpecifierDependency, ESMImportedBooleanGuardNode},
-  parser_plugin::{JavascriptParserPlugin, is_logic_op},
+  parser_plugin::{CallExprRef, JavascriptParserPlugin, is_logic_op},
   visitors::{
     AtomMembers, ExportedVariableInfo, ExprRef, VariableDeclaration,
     dependency::parser::ExtractedMemberExpressionChainData, get_non_optional_part,
@@ -1157,14 +1157,7 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_opt_call(&mut self, expr: &OptCall) {
-    // TODO: remove clone
-    self.walk_call_expression(&CallExpr {
-      ctxt: expr.ctxt,
-      span: expr.span,
-      callee: Callee::Expr(expr.callee.clone()),
-      args: expr.args.clone(),
-      type_args: None,
-    })
+    self.walk_call_expression_callee(&expr.callee, &expr.args, expr.into())
   }
 
   /// Walk IIFE function
@@ -1295,154 +1288,9 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_call_expression(&mut self, expr: &CallExpr) {
-    fn is_simple_function(params: &[Param]) -> bool {
-      params.iter().all(|p| matches!(p.pat, Pat::Ident(_)))
-    }
-
-    // FIXME: should align to webpack
     match &expr.callee {
       Callee::Expr(callee) => {
-        if let Expr::Member(member_expr) = &**callee
-          && let Expr::Fn(fn_expr) = &*member_expr.obj
-          && let MemberProp::Ident(ident) = &member_expr.prop
-          && (ident.sym == "call" || ident.sym == "bind")
-          && !expr.args.is_empty()
-          && is_simple_function(&fn_expr.function.params)
-        {
-          // (function(…) { }).call(…)
-          let mut params = expr.args.iter().map(|arg| &*arg.expr);
-          let this = params.next();
-          self._walk_iife(&member_expr.obj, params, this)
-        } else if let Expr::Member(member_expr) = &**callee
-          && let Expr::Fn(fn_expr) = &*member_expr.obj
-          && let MemberProp::Ident(ident) = &member_expr.prop
-          && (ident.sym == "call" || ident.sym == "bind")
-          && !expr.args.is_empty()
-          && is_simple_function(&fn_expr.function.params)
-        {
-          // (function(…) { }.call(…))
-          let mut params = expr.args.iter().map(|arg| &*arg.expr);
-          let this = params.next();
-          self._walk_iife(&member_expr.obj, params, this)
-        } else if let Expr::Fn(fn_expr) = &**callee
-          && is_simple_function(&fn_expr.function.params)
-        {
-          // (function(…) { })(…)
-          self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
-        } else if let Expr::Fn(fn_expr) = &**callee
-          && is_simple_function(&fn_expr.function.params)
-        {
-          // ((…) => { }(…))
-          self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
-        } else if let Expr::Arrow(arrow_expr) = &**callee
-          && arrow_expr.params.iter().all(|p| p.as_ident().is_some())
-        {
-          // (function(…) { }(…))
-          self._walk_iife(callee, expr.args.iter().map(|arg| &*arg.expr), None)
-        } else {
-          if let Expr::Member(member) = &**callee {
-            if let Some(MemberExpressionInfo::Call(expr_info)) = self.get_member_expression_info(
-              ExprRef::Member(member),
-              AllowedMemberTypes::CallExpression,
-            ) && expr_info
-              .root_info
-              .call_hooks_name(self, |this, for_name| {
-                this
-                  .plugin_drive
-                  .clone()
-                  .call_member_chain_of_call_member_chain(
-                    this,
-                    expr,
-                    &expr_info.callee_members,
-                    expr_info.call,
-                    &expr_info.members,
-                    &expr_info.member_ranges,
-                    for_name,
-                  )
-              })
-              .unwrap_or_default()
-            {
-              return;
-            }
-            // import(...).then(...)
-            if let Some(call) = member.obj.as_call()
-              && call.callee.is_import()
-              && let Some(prop) = member.prop.as_ident()
-              && prop.sym == "then"
-              && self
-                .plugin_drive
-                .clone()
-                .import_call(self, call, Some(expr), None)
-                .unwrap_or_default()
-            {
-              return;
-            }
-            // (await import(...)).a.b()
-            if let Some((call, members)) = self.extract_await_import_member(member)
-              && self
-                .plugin_drive
-                .clone()
-                .import_call(self, call, None, Some((&members, true)))
-                .unwrap_or_default()
-            {
-              self.walk_expr_or_spread(&expr.args);
-              return;
-            }
-          }
-          let evaluated_callee = self.evaluate_expression(callee);
-          if evaluated_callee.is_identifier() {
-            let members = evaluated_callee
-              .members()
-              .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
-            let members_optionals = evaluated_callee.members_optionals().map_or_else(
-              || Cow::Owned(members.iter().map(|_| false).collect::<Vec<_>>()),
-              Cow::Borrowed,
-            );
-            let member_ranges = evaluated_callee
-              .member_ranges()
-              .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
-            let drive = self.plugin_drive.clone();
-            if evaluated_callee
-              .root_info()
-              .call_hooks_name(self, |parser, for_name| {
-                drive.call_member_chain(
-                  parser,
-                  expr,
-                  for_name,
-                  &members,
-                  &members_optionals,
-                  &member_ranges,
-                )
-              })
-              .unwrap_or_default()
-            {
-              /* result1 */
-              return;
-            }
-
-            if drive
-              .call(self, expr, evaluated_callee.identifier())
-              .unwrap_or_default()
-            {
-              /* result2 */
-              return;
-            }
-          }
-
-          if let Some(member) = callee.as_member() {
-            self.walk_expression(&member.obj);
-            if let Some(computed) = member.prop.as_computed() {
-              self.walk_expression(&computed.expr);
-            }
-          } else if let Some(member) = callee.as_super_prop() {
-            if let Some(computed) = member.prop.as_computed() {
-              self.walk_expression(&computed.expr);
-            }
-          } else {
-            self.walk_expression(callee);
-          }
-          self.walk_expr_or_spread(&expr.args);
-        }
+        self.walk_call_expression_callee(callee, &expr.args, expr.into());
       }
       Callee::Import(_) => {
         // In webpack this is walkImportExpression, import() is a ImportExpression instead of CallExpression with Callee::Import
@@ -1461,6 +1309,159 @@ impl JavascriptParser<'_> {
         // Do nothing about super, same as webpack
         self.walk_expr_or_spread(&expr.args);
       }
+    }
+  }
+
+  fn walk_call_expression_callee(
+    &mut self,
+    callee: &Expr,
+    args: &[ExprOrSpread],
+    expr: CallExprRef<'_>,
+  ) {
+    fn is_simple_function(params: &[Param]) -> bool {
+      params.iter().all(|p| matches!(p.pat, Pat::Ident(_)))
+    }
+
+    // FIXME: should align to webpack
+    if let Expr::Member(member_expr) = callee
+      && let Expr::Fn(fn_expr) = &*member_expr.obj
+      && let MemberProp::Ident(ident) = &member_expr.prop
+      && (ident.sym == "call" || ident.sym == "bind")
+      && !args.is_empty()
+      && is_simple_function(&fn_expr.function.params)
+    {
+      // (function(…) { }).call(…)
+      let mut params = args.iter().map(|arg| &*arg.expr);
+      let this = params.next();
+      self._walk_iife(&member_expr.obj, params, this)
+    } else if let Expr::Member(member_expr) = callee
+      && let Expr::Fn(fn_expr) = &*member_expr.obj
+      && let MemberProp::Ident(ident) = &member_expr.prop
+      && (ident.sym == "call" || ident.sym == "bind")
+      && !args.is_empty()
+      && is_simple_function(&fn_expr.function.params)
+    {
+      // (function(…) { }.call(…))
+      let mut params = args.iter().map(|arg| &*arg.expr);
+      let this = params.next();
+      self._walk_iife(&member_expr.obj, params, this)
+    } else if let Expr::Fn(fn_expr) = callee
+      && is_simple_function(&fn_expr.function.params)
+    {
+      // (function(…) { })(…)
+      self._walk_iife(callee, args.iter().map(|arg| &*arg.expr), None)
+    } else if let Expr::Fn(fn_expr) = callee
+      && is_simple_function(&fn_expr.function.params)
+    {
+      // ((…) => { }(…))
+      self._walk_iife(callee, args.iter().map(|arg| &*arg.expr), None)
+    } else if let Expr::Arrow(arrow_expr) = callee
+      && arrow_expr.params.iter().all(|p| p.as_ident().is_some())
+    {
+      // (function(…) { }(…))
+      self._walk_iife(callee, args.iter().map(|arg| &*arg.expr), None)
+    } else {
+      if let Expr::Member(member) = callee {
+        if let Some(MemberExpressionInfo::Call(expr_info)) = self
+          .get_member_expression_info(ExprRef::Member(member), AllowedMemberTypes::CallExpression)
+          && expr_info
+            .root_info
+            .call_hooks_name(self, |this, for_name| {
+              this
+                .plugin_drive
+                .clone()
+                .call_member_chain_of_call_member_chain(
+                  this,
+                  expr,
+                  &expr_info.callee_members,
+                  expr_info.call,
+                  &expr_info.members,
+                  &expr_info.member_ranges,
+                  for_name,
+                )
+            })
+            .unwrap_or_default()
+        {
+          return;
+        }
+        // import(...).then(...)
+        if let Some(call) = member.obj.as_call()
+          && call.callee.is_import()
+          && let Some(prop) = member.prop.as_ident()
+          && prop.sym == "then"
+          && self
+            .plugin_drive
+            .clone()
+            .import_call(self, call, Some(expr), None)
+            .unwrap_or_default()
+        {
+          return;
+        }
+        // (await import(...)).a.b()
+        if let Some((call, members)) = self.extract_await_import_member(member)
+          && self
+            .plugin_drive
+            .clone()
+            .import_call(self, call, None, Some((&members, true)))
+            .unwrap_or_default()
+        {
+          self.walk_expr_or_spread(args);
+          return;
+        }
+      }
+      let evaluated_callee = self.evaluate_expression(callee);
+      if evaluated_callee.is_identifier() {
+        let members = evaluated_callee
+          .members()
+          .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
+        let members_optionals = evaluated_callee.members_optionals().map_or_else(
+          || Cow::Owned(members.iter().map(|_| false).collect::<Vec<_>>()),
+          Cow::Borrowed,
+        );
+        let member_ranges = evaluated_callee
+          .member_ranges()
+          .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
+        let drive = self.plugin_drive.clone();
+        if evaluated_callee
+          .root_info()
+          .call_hooks_name(self, |parser, for_name| {
+            drive.call_member_chain(
+              parser,
+              expr,
+              for_name,
+              &members,
+              &members_optionals,
+              &member_ranges,
+            )
+          })
+          .unwrap_or_default()
+        {
+          /* result1 */
+          return;
+        }
+
+        if drive
+          .call(self, expr, evaluated_callee.identifier())
+          .unwrap_or_default()
+        {
+          /* result2 */
+          return;
+        }
+      }
+
+      if let Some(member) = callee.as_member() {
+        self.walk_expression(&member.obj);
+        if let Some(computed) = member.prop.as_computed() {
+          self.walk_expression(&computed.expr);
+        }
+      } else if let Some(member) = callee.as_super_prop() {
+        if let Some(computed) = member.prop.as_computed() {
+          self.walk_expression(&computed.expr);
+        }
+      } else {
+        self.walk_expression(callee);
+      }
+      self.walk_expr_or_spread(args);
     }
   }
 

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -15,7 +15,7 @@ use rspack_plugin_javascript::{
 use rspack_util::{SpanExt, atom::Atom, json_stringify_str, swc::get_swc_comments};
 use swc_core::{
   common::{Span, Spanned},
-  ecma::ast::{CallExpr, Callee, Ident, MemberExpr, UnaryExpr},
+  ecma::ast::{CallExpr, Ident, MemberExpr, UnaryExpr},
 };
 
 static RSTEST_MOCK_FIRST_ARG_TAG: &str = "strip the import call from the first arg of mock series";
@@ -80,7 +80,7 @@ impl RstestParserPlugin {
   fn process_require_actual(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: rspack_plugin_javascript::CallExprRef<'_>,
   ) -> Option<bool> {
     match call_expr.args.len() {
       1 => {
@@ -134,7 +134,7 @@ impl RstestParserPlugin {
   fn process_import_actual(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: rspack_plugin_javascript::CallExprRef<'_>,
   ) -> Option<bool> {
     match call_expr.args.len() {
       1 => {
@@ -713,7 +713,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     call_expr: &CallExpr,
-    import_then: Option<&CallExpr>,
+    import_then: Option<rspack_plugin_javascript::CallExprRef<'_>>,
     _members: Option<(&[Atom], bool)>,
   ) -> Option<bool> {
     let first_arg = self.handle_mock_first_arg(parser, call_expr);
@@ -782,7 +782,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
       // dropped from the dependency graph.
       parser.walk_expr_or_spread(&call_expr.args);
       if let Some(import_then) = import_then {
-        parser.walk_expr_or_spread(&import_then.args);
+        parser.walk_expr_or_spread(import_then.args);
       }
 
       return Some(true);
@@ -794,7 +794,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    call_expr: &CallExpr,
+    call_expr: rspack_plugin_javascript::CallExprRef<'_>,
     for_name: &str,
     members: &[Atom],
     _members_optionals: &[bool],
@@ -805,7 +805,7 @@ impl JavascriptParserPlugin for RstestParserPlugin {
     // 1. Global variables: rs.importActual() or rstest.importActual()
     // 2. ESM imports: import { rs } from '@rstest/core'; rs.importActual()
     if members.len() == 1
-      && let Callee::Expr(callee) = &call_expr.callee
+      && let Some(callee) = call_expr.callee.as_expr()
       && let Some(member_expr) = callee.as_member()
       && let Some(ident) = member_expr.obj.as_ident()
     {

--- a/tests/rspack-test/normalCases/parsing/optional-chaining/index.js
+++ b/tests/rspack-test/normalCases/parsing/optional-chaining/index.js
@@ -25,3 +25,7 @@ it("should evaluate optional chaining as a part of statement", () => {
 		expect(module.hot).toBe(undefined);
 	}
 });
+
+it("should collect dependencies in optional calls", () => {
+	expect(require?.("./optional-require")).toBe("optional require");
+});

--- a/tests/rspack-test/normalCases/parsing/optional-chaining/optional-require.js
+++ b/tests/rspack-test/normalCases/parsing/optional-chaining/optional-require.js
@@ -1,0 +1,1 @@
+module.exports = "optional require";


### PR DESCRIPTION
## Summary

- add borrowed `CallExprRef` / `CallCalleeRef` wrappers for parser plugin call hooks
- make optional-call walking reuse borrowed callee/args instead of constructing a cloned temporary `CallExpr`
- update parser plugins to consume borrowed call refs and add optional-call dependency coverage

## Why

`walk_opt_call` previously cloned the optional-call callee and args just to route through `walk_call_expression`. This adds avoidable AST cloning in parser walk. The new shared callee walker keeps behavior aligned while avoiding that clone.

## Validation

- `pnpm run build:cli:dev`
- `pnpm run lint:rs`
- `cargo clippy -p rspack_plugin_javascript -p rspack_plugin_rstest --all-targets --all-features`
- `pnpm run test:rs`
- `pnpm --filter @rspack/cli test`
- `pnpm --filter @rspack/binding test`
- `cd tests/rspack-test && DEFAULT_MAX_CONCURRENT=1 pnpm exec rstest --pool.maxWorkers=1 --maxConcurrency=1` *(before reverting the unrelated stats snapshot update; the full suite otherwise exposes that unrelated existing snapshot mismatch)*
- `pnpm run bench:ci`
- `git diff --check`