### PR TITLE
perf: reduce flag dependency usage allocations

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -13,7 +13,7 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::{queue::Queue, swc::join_atom};
+use rspack_util::{atom::Atom, queue::Queue};
 use rustc_hash::FxHashMap as HashMap;
 
 type ProcessBlockTask = (ModuleOrAsyncDependenciesBlock, Option<RuntimeSpec>, bool);
@@ -27,7 +27,7 @@ enum ModuleOrAsyncDependenciesBlock {
 
 #[derive(Debug, Clone)]
 enum ProcessModuleReferencedExports {
-  Map(HashMap<String, ExtendedReferencedExport>),
+  Map(HashMap<Vec<Atom>, ExtendedReferencedExport>),
   ExtendRef(Vec<ExtendedReferencedExport>),
 }
 #[allow(unused)]
@@ -36,7 +36,7 @@ pub struct FlagDependencyUsagePluginProxy<'a> {
   compilation: &'a Compilation,
   build_module_graph_artifact: &'a mut BuildModuleGraphArtifact,
   exports_info_artifact: &'a mut ExportsInfoArtifact,
-  exports_info_module_map: HashMap<ExportsInfo, ModuleIdentifier>,
+  exports_info_module_map: Option<HashMap<ExportsInfo, ModuleIdentifier>>,
 }
 
 #[allow(unused)]
@@ -52,7 +52,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       compilation,
       build_module_graph_artifact,
       exports_info_artifact,
-      exports_info_module_map: HashMap::default(),
+      exports_info_module_map: None,
     }
   }
 
@@ -64,14 +64,6 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     let mut module_graph = self.build_module_graph_artifact.get_module_graph_mut();
     self.exports_info_artifact.reset_all_exports_info_used();
 
-    for (_, mgm) in module_graph.module_graph_modules() {
-      self.exports_info_module_map.insert(
-        self
-          .exports_info_artifact
-          .get_exports_info(&mgm.module_identifier),
-        mgm.module_identifier,
-      );
-    }
     let mut q = Queue::new();
     let mg = &mut *module_graph;
 
@@ -214,7 +206,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       // preserving the original rayon work shape.
       let non_nested_res = {
         let mg = self.build_module_graph_artifact.get_module_graph();
-        non_nested_tasks
+        let non_nested_tasks = non_nested_tasks
           .into_iter()
           .map(|(module_id, tasks)| {
             let exports_info_id = self.exports_info_artifact.get_exports_info(&module_id);
@@ -230,7 +222,8 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             );
             (module_id, (tasks, exports_info))
           })
-          .collect::<IdentifierMap<_>>()
+          .collect::<Vec<_>>();
+        non_nested_tasks
           .into_par_iter()
           .map(|(module_id, (tasks, mut exports_info))| {
             let module = mg
@@ -276,6 +269,9 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       }
 
       // for nested tasks, just process them one by one to prevent conflicts while modifying the exports info data
+      if !nested_tasks.is_empty() {
+        self.ensure_exports_info_module_map();
+      }
       for (runtime, force_side_effects, module_id, exports_info, referenced_exports) in nested_tasks
       {
         let res = self.process_referenced_module(
@@ -299,6 +295,24 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     }
   }
 
+  fn ensure_exports_info_module_map(&mut self) {
+    if self.exports_info_module_map.is_some() {
+      return;
+    }
+
+    let module_graph = self.build_module_graph_artifact.get_module_graph();
+    let mut map = HashMap::default();
+    for (_, mgm) in module_graph.module_graph_modules() {
+      map.insert(
+        self
+          .exports_info_artifact
+          .get_exports_info(&mgm.module_identifier),
+        mgm.module_identifier,
+      );
+    }
+    self.exports_info_module_map = Some(map);
+  }
+
   fn process_module(
     &self,
     module_graph: &ModuleGraph,
@@ -308,7 +322,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     force_side_effects: bool,
     global: bool,
   ) -> (
-    IdentifierMap<Vec<ExtendedReferencedExport>>,
+    Vec<(ModuleIdentifier, Vec<ExtendedReferencedExport>)>,
     Vec<ProcessBlockTask>,
   ) {
     let compilation = self.compilation;
@@ -386,7 +400,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             },
           )
         })
-        .collect::<IdentifierMap<_>>(),
+        .collect::<Vec<_>>(),
       q,
     )
   }
@@ -515,6 +529,8 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
                 } else {
                   self
                     .exports_info_module_map
+                    .as_ref()
+                    .expect("nested exports info module map should be initialized")
                     .get(&current_exports_info)
                     .copied()
                 };
