### PR TITLE
chore(deps): upgrade pnpm to 11.3.0

### DIFF
--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -24,14 +24,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Enable corepack
-      shell: bash
-      run: |
-        if [[ "${{runner.os}}" == "Windows" ]]; then
-          # add the npm prefix to PATH to ensure the installed corepack work properly
-          NPM_PREFIX=$(cygpath -u "$(npm config get prefix)")
-          export PATH="$NPM_PREFIX:$PATH"
-        fi
-        npm install -g corepack@0.31.0 --force
-        echo "Corepack version: $(corepack --version)"
-        corepack enable
+    - name: Install pnpm
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      with:
+        standalone: ${{ startsWith(inputs.node-version, '20') }}

--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -25,6 +25,19 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Install pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      with:
-        standalone: ${{ startsWith(inputs.node-version, '20') }}
+      shell: bash
+      run: |
+        if [[ "${{runner.os}}" == "Windows" ]]; then
+          # add the npm prefix to PATH to ensure the installed corepack work properly
+          NPM_PREFIX=$(cygpath -u "$(npm config get prefix)")
+          export PATH="$NPM_PREFIX:$PATH"
+        fi
+        PNPM_VERSION=$(node -p "require('./package.json').packageManager.replace('pnpm@', '')")
+        if [[ "${{ inputs.node-version }}" == 20* ]]; then
+          npm install -g "@pnpm/exe@$PNPM_VERSION" --force
+        else
+          npm install -g corepack@0.31.0 --force
+          echo "Corepack version: $(corepack --version)"
+          corepack enable
+        fi
+        pnpm --version

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "bench:prepare": "node ./scripts/bench/setup.mjs"
   },
   "engines": {
-    "pnpm": "10.33.4"
+    "pnpm": "11.3.0"
   },
   "devDependencies": {
     "@rslint/core": "0.5.3",
@@ -72,5 +72,5 @@
     "typescript": "^6.0.3",
     "zx": "8.8.5"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -15,7 +15,7 @@
     "create-rspack": "bin.js"
   },
   "files": [
-    "template-*",
+    "template-*/**",
     "dist",
     "bin.js"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  webpack-sources@3.3.4:
-    hash: 0d62122aa5f9ac77d9ad3b4959c3c0492778a5948c0b00b45a673f3facfca327
-    path: patches/webpack-sources@3.3.4.patch
+  webpack-sources@3.3.4: 0d62122aa5f9ac77d9ad3b4959c3c0492778a5948c0b00b45a673f3facfca327
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,8 @@ minimumReleaseAgeExclude:
   - '@rsdoctor/*'
   - '@rslint/*'
   - '@rstack-dev/doc-ui'
+  - 'rsbuild-plugin-*'
+  - '@swc/*'
 
 patchedDependencies:
   webpack-sources@3.3.4: patches/webpack-sources@3.3.4.patch


### PR DESCRIPTION
## Summary

This PR upgrades the repo package manager requirement to pnpm 11.3.0 and refreshes the lockfile patched dependency metadata to pnpm 11's format. It also updates `create-rspack`'s package files glob so nested template files are included when packing with pnpm 11.

The shared pnpm setup action now installs `@pnpm/exe` only for Node 20 jobs, so the repo can run pnpm 11 while still testing Rspack's Node 20 support without adding a new external GitHub Action dependency.

## Related links

- https://github.com/pnpm/pnpm/releases/tag/v11.3.0
- https://github.com/web-infra-dev/rsbuild/pull/7767

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).