### PR TITLE
[codex] perf: use BTreeMap for DependencyId

### DIFF
--- a/crates/rspack_binding_api/src/dependency.rs
+++ b/crates/rspack_binding_api/src/dependency.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, ptr::NonNull};
+use std::{cell::RefCell, collections::BTreeMap, ptr::NonNull};
 
 use napi::{
   Either, Env,
@@ -201,7 +201,7 @@ impl Dependency {
   }
 }
 
-type DependencyInstanceRefs = HashMap<DependencyId, OneShotInstanceRef<Dependency>>;
+type DependencyInstanceRefs = BTreeMap<DependencyId, OneShotInstanceRef<Dependency>>;
 
 type DependencyInstanceRefsByCompilationId =
   RefCell<HashMap<CompilationId, DependencyInstanceRefs>>;
@@ -271,13 +271,13 @@ impl ToNapiValue for DependencyWrapper {
         let refs = match entry {
           std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
           std::collections::hash_map::Entry::Vacant(entry) => {
-            let refs = HashMap::default();
+            let refs = BTreeMap::default();
             entry.insert(refs)
           }
         };
 
         match refs.entry(val.dependency_id) {
-          std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
+          std::collections::btree_map::Entry::Occupied(mut occupied_entry) => {
             let r = occupied_entry.get_mut();
             let instance = &mut **r;
             instance.compilation = val.compilation;
@@ -285,7 +285,7 @@ impl ToNapiValue for DependencyWrapper {
 
             ToNapiValue::to_napi_value(env, r)
           }
-          std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+          std::collections::btree_map::Entry::Vacant(vacant_entry) => {
             let js_dependency = Dependency {
               compilation: val.compilation,
               dependency_id: val.dependency_id,

--- a/crates/rspack_binding_api/src/module_graph_connection.rs
+++ b/crates/rspack_binding_api/src/module_graph_connection.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, ptr::NonNull};
+use std::{cell::RefCell, collections::BTreeMap, ptr::NonNull};
 
 use napi::bindgen_prelude::ToNapiValue;
 use napi_derive::napi;
@@ -183,7 +183,7 @@ impl ModuleGraphConnection {
   }
 }
 
-type ModuleGraphConnectionRefs = FxHashMap<DependencyId, OneShotRef>;
+type ModuleGraphConnectionRefs = BTreeMap<DependencyId, OneShotRef>;
 
 type ModuleGraphConnectionRefsByCompilationId =
   RefCell<FxHashMap<CompilationId, ModuleGraphConnectionRefs>>;
@@ -228,17 +228,17 @@ impl ToNapiValue for ModuleGraphConnectionWrapper {
         let refs = match entry {
           std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
           std::collections::hash_map::Entry::Vacant(entry) => {
-            let refs = FxHashMap::default();
+            let refs = BTreeMap::default();
             entry.insert(refs)
           }
         };
 
         match refs.entry(val.dependency_id) {
-          std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+          std::collections::btree_map::Entry::Occupied(occupied_entry) => {
             let r = occupied_entry.get();
             ToNapiValue::to_napi_value(env, r)
           }
-          std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+          std::collections::btree_map::Entry::Vacant(vacant_entry) => {
             let js_dependency = ModuleGraphConnection {
               compilation: val.compilation,
               dependency_id: val.dependency_id,

--- a/crates/rspack_cacheable_macros/src/cacheable/args.rs
+++ b/crates/rspack_cacheable_macros/src/cacheable/args.rs
@@ -7,6 +7,7 @@ use syn::{
 mod kw {
   syn::custom_keyword!(with);
   syn::custom_keyword!(hashable);
+  syn::custom_keyword!(orderable);
 }
 
 /// #[cacheable] type-only args
@@ -14,6 +15,7 @@ pub struct CacheableArgs {
   pub crate_path: syn::Path,
   pub with: Option<syn::Type>,
   pub hashable: bool,
+  pub orderable: bool,
 }
 
 impl Parse for CacheableArgs {
@@ -21,6 +23,7 @@ impl Parse for CacheableArgs {
     let mut crate_path = parse_quote! { ::rspack_cacheable };
     let mut with = None;
     let mut hashable = false;
+    let mut orderable = false;
 
     let mut needs_punct = false;
     while !input.is_empty() {
@@ -43,6 +46,9 @@ impl Parse for CacheableArgs {
       } else if input.peek(kw::hashable) {
         input.parse::<kw::hashable>()?;
         hashable = true;
+      } else if input.peek(kw::orderable) {
+        input.parse::<kw::orderable>()?;
+        orderable = true;
       } else {
         return Err(input.error("unexpected #[cacheable] type-only parameters"));
       }
@@ -54,6 +60,7 @@ impl Parse for CacheableArgs {
       crate_path,
       with,
       hashable,
+      orderable,
     })
   }
 }

--- a/crates/rspack_cacheable_macros/src/cacheable/impl.rs
+++ b/crates/rspack_cacheable_macros/src/cacheable/impl.rs
@@ -55,10 +55,11 @@ pub fn impl_cacheable(tokens: TokenStream, args: CacheableArgs) -> TokenStream {
   visitor.visit_item_mut(&mut input);
 
   let crate_path = &args.crate_path;
-  let archived_impl_hash = if args.hashable {
-    quote! {#[rkyv(derive(Hash, PartialEq, Eq))]}
-  } else {
-    quote! {}
+  let archived_impl_traits = match (args.hashable, args.orderable) {
+    (true, true) => quote! {#[rkyv(derive(Hash, PartialEq, Eq, PartialOrd, Ord))]},
+    (true, false) => quote! {#[rkyv(derive(Hash, PartialEq, Eq))]},
+    (false, true) => quote! {#[rkyv(derive(PartialEq, Eq, PartialOrd, Ord))]},
+    (false, false) => quote! {},
   };
   let bounds = if visitor.omit_bounds {
     quote! {
@@ -85,7 +86,7 @@ pub fn impl_cacheable(tokens: TokenStream, args: CacheableArgs) -> TokenStream {
           #crate_path::__private::rkyv::Serialize
       )]
       #[rkyv(crate=#crate_path::__private::rkyv)]
-      #archived_impl_hash
+      #archived_impl_traits
       #bounds
       #input
   }

--- a/crates/rspack_cacheable_test/tests/macro/cacheable/mod.rs
+++ b/crates/rspack_cacheable_test/tests/macro/cacheable/mod.rs
@@ -1,5 +1,6 @@
 mod basic;
 mod hashable;
 mod omit_bounds;
+mod orderable;
 mod with_attr;
 mod with_attr_and_generics;

--- a/crates/rspack_cacheable_test/tests/macro/cacheable/orderable.rs
+++ b/crates/rspack_cacheable_test/tests/macro/cacheable/orderable.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeSet;
+
+use rspack_cacheable::{enable_cacheable as cacheable, from_bytes, to_bytes};
+
+#[cacheable(orderable)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Person {
+  name: String,
+}
+
+#[test]
+fn orderable_attr() {
+  let mut a = BTreeSet::default();
+  a.insert(Person {
+    name: String::from("a"),
+  });
+  let bytes = to_bytes(&a, &()).unwrap();
+  let deserialize_a: BTreeSet<Person> = from_bytes(&bytes, &()).unwrap();
+  assert_eq!(a, deserialize_a);
+}

--- a/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
+++ b/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
@@ -1,8 +1,10 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+  collections::BTreeMap,
+  ops::{Deref, DerefMut},
+};
 
 use rayon::prelude::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 use rspack_util::atom::Atom;
-use rustc_hash::FxHashMap;
 
 use crate::{
   ArtifactExt, DependencyId, ExportInfo, ModuleIdentifier, incremental::IncrementalPasses,
@@ -22,10 +24,10 @@ pub struct SideEffectsDoOptimizeMoveTarget {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct SideEffectsOptimizeArtifact(FxHashMap<DependencyId, SideEffectsDoOptimize>);
+pub struct SideEffectsOptimizeArtifact(BTreeMap<DependencyId, SideEffectsDoOptimize>);
 
 impl Deref for SideEffectsOptimizeArtifact {
-  type Target = FxHashMap<DependencyId, SideEffectsDoOptimize>;
+  type Target = BTreeMap<DependencyId, SideEffectsDoOptimize>;
 
   fn deref(&self) -> &Self::Target {
     &self.0
@@ -38,33 +40,33 @@ impl DerefMut for SideEffectsOptimizeArtifact {
   }
 }
 
-impl From<FxHashMap<DependencyId, SideEffectsDoOptimize>> for SideEffectsOptimizeArtifact {
-  fn from(value: FxHashMap<DependencyId, SideEffectsDoOptimize>) -> Self {
+impl From<BTreeMap<DependencyId, SideEffectsDoOptimize>> for SideEffectsOptimizeArtifact {
+  fn from(value: BTreeMap<DependencyId, SideEffectsDoOptimize>) -> Self {
     Self(value)
   }
 }
 
-impl From<SideEffectsOptimizeArtifact> for FxHashMap<DependencyId, SideEffectsDoOptimize> {
+impl From<SideEffectsOptimizeArtifact> for BTreeMap<DependencyId, SideEffectsDoOptimize> {
   fn from(value: SideEffectsOptimizeArtifact) -> Self {
     value.0
   }
 }
 
-impl FromIterator<<FxHashMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::Item>
+impl FromIterator<<BTreeMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::Item>
   for SideEffectsOptimizeArtifact
 {
   fn from_iter<
-    T: IntoIterator<Item = <FxHashMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::Item>,
+    T: IntoIterator<Item = <BTreeMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::Item>,
   >(
     iter: T,
   ) -> Self {
-    Self(FxHashMap::from_iter(iter))
+    Self(BTreeMap::from_iter(iter))
   }
 }
 
 impl IntoIterator for SideEffectsOptimizeArtifact {
-  type Item = <FxHashMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::Item;
-  type IntoIter = <FxHashMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::IntoIter;
+  type Item = <BTreeMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::Item;
+  type IntoIter = <BTreeMap<DependencyId, SideEffectsDoOptimize> as IntoIterator>::IntoIter;
 
   fn into_iter(self) -> Self::IntoIter {
     self.0.into_iter()

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/module_tracker.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/module_tracker.rs
@@ -1,7 +1,6 @@
-use std::collections::{VecDeque, hash_map::Entry};
+use std::collections::{BTreeMap, VecDeque, btree_map::Entry};
 
 use rspack_collections::{IdentifierMap, IdentifierSet};
-use rustc_hash::FxHashMap;
 
 use super::{super::graph_updater::repair::context::TaskContext, context::ExecutorTaskContext};
 use crate::{DependencyId, ModuleIdentifier, ModuleIssuer, task_loop::Task};
@@ -22,7 +21,7 @@ pub struct ModuleTracker {
   /// when entry dependency submodules are built,
   /// 1. if reused_unfinished_module is empty, return box tasks directly.
   /// 2. if reused_unfinished_module is not empty, add box tasks to pending_callbacks.
-  entry_finish_tasks: FxHashMap<DependencyId, Vec<BoxTask>>,
+  entry_finish_tasks: BTreeMap<DependencyId, Vec<BoxTask>>,
 
   /// Reused and unfinished modules.
   ///

--- a/crates/rspack_core/src/dependency/dependency_id.rs
+++ b/crates/rspack_core/src/dependency/dependency_id.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::cacheable;
 use rspack_tasks::fetch_new_dependency_id;
 use serde::Serialize;
 
-#[cacheable(hashable)]
+#[cacheable(hashable, orderable)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
 pub struct DependencyId(u32);
 

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -1,5 +1,6 @@
+use std::collections::BTreeMap;
+
 use rspack_util::atom::Atom;
-use rustc_hash::FxHashMap as HashMap;
 
 use super::{ExportInfoTargetValue, ExportProvided, ExportsInfo, ExportsInfoData, UsageState};
 use crate::{
@@ -45,7 +46,7 @@ pub struct ExportInfoData {
   name: Option<Atom>,
   /// this is mangled name, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ExportsInfo.js#L1181-L1188
   used_name: Option<UsedNameItem>,
-  target: HashMap<Option<DependencyId>, ExportInfoTargetValue>,
+  target: BTreeMap<Option<DependencyId>, ExportInfoTargetValue>,
   /// This is rspack only variable, it is used to flag if the target has been initialized
   target_is_set: bool,
   provided: Option<ExportProvided>,
@@ -105,7 +106,7 @@ impl ExportInfoData {
                   },
                 )
               })
-              .collect::<HashMap<Option<DependencyId>, ExportInfoTargetValue>>(),
+              .collect::<BTreeMap<Option<DependencyId>, ExportInfoTargetValue>>(),
           )
         } else {
           None
@@ -147,7 +148,7 @@ impl ExportInfoData {
     self.used_name.as_ref()
   }
 
-  pub fn target(&self) -> &HashMap<Option<DependencyId>, ExportInfoTargetValue> {
+  pub fn target(&self) -> &BTreeMap<Option<DependencyId>, ExportInfoTargetValue> {
     &self.target
   }
 
@@ -155,7 +156,7 @@ impl ExportInfoData {
     self.target_is_set
   }
 
-  pub fn target_mut(&mut self) -> &mut HashMap<Option<DependencyId>, ExportInfoTargetValue> {
+  pub fn target_mut(&mut self) -> &mut BTreeMap<Option<DependencyId>, ExportInfoTargetValue> {
     &mut self.target
   }
 

--- a/crates/rspack_core/src/exports/export_info_getter.rs
+++ b/crates/rspack_core/src/exports/export_info_getter.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use itertools::Itertools;
 use rspack_util::atom::Atom;
@@ -231,7 +231,7 @@ impl ExportInfoData {
     self.used_name().is_some()
   }
 
-  pub fn get_max_target(&self) -> Cow<'_, HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
+  pub fn get_max_target(&self) -> Cow<'_, BTreeMap<Option<DependencyId>, ExportInfoTargetValue>> {
     if self.target().len() <= 1 {
       return Cow::Borrowed(self.target());
     }
@@ -244,7 +244,7 @@ impl ExportInfoData {
     if max_priority == min_priority {
       return Cow::Borrowed(self.target());
     }
-    let mut map = HashMap::default();
+    let mut map = BTreeMap::default();
     for (k, v) in self.target().iter() {
       if max_priority == v.priority {
         map.insert(*k, v.clone());

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1,7 +1,7 @@
 pub mod internal;
 pub mod rollback;
 
-use std::hash::BuildHasherDefault;
+use std::{collections::BTreeMap, hash::BuildHasherDefault};
 
 use internal::try_get_module_graph_module_mut_by_identifier;
 use rayon::prelude::*;
@@ -26,6 +26,8 @@ use crate::{
   BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportsInfoArtifact,
   ModuleIdentifier,
 };
+
+type DependencyIdMap<V> = BTreeMap<DependencyId, V>;
 
 // TODO Here request can be used Atom
 pub type ImportVarMap = HashMap<(Option<ModuleIdentifier>, bool), String /* import_var */>;
@@ -112,7 +114,7 @@ pub(crate) struct ModuleGraphData {
     rollback::RollbackMap<ModuleIdentifier, BoxModule, BuildHasherDefault<IdentifierHasher>>,
 
   /// Dependencies indexed by `DependencyId`.
-  dependencies: HashMap<DependencyId, BoxDependency>,
+  dependencies: DependencyIdMap<BoxDependency>,
   /// AsyncDependenciesBlocks indexed by `AsyncDependenciesBlockIdentifier`.
   blocks: AsyncDependenciesBlockIdentifierMap<Box<AsyncDependenciesBlock>>,
 
@@ -133,9 +135,9 @@ pub(crate) struct ModuleGraphData {
   ///     assert_eq!(parents_info.module, parent_module_id);
   ///   })
   /// ```
-  dependency_id_to_parents: HashMap<DependencyId, DependencyParents>,
+  dependency_id_to_parents: DependencyIdMap<DependencyParents>,
   // TODO try move condition as connection field
-  connection_to_condition: HashMap<DependencyId, DependencyCondition>,
+  connection_to_condition: DependencyIdMap<DependencyCondition>,
 
   /************************** Modified by Seal Phase **********************/
   /// ModuleGraphModule indexed by `ModuleIdentifier`.
@@ -149,7 +151,7 @@ pub(crate) struct ModuleGraphData {
 
   /***************** only Modified during Seal Phase ********************/
   // setting here https://github.com/web-infra-dev/rspack/blob/9ae2f0f3be22370197cd9ed3308982f84f2bb738/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs#L318
-  dep_meta_map: HashMap<DependencyId, DependencyExtraMeta>,
+  dep_meta_map: DependencyIdMap<DependencyExtraMeta>,
 }
 impl ModuleGraphData {
   fn checkpoint(&mut self) {

--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -1,7 +1,6 @@
-use std::fmt;
+use std::{collections::BTreeSet, fmt};
 
 use rspack_cacheable::{cacheable, with::Skip};
-use rustc_hash::FxHashSet;
 
 use crate::{DependencyId, ModuleIdentifier, ModuleIssuer};
 
@@ -38,10 +37,10 @@ impl fmt::Display for OptimizationBailoutItem {
 #[derive(Debug, Clone)]
 pub struct ModuleGraphModule {
   // edges from module to module
-  outgoing_connections: FxHashSet<DependencyId>,
+  outgoing_connections: BTreeSet<DependencyId>,
   // incoming connections will regenerate by persistent cache recovery.
   #[cacheable(with=Skip)]
-  incoming_connections: FxHashSet<DependencyId>,
+  incoming_connections: BTreeSet<DependencyId>,
 
   issuer: ModuleIssuer,
 
@@ -88,11 +87,11 @@ impl ModuleGraphModule {
     self.outgoing_connections.remove(dependency_id);
   }
 
-  pub fn incoming_connections(&self) -> &FxHashSet<DependencyId> {
+  pub fn incoming_connections(&self) -> &BTreeSet<DependencyId> {
     &self.incoming_connections
   }
 
-  pub fn outgoing_connections(&self) -> &FxHashSet<DependencyId> {
+  pub fn outgoing_connections(&self) -> &BTreeSet<DependencyId> {
     &self.outgoing_connections
   }
 

--- a/crates/rspack_plugin_css/src/parser_and_generator/parser.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/parser.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+  collections::{BTreeMap, BTreeSet},
+  sync::Arc,
+};
 
 use once_cell::sync::OnceCell;
 use rspack_core::{
@@ -46,13 +49,13 @@ pub(super) struct CssModuleParser<'context> {
 
 #[derive(Default)]
 struct ComposesOrderState {
-  graph: FxHashMap<DependencyId, FxHashSet<DependencyId>>,
+  graph: BTreeMap<DependencyId, BTreeSet<DependencyId>>,
   request_to_dependency: FxHashMap<String, DependencyId>,
   dependencies_in_source_order: Vec<(DependencyId, i32)>,
   compose_dependency_count: usize,
   current_rule_key: Option<String>,
   current_rule_prev_dependency: Option<DependencyId>,
-  current_rule_dependencies: FxHashSet<DependencyId>,
+  current_rule_dependencies: BTreeSet<DependencyId>,
 }
 
 impl ComposesOrderState {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::only_used_in_recursion)]
-use std::{borrow::Cow, collections::VecDeque, sync::Arc};
+use std::{
+  borrow::Cow,
+  collections::{BTreeMap, VecDeque},
+  sync::Arc,
+};
 
 use rayon::prelude::*;
 use rspack_collections::{
@@ -981,14 +985,7 @@ impl ModuleConcatenationPlugin {
             })
             .collect(),
         };
-        let incoming_connections_len = incomings.from_non_modules.len()
-          + incomings
-            .from_modules
-            .values()
-            .map(std::vec::Vec::len)
-            .sum::<usize>();
-        let mut active_incomings =
-          HashMap::with_capacity_and_hasher(incoming_connections_len, Default::default());
+        let mut active_incomings = BTreeMap::new();
         for connection in incomings
           .from_non_modules
           .iter()
@@ -1344,7 +1341,7 @@ pub struct NoRuntimeModuleCache {
   provided_names: bool,
   connections: Vec<(ModuleGraphConnection, (bool, bool))>,
   incomings: IncomingConnections,
-  active_incomings: HashMap<DependencyId, bool>,
+  active_incomings: BTreeMap<DependencyId, bool>,
   number_of_chunks: usize,
 }
 
@@ -1619,7 +1616,7 @@ fn add_concatenated_module(
 fn is_connection_active_in_runtime(
   connection: &ModuleGraphConnection,
   runtime: Option<&RuntimeSpec>,
-  cached_active_incomings: &HashMap<DependencyId, bool>,
+  cached_active_incomings: &BTreeMap<DependencyId, bool>,
   cached_runtime: &RuntimeSpec,
   mg: &ModuleGraph,
   artifacts: &ModuleGraphArtifacts,

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 pub use rspack_core::cache::persistent::occasion::make::SCOPE;
 use rspack_core::{
@@ -15,6 +15,8 @@ use rspack_paths::Utf8PathBuf;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{debug_info::DebugInfo, utils::ensure_iter_equal};
+
+type DependencyIdMap = BTreeMap<DependencyId, DependencyId>;
 
 /// Compare make scope data between two storages
 pub async fn compare(
@@ -85,7 +87,7 @@ impl<'a> ArtifactComparator<'a> {
 
     // First pass: Compare dependencies and build DependencyId mapping
     // DependencyId mapping: dep_id1 -> dep_id2
-    let mut dep_id_map: HashMap<DependencyId, DependencyId> = HashMap::default();
+    let mut dep_id_map: DependencyIdMap = BTreeMap::default();
 
     for (module_id, module1) in &modules1 {
       let module2 = modules2
@@ -123,7 +125,7 @@ impl<'a> ArtifactComparator<'a> {
     &self,
     module_id: &rspack_core::ModuleIdentifier,
     debug_info: &DebugInfo,
-    dep_id_map: &HashMap<DependencyId, DependencyId>,
+    dep_id_map: &DependencyIdMap,
   ) -> Result<()> {
     // Get outgoing connections for this module from both graphs
     let connections1: Vec<_> = self.mg1.get_outgoing_connections(module_id).collect();
@@ -182,7 +184,7 @@ impl<'a> ArtifactComparator<'a> {
     module1: &rspack_core::BoxModule,
     module2: &rspack_core::BoxModule,
     debug_info: &DebugInfo,
-    dep_id_map: &mut HashMap<DependencyId, DependencyId>,
+    dep_id_map: &mut DependencyIdMap,
   ) -> Result<()> {
     let deps1 = module1.get_dependencies();
     let deps2 = module2.get_dependencies();
@@ -233,7 +235,7 @@ impl<'a> ArtifactComparator<'a> {
     module1: &rspack_core::BoxModule,
     module2: &rspack_core::BoxModule,
     debug_info: &DebugInfo,
-    dep_id_map: &HashMap<DependencyId, DependencyId>,
+    dep_id_map: &DependencyIdMap,
   ) -> Result<()> {
     let build_info1 = module1.build_info();
     let build_info2 = module2.build_info();
@@ -276,7 +278,7 @@ impl<'a> ArtifactComparator<'a> {
     &self,
     exports1: &[DependencyId],
     exports2: &[DependencyId],
-    dep_id_map: &HashMap<DependencyId, DependencyId>,
+    dep_id_map: &DependencyIdMap,
     debug_info: &DebugInfo,
   ) -> Result<()> {
     if exports1.len() != exports2.len() {


### PR DESCRIPTION
## Summary

- Replace `ModuleGraphModule` incoming/outgoing dependency connection sets with ordered `BTreeSet`s.
- Replace maps keyed by `DependencyId` or `Option<DependencyId>` with `BTreeMap` in module graph, export info, side-effects artifacts, binding refs, CSS compose ordering, module concatenation cache, and cache compare tooling.
- Add `cacheable(orderable)` support so archived `DependencyId` can satisfy `BTreeSet` ordering requirements.

## Validation

- `cargo check -p rspack_core -p rspack_plugin_css -p rspack_plugin_javascript -p rspack_binding_api -p rspack_tools`
- `cargo test -p rspack_cacheable_test orderable_attr`

---
_by OpenAI Codex_