### PR TITLE
chore: add Rust CodSpeed walltime benchmark

### DIFF
--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -9,6 +9,18 @@ on:
       runner: # Runner labels
         required: true
         type: string
+      measurement: # CodSpeed measurement mode, "simulation" or "walltime"
+        required: false
+        type: string
+        default: 'simulation'
+      bench_target: # Optional Cargo benchmark target to build and run
+        required: false
+        type: string
+        default: ''
+      bench_filter: # Optional Cargo benchmark name filter to run
+        required: false
+        type: string
+        default: ''
       ref: # Git reference to checkout
         required: false
         type: string
@@ -23,7 +35,7 @@ permissions:
 
 jobs:
   bench-rust:
-    name: 'Bench Rust'
+    name: 'Bench Rust ${{ inputs.measurement }}'
     runs-on: ${{ fromJSON(inputs.runner) }}
     defaults:
       run:
@@ -59,13 +71,21 @@ jobs:
       - name: Run Cargo codegen
         run: cargo codegen
 
-      - name: Build benchmark (simulation,memory)
-        run: pnpm run build:bench
+      - name: Build benchmark (${{ inputs.measurement }})
+        run: |
+          bench_args=()
+          if [ -n "${{ inputs.bench_target }}" ]; then
+            bench_args+=(--bench "${{ inputs.bench_target }}")
+          else
+            bench_args+=(--bench benches --bench rspack_sources)
+          fi
+          cargo codspeed build -m ${{ inputs.measurement }} --profile codspeed -p rspack_benchmark "${bench_args[@]}"
 
-      - name: Prepare Valgrind temporary directory
+      - name: Prepare CodSpeed temporary directory
         run: mkdir -p "${RUNNER_TEMP}/codspeed-valgrind-tmp"
 
-      - name: Run benchmark (simulation,memory)
+      - name: Run benchmark (simulation)
+        if: ${{ inputs.measurement == 'simulation' }}
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
         timeout-minutes: 30
         env:
@@ -73,13 +93,43 @@ jobs:
           RAYON_NUM_THREADS: 1
           CODSPEED_EXPERIMENTAL_FAIR_SCHED: true
         with:
-          mode: 'simulation'
-          run: pnpm run bench:rust
+          mode: simulation
+          run: |
+            if [ -n "${{ inputs.bench_target }}" ]; then
+              bench_args=(--bench "${{ inputs.bench_target }}")
+              if [ -n "${{ inputs.bench_filter }}" ]; then
+                bench_args+=("${{ inputs.bench_filter }}")
+              fi
+              RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run "${bench_args[@]}"
+            else
+              pnpm run bench:rust
+            fi
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          runner-version: 4.13.0
+
+      - name: Run benchmark (walltime)
+        if: ${{ inputs.measurement == 'walltime' }}
+        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
+        timeout-minutes: 30
+        env:
+          TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
+        with:
+          mode: walltime
+          run: |
+            if [ -n "${{ inputs.bench_target }}" ]; then
+              bench_args=(--bench "${{ inputs.bench_target }}")
+              if [ -n "${{ inputs.bench_filter }}" ]; then
+                bench_args+=("${{ inputs.bench_filter }}")
+              fi
+              RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run "${bench_args[@]}"
+            else
+              pnpm run bench:rust
+            fi
           token: ${{ secrets.CODSPEED_TOKEN }}
           runner-version: 4.13.0
 
       - name: Prepare Valgrind temporary files artifact
-        if: ${{ always() }}
+        if: ${{ always() && inputs.measurement == 'simulation' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/codspeed-valgrind-tmp"
           {
@@ -89,7 +139,7 @@ jobs:
           } > "${RUNNER_TEMP}/codspeed-valgrind-tmp/MANIFEST.txt"
 
       - name: Upload Valgrind temporary files
-        if: ${{ always() }}
+        if: ${{ always() && inputs.measurement == 'simulation' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: codspeed-valgrind-tmp-${{ inputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,18 @@ jobs:
       target: x86_64-unknown-linux-gnu
       runner: '"ubuntu-22.04"'
 
+  bench-rust-walltime:
+    name: Rust Bench Walltime
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/bench-rust.yml
+    with:
+      target: x86_64-unknown-linux-gnu
+      measurement: walltime
+      bench_target: benches
+      bench_filter: bundle@threejs
+      runner: '["self-hosted", "Linux", "X64"]'
+
   test-windows:
     name: Test Windows
     needs: [check-changed]


### PR DESCRIPTION
## Summary
- Add a Rust CodSpeed walltime benchmark job based on the existing Rust benchmark workflow.
- Run the new walltime job on `[self-hosted, Linux, X64]`.
- Run the walltime job against the `benches` Cargo benchmark target, filtered to `bundle@threejs`, so it only executes `bundle@threejs-development` and `bundle@threejs-production-sourcemap`; the existing simulation job continues to run the full Rust benchmark suite.
- Keep `RAYON_NUM_THREADS=1` and CodSpeed's experimental fair scheduler only on the simulation path; walltime uses the physical runner without forcing Rayon single-threaded execution.

## Testing
- `git diff --check`
- `python3` YAML parse for `.github/workflows/ci.yml` and `.github/workflows/bench-rust.yml`
- `node_modules/.bin/prettier --check .github/workflows/ci.yml .github/workflows/bench-rust.yml`
- Confirmed `cargo codspeed run` supports `--bench <BENCH>` and `[BENCHNAME]` filtering