### PR TITLE
fix(rstest): support mocking dynamic import() of external modules

### DIFF
--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -137,16 +137,14 @@ fn module_namespace_promise_rstest(
   // both the static/mock dependency and the dynamic import to the SAME id, so a
   // hoisted `rs.mock` already covers their dynamic import — leave that codegen
   // byte-identical to upstream. importActual keeps its dedicated
-  // `rstest_import_actual` path regardless.
-  let target_is_external = {
-    let module_graph = compilation.get_module_graph();
-    module_graph
-      .module_identifier_by_dependency_id(dep_id)
-      .and_then(|mid| module_graph.module_by_identifier(mid))
+  // `rstest_import_actual` path regardless, so `&&` short-circuits the
+  // module-graph lookup for it.
+  let use_dynamic_shim = !is_import_actual && {
+    compilation
+      .get_module_graph()
+      .get_module_by_dependency_id(dep_id)
       .is_some_and(|m| m.as_external_module().is_some())
   };
-
-  let use_dynamic_shim = !is_import_actual && target_is_external;
 
   let header = if weak {
     Some(format!(

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -131,14 +131,14 @@ fn module_namespace_promise_rstest(
     runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE)
   };
 
-  // Only an externalized specifier exhibits the two-id split: rspack mints a
-  // distinct id for the dynamic import (`external import "X"`) than the one the
-  // hoisted `rs.mock` patches (`external module "X"`). Internal modules resolve
-  // both the static/mock dependency and the dynamic import to the SAME id, so a
-  // hoisted `rs.mock` already covers their dynamic import — leave that codegen
-  // byte-identical to upstream. importActual keeps its dedicated
-  // `rstest_import_actual` path regardless, so `&&` short-circuits the
-  // module-graph lookup for it.
+  // Externalized specifiers exhibit a two-id split: rspack mints a distinct id
+  // for the dynamic import (`external import "X"`) vs the one `rs.mock` patches
+  // (`external module "X"`). Internal modules share one id, so a hoisted
+  // `rs.mock` already covers their dynamic import — leave that byte-identical.
+  // Only the Namespace arm below needs the shim: a split always resolves to
+  // `import`/`module` (= Namespace) for rstest's plain-string externals (a
+  // `has_rest()` property-access external would resolve to Dynamic and miss it,
+  // but rstest never emits those).
   let use_dynamic_shim = !is_import_actual && {
     compilation
       .get_module_graph()
@@ -165,18 +165,13 @@ fn module_namespace_promise_rstest(
           runtime_template.module_raw(compilation, dep_id, request, weak)
         )
       } else if use_dynamic_shim {
-        // External dynamic `import(request)`: route through `rstest_dynamic_require`
-        // with the clean request literal so the hoisted `rs.mock` (installed under
-        // the different static id) is found by request. `final_require` is the
-        // REQUIRE global here (use_dynamic_shim implies !is_import_actual).
-        // See packages/core/src/core/plugins/mockRuntimeCode.js.
+        // Route the external dynamic import through the request-keyed
+        // `rstest_dynamic_require` (in the @rstest/core runtime, a separate repo:
+        // .../plugins/mockRuntimeCode.js) so the hoisted `rs.mock` is found.
         //
-        // TODO(compat): the `rstest_dynamic_require ? … : <plain require>` guard is
-        // a fallback for an OLDER @rstest/core runtime that predates the helper
-        // (`undefined` → degrade to the plain `__webpack_require__(id)` form instead
-        // of throwing `undefined.bind(...)`). Drop the guard, leaving the
-        // unconditional `.bind` shim, once the minimum supported @rstest/core always
-        // ships `rstest_dynamic_require`.
+        // TODO(compat): the `rstest_dynamic_require ? … : <plain require>` guard
+        // falls back to plain require for an older @rstest/core lacking the helper;
+        // drop it once the minimum @rstest/core always ships it.
         appending = format!(
           ".then({final_require}.rstest_dynamic_require ? {final_require}.rstest_dynamic_require.bind({final_require}.rstest_dynamic_require, {module_id_expr}, {}) : {final_require}.bind({final_require}, {module_id_expr}))",
           json_stringify_str(request)

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -6,6 +6,7 @@ use rspack_core::{
   TemplateContext, TemplateReplaceSource, get_exports_type,
 };
 use rspack_plugin_javascript::dependency::ImportDependency;
+use rspack_util::json_stringify_str;
 
 #[cacheable]
 #[derive(Debug, Default)]
@@ -130,6 +131,24 @@ fn module_namespace_promise_rstest(
     runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE)
   };
 
+  // Only an externalized specifier exhibits the two-id split: rspack mints a
+  // distinct id for the dynamic import (`external import "X"`) than the one the
+  // hoisted `rs.mock` patches (`external module "X"`). Internal modules resolve
+  // both the static/mock dependency and the dynamic import to the SAME id, so a
+  // hoisted `rs.mock` already covers their dynamic import — leave that codegen
+  // byte-identical to upstream. importActual keeps its dedicated
+  // `rstest_import_actual` path regardless.
+  let target_is_external = {
+    let module_graph = compilation.get_module_graph();
+    module_graph
+      .module_identifier_by_dependency_id(dep_id)
+      .and_then(|mid| module_graph.module_by_identifier(mid))
+      .map(|m| m.as_external_module().is_some())
+      .unwrap_or(false)
+  };
+
+  let use_dynamic_shim = !is_import_actual && target_is_external;
+
   let header = if weak {
     Some(format!(
       "if(!{}[{module_id_expr}]) {{\n {} \n}}",
@@ -148,6 +167,24 @@ fn module_namespace_promise_rstest(
           ".then(function() {{ {header}\nreturn {}}})",
           runtime_template.module_raw(compilation, dep_id, request, weak)
         )
+      } else if use_dynamic_shim {
+        // External dynamic `import(request)`: route through
+        // `rstest_dynamic_require` with the clean request literal, so the hoisted
+        // `rs.mock` (installed under the different static id) is found by request.
+        // `final_require` is the REQUIRE global here (use_dynamic_shim implies
+        // !is_import_actual). See packages/core/src/core/plugins/mockRuntimeCode.js.
+        //
+        // Guarded by `rstest_dynamic_require ? … : …` so this codegen stays safe
+        // when a NEWER @rspack/core runs against an OLDER @rstest/core runtime
+        // that predates `rstest_dynamic_require`: the helper is then `undefined`,
+        // and we fall back to the plain `__webpack_require__(id)` form (identical
+        // to the non-shim branch below), degrading to pre-fix behavior instead of
+        // throwing `undefined.bind(...)`. Without this guard, any external dynamic
+        // `import()` — even unmocked — would crash under a stale runtime.
+        appending = format!(
+          ".then({final_require}.rstest_dynamic_require ? {final_require}.rstest_dynamic_require.bind({final_require}.rstest_dynamic_require, {module_id_expr}, {}) : {final_require}.bind({final_require}, {module_id_expr}))",
+          json_stringify_str(request)
+        );
       } else {
         appending = format!(".then({final_require}.bind({final_require}, {module_id_expr}))");
       }

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -143,8 +143,7 @@ fn module_namespace_promise_rstest(
     module_graph
       .module_identifier_by_dependency_id(dep_id)
       .and_then(|mid| module_graph.module_by_identifier(mid))
-      .map(|m| m.as_external_module().is_some())
-      .unwrap_or(false)
+      .is_some_and(|m| m.as_external_module().is_some())
   };
 
   let use_dynamic_shim = !is_import_actual && target_is_external;

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -165,19 +165,18 @@ fn module_namespace_promise_rstest(
           runtime_template.module_raw(compilation, dep_id, request, weak)
         )
       } else if use_dynamic_shim {
-        // External dynamic `import(request)`: route through
-        // `rstest_dynamic_require` with the clean request literal, so the hoisted
-        // `rs.mock` (installed under the different static id) is found by request.
-        // `final_require` is the REQUIRE global here (use_dynamic_shim implies
-        // !is_import_actual). See packages/core/src/core/plugins/mockRuntimeCode.js.
+        // External dynamic `import(request)`: route through `rstest_dynamic_require`
+        // with the clean request literal so the hoisted `rs.mock` (installed under
+        // the different static id) is found by request. `final_require` is the
+        // REQUIRE global here (use_dynamic_shim implies !is_import_actual).
+        // See packages/core/src/core/plugins/mockRuntimeCode.js.
         //
-        // Guarded by `rstest_dynamic_require ? … : …` so this codegen stays safe
-        // when a NEWER @rspack/core runs against an OLDER @rstest/core runtime
-        // that predates `rstest_dynamic_require`: the helper is then `undefined`,
-        // and we fall back to the plain `__webpack_require__(id)` form (identical
-        // to the non-shim branch below), degrading to pre-fix behavior instead of
-        // throwing `undefined.bind(...)`. Without this guard, any external dynamic
-        // `import()` — even unmocked — would crash under a stale runtime.
+        // TODO(compat): the `rstest_dynamic_require ? … : <plain require>` guard is
+        // a fallback for an OLDER @rstest/core runtime that predates the helper
+        // (`undefined` → degrade to the plain `__webpack_require__(id)` form instead
+        // of throwing `undefined.bind(...)`). Drop the guard, leaving the
+        // unconditional `.bind` shim, once the minimum supported @rstest/core always
+        // ships `rstest_dynamic_require`.
         appending = format!(
           ".then({final_require}.rstest_dynamic_require ? {final_require}.rstest_dynamic_require.bind({final_require}.rstest_dynamic_require, {module_id_expr}, {}) : {final_require}.bind({final_require}, {module_id_expr}))",
           json_stringify_str(request)

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -79,8 +79,7 @@ impl MockMethodDependency {
     }
   }
 
-  /// Set the byte offset at which to inject the clean `request` literal as the
-  /// trailing argument of the emitted `rstest_*` call. See [`Self::args_request_end`].
+  /// Set the request-injection offset. See [`Self::args_request_end`].
   pub fn with_request_arg_end(mut self, end: Option<u32>) -> Self {
     self.args_request_end = end;
     self
@@ -150,12 +149,11 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       request,
     );
 
-    // Step 4: Inject the clean request as the trailing argument of the call,
-    // e.g. `rstest_mock(id, factory)` -> `rstest_mock(id, factory, "request")`,
-    // so a dynamic `import(request)` (a different external module id) can be
-    // intercepted by request via rstest_dynamic_require. Inserted at the end of
-    // the last argument expression (before any trailing comma) to stay valid
-    // for `rs.mock('x', f,)`. `None` for rs.hoisted and the 1-arg auto-mock form.
+    // Step 4: Inject the clean request as the call's trailing argument so a
+    // dynamic `import(request)` (a different external module id) can be
+    // intercepted by request via rstest_dynamic_require. Inserted before any
+    // trailing comma to stay valid for `rs.mock('x', f,)`. See `args_request_end`
+    // for the `None` cases.
     if let Some(end) = dep.args_request_end {
       source.replace(end, end, format!(", {}", json_stringify_str(request)), None);
     }

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -5,6 +5,7 @@ use rspack_core::{
   InitFragmentKey, InitFragmentStage, NormalInitFragment, RuntimeCondition, RuntimeGlobals,
   TemplateContext, TemplateReplaceSource,
 };
+use rspack_util::json_stringify_str;
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -17,6 +18,14 @@ pub struct MockMethodDependency {
   request: String,
   hoist: bool,
   method: MockMethod,
+  /// Byte offset (end of the last call argument's expression, before any
+  /// trailing comma) at which to inject the clean `request` literal as the
+  /// trailing argument of the emitted `rstest_*` call, e.g. turning
+  /// `rstest_mock(id, factory)` into `rstest_mock(id, factory, "request")`.
+  /// `None` skips injection — used for `rs.hoisted` (no request) and the 1-arg
+  /// auto-mock form (whose request is carried by the synthetic-target
+  /// dependency's suffix instead, to avoid colliding at the same offset).
+  args_request_end: Option<u32>,
 }
 
 #[cacheable]
@@ -47,6 +56,7 @@ impl MockMethodDependency {
       request,
       hoist,
       method,
+      args_request_end: None,
     }
   }
 
@@ -65,7 +75,15 @@ impl MockMethodDependency {
       request,
       hoist,
       method,
+      args_request_end: None,
     }
+  }
+
+  /// Set the byte offset at which to inject the clean `request` literal as the
+  /// trailing argument of the emitted `rstest_*` call. See [`Self::args_request_end`].
+  pub fn with_request_arg_end(mut self, end: Option<u32>) -> Self {
+    self.args_request_end = end;
+    self
   }
 }
 
@@ -131,6 +149,16 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       &hoist_id,
       request,
     );
+
+    // Step 4: Inject the clean request as the trailing argument of the call,
+    // e.g. `rstest_mock(id, factory)` -> `rstest_mock(id, factory, "request")`,
+    // so a dynamic `import(request)` (a different external module id) can be
+    // intercepted by request via rstest_dynamic_require. Inserted at the end of
+    // the last argument expression (before any trailing comma) to stay valid
+    // for `rs.mock('x', f,)`. `None` for rs.hoisted and the 1-arg auto-mock form.
+    if let Some(end) = dep.args_request_end {
+      source.replace(end, end, format!(", {}", json_stringify_str(request)), None);
+    }
   }
 }
 

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -149,11 +149,9 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       request,
     );
 
