### PR TITLE
refactor: use simdutf8 for utf-8 validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,7 +3871,6 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "simdutf8",
  "smol_str",
  "sugar_path",
  "swc_core",
@@ -3907,6 +3906,7 @@ dependencies = [
  "rspack_location",
  "rspack_paths",
  "serde_json",
+ "simdutf8",
  "termcolor",
  "textwrap",
  "unicode-width 0.2.2",
@@ -4003,6 +4003,7 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_loader_runner",
+ "rspack_util",
  "serde",
  "serde_json",
  "tokio",
@@ -4053,7 +4054,6 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
- "simdutf8",
  "tokio",
  "tracing",
  "winnow",
@@ -4149,6 +4149,7 @@ dependencies = [
  "oneshot",
  "rspack_error",
  "serde_json",
+ "simdutf8",
  "tokio",
 ]
 
@@ -4168,6 +4169,7 @@ dependencies = [
  "napi-derive",
  "rspack_binding_api",
  "rspack_binding_build",
+ "simdutf8",
  "tracing",
 ]
 
@@ -5094,6 +5096,7 @@ dependencies = [
  "regress",
  "rspack_cacheable",
  "rspack_error",
+ "simdutf8",
  "swc_core",
 ]
 
@@ -5133,6 +5136,7 @@ dependencies = [
  "serde",
  "simd-json",
  "simd-utf16-len",
+ "simdutf8",
  "static_assertions",
  "twox-hash",
 ]
@@ -5150,6 +5154,7 @@ dependencies = [
  "rspack_parallel",
  "rspack_paths",
  "rustc-hash",
+ "simdutf8",
  "tokio",
 ]
 
@@ -5194,6 +5199,7 @@ dependencies = [
  "rspack_fs",
  "rspack_paths",
  "rustc-hash",
+ "simdutf8",
  "tokio",
 ]
 
@@ -5247,6 +5253,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "simdutf8",
  "sugar_path",
  "swc_config",
  "swc_core",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -33,6 +33,7 @@ tracing     = { workspace = true }
 
 [build-dependencies]
 rspack_binding_build = { workspace = true }
+simdutf8             = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/node_binding/build.rs
+++ b/crates/node_binding/build.rs
@@ -24,7 +24,10 @@ fn sftrace_setup() {
 
     match result {
       Ok(output) if output.status.success() => {
-        let out = String::from_utf8(output.stdout).ok()?;
+        simdutf8::basic::from_utf8(&output.stdout).ok()?;
+        // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+        #[allow(unsafe_code)]
+        let out = unsafe { String::from_utf8_unchecked(output.stdout) };
         let mut out = PathBuf::from(out);
         out.pop();
         Some(out)

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1473,7 +1473,7 @@ impl CompilationRuntimeModule for CompilationRuntimeModuleTap {
           module.set_custom_source(string);
         }
         napi::Either::B(buffer) => {
-          module.set_custom_source(String::from_utf8_lossy(&buffer).into_owned());
+          module.set_custom_source(rspack_util::utf8::from_utf8_lossy(&buffer).into_owned());
         }
       }
     }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -59,7 +59,6 @@ rustc-hash                 = { workspace = true }
 scopeguard                 = { workspace = true }
 serde                      = { workspace = true }
 serde_json                 = { workspace = true }
-simdutf8                   = { workspace = true }
 smol_str                   = { workspace = true }
 sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -4,6 +4,7 @@ use rspack_error::{Diagnostic, Result};
 use rspack_fs::ReadableFileSystem;
 use rspack_loader_runner::{Content, LoaderContext, LoaderRunnerPlugin, ResourceData};
 use rspack_sources::SourceMap;
+use rspack_util::utf8;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{RunnerContext, SharedPluginDriver, utils::extract_source_map};
@@ -48,10 +49,10 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
         // Try to extract source map from the content
         let extract_result = match &content {
           Content::String(s) => extract_source_map(fs, s, resource_data.resource()).await,
-          Content::Buffer(b) => match simdutf8::basic::from_utf8(b) {
+          Content::Buffer(b) => match utf8::from_utf8(b) {
             Ok(s) => extract_source_map(fs, s, resource_data.resource()).await,
             Err(_) => {
-              extract_source_map(fs, &String::from_utf8_lossy(b), resource_data.resource()).await
+              extract_source_map(fs, &utf8::from_utf8_lossy(b), resource_data.resource()).await
             }
           },
         };

--- a/crates/rspack_core/src/resolver/boxfs.rs
+++ b/crates/rspack_core/src/resolver/boxfs.rs
@@ -6,6 +6,7 @@ use std::{
 use rspack_fs::{Error, FsResultToIoResultExt, ReadableFileSystem};
 use rspack_paths::AssertUtf8;
 use rspack_resolver::{FileMetadata, FileSystem as ResolverFileSystem};
+use rspack_util::utf8;
 
 #[derive(Clone)]
 pub struct BoxFS(Arc<dyn ReadableFileSystem>);
@@ -22,7 +23,8 @@ impl ResolverFileSystem for BoxFS {
   }
   async fn read_to_string(&self, path: &std::path::Path) -> std::io::Result<String> {
     match self.0.read(path.assert_utf8()).await {
-      Ok(x) => String::from_utf8(x).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err)),
+      Ok(x) => utf8::string_from_utf8_compat(x)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err)),
       Err(Error::Io(e)) => Err(e),
     }
   }

