### PR TITLE
chore(dep): css-module-lexer 0.0.16 → 0.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "css-module-lexer"
-version = "0.0.16"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e7fc839dc74cb494cd56d32b47504f9ac25aef27a4dff9577cf76058feb075"
+checksum = "0b51940c54c6ca015d3add383571ec5610114466eb67aa0a27096e1dcf3c9e29"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cow-utils       = { version = "0.1.3", default-features = false }
 
 criterion = { package = "codspeed-criterion-compat", default-features = false, version = "4.4.1", features = ["async_tokio"] }
 
-css-module-lexer    = { version = "0.0.16", default-features = false }
+css-module-lexer    = { version = "0.0.15", default-features = false }
 dashmap             = { version = "6.1.0", default-features = false }
 derive_more         = { version = "2.0.1", default-features = false }
 dunce               = { version = "1.0.5", default-features = false }


### PR DESCRIPTION
## Why

Revert the `css-module-lexer` bump (`0.0.16` → `0.0.15`) to verify whether the upgrade introduced a regression. Draft PR so CI can validate the downgrade end-to-end.

| | version |
|---|---|
| before | `0.0.16` |
| after | `0.0.15` |

`cargo check -p rspack_plugin_css` passes locally — no API changes required.