-    // Step 4: Inject the clean request as the call's trailing argument so a
-    // dynamic `import(request)` (a different external module id) can be
-    // intercepted by request via rstest_dynamic_require. Inserted before any
-    // trailing comma to stay valid for `rs.mock('x', f,)`. See `args_request_end`
-    // for the `None` cases.
+    // Inject the request as the call's trailing arg (before any trailing comma,
+    // valid for `rs.mock('x', f,)`) so a dynamic `import(request)` resolves to the
+    // mock by request. See `args_request_end` for the `None` cases.
     if let Some(end) = dep.args_request_end {
       source.replace(end, end, format!(", {}", json_stringify_str(request)), None);
     }

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -355,13 +355,25 @@ impl RstestParserPlugin {
           );
           parser.add_dependency(Box::new(dep));
 
-          parser.add_presentational_dependency(Box::new(MockMethodDependency::new(
-            call_expr.span().into(),
-            call_expr.callee.span().into(),
-            lit_str.clone(),
-            hoist,
-            method,
-          )));
+          parser.add_presentational_dependency(Box::new(
+            MockMethodDependency::new(
+              call_expr.span().into(),
+              call_expr.callee.span().into(),
+              lit_str.clone(),
+              hoist,
+              method,
+            )
+            // 1-arg unmock (`rs.unmock('X')`, has_b=false): append the request
+            // after the single id argument. 1-arg auto-mock (`rs.mock('X')`,
+            // has_b=true): the request is carried by the synthetic-target
+            // dependency's suffix below instead, so skip here to avoid two
+            // inserts colliding at the same byte offset.
+            .with_request_arg_end(if has_b {
+              None
+            } else {
+              Some(first_arg.span().real_hi())
+            }),
+          ));
 
           if has_b {
             let second_arg = Span::new(
@@ -378,7 +390,9 @@ impl RstestParserPlugin {
               } else {
                 rspack_core::DependencyCategory::CommonJS
               },
-              None,
+              // Render the synthetic target id followed by the clean request
+              // literal, yielding `rstest_mock(<id>, <targetId>, "X")`.
+              Some(format!(", {}", json_stringify_str(&lit_str))),
             )));
           }
         }