--- a/crates/rspack_core/src/utils/extract_source_map.rs
+++ b/crates/rspack_core/src/utils/extract_source_map.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
 use rspack_sources::SourceMap;
-use rspack_util::{base64, node_path::NodePath};
+use rspack_util::{base64, node_path::NodePath, utf8};
 use rustc_hash::FxHashSet;
 
 /// Source map extractor result
@@ -90,7 +90,7 @@ fn decode_data_uri(uri: &str) -> Option<String> {
   if is_base64 {
     return base64::decode_to_vec(body)
       .ok()
-      .and_then(|bytes| String::from_utf8(bytes).ok());
+      .and_then(|bytes| utf8::string_from_utf8(bytes).ok());
   }
 
   // CSS allows to use `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" style="stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px" /></svg>`

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -16,6 +16,7 @@ rspack_collections = { workspace = true }
 rspack_location    = { workspace = true }
 rspack_paths       = { workspace = true }
 serde_json         = { workspace = true }
+simdutf8           = { workspace = true }
 termcolor          = { workspace = true }
 textwrap           = { workspace = true }
 

--- a/crates/rspack_error/src/displayer/renderer/graphical.rs
+++ b/crates/rspack_error/src/displayer/renderer/graphical.rs
@@ -727,7 +727,7 @@ impl GraphicalReportHandler {
     let context_data = source
       .read_span(context_span, self.context_lines, self.context_lines)
       .map_err(|_| fmt::Error)?;
-    let context = std::str::from_utf8(context_data.data()).expect("Bad utf8 detected");
+    let context = simdutf8::compat::from_utf8(context_data.data()).expect("Bad utf8 detected");
     let mut line = context_data.line();
     let mut column = context_data.column();
     let mut offset = context_data.span().offset();

--- a/crates/rspack_error/src/displayer/string.rs
+++ b/crates/rspack_error/src/displayer/string.rs
@@ -38,7 +38,11 @@ impl Display for StringDisplayer {
         writer.write_all(s.as_bytes())?;
         writer.reset()?;
       }
-      return Ok(String::from_utf8(writer.into_inner())?);
+      let bytes = writer.into_inner();
+      simdutf8::compat::from_utf8(&bytes).map_err(|e| crate::error!(e.to_string()))?;
+      // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+      #[allow(unsafe_code)]
+      return Ok(unsafe { String::from_utf8_unchecked(bytes) });
     }
     Ok(diagnostic_strings.join(""))
   }

--- a/crates/rspack_fs/src/intermediate.rs
+++ b/crates/rspack_fs/src/intermediate.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use rspack_paths::Utf8Path;
+use rspack_util::utf8;
 
 use super::Result;
 use crate::{Error, WritableFileSystem};
