### PR TITLE
perf: reduce sourcemap benchmark overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,8 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.23"
-source = "git+https://github.com/rstackjs/rspack-sources?branch=perf%2Foptimize-mappings-encoder#0c054acc75ccc1dbfeaacfa1d126ad689a0ce938"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a72d10c90a000749a73245046be8071ecdd1ce6d21673ff17fe1da8eed6e8d"
 dependencies = [
  "dyn-clone",
  "memchr",
@@ -6611,8 +6612,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ast_macros"
-version = "0.6.7"
-source = "git+https://github.com/hardfist/swc-experimental?branch=perf%2Foptimize-ast-allocation#80d0d713c6590fabb325212390560577e5b1063f"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84de9820debe553b4316c3b12860d6da49a0f4170af49d49496425b9be87d94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6622,7 +6624,8 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_ast"
 version = "0.6.7"
-source = "git+https://github.com/hardfist/swc-experimental?branch=perf%2Foptimize-ast-allocation#80d0d713c6590fabb325212390560577e5b1063f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078f89faf183e8af0817206ed39008c765e35c80a3656c0a0e1dab47f15bd947"
 dependencies = [
  "hashbrown 0.16.1",
  "num-bigint",
@@ -6635,7 +6638,8 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_parser"
 version = "0.6.7"
-source = "git+https://github.com/hardfist/swc-experimental?branch=perf%2Foptimize-ast-allocation#80d0d713c6590fabb325212390560577e5b1063f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8beae6cf921cb8f0cef7433320aeb9cbf9ff877b7bc8bcd35c3a20b8f848c721"
 dependencies = [
  "bitflags 2.11.1",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,7 +5085,7 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.23"
-source = "git+https://github.com/rstackjs/rspack-sources?branch=perf%2Foptimize-mappings-encoder#55d8ae98cf12ef0914d29b730d941ffbf95d1477"
+source = "git+https://github.com/rstackjs/rspack-sources?branch=perf%2Foptimize-mappings-encoder#0c054acc75ccc1dbfeaacfa1d126ad689a0ce938"
 dependencies = [
  "dyn-clone",
  "memchr",
@@ -6611,9 +6611,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ast_macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84de9820debe553b4316c3b12860d6da49a0f4170af49d49496425b9be87d94"
+version = "0.6.7"
+source = "git+https://github.com/hardfist/swc-experimental?branch=perf%2Foptimize-ast-allocation#80d0d713c6590fabb325212390560577e5b1063f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6623,8 +6622,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_ast"
 version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078f89faf183e8af0817206ed39008c765e35c80a3656c0a0e1dab47f15bd947"
+source = "git+https://github.com/hardfist/swc-experimental?branch=perf%2Foptimize-ast-allocation#80d0d713c6590fabb325212390560577e5b1063f"
 dependencies = [
  "hashbrown 0.16.1",
  "num-bigint",
@@ -6637,8 +6635,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_parser"
 version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8beae6cf921cb8f0cef7433320aeb9cbf9ff877b7bc8bcd35c3a20b8f848c721"
+source = "git+https://github.com/hardfist/swc-experimental?branch=perf%2Foptimize-ast-allocation#80d0d713c6590fabb325212390560577e5b1063f"
 dependencies = [
  "bitflags 2.11.1",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,6 +3835,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "simdutf8",
  "sugar_path",
  "swc_core",
  "swc_experimental_ecma_ast",
@@ -4015,6 +4016,7 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
+ "simdutf8",
  "tokio",
  "tracing",
  "winnow",
@@ -5083,8 +5085,7 @@ dependencies = [
 [[package]]
 name = "rspack_sources"
 version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a72d10c90a000749a73245046be8071ecdd1ce6d21673ff17fe1da8eed6e8d"
+source = "git+https://github.com/rstackjs/rspack-sources?branch=perf%2Foptimize-mappings-encoder#55d8ae98cf12ef0914d29b730d941ffbf95d1477"
 dependencies = [
  "dyn-clone",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,10 +237,6 @@ rspack_util                            = { version = "=0.100.4", path = "crates/
 rspack_watcher                         = { version = "=0.100.4", path = "crates/rspack_watcher", default-features = false }
 rspack_workspace                       = { version = "=0.100.4", path = "crates/rspack_workspace", default-features = false }
 
-[patch.crates-io]
-rspack_sources               = { git = "https://github.com/rstackjs/rspack-sources", branch = "perf/optimize-mappings-encoder" }
-swc_experimental_ecma_ast    = { git = "https://github.com/hardfist/swc-experimental", branch = "perf/optimize-ast-allocation" }
-swc_experimental_ecma_parser = { git = "https://github.com/hardfist/swc-experimental", branch = "perf/optimize-ast-allocation" }
 
 [workspace.metadata.release]
 rate-limit = { existing-packages = 70, new-packages = 70 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ sftrace-setup       = { version = "0.1.2", default-features = false }
 sha2                = { version = "0.10.9", default-features = false }
 signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
 simd-json           = { version = "0.17.0", default-features = false }
+simdutf8            = { version = "0.1.5", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }
 smallvec            = { version = "1.15.1", default-features = false }
 smol_str            = { version = "0.3.6", default-features = false }
@@ -235,6 +236,9 @@ rspack_tracing_perfetto                = { version = "=0.100.4", path = "crates/
 rspack_util                            = { version = "=0.100.4", path = "crates/rspack_util", default-features = false }
 rspack_watcher                         = { version = "=0.100.4", path = "crates/rspack_watcher", default-features = false }
 rspack_workspace                       = { version = "=0.100.4", path = "crates/rspack_workspace", default-features = false }
+
+[patch.crates-io]
+rspack_sources = { git = "https://github.com/rstackjs/rspack-sources", branch = "perf/optimize-mappings-encoder" }
 
 [workspace.metadata.release]
 rate-limit = { existing-packages = 70, new-packages = 70 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,9 @@ rspack_watcher                         = { version = "=0.100.4", path = "crates/
 rspack_workspace                       = { version = "=0.100.4", path = "crates/rspack_workspace", default-features = false }
 
 [patch.crates-io]
-rspack_sources = { git = "https://github.com/rstackjs/rspack-sources", branch = "perf/optimize-mappings-encoder" }
+rspack_sources               = { git = "https://github.com/rstackjs/rspack-sources", branch = "perf/optimize-mappings-encoder" }
+swc_experimental_ecma_ast    = { git = "https://github.com/hardfist/swc-experimental", branch = "perf/optimize-ast-allocation" }
+swc_experimental_ecma_parser = { git = "https://github.com/hardfist/swc-experimental", branch = "perf/optimize-ast-allocation" }
 
 [workspace.metadata.release]
 rate-limit = { existing-packages = 70, new-packages = 70 }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -59,6 +59,7 @@ rustc-hash                 = { workspace = true }
 scopeguard                 = { workspace = true }
 serde                      = { workspace = true }
 serde_json                 = { workspace = true }
+simdutf8                   = { workspace = true }
 sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }
 tokio                      = { workspace = true, features = ["rt", "macros"] }

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -48,9 +48,12 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
         // Try to extract source map from the content
         let extract_result = match &content {
           Content::String(s) => extract_source_map(fs, s, resource_data.resource()).await,
-          Content::Buffer(b) => {
-            extract_source_map(fs, &String::from_utf8_lossy(b), resource_data.resource()).await
-          }
+          Content::Buffer(b) => match simdutf8::basic::from_utf8(b) {
+            Ok(s) => extract_source_map(fs, s, resource_data.resource()).await,
+            Err(_) => {
+              extract_source_map(fs, &String::from_utf8_lossy(b), resource_data.resource()).await
+            }
+          },
         };
 
         match extract_result {

--- a/crates/rspack_core/src/utils/identifier.rs
+++ b/crates/rspack_core/src/utils/identifier.rs
@@ -110,9 +110,10 @@ fn escape_identifier_impl(v: &str, out: &mut String) -> bool {
   out.push_str(&vstr[..first_invalid]);
   out.push('_');
 
-  let mut pos = first_invalid + 1;
+  let start = first_invalid + 1;
+  let mut pos = start;
   let mut is_safe = false;
-  for i in pos..v.len() {
+  for i in start..v.len() {
     if is_ident_safe(v[i]) {
       if !is_safe {
         pos = i;
@@ -128,7 +129,6 @@ fn escape_identifier_impl(v: &str, out: &mut String) -> bool {
         out.push('_');
         is_safe = false;
       }
-      pos = i + 1;
     }
   }
 

--- a/crates/rspack_core/src/utils/identifier.rs
+++ b/crates/rspack_core/src/utils/identifier.rs
@@ -31,49 +31,14 @@ pub fn contextify(context: impl AsRef<Utf8Path>, request: &str) -> String {
   result
 }
 
-macro_rules! ident_table {
-  ( $( range: $range_start:literal, $range_end:expr ; )* $( unit: $unit:expr ; )* ) => {{
-    let mut table = 0u128;
-
-    $(
-      assert!($range_start <= 128);
-      assert!($range_end <= 128);
-      let mut curr = $range_start;
-      while curr <= $range_end {
-        table |= 1 << curr;
-        curr += 1;
-      }
-    )*
-
-    $(
-      assert!($unit <= 128);
-      table |= 1 << $unit;
-    )*
-
-    table
-  }}
-}
-
+#[inline]
 fn is_ident_first_safe(b: u8) -> bool {
-  const TABLE: u128 = ident_table! {
-    range: b'A', b'Z';
-    range: b'a', b'z';
-    unit : b'$';
-    unit : b'_';
-  };
-
-  b < 128 && (TABLE & (1 << b)) != 0
+  matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'$' | b'_')
 }
 
+#[inline]
 fn is_ident_safe(b: u8) -> bool {
-  const TABLE: u128 = ident_table! {
-    range: b'0', b'9';
-    range: b'A', b'Z';
-    range: b'a', b'z';
-    unit : b'$';
-  };
-
-  b < 128 && (TABLE & (1 << b)) != 0
+  matches!(b, b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' | b'$')
 }
 
 #[inline]
@@ -132,41 +97,51 @@ pub fn escape_identifier(v: &str) -> Cow<'_, str> {
 fn escape_identifier_impl(v: &str, out: &mut String) -> bool {
   let vstr = v;
   let v = v.as_bytes();
-  let mut pos = 0;
-  let mut is_safe = true;
 
   // hot path
-  if v.iter().all(|&b| is_ident_safe(b)) {
+  let Some(first_invalid) = v.iter().position(|&b| !is_ident_safe(b)) else {
     return true;
-  }
+  };
 
-  for i in 0..v.len() {
-    match (is_ident_safe(v[i]), is_safe) {
-      (true, true) => (),
-      (false, true) => {
+  // # Safety
+  //
+  // `first_invalid` is either an ASCII byte offset or the first byte of a
+  // non-ASCII character, so slicing before it stays on a UTF-8 boundary.
+  out.push_str(&vstr[..first_invalid]);
+  out.push('_');
+
+  let mut pos = first_invalid + 1;
+  let mut is_safe = false;
+  for i in pos..v.len() {
+    if is_ident_safe(v[i]) {
+      if !is_safe {
+        pos = i;
+        is_safe = true;
+      }
+    } else {
+      if is_safe {
         // # Safety
         //
-        // always ascii
-        let s = &vstr[pos..i];
-        out.push_str(s);
+        // `pos` and `i` are ASCII byte offsets because they are only assigned
+        // while `is_ident_safe` is true.
+        out.push_str(&vstr[pos..i]);
         out.push('_');
-        pos = i + 1;
         is_safe = false;
       }
-      (false, false) => pos = i + 1,
-      (true, false) => is_safe = true,
+      pos = i + 1;
     }
   }
 
-  if pos != 0 {
+  if is_safe {
     // # Safety
     //
-    // always ascii
+    // `pos` is an ASCII byte offset because it is only assigned while
+    // `is_ident_safe` is true.
     let s = &vstr[pos..];
     out.push_str(s);
   }
 
-  pos == 0
+  false
 }
 
 pub fn stringify_loaders_and_resource<'a>(

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -22,6 +22,7 @@ rspack_paths       = { workspace = true }
 rspack_sources     = { workspace = true }
 rspack_util        = { workspace = true }
 serde_json         = { workspace = true }
+simdutf8           = { workspace = true }
 tracing            = { workspace = true }
 winnow             = { workspace = true }
 

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -31,10 +31,18 @@ impl Content {
     }
   }
 
+  #[allow(unsafe_code)]
   pub fn into_string_lossy(self) -> String {
     match self {
       Content::String(s) => s,
-      Content::Buffer(b) => String::from_utf8_lossy_owned(b),
+      Content::Buffer(b) => {
+        if simdutf8::basic::from_utf8(&b).is_ok() {
+          // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+          unsafe { String::from_utf8_unchecked(b) }
+        } else {
+          String::from_utf8_lossy_owned(b)
+        }
+      }
     }
   }
 

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -216,6 +216,10 @@ impl ModuleFilenameHelpers {
     namespace: &str,
     unresolved_source_map_path: Option<&Utf8Path>,
   ) -> String {
+    if module_filename_template == "webpack://[namespace]/[resourcePath]" {
+      return create_default_module_filename(source_reference, compilation, namespace);
+    }
+
     let ctx = ModuleFilenameHelpers::create_module_filename_template_string_ctx(
       source_reference,
       compilation,
@@ -277,6 +281,39 @@ impl ModuleFilenameHelpers {
       identifier: Default::default(),
     }
   }
+}
+
+fn create_default_module_filename(
+  source_reference: &SourceReference,
+  compilation: &Compilation,
+  namespace: &str,
+) -> String {
+  let Compilation { options, .. } = compilation;
+  let context = &options.context;
+
+  let short_identifier = match source_reference {
+    SourceReference::Module(module_identifier) => {
+      let module_graph = compilation.get_module_graph();
+      let module = module_graph
+        .module_by_identifier(module_identifier)
+        .unwrap_or_else(|| {
+          panic!("failed to find a module for the given identifier '{module_identifier}'")
+        });
+      module.readable_identifier(context)
+    }
+    SourceReference::Source(source) => Cow::Owned(contextify(context, source)),
+  };
+
+  let resource = short_identifier.split('!').next_back().unwrap_or("");
+  let resource_path = resource.split_once('?').map_or(resource, |(path, _)| path);
+
+  let mut result =
+    String::with_capacity("webpack://".len() + namespace.len() + 1 + resource_path.len());
+  result.push_str("webpack://");
+  result.push_str(namespace);
+  result.push('/');
+  result.push_str(resource_path);
+  result
 }
 
 struct ModuleFilenameTemplateStringCtx<'a> {


### PR DESCRIPTION
## Summary

- Keep this PR scoped to Rspack-side performance changes only; the temporary third-party crate patches were reverted.
- Add `simdutf8` fast paths for loader/source buffer UTF-8 conversion.
- Reduce overhead in identifier escaping while preserving the invalid-character escape behavior.
- Add a fast path for the default devtool module filename template.

## Benchmark

Target benchmark: `threejs-production-sourcemap`  
Measurement mode: CodSpeed CPU simulation with `RAYON_NUM_THREADS=1` for local comparability. Rayon scheduling cost was intentionally not optimized because it is distorted under Valgrind/CodSpeed.  
Primary metrics: accesses and estimated cycles.

| Scope | Accesses Before | Accesses After | Accesses Delta | Estimated Cycles Before | Estimated Cycles After | Estimated Cycles Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Rspack-only changes | 1,184,875,619 | 1,171,950,653 | -12,924,966 (-1.091%) | 1,359,247,384 | 1,347,093,638 | -12,153,746 (-0.894%) |

Raw local artifact: `optimization-artifacts/codspeed/20260528-144134-rspack-only-rerun/metrics.txt`

## Validation

- `cargo lint`