### PR TITLE
refactor: use Node.js WebAssembly for SWC plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -66,12 +66,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "ambient-authority"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -167,12 +161,6 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arc-swap"
@@ -503,72 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-fs-ext"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41cc18551193fe8fa6f15c1e3c799bc5ec9e2cfbfaa8ed46f37013e3e6c173c"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e394ed14f39f8bc26f59d4c0c010dbe7f0a1b9bafff451b1f98b67c8af62a"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "rustix 1.0.8",
- "rustix-linux-procfs",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acb89ccf798a28683f00089d0630dfaceec087234eae0d308c05ddeaa941b40"
-dependencies = [
- "ambient-authority",
- "rand",
-]
-
-[[package]]
-name = "cap-std"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0355ca583dd58f176c3c12489d684163861ede3c9efa6fd8bba314c984189"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
- "rustix 1.0.8",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491af520b8770085daa0466978c75db90368c71896523f2464214e38359b1a5b"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.0.8",
- "winx",
-]
-
-[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,15 +657,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.17",
-]
 
 [[package]]
 name = "codspeed"
@@ -926,143 +839,6 @@ checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cranelift-assembler-x64"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae7b60ec3fd7162427d3b3801520a1908bef7c035b52983cd3ca11b8e7deb51"
-dependencies = [
- "cranelift-assembler-x64-meta",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511c200fed36452697b4b6b161eae57d917a2044e6333b1c1389ed63ccadeee"
-dependencies = [
- "cranelift-srcgen",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
-dependencies = [
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
- "hashbrown 0.15.2",
- "log",
- "pulley-interpreter",
- "regalloc2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
-dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
- "pulley-interpreter",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306041099499833f167a0ddb707e1e54100f1a84eab5631bc3dad249708f482"
-
-[[package]]
-name = "cranelift-control"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1672945e1f9afc2297f49c92623f5eabc64398e2cb0d824f8f72a2db2df5af23"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
-dependencies = [
- "cranelift-bitset",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
-dependencies = [
- "cranelift-codegen",
- "log",
- "smallvec",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
-
-[[package]]
-name = "cranelift-native"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
-dependencies = [
- "cranelift-codegen",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.122.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
 
 [[package]]
 name = "crc32fast"
@@ -1397,18 +1173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,12 +1221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,17 +1245,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.0.8",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1566,17 +1313,6 @@ checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "fs-set-times"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
-dependencies = [
- "io-lifetimes",
- "rustix 1.0.8",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1734,11 +1470,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "glob"
@@ -1795,16 +1526,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -2096,28 +1817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
-name = "ipnet"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-
-[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,18 +1951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,12 +1965,6 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2405,15 +2086,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,12 +2101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
 name = "md4"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,15 +2114,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memfd"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
-dependencies = [
- "rustix 0.38.42",
-]
 
 [[package]]
 name = "micromegas-perfetto"
@@ -2784,9 +2441,6 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
- "crc32fast",
- "hashbrown 0.15.2",
- "indexmap",
  "memchr",
 ]
 
@@ -3045,18 +2699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,15 +2712,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy 0.7.35",
-]
 
 [[package]]
 name = "precomputed-hash"
@@ -3202,29 +2835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
-dependencies = [
- "cranelift-bitset",
- "log",
- "pulley-macros",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,18 +2886,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -3296,9 +2894,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
-]
 
 [[package]]
 name = "rayon"
@@ -3347,20 +2942,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.2",
- "log",
- "rustc-hash",
- "smallvec",
 ]
 
 [[package]]
@@ -3693,6 +3274,7 @@ dependencies = [
  "serde_json",
  "sftrace-setup",
  "swc_core",
+ "swc_plugin_runner",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5236,7 +4818,6 @@ dependencies = [
  "itoa",
  "json-escape-simd",
  "memchr",
- "once_cell",
  "regex",
  "rspack-allocative",
  "rspack_cacheable",
@@ -5252,8 +4833,6 @@ dependencies = [
  "swc_core",
  "swc_plugin_runner",
  "unicase",
- "wasi-common",
- "wasmtime",
 ]
 
 [[package]]
@@ -5313,16 +4892,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "rustix-linux-procfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
-dependencies = [
- "once_cell",
- "rustix 1.0.8",
 ]
 
 [[package]]
@@ -7039,32 +6608,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.11.1",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.42",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "target-triple"
@@ -7685,31 +7232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi-common"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17747bf7f2275572f4e3ed884e8143285a711fbf25999244d61644fe212340"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "cap-fs-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "log",
- "rustix 1.0.8",
- "system-interface",
- "thiserror 2.0.17",
- "tracing",
- "wasmtime",
- "wiggle",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7768,230 +7290,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.11.1",
- "hashbrown 0.15.2",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmtime"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
-dependencies = [
- "addr2line",
- "anyhow",
- "bitflags 2.11.1",
- "bumpalo",
- "cc",
- "cfg-if",
- "hashbrown 0.15.2",
- "indexmap",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object",
- "once_cell",
- "postcard",
- "pulley-interpreter",
- "rustix 1.0.8",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-asm-macros",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
-dependencies = [
- "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap",
- "log",
- "object",
- "postcard",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasm-encoder",
- "wasmparser",
- "wasmprinter",
-]
-
-[[package]]
-name = "wasmtime-internal-asm-macros"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6775a9b516559716e5710e95a8014ca0adcc81e5bf4d3ad7899d89ae40094d1a"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
- "itertools 0.14.0",
- "log",
- "object",
- "pulley-interpreter",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.17",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-math",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b636ff8b220ebaf29dfe3b23770e4b2bad317b9683e3bf7345e162387385b39"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "libc",
- "rustix 1.0.8",
- "wasmtime-internal-asm-macros",
- "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4417e06b7f80baff87d9770852c757a39b8d7f11d78b2620ca992b8725f16f50"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ab22fabe1eed27ab01fd47cd89deacf43ad222ed7fd169ba6f4dd1fbddc53b"
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "log",
- "object",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342b0466f92b7217a4de9e114175fedee1907028567d2548bcd42f71a8b5b016"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object",
- "target-lexicon",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
-name = "wast"
-version = "35.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -8002,47 +7306,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wiggle"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3ea480ce117a35b61e466e4f77422f2b29f744400e05de3ad87d73b8a1877c"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.11.1",
- "thiserror 2.0.17",
- "tracing",
- "wasmtime",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec945b902cacd960fe5d441b60146b24639d81b887451a30bf86824a8185d79"
-dependencies = [
- "anyhow",
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5872fbe512b73acd514e7ef5bd5aee0ff951a12c1fed0293e1f7992de30df9f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wiggle-generate",
 ]
 
 [[package]]
@@ -8075,26 +7338,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.17",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "windows"
@@ -8396,34 +7639,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winx"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
-dependencies = [
- "bitflags 2.11.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.11.1",
-]
-
-[[package]]
-name = "witx"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
-dependencies = [
- "anyhow",
- "log",
- "thiserror 1.0.69",
- "wast",
 ]
 
 [[package]]
@@ -8488,32 +7709,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,8 +148,6 @@ swc_experimental_ecma_semantic = { version = "0.6.7", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }
-wasi-common   = { version = "35.0.0", default-features = false }
-wasmtime      = { version = "35.0.0", default-features = false }
 
 
 # all rspack workspace dependencies
@@ -402,27 +400,6 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package.oneshot]
-opt-level = "s"
-
-[profile.release.package."cranelift-codegen"]
-opt-level = "s"
-
-[profile.release.package.wasmtime]
-opt-level = "s"
-
-[profile.release.package."wasi-common"]
-opt-level = "s"
-
-[profile.release.package."cranelift-assembler-x64"]
-opt-level = "s"
-
-[profile.release.package."cranelift-frontend"]
-opt-level = "s"
-
-[profile.release.package."wasmtime-environ"]
-opt-level = "s"
-
-[profile.release.package."wasmtime-internal-cranelift"]
 opt-level = "s"
 
 [profile.release.package.notify]

--- a/crates/node_binding/binding.js
+++ b/crates/node_binding/binding.js
@@ -63,6 +63,156 @@ const isMuslFromChildProcess = () => {
   }
 }
 
+function registerNodeWasmRuntime(binding) {
+  if (
+    typeof binding?.__registerNodeWasmRuntime !== 'function' ||
+    typeof binding?.__nodeWasmImportCall !== 'function'
+  ) {
+    return
+  }
+
+  let WASI
+  const modules = new Map()
+  const instances = new Map()
+  const debugNodeWasm = (...args) => {
+    if (process.env.RSPACK_DEBUG_NODE_WASM && process.env.RSPACK_DEBUG_NODE_WASM !== '0') {
+      console.error('[rspack:node-wasm-runtime]', ...args)
+    }
+  }
+
+  const getInstance = (instanceId) => {
+    const state = instances.get(instanceId)
+    if (!state) {
+      throw new Error(`SWC Wasm plugin instance ${instanceId} does not exist`)
+    }
+    return state
+  }
+
+  binding.__registerNodeWasmRuntime({
+    compile(moduleId, bytes) {
+      debugNodeWasm('compile', moduleId, bytes.length)
+      modules.set(moduleId, new WebAssembly.Module(bytes))
+    },
+    instantiate(instanceId, moduleId, importNames, envsJson) {
+      debugNodeWasm('instantiate:start', instanceId, moduleId, importNames.length)
+      const mod = modules.get(moduleId)
+      if (!mod) {
+        throw new Error(`SWC Wasm plugin module ${moduleId} does not exist`)
+      }
+
+      const importObject = {
+        env: Object.create(null),
+      }
+
+      for (let index = 0; index < importNames.length; index++) {
+        importObject.env[importNames[index]] = (...args) => {
+          debugNodeWasm('import', instanceId, index, importNames[index], args)
+          const results = binding.__nodeWasmImportCall(
+            instanceId,
+            index,
+            args,
+            getInstance(instanceId).memory.buffer,
+          )
+          debugNodeWasm('import:return', instanceId, index, results)
+          if (results.length === 0) {
+            return
+          }
+          if (results.length === 1) {
+            return results[0]
+          }
+          return results
+        }
+      }
+
+      const env = Object.create(null)
+      for (const [key, value] of JSON.parse(envsJson)) {
+        env[key] = value
+      }
+
+      WASI ??= require('node:wasi').WASI
+      const wasi = new WASI({
+        version: 'preview1',
+        args: [],
+        env,
+        preopens: {
+          '/cwd': process.cwd(),
+        },
+        returnOnExit: true,
+      })
+      importObject.wasi_snapshot_preview1 = wasi.wasiImport
+
+      const instance = new WebAssembly.Instance(mod, importObject)
+      debugNodeWasm('instantiate:created', instanceId)
+      const exports = instance.exports
+      const memory = exports.memory
+      const alloc = exports.__alloc
+      const free = exports.__free
+      const transform = exports.__transform_plugin_process_impl
+      const coreDiag = exports.__get_transform_plugin_core_pkg_diag
+
+      if (!(memory instanceof WebAssembly.Memory)) {
+        throw new Error('SWC Wasm plugin does not export WebAssembly.Memory as "memory"')
+      }
+      if (typeof alloc !== 'function') {
+        throw new Error('SWC Wasm plugin does not export "__alloc"')
+      }
+      if (typeof free !== 'function') {
+        throw new Error('SWC Wasm plugin does not export "__free"')
+      }
+      if (typeof transform !== 'function') {
+        throw new Error('SWC Wasm plugin does not export "__transform_plugin_process_impl"')
+      }
+      if (typeof coreDiag !== 'function') {
+        throw new Error('SWC Wasm plugin does not export "__get_transform_plugin_core_pkg_diag"')
+      }
+
+      const state = {
+        instance,
+        memory,
+        alloc,
+        free,
+        transform,
+        wasi,
+      }
+      instances.set(instanceId, state)
+      debugNodeWasm('instantiate:wasi.initialize', instanceId)
+      wasi.initialize(instance)
+      debugNodeWasm('instantiate:coreDiag', instanceId)
+      coreDiag()
+      debugNodeWasm('instantiate:done', instanceId)
+    },
+    transform(instanceId, programPtr, programLen, unresolvedMark, shouldEnableCommentsProxy) {
+      debugNodeWasm('transform', instanceId, programPtr, programLen)
+      return getInstance(instanceId).transform(
+        programPtr,
+        programLen,
+        unresolvedMark,
+        shouldEnableCommentsProxy,
+      ) >>> 0
+    },
+    alloc(instanceId, size) {
+      return getInstance(instanceId).alloc(size) >>> 0
+    },
+    free(instanceId, ptr, size) {
+      return getInstance(instanceId).free(ptr, size) >>> 0
+    },
+    read(instanceId, ptr, len) {
+      const { memory } = getInstance(instanceId)
+      return Buffer.from(new Uint8Array(memory.buffer, ptr, len))
+    },
+    write(instanceId, ptr, bytes) {
+      const { memory } = getInstance(instanceId)
+      new Uint8Array(memory.buffer, ptr, bytes.length).set(bytes)
+    },
+    dropInstance(instanceId) {
+      instances.delete(instanceId)
+    },
+    dropModule(moduleId) {
+      modules.delete(moduleId)
+    },
+  })
+}
+
 function requireNative() {
   if (process.env.NAPI_RS_NATIVE_LIBRARY_PATH) {
     try {
@@ -402,5 +552,7 @@ if (!nativeBinding) {
   }
   throw new Error(`Failed to load native binding`)
 }
+
+registerNodeWasmRuntime(nativeBinding)
 
 module.exports.default = module.exports = nativeBinding

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -514,10 +514,6 @@ export declare class VirtualFileStore {
 }
 export type JsVirtualFileStore = VirtualFileStore
 
-export declare function __nodeWasmImportCall(instanceId: number, importIndex: number, args: Array<number>, memoryBuffer: ArrayBuffer): Array<number>
-
-export declare function __registerNodeWasmRuntime(helper: object): void
-
 export interface AssetInfoRelated {
   sourceMap?: string | null
 }

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -514,6 +514,10 @@ export declare class VirtualFileStore {
 }
 export type JsVirtualFileStore = VirtualFileStore
 
+export declare function __nodeWasmImportCall(instanceId: number, importIndex: number, args: Array<number>, memoryBuffer: ArrayBuffer): Array<number>
+
+export declare function __registerNodeWasmRuntime(helper: object): void
+
 export interface AssetInfoRelated {
   sourceMap?: string | null
 }

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -15,7 +15,7 @@ allocative    = ["rspack_util/allocative", "rspack_collections/allocative", "rsp
 browser       = []
 debug_tool    = ["rspack_core/debug_tool"]
 perfetto      = ["dep:rspack_tracing_perfetto", "rspack_tracing/perfetto"]
-plugin        = ["rspack_loader_swc/plugin", "rspack_util/plugin"]
+plugin        = ["rspack_loader_swc/plugin", "rspack_util/plugin", "swc_plugin_runner"]
 sftrace-setup = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
 tracy-client  = ["dep:tracy-client", "rspack_allocator/tracy-client"]
 
@@ -115,6 +115,7 @@ rustc-hash                             = { workspace = true }
 serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
+swc_plugin_runner                      = { workspace = true, optional = true }
 tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
 ustr                                   = { workspace = true }
 

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -79,6 +79,8 @@ mod module_graph;
 mod module_graph_connection;
 mod modules;
 mod native_watcher;
+#[cfg(feature = "plugin")]
+mod node_wasm_runtime;
 mod normal_module_factory;
 mod options;
 mod panic;

--- a/crates/rspack_binding_api/src/node_wasm_runtime.rs
+++ b/crates/rspack_binding_api/src/node_wasm_runtime.rs
@@ -1,0 +1,744 @@
+use std::{
+  collections::HashMap,
+  ffi::c_void,
+  fmt,
+  path::Path,
+  ptr,
+  sync::{
+    Arc, Mutex, OnceLock,
+    atomic::{AtomicU32, Ordering},
+    mpsc,
+  },
+  thread::ThreadId,
+};
+
+use anyhow::{Context, anyhow};
+use napi::{
+  Env, JsValue, Status,
+  bindgen_prelude::{ArrayBuffer, Buffer, FnArgs, FromNapiValue, Function, JsObjectValue, Object},
+  sys,
+};
+use rspack_util::swc::runtime as rspack_swc_runtime;
+use swc_plugin_runner::runtime;
+
+const RUNTIME_IDENTIFIER: &str = "node-webassembly-v8-v1";
+
+static NODE_WASM_HOST: OnceLock<Arc<NodeWasmHost>> = OnceLock::new();
+
+#[napi(js_name = "__registerNodeWasmRuntime")]
+pub fn register_node_wasm_runtime(env: Env, helper: Object) -> napi::Result<()> {
+  let host = if let Some(host) = NODE_WASM_HOST.get() {
+    Arc::clone(host)
+  } else {
+    let host = NodeWasmHost::new(env, helper)?;
+    let _ = NODE_WASM_HOST.set(Arc::clone(&host));
+    host
+  };
+
+  rspack_swc_runtime::set_plugin_runtime(Arc::new(NodeWasmRuntime { host }));
+  Ok(())
+}
+
+#[napi(js_name = "__nodeWasmImportCall")]
+pub fn node_wasm_import_call(
+  env: Env,
+  instance_id: u32,
+  import_index: u32,
+  args: Vec<i32>,
+  mut memory_buffer: ArrayBuffer,
+) -> napi::Result<Vec<i32>> {
+  let host = NODE_WASM_HOST.get().ok_or_else(|| {
+    napi::Error::from_reason("Node.js WebAssembly runtime has not been registered")
+  })?;
+
+  let imports = host
+    .instances
+    .lock()
+    .expect("node wasm imports should not be poisoned")
+    .get(&instance_id)
+    .cloned()
+    .ok_or_else(|| {
+      napi::Error::from_reason(format!(
+        "SWC Wasm plugin instance {instance_id} no longer exists"
+      ))
+    })?;
+
+  let func = imports.imports.get(import_index as usize).ok_or_else(|| {
+    napi::Error::from_reason(format!(
+      "SWC Wasm plugin import {import_index} does not exist for instance {instance_id}"
+    ))
+  })?;
+
+  if args.len() != func.sign.0 as usize {
+    return Err(napi::Error::from_reason(format!(
+      "SWC Wasm plugin import {import_index} expected {} arguments, received {}",
+      func.sign.0,
+      args.len()
+    )));
+  }
+
+  let mut output = vec![0; func.sign.1 as usize];
+  let direct_memory = {
+    let memory = unsafe { memory_buffer.as_mut() };
+    DirectMemory {
+      ptr: memory.as_mut_ptr(),
+      len: memory.len(),
+    }
+  };
+  let mut caller = NodeWasmCaller {
+    host: Arc::clone(host),
+    instance_id,
+    direct_env: Some(env.raw()),
+    direct_memory: Some(direct_memory),
+  };
+  (func.func)(&mut caller, &args, &mut output);
+  Ok(output)
+}
+
+struct NodeWasmHost {
+  env: sys::napi_env,
+  js_thread_id: ThreadId,
+  helper_ref: sys::napi_ref,
+  task_tsfn: sys::napi_threadsafe_function,
+  next_module_id: AtomicU32,
+  next_instance_id: AtomicU32,
+  instances: Mutex<HashMap<u32, Arc<InstanceImports>>>,
+}
+
+unsafe impl Send for NodeWasmHost {}
+unsafe impl Sync for NodeWasmHost {}
+
+impl NodeWasmHost {
+  fn new(env: Env, helper: Object) -> napi::Result<Arc<Self>> {
+    let raw_env = env.raw();
+    let mut helper_ref = ptr::null_mut();
+    check_napi_status(
+      unsafe { sys::napi_create_reference(raw_env, helper.raw(), 1, &mut helper_ref) },
+      "Failed to create Node.js WebAssembly runtime helper reference",
+    )?;
+
+    let mut async_resource_name = ptr::null_mut();
+    let name = c"rspack_node_wasm_runtime";
+    check_napi_status(
+      unsafe {
+        sys::napi_create_string_utf8(
+          raw_env,
+          name.as_ptr(),
+          name.to_bytes().len() as isize,
+          &mut async_resource_name,
+        )
+      },
+      "Failed to create Node.js WebAssembly runtime async resource name",
+    )?;
+
+    let mut task_tsfn = ptr::null_mut();
+    check_napi_status(
+      unsafe {
+        sys::napi_create_threadsafe_function(
+          raw_env,
+          ptr::null_mut(),
+          ptr::null_mut(),
+          async_resource_name,
+          0,
+          1,
+          ptr::null_mut(),
+          None,
+          ptr::null_mut(),
+          Some(node_wasm_task_callback),
+          &mut task_tsfn,
+        )
+      },
+      "Failed to create Node.js WebAssembly runtime threadsafe function",
+    )?;
+    check_napi_status(
+      unsafe { sys::napi_unref_threadsafe_function(raw_env, task_tsfn) },
+      "Failed to unref Node.js WebAssembly runtime threadsafe function",
+    )?;
+
+    Ok(Arc::new(Self {
+      env: raw_env,
+      js_thread_id: std::thread::current().id(),
+      helper_ref,
+      task_tsfn,
+      next_module_id: AtomicU32::new(1),
+      next_instance_id: AtomicU32::new(1),
+      instances: Default::default(),
+    }))
+  }
+
+  fn next_module_id(&self) -> u32 {
+    self.next_module_id.fetch_add(1, Ordering::Relaxed)
+  }
+
+  fn next_instance_id(&self) -> u32 {
+    self.next_instance_id.fetch_add(1, Ordering::Relaxed)
+  }
+}
+
+struct InstanceImports {
+  imports: Vec<runtime::Func>,
+}
+
+#[derive(Clone)]
+struct NodeWasmRuntime {
+  host: Arc<NodeWasmHost>,
+}
+
+impl fmt::Debug for NodeWasmRuntime {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("NodeWasmRuntime").finish()
+  }
+}
+
+impl runtime::Runtime for NodeWasmRuntime {
+  fn identifier(&self) -> &'static str {
+    RUNTIME_IDENTIFIER
+  }
+
+  fn prepare_module(&self, bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
+    let module = compile_module(&self.host, bytes.to_vec())?;
+    Ok(runtime::ModuleCache(Box::new(NodeWasmCache { module })))
+  }
+
+  fn clone_cache(&self, cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
+    let cache = cache.0.downcast_ref::<NodeWasmCache>()?;
+    Some(runtime::ModuleCache(Box::new(NodeWasmCache {
+      module: Arc::clone(&cache.module),
+    })))
+  }
+
+  unsafe fn load_cache(&self, _path: &Path) -> Option<runtime::ModuleCache> {
+    None
+  }
+
+  fn store_cache(&self, _path: &Path, _cache: &runtime::ModuleCache) -> anyhow::Result<()> {
+    // V8 WebAssembly.Module objects are not serialized to Rspack's filesystem
+    // cache. We still use in-memory compiled modules through `prepare_module`.
+    Ok(())
+  }
+
+  fn init(
+    &self,
+    _name: &str,
+    imports: Vec<(String, runtime::Func)>,
+    envs: Vec<(String, String)>,
+    module: runtime::Module,
+  ) -> anyhow::Result<Box<dyn runtime::Instance>> {
+    let module = match module {
+      runtime::Module::Cache(cache) => {
+        let cache = cache
+          .0
+          .downcast::<NodeWasmCache>()
+          .map_err(|_| anyhow!("invalid SWC Wasm module cache for Node.js runtime"))?;
+        cache.module
+      }
+      runtime::Module::Bytes(bytes) => compile_module(&self.host, bytes.into_vec())?,
+    };
+
+    let instance_id = self.host.next_instance_id();
+    let import_names = imports
+      .iter()
+      .map(|(name, _)| name.clone())
+      .collect::<Vec<_>>();
+    let imports = Arc::new(InstanceImports {
+      imports: imports.into_iter().map(|(_, func)| func).collect(),
+    });
+
+    self
+      .host
+      .instances
+      .lock()
+      .expect("node wasm imports should not be poisoned")
+      .insert(instance_id, imports);
+
+    let envs_json = serde_json::to_string(&envs)?;
+    if let Err(error) = run_js(
+      &self.host,
+      JsOp::Instantiate {
+        instance_id,
+        module_id: module.id,
+        import_names,
+        envs_json,
+      },
+    ) {
+      self
+        .host
+        .instances
+        .lock()
+        .expect("node wasm imports should not be poisoned")
+        .remove(&instance_id);
+      return Err(error);
+    }
+
+    Ok(Box::new(NodeWasmInstance {
+      host: Arc::clone(&self.host),
+      instance_id,
+      module,
+    }))
+  }
+}
+
+fn compile_module(host: &Arc<NodeWasmHost>, bytes: Vec<u8>) -> anyhow::Result<Arc<NodeWasmModule>> {
+  let module_id = host.next_module_id();
+  run_js(host, JsOp::Compile { module_id, bytes })?;
+  Ok(Arc::new(NodeWasmModule {
+    id: module_id,
+    host: Arc::clone(host),
+  }))
+}
+
+struct NodeWasmModule {
+  id: u32,
+  host: Arc<NodeWasmHost>,
+}
+
+impl Drop for NodeWasmModule {
+  fn drop(&mut self) {
+    let _ = run_js(&self.host, JsOp::DropModule { module_id: self.id });
+  }
+}
+
+struct NodeWasmCache {
+  module: Arc<NodeWasmModule>,
+}
+
+struct NodeWasmInstance {
+  host: Arc<NodeWasmHost>,
+  instance_id: u32,
+  #[allow(dead_code)]
+  module: Arc<NodeWasmModule>,
+}
+
+impl Drop for NodeWasmInstance {
+  fn drop(&mut self) {
+    self
+      .host
+      .instances
+      .lock()
+      .expect("node wasm imports should not be poisoned")
+      .remove(&self.instance_id);
+    let _ = run_js(
+      &self.host,
+      JsOp::DropInstance {
+        instance_id: self.instance_id,
+      },
+    );
+  }
+}
+
+impl runtime::Instance for NodeWasmInstance {
+  fn transform(
+    &mut self,
+    program_ptr: u32,
+    program_len: u32,
+    unresolved_mark: u32,
+    should_enable_comments_proxy: u32,
+  ) -> anyhow::Result<u32> {
+    match run_js(
+      &self.host,
+      JsOp::Transform {
+        instance_id: self.instance_id,
+        program_ptr,
+        program_len,
+        unresolved_mark,
+        should_enable_comments_proxy,
+      },
+    )? {
+      JsResult::U32(value) => Ok(value),
+      _ => unreachable!("transform must return u32"),
+    }
+  }
+
+  fn caller(&mut self) -> anyhow::Result<Box<dyn runtime::Caller<'_> + '_>> {
+    Ok(Box::new(NodeWasmCaller {
+      host: Arc::clone(&self.host),
+      instance_id: self.instance_id,
+      direct_env: None,
+      direct_memory: None,
+    }))
+  }
+
+  fn cache(&self) -> Option<runtime::ModuleCache> {
+    Some(runtime::ModuleCache(Box::new(NodeWasmCache {
+      module: Arc::clone(&self.module),
+    })))
+  }
+}
+
+struct NodeWasmCaller {
+  host: Arc<NodeWasmHost>,
+  instance_id: u32,
+  direct_env: Option<sys::napi_env>,
+  direct_memory: Option<DirectMemory>,
+}
+
+#[derive(Clone, Copy)]
+struct DirectMemory {
+  ptr: *mut u8,
+  len: usize,
+}
+
+impl NodeWasmCaller {
+  fn run(&self, op: JsOp) -> anyhow::Result<JsResult> {
+    if let Some(env) = self.direct_env {
+      execute_js_op(&self.host, env, op)
+    } else {
+      run_js(&self.host, op)
+    }
+  }
+}
+
+impl runtime::Caller<'_> for NodeWasmCaller {
+  fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
+    if let Some(memory) = self.direct_memory {
+      let start = ptr as usize;
+      let end = start
+        .checked_add(buf.len())
+        .context("SWC Wasm read range overflowed")?;
+      if end > memory.len {
+        anyhow::bail!(
+          "SWC Wasm read out of bounds: ptr={ptr}, len={}, memory={}",
+          buf.len(),
+          memory.len
+        );
+      }
+      unsafe {
+        std::ptr::copy_nonoverlapping(memory.ptr.add(start), buf.as_mut_ptr(), buf.len());
+      }
+      return Ok(());
+    }
+
+    match self.run(JsOp::Read {
+      instance_id: self.instance_id,
+      ptr,
+      len: buf
+        .len()
+        .try_into()
+        .context("SWC Wasm read length does not fit into u32")?,
+    })? {
+      JsResult::Bytes(bytes) => {
+        if bytes.len() != buf.len() {
+          anyhow::bail!(
+            "SWC Wasm read returned {} bytes, expected {} bytes",
+            bytes.len(),
+            buf.len()
+          );
+        }
+        buf.copy_from_slice(&bytes);
+        Ok(())
+      }
+      _ => unreachable!("read must return bytes"),
+    }
+  }
+
+  fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
+    if let Some(memory) = self.direct_memory {
+      let start = ptr as usize;
+      let end = start
+        .checked_add(buf.len())
+        .context("SWC Wasm write range overflowed")?;
+      if end > memory.len {
+        anyhow::bail!(
+          "SWC Wasm write out of bounds: ptr={ptr}, len={}, memory={}",
+          buf.len(),
+          memory.len
+        );
+      }
+      unsafe {
+        std::ptr::copy_nonoverlapping(buf.as_ptr(), memory.ptr.add(start), buf.len());
+      }
+      return Ok(());
+    }
+
+    self.run(JsOp::Write {
+      instance_id: self.instance_id,
+      ptr,
+      bytes: buf.to_vec(),
+    })?;
+    Ok(())
+  }
+
+  fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
+    // `__alloc` may grow WebAssembly.Memory, which detaches the old
+    // ArrayBuffer. Fall back to JS-side memory access after allocation.
+    self.direct_memory = None;
+    match self.run(JsOp::Alloc {
+      instance_id: self.instance_id,
+      size,
+    })? {
+      JsResult::U32(value) => Ok(value),
+      _ => unreachable!("alloc must return u32"),
+    }
+  }
+
+  fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
+    match self.run(JsOp::Free {
+      instance_id: self.instance_id,
+      ptr,
+      size,
+    })? {
+      JsResult::U32(value) => Ok(value),
+      _ => unreachable!("free must return u32"),
+    }
+  }
+}
+
+enum JsOp {
+  Compile {
+    module_id: u32,
+    bytes: Vec<u8>,
+  },
+  Instantiate {
+    instance_id: u32,
+    module_id: u32,
+    import_names: Vec<String>,
+    envs_json: String,
+  },
+  Transform {
+    instance_id: u32,
+    program_ptr: u32,
+    program_len: u32,
+    unresolved_mark: u32,
+    should_enable_comments_proxy: u32,
+  },
+  Alloc {
+    instance_id: u32,
+    size: u32,
+  },
+  Free {
+    instance_id: u32,
+    ptr: u32,
+    size: u32,
+  },
+  Read {
+    instance_id: u32,
+    ptr: u32,
+    len: u32,
+  },
+  Write {
+    instance_id: u32,
+    ptr: u32,
+    bytes: Vec<u8>,
+  },
+  DropInstance {
+    instance_id: u32,
+  },
+  DropModule {
+    module_id: u32,
+  },
+}
+
+enum JsResult {
+  Unit,
+  U32(u32),
+  Bytes(Vec<u8>),
+}
+
+struct JsTask {
+  host: Arc<NodeWasmHost>,
+  op: JsOp,
+  tx: mpsc::SyncSender<anyhow::Result<JsResult>>,
+}
+
+extern "C" fn node_wasm_task_callback(
+  env: sys::napi_env,
+  _js_callback: sys::napi_value,
+  _context: *mut c_void,
+  data: *mut c_void,
+) {
+  if data.is_null() {
+    return;
+  }
+
+  let task: Box<JsTask> = unsafe { Box::from_raw(data.cast()) };
+  let result = if env.is_null() {
+    Err(anyhow!(
+      "Node.js WebAssembly runtime is shutting down before the SWC Wasm task completed"
+    ))
+  } else {
+    execute_js_op(&task.host, env, task.op)
+  };
+  let _ = task.tx.send(result);
+}
+
+fn run_js(host: &Arc<NodeWasmHost>, op: JsOp) -> anyhow::Result<JsResult> {
+  if std::thread::current().id() == host.js_thread_id {
+    return execute_js_op(host, host.env, op);
+  }
+
+  let (tx, rx) = mpsc::sync_channel(1);
+  let task = Box::new(JsTask {
+    host: Arc::clone(host),
+    op,
+    tx,
+  });
+  let raw_task = Box::into_raw(task);
+  let status = unsafe {
+    sys::napi_call_threadsafe_function(
+      host.task_tsfn,
+      raw_task.cast(),
+      sys::ThreadsafeFunctionCallMode::blocking,
+    )
+  };
+  if status != sys::Status::napi_ok {
+    unsafe { drop(Box::from_raw(raw_task)) };
+    anyhow::bail!(
+      "Failed to schedule Node.js WebAssembly runtime task: {}",
+      Status::from(status)
+    );
+  }
+
+  rx.recv()
+    .context("Node.js WebAssembly runtime task channel closed")?
+}
+
+fn execute_js_op(host: &NodeWasmHost, env: sys::napi_env, op: JsOp) -> anyhow::Result<JsResult> {
+  let env = unsafe { Env::from_raw(env) };
+  let helper = helper_object(host, &env)?;
+
+  let result = match op {
+    JsOp::Compile { module_id, bytes } => {
+      let compile = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, Buffer)>, ()>>("compile")
+        .map_err(napi_to_anyhow)?;
+      compile
+        .call(FnArgs::from((module_id, Buffer::from(bytes))))
+        .map_err(napi_to_anyhow)?;
+      JsResult::Unit
+    }
+    JsOp::Instantiate {
+      instance_id,
+      module_id,
+      import_names,
+      envs_json,
+    } => {
+      let instantiate = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, u32, Vec<String>, String)>, ()>>(
+          "instantiate",
+        )
+        .map_err(napi_to_anyhow)?;
+      instantiate
+        .call(FnArgs::from((
+          instance_id,
+          module_id,
+          import_names,
+          envs_json,
+        )))
+        .map_err(napi_to_anyhow)?;
+      JsResult::Unit
+    }
+    JsOp::Transform {
+      instance_id,
+      program_ptr,
+      program_len,
+      unresolved_mark,
+      should_enable_comments_proxy,
+    } => {
+      let transform = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, u32, u32, u32, u32)>, u32>>("transform")
+        .map_err(napi_to_anyhow)?;
+      JsResult::U32(
+        transform
+          .call(FnArgs::from((
+            instance_id,
+            program_ptr,
+            program_len,
+            unresolved_mark,
+            should_enable_comments_proxy,
+          )))
+          .map_err(napi_to_anyhow)?,
+      )
+    }
+    JsOp::Alloc { instance_id, size } => {
+      let alloc = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, u32)>, u32>>("alloc")
+        .map_err(napi_to_anyhow)?;
+      JsResult::U32(
+        alloc
+          .call(FnArgs::from((instance_id, size)))
+          .map_err(napi_to_anyhow)?,
+      )
+    }
+    JsOp::Free {
+      instance_id,
+      ptr,
+      size,
+    } => {
+      let free = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, u32, u32)>, u32>>("free")
+        .map_err(napi_to_anyhow)?;
+      JsResult::U32(
+        free
+          .call(FnArgs::from((instance_id, ptr, size)))
+          .map_err(napi_to_anyhow)?,
+      )
+    }
+    JsOp::Read {
+      instance_id,
+      ptr,
+      len,
+    } => {
+      let read = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, u32, u32)>, Buffer>>("read")
+        .map_err(napi_to_anyhow)?;
+      let bytes = read
+        .call(FnArgs::from((instance_id, ptr, len)))
+        .map(Vec::<u8>::from)
+        .map_err(napi_to_anyhow)?;
+      JsResult::Bytes(bytes)
+    }
+    JsOp::Write {
+      instance_id,
+      ptr,
+      bytes,
+    } => {
+      let write = helper
+        .get_named_property::<Function<'_, FnArgs<(u32, u32, Buffer)>, ()>>("write")
+        .map_err(napi_to_anyhow)?;
+      write
+        .call(FnArgs::from((instance_id, ptr, Buffer::from(bytes))))
+        .map_err(napi_to_anyhow)?;
+      JsResult::Unit
+    }
+    JsOp::DropInstance { instance_id } => {
+      let drop_instance = helper
+        .get_named_property::<Function<'_, u32, ()>>("dropInstance")
+        .map_err(napi_to_anyhow)?;
+      drop_instance.call(instance_id).map_err(napi_to_anyhow)?;
+      JsResult::Unit
+    }
+    JsOp::DropModule { module_id } => {
+      let drop_module = helper
+        .get_named_property::<Function<'_, u32, ()>>("dropModule")
+        .map_err(napi_to_anyhow)?;
+      drop_module.call(module_id).map_err(napi_to_anyhow)?;
+      JsResult::Unit
+    }
+  };
+
+  Ok(result)
+}
+
+fn helper_object<'env>(host: &NodeWasmHost, env: &'env Env) -> anyhow::Result<Object<'env>> {
+  let mut value = ptr::null_mut();
+  let status = unsafe { sys::napi_get_reference_value(env.raw(), host.helper_ref, &mut value) };
+  if status != sys::Status::napi_ok {
+    anyhow::bail!(
+      "Failed to get Node.js WebAssembly runtime helper: {}",
+      Status::from(status)
+    );
+  }
+  unsafe { Object::from_napi_value(env.raw(), value) }.map_err(napi_to_anyhow)
+}
+
+fn napi_to_anyhow(error: napi::Error) -> anyhow::Error {
+  anyhow!(error.to_string())
+}
+
+fn check_napi_status(status: sys::napi_status, message: &'static str) -> napi::Result<()> {
+  if status == sys::Status::napi_ok {
+    Ok(())
+  } else {
+    Err(napi::Error::new(Status::from(status), message))
+  }
+}