@@ -20,7 +21,7 @@ pub trait IntermediateFileSystemExtras: Debug + Send + Sync {
 #[async_trait::async_trait]
 pub trait ReadStream: Debug + Sync + Send {
   async fn read_line(&mut self) -> Result<String> {
-    match String::from_utf8(self.read_until(b'\n').await?) {
+    match utf8::string_from_utf8(self.read_until(b'\n').await?) {
       Ok(s) => Ok(s),
       Err(_) => Err(Error::Io(std::io::Error::other("invalid utf8 line"))),
     }

--- a/crates/rspack_fs/src/read.rs
+++ b/crates/rspack_fs/src/read.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use rspack_paths::{Utf8Path, Utf8PathBuf};
+use rspack_util::utf8;
 
 use crate::{Error, FileMetadata, FilePermissions, Result};
 
@@ -13,7 +14,7 @@ pub trait ReadableFileSystem: Debug + Send + Sync {
   // See [std::fs::read_to_string]
   async fn read_to_string(&self, path: &Utf8Path) -> Result<String> {
     let data = self.read(path).await?;
-    String::from_utf8(data).map_err(|_| {
+    utf8::string_from_utf8(data).map_err(|_| {
       Error::Io(std::io::Error::new(
         std::io::ErrorKind::InvalidData,
         "stream did not contain valid UTF-8",
@@ -23,7 +24,7 @@ pub trait ReadableFileSystem: Debug + Send + Sync {
 
   fn read_to_string_sync(&self, path: &Utf8Path) -> Result<String> {
     let data = self.read_sync(path)?;
-    String::from_utf8(data).map_err(|_| {
+    utf8::string_from_utf8(data).map_err(|_| {
       Error::Io(std::io::Error::new(
         std::io::ErrorKind::InvalidData,
         "stream did not contain valid UTF-8",

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -19,6 +19,7 @@ rspack_core          = { workspace = true }
 rspack_error         = { workspace = true }
 rspack_hook          = { workspace = true }
 rspack_loader_runner = { workspace = true }
+rspack_util          = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tokio                = { workspace = true }

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -23,6 +23,7 @@ use rspack_core::{
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_loader_runner::Identifier;
+use rspack_util::utf8;
 use tokio::sync::Mutex;
 
 pub mod config;
@@ -70,7 +71,7 @@ impl LightningCssLoader {
 
     let content_str = match &content {
       rspack_core::Content::String(s) => Cow::Borrowed(s.as_str()),
-      rspack_core::Content::Buffer(buf) => String::from_utf8_lossy(buf),
+      rspack_core::Content::Buffer(buf) => utf8::from_utf8_lossy(buf),
     };
 
     let mut parser_flags = ParserFlags::empty();

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -22,7 +22,6 @@ rspack_paths       = { workspace = true }
 rspack_sources     = { workspace = true }
 rspack_util        = { workspace = true }
 serde_json         = { workspace = true }
-simdutf8           = { workspace = true }
 tracing            = { workspace = true }
 winnow             = { workspace = true }
 

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -13,6 +13,7 @@ use rspack_cacheable::{
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
+use rspack_util::utf8;
 use rustc_hash::FxHashMap;
 
 use crate::{Scheme, get_scheme, parse_resource};
@@ -27,22 +28,14 @@ impl Content {
   pub fn try_into_string(self) -> Result<String> {
     match self {
       Content::String(s) => Ok(s),
-      Content::Buffer(b) => String::from_utf8(b).to_rspack_result(),
+      Content::Buffer(b) => utf8::string_from_utf8_compat(b).to_rspack_result(),
     }
   }
 
-  #[allow(unsafe_code)]
   pub fn into_string_lossy(self) -> String {
     match self {
       Content::String(s) => s,
-      Content::Buffer(b) => {
-        if simdutf8::basic::from_utf8(&b).is_ok() {
-          // SAFETY: simdutf8 validated the buffer as UTF-8 above.
-          unsafe { String::from_utf8_unchecked(b) }
-        } else {
-          String::from_utf8_lossy_owned(b)
-        }
-      }
+      Content::Buffer(b) => utf8::string_from_utf8_lossy(b),
     }
   }
 
@@ -101,7 +94,7 @@ impl Debug for Content {
 
     let s = match self {
       Self::String(s) => s.clone(),
-      Self::Buffer(b) => String::from_utf8_lossy(b).to_string(),
+      Self::Buffer(b) => utf8::from_utf8_lossy(b).to_string(),
     };
 
     let ty = match self {

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(string_from_utf8_lossy_owned)]
-
 mod content;
 mod context;
 mod loader;

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -12,6 +12,7 @@ napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json"
 oneshot      = { workspace = true }
 rspack_error = { workspace = true }
 serde_json   = { workspace = true }
+simdutf8     = { workspace = true }
 tokio        = { workspace = true, features = ["sync"] }
 
 [lints]

--- a/crates/rspack_napi/src/errors.rs
+++ b/crates/rspack_napi/src/errors.rs
@@ -106,5 +106,9 @@ fn try_extract_string_value_from_property<S: AsRef<str>>(
 
   let buf = unsafe { Vec::from_raw_parts(buf.as_mut_ptr() as *mut u8, copied_len, copied_len) };
 
-  Ok(String::from_utf8_lossy(&buf).into_owned())
+  Ok(
+    simdutf8::basic::from_utf8(&buf)
+      .map(str::to_owned)
+      .unwrap_or_else(|_| String::from_utf8_lossy(&buf).into_owned()),
+  )
 }

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -543,7 +543,7 @@ fn template_replace<'a>(s: &str, ctx: &ModuleFilenameTemplateStringCtx<'a>) -> S
                 //
                 // always utf8
                 #[allow(clippy::unwrap_used)]
-                let s = str::from_utf8(matched).unwrap();
+                let s = rspack_util::utf8::from_utf8(matched).unwrap();
                 buf.push('[');
                 buf.push_str(s);
                 buf.push(']');

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -10,6 +10,7 @@ use rspack_core::{
 };
 use rspack_paths::Utf8PathBuf;
 use rspack_plugin_json::create_object_for_exports_info;
+use rspack_util::utf8;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use thread_local::ThreadLocal;
 
@@ -209,7 +210,7 @@ pub fn collect_module_original_sources(
         .or_else(|| {
           let resource = Utf8PathBuf::from(resource);
           let buffer = ifs.read_sync(&resource).ok()?;
-          let content = String::from_utf8(buffer).ok()?;
+          let content = utf8::string_from_utf8(buffer).ok()?;
           Some(RsdoctorModuleOriginalSource {
             module: *module_ukey,
             size: content.len() as i32,

--- a/crates/rspack_plugin_schemes/src/http_uri/http_cache.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/http_cache.rs
@@ -219,7 +219,7 @@ impl HttpCache {
       return Err(anyhow::anyhow!(
         "Request failed with status: {}\n{}",
         status,
-        String::from_utf8_lossy(&response.body)
+        rspack_util::utf8::from_utf8_lossy(&response.body)
       ));
     }
 

--- a/crates/rspack_plugin_schemes/src/http_uri/lockfile.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/lockfile.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use rspack_fs::WritableFileSystem;
 use rspack_paths::Utf8Path;
-use rspack_util::fx_hash::FxHashMap;
+use rspack_util::{fx_hash::FxHashMap, utf8};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
@@ -134,8 +134,8 @@ impl LockfileAsync for Lockfile {
       .read_file(utf8_path)
       .await
       .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{e:?}")))?;
-    let content_str =
-      String::from_utf8(content).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let content_str = utf8::string_from_utf8_compat(content)
+      .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     Lockfile::parse(&content_str).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
   }
 

--- a/crates/rspack_plugin_sri/src/html.rs
+++ b/crates/rspack_plugin_sri/src/html.rs
@@ -11,6 +11,7 @@ use rspack_plugin_html::{
   HtmlPluginBeforeAssetTagGeneration,
   tag::{HtmlPluginAttribute, HtmlPluginTag},
 };
+use rspack_util::utf8;
 use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::RwLock;
 use url::Url;
@@ -273,7 +274,7 @@ async fn compute_file_integrity(
   hash_func_names: &Vec<SubresourceIntegrityHashFunction>,
 ) -> Result<String> {
   let file = fs.read_file(path).await?;
-  let content = String::from_utf8(file).to_rspack_result()?;
+  let content = utf8::string_from_utf8_compat(file).to_rspack_result()?;
   let integrity = compute_integrity(hash_func_names, &content);
   Ok(integrity)
 }

--- a/crates/rspack_regex/Cargo.toml
+++ b/crates/rspack_regex/Cargo.toml
@@ -16,6 +16,7 @@ regex-syntax     = { workspace = true }
 regress          = { workspace = true, features = ["backend-pikevm", "std"] }
 rspack_cacheable = { workspace = true }
 rspack_error     = { workspace = true }
+simdutf8         = { workspace = true }
 swc_core         = { workspace = true, features = ["ecma_ast"] }
 
 [dev-dependencies]

--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -165,11 +165,20 @@ impl Algo {
           if !bytes.iter().all(u8::is_ascii) {
             return None;
           }
-          pats.push(String::from_utf8_lossy(bytes).to_string());
+          pats.push(
+            simdutf8::basic::from_utf8(bytes)
+              .map(str::to_owned)
+              .unwrap_or_else(|_| String::from_utf8_lossy(bytes).into_owned()),
+          );
         }
       } else {
         for item in literals.iter() {
-          pats.push(String::from_utf8_lossy(item.as_bytes()).to_string());
+          let bytes = item.as_bytes();
+          pats.push(
+            simdutf8::basic::from_utf8(bytes)
+              .map(str::to_owned)
+              .unwrap_or_else(|_| String::from_utf8_lossy(bytes).into_owned()),
+          );
         }
       }
 

--- a/crates/rspack_sources/Cargo.toml
+++ b/crates/rspack_sources/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash        = { workspace = true, features = ["std"] }
 serde             = { workspace = true, features = ["rc", "std"] }
 simd-json         = { workspace = true, features = ["runtime-detection", "serde_impl", "swar-number-parsing"] }
 simd-utf16-len    = { workspace = true }
+simdutf8          = { workspace = true }
 static_assertions = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rspack_sources/src/raw_source.rs
+++ b/crates/rspack_sources/src/raw_source.rs
@@ -159,9 +159,9 @@ impl RawBufferSource {
   fn get_or_init_value_as_string(&self) -> &str {
     self
       .value_as_string
-      .get_or_init(|| match String::from_utf8_lossy(&self.value) {
-        Cow::Owned(s) => Some(s),
-        Cow::Borrowed(_) => None,
+      .get_or_init(|| match simdutf8::basic::from_utf8(&self.value) {
+        Ok(_) => None,
+        Err(_) => Some(String::from_utf8_lossy(&self.value).into_owned()),
       })
       .as_deref()
       .unwrap_or_else(|| unsafe { std::str::from_utf8_unchecked(&self.value) })

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -42,22 +42,17 @@ impl<'a> SourceValue<'a> {
     match self {
       SourceValue::String(cow) => cow,
       SourceValue::Buffer(cow) => match cow {
-        Cow::Borrowed(bytes) => String::from_utf8_lossy(bytes),
+        Cow::Borrowed(bytes) => match simdutf8::basic::from_utf8(bytes) {
+          Ok(s) => Cow::Borrowed(s),
+          Err(_) => String::from_utf8_lossy(bytes),
+        },
         Cow::Owned(bytes) => {
-          match String::from_utf8_lossy(&bytes) {
-            Cow::Borrowed(_) => {
-              // SAFETY: When `String::from_utf8_lossy` returns `Cow::Borrowed(_)`,
-              // it guarantees that the input slice contains only valid UTF-8 bytes.
-              // Since we're operating on the exact same `bytes` that were just
-              // validated by `from_utf8_lossy`, we can safely skip the UTF-8
-              // validation in `String::from_utf8_unchecked`.
-              //
-              // This optimization avoids the redundant UTF-8 validation that would
-              // occur if we used `String::from_utf8(bytes).unwrap()` or similar.
-              #[allow(unsafe_code)]
-              Cow::Owned(unsafe { String::from_utf8_unchecked(bytes) })
-            }
-            Cow::Owned(s) => Cow::Owned(s),
+          if simdutf8::basic::from_utf8(&bytes).is_ok() {
+            // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+            #[allow(unsafe_code)]
+            Cow::Owned(unsafe { String::from_utf8_unchecked(bytes) })
+          } else {
+            Cow::Owned(String::from_utf8_lossy(&bytes).into_owned())
           }
         }
       },

--- a/crates/rspack_storage/Cargo.toml
+++ b/crates/rspack_storage/Cargo.toml
@@ -18,6 +18,7 @@ rspack_fs       = { workspace = true }
 rspack_parallel = { workspace = true }
 rspack_paths    = { workspace = true }
 rustc-hash      = { workspace = true }
+simdutf8        = { workspace = true }
 tokio           = { workspace = true, features = ["time"] }
 
 [lints]

--- a/crates/rspack_storage/src/filesystem/db/transaction/lock/state.rs
+++ b/crates/rspack_storage/src/filesystem/db/transaction/lock/state.rs
@@ -56,11 +56,20 @@ impl StateLock {
       ))
     })?;
 
-    let process_name = String::from_utf8(name_bytes).map_err(|e| {
-      Error::InvalidFormat(format!(
-        "Invalid UTF-8 in process name in '{STATE_LOCK_FILE}': {e}"
-      ))
-    })?;
+    let process_name = match simdutf8::compat::from_utf8(&name_bytes) {
+      Ok(_) => {
+        // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+        #[allow(unsafe_code)]
+        unsafe {
+          String::from_utf8_unchecked(name_bytes)
+        }
+      }
+      Err(e) => {
+        return Err(Error::InvalidFormat(format!(
+          "Invalid UTF-8 in process name in '{STATE_LOCK_FILE}': {e}"
+        )));
+      }
+    };
 
     Ok(Self { pid, process_name })
   }
@@ -114,7 +123,11 @@ fn get_process_name(pid: u32) -> Option<String> {
     .ok()?;
 
   if output.status.success() {
-    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let name = simdutf8::basic::from_utf8(&output.stdout)
+      .map(str::to_owned)
+      .unwrap_or_else(|_| String::from_utf8_lossy(&output.stdout).into_owned())
+      .trim()
+      .to_string();
     if !name.is_empty() {
       return Some(name);
     }
@@ -137,7 +150,9 @@ fn get_process_name(pid: u32) -> Option<String> {
     .ok()?;
 
   if output.status.success() {
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = simdutf8::basic::from_utf8(&output.stdout)
+      .map(std::borrow::Cow::Borrowed)
+      .unwrap_or_else(|_| String::from_utf8_lossy(&output.stdout));
     if stdout.contains(&pid.to_string()) {
       // Parse CSV output: "name","pid","session","mem"
       // Extract the process name (first field)

--- a/crates/rspack_tools/Cargo.toml
+++ b/crates/rspack_tools/Cargo.toml
@@ -20,6 +20,7 @@ rspack_error     = { workspace = true }
 rspack_fs        = { workspace = true }
 rspack_paths     = { workspace = true }
 rustc-hash       = { workspace = true }
+simdutf8         = { workspace = true }
 tokio            = { workspace = true }
 
 [lints]

--- a/crates/rspack_tools/src/compare/snapshot.rs
+++ b/crates/rspack_tools/src/compare/snapshot.rs
@@ -48,7 +48,9 @@ pub async fn compare(
     let strategy2 = map2.get(key).expect("should have strategy");
 
     if strategy1 != strategy2 {
-      let path_str = String::from_utf8_lossy(key);
+      let path_str = simdutf8::basic::from_utf8(key)
+        .map(std::borrow::Cow::Borrowed)
+        .unwrap_or_else(|_| String::from_utf8_lossy(key));
       let mut error_msg = format!("Snapshot strategy mismatch for path: {path_str}\n");
       error_msg.push_str(&format!("  storage1: {strategy1:?}\n"));
       error_msg.push_str(&format!("  storage2: {strategy2:?}\n"));

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -27,6 +27,7 @@ rustc-hash       = { workspace = true }
 ryu-js           = { workspace = true }
 serde            = { workspace = true }
 serde_json       = { workspace = true }
+simdutf8         = { workspace = true }
 sugar_path       = { workspace = true }
 unicase          = { workspace = true }
 

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -22,6 +22,7 @@ pub mod span;
 pub mod swc;
 pub mod test;
 pub mod tracing_preset;
+pub mod utf8;
 
 use std::{
   future::Future,

--- a/crates/rspack_util/src/utf8.rs
+++ b/crates/rspack_util/src/utf8.rs
@@ -1,0 +1,46 @@
+use std::borrow::Cow;
+
+#[inline]
+pub fn from_utf8(bytes: &[u8]) -> Result<&str, simdutf8::basic::Utf8Error> {
+  simdutf8::basic::from_utf8(bytes)
+}
+
+#[inline]
+pub fn from_utf8_compat(bytes: &[u8]) -> Result<&str, simdutf8::compat::Utf8Error> {
+  simdutf8::compat::from_utf8(bytes)
+}
+
+#[inline]
+#[allow(unsafe_code)]
+pub fn string_from_utf8(bytes: Vec<u8>) -> Result<String, simdutf8::basic::Utf8Error> {
+  from_utf8(&bytes)?;
+  // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+  Ok(unsafe { String::from_utf8_unchecked(bytes) })
+}
+
+#[inline]
+#[allow(unsafe_code)]
+pub fn string_from_utf8_compat(bytes: Vec<u8>) -> Result<String, simdutf8::compat::Utf8Error> {
+  from_utf8_compat(&bytes)?;
+  // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+  Ok(unsafe { String::from_utf8_unchecked(bytes) })
+}
+
+#[inline]
+pub fn from_utf8_lossy(bytes: &[u8]) -> Cow<'_, str> {
+  match from_utf8(bytes) {
+    Ok(s) => Cow::Borrowed(s),
+    Err(_) => String::from_utf8_lossy(bytes),
+  }
+}
+
+#[inline]
+#[allow(unsafe_code)]
+pub fn string_from_utf8_lossy(bytes: Vec<u8>) -> String {
+  if from_utf8(&bytes).is_ok() {
+    // SAFETY: simdutf8 validated the buffer as UTF-8 above.
+    unsafe { String::from_utf8_unchecked(bytes) }
+  } else {
+    String::from_utf8_lossy(&bytes).into_owned()
+  }
+}


### PR DESCRIPTION
## Summary

Use `simdutf8` for UTF-8 validation paths across Rspack instead of relying on standard-library validation directly. This adds a small `rspack_util::utf8` helper and updates loader content conversion, filesystem read-to-string helpers, resolver reads, source handling, source-map data URI decoding, SRI/schemes/rsdoctor paths, and related tooling fallbacks.

Valgrind Callgrind instruction comparison for representative valid UTF-8 paths:

| Probe | Baseline Ir | Current Ir | Delta |
|---|---:|---:|---:|
| `SourceValue::Buffer(...).into_string_lossy()` | 919,230,811 | 20,113,199 | -97.81% |
| `Content::Buffer(...).try_into_string()` | 190,979,491 | 152,097,965 | -20.36% |

Local artifacts are under `artifacts/valgrind/simdutf8/20260528-223655/` and are ignored by git.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `cargo check -p rspack_util -p rspack_loader_runner -p rspack_core -p rspack_fs -p rspack_sources -p rspack_storage -p rspack_regex -p rspack_napi -p rspack_error -p rspack_loader_lightningcss -p rspack_plugin_sri -p rspack_plugin_rsdoctor -p rspack_plugin_schemes`
- `cargo test -p rspack_sources -p rspack_loader_runner`
- `cargo test -p rspack_regex -p rspack_storage -p rspack_error`
- `cargo check -p rspack_tools -p rspack_node`
- `cargo fmt --all -- --check`
