### PR TITLE
feat(rsc): validate server-only and client-only imports

### DIFF
--- a/crates/rspack_loader_swc/src/rsc_transforms/react_server_components.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/react_server_components.rs
@@ -9,8 +9,8 @@ use regex::Regex;
 use rspack_core::{RscMeta, RscModuleType};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
-use swc::atoms::Wtf8Atom;
 use swc_core::{
+  atoms::{Wtf8Atom, atom},
   common::{FileName, Span, errors::HANDLER, util::take::Take},
   ecma::{
     ast::*,
@@ -419,8 +419,8 @@ struct ReactServerComponentValidator {
   disable_client_api_checks: bool,
   filepath: String,
   invalid_server_lib_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
-  invalid_server_imports: Vec<&'static str>,
-  invalid_client_imports: Vec<&'static str>,
+  invalid_server_imports: Vec<Wtf8Atom>,
+  invalid_client_imports: Vec<Wtf8Atom>,
   pub directive_import_collection: Option<DirectiveImportCollection>,
   imports: ImportMap,
 }
@@ -471,8 +471,12 @@ impl ReactServerComponentValidator {
           ],
         ),
       ]),
-      invalid_server_imports: vec!["client-only"],
-      invalid_client_imports: vec!["server-only"],
+      invalid_server_imports: vec![
+        atom!("client-only").into(),
+        atom!("react-dom/client").into(),
+        atom!("react-dom/server").into(),
+      ],
+      invalid_client_imports: vec![atom!("server-only").into()],
       imports: ImportMap::default(),
     }
   }
@@ -506,17 +510,18 @@ impl ReactServerComponentValidator {
       return;
     }
     for import in imports {
-      if let Some(source_str) = import.source.0.as_str() {
-        if self.invalid_server_imports.contains(&source_str) {
-          report_error(RSCErrorKind::ErrServerImport((
-            source_str.to_string(),
-            import.source.1,
-          )));
-        }
+      let source = &import.source.0;
+      if self.invalid_server_imports.contains(source) {
+        report_error(RSCErrorKind::ErrServerImport((
+          source.to_string_lossy().into_owned(),
+          import.source.1,
+        )));
+      }
 
-        if !self.disable_client_api_checks {
-          self.assert_invalid_server_lib_apis(source_str, import);
-        }
+      if let Some(source_str) = source.as_str()
+        && !self.disable_client_api_checks
+      {
+        self.assert_invalid_server_lib_apis(source_str, import);
       }
     }
   }
@@ -526,11 +531,10 @@ impl ReactServerComponentValidator {
       return;
     }
     for import in imports {
-      if let Some(source_str) = import.source.0.as_str()
-        && self.invalid_client_imports.contains(&source_str)
-      {
+      let source = &import.source.0;
+      if self.invalid_client_imports.contains(source) {
         report_error(RSCErrorKind::ErrClientImport((
-          source_str.to_string(),
+          source.to_string_lossy().into_owned(),
           import.source.1,
         )));
       }

--- a/crates/rspack_loader_swc/src/rsc_transforms/react_server_components.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/react_server_components.rs
@@ -50,6 +50,7 @@ pub struct Options {
 struct DirectiveImportCollection {
   pub is_server_entry: bool,
   pub is_client_entry: bool,
+  pub is_action_file: bool,
   pub imports: Vec<ModuleImports>,
   pub export_names: Vec<Wtf8Atom>,
 }
@@ -80,6 +81,8 @@ enum RSCErrorKind {
   RedundantDirectives(Span),
   ErrClientDirective(Span),
   ErrReactApi((String, Span)),
+  ErrServerImport((String, Span)),
+  ErrClientImport((String, Span)),
 }
 
 impl VisitMut for ReactServerComponents<'_> {
@@ -221,6 +224,18 @@ fn report_error(error_kind: RSCErrorKind) {
 
       (msg, vec![span])
     }
+    RSCErrorKind::ErrServerImport((source, span)) => (
+      format!(
+        "You're importing a module that depends on \"{source}\". This package only works in a Client Component. To fix, mark the file (or its parent) with the `\"use client\"` directive.\n\n"
+      ),
+      vec![span],
+    ),
+    RSCErrorKind::ErrClientImport((source, span)) => (
+      format!(
+        "You're importing a module that depends on \"{source}\". This package only works in a Server Component or a top-level `\"use server\"` module.\n\n"
+      ),
+      vec![span],
+    ),
   };
 
   HANDLER.with(|handler| handler.struct_span_err(spans, msg.as_str()).emit())
@@ -392,6 +407,7 @@ fn collect_top_level_directives_and_imports(module: &Module) -> DirectiveImportC
   DirectiveImportCollection {
     is_server_entry,
     is_client_entry,
+    is_action_file,
     imports,
     export_names,
   }
@@ -403,6 +419,8 @@ struct ReactServerComponentValidator {
   disable_client_api_checks: bool,
   filepath: String,
   invalid_server_lib_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
+  invalid_server_imports: Vec<&'static str>,
+  invalid_client_imports: Vec<&'static str>,
   pub directive_import_collection: Option<DirectiveImportCollection>,
   imports: ImportMap,
 }
@@ -453,6 +471,8 @@ impl ReactServerComponentValidator {
           ],
         ),
       ]),