@@ -408,13 +422,18 @@ impl RstestParserPlugin {
             None,
           );
 
-          parser.add_presentational_dependency(Box::new(MockMethodDependency::new(
-            call_expr.span().into(),
-            call_expr.callee.span().into(),
-            lit_str,
-            hoist,
-            method,
-          )));
+          parser.add_presentational_dependency(Box::new(
+            MockMethodDependency::new(
+              call_expr.span().into(),
+              call_expr.callee.span().into(),
+              lit_str,
+              hoist,
+              method,
+            )
+            // 2-arg form (`rs.mock('X', factory)`): append the request after
+            // the factory argument -> `rstest_mock(id, factory, "X")`.
+            .with_request_arg_end(Some(second_arg.span().real_hi())),
+          ));
           parser.add_dependency(Box::new(module_dep));
         } else {
           parser.add_error(

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -363,11 +363,9 @@ impl RstestParserPlugin {
               hoist,
               method,
             )
-            // 1-arg unmock (`rs.unmock('X')`, has_b=false): append the request
-            // after the single id argument. 1-arg auto-mock (`rs.mock('X')`,
-            // has_b=true): the request is carried by the synthetic-target
-            // dependency's suffix below instead, so skip here to avoid two
-            // inserts colliding at the same byte offset.
+            // has_b=false (1-arg `rs.unmock('X')`): append request after the id.
+            // has_b=true (1-arg auto-mock): request rides the synthetic-target
+            // suffix below instead — skip here to avoid a same-offset collision.
             .with_request_arg_end(if has_b {
               None
             } else {
@@ -430,8 +428,7 @@ impl RstestParserPlugin {
               hoist,
               method,
             )
-            // 2-arg form (`rs.mock('X', factory)`): append the request after
-            // the factory argument -> `rstest_mock(id, factory, "X")`.
+            // 2-arg `rs.mock('X', factory)`: append request after the factory.
             .with_request_arg_end(Some(second_arg.span().real_hi())),
           ));
           parser.add_dependency(Box::new(module_dep));

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/index.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/index.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+// Regression for rstest #1327 (node builtins) / #1328 (ESM-only npm packages):
+// a dynamic `import()` of a MOCKED externalized specifier resolved to the real
+// module because rspack mints a different external module id for the dynamic
+// import (`external import "X"`) than the one the hoisted `rs.mock` patches
+// (`external module "X"`). The RstestPlugin now routes EXTERNAL dynamic imports
+// through `rstest_dynamic_require`, keyed on the clean request literal, so the
+// mock installed under the (different) static id is found by request.
+it('routes external dynamic import() of a mocked module through rstest_dynamic_require keyed on the request', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'mockDynamicImport.mjs'),
+		'utf-8',
+	);
+
+	// The hoisted `rs.mock` appends the clean request literal as the 3rd arg, so
+	// the mock factory is also registered under the request (not just the id).
+	expect(content).toMatch(
+		/rstest_mock\("node:child_process[^"]*",[\s\S]*?,\s*"node:child_process"\)/,
+	);
+
+	// The external, mocked, dynamic import is routed through the shim with the
+	// clean request literal as the trailing bound argument.
+	expect(content).toMatch(
+		/rstest_dynamic_require\.bind\([^)]*,\s*"node:child_process"\)/,
+	);
+
+	// A request literal that itself contains `?` is emitted verbatim as a json
+	// literal — never parsed/split on `?` (the old base-split fragility).
+	expect(content).toMatch(
+		/rstest_dynamic_require\.bind\([^)]*,\s*"node:child_process\?weird"\)/,
+	);
+
+	// An UNMOCKED external dynamic import is still routed through the shim
+	// (pass-through at runtime). This proves the gate is "target is external",
+	// not "target is mocked".
+	expect(content).toMatch(/rstest_dynamic_require\.bind\([^)]*,\s*"node:os"\)/);
+
+	// The shim is GUARDED: `rstest_dynamic_require ? <shim> : <plain require>`, so a
+	// NEWER @rspack/core codegen degrades to pre-fix behavior (plain
+	// `__webpack_require__(id)`) on an OLDER @rstest/core runtime that lacks
+	// rstest_dynamic_require — never throwing `undefined.bind(...)`. Without this
+	// guard, every external dynamic import() (even unmocked) would crash a stale
+	// runtime.
+	expect(content).toMatch(
+		/rstest_dynamic_require\s*\?[\s\S]*?:\s*__webpack_require__\.bind\(__webpack_require__,/,
+	);
+
+	// The INTERNAL dynamic import must remain a bare `__webpack_require__.bind`
+	// (byte-identical to upstream) — internal modules never split, so the gate
+	// must leave their codegen untouched.
+	expect(content).toMatch(
+		/\.then\(__webpack_require__\.bind\(__webpack_require__,\s*"\.\/src\/internal\.js"\)\)/,
+	);
+	expect(content).not.toMatch(/rstest_dynamic_require\.bind\([^)]*internal/);
+});

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/rspack.config.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+  // Entry 1: the codegen target. Built with rstest's real shape (outputModule +
+  // `module-import` externals, the type that forks `external module` vs
+  // `external import`). Emitted as `.mjs` and inspected by entry 2 — never run.
+  {
+    entry: './src/fixture.js',
+    target: 'node',
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: 'mockDynamicImport.mjs',
+      module: true,
+      chunkFormat: 'module',
+    },
+    externalsType: 'module-import',
+    externals: {
+      'node:child_process': 'node:child_process',
+      'node:child_process?weird': 'node:child_process',
+      'node:os': 'node:os',
+    },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+      moduleIds: 'named',
+      chunkIds: 'named',
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: true,
+        hoistMockModule: true,
+        importMetaPathName: true,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+      }),
+    ],
+  },
+  // Entry 2: the test. Reads entry 1's output and asserts the codegen contract.
+  {
+    entry: {
+      main: './index.js',
+    },
+    output: {
+      filename: '[name].js',
+    },
+    externalsPresets: {
+      node: true,
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/src/fixture.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/src/fixture.js
@@ -1,0 +1,30 @@
+// Codegen target (NOT executed) for the #1327/#1328 regression.
+//
+// `rs.mock` of an externalized specifier emits `external module "X"` for the
+// hoisted mock dependency, while a dynamic `import("X")` emits a DISTINCT
+// `external import "X"` — two different module ids (e.g. `X?2a28` vs `X?2d83`).
+// The fix routes the EXTERNAL dynamic import through `rstest_dynamic_require`
+// keyed on the clean request literal so it still resolves to the mock, while
+// leaving INTERNAL dynamic imports byte-identical to upstream.
+rs.mock('node:child_process', () => ({ execSync: () => 'MOCKED', __mock: true }));
+
+// External, mocked, dynamic-only (no static import of the same request) -> split.
+export async function importMocked() {
+  return import('node:child_process');
+}
+
+// External whose request literal itself contains `?` -> the request arg must be
+// emitted as a clean json literal, never parsed/split on `?`.
+export async function importWeird() {
+  return import('node:child_process?weird');
+}
+
+// External, unmocked -> still routed through the shim (pass-through at runtime).
+export async function importUnmocked() {
+  return import('node:os');
+}
+
+// Internal -> the gate must leave this as a bare `__webpack_require__.bind`.
+export async function importInternal() {
+  return import('./internal.js');
+}

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/src/internal.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/src/internal.js
@@ -1,0 +1,1 @@
+export const value = 'INTERNAL';

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/test.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: function () {
+		return ['main.js'];
+	},
+};


### PR DESCRIPTION
## Summary

Fixes a mock-resolution gap reported in rstest (web-infra-dev/rstest#1327, web-infra-dev/rstest#1328): a dynamic `import()` of a mocked external resolved to the **real** module.

rspack assigns a different external module id to a dynamic `import("X")` (`external import "X"`) than to the hoisted `rs.mock` dependency (`external module "X"`) — the dynamic `ImportDependency` carries the `Import` external-type meta, which `resolve_external_type` upgrades `module-import` → `import`. The mock installed on the static id was therefore missed by the dynamic import.

This PR:

- Appends the clean request literal as a trailing argument to the rstest mock-method codegen, so the runtime registers the mock by request.
- Routes **external** dynamic imports through `__webpack_require__.rstest_dynamic_require(id, request)`, so the runtime can find that mock by request. Internal modules don't split (static and dynamic share one id), so their codegen is left byte-identical — the shim is gated on `target_is_external`.

The emitted call is **guarded** — `rstest_dynamic_require ? <shim> : <plain require>` — so a newer `@rspack/core` stays safe against an older `@rstest/core` runtime that predates the helper: it falls back to the plain `__webpack_require__(id)` form (pre-fix behavior) instead of throwing `undefined.bind(...)`. This decouples release order between the two packages.

A `configCases/rstest/mock-dynamic-import-external` test asserts the emitted codegen, including the guard and the byte-identical internal path.

## Related links

- web-infra-dev/rstest#1327
- web-infra-dev/rstest#1328
- Runtime counterpart (rstest): https://github.com/web-infra-dev/rstest/pull/1357

## Checklist

- [x] Tests updated (or not required). — added `configCases/rstest/mock-dynamic-import-external`
- [x] Documentation updated (or not required). — internal rstest plugin codegen, no docs change
