### PR TITLE
feat: expose DeterministicModuleIdsPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3956,6 +3956,8 @@ dependencies = [
 name = "rspack_ids"
 version = "0.100.5"
 dependencies = [
+ "derive_more",
+ "futures",
  "itertools 0.14.0",
  "rayon",
  "rspack_collections",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2156,6 +2156,15 @@ export interface RawCssParserOptions {
   dashedIdents?: boolean
 }
 
+export interface RawDeterministicModuleIdsPluginOptions {
+  context?: string
+  test?: RawModuleFilter
+  maxLength?: number
+  salt?: number
+  fixedLength?: boolean
+  failOnConflict?: boolean
+}
+
 export interface RawDllEntryPluginOptions {
   context: string
   entries: Array<string>

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2158,7 +2158,7 @@ export interface RawCssParserOptions {
 
 export interface RawDeterministicModuleIdsPluginOptions {
   context?: string
-  test?: RawModuleFilter
+  test?: (module: Module) => boolean
   maxLength?: number
   salt?: number
   fixedLength?: boolean

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -30,7 +30,10 @@ use napi::{
 };
 use napi_derive::napi;
 use raw_dll::{RawDllReferenceAgencyPluginOptions, RawFlagAllModulesAsUsedPluginOptions};
-use raw_ids::{RawHashedModuleIdsPluginOptions, RawOccurrenceChunkIdsPluginOptions};
+use raw_ids::{
+  RawDeterministicModuleIdsPluginOptions, RawHashedModuleIdsPluginOptions,
+  RawOccurrenceChunkIdsPluginOptions,
+};
 use raw_lightning_css_minimizer::RawLightningCssMinimizerRspackPluginOptions;
 use raw_mf::{
   RawCollectShareEntryPluginOptions, RawModuleFederationManifestPluginOptions,
@@ -570,9 +573,14 @@ impl<'a> BuiltinPlugin<'a> {
       BuiltinPluginName::NaturalModuleIdsPlugin => {
         plugins.push(NaturalModuleIdsPlugin::default().boxed())
       }
-      BuiltinPluginName::DeterministicModuleIdsPlugin => {
-        plugins.push(DeterministicModuleIdsPlugin::default().boxed())
-      }
+      BuiltinPluginName::DeterministicModuleIdsPlugin => plugins.push(
+        DeterministicModuleIdsPlugin::new(
+          downcast_into::<RawDeterministicModuleIdsPluginOptions>(self.options)
+            .map_err(|report| napi::Error::from_reason(report.to_string()))?
+            .into(),
+        )
+        .boxed(),
+      ),
       BuiltinPluginName::HashedModuleIdsPlugin => plugins.push(
         HashedModuleIdsPlugin::new(
           downcast_into::<RawHashedModuleIdsPluginOptions>(self.options)

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
@@ -1,6 +1,17 @@
+use std::{ptr::NonNull, sync::Arc};
+
+use futures::future::BoxFuture;
 use napi_derive::napi;
+use rspack_core::{CompilerId, Module};
 use rspack_hash::{HashDigest, HashFunction};
-use rspack_ids::{HashedModuleIdsPluginOptions, OccurrenceChunkIdsPluginOptions};
+use rspack_ids::{
+  DeterministicModuleIdsPluginOptions, HashedModuleIdsPluginOptions, ModuleFilterFn,
+  OccurrenceChunkIdsPluginOptions,
+};
+
+use crate::{
+  compiler_scoped_tsfn::CompilerScopedTsFnHandle as ThreadsafeFunction, module::ModuleObject,
+};
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]
@@ -39,6 +50,48 @@ impl From<RawHashedModuleIdsPluginOptions> for HashedModuleIdsPluginOptions {
       hash_digest_length: value
         .hash_digest_length
         .map_or(defaults.hash_digest_length, |n| n as usize),
+    }
+  }
+}
+
+type RawModuleFilter = ThreadsafeFunction<ModuleObject, Option<bool>>;
+
+fn into_module_filter(test: RawModuleFilter) -> ModuleFilterFn {
+  Arc::new(
+    move |compiler_id: CompilerId,
+          module: &dyn Module|
+          -> BoxFuture<'_, rspack_error::Result<bool>> {
+      let test = test.clone();
+      let module = ModuleObject::with_ptr(
+        NonNull::new(module as *const dyn Module as *mut dyn Module)
+          .expect("module pointer should not be null"),
+        compiler_id,
+      );
+      Box::pin(async move { Ok(test.call_with_sync(module).await?.unwrap_or(false)) })
+    },
+  )
+}
+
+#[derive(Debug)]
+#[napi(object, object_to_js = false)]
+pub struct RawDeterministicModuleIdsPluginOptions {
+  pub context: Option<String>,
+  pub test: Option<RawModuleFilter>,
+  pub max_length: Option<u32>,
+  pub salt: Option<u32>,
+  pub fixed_length: Option<bool>,
+  pub fail_on_conflict: Option<bool>,
+}
+
+impl From<RawDeterministicModuleIdsPluginOptions> for DeterministicModuleIdsPluginOptions {
+  fn from(value: RawDeterministicModuleIdsPluginOptions) -> Self {
+    Self {
+      context: value.context,
+      test: value.test.map(into_module_filter),
+      max_length: value.max_length.map(|n| n as usize),
+      salt: value.salt.map(|n| n as usize),
+      fixed_length: value.fixed_length,
+      fail_on_conflict: value.fail_on_conflict,
     }
   }
 }

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
@@ -76,6 +76,7 @@ fn into_module_filter(test: RawModuleFilter) -> ModuleFilterFn {
 #[napi(object, object_to_js = false)]
 pub struct RawDeterministicModuleIdsPluginOptions {
   pub context: Option<String>,
+  #[napi(ts_type = "(module: Module) => boolean")]
   pub test: Option<RawModuleFilter>,
   pub max_length: Option<u32>,
   pub salt: Option<u32>,

--- a/crates/rspack_ids/Cargo.toml
+++ b/crates/rspack_ids/Cargo.toml
@@ -8,6 +8,8 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+derive_more        = { workspace = true, features = ["debug"] }
+futures            = { workspace = true }
 itertools          = { workspace = true }
 rayon              = { workspace = true }
 rspack_collections = { workspace = true }

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -1,22 +1,64 @@
 use std::borrow::Cow;
 
+use derive_more::Debug;
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkGraph, Compilation, CompilationModuleIds, ModuleIdsArtifact, Plugin,
   incremental::IncrementalPasses,
 };
-use rspack_error::{Diagnostic, Result};
+use rspack_error::{Diagnostic, Result, error};
 use rspack_hook::{plugin, plugin_hook};
 
 use crate::id_helpers::{
-  assign_deterministic_ids, compare_modules_by_pre_order_index_or_identifier, get_full_module_name,
-  get_used_module_ids_and_modules_with_artifact,
+  ModuleFilterFn, assign_deterministic_ids, compare_modules_by_pre_order_index_or_identifier,
+  get_full_module_name, get_used_module_ids_and_modules_with_async_filter,
 };
 
+#[derive(Debug, Clone, Default)]
+pub struct DeterministicModuleIdsPluginOptions {
+  pub context: Option<String>,
+  #[debug(skip)]
+  pub test: Option<ModuleFilterFn>,
+  pub max_length: Option<usize>,
+  pub salt: Option<usize>,
+  pub fixed_length: Option<bool>,
+  pub fail_on_conflict: Option<bool>,
+}
+
 #[plugin]
-#[derive(Debug, Default)]
-pub struct DeterministicModuleIdsPlugin;
+#[derive(Debug)]
+pub struct DeterministicModuleIdsPlugin {
+  context: Option<String>,
+  #[debug(skip)]
+  test: Option<ModuleFilterFn>,
+  max_length: usize,
+  salt: usize,
+  fixed_length: bool,
+  fail_on_conflict: bool,
+}
+
+impl Default for DeterministicModuleIdsPlugin {
+  fn default() -> Self {
+    Self::new(Default::default())
+  }
+}
+
+impl DeterministicModuleIdsPlugin {
+  pub fn new(options: DeterministicModuleIdsPluginOptions) -> Self {
+    Self::new_inner(
+      options.context,
+      options.test,
+      options
+        .max_length
+        .filter(|max_length| *max_length != 0)
+        .unwrap_or(3),
+      options.salt.unwrap_or_default(),
+      options.fixed_length.unwrap_or_default(),
+      options.fail_on_conflict.unwrap_or_default(),
+    )
+  }
+}
 
 #[plugin_hook(CompilationModuleIds for DeterministicModuleIdsPlugin)]
 async fn module_ids(
@@ -37,14 +79,14 @@ async fn module_ids(
   }
 
   let (mut used_ids, modules) =
-    get_used_module_ids_and_modules_with_artifact(compilation, module_ids, None);
+    get_used_module_ids_and_modules_with_async_filter(compilation, module_ids, self.test.as_ref())
+      .await?;
 
   let mut module_ids_map = std::mem::take(module_ids);
-  let context = compilation.options.context.as_ref();
-  let max_length = 3;
-  let fail_on_conflict = false;
-  let fixed_length = false;
-  let salt = 0;
+  let context = self
+    .context
+    .as_deref()
+    .unwrap_or(compilation.options.context.as_ref());
   let mut conflicts = 0;
 
   let module_graph = compilation.get_module_graph();
@@ -88,15 +130,19 @@ async fn module_ids(
       );
       true
     },
-    &[usize::pow(10, max_length)],
-    if fixed_length { 0 } else { 10 },
+    &[10usize
+      .checked_pow(self.max_length as u32)
+      .unwrap_or(usize::MAX)],
+    if self.fixed_length { 0 } else { 10 },
     used_ids_len,
-    salt,
+    self.salt,
   );
   *module_ids = module_ids_map;
-  if fail_on_conflict && conflicts > 0 {
-    // TODO: better error msg
-    panic!("Assigning deterministic module ids has lead to conflicts {conflicts}");
+  if self.fail_on_conflict && conflicts > 0 {
+    return Err(error!(
+      "Assigning deterministic module ids has lead to {conflicts} conflict{}.\nIncrease the 'maxLength' to increase the id space and make conflicts less likely (recommended when there are many conflicts or application is expected to grow), or add an 'salt' number to try another hash starting value in the same id space (recommended when there is only a single conflict).",
+      if conflicts > 1 { "s" } else { "" }
+    ));
   }
   Ok(())
 }

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -12,7 +12,8 @@ use rspack_hook::{plugin, plugin_hook};
 
 use crate::id_helpers::{
   ModuleFilterFn, assign_deterministic_ids, compare_modules_by_pre_order_index_or_identifier,
-  get_full_module_name, get_used_module_ids_and_modules_with_async_filter,
+  get_full_module_name, get_used_module_ids_and_modules_with_artifact,
+  get_used_module_ids_and_modules_with_async_filter,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -78,9 +79,14 @@ async fn module_ids(
     module_ids.clear();
   }
 
-  let (mut used_ids, modules) =
+  // Use the sync path when no async test filter is provided (the common case),
+  // avoiding unnecessary async overhead on the hot path.
+  let (mut used_ids, modules) = if self.test.is_some() {
     get_used_module_ids_and_modules_with_async_filter(compilation, module_ids, self.test.as_ref())
-      .await?;
+      .await?
+  } else {
+    get_used_module_ids_and_modules_with_artifact(compilation, module_ids, None)
+  };
 
   let mut module_ids_map = std::mem::take(module_ids);
   let context = self

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -2,8 +2,10 @@ use std::{
   borrow::Cow,
   cmp::Ordering,
   hash::{Hash, Hasher},
+  sync::Arc,
 };
 
+use futures::future::BoxFuture;
 use itertools::{
   EitherOrBoth::{Both, Left, Right},
   Itertools,
@@ -11,16 +13,20 @@ use itertools::{
 use rspack_collections::Identifier;
 use rspack_core::{
   BoxModule, Chunk, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey,
-  ChunkNamedIdArtifact, ChunkUkey, Compilation, ExportsInfoArtifact, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact, SideEffectsStateArtifact,
-  compare_runtime,
+  ChunkNamedIdArtifact, ChunkUkey, Compilation, CompilerId, ExportsInfoArtifact, Module,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact,
+  SideEffectsStateArtifact, compare_runtime,
 };
+use rspack_error::Result;
 use rspack_util::{
   comparators::{compare_ids, compare_numbers},
   identifier::make_paths_relative,
   number_hash::get_number_hash_combined,
 };
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+
+pub type ModuleFilterFn =
+  Arc<dyn for<'a> Fn(CompilerId, &'a dyn Module) -> BoxFuture<'a, Result<bool>> + Send + Sync>;
 
 #[allow(clippy::type_complexity)]
 #[allow(clippy::collapsible_else_if)]
@@ -71,6 +77,37 @@ pub fn get_used_module_ids_and_modules_with_artifact(
       }
     });
   (used_ids, modules)
+}
+
+pub async fn get_used_module_ids_and_modules_with_async_filter(
+  compilation: &Compilation,
+  module_ids_artifact: &ModuleIdsArtifact,
+  filter: Option<&ModuleFilterFn>,
+) -> Result<(FxHashSet<String>, Vec<ModuleIdentifier>)> {
+  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+  let mut modules = vec![];
+  let mut used_ids = FxHashSet::default();
+
+  for module in compilation
+    .get_module_graph()
+    .modules()
+    .map(|(_, module)| module)
+    .filter(|m| m.need_id())
+  {
+    let module_id = ChunkGraph::get_module_id(module_ids_artifact, module.identifier());
+    if let Some(module_id) = module_id {
+      used_ids.insert(module_id.to_string());
+    } else if chunk_graph.get_number_of_module_chunks(module.identifier()) != 0
+      && match filter {
+        Some(filter) => filter(compilation.compiler_id(), module.as_ref()).await?,
+        None => true,
+      }
+    {
+      modules.push(module.identifier());
+    }
+  }
+
+  Ok((used_ids, modules))
 }
 
 pub fn get_short_module_name(module: &BoxModule, context: &str) -> String {

--- a/crates/rspack_ids/src/lib.rs
+++ b/crates/rspack_ids/src/lib.rs
@@ -5,6 +5,7 @@ pub use hashed_module_ids_plugin::*;
 mod named_module_ids_plugin;
 pub use named_module_ids_plugin::*;
 pub mod id_helpers;
+pub use id_helpers::ModuleFilterFn;
 mod named_chunk_ids_plugin;
 pub use named_chunk_ids_plugin::*;
 mod deterministic_chunk_ids_plugin;

--- a/packages/rspack/src/builtin-plugin/DeterministicModuleIdsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DeterministicModuleIdsPlugin.ts
@@ -1,11 +1,25 @@
 import { type BuiltinPlugin, BuiltinPluginName } from '@rspack/binding';
 import { createBuiltinPlugin, RspackBuiltinPlugin } from './base';
+import type { Module } from '../Module';
+
+export interface DeterministicModuleIdsPluginOptions {
+  context?: string;
+  test?: (module: Module) => boolean;
+  maxLength?: number;
+  salt?: number;
+  fixedLength?: boolean;
+  failOnConflict?: boolean;
+}
 
 export class DeterministicModuleIdsPlugin extends RspackBuiltinPlugin {
   name = BuiltinPluginName.DeterministicModuleIdsPlugin;
   affectedHooks = 'compilation' as const;
 
+  constructor(private options: DeterministicModuleIdsPluginOptions = {}) {
+    super();
+  }
+
   raw(): BuiltinPlugin {
-    return createBuiltinPlugin(this.name, undefined);
+    return createBuiltinPlugin(this.name, { ...this.options });
   }
 }

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -182,13 +182,17 @@ interface Electron {
 
 export const electron: Electron = { ElectronTargetPlugin };
 
-import { HashedModuleIdsPlugin } from './builtin-plugin';
+import {
+  DeterministicModuleIdsPlugin,
+  HashedModuleIdsPlugin,
+} from './builtin-plugin';
 
 interface Ids {
+  DeterministicModuleIdsPlugin: typeof DeterministicModuleIdsPlugin;
   HashedModuleIdsPlugin: typeof HashedModuleIdsPlugin;
 }
 
-export const ids: Ids = { HashedModuleIdsPlugin };
+export const ids: Ids = { DeterministicModuleIdsPlugin, HashedModuleIdsPlugin };
 
 import { EnableLibraryPlugin } from './builtin-plugin';
 

--- a/tests/rspack-test/configCases/hash-length/deterministic-module-ids/test.filter.js
+++ b/tests/rspack-test/configCases/hash-length/deterministic-module-ids/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "TODO: DeterministicModuleIdsPlugin is not exposed"

--- a/website/docs/en/plugins/webpack/_meta.json
+++ b/website/docs/en/plugins/webpack/_meta.json
@@ -3,6 +3,7 @@
   "banner-plugin",
   "context-replacement-plugin",
   "define-plugin",
+  "deterministic-module-ids-plugin",
   "dll-plugin",
   "dll-reference-plugin",
   "electron-target-plugin",

--- a/website/docs/en/plugins/webpack/deterministic-module-ids-plugin.mdx
+++ b/website/docs/en/plugins/webpack/deterministic-module-ids-plugin.mdx
@@ -1,0 +1,101 @@
+---
+description: 'Assign short numeric module ids that stay stable between compilations'
+---
+
+import WebpackLicense from '@components/WebpackLicense';
+
+<WebpackLicense from="https://webpack.js.org/configuration/optimization/#optimizationmoduleids" />
+
+# DeterministicModuleIdsPlugin
+
+`DeterministicModuleIdsPlugin` assigns short numeric ids to modules based on their module identifiers. The ids are stable between compilations, which makes the plugin useful for long-term caching.
+
+`optimization.moduleIds: 'deterministic'` uses this plugin internally. Use the plugin directly when you need to customize the deterministic id generation behavior.
+
+```js title="rspack.config.mjs"
+import rspack from '@rspack/core';
+
+export default {
+  optimization: {
+    moduleIds: false,
+  },
+  plugins: [
+    new rspack.ids.DeterministicModuleIdsPlugin({
+      maxLength: 4,
+    }),
+  ],
+};
+```
+
+## Options
+
+### context
+
+- **Type:** `string`
+- **Default:** `compiler.context`
+
+The context used to create relative module identifiers before ids are generated.
+
+### test
+
+- **Type:** `(module: Module) => boolean`
+- **Default:** `undefined`
+
+Selects which modules should receive deterministic ids from this plugin. When omitted, all modules that need ids are included.
+
+```js title="rspack.config.mjs"
+import rspack from '@rspack/core';
+
+export default {
+  optimization: {
+    moduleIds: false,
+  },
+  plugins: [
+    new rspack.ids.DeterministicModuleIdsPlugin({
+      test: (module) => module.type.startsWith('css'),
+    }),
+  ],
+};
+```
+
+### maxLength
+
+- **Type:** `number`
+- **Default:** `3`
+
+The maximum id length in digits used as the starting id space. The generated numeric id space starts at `10 ** maxLength`.
+
+### salt
+
+- **Type:** `number`
+- **Default:** `0`
+
+The hash salt used when generating ids. Change this value to try a different hash starting value in the same id space.
+
+### fixedLength
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+When enabled, Rspack does not increase the id length to find a larger id space.
+
+### failOnConflict
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+When enabled, Rspack reports an error if deterministic id assignment produces conflicts. By default, Rspack resolves conflicts by retrying with a larger id space.
+
+## Usage with optimization.moduleIds
+
+For the common long-term caching setup, prefer the built-in optimization option:
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    moduleIds: 'deterministic',
+  },
+};
+```
+
+Use `DeterministicModuleIdsPlugin` directly only when you need the options above.

--- a/website/docs/zh/plugins/webpack/_meta.json
+++ b/website/docs/zh/plugins/webpack/_meta.json
@@ -3,6 +3,7 @@
   "banner-plugin",
   "context-replacement-plugin",
   "define-plugin",
+  "deterministic-module-ids-plugin",
   "dll-plugin",
   "dll-reference-plugin",
   "electron-target-plugin",

--- a/website/docs/zh/plugins/webpack/deterministic-module-ids-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/deterministic-module-ids-plugin.mdx
@@ -1,0 +1,101 @@
+---
+description: '为模块分配较短且在多次编译间保持稳定的数字 id'
+---
+
+import WebpackLicense from '@components/WebpackLicense';
+
+<WebpackLicense from="https://webpack.js.org/configuration/optimization/#optimizationmoduleids" />
+
+# DeterministicModuleIdsPlugin
+
+`DeterministicModuleIdsPlugin` 会基于模块标识符为模块分配较短的数字 id。生成的 id 在多次编译之间保持稳定，因此适合用于长期缓存。
+
+`optimization.moduleIds: 'deterministic'` 内部会使用该插件。只有在需要自定义 deterministic id 生成行为时，才需要直接使用该插件。
+
+```js title="rspack.config.mjs"
+import rspack from '@rspack/core';
+
+export default {
+  optimization: {
+    moduleIds: false,
+  },
+  plugins: [
+    new rspack.ids.DeterministicModuleIdsPlugin({
+      maxLength: 4,
+    }),
+  ],
+};
+```
+
+## 选项
+
+### context
+
+- **类型：** `string`
+- **默认值：** `compiler.context`
+
+生成 id 前，用于创建相对模块标识符的上下文。
+
+### test
+
+- **类型：** `(module: Module) => boolean`
+- **默认值：** `undefined`
+
+用于筛选哪些模块由该插件分配 deterministic id。未设置时，会包含所有需要 id 的模块。
+
+```js title="rspack.config.mjs"
+import rspack from '@rspack/core';
+
+export default {
+  optimization: {
+    moduleIds: false,
+  },
+  plugins: [
+    new rspack.ids.DeterministicModuleIdsPlugin({
+      test: (module) => module.type.startsWith('css'),
+    }),
+  ],
+};
+```
+
+### maxLength
+
+- **类型：** `number`
+- **默认值：** `3`
+
+作为起始 id 空间使用的最大 id 位数。生成的数字 id 空间从 `10 ** maxLength` 开始。
+
+### salt
+
+- **类型：** `number`
+- **默认值：** `0`
+
+生成 id 时使用的哈希盐值。调整该值可以在相同 id 空间中尝试不同的哈希起始值。
+
+### fixedLength
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+启用后，Rspack 不会为了寻找更大的 id 空间而增加 id 长度。
+
+### failOnConflict
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+启用后，如果 deterministic id 分配出现冲突，Rspack 会报告错误。默认情况下，Rspack 会通过使用更大的 id 空间来解决冲突。
+
+## 与 optimization.moduleIds 一起使用
+
+对于常见的长期缓存场景，建议优先使用内置的优化选项：
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    moduleIds: 'deterministic',
+  },
+};
+```
+
+只有在需要上述自定义选项时，才直接使用 `DeterministicModuleIdsPlugin`。


### PR DESCRIPTION
## Summary

- expose `rspack.ids.DeterministicModuleIdsPlugin` through the JS API
- add webpack-compatible deterministic module id plugin options including `test`, `maxLength`, `salt`, `fixedLength`, and `failOnConflict`
- enable the webpack-derived `hash-length/deterministic-module-ids` config case
- document `DeterministicModuleIdsPlugin` in the English and Chinese webpack plugin docs
- fix generated binding types so `test` no longer references a private `RawModuleFilter` alias

## Testing

- `cargo fmt --all`
- `pnpm exec prettier --write packages/rspack/src/builtin-plugin/DeterministicModuleIdsPlugin.ts packages/rspack/src/exports.ts`
- `cargo check -p rspack_ids`
- `cargo check -p rspack_binding_api`
- `pnpm run build:cli:dev`
- `pnpm run test:type`
- `pnpm --filter @rspack/tests test -- -t "configCases/hash-length/deterministic-module-ids"`
- `pnpm exec prettier --write website/docs/en/plugins/webpack/deterministic-module-ids-plugin.mdx website/docs/zh/plugins/webpack/deterministic-module-ids-plugin.mdx website/docs/en/plugins/webpack/_meta.json website/docs/zh/plugins/webpack/_meta.json`

---
_by OpenAI Codex_