### PR TITLE
fix: remove wasmtime threads feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7838,7 +7838,6 @@ dependencies = [
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "windows-sys 0.59.0",
 ]
 
@@ -7969,23 +7968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object",
- "target-lexicon",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wast"
 version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8075,26 +8057,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "35.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.17",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "windows"

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -38,7 +38,7 @@ anyhow            = { workspace = true, optional = true }
 once_cell         = { workspace = true, optional = true }
 swc_plugin_runner = { workspace = true, optional = true }
 wasi-common       = { workspace = true, optional = true, features = ["sync", "wasmtime"] }
-wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift", "threads"] }
+wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift"] }
 
 rspack_regex = { workspace = true }
 signal-hook  = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Remove the explicit `threads` feature from the `wasmtime` dependency used by `rspack_util`'s `plugin` feature.

Reason: SWC plugins don't compile when Wasmtime threads support is enabled https://github.com/swc-project/plugins/blob/d16fe5e26d59f3c9d8db558b2eac591b994a533d/packages/styled-components/package.json#L12. Removing the feature keeps the SWC plugin runtime buildable while retaining the required `runtime` and `cranelift` Wasmtime features.

This also updates `Cargo.lock` to drop now-unused Wasmtime Winch-related dependencies.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `cargo check -p rspack_util --features plugin`