### PR TITLE
fix: infer modern-module cjs externals from target

### DIFF
--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -71,6 +71,7 @@ import {
   URLPlugin,
   WorkerPlugin,
 } from './builtin-plugin';
+import { getTargetProperties, getTargetsProperties } from './config/target';
 import MemoryCachePlugin from './lib/cache/MemoryCachePlugin';
 import EntryOptionPlugin from './lib/EntryOptionPlugin';
 import IgnoreWarningsPlugin from './lib/IgnoreWarningsPlugin';
@@ -442,13 +443,17 @@ export class RspackOptionsApply {
 function getModernModuleCjsExternalType(
   options: RspackOptionsNormalized,
 ): 'commonjs' | 'node-commonjs' {
-  const presets = options.externalsPresets;
-  return presets.node ||
-    presets.electron ||
-    presets.electronMain ||
-    presets.electronPreload ||
-    presets.electronRenderer ||
-    presets.nwjs
-    ? 'node-commonjs'
-    : 'commonjs';
+  const { context, target } = options;
+  assertNotNill(context);
+
+  if (target == null || target === false) {
+    return 'commonjs';
+  }
+
+  const targetProperties =
+    typeof target === 'string'
+      ? getTargetProperties(target, context)
+      : getTargetsProperties(target, context);
+
+  return targetProperties.nodeBuiltins ? 'node-commonjs' : 'commonjs';
 }

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-node-target-without-node-preset/index.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-node-target-without-node-preset/index.js
@@ -1,0 +1,11 @@
+import { resolve } from "path";
+
+const fs = require("fs");
+
+export const readFile = fs.readFile;
+export const pathResolve = resolve;
+
+export async function loadPlatform() {
+	const os = await import("os");
+	return os.platform;
+}

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-node-target-without-node-preset/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-node-target-without-node-preset/rspack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  externalsType: 'modern-module',
+  externalsPresets: {
+    node: false,
+  },
+  externals: {
+    fs: 'fs',
+    os: 'os',
+    path: 'path',
+  },
+};

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-node-target-without-node-preset/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-node-target-without-node-preset/test.config.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+function readOutput(options) {
+	return fs
+		.readdirSync(options.output.path)
+		.filter(file => file.endsWith(".mjs"))
+		.map(file => fs.readFileSync(path.join(options.output.path, file), "utf-8"))
+		.join("\n");
+}
+
+module.exports = {
+	findBundle() {
+		return [];
+	},
+	snapshotFileFilter() {
+		return false;
+	},
+	afterExecute(options) {
+		const source = readOutput(options);
+
+		expect(source).toMatch(/import\s*\{\s*resolve\s*\}\s*from\s*["']path["']/);
+		expect(source).toMatch(/import\s*\(\s*["']os["']\s*\)/);
+		expect(source).toMatch(/createRequire\s+as\s+__rspack_createRequire/);
+		expect(source).toMatch(
+			/__rspack_createRequire_require\s*\(\s*["']fs["']\s*\)/
+		);
+	}
+};


### PR DESCRIPTION
## Summary

This PR fixes `externalsType: 'modern-module'` CJS external fallback detection for Node-like targets. The fallback now uses the target's `nodeBuiltins` capability instead of `externalsPresets`, so users can disable `externalsPresets.node` while still externalizing Node builtins through custom `externals` and get `node-commonjs` rendering.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).