### PR TITLE
perf: using simd utf8 in into_string_lossy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,6 +5134,7 @@ dependencies = [
  "serde",
  "simd-json",
  "simd-utf16-len",
+ "simdutf8",
  "static_assertions",
  "twox-hash",
 ]

--- a/crates/rspack_sources/Cargo.toml
+++ b/crates/rspack_sources/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash        = { workspace = true, features = ["std"] }
 serde             = { workspace = true, features = ["rc", "std"] }
 simd-json         = { workspace = true, features = ["runtime-detection", "serde_impl", "swar-number-parsing"] }
 simd-utf16-len    = { workspace = true }
+simdutf8          = { workspace = true }
 static_assertions = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rspack_sources/src/concat_source.rs
+++ b/crates/rspack_sources/src/concat_source.rs
@@ -439,7 +439,7 @@ fn optimize(children: &mut Vec<BoxSource>) -> Vec<BoxSource> {
   }
 
   let mut new_children = Vec::new();
-  let mut current_raw_sources = Vec::new();
+  let mut current_raw_sources = Vec::with_capacity(original_children.len());
 
   for child in original_children {
     if child.as_ref().as_any().is::<RawStringSource>() {

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -44,21 +44,16 @@ impl<'a> SourceValue<'a> {
       SourceValue::Buffer(cow) => match cow {
         Cow::Borrowed(bytes) => String::from_utf8_lossy(bytes),
         Cow::Owned(bytes) => {
-          match String::from_utf8_lossy(&bytes) {
-            Cow::Borrowed(_) => {
-              // SAFETY: When `String::from_utf8_lossy` returns `Cow::Borrowed(_)`,
-              // it guarantees that the input slice contains only valid UTF-8 bytes.
-              // Since we're operating on the exact same `bytes` that were just
-              // validated by `from_utf8_lossy`, we can safely skip the UTF-8
-              // validation in `String::from_utf8_unchecked`.
-              //
-              // This optimization avoids the redundant UTF-8 validation that would
-              // occur if we used `String::from_utf8(bytes).unwrap()` or similar.
-              #[allow(unsafe_code)]
-              Cow::Owned(unsafe { String::from_utf8_unchecked(bytes) })
+          let s = if simdutf8::basic::from_utf8(&bytes).is_ok() {
+            // SAFETY: `simdutf8::basic::from_utf8` has validated these exact bytes.
+            #[allow(unsafe_code)]
+            unsafe {
+              String::from_utf8_unchecked(bytes)
             }
-            Cow::Owned(s) => Cow::Owned(s),
-          }
+          } else {
+            String::from_utf8_lossy(&bytes).into_owned()
+          };
+          Cow::Owned(s)
         }
       },
     }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

This PR optimizes lossy UTF-8 conversion for owned byte buffers in `rspack_sources` by adding a SIMD-based UTF-8 validation fast-path, aiming to reduce overhead when converting valid UTF-8 buffers into `String`.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