+      invalid_server_imports: vec!["client-only"],
+      invalid_client_imports: vec!["server-only"],
       imports: ImportMap::default(),
     }
   }
@@ -482,16 +502,37 @@ impl ReactServerComponentValidator {
   }
 
   fn assert_server_graph(&self, imports: &[ModuleImports]) {
-    if self.disable_client_api_checks {
-      return;
-    }
     if self.is_from_node_modules(&self.filepath) {
       return;
     }
     for import in imports {
-      let source = import.source.0.clone();
-      if let Some(source_str) = source.as_str() {
-        self.assert_invalid_server_lib_apis(source_str, import);
+      if let Some(source_str) = import.source.0.as_str() {
+        if self.invalid_server_imports.contains(&source_str) {
+          report_error(RSCErrorKind::ErrServerImport((
+            source_str.to_string(),
+            import.source.1,
+          )));
+        }
+
+        if !self.disable_client_api_checks {
+          self.assert_invalid_server_lib_apis(source_str, import);
+        }
+      }
+    }
+  }
+
+  fn assert_client_graph(&self, imports: &[ModuleImports]) {
+    if self.is_from_node_modules(&self.filepath) {
+      return;
+    }
+    for import in imports {
+      if let Some(source_str) = import.source.0.as_str()
+        && self.invalid_client_imports.contains(&source_str)
+      {
+        report_error(RSCErrorKind::ErrClientImport((
+          source_str.to_string(),
+          import.source.1,
+        )));
       }
     }
   }
@@ -520,6 +561,8 @@ impl Visit for ReactServerComponentValidator {
       // * middleware
       // * app/pages api routes
       self.assert_server_graph(&directive_import_collection.imports)
+    } else if !self.is_react_server_layer && !directive_import_collection.is_action_file {
+      self.assert_client_graph(&directive_import_collection.imports)
     }
     self.directive_import_collection = Some(directive_import_collection);
 

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/client-graph/server-only/input.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/client-graph/server-only/input.js
@@ -1,0 +1,13 @@
+// This is a comment.
+
+'use strict'
+
+/**
+ * This is a comment.
+ */
+
+import 'server-only'
+
+export default function () {
+  return null
+}

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/client-graph/server-only/output.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/client-graph/server-only/output.js
@@ -1,0 +1,8 @@
+// This is a comment.
+'use strict';
+/**
+ * This is a comment.
+ */ import 'server-only';
+export default function() {
+    return null;
+}

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/client-graph/server-only/output.stderr
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/client-graph/server-only/output.stderr
@@ -1,0 +1,8 @@
+  x You're importing a module that depends on "server-only". This package only works in a Server Component or a top-level `"use server"` module.
+  | 
+  | 
+   ,-[input.js:9:1]
+ 8 | 
+ 9 | import 'server-only'
+   : ^^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/client-only/input.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/client-only/input.js
@@ -1,0 +1,13 @@
+// This is a comment.
+
+'use strict'
+
+/**
+ * This is a comment.
+ */
+
+import 'client-only'
+
+export default function () {
+  return null
+}

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/client-only/output.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/client-only/output.js
@@ -1,0 +1,8 @@
+// This is a comment.
+'use strict';
+/**
+ * This is a comment.
+ */ import 'client-only';
+export default function() {
+    return null;
+}

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/client-only/output.stderr
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/client-only/output.stderr
@@ -1,0 +1,8 @@
+  x You're importing a module that depends on "client-only". This package only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  | 
+  | 
+   ,-[input.js:9:1]
+ 8 | 
+ 9 | import 'client-only'
+   : ^^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/react-dom-server-client/output.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/react-dom-server-client/output.js
@@ -1,0 +1,9 @@
+// This is a comment.
+'use strict';
+/**
+ * This is a comment.
+ */ import 'react-dom/server';
+import 'react-dom/client';
+export default function() {
+    return null;
+}

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
@@ -1,0 +1,16 @@
+  x You're importing a module that depends on "react-dom/server". This package only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  | 
+  | 
+   ,-[input.js:9:1]
+ 8 | 
+ 9 | import 'react-dom/server'
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+  x You're importing a module that depends on "react-dom/client". This package only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  | 
+  | 
+    ,-[input.js:11:1]
+ 10 | 
+ 11 | import 'react-dom/client'
+    : ^^^^^^^^^^^^^^^^^^^^^^^^^
+    `----

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/react-dom-server-client/page.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/errors/react-server-components/server-graph/react-dom-server-client/page.js
@@ -1,0 +1,15 @@
+// This is a comment.
+
+'use strict'
+
+/**
+ * This is a comment.
+ */
+
+import 'react-dom/server'
+
+import 'react-dom/client'
+
+export default function () {
+  return null
+}


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Add RSC marker-package validation for `server-only` and `client-only` imports.
- Report `client-only` imports in server graph modules and `server-only` imports in client graph modules.
- Keep `disableClientApiChecks` scoped to React client API checks only; marker-package validation always runs.
- Migrate Next.js-derived RSC error fixtures for the new marker-package diagnostics.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
