### PR TITLE
fix(pure-functions): keep deferred local dependencies

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -114,11 +114,14 @@ impl InnerGraphParserPlugin {
               InnerGraphMapSetValue::Str(v) => {
                 new_set.insert(InnerGraphMapSetValue::Str(v));
               }
-              InnerGraphMapSetValue::TopLevel(v) => {
-                if v == *key {
+              InnerGraphMapSetValue::TopLevel(dep_symbol) => {
+                if dep_symbol == *key {
                   continue;
                 }
-                match state.inner_graph.get(&v) {
+                if deferred_pure_checks_by_symbol.contains_key(&dep_symbol) {
+                  new_set.insert(InnerGraphMapSetValue::TopLevel(dep_symbol));
+                }
+                match state.inner_graph.get(&dep_symbol) {
                   Some(InnerGraphMapValue::True) => {
                     set_is_true = true;
                     break;
@@ -191,7 +194,7 @@ impl InnerGraphParserPlugin {
 
     let mut finalized = vec![];
     for (symbol, cbs) in state.usage_map.drain() {
-      let deferred_pure_checks = deferred_pure_checks_by_symbol
+      let mut deferred_pure_checks = deferred_pure_checks_by_symbol
         .get(&symbol)
         .cloned()
         .unwrap_or_default();
@@ -199,10 +202,19 @@ impl InnerGraphParserPlugin {
       let used_by_exports = if let Some(usage) = usage {
         match usage {
           InnerGraphMapValue::Set(set) => {
-            let finalized_set = set
-              .iter()
-              .map(|item| item.to_atom(&state.symbol_map))
-              .collect::<HashSet<_>>();
+            let mut finalized_set = HashSet::default();
+            for item in set {
+              match item {
+                InnerGraphMapSetValue::TopLevel(dep_symbol) => {
+                  if let Some(checks) = deferred_pure_checks_by_symbol.get(dep_symbol) {
+                    deferred_pure_checks.extend(checks.iter().cloned());
+                  }
+                }
+                InnerGraphMapSetValue::Str(export_name) => {
+                  finalized_set.insert(export_name.clone());
+                }
+              }
+            }
             UsedByExports::set(finalized_set)
           }
           InnerGraphMapValue::True => UsedByExports::bool(true),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
@@ -57,17 +57,6 @@ pub(super) enum InnerGraphMapSetValue {
   Str(Atom),
 }
 
-impl InnerGraphMapSetValue {
-  pub(super) fn to_atom(&self, symbol_map: &HashMap<TopLevelSymbol, TopLevelSymbolData>) -> Atom {
-    match self {
-      InnerGraphMapSetValue::TopLevel(v) => {
-        symbol_map.get(v).expect("should have symbol").name.clone()
-      }
-      InnerGraphMapSetValue::Str(v) => v.clone(),
-    }
-  }
-}
-
 #[derive(PartialEq, Eq, Debug)]
 pub(crate) enum InnerGraphMapUsage {
   TopLevel(TopLevelSymbol),

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/dep.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/dep.js
@@ -1,0 +1,5 @@
+export function foo() {}
+
+export function sideEffect(fn) {
+  fn();
+}

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/index.js
@@ -1,0 +1,5 @@
+import { c } from "./re-export";
+
+it("should keep local bindings read by retained deferred-impure expressions", () => {
+  expect(c).toBeUndefined();
+});

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/re-export.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/re-export.js
@@ -1,0 +1,5 @@
+import { foo, sideEffect } from "./dep";
+
+export const a = foo;
+export const b = sideEffect(a);
+export const c = sideEffect(function () {});

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-local-dependency/rspack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  mode: 'production',
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+};


### PR DESCRIPTION
## What

- Propagate deferred pure checks through InnerGraph top-level symbol dependencies.
- Add a regression case for a retained deferred-impure expression reading a local binding that would otherwise be replaced by an unused pure expression.

## Why

When `experiments.pureFunctions` was enabled, InnerGraph could treat `const a = foo` as an unused pure declarator even though a retained expression like `const b = sideEffect(a)` still reads `a`. If `sideEffect` later resolves as impure through a deferred pure check, `b` is kept but `a` was still rendered as `null && foo`, causing runtime failures such as `fn is not a function`.

## How

- Keep `TopLevel` dependencies in the usage set when the referenced symbol has deferred pure checks.
- Merge deferred pure checks from referenced top-level symbols into the current symbol's `UsedByExports`, so the local binding is preserved when the dependent expression is retained.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "deferred-pure-keeps-local-dependency"`
- `cd tests/rspack-test && pnpm run test -t "user-mark-pure-functions"`
- `cd tests/rspack-test && pnpm run test -t "tree-shaking"`
- `pnpm exec cargo fmt --all --check`
- `git diff --check`
- Verified the original `jfirebaugh/rspack-pure-functions-bug` repro with the local patched Rspack output now runs successfully and prints `undefined`.

Closes #14188