--- a/crates/rspack_binding_api/src/node_wasm_runtime.rs
+++ b/crates/rspack_binding_api/src/node_wasm_runtime.rs
@@ -25,7 +25,7 @@ const RUNTIME_IDENTIFIER: &str = "node-webassembly-v8-v1";
 
 static NODE_WASM_HOST: OnceLock<Arc<NodeWasmHost>> = OnceLock::new();
 
-#[napi(js_name = "__registerNodeWasmRuntime")]
+#[napi(skip_typescript, js_name = "__registerNodeWasmRuntime")]
 pub fn register_node_wasm_runtime(env: Env, helper: Object) -> napi::Result<()> {
   let host = if let Some(host) = NODE_WASM_HOST.get() {
     Arc::clone(host)
@@ -39,7 +39,7 @@ pub fn register_node_wasm_runtime(env: Env, helper: Object) -> napi::Result<()> 
   Ok(())
 }
 
-#[napi(js_name = "__nodeWasmImportCall")]
+#[napi(skip_typescript, js_name = "__nodeWasmImportCall")]
 pub fn node_wasm_import_call(
   env: Env,
   instance_id: u32,

--- a/crates/rspack_binding_api/src/swc.rs
+++ b/crates/rspack_binding_api/src/swc.rs
@@ -48,9 +48,9 @@ fn _transform(source: String, options: String) -> napi::Result<TransformOutput> 
 
   #[cfg(feature = "plugin")]
   {
-    options.runtime_options = options.runtime_options.plugin_runtime(std::sync::Arc::new(
-      rspack_util::swc::runtime::WasmtimeRuntime,
-    ));
+    options.runtime_options = options
+      .runtime_options
+      .plugin_runtime(rspack_util::swc::runtime::plugin_runtime());
   }
 
   let compiler = JavaScriptCompiler::new();
@@ -70,7 +70,14 @@ fn _transform(source: String, options: String) -> napi::Result<TransformOutput> 
       |_| noop_pass(),
     )
     .map(TransformOutput::from)
-    .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("{e}")))
+    .map_err(|e| {
+      let message = format!("{e}");
+      if message.is_empty() {
+        napi::Error::new(napi::Status::GenericFailure, format!("{e:?}"))
+      } else {
+        napi::Error::new(napi::Status::GenericFailure, message)
+      }
+    })
 }
 
 #[napi]

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -111,12 +111,9 @@ impl SwcLoader {
 
       #[cfg(feature = "plugin")]
       {
-        swc_options.runtime_options =
-          swc_options
-            .runtime_options
-            .plugin_runtime(std::sync::Arc::new(
-              rspack_util::swc::runtime::WasmtimeRuntime,
-            ));
+        swc_options.runtime_options = swc_options
+          .runtime_options
+          .plugin_runtime(rspack_util::swc::runtime::plugin_runtime());
       }
 
       swc_options

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -41,7 +41,7 @@ rspack_regex = { workspace = true }
 signal-hook  = { workspace = true, optional = true }
 
 [features]
-debug_tool = ["signal-hook"]                                                         # only used for local debug and  should not be enabled in production release
+debug_tool = ["signal-hook"]                 # only used for local debug and  should not be enabled in production release
 plugin     = ["anyhow", "swc_plugin_runner"]
 
 [lints]

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -35,17 +35,14 @@ swc_core   = { workspace = true, features = ["__common", "base", "ecma_ast"] }
 
 # wasm runtime
 anyhow            = { workspace = true, optional = true }
-once_cell         = { workspace = true, optional = true }
 swc_plugin_runner = { workspace = true, optional = true }
-wasi-common       = { workspace = true, optional = true, features = ["sync", "wasmtime"] }
-wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift", "threads"] }
 
 rspack_regex = { workspace = true }
 signal-hook  = { workspace = true, optional = true }
 
 [features]
 debug_tool = ["signal-hook"]                                                         # only used for local debug and  should not be enabled in production release
-plugin     = ["anyhow", "once_cell", "wasmtime", "wasi-common", "swc_plugin_runner"]
+plugin     = ["anyhow", "swc_plugin_runner"]
 
 [lints]
 workspace = true

--- a/crates/rspack_util/src/swc/runtime.rs
+++ b/crates/rspack_util/src/swc/runtime.rs
@@ -1,303 +1,86 @@
-//! temp fork from https://github.com/swc-project/swc/blob/main/crates/swc_plugin_backend_wasmtime/src/lib.rs
+//! SWC plugin runtime registration.
+//!
+//! Rspack's Node.js binding registers a runtime backed by Node/V8's built-in
+//! `WebAssembly` implementation at module initialization time. Keeping the
+//! runtime behind a process-wide registration point lets non-Node crates avoid a
+//! direct N-API dependency while still allowing `builtin:swc-loader` and the SWC
+//! transform API to use the same runtime.
 
-use std::path::Path;
+use std::{
+  fmt,
+  path::Path,
+  sync::{Arc, OnceLock, RwLock},
+};
 
-use anyhow::Context;
-use once_cell::sync::OnceCell;
 use swc_plugin_runner::runtime;
 
-/// Identifier for bytecode cache stored in local filesystem.
+static PLUGIN_RUNTIME: OnceLock<RwLock<Option<Arc<dyn runtime::Runtime>>>> = OnceLock::new();
+
+fn runtime_slot() -> &'static RwLock<Option<Arc<dyn runtime::Runtime>>> {
+  PLUGIN_RUNTIME.get_or_init(Default::default)
+}
+
+/// Registers the process-wide SWC Wasm plugin runtime.
 ///