@@ -541,6 +557,8 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               } else {
                 self
                   .exports_info_module_map
+                  .as_ref()
+                  .expect("nested exports info module map should be initialized")
                   .get(&current_exports_info)
                   .copied()
               };
@@ -647,50 +665,51 @@ fn merge_referenced_exports(
       ProcessModuleReferencedExports::ExtendRef(ref_items) => ref_items
         .into_iter()
         .map(|item| {
-          let key = match &item {
-            ExtendedReferencedExport::Array(arr) => join_atom(arr.iter(), "\n"),
-            ExtendedReferencedExport::Export(export) => join_atom(export.name.iter(), "\n"),
-          };
+          let key = referenced_export_key(&item);
           (key, item)
         })
         .collect::<HashMap<_, _>>(),
     };
 
     for mut item in referenced_exports {
+      let key = referenced_export_key(&item);
       match item {
-        ExtendedReferencedExport::Array(ref arr) => {
-          let key = join_atom(arr.iter(), "\n");
+        ExtendedReferencedExport::Array(_) => {
           exports_map.entry(key).or_insert(item);
         }
-        ExtendedReferencedExport::Export(ref mut export) => {
-          let key = join_atom(export.name.iter(), "\n");
-          match exports_map.entry(key) {
-            Entry::Occupied(mut occ) => {
-              let old_item = occ.get();
-              match old_item {
-                ExtendedReferencedExport::Array(_) => {
-                  occ.insert(item);
-                }
-                ExtendedReferencedExport::Export(old_item) => {
-                  occ.insert(ExtendedReferencedExport::Export(ReferencedExport {
-                    name: std::mem::take(&mut export.name),
-                    can_mangle: export.can_mangle && old_item.can_mangle,
-                    can_inline: export.can_inline && old_item.can_inline,
-                    ns_access: export.ns_access || old_item.ns_access,
-                  }));
-                }
+        ExtendedReferencedExport::Export(ref mut export) => match exports_map.entry(key) {
+          Entry::Occupied(mut occ) => {
+            let old_item = occ.get();
+            match old_item {
+              ExtendedReferencedExport::Array(_) => {
+                occ.insert(item);
+              }
+              ExtendedReferencedExport::Export(old_item) => {
+                occ.insert(ExtendedReferencedExport::Export(ReferencedExport {
+                  name: std::mem::take(&mut export.name),
+                  can_mangle: export.can_mangle && old_item.can_mangle,
+                  can_inline: export.can_inline && old_item.can_inline,
+                  ns_access: export.ns_access || old_item.ns_access,
+                }));
               }
             }
-            Entry::Vacant(vac) => {
-              vac.insert(item);
-            }
           }
-        }
+          Entry::Vacant(vac) => {
+            vac.insert(item);
+          }
+        },
       }
     }
     return Some(ProcessModuleReferencedExports::Map(exports_map));
   }
   None
+}
+
+fn referenced_export_key(item: &ExtendedReferencedExport) -> Vec<Atom> {
+  match item {
+    ExtendedReferencedExport::Array(arr) => arr.clone(),
+    ExtendedReferencedExport::Export(export) => export.name.clone(),
+  }
 }
 
 fn collect_active_dependencies(


### PR DESCRIPTION
## Summary

Reduces allocation work in `FlagDependencyUsagePlugin` by keeping referenced export merge keys as `Vec<Atom>` instead of joining export paths into temporary strings.

Also removes an extra intermediate `IdentifierMap` when dispatching non-nested referenced-export tasks into rayon; the tasks are already grouped by module, so a `Vec` avoids another hash table allocation.

The `ExportsInfo -> ModuleIdentifier` lookup is now built lazily, only when nested export tasks need it. Nested export tasks still use the original serialized mutation path, and non-nested module requeue semantics are preserved.

This PR is rebased onto latest `origin/main`. It does not update CSS snapshots; the CSS reexport expectations remain aligned with `main`.

## CodSpeed

- Target: `rust@flag_dependency_usage` at least `+10%`
- Latest head: `ebdb26a`
- Status: waiting for refreshed CodSpeed results after the correctness fix/rebase.

## Why this should help

The target benchmark is `rust@flag_dependency_usage`. This plugin works at dependency/export-info cardinality, so repeated string joins, extra hash table materialization, and unconditional module lookup construction land on a high-volume path. The change keeps the same propagation semantics while reducing per-export CPU and allocation overhead.

## Local checks

- `pnpm install`
- `cargo check -p rspack_plugin_javascript --all-targets`
- `pnpm run build:binding:dev`
- `cd tests/rspack-test && pnpm run test -t "configCases/css/reexport"`
- `cd tests/rspack-test && pnpm run test -t "configCases/tree-shaking"`
- `pnpm run build:bench:main`