### PR TITLE
perf(split-chunks): reduce module grouping overhead

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -131,12 +131,20 @@ impl SplitChunksPlugin {
 
     let mut combinator = module_group::Combinator::default();
 
-    if self
+    let non_used_exports_min_chunks = self
       .cache_groups
       .iter()
-      .any(|cache_group| !cache_group.used_exports)
-    {
-      combinator.prepare_group_by_chunks(&all_modules, &module_chunks, &chunk_index_map);
+      .filter(|cache_group| !cache_group.used_exports)
+      .map(|cache_group| cache_group.min_chunks as usize)
+      .min();
+
+    if let Some(min_chunks) = non_used_exports_min_chunks {
+      combinator.prepare_group_by_chunks(
+        &all_modules,
+        &module_chunks,
+        &chunk_index_map,
+        min_chunks,
+      );
     }
 
     if self

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -794,7 +794,7 @@ async fn merge_matched_item_into_module_group_map(
       .entry(key)
       .or_insert_with(|| ModuleGroup::new(chunk_name, cache_group_index, cache_group))
   };
-  let should_extend_chunks = !(is_anonymous && matches!(selected_chunks, SelectedChunks::All(_)))
+  let should_extend_chunks = !(is_anonymous && matches!(&selected_chunks, SelectedChunks::All(_)))
     || module_group.chunks.is_empty();
   module_group.add_module(module.identifier());
   if should_extend_chunks {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -293,6 +293,7 @@ impl Combinator {
     all_modules: &[ModuleIdentifier],
     module_chunks: &ModuleChunks,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
+    min_chunks: usize,
   ) {
     self.non_used_exports_chunks_keys = all_modules
       .par_iter()
@@ -301,7 +302,7 @@ impl Combinator {
         let chunks = module_chunks
           .get(module_index)
           .expect("should have module chunks");
-        if chunks.is_empty() {
+        if chunks.is_empty() || chunks.len() < min_chunks {
           None
         } else {
           Some(get_key(chunks.iter().copied(), chunk_index_map))
@@ -494,6 +495,9 @@ impl SplitChunksPlugin {
               cache_group_index,
               cache_group,
             } = cache_group;
+            if belong_to_chunks.len() < cache_group.min_chunks as usize {
+              continue;
+            }
             let combs = if cache_group.used_exports {
               if used_exports_combs.is_none() {
                 used_exports_combs = Some(combinator.get_combs(

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -745,6 +745,7 @@ async fn merge_matched_item_into_module_group_map(
       f(ctx).await?
     }
   };
+  let is_anonymous = chunk_name.is_none();
   let key = if let Some(cache_group_name) = &chunk_name {
     ModuleGroupKey::Named {
       cache_group_index,
@@ -764,8 +765,12 @@ async fn merge_matched_item_into_module_group_map(
       .entry(key)
       .or_insert_with(|| ModuleGroup::new(chunk_name, cache_group_index, cache_group))
   };
+  let should_extend_chunks = !(is_anonymous && matches!(selected_chunks, SelectedChunks::All(_)))
+    || module_group.chunks.is_empty();
   module_group.add_module(module.identifier());
-  module_group.chunks.extend(selected_chunks.iter().copied());
+  if should_extend_chunks {
+    module_group.chunks.extend(selected_chunks.iter().copied());
+  }
 
   Ok(())
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -537,6 +537,31 @@ impl SplitChunksPlugin {
                 continue;
               }
 
+              if matches!(&cache_group.chunk_filter, ChunkFilter::All)
+                && matches!(&cache_group.name, ChunkNameGetter::Disabled)
+              {
+                if let Some(removed_chunks) = removed_chunks
+                  && chunk_combination
+                    .iter()
+                    .any(|c| removed_chunks.contains(c))
+                {
+                  continue;
+                }
+
+                let mut module_group = {
+                  module_group_map
+                    .entry(ModuleGroupKey::Anonymous {
+                      cache_group_index: *cache_group_index,
+                      chunks_key: chunk_combination.key,
+                    })
+                    .or_insert_with(|| ModuleGroup::new(None, *cache_group_index, cache_group))
+                };
+                module_group.add_module(module.identifier());
+                if module_group.chunks.is_empty() {
+                  module_group.chunks.extend(chunk_combination.iter().copied());
+                }
+                continue;
+              }
 
               let selected_chunks = if matches!(&cache_group.chunk_filter, ChunkFilter::All) {
                 SelectedChunks::All(chunk_combination)

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -129,6 +129,7 @@ fn get_key<I: Iterator<Item = ChunkUkey>>(
 pub(crate) struct Combinator {
   combinations: FxHashMap<ChunksKey, Vec<ChunkCombination>>,
   used_exports_combinations: FxHashMap<ChunksKey, Vec<ChunkCombination>>,
+  non_used_exports_chunks_keys: Vec<Option<ChunksKey>>,
   grouped_by_exports: Vec<Vec<ChunksKey>>,
 }
 
@@ -184,7 +185,11 @@ impl Combinator {
     let chunks = module_chunks
       .get(module_index)
       .expect("should have module chunks");
-    let chunks_key = get_key(chunks.iter().copied(), chunk_index_map);
+    let chunks_key = self
+      .non_used_exports_chunks_keys
+      .get(module_index)
+      .and_then(|key| *key)
+      .unwrap_or_else(|| get_key(chunks.iter().copied(), chunk_index_map));
     self
       .combinations
       .get(&chunks_key)
@@ -289,26 +294,43 @@ impl Combinator {
     module_chunks: &ModuleChunks,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) {
-    let chunk_sets_in_graph = all_modules
+    self.non_used_exports_chunks_keys = all_modules
       .par_iter()
       .enumerate()
-      .filter_map(|(module_index, _)| {
+      .map(|(module_index, _)| {
         let chunks = module_chunks
           .get(module_index)
           .expect("should have module chunks");
         if chunks.is_empty() {
-          return None;
+          None
+        } else {
+          Some(get_key(chunks.iter().copied(), chunk_index_map))
         }
-        let chunk_key = get_key(chunks.iter().copied(), chunk_index_map);
-        Some((
-          chunk_key,
-          ChunkCombination {
-            key: chunk_key,
-            chunks: Arc::new(chunks.clone()),
-          },
-        ))
       })
-      .collect::<FxHashMap<_, _>>();
+      .collect::<Vec<_>>();
+
+    let mut chunk_sets_in_graph = FxHashMap::with_capacity_and_hasher(
+      self.non_used_exports_chunks_keys.len(),
+      Default::default(),
+    );
+    for (module_index, chunk_key) in self
+      .non_used_exports_chunks_keys
+      .iter()
+      .enumerate()
+      .filter_map(|(module_index, chunk_key)| chunk_key.map(|chunk_key| (module_index, chunk_key)))
+    {
+      chunk_sets_in_graph
+        .entry(chunk_key)
+        .or_insert_with(|| ChunkCombination {
+          key: chunk_key,
+          chunks: Arc::new(
+            module_chunks
+              .get(module_index)
+              .expect("should have module chunks")
+              .clone(),
+          ),
+        });
+    }
 
     let mut chunk_sets_by_count = Vec::<ChunkCombination>::with_capacity(chunk_sets_in_graph.len());
     for chunks in chunk_sets_in_graph.values() {
@@ -430,7 +452,10 @@ impl SplitChunksPlugin {
             return Ok(());
           }
 
-          if let Some(removed_chunks) = removed_module_chunks.get(mid) && belong_to_chunks.iter().all(|c| removed_chunks.contains(c)) {
+          let removed_chunks = removed_module_chunks.get(mid);
+          if let Some(removed_chunks) = removed_chunks
+            && belong_to_chunks.iter().all(|c| removed_chunks.contains(c))
+          {
             return Ok(());
           }
           let module = module_graph.module_by_identifier(mid).expect("should have module").as_ref();
@@ -551,7 +576,9 @@ impl SplitChunksPlugin {
                 continue;
               }
 
-              if selected_chunks.iter().any(|c| removed_module_chunks.get(mid).is_some_and(|chunks| chunks.contains(c))) {
+              if let Some(removed_chunks) = removed_chunks
+                && selected_chunks.iter().any(|c| removed_chunks.contains(c))
+              {
                 continue;
               }
               merge_matched_item_into_module_group_map(


### PR DESCRIPTION
## What changed

This PR optimizes the SplitChunks module grouping path with a few focused reductions in repeated work:

- Cache each module's non-used-exports chunk-set key during combination preparation, then reuse that key when looking up combinations during module group preparation.
- Skip non-used-exports chunk-set preparation for modules whose chunk count is below the smallest relevant `minChunks` value.
- Skip cache group processing early when a module's total chunk count is below that cache group's `minChunks`, because no generated chunk combination can satisfy the threshold.
- Reuse the per-module `removed_chunks` lookup while checking candidate combinations, instead of looking it up again for each selected chunk check.
- Add a fast path for anonymous cache groups with `chunks: "all"` and `name: false`, inserting the module group directly without building a `SelectedChunks` wrapper or running the generic merge path.
- Avoid repeatedly extending `module_group.chunks` for anonymous `chunks: "all"` groups after the first insertion, since all modules in the same anonymous group share the same chunk set.

## Why this improves performance

The SplitChunks stage repeatedly groups modules by the chunks they belong to. In the common non-used-exports path, the chunk-set key is stable for the whole pass, but the old flow recomputed it by collecting, sorting, and hashing chunk indexes during module group preparation. Caching the key moves that work into the preparation phase and lets later lookups reuse the same derived value.

The `minChunks` pruning removes impossible candidates before combination generation and before per-cache-group combination traversal. Because every generated chunk combination is a subset of the module's chunks, a module with fewer chunks than `minChunks` can never produce a valid group for that cache group.

The anonymous `chunks: "all"` fast path targets the default/simple split-chunks shape where no chunk filtering or name callback is needed. It bypasses generic selection and merge machinery while preserving the same anonymous group key, module insertion, removed-chunks checks, and first-time chunk initialization.

Finally, reusing `removed_chunks` and avoiding repeated chunk-set extensions reduces small but hot hash map/hash set work inside the nested module/cache-group/combination loops.