### PR TITLE
chore(ci): migrate rust build and benches to physical runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     with:
       target: x86_64-unknown-linux-gnu
       profile: 'ci'
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+      runner: '"physical-1"'
 
   test-linux:
     name: Test Linux
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/bench-binding.yml
     with:
       target: x86_64-unknown-linux-gnu
-      runner: '"ubuntu-22.04"'
+      runner: '"physical-1"'
 
   bench-rust:
     name: Rust Bench
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/bench-rust.yml
     with:
       target: x86_64-unknown-linux-gnu
-      runner: '"ubuntu-22.04"'
+      runner: '"physical-1"'
 
   test-windows:
     name: Test Windows


### PR DESCRIPTION
### Motivation
- Run heavy Rust builds and CodSpeed benchmarks on a dedicated physical runner by migrating the Linux build and benchmark jobs to the `physical-1` label.

### Description
- Updated `.github/workflows/ci.yml` to set `runner: '"physical-1"'` for the `build-linux`, `bench-binding`, and `bench-rust` workflow call inputs.
- No other workflow files were modified.

### Testing
- Verified the modified workflow file parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` which succeeded.
- Ran `git diff --check` on the changed workflow which reported no issues, and an attempted Python `yaml.safe_load` check was skipped because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a193ff8c51c8331bb71721094e13fc6)