### PR TITLE
perf(bench): enable fat LTO in codspeed profile to measure impact

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,8 +278,9 @@ strip     = true
 [profile.codspeed]
 debug    = "full"
 inherits = "release"
-lto      = "off"
-strip    = "none"
+# Match the production `release` profile's fat LTO so benchmarks reflect what users actually run.
+lto   = "fat"
+strip = "none"
 
 [profile.release.package]
 


### PR DESCRIPTION
## Why

The Rust CodSpeed benchmarks are built with `--profile codspeed`, which inherits from `release` but explicitly overrides `lto = "off"`. As a result the benchmark numbers reported by CodSpeed do **not** reflect the fat-LTO build that actually ships to users (`[profile.release]` uses `lto = "fat"`).

This draft enables fat LTO in the `codspeed` profile so the CI CodSpeed comparison (PR vs. `main`, which is still `lto = "off"`) reveals how much LTO affects the benchmark results.

### Before / After

| | `[profile.codspeed]` `lto` |
|---|---|
| Before | `off` |
| After | `fat` (matches `[profile.release]`) |

## Notes

- Draft / experimental — purpose is to read the CodSpeed delta, not necessarily to merge.
- Fat LTO + single codegen unit makes the benchmark build slower; watch the `Rust Bench` job build time.
- `debug = "full"` / `strip = "none"` are kept so CodSpeed can still attribute instructions to source.