-/// This MUST be updated when bump up wasmtime.
-const MODULE_SERIALIZATION_IDENTIFIER: &str = concat!("wasmtime", "-", "v35");
-
-static ENGINE: OnceCell<wasmtime::Engine> = OnceCell::new();
-
-#[derive(Clone, Copy, Debug)]
-pub struct WasmtimeRuntime;
-
-struct WasmtimeCache(wasmtime::Module);
-
-struct WasmtimeTable {
-  memory: Option<wasmtime::Memory>,
-  alloc_func: Option<wasmtime::TypedFunc<u32, u32>>,
-  free_func: Option<wasmtime::TypedFunc<(u32, u32), u32>>,
-
-  wasi: wasi_common::WasiCtx,
+/// The Node.js binding calls this with a runtime backed by Node's built-in
+/// `WebAssembly` implementation. Calling it again replaces the previous runtime,
+/// which is useful for tests and for reloading the binding in the same process.
+pub fn set_plugin_runtime(runtime: Arc<dyn runtime::Runtime>) {
+  *runtime_slot()
+    .write()
+    .expect("SWC plugin runtime slot should not be poisoned") = Some(runtime);
 }
 
-struct WasmtimeInstance {
-  instance: wasmtime::Instance,
-  store: wasmtime::Store<WasmtimeTable>,
-
-  memory: wasmtime::Memory,
-  alloc_func: wasmtime::TypedFunc<u32, u32>,
-  free_func: wasmtime::TypedFunc<(u32, u32), u32>,
-  transform_func: wasmtime::TypedFunc<(u32, u32, u32, u32), u32>,
+/// Returns the registered SWC Wasm plugin runtime.
+///
+/// If no runtime has been registered yet, a placeholder runtime is returned. The
+/// placeholder reports a clear error when a Wasm plugin is actually used instead
+/// of failing at configuration time for builds that do not use Wasm plugins.
+pub fn plugin_runtime() -> Arc<dyn runtime::Runtime> {
+  runtime_slot()
+    .read()
+    .expect("SWC plugin runtime slot should not be poisoned")
+    .clone()
+    .unwrap_or_else(|| Arc::new(MissingPluginRuntime))
 }
 
-struct WasmtimeCaller<'a> {
-  store: &'a mut wasmtime::Store<WasmtimeTable>,
-  memory: &'a wasmtime::Memory,
-  alloc_func: &'a wasmtime::TypedFunc<u32, u32>,
-  free_func: &'a wasmtime::TypedFunc<(u32, u32), u32>,
+#[derive(Clone, Copy)]
+struct MissingPluginRuntime;
+
+impl fmt::Debug for MissingPluginRuntime {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("MissingPluginRuntime").finish()
+  }
 }
 
-struct WasmtimeCallerRef<'a> {
-  caller: wasmtime::Caller<'a, WasmtimeTable>,
-  memory: wasmtime::Memory,
-  alloc_func: wasmtime::TypedFunc<u32, u32>,
-  free_func: wasmtime::TypedFunc<(u32, u32), u32>,
-}
-
-fn init_engine() -> anyhow::Result<wasmtime::Engine> {
-  let config = wasmtime::Config::default();
-  wasmtime::Engine::new(&config)
-}
-
-impl runtime::Runtime for WasmtimeRuntime {
+impl runtime::Runtime for MissingPluginRuntime {
   fn identifier(&self) -> &'static str {
-    MODULE_SERIALIZATION_IDENTIFIER
+    "missing-node-wasm-runtime"
   }
 
-  fn prepare_module(&self, bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
-    let engine = ENGINE.get_or_try_init(init_engine)?;
-    let cache = WasmtimeCache(wasmtime::Module::new(engine, bytes)?);
-    Ok(runtime::ModuleCache(Box::new(cache)))
-  }
-
-  fn clone_cache(&self, cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
-    let WasmtimeCache(module) = cache.0.downcast_ref().unwrap();
-    let cache = WasmtimeCache(module.clone());
-    Some(runtime::ModuleCache(Box::new(cache)))
-  }
-
-  unsafe fn load_cache(&self, path: &Path) -> Option<runtime::ModuleCache> {
-    let module = std::fs::read(path).ok()?;
-    let engine = ENGINE.get_or_try_init(init_engine).ok()?;
-    let cache = unsafe { wasmtime::Module::deserialize(engine, module).ok()? };
-    let cache = WasmtimeCache(cache);
-    Some(runtime::ModuleCache(Box::new(cache)))
-  }
-
-  fn store_cache(&self, path: &Path, cache: &runtime::ModuleCache) -> anyhow::Result<()> {
-    use std::io::{ErrorKind, Write};
-
-    let WasmtimeCache(module) = cache.0.downcast_ref().unwrap();
-    let data = module.serialize()?;
-
-    // atomic write
-    //
-    // TODO use `with_added_extension`
-    let tmppath = {
-      let mut ext = path.extension().unwrap_or_default().to_owned();
-      ext.push(".tmp");
-      path.with_extension(ext)
-    };
-    let mut fd = match std::fs::OpenOptions::new()
-      .create_new(true)
-      .write(true)
-      .open(&tmppath)
-    {
-      Ok(fd) => fd,
-      Err(ref err) if err.kind() == ErrorKind::AlreadyExists => return Ok(()),
-      Err(err) => return Err(err.into()),
-    };
-    fd.write_all(&data)?;
-    drop(fd);
-    std::fs::rename(&tmppath, path)?;
-    Ok(())
+  fn prepare_module(&self, _bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
+    anyhow::bail!(missing_runtime_message())
   }
 
   fn init(
     &self,
     _name: &str,
-    imports: Vec<(String, runtime::Func)>,
-    envs: Vec<(String, String)>,
-    module: runtime::Module,
+    _imports: Vec<(String, runtime::Func)>,
+    _envs: Vec<(String, String)>,
+    _module: runtime::Module,
   ) -> anyhow::Result<Box<dyn runtime::Instance>> {
-    let engine = ENGINE.get_or_try_init(init_engine)?;
+    anyhow::bail!(missing_runtime_message())
+  }
 
-    let module = match module {
-      runtime::Module::Cache(cache) => {
-        let cache = cache.0.downcast::<WasmtimeCache>().unwrap();
-        cache.0
-      }
-      runtime::Module::Bytes(buf) => wasmtime::Module::new(engine, buf)?,
-    };
+  fn clone_cache(&self, _cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
+    None
+  }
 
-    let current_dir = std::env::current_dir()?;
-    let dir = wasi_common::sync::Dir::open_ambient_dir(
-      &current_dir,
-      wasi_common::sync::ambient_authority(),
-    )?;
-    let wasi = wasi_common::sync::WasiCtxBuilder::new()
-      .envs(&envs)?
-      .preopened_dir(dir, "/cwd")?
-      .build();
-
-    let table = WasmtimeTable {
-      memory: None,
-      alloc_func: None,
-      free_func: None,
-
-      wasi,
-    };
-    let mut linker: wasmtime::Linker<WasmtimeTable> = wasmtime::Linker::new(engine);
-    for (name, func) in imports {
-      let ty = wasmtime::FuncType::new(
-        engine,
-        (0..func.sign.0).map(|_| wasmtime::ValType::I32),
-        (0..func.sign.1).map(|_| wasmtime::ValType::I32),
-      );
-      linker.func_new("env", &name, ty, move |caller, input, output| {
-        wasmtime_func_call(caller, input, output, &func)
-      })?;
-    }
-
-    wasi_common::sync::add_to_linker(&mut linker, |t| &mut t.wasi)?;
-
-    let mut store = wasmtime::Store::new(engine, table);
-    let instance = linker.instantiate(&mut store, &module)?;
-
-    let memory = instance
-      .get_memory(&mut store, "memory")
-      .context("miss memory export")?;
-    let alloc_func: wasmtime::TypedFunc<u32, u32> =
-      instance.get_typed_func(&mut store, "__alloc")?;
-    let free_func: wasmtime::TypedFunc<(u32, u32), u32> =
-      instance.get_typed_func(&mut store, "__free")?;
-    let transform_func: wasmtime::TypedFunc<(u32, u32, u32, u32), u32> =
-      instance.get_typed_func(&mut store, "__transform_plugin_process_impl")?;
-
-    store.data_mut().memory = Some(memory);
-    store.data_mut().alloc_func = Some(alloc_func.clone());
-    store.data_mut().free_func = Some(free_func.clone());
-
-    instance
-      .get_typed_func::<(), u32>(&mut store, "__get_transform_plugin_core_pkg_diag")?
-      .call(&mut store, ())?;
-
-    Ok(Box::new(WasmtimeInstance {
-      store,
-      instance,
-      memory,
-      alloc_func,
-      free_func,
-      transform_func,
-    }))
+  unsafe fn load_cache(&self, _path: &Path) -> Option<runtime::ModuleCache> {
+    None
   }
 }
 
-impl runtime::Instance for WasmtimeInstance {
-  fn transform(
-    &mut self,
-    program_ptr: u32,
-    program_len: u32,
-    unresolved_mark: u32,
-    should_enable_comments_proxy: u32,
-  ) -> anyhow::Result<u32> {
-    self.transform_func.call(
-      &mut self.store,
-      (
-        program_ptr,
-        program_len,
-        unresolved_mark,
-        should_enable_comments_proxy,
-      ),
-    )
-  }
-
-  fn caller(&mut self) -> anyhow::Result<Box<dyn runtime::Caller<'_> + '_>> {
-    Ok(Box::new(WasmtimeCaller {
-      store: &mut self.store,
-      memory: &self.memory,
-      alloc_func: &self.alloc_func,
-      free_func: &self.free_func,
-    }))
-  }
-
-  fn cache(&self) -> Option<runtime::ModuleCache> {
-    let module = self.instance.module(&self.store);
-    let cache = WasmtimeCache(module.clone());
-    Some(runtime::ModuleCache(Box::new(cache)))
-  }
-}
-
-impl<'a> runtime::Caller<'a> for WasmtimeCaller<'a> {
-  fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
-    self.memory.read(&self.store, ptr as usize, buf)?;
-    Ok(())
-  }
-
-  fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-    self.memory.write(&mut self.store, ptr as usize, buf)?;
-    Ok(())
-  }
-
-  fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-    self.alloc_func.call(&mut self.store, size)
-  }
-
-  fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-    self.free_func.call(&mut self.store, (ptr, size))
-  }
-}
-
-impl<'a> runtime::Caller<'a> for WasmtimeCallerRef<'a> {
-  fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
-    self.memory.read(&self.caller, ptr as usize, buf)?;
-    Ok(())
-  }
-
-  fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-    self.memory.write(&mut self.caller, ptr as usize, buf)?;
-    Ok(())
-  }
-
-  fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-    self.alloc_func.call(&mut self.caller, size)
-  }
-
-  fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-    self.free_func.call(&mut self.caller, (ptr, size))
-  }
-}
-
-fn wasmtime_func_call(
-  caller: wasmtime::Caller<'_, WasmtimeTable>,
-  input: &[wasmtime::Val],
-  output: &mut [wasmtime::Val],
-  func: &runtime::Func,
-) -> anyhow::Result<()> {
-  assert_eq!(func.sign.0 as usize, input.len());
-  assert_eq!(func.sign.1 as usize, output.len());
-
-  let memory = caller.data().memory.unwrap();
-  let alloc_func = caller.data().alloc_func.clone().unwrap();
-  let free_func = caller.data().free_func.clone().unwrap();
-
-  let mut caller = WasmtimeCallerRef {
-    caller,
-    memory,
-    alloc_func,
-    free_func,
-  };
-
-  let input = input
-    .iter()
-    .map(|val| match val {
-      wasmtime::Val::I32(v) => Ok(*v),
-      _ => Err(anyhow::format_err!("not support argument type")),
-    })
-    .collect::<anyhow::Result<Vec<i32>>>()?;
-  let mut output2 = vec![0; output.len()];
-
-  (func.func)(&mut caller, &input, &mut output2);
-
-  for i in 0..output.len() {
-    output[i] = wasmtime::Val::I32(output2[i]);
-  }
-
-  Ok(())
+fn missing_runtime_message() -> &'static str {
+  "SWC Wasm plugin runtime is not registered. Rspack's Node.js binding registers the runtime backed by Node.js built-in WebAssembly during module initialization; make sure @rspack/binding is loaded through its JavaScript entry."
 }


### PR DESCRIPTION
## What changed

- Replaced the in-tree SWC Wasm plugin runtime implementation backed by `wasmtime` with a process-wide runtime registered by the Node binding.
- Added a Node/V8-backed WebAssembly runtime for SWC plugins, including N-API registration, JS-thread WebAssembly execution, worker-thread scheduling, WASI setup, and host import bridging.
- Removed `wasmtime`, `wasi-common`, and related Cranelift release-profile entries from Cargo dependencies.
- Updated `builtin:swc-loader` and the binding SWC transform API to use the registered plugin runtime.

## Why

This removes the native wasmtime dependency from Rspack's Node binding path and uses Node.js's built-in WebAssembly runtime instead, reducing the binding's dependency and binary-size footprint.

## Impact

- Debug/CI test builds showed the native binding no longer pulls in wasmtime/wasi-common.
- In the local microbenchmark with `@swc/plugin-remove-console`, the CI-profile binary dropped from ~603 MB to ~544 MB.
- Cold plugin startup without wasmtime filesystem cache improved significantly in the local benchmark, while warm plugin transforms are currently slower because host imports cross the Rust ↔ JS ↔ Wasm boundary.

## Checks

- `cargo check -p rspack_node --no-default-features --features plugin`
- `cargo build -p rspack_node --no-default-features --features plugin`
- `cargo check -p rspack_node --no-default-features --features plugin,perfetto`
- `cargo fmt --all --check`
- Local smoke test for `transformSync` with TypeScript input
- Local smoke test for `@swc/plugin-remove-console@12.9.0`
- Local before/after microbenchmark using `@swc/plugin-remove-console`