### PR TITLE
fix(rspack_watcher): scan after arming the disk watcher to close a startup race

### DIFF
--- a/crates/rspack_watcher/src/lib.rs
+++ b/crates/rspack_watcher/src/lib.rs
@@ -195,10 +195,20 @@ impl FsWatcher {
     //     in flight for that write would then be suppressed as a duplicate.
     self.record_initial_file_mtimes();
 
-    self.scanner.scan(start_time);
-
     let watch_patterns = self.analyzer.analyze(self.path_manager.access());
     self.disk_watcher.watch(watch_patterns.into_iter())?;
+
+    // Scan AFTER the disk watcher is armed, not before. notify's `watch()`
+    // registers the underlying inotify/FSEvents watch synchronously, so once it
+    // returns every later change is delivered as a live event. Scanning here
+    // closes a startup race: previously the scan ran (in spawned tasks) before
+    // `disk_watcher.watch()`, so it could snapshot a file's mtime before the
+    // watch was armed. A change landing in that gap was seen by neither path —
+    // the scan read the pre-change mtime, and the watch was not yet active to
+    // deliver the event — so no rebuild was triggered. With this order, a change
+    // before arm is on disk by scan time (caught by `mtime > start_time`) and a
+    // change after arm is caught live.
+    self.scanner.scan(start_time);
 
     Ok(())
   }


### PR DESCRIPTION
## Why
The native-watcher test `nativeWatcherCases-watchCases/change-event/metadata > should compile step 1` flakily timed out at 30s on Linux CI (e.g. [run 26564410186](https://github.com/web-infra-dev/rspack/actions/runs/26564410186/job/78257139614)).

Root cause: `FsWatcher::wait_for_event` ran the startup **scan** (which catches changes whose `mtime > start_time`) **before** `disk_watcher.watch()`, and the scan runs in spawned tasks. So it could snapshot a file's mtime *before* the inotify/FSEvents watch was armed. A change landing in that window was seen by **neither** path:
- the scan read the *pre-change* mtime → `mtime > start_time` was false → no event;
- the watch wasn't armed yet → the live event was never delivered.

→ no rebuild → step 1 hangs to timeout. (The case touches `index.js` via an async `fs.utimes` in the compile `done` hook; under CI load that write lands inside the gap.)

## What
`notify`'s `watch()` registers the kernel watch **synchronously**, so moving the scan to run **after** it returns closes the gap: a change before arm is on disk by scan time (caught by the scan), a change after arm is caught by the live watcher. Same order webpack/watchpack uses (watch, then scan). One-file change, no extra syscalls, no timers.

## Evidence
Verified with a temporary diagnostic build (env-gated `[WDBG]` watcher logging + a CI job looping the native-watcher suite). Both the instrumentation and CI trim were reverted; this PR is the fix only.

- **Before** (failure reproduced): [run 26619156932](https://github.com/web-infra-dev/rspack/actions/runs/26619156932) — shard 2 hit the timeout at iteration 4; trace showed `scanner changed=false` (stale mtime) and no inotify event for `index.js`.
- **After** (fix): [run 26621634345](https://github.com/web-infra-dev/rspack/actions/runs/26621634345) — 4 shards × 30 iterations = **120/120 green**.