### PR TITLE
perf: concat source with capacity

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1591,7 +1591,6 @@ impl Module for ConcatenatedModule {
       });
     }
 
-    let mut result: ConcatSource = ConcatSource::default();
     let mut should_add_esm_flag = false;
     let mut chunk_init_fragments: Vec<Box<dyn InitFragment<ChunkRenderContext>>> = Vec::new();
 
@@ -1620,6 +1619,19 @@ impl Module for ConcatenatedModule {
     {
       should_add_esm_flag = true
     }
+
+    // Keep this estimate O(1): `with_capacity` is a performance hint, and
+    // calculating the exact number of child sources would require extra scans.
+    let capacity = references_info.len() * 2
+      + module_to_info_map.len()
+      + if exports_map.is_empty() {
+        0
+      } else {
+        2 + usize::from(should_add_esm_flag) * 2
+      }
+      + usize::from(!unused_exports.is_empty())
+      + usize::from(!inlined_exports.is_empty());
+    let mut result = ConcatSource::with_capacity(capacity);
 
     // Assuming the necessary imports and dependencies are declared
 
@@ -1684,7 +1696,7 @@ impl Module for ConcatenatedModule {
       )));
     }
 
-    let mut namespace_object_sources: IdentifierMap<String> = IdentifierMap::default();
+    let mut namespace_object_sources: IdentifierMap<BoxSource> = IdentifierMap::default();
 
     while let Some(module_info_id) = needed_namespace_objects_queue.pop_front() {
       let module_info = module_to_info_map
@@ -1763,14 +1775,15 @@ impl Module for ConcatenatedModule {
 
       namespace_object_sources.insert(
         module_info_id,
-        format!(
+        RawStringSource::from(format!(
           "// NAMESPACE OBJECT: {}\nvar {} = {{}};\n{}({});\n{}\n",
           module_readable_identifier,
           name,
           runtime_template.render_runtime_globals(&RuntimeGlobals::MAKE_NAMESPACE_OBJECT),
           name,
           define_getters
-        ),
+        ))
+        .boxed(),
       );
     }
 
@@ -1780,7 +1793,7 @@ impl Module for ConcatenatedModule {
       if let Some(info) = info.try_as_concatenated()
         && let Some(source) = namespace_object_sources.get(&info.module)
       {
-        result.add(RawStringSource::from(source.as_str()));
+        result.add(source.clone());
       }
 
       // Define deferred modules namespace objects

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -238,8 +238,8 @@ pub fn render_init_fragments<C: InitFragmentRenderContext>(
     }
   }
 
-  let mut end_contents = vec![];
-  let mut concat_source = ConcatSource::default();
+  let mut end_contents = Vec::with_capacity(keyed_fragments.len());
+  let mut concat_source = ConcatSource::with_capacity(keyed_fragments.len());
 
   for (key, fragments) in keyed_fragments {
     let f = key.merge_fragments(fragments);

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -107,14 +107,14 @@ impl BannerPlugin {
     if let Some(footer) = footer
       && footer
     {
-      ConcatSource::new([
+      ConcatSource::new(vec![
         old_source,
         RawStringSource::from_static("\n").boxed(),
         RawStringSource::from(comment).boxed(),
       ])
       .boxed()
     } else {
-      ConcatSource::new([
+      ConcatSource::new(vec![
         RawStringSource::from(comment).boxed(),
         RawStringSource::from_static("\n").boxed(),
         old_source,

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -107,14 +107,14 @@ impl BannerPlugin {
     if let Some(footer) = footer
       && footer
     {
-      ConcatSource::new(vec![
+      ConcatSource::new([
         old_source,
         RawStringSource::from_static("\n").boxed(),
         RawStringSource::from(comment).boxed(),
       ])
       .boxed()
     } else {
-      ConcatSource::new(vec![
+      ConcatSource::new([
         RawStringSource::from(comment).boxed(),
         RawStringSource::from_static("\n").boxed(),
         old_source,

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -255,7 +255,7 @@ impl CssPlugin {
     .map(|r| r.to_rspack_result())
     .collect::<Result<Vec<_>>>()?;
 
-    let mut source = ConcatSource::default();
+    let mut source = ConcatSource::with_capacity(module_sources.len());
 
     for module_source in module_sources {
       source.add(module_source?);

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -13,7 +13,7 @@ use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
-  JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
+  JavascriptModulesRenderModuleContent, JsPlugin,
 };
 use rspack_util::fx_hash::FxDashMap;
 
@@ -90,13 +90,13 @@ async fn render_module_content(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   module: &dyn Module,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _init_fragments: &mut ChunkInitFragments,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
-  let origin_source = render_source.source.clone();
+  let origin_source = render_source.clone();
   if let Some(cached_source) = self.cache.get(&origin_source) {
-    render_source.source = cached_source.value().clone();
+    *render_source = cached_source.value().clone();
     return Ok(());
   } else if module.as_external_module().is_some() {
     return Ok(());
@@ -175,7 +175,7 @@ async fn render_module_content(
   };
 
   self.cache.insert(origin_source, source.clone());
-  render_source.source = source;
+  *render_source = source;
   Ok(())
 }
 

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -13,7 +13,7 @@ use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
-  JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
+  JavascriptModulesRenderModuleContent, JsPlugin,
 };
 use rspack_util::{
   asset_condition::{AssetConditions, AssetConditionsObject, match_object},
@@ -99,7 +99,7 @@ async fn render_module_content(
   compilation: &Compilation,
   chunk: &ChunkUkey,
   module: &dyn Module,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _init_fragments: &mut ChunkInitFragments,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
@@ -135,9 +135,9 @@ async fn render_module_content(
     return Ok(());
   }
 
-  let origin_source = render_source.source.clone();
+  let origin_source = render_source.clone();
   if let Some(cached_source) = self.cache.get(module_hash) {
-    render_source.source = cached_source.value().clone();
+    *render_source = cached_source.value().clone();
     return Ok(());
   } else if let Some(mut map) =
     origin_source.map(&ObjectPool::default(), &MapOptions::new(self.columns))
@@ -274,7 +274,7 @@ async fn render_module_content(
       .boxed()
     };
     self.cache.insert(module_hash.clone(), source.clone());
-    render_source.source = source;
+    *render_source = source;
     return Ok(());
   }
   Ok(())

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -964,7 +964,7 @@ impl SourceMapDevToolPlugin {
           .unwrap_or_default();
 
         asset.source = Some(
-          ConcatSource::new(vec![
+          ConcatSource::new([
             source.clone(),
             RawStringSource::from(debug_id_comment).boxed(),
             RawStringSource::from(current_source_mapping_url_comment).boxed(),
@@ -1001,7 +1001,7 @@ impl SourceMapDevToolPlugin {
       };
       let base64 = base64::encode_to_string(source_map_json.as_bytes());
       asset.source = Some(
-        ConcatSource::new(vec![
+        ConcatSource::new([
           source.clone(),
           RawStringSource::from(
             current_source_mapping_url_comment

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -964,7 +964,7 @@ impl SourceMapDevToolPlugin {
           .unwrap_or_default();
 
         asset.source = Some(
-          ConcatSource::new([
+          ConcatSource::new(vec![
             source.clone(),
             RawStringSource::from(debug_id_comment).boxed(),
             RawStringSource::from(current_source_mapping_url_comment).boxed(),
@@ -1001,7 +1001,7 @@ impl SourceMapDevToolPlugin {
       };
       let base64 = base64::encode_to_string(source_map_json.as_bytes());
       asset.source = Some(
-        ConcatSource::new([
+        ConcatSource::new(vec![
           source.clone(),
           RawStringSource::from(
             current_source_mapping_url_comment

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -19,9 +19,7 @@ use rspack_core::{
   rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
-use rspack_plugin_javascript::{
-  JsPlugin, RenderSource, dependency::ESMExportImportedSpecifierDependency,
-};
+use rspack_plugin_javascript::{JsPlugin, dependency::ESMExportImportedSpecifierDependency};
 use rspack_plugin_runtime::should_export_webpack_require_for_module_chunk_loading;
 use rspack_util::{
   SpanExt,
@@ -1478,9 +1476,7 @@ var {} = {{}};
                   return Ok((ModuleInfo::Concatenated(concate_info), None));
                 };
 
-                let mut render_source = RenderSource {
-                  source: js_source.clone(),
-                };
+                let mut render_source = js_source.clone();
 
                 let mut chunk_init_fragments = vec![];
                 hooks
@@ -1517,11 +1513,7 @@ var {} = {{}};
                       .and_then(|js_options| js_options.jsx)
                   })
                   .unwrap_or(false);
-                let source_str = render_source
-                  .source
-                  .source()
-                  .into_string_lossy()
-                  .into_owned();
+                let source_str = render_source.source().into_string_lossy().into_owned();
                 let comments = SingleThreadedComments::default();
                 let mut ast = Ast::new(source_str.len(), StringAllocator::default());
                 let lexer = swc_experimental_ecma_parser::Lexer::new(
@@ -1594,8 +1586,8 @@ var {} = {{}};
                 concate_info.all_used_names = all_used_names;
                 concate_info.binding_to_ref = binding_to_ref;
                 concate_info.has_ast = true;
-                concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
-                concate_info.internal_source = Some(render_source.source.clone());
+                concate_info.source = Some(ReplaceSource::new(render_source.clone()));
+                concate_info.internal_source = Some(render_source.clone());
                 concate_info.runtime_requirements = codegen_res.runtime_requirements;
                 concate_info.chunk_init_fragments = codegen_res
                   .data

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -21,13 +21,13 @@ use rspack_core::{
   NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, REQUIRE_SCOPE_GLOBALS,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SideEffectsOptimizeArtifact,
   SideEffectsStateArtifact, get_target, is_esm_dep_like,
-  rspack_sources::{ReplaceSource, Source},
+  rspack_sources::{BoxSource, ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
-  JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
-  dependency::ImportDependencyTemplate, parser_and_generator::JavaScriptParserAndGenerator,
+  JavascriptModulesRenderChunkContent, JsPlugin, dependency::ImportDependencyTemplate,
+  parser_and_generator::JavaScriptParserAndGenerator,
 };
 use rspack_plugin_rslib::dyn_import_external::cutout_dyn_import_externals;
 use rspack_plugin_split_chunks::CacheGroup;
@@ -285,7 +285,7 @@ async fn render_chunk_content(
   chunk_ukey: &ChunkUkey,
   asset_info: &mut AssetInfo,
   runtime_template: &RuntimeCodeTemplate<'_>,
-) -> Result<Option<RenderSource>> {
+) -> Result<Option<BoxSource>> {
   self
     .render_chunk(compilation, chunk_ukey, asset_info, runtime_template)
     .await

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -218,7 +218,7 @@ impl EsmLibraryPlugin {
         decl_inner.add(module_source.clone());
       }
 
-      if !decl_inner.source().is_empty() {
+      if decl_inner.size() != 0 {
         // __webpack_require__.add({ "./src/main.js"(require, exports) { ... } })
         decl_source.add(RawStringSource::from(format!(
           "{}({{\n",
@@ -617,7 +617,7 @@ var {} = {{}};
     }
     final_source.add(import_source.boxed());
     final_source.add(render_init_fragments(
-      ConcatSource::new([
+      ConcatSource::new(vec![
         runtime_source.boxed(),
         decl_source.boxed(),
         render_source.boxed(),

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -7,11 +7,11 @@ use rspack_core::{
   ModuleIdentifier, PathData, PathInfo, RuntimeCodeTemplate, RuntimeGlobals, RuntimeVariable,
   SourceType, export_name, get_js_chunk_filename_template, get_undo_path, render_imports,
   render_init_fragments,
-  rspack_sources::{ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::Result;
 use rspack_plugin_javascript::{
-  JsPlugin, RenderSource,
+  JsPlugin,
   dependency::{URL_STATIC_PLACEHOLDER, URL_STATIC_PLACEHOLDER_RE},
   runtime::{AUTO_PUBLIC_PATH_PLACEHOLDER, render_module, render_runtime_modules},
 };
@@ -138,7 +138,7 @@ impl EsmLibraryPlugin {
     chunk_ukey: &ChunkUkey,
     asset_info: &mut AssetInfo,
     runtime_template: &RuntimeCodeTemplate<'_>,
-  ) -> Result<Option<RenderSource>> {
+  ) -> Result<Option<BoxSource>> {
     let module_graph = compilation.get_module_graph();
 
     // In this phase we only read from the lock, no write happen in this phase, the
@@ -823,9 +823,7 @@ var {} = {{}};
       final_source
     };
 
-    Ok(Some(RenderSource {
-      source: final_source,
-    }))
+    Ok(Some(final_source))
   }
 
   pub async fn render_runtime(

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -402,12 +402,17 @@ despite it was not able to fulfill desired ordering with these modules:
       }));
     }
 
+    let used_modules_count = used_modules.len();
     let used_modules = used_modules
       .into_iter()
       .filter_map(|module| module.downcast_ref::<CssModule>());
 
-    let mut source = ConcatSource::default();
-    let mut external_source = ConcatSource::default();
+    let source_capacity_per_module = if self.options.pathinfo { 9 } else { 8 };
+    let external_capacity_per_module = if self.options.pathinfo { 2 } else { 1 };
+    let mut source =
+      ConcatSource::with_capacity(used_modules_count.saturating_mul(source_capacity_per_module));
+    let mut external_source =
+      ConcatSource::with_capacity(used_modules_count * external_capacity_per_module + 1);
 
     for module in used_modules {
       let content = Cow::Borrowed(module.content.as_str());

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -1,12 +1,12 @@
 use rspack_core::{
   ChunkInitFragments, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
   InitFragmentExt, InitFragmentKey, InitFragmentStage, Module, NormalInitFragment, Plugin,
-  RuntimeCodeTemplate,
+  RuntimeCodeTemplate, rspack_sources::BoxSource,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
-use crate::{JavascriptModulesRenderModuleContent, JsPlugin, RenderSource};
+use crate::{JavascriptModulesRenderModuleContent, JsPlugin};
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -33,7 +33,7 @@ async fn render_module_content(
   compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
   module: &dyn Module,
-  _source: &mut RenderSource,
+  _source: &mut BoxSource,
   init_fragments: &mut ChunkInitFragments,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -7,13 +7,13 @@ use rspack_hook::define_hook;
 #[cfg(allocative)]
 use rspack_util::allocative;
 
-define_hook!(JavascriptModulesRenderChunk: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource, runtime_template: &RuntimeCodeTemplate<'_>));
-define_hook!(JavascriptModulesRenderChunkContent: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, asset_info: &mut AssetInfo, runtime_template: &RuntimeCodeTemplate<'_>) -> RenderSource);
-define_hook!(JavascriptModulesRender: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource, runtime_template: &RuntimeCodeTemplate<'_>));
-define_hook!(JavascriptModulesRenderStartup: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut RenderSource, runtime_template: &RuntimeCodeTemplate<'_>));
-define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate<'_>),tracing=false);
-define_hook!(JavascriptModulesRenderModuleContainer: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate<'_>),tracing=false);
-define_hook!(JavascriptModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate<'_>),tracing=false);
+define_hook!(JavascriptModulesRenderChunk: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut BoxSource, runtime_template: &RuntimeCodeTemplate<'_>));
+define_hook!(JavascriptModulesRenderChunkContent: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, asset_info: &mut AssetInfo, runtime_template: &RuntimeCodeTemplate<'_>) -> BoxSource);
+define_hook!(JavascriptModulesRender: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut BoxSource, runtime_template: &RuntimeCodeTemplate<'_>));
+define_hook!(JavascriptModulesRenderStartup: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut BoxSource, runtime_template: &RuntimeCodeTemplate<'_>));
+define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut BoxSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate<'_>),tracing=false);
+define_hook!(JavascriptModulesRenderModuleContainer: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut BoxSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate<'_>),tracing=false);
+define_hook!(JavascriptModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &dyn Module, source: &mut BoxSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate<'_>),tracing=false);
 define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
 define_hook!(JavascriptModulesInlineInRuntimeBailout: SeriesBail(compilation: &Compilation) -> String);
 define_hook!(JavascriptModulesEmbedInRuntimeBailout: SeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
@@ -44,9 +44,4 @@ pub struct JavascriptModulesPluginHooks {
   pub embed_in_runtime_bailout: JavascriptModulesEmbedInRuntimeBailoutHook,
   #[cfg_attr(allocative, allocative(skip))]
   pub strict_runtime_bailout: JavascriptModulesStrictRuntimeBailoutHook,
-}
-
-#[derive(Debug)]
-pub struct RenderSource {
-  pub source: BoxSource,
 }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -622,7 +622,7 @@ async fn render_manifest(
         .call(compilation, chunk_ukey, &mut asset_info, &runtime_template)
         .await?
       {
-        source.source
+        source
       } else if is_hot_update {
         self
           .render_chunk(compilation, chunk_ukey, &output_path, &runtime_template)

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -716,7 +716,13 @@ var {} = {{}};
     } else {
       None
     };
-    let mut sources = ConcatSource::default();
+    let inlined_module_count = inlined_modules.as_ref().map_or(0, |modules| modules.len());
+    let has_runtime_modules = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .has_chunk_runtime_modules(chunk_ukey);
+    let capacity = 8usize + inlined_module_count + if has_runtime_modules { 8 } else { 0 };
+    let mut sources = ConcatSource::with_capacity(capacity);
     if iife {
       sources.add(RawStringSource::from(if supports_arrow_function {
         "(() => {\n"
@@ -785,11 +791,7 @@ var {} = {{}};
       sources.add(RawStringSource::from(header));
     }
 
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .has_chunk_runtime_modules(chunk_ukey)
-    {
+    if has_runtime_modules {
       sources.add(render_runtime_modules(compilation, chunk_ukey, runtime_template).await?);
     }
     if let Some(inlined_modules) = inlined_modules {
@@ -797,7 +799,7 @@ var {} = {{}};
         .keys()
         .next_back()
         .expect("should have last entry module");
-      let mut startup_sources = ConcatSource::default();
+      let mut startup_sources = ConcatSource::with_capacity(8);
 
       if runtime_requirements.contains(RuntimeGlobals::EXPORTS) {
         startup_sources.add(RawStringSource::from(format!(
@@ -989,7 +991,7 @@ var {} = {{}};
       )
       .await?;
     Ok(if iife {
-      ConcatSource::new([
+      ConcatSource::new(vec![
         render_source.source,
         RawStringSource::from_static(";").boxed(),
       ])
@@ -1379,18 +1381,18 @@ var {} = {{}};
       .build_chunk_graph_artifact
       .chunk_graph
       .get_chunk_modules_by_source_type(chunk_ukey, SourceType::JavaScript, module_graph);
-    let mut sources = ConcatSource::default();
+    let mut concat_source = ConcatSource::with_capacity(3);
     if !all_strict && chunk_modules.iter().all(|m| m.build_info().strict) {
       if let Some(strict_bailout) = hooks
         .strict_runtime_bailout
         .call(compilation, chunk_ukey)
         .await?
       {
-        sources.add(RawStringSource::from(format!(
+        concat_source.add(RawStringSource::from(format!(
           "// runtime can't be in strict mode because {strict_bailout}.\n"
         )));
       } else {
-        sources.add(RawStringSource::from_static("\"use strict\";\n"));
+        concat_source.add(RawStringSource::from_static("\"use strict\";\n"));
         all_strict = true;
       }
     }
@@ -1434,11 +1436,11 @@ var {} = {{}};
         runtime_template,
       )
       .await?;
-    sources.add(render_source.source);
+    concat_source.add(render_source.source);
     if !is_module {
-      sources.add(RawStringSource::from_static(";"));
+      concat_source.add(RawStringSource::from_static(";"));
     }
-    Ok(sources.boxed())
+    Ok(concat_source.boxed())
   }
 
   #[inline]

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -926,9 +926,7 @@ var {} = {{}};
           runtime_template.render_runtime_globals(&RuntimeGlobals::EXPORTS),
         )));
       }
-      let mut render_source = RenderSource {
-        source: startup_sources.boxed(),
-      };
+      let mut render_source = startup_sources.boxed();
       hooks
         .render_startup
         .call(
@@ -939,7 +937,7 @@ var {} = {{}};
           runtime_template,
         )
         .await?;
-      sources.add(render_source.source);
+      sources.add(render_source);
     } else if let Some(last_entry_module) = compilation
       .build_chunk_graph_artifact
       .chunk_graph
@@ -947,9 +945,7 @@ var {} = {{}};
       .keys()
       .next_back()
     {
-      let mut render_source = RenderSource {
-        source: RawStringSource::from(startup.join("\n") + "\n").boxed(),
-      };
+      let mut render_source = RawStringSource::from(startup.join("\n") + "\n").boxed();
       hooks
         .render_startup
         .call(
@@ -960,7 +956,7 @@ var {} = {{}};
           runtime_template,
         )
         .await?;
-      sources.add(render_source.source);
+      sources.add(render_source);
     }
     if has_entry_modules
       && runtime_requirements.contains(RuntimeGlobals::RETURN_EXPORTS_FROM_RUNTIME)
@@ -978,9 +974,7 @@ var {} = {{}};
       chunk_init_fragments,
       &mut ChunkRenderContext {},
     )?;
-    let mut render_source = RenderSource {
-      source: final_source,
-    };
+    let mut render_source = final_source;
     hooks
       .render
       .call(
@@ -991,13 +985,9 @@ var {} = {{}};
       )
       .await?;
     Ok(if iife {
-      ConcatSource::new(vec![
-        render_source.source,
-        RawStringSource::from_static(";").boxed(),
-      ])
-      .boxed()
+      ConcatSource::new([render_source, RawStringSource::from_static(";").boxed()]).boxed()
     } else {
-      render_source.source
+      render_source
     })
   }
 
@@ -1407,9 +1397,7 @@ var {} = {{}};
     )
     .await?
     .unwrap_or_else(|| (RawStringSource::from_static("{}").boxed(), Vec::new()));
-    let mut render_source = RenderSource {
-      source: chunk_modules_source,
-    };
+    let mut render_source = chunk_modules_source;
     hooks
       .render_chunk
       .call(
@@ -1420,13 +1408,11 @@ var {} = {{}};
       )
       .await?;
     let source_with_fragments = render_init_fragments(
-      render_source.source,
+      render_source,
       chunk_init_fragments,
       &mut ChunkRenderContext {},
     )?;
-    let mut render_source = RenderSource {
-      source: source_with_fragments,
-    };
+    let mut render_source = source_with_fragments;
     hooks
       .render
       .call(
@@ -1436,7 +1422,7 @@ var {} = {{}};
         runtime_template,
       )
       .await?;
-    concat_source.add(render_source.source);
+    concat_source.add(render_source);
     if !is_module {
       concat_source.add(RawStringSource::from_static(";"));
     }

--- a/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
@@ -4,13 +4,14 @@ use rspack_core::{
   ChunkInitFragments, ChunkUkey, CodeGenerationDataFilename, Compilation, CompilationParams,
   CompilerCompilation, DependencyId, JavascriptParserUrl, Module, ModuleType,
   NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, RuntimeCodeTemplate,
-  URLStaticMode, rspack_sources::ReplaceSource,
+  URLStaticMode,
+  rspack_sources::{BoxSource, ReplaceSource},
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
 use crate::{
-  JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
+  JavascriptModulesRenderModuleContent, JsPlugin,
   dependency::{URL_STATIC_PLACEHOLDER, URL_STATIC_PLACEHOLDER_RE},
   parser_and_generator::JavaScriptParserAndGenerator,
 };
@@ -61,7 +62,7 @@ async fn render_module_content(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   module: &dyn Module,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _init_fragments: &mut ChunkInitFragments,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
@@ -75,8 +76,8 @@ async fn render_module_content(
     .code_generation_results
     .get(&module.identifier(), Some(runtime));
   if codegen_result.data.contains::<URLStaticMode>() {
-    let content = render_source.source.source().into_string_lossy();
-    let mut replace_source = ReplaceSource::new(render_source.source.clone());
+    let content = render_source.source().into_string_lossy();
+    let mut replace_source = ReplaceSource::new(render_source.clone());
     let replacement = URL_STATIC_PLACEHOLDER_RE
       .find_iter(&content)
       .map(|cap| (cap.start(), cap.end()));
@@ -105,7 +106,7 @@ async fn render_module_content(
       );
     }
 
-    render_source.source = Arc::new(replace_source);
+    *render_source = Arc::new(replace_source);
   }
   Ok(())
 }

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -1,4 +1,3 @@
-use rayon::prelude::*;
 use rspack_core::{
   ChunkGraph, ChunkInitFragments, ChunkUkey, CodeGenerationPublicPathAutoReplace, Compilation,
   Module, ModuleCodeGenerationContext, RuntimeCodeTemplate, RuntimeGlobals, SourceType,
@@ -57,7 +56,7 @@ pub async fn render_chunk_modules(
   .map(|r| r.to_rspack_result())
   .collect::<Result<Vec<_>>>()?;
 
-  let mut module_code_array = vec![];
+  let mut module_code_array = Vec::with_capacity(module_sources.len());
   for item in module_sources {
     if let Some(i) = item? {
       module_code_array.push(i);
@@ -83,20 +82,14 @@ pub async fn render_chunk_modules(
     .into_iter()
     .map(|(_, source, _, _)| source)
     .collect();
-  let module_sources = module_sources
-    .into_par_iter()
-    .fold(ConcatSource::default, |mut output, source| {
-      output.add(source);
-      output
-    })
-    .collect::<Vec<ConcatSource>>();
 
-  let mut sources = ConcatSource::default();
-  sources.add(RawStringSource::from_static("{\n"));
-  sources.add(ConcatSource::new(module_sources));
-  sources.add(RawStringSource::from_static("\n}"));
+  let chunk_modules_source = ConcatSource::new(vec![
+    RawStringSource::from_static("{\n").boxed(),
+    ConcatSource::new(module_sources).boxed(),
+    RawStringSource::from_static("\n}").boxed(),
+  ]);
 
-  Ok(Some((sources.boxed(), chunk_init_fragments)))
+  Ok(Some((chunk_modules_source.boxed(), chunk_init_fragments)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -186,7 +179,7 @@ pub async fn render_module(
     .await?;
 
   let sources = if factory {
-    let mut sources = ConcatSource::default();
+    let mut sources = ConcatSource::with_capacity(2);
     let module_id =
       ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier())
         .expect("should have module_id in render_module");
@@ -230,7 +223,8 @@ pub async fn render_module(
         args.push(runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE));
       }
 
-      let mut container_sources = ConcatSource::default();
+      let use_strict = module.build_info().strict && !all_strict;
+      let mut container_sources = ConcatSource::with_capacity(if use_strict { 4 } else { 3 });
 
       if use_method_shorthand {
         container_sources.add(RawStringSource::from(format!("({}) {{\n", args.join(", "))));
@@ -240,7 +234,7 @@ pub async fn render_module(
           args.join(", ")
         )));
       }
-      if module.build_info().strict && !all_strict {
+      if use_strict {
         container_sources.add(RawStringSource::from_static("\"use strict\";\n"));
       }
       container_sources.add(render_source.source);
@@ -312,20 +306,22 @@ pub async fn render_chunk_runtime_modules(
   chunk_ukey: &ChunkUkey,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<BoxSource> {
-  let runtime_modules_sources =
+  let runtime_modules_source =
     render_runtime_modules(compilation, chunk_ukey, runtime_template).await?;
-  if runtime_modules_sources.source().is_empty() {
-    return Ok(runtime_modules_sources);
+  if runtime_modules_source.size() == 0 {
+    return Ok(runtime_modules_source);
   }
 
-  let mut sources = ConcatSource::default();
-  sources.add(RawStringSource::from(format!(
-    "function({}) {{\n",
-    runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
-  )));
-  sources.add(runtime_modules_sources);
-  sources.add(RawStringSource::from_static("\n}\n"));
-  Ok(sources.boxed())
+  let concat_source = ConcatSource::new(vec![
+    RawStringSource::from(format!(
+      "function({}) {{\n",
+      runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
+    ))
+    .boxed(),
+    runtime_modules_source,
+    RawStringSource::from_static("\n}\n").boxed(),
+  ]);
+  Ok(concat_source.boxed())
 }
 
 pub async fn render_runtime_modules(
@@ -333,7 +329,6 @@ pub async fn render_runtime_modules(
   chunk_ukey: &ChunkUkey,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<BoxSource> {
-  let mut sources = ConcatSource::default();
   let runtime_module_sources = rspack_parallel::scope::<_, Result<_>>(|token| {
     compilation
       .build_chunk_graph_artifact
@@ -351,10 +346,12 @@ pub async fn render_runtime_modules(
       .for_each(|(source, module)| {
         let s = unsafe { token.used((compilation, source, module)) };
         s.spawn(|(compilation, source, module)| async move {
-          let mut sources = ConcatSource::default();
           if source.size() == 0 {
-            return Ok(sources);
+            return Ok(ConcatSource::default());
           }
+          let should_isolate = module.should_isolate();
+          let capacity = if should_isolate { 4 } else { 2 };
+          let mut sources = ConcatSource::with_capacity(capacity);
           sources.add(RawStringSource::from(format!(
             "// {}\n",
             module.identifier()
@@ -364,7 +361,7 @@ pub async fn render_runtime_modules(
             .output
             .environment
             .supports_arrow_function();
-          if module.should_isolate() {
+          if should_isolate {
             sources.add(RawStringSource::from(if supports_arrow_function {
               "(() => {\n"
             } else {
@@ -387,7 +384,7 @@ pub async fn render_runtime_modules(
             let source = result.get(&SourceType::Runtime).unwrap();
             sources.add(source.clone());
           }
-          if module.should_isolate() {
+          if should_isolate {
             sources.add(RawStringSource::from(if supports_arrow_function {
               "\n})();\n"
             } else {
@@ -403,11 +400,12 @@ pub async fn render_runtime_modules(
   .map(|r| r.to_rspack_result())
   .collect::<Result<Vec<_>>>()?;
 
+  let mut concat_source = ConcatSource::with_capacity(runtime_module_sources.len());
   for runtime_module_source in runtime_module_sources {
-    sources.add(runtime_module_source?);
+    concat_source.add(runtime_module_source?);
   }
 
-  Ok(sources.boxed())
+  Ok(concat_source.boxed())
 }
 
 pub fn stringify_chunks_to_array(chunks: &ChunkIdSet) -> String {

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -7,7 +7,7 @@ use rspack_core::{
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 
-use crate::{JavascriptModulesPluginHooks, RenderSource};
+use crate::JavascriptModulesPluginHooks;
 
 pub const AUTO_PUBLIC_PATH_PLACEHOLDER: &str = "__RSPACK_PLUGIN_ASSET_AUTO_PUBLIC_PATH__";
 
@@ -78,16 +78,12 @@ pub async fn render_chunk_modules(
     },
   );
 
-  let module_sources: Vec<_> = module_code_array
-    .into_iter()
-    .map(|(_, source, _, _)| source)
-    .collect();
-
-  let chunk_modules_source = ConcatSource::new(vec![
-    RawStringSource::from_static("{\n").boxed(),
-    ConcatSource::new(module_sources).boxed(),
-    RawStringSource::from_static("\n}").boxed(),
-  ]);
+  let mut chunk_modules_source = ConcatSource::with_capacity(module_code_array.len() + 2);
+  chunk_modules_source.add(RawStringSource::from_static("{\n"));
+  for (_, source, _, _) in module_code_array {
+    chunk_modules_source.add(source);
+  }
+  chunk_modules_source.add(RawStringSource::from_static("\n}"));
 
   Ok(Some((chunk_modules_source.boxed(), chunk_init_fragments)))
 }
@@ -140,18 +136,12 @@ pub async fn render_module(
         );
         replace.replace(start as u32, end as u32, relative, None);
       }
-      RenderSource {
-        source: replace.boxed(),
-      }
+      replace.boxed()
     } else {
-      RenderSource {
-        source: origin_source.clone(),
-      }
+      origin_source.clone()
     }
   } else {
-    RenderSource {
-      source: origin_source.clone(),
-    }
+    origin_source.clone()
   };
 
   /*
@@ -237,7 +227,7 @@ pub async fn render_module(
       if use_strict {
         container_sources.add(RawStringSource::from_static("\"use strict\";\n"));
       }
-      container_sources.add(render_source.source);
+      container_sources.add(render_source);
 
       if use_method_shorthand {
         container_sources.add(RawStringSource::from_static("\n\n},\n"));
@@ -245,9 +235,7 @@ pub async fn render_module(
         container_sources.add(RawStringSource::from_static("\n\n}),\n"));
       }
 
-      RenderSource {
-        source: container_sources.boxed(),
-      }
+      container_sources.boxed()
     };
 
     hooks
@@ -276,7 +264,7 @@ pub async fn render_module(
       )
       .await?;
 
-    sources.add(post_module_package.source);
+    sources.add(post_module_package);
     sources.boxed()
   } else {
     hooks
@@ -291,7 +279,7 @@ pub async fn render_module(
       )
       .await?;
 
-    render_source.source
+    render_source
   };
 
   Ok(Some((
@@ -312,7 +300,7 @@ pub async fn render_chunk_runtime_modules(
     return Ok(runtime_modules_source);
   }
 
-  let concat_source = ConcatSource::new(vec![
+  let concat_source = ConcatSource::new([
     RawStringSource::from(format!(
       "function({}) {{\n",
       runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -4,14 +4,12 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
   CompilerCompilation, ExternalModule, Filename, LibraryName, LibraryNonUmdObject, LibraryOptions,
   LibraryType, PathData, Plugin, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SourceType,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
-};
+use rspack_plugin_javascript::{JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin};
 
 use crate::utils::{
   COMMON_LIBRARY_NAME_MESSAGE, external_arguments, externals_dep_array, get_options_for_chunk,
@@ -91,7 +89,7 @@ async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
@@ -164,9 +162,9 @@ async fn render(
       "{amd_container_prefix}define({externals_deps_array}, {fn_start}"
     )));
   }
-  source.add(render_source.source.clone());
+  source.add(render_source.clone());
   source.add(RawStringSource::from_static("\n})"));
-  render_source.source = source.boxed();
+  *render_source = source.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -232,7 +232,7 @@ async fn render(
         "Library name base ({base}) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. {base_identifier}) or use a different library type (e. g. `type: 'global'`, which assign a property on the global scope instead of declaring a variable). {COMMON_LIBRARY_NAME_MESSAGE}"
       ));
     }
-    let mut concat_source = ConcatSource::new([
+    let concat_source = ConcatSource::new([
       RawStringSource::from(format!("var {base};\n")).boxed(),
       render_source.clone(),
     ]);

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData, Plugin,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, RuntimeVariable, SideEffectsStateArtifact,
   SourceType, UsageState, get_entry_runtime, property_access,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
   to_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error, error_bail};
@@ -18,7 +18,7 @@ use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesEmbedInRuntimeBailout, JavascriptModulesRender,
-  JavascriptModulesRenderStartup, JavascriptModulesStrictRuntimeBailout, JsPlugin, RenderSource,
+  JavascriptModulesRenderStartup, JavascriptModulesStrictRuntimeBailout, JsPlugin,
 };
 use swc_core::atoms::Atom;
 
@@ -212,7 +212,7 @@ async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
@@ -232,10 +232,11 @@ async fn render(
         "Library name base ({base}) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. {base_identifier}) or use a different library type (e. g. `type: 'global'`, which assign a property on the global scope instead of declaring a variable). {COMMON_LIBRARY_NAME_MESSAGE}"
       ));
     }
-    let mut source = ConcatSource::default();
-    source.add(RawStringSource::from(format!("var {base};\n")));
-    source.add(render_source.source.clone());
-    render_source.source = source.boxed();
+    let mut concat_source = ConcatSource::new([
+      RawStringSource::from(format!("var {base};\n")).boxed(),
+      render_source.clone(),
+    ]);
+    *render_source = concat_source.boxed();
     return Ok(());
   }
   Ok(())
@@ -247,14 +248,14 @@ async fn render_startup(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   module: &ModuleIdentifier,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());
   };
   let mut source = ConcatSource::default();
-  source.add(render_source.source.clone());
+  source.add(render_source.clone());
   let chunk = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey
@@ -347,7 +348,7 @@ async fn render_startup(
       access_with_init(&full_name_resolved, self.options.prefix.len(), false)
     )));
   }
-  render_source.source = source.boxed();
+  *render_source = source.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -6,13 +6,13 @@ use rspack_core::{
   CompilerCompilation, EntryData, ExportsInfoArtifact, LibraryExport, LibraryOptions, LibraryType,
   ModuleIdentifier, Plugin, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
   SideEffectsStateArtifact, UsageState, get_entry_runtime, property_access,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,
+  JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin,
 };
 
 use crate::utils::get_options_for_chunk;
@@ -76,20 +76,22 @@ async fn render_startup(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _module: &ModuleIdentifier,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey) else {
     return Ok(());
   };
   if let Some(export) = options.export {
-    let mut s = ConcatSource::default();
-    s.add(render_source.source.clone());
-    s.add(RawStringSource::from(format!(
-      "__webpack_exports__ = __webpack_exports__{};",
-      property_access(export, 0)
-    )));
-    render_source.source = s.boxed();
+    let mut concat_source = ConcatSource::new([
+      render_source.clone(),
+      RawStringSource::from(format!(
+        "var __webpack_exports__ = {};\n",
+        property_access(export, 0)
+      ))
+      .boxed(),
+    ]);
+    *render_source = concat_source.boxed();
     return Ok(());
   }
   Ok(())

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -86,7 +86,7 @@ async fn render_startup(
     let concat_source = ConcatSource::new([
       render_source.clone(),
       RawStringSource::from(format!(
-        "var __webpack_exports__ = {};\n",
+        "__webpack_exports__ = __webpack_exports__{};",
         property_access(export, 0)
       ))
       .boxed(),

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -83,7 +83,7 @@ async fn render_startup(
     return Ok(());
   };
   if let Some(export) = options.export {
-    let mut concat_source = ConcatSource::new([
+    let concat_source = ConcatSource::new([
       render_source.clone(),
       RawStringSource::from(format!(
         "var __webpack_exports__ = {};\n",

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -4,14 +4,14 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationParams, CompilerCompilation, ExportProvided, ExportsType,
   LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin, RuntimeCodeTemplate, RuntimeVariable,
   UsedNameItem, property_access,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
   to_identifier, to_module_export_name,
 };
 use rspack_error::{Result, error_bail};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,
+  JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin,
 };
 
 use crate::utils::{COMMON_LIBRARY_NAME_MESSAGE, get_options_for_chunk};
@@ -61,7 +61,7 @@ async fn render_startup(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   module: &ModuleIdentifier,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(_) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
@@ -71,7 +71,7 @@ async fn render_startup(
   let mut source = ConcatSource::default();
   let is_async = ModuleGraph::is_async(&compilation.async_modules_artifact, module);
   let module_graph = compilation.get_module_graph();
-  source.add(render_source.source.clone());
+  source.add(render_source.clone());
   // export { local as exported }
   let mut exports: Vec<(String, Option<String>)> = vec![];
   if is_async {
@@ -140,7 +140,7 @@ async fn render_startup(
     };
     source.add(RawStringSource::from(exports_string));
   }
-  render_source.source = source.boxed();
+  *render_source = source.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -4,14 +4,12 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
   CompilerCompilation, ExternalModule, ExternalRequest, Filename, LibraryName, LibraryNonUmdObject,
   LibraryOptions, PathData, Plugin, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error_bail};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
-};
+use rspack_plugin_javascript::{JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin};
 
 use crate::utils::{COMMON_LIBRARY_NAME_MESSAGE, external_module_names, get_options_for_chunk};
 
@@ -83,7 +81,7 @@ async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
@@ -174,11 +172,11 @@ async fn render(
   }
   source.add(RawStringSource::from_static("execute: function() {\n"));
   source.add(RawStringSource::from(format!("{dynamic_export}(")));
-  source.add(render_source.source.clone());
+  source.add(render_source.clone());
   source.add(RawStringSource::from_static(")}\n"));
   source.add(RawStringSource::from_static("}\n"));
   source.add(RawStringSource::from_static("\n})"));
-  render_source.source = source.boxed();
+  *render_source = source.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -6,14 +6,12 @@ use rspack_core::{
   LibraryAuxiliaryComment, LibraryCustomUmdObject, LibraryName, LibraryNonUmdObject,
   LibraryOptions, LibraryType, ModuleGraph, ModuleGraphCacheArtifact, PathData, Plugin,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SideEffectsStateArtifact, SourceType,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
-};
+use rspack_plugin_javascript::{JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin};
 
 use crate::utils::{external_arguments, externals_dep_array, get_options_for_chunk};
 
@@ -97,7 +95,7 @@ async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey) else {
@@ -318,9 +316,9 @@ async fn render(
       format!("function({})", external_arguments(&externals, compilation))
     },
   )));
-  source.add(render_source.source.clone());
+  source.add(render_source.clone());
   source.add(RawStringSource::from_static("\n})"));
-  render_source.source = source.boxed();
+  *render_source = source.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
@@ -10,11 +10,11 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
   CompilationRuntimeRequirementInTree, CompilerCompilation, DependencyId, ModuleIdentifier, Plugin,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_plugin_javascript::{JavascriptModulesRenderStartup, JsPlugin, RenderSource};
+use rspack_plugin_javascript::{JavascriptModulesRenderStartup, JsPlugin};
 use rustc_hash::FxHashSet;
 
 use super::{
@@ -182,7 +182,7 @@ async fn render_startup(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _module: &ModuleIdentifier,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let chunk = compilation
@@ -228,17 +228,15 @@ async fn render_startup(
     if self.experiments.async_startup {
       return Ok(());
     }
-    let mut startup_with_call = ConcatSource::default();
 
-    // Add startup call
-    startup_with_call.add(RawStringSource::from_static(
-      "\n// Federation startup call\n",
-    ));
     let startup_global = runtime_template.render_runtime_globals(&RuntimeGlobals::STARTUP);
-    startup_with_call.add(RawStringSource::from(format!("{startup_global}();\n",)));
+    let mut startup_with_call = ConcatSource::new([
+      RawStringSource::from_static("\n// Federation startup call\n").boxed(),
+      RawStringSource::from(format!("{startup_global}();\n",)).boxed(),
+      render_source.clone(),
+    ]);
 
-    startup_with_call.add(render_source.source.clone());
-    render_source.source = startup_with_call.boxed();
+    *render_source = startup_with_call.boxed();
   }
 
   Ok(())

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_plugin.rs
@@ -230,7 +230,7 @@ async fn render_startup(
     }
 
     let startup_global = runtime_template.render_runtime_globals(&RuntimeGlobals::STARTUP);
-    let mut startup_with_call = ConcatSource::new([
+    let startup_with_call = ConcatSource::new([
       RawStringSource::from_static("\n// Federation startup call\n").boxed(),
       RawStringSource::from(format!("{startup_global}();\n",)).boxed(),
       render_source.clone(),

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   CompilerCompilation, ExportInfo, ExportProvided, ExportsInfoArtifact, ExportsInfoData,
   GetTargetResult, Module, ModuleGraph, ModuleIdentifier, OptimizationBailoutItem, Plugin,
   RuntimeCodeTemplate, UsageState, get_target,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
   to_comment_with_nl,
 };
 use rspack_error::Result;
@@ -17,7 +17,7 @@ use rspack_plugin_css::{
   plugin::{CssModulesRenderModulePackage, CssModulesRenderSource},
 };
 use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRenderModulePackage, JsPlugin, RenderSource,
+  JavascriptModulesChunkHash, JavascriptModulesRenderModulePackage, JsPlugin,
 };
 use rustc_hash::FxHashSet;
 
@@ -236,7 +236,7 @@ async fn render_js_module_package(
   compilation: &Compilation,
   chunk_key: &ChunkUkey,
   module: &dyn Module,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _init_fragments: &mut ChunkInitFragments,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
@@ -311,9 +311,9 @@ async fn render_js_module_package(
     }
   }
 
-  new_source.add(render_source.source.clone());
+  new_source.add(render_source.clone());
 
-  render_source.source = new_source.boxed();
+  *render_source = new_source.boxed();
 
   Ok(())
 }

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   CompilerAssetEmitted, CompilerCompilation, DependencyType, ExportsInfoArtifact, ModuleType,
   NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, RuntimeCodeTemplate,
   SideEffectsOptimizeArtifact, get_module_directives, get_module_hashbang,
-  rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, error};
 use rspack_hook::{plugin, plugin_hook};
@@ -19,7 +19,7 @@ use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_plugin_asset::AssetParserAndGenerator;
 use rspack_plugin_externals::EsmNodeTargetPlugin;
 use rspack_plugin_javascript::{
-  BoxJavascriptParserPlugin, JavascriptModulesRender, JsPlugin, RenderSource,
+  BoxJavascriptParserPlugin, JavascriptModulesRender, JsPlugin,
   parser_and_generator::JavaScriptParserAndGenerator,
 };
 use rspack_util::node_path::NodePath;
@@ -248,7 +248,7 @@ async fn render(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   _runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   // NOTE: This function handles hashbang and directives for non new ESM library formats.
@@ -272,7 +272,7 @@ async fn render(
       continue;
     }
 
-    let original_source_str = render_source.source.source().into_string_lossy();
+    let original_source_str = render_source.source().into_string_lossy();
 
     let mut new_source = ConcatSource::default();
 
@@ -292,13 +292,13 @@ async fn render(
         for directive in directives {
           new_source.add(RawStringSource::from(format!("{directive}\n")));
         }
-        new_source.add(render_source.source.clone());
+        new_source.add(render_source.clone());
       }
     } else {
-      new_source.add(render_source.source.clone());
+      new_source.add(render_source.clone());
     }
 
-    render_source.source = new_source.boxed();
+    *render_source = new_source.boxed();
     break;
   }
 

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -4,13 +4,13 @@ use rspack_core::{
   ChunkGraph, ChunkKind, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationParams, CompilerCompilation, Plugin, RuntimeCodeTemplate, RuntimeGlobals,
   RuntimeModule, RuntimeVariable,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,
+  JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin,
   runtime::{render_chunk_runtime_modules, render_runtime_modules},
 };
 
@@ -106,7 +106,7 @@ async fn render_chunk(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let hooks = JsPlugin::get_compilation_hooks(compilation.id());
@@ -129,7 +129,7 @@ async fn render_chunk(
       rspack_util::json_stringify_str(hot_update_global),
       rspack_util::json_stringify(chunk.expect_id())
     )));
-    source.add(render_source.source.clone());
+    source.add(render_source.clone());
     if has_runtime_modules {
       source.add(RawStringSource::from_static(","));
       source.add(render_chunk_runtime_modules(compilation, chunk_ukey, runtime_template).await?);
@@ -146,7 +146,7 @@ async fn render_chunk(
       chunk_loading_global,
       rspack_util::json_stringify(chunk.expect_id()),
     )));
-    source.add(render_source.source.clone());
+    source.add(render_source.clone());
     let has_entry = chunk.has_entry_module(&compilation.build_chunk_graph_artifact.chunk_graph);
     if has_entry || has_runtime_modules {
       source.add(RawStringSource::from_static(","));
@@ -171,9 +171,7 @@ async fn render_chunk(
           .keys()
           .next_back()
           .expect("should have last entry module");
-        let mut render_source = RenderSource {
-          source: start_up_source,
-        };
+        let mut render_source = start_up_source;
         hooks
           .try_read()
           .expect("should have js plugin drive")
@@ -186,7 +184,7 @@ async fn render_chunk(
             runtime_template,
           )
           .await?;
-        source.add(render_source.source);
+        source.add(render_source);
         if runtime_requirements.contains(RuntimeGlobals::RETURN_EXPORTS_FROM_RUNTIME) {
           source.add(RawStringSource::from(format!(
             "return {};\n",
@@ -198,7 +196,7 @@ async fn render_chunk(
     }
     source.add(RawStringSource::from_static("])"));
   }
-  render_source.source = source.boxed();
+  *render_source = source.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -196,7 +196,7 @@ var {} = require({});
       )
       .await?;
     sources.add(startup_render_source.source);
-    render_source.source = ConcatSource::new([
+    render_source.source = ConcatSource::new(vec![
       RawStringSource::from_static("(function() {\n").boxed(),
       sources.boxed(),
       RawStringSource::from_static("\n})()").boxed(),

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -4,13 +4,13 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationDependentFullHash, CompilationParams, CompilerCompilation, Plugin,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
-  JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,
+  JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin,
   runtime::render_chunk_runtime_modules,
 };
 use rspack_util::json_stringify_str;
@@ -124,7 +124,7 @@ async fn render_chunk(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let hooks = JsPlugin::get_compilation_hooks(compilation.id());
@@ -133,14 +133,16 @@ async fn render_chunk(
     .chunk_by_ukey
     .expect_get(chunk_ukey);
   let base_chunk_output_name = get_chunk_output_name(chunk, compilation).await?;
-  let mut sources = ConcatSource::default();
-  sources.add(RawStringSource::from(format!(
-    "exports.ids = [{}];\n",
-    rspack_util::json_stringify(chunk.expect_id())
-  )));
-  sources.add(RawStringSource::from_static("exports.modules = "));
-  sources.add(render_source.source.clone());
-  sources.add(RawStringSource::from_static(";\n"));
+  let mut sources = ConcatSource::new([
+    RawStringSource::from(format!(
+      "exports.ids = [{}];\n",
+      rspack_util::json_stringify(chunk.expect_id())
+    ))
+    .boxed(),
+    RawStringSource::from_static("exports.modules = ").boxed(),
+    render_source.clone(),
+    RawStringSource::from_static(";\n").boxed(),
+  ]);
   if compilation
     .build_chunk_graph_artifact
     .chunk_graph
@@ -180,9 +182,7 @@ var {} = require({});
       .keys()
       .next_back()
       .expect("should have last entry module");
-    let mut startup_render_source = RenderSource {
-      source: start_up_source,
-    };
+    let mut startup_render_source = start_up_source;
     hooks
       .try_read()
       .expect("should have js plugin drive")
@@ -195,8 +195,8 @@ var {} = require({});
         runtime_template,
       )
       .await?;
-    sources.add(startup_render_source.source);
-    render_source.source = ConcatSource::new(vec![
+    sources.add(startup_render_source);
+    *render_source = ConcatSource::new([
       RawStringSource::from_static("(function() {\n").boxed(),
       sources.boxed(),
       RawStringSource::from_static("\n})()").boxed(),
@@ -204,7 +204,7 @@ var {} = require({});
     .boxed();
     return Ok(());
   }
-  render_source.source = sources.boxed();
+  *render_source = sources.boxed();
   Ok(())
 }
 

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -4,15 +4,14 @@ use rspack_core::{
   ChunkGraph, ChunkKind, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationDependentFullHash, CompilationParams, CompilerCompilation, ModuleIdentifier, Plugin,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, RuntimeVariable, SourceType,
-  rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JavascriptModulesRenderStartup,
-  JsPlugin, RenderSource, impl_plugin_for_js_plugin::chunk_has_js,
-  runtime::render_chunk_runtime_modules,
+  JsPlugin, impl_plugin_for_js_plugin::chunk_has_js, runtime::render_chunk_runtime_modules,
 };
 use rspack_util::itoa;
 use rustc_hash::FxHashSet as HashSet;
@@ -134,7 +133,7 @@ async fn render_chunk(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let hooks = JsPlugin::get_compilation_hooks(compilation.id());
@@ -146,7 +145,7 @@ async fn render_chunk(
 
   let chunk_id_expr = rspack_util::json_stringify(chunk.expect_id());
 
-  let mut sources = ConcatSource::new(vec![
+  let mut sources = ConcatSource::new([
     RawStringSource::from(format!("export const __rspack_esm_id = {chunk_id_expr};\n",)).boxed(),
     RawStringSource::from(format!(
       "export const __rspack_esm_ids = [{chunk_id_expr}];\n",
@@ -157,7 +156,7 @@ async fn render_chunk(
       runtime_template.render_runtime_variable(&RuntimeVariable::Modules),
     ))
     .boxed(),
-    render_source.source.clone(),
+    render_source.clone(),
     RawStringSource::from_static(";\n").boxed(),
   ]);
 
@@ -174,7 +173,7 @@ async fn render_chunk(
   }
 
   if matches!(chunk.kind(), ChunkKind::HotUpdate) {
-    render_source.source = sources.boxed();
+    *render_source = sources.boxed();
     return Ok(());
   }
 
@@ -305,9 +304,7 @@ async fn render_chunk(
       .keys()
       .next_back()
       .expect("should have last entry module");
-    let mut render_source = RenderSource {
-      source: RawStringSource::from(startup_source.join("\n")).boxed(),
-    };
+    let mut render_source = RawStringSource::from(startup_source.join("\n")).boxed();
     hooks
       .try_read()
       .expect("should have js plugin drive")
@@ -320,9 +317,9 @@ async fn render_chunk(
         runtime_template,
       )
       .await?;
-    sources.add(render_source.source);
+    sources.add(render_source);
   }
-  render_source.source = sources.boxed();
+  *render_source = sources.boxed();
   Ok(())
 }
 
@@ -335,7 +332,7 @@ async fn render_startup(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   _module: &ModuleIdentifier,
-  render_source: &mut RenderSource,
+  render_source: &mut BoxSource,
   runtime_template: &RuntimeCodeTemplate<'_>,
 ) -> Result<()> {
   let chunk = compilation
@@ -389,9 +386,8 @@ async fn render_startup(
     }
 
     if dependent_load.size() != 0 {
-      let concat_source =
-        ConcatSource::new(vec![dependent_load.boxed(), render_source.source.clone()]);
-      render_source.source = concat_source.boxed();
+      dependent_load.add(render_source.clone());
+      *render_source = dependent_load.boxed();
     }
   }
   Ok(())

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -389,9 +389,9 @@ async fn render_startup(
     }
 
     if dependent_load.size() != 0 {
-      let mut sources =
+      let concat_source =
         ConcatSource::new(vec![dependent_load.boxed(), render_source.source.clone()]);
-      render_source.source = sources.boxed();
+      render_source.source = concat_source.boxed();
     }
   }
   Ok(())

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -146,19 +146,20 @@ async fn render_chunk(
 
   let chunk_id_expr = rspack_util::json_stringify(chunk.expect_id());
 
-  let mut sources = ConcatSource::default();
-  sources.add(RawStringSource::from(format!(
-    "export const __rspack_esm_id = {chunk_id_expr};\n",
-  )));
-  sources.add(RawStringSource::from(format!(
-    "export const __rspack_esm_ids = [{chunk_id_expr}];\n",
-  )));
-  sources.add(RawStringSource::from(format!(
-    "export const {} = ",
-    runtime_template.render_runtime_variable(&RuntimeVariable::Modules),
-  )));
-  sources.add(render_source.source.clone());
-  sources.add(RawStringSource::from_static(";\n"));
+  let mut sources = ConcatSource::new(vec![
+    RawStringSource::from(format!("export const __rspack_esm_id = {chunk_id_expr};\n",)).boxed(),
+    RawStringSource::from(format!(
+      "export const __rspack_esm_ids = [{chunk_id_expr}];\n",
+    ))
+    .boxed(),
+    RawStringSource::from(format!(
+      "export const {} = ",
+      runtime_template.render_runtime_variable(&RuntimeVariable::Modules),
+    ))
+    .boxed(),
+    render_source.source.clone(),
+    RawStringSource::from_static(";\n").boxed(),
+  ]);
 
   if compilation
     .build_chunk_graph_artifact
@@ -359,7 +360,7 @@ async fn render_startup(
 
     let base_chunk_output_name = get_chunk_output_name(chunk, compilation).await?;
 
-    let mut dependent_load = ConcatSource::default();
+    let mut dependent_load = ConcatSource::with_capacity(dependent_chunks.size_hint().0 * 2 + 1);
     for (index, ck) in dependent_chunks.enumerate() {
       if !chunk_has_js(&ck, compilation) {
         continue;
@@ -387,10 +388,9 @@ async fn render_startup(
       )));
     }
 
-    if !dependent_load.source().is_empty() {
-      let mut sources = ConcatSource::default();
-      sources.add(dependent_load);
-      sources.add(render_source.source.clone());
+    if dependent_load.size() != 0 {
+      let mut sources =
+        ConcatSource::new(vec![dependent_load.boxed(), render_source.source.clone()]);
       render_source.source = sources.boxed();
     }
   }

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -424,14 +424,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               };
 
               if let Some(shebang) = shebang {
-                ConcatSource::new(vec![
+                ConcatSource::new([
                   RawStringSource::from(shebang).boxed(),
                   RawStringSource::from(banner).boxed(),
                   RawStringSource::from_static("\n").boxed(),
                   source
                 ]).boxed()
               } else {
-                ConcatSource::new(vec![
+                ConcatSource::new([
                   RawStringSource::from(banner).boxed(),
                   RawStringSource::from_static("\n").boxed(),
                   source

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -424,14 +424,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               };
 
               if let Some(shebang) = shebang {
-                ConcatSource::new([
+                ConcatSource::new(vec![
                   RawStringSource::from(shebang).boxed(),
                   RawStringSource::from(banner).boxed(),
                   RawStringSource::from_static("\n").boxed(),
                   source
                 ]).boxed()
               } else {
-                ConcatSource::new([
+                ConcatSource::new(vec![
                   RawStringSource::from(banner).boxed(),
                   RawStringSource::from_static("\n").boxed(),
                   source

--- a/crates/rspack_sources/src/cached_source.rs
+++ b/crates/rspack_sources/src/cached_source.rs
@@ -319,7 +319,7 @@ mod tests {
 
   #[test]
   fn line_number_should_not_add_one() {
-    let source = ConcatSource::new([
+    let source = ConcatSource::new(vec![
       CachedSource::new(RawStringSource::from("\n")).boxed(),
       SourceMapSource::new(WithoutOriginalOptions {
         value: "\nconsole.log(1);\n".to_string(),

--- a/crates/rspack_sources/src/concat_source.rs
+++ b/crates/rspack_sources/src/concat_source.rs
@@ -487,7 +487,7 @@ mod tests {
 
   #[test]
   fn should_concat_two_sources() {
-    let mut source = ConcatSource::new([
+    let mut source = ConcatSource::new(vec![
       RawStringSource::from("Hello World\n".to_string()).boxed(),
       OriginalSource::new(
         "console.log('test');\nconsole.log('test2');\n",
@@ -540,7 +540,7 @@ mod tests {
 
   #[test]
   fn should_concat_two_sources2() {
-    let mut source = ConcatSource::new([
+    let mut source = ConcatSource::new(vec![
       RawStringSource::from("Hello World\n".to_string()).boxed(),
       OriginalSource::new(
         "console.log('test');\nconsole.log('test2');\n",
@@ -593,7 +593,7 @@ mod tests {
 
   #[test]
   fn should_concat_two_sources3() {
-    let mut source = ConcatSource::new([
+    let mut source = ConcatSource::new(vec![
       RawBufferSource::from("Hello World\n".as_bytes()).boxed(),
       OriginalSource::new(
         "console.log('test');\nconsole.log('test2');\n",
@@ -646,7 +646,7 @@ mod tests {
 
   #[test]
   fn should_be_able_to_handle_strings_for_all_methods() {
-    let mut source = ConcatSource::new([
+    let mut source = ConcatSource::new(vec![
       RawStringSource::from("Hello World\n".to_string()).boxed(),
       OriginalSource::new(
         "console.log('test');\nconsole.log('test2');\n",
@@ -654,8 +654,11 @@ mod tests {
       )
       .boxed(),
     ]);
-    let inner_source =
-      ConcatSource::new([RawStringSource::from("("), "'string'".into(), ")".into()]);
+    let inner_source = ConcatSource::new(vec![
+      RawStringSource::from("(").boxed(),
+      RawStringSource::from("'string'").boxed(),
+      RawStringSource::from(")").boxed(),
+    ]);
     source.add(RawStringSource::from("console"));
     source.add(RawStringSource::from("."));
     source.add(RawStringSource::from("log"));
@@ -686,10 +689,10 @@ mod tests {
 
   #[test]
   fn should_return_null_as_map_when_only_generated_code_is_concatenated() {
-    let source = ConcatSource::new([
-      RawStringSource::from("Hello World\n"),
-      RawStringSource::from("Hello World\n".to_string()),
-      RawStringSource::from(""),
+    let source = ConcatSource::new(vec![
+      RawStringSource::from("Hello World\n").boxed(),
+      RawStringSource::from("Hello World\n".to_string()).boxed(),
+      RawStringSource::from("").boxed(),
     ]);
 
     let result_text = source.source();
@@ -706,7 +709,7 @@ mod tests {
 
   #[test]
   fn should_allow_to_concatenate_in_a_single_line() {
-    let source = ConcatSource::new([
+    let source = ConcatSource::new(vec![
       OriginalSource::new("Hello", "hello.txt").boxed(),
       RawStringSource::from(" ").boxed(),
       OriginalSource::new("World ", "world.txt").boxed(),
@@ -740,10 +743,10 @@ mod tests {
 
   #[test]
   fn should_allow_to_concat_buffer_sources() {
-    let source = ConcatSource::new([
-      RawStringSource::from("a"),
-      RawStringSource::from("b"),
-      RawStringSource::from("c"),
+    let source = ConcatSource::new(vec![
+      RawStringSource::from("a").boxed(),
+      RawStringSource::from("b").boxed(),
+      RawStringSource::from("c").boxed(),
     ]);
     assert_eq!(source.source().into_string_lossy(), "abc");
     assert!(
@@ -755,15 +758,19 @@ mod tests {
 
   #[test]
   fn should_flatten_nested_concat_sources() {
-    let inner_concat = ConcatSource::new([
-      RawStringSource::from("Hello "),
-      RawStringSource::from("World"),
+    let inner_concat = ConcatSource::new(vec![
+      RawStringSource::from("Hello ").boxed(),
+      RawStringSource::from("World").boxed(),
     ]);
 
-    let outer_concat = ConcatSource::new([
+    let outer_concat = ConcatSource::new(vec![
       inner_concat.boxed(),
       RawStringSource::from("!").boxed(),
-      ConcatSource::new([RawStringSource::from(" How"), RawStringSource::from(" are")]).boxed(),
+      ConcatSource::new(vec![
+        RawStringSource::from(" How").boxed(),
+        RawStringSource::from(" are").boxed(),
+      ])
+      .boxed(),
       RawStringSource::from(" you?").boxed(),
     ]);
 
@@ -778,9 +785,9 @@ mod tests {
 
   #[test]
   fn test_self_equality_no_deadlock() {
-    let concat_source = ConcatSource::new([
-      RawStringSource::from("Hello "),
-      RawStringSource::from("World"),
+    let concat_source = ConcatSource::new(vec![
+      RawStringSource::from("Hello ").boxed(),
+      RawStringSource::from("World").boxed(),
     ])
     .boxed();
     assert_eq!(concat_source.as_ref(), concat_source.as_ref());
@@ -792,15 +799,19 @@ mod tests {
 
   #[test]
   fn test_debug_output() {
-    let inner_concat = ConcatSource::new([
-      RawStringSource::from("Hello "),
-      RawStringSource::from("World"),
+    let inner_concat = ConcatSource::new(vec![
+      RawStringSource::from("Hello ").boxed(),
+      RawStringSource::from("World").boxed(),
     ]);
 
-    let mut outer_concat = ConcatSource::new([
+    let mut outer_concat = ConcatSource::new(vec![
       inner_concat.boxed(),
       RawStringSource::from("!").boxed(),
-      ConcatSource::new([RawStringSource::from(" How"), RawStringSource::from(" are")]).boxed(),
+      ConcatSource::new(vec![
+        RawStringSource::from(" How").boxed(),
+        RawStringSource::from(" are").boxed(),
+      ])
+      .boxed(),
       RawStringSource::from(" you?\n").boxed(),
     ]);
 

--- a/crates/rspack_sources/src/concat_source.rs
+++ b/crates/rspack_sources/src/concat_source.rs
@@ -102,16 +102,18 @@ impl std::fmt::Debug for ConcatSource {
 
 impl ConcatSource {
   /// Create a [ConcatSource] with [Source]s.
-  pub fn new<S, T>(sources: S) -> Self
-  where
-    T: Source + 'static,
-    S: IntoIterator<Item = T>,
-  {
-    let mut concat_source = ConcatSource::default();
-    for source in sources {
-      concat_source.add(source);
+  pub fn new(sources: Vec<BoxSource>) -> Self {
+    Self {
+      children: Mutex::new(sources),
+      is_optimized: OnceLock::default(),
     }
-    concat_source
+  }
+
+  pub fn with_capacity(capacity: usize) -> Self {
+    Self {
+      children: Mutex::new(Vec::with_capacity(capacity)),
+      is_optimized: OnceLock::default(),
+    }
   }
 
   fn optimized_children(&self) -> &[BoxSource] {

--- a/crates/rspack_sources/src/concat_source.rs
+++ b/crates/rspack_sources/src/concat_source.rs
@@ -102,11 +102,16 @@ impl std::fmt::Debug for ConcatSource {
 
 impl ConcatSource {
   /// Create a [ConcatSource] with [Source]s.
-  pub fn new(sources: Vec<BoxSource>) -> Self {
-    Self {
-      children: Mutex::new(sources),
-      is_optimized: OnceLock::default(),
+  pub fn new<S>(sources: S) -> Self
+  where
+    S: IntoIterator<Item = BoxSource>,
+  {
+    let sources_iter = sources.into_iter();
+    let mut concat_source = ConcatSource::with_capacity(sources_iter.size_hint().0);
+    for source in sources_iter {
+      concat_source.add(source);
     }
+    concat_source
   }
 
   pub fn with_capacity(capacity: usize) -> Self {

--- a/crates/rspack_sources/src/original_source.rs
+++ b/crates/rspack_sources/src/original_source.rs
@@ -349,7 +349,7 @@ mod tests {
     let code2 = "world";
     let source2 = OriginalSource::new(code2, "world.txt");
 
-    let concat = ConcatSource::new([source1.boxed(), source2.boxed()]);
+    let concat = ConcatSource::new(vec![source1.boxed(), source2.boxed()]);
     let map = concat
       .map(&ObjectPool::default(), &MapOptions::new(false))
       .unwrap();

--- a/crates/rspack_sources/src/raw_source.rs
+++ b/crates/rspack_sources/src/raw_source.rs
@@ -286,7 +286,7 @@ mod tests {
     let source1 = RawStringSource::from_static("hello\n\n");
     let source1 = ReplaceSource::new(source1);
     let source2 = OriginalSource::new("world".to_string(), "world.txt");
-    let concat = ConcatSource::new([source1.boxed(), source2.boxed()]);
+    let concat = ConcatSource::new(vec![source1.boxed(), source2.boxed()]);
     let map = concat
       .map(&ObjectPool::default(), &MapOptions::new(false))
       .unwrap();

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -713,7 +713,7 @@ mod tests {
       source_map: SourceMap::from_json("{\"mappings\": \";\"}").unwrap(),
     })
     .hash(&mut state);
-    ConcatSource::new([RawStringSource::from("d")]).hash(&mut state);
+    ConcatSource::new(vec![RawStringSource::from("d").boxed()]).hash(&mut state);
     CachedSource::new(RawStringSource::from("e")).hash(&mut state);
     ReplaceSource::new(RawStringSource::from("f")).hash(&mut state);
     RawStringSource::from("g").boxed().hash(&mut state);
@@ -749,8 +749,8 @@ mod tests {
       })
     );
     assert_eq!(
-      ConcatSource::new([RawStringSource::from("d")]),
-      ConcatSource::new([RawStringSource::from("d")])
+      ConcatSource::new(vec![RawStringSource::from("d").boxed()]),
+      ConcatSource::new(vec![RawStringSource::from("d").boxed()])
     );
     assert_eq!(
       CachedSource::new(RawStringSource::from("e")),
@@ -791,7 +791,7 @@ mod tests {
       source_map: SourceMap::from_json("{\"mappings\": \";\"}").unwrap(),
     });
     assert_eq!(c, c.clone());
-    let d = ConcatSource::new([RawStringSource::from("d")]);
+    let d = ConcatSource::new(vec![RawStringSource::from("d").boxed()]);
     assert_eq!(d, d.clone());
     let e = CachedSource::new(RawStringSource::from("e"));
     assert_eq!(e, e.clone());
@@ -830,7 +830,10 @@ mod tests {
 
   #[test]
   fn to_writer() {
-    let sources = ConcatSource::new([RawStringSource::from("a"), RawStringSource::from("b")]);
+    let sources = ConcatSource::new(vec![
+      RawStringSource::from("a").boxed(),
+      RawStringSource::from("b").boxed(),
+    ]);
     let mut writer = std::io::BufWriter::new(Vec::new());
     let result = sources.to_writer(&mut writer);
     assert!(result.is_ok());

--- a/crates/rspack_sources/src/source_map_source.rs
+++ b/crates/rspack_sources/src/source_map_source.rs
@@ -260,13 +260,14 @@ impl StreamChunks for SourceMapSource {
 mod tests {
   use super::*;
   use crate::{
-    CachedSource, ConcatSource, OriginalSource, RawStringSource, ReplaceSource, SourceExt,
+    BoxSource, CachedSource, ConcatSource, OriginalSource, RawStringSource, ReplaceSource,
+    SourceExt,
   };
 
   #[test]
   fn map_correctly() {
     let inner_source_code = "Hello World\nis a test string\n";
-    let inner_source = ConcatSource::new([
+    let inner_source = ConcatSource::new(vec![
       OriginalSource::new(inner_source_code, "hello-world.txt").boxed(),
       OriginalSource::new("Translate: ", "header.txt").boxed(),
       RawStringSource::from("Other text").boxed(),
@@ -363,11 +364,14 @@ mod tests {
         vec![],
       ),
     });
-    let sources = [a, b, c].into_iter().map(|s| {
-      let mut r = ReplaceSource::new(s);
-      r.replace_static(1, 5, "i", None);
-      r
-    });
+    let sources = [a, b, c]
+      .into_iter()
+      .map(|s| {
+        let mut r = ReplaceSource::new(s);
+        r.replace_static(1, 5, "i", None);
+        r.boxed()
+      })
+      .collect::<Vec<BoxSource>>();
     let source = ConcatSource::new(sources);
     assert_eq!(
       source.source().into_string_lossy(),
@@ -420,8 +424,9 @@ mod tests {
       value: code,
       name: "es6-promise.js",
       source_map: map,
-    });
-    let source = ConcatSource::new([inner.clone(), inner]);
+    })
+    .boxed();
+    let source = ConcatSource::new(vec![inner.clone(), inner.boxed()]);
     assert_eq!(source.source().into_string_lossy(), format!("{code}{code}"));
   }
 
@@ -436,7 +441,8 @@ mod tests {
         vec![],
         vec![],
       ),
-    });
+    })
+    .boxed();
     let b = SourceMapSource::new(WithoutOriginalOptions {
       value: "hi",
       name: "b",
@@ -446,7 +452,8 @@ mod tests {
         vec![],
         vec![],
       ),
-    });
+    })
+    .boxed();
     let b2 = SourceMapSource::new(WithoutOriginalOptions {
       value: "hi",
       name: "b",
@@ -456,13 +463,15 @@ mod tests {
         vec![],
         vec![],
       ),
-    });
+    })
+    .boxed();
     let c = SourceMapSource::new(WithoutOriginalOptions {
       value: "",
       name: "c",
       source_map: SourceMap::new("AAAA".to_string(), vec!["hello4".into()], vec![], vec![]),
-    });
-    let source = ConcatSource::new([
+    })
+    .boxed();
+    let source = ConcatSource::new(vec![
       a.clone(),
       a.clone(),
       b.clone(),
@@ -473,10 +482,10 @@ mod tests {
       c.clone(),
       b2.clone(),
       a.clone(),
-      b2,
-      c,
-      a,
-      b,
+      b2.clone(),
+      c.clone(),
+      a.clone(),
+      b.clone(),
     ]);
     let map = source
       .map(&ObjectPool::default(), &MapOptions::default())
@@ -664,7 +673,7 @@ mod tests {
         .map(&ObjectPool::default(), &MapOptions::new(false))
         .unwrap(),
     });
-    let source = ConcatSource::new([
+    let source = ConcatSource::new(vec![
       RawStringSource::from("\n").boxed(),
       RawStringSource::from("\n").boxed(),
       RawStringSource::from("\n").boxed(),
@@ -679,7 +688,7 @@ mod tests {
   #[test]
   fn source_root_is_correctly_applied_to_mappings() {
     let inner_source_code = "Hello World\nis a test string\n";
-    let inner_source = ConcatSource::new([
+    let inner_source = ConcatSource::new(vec![
       OriginalSource::new(inner_source_code, "hello-world.txt").boxed(),
       OriginalSource::new("Translate: ", "header.txt").boxed(),
       RawStringSource::from("Other text").boxed(),

--- a/crates/rspack_sources/tests/compat_source.rs
+++ b/crates/rspack_sources/tests/compat_source.rs
@@ -118,7 +118,7 @@ fn should_generate_correct_source_map() {
   )
   .unwrap();
 
-  let result = ConcatSource::new([
+  let result = ConcatSource::new(vec![
     RawStringSource::from("Line0\n").boxed(),
     CompatSource("Line1\nLine2\nLine3\n", Some(source_map)).boxed(),
   ]);

--- a/xtask/benchmark/benches/groups/rspack_sources.rs
+++ b/xtask/benchmark/benches/groups/rspack_sources.rs
@@ -59,7 +59,8 @@ fn benchmark_concat_generate_string(b: &mut Bencher) {
     original_source: Some(HELLOWORLD_JS.to_string().into()),
     inner_source_map: Some(SourceMap::from_json(HELLOWORLD_JS_MAP).unwrap()),
     remove_original_source: false,
-  });
+  })
+  .boxed();
 
   let sms_rollup = SourceMapSource::new(SourceMapSourceOptions {
     value: BUNDLE_JS,
@@ -68,9 +69,10 @@ fn benchmark_concat_generate_string(b: &mut Bencher) {
     original_source: None,
     inner_source_map: None,
     remove_original_source: false,
-  });
+  })
+  .boxed();
 
-  let concat = ConcatSource::new([sms_minify, sms_rollup]);
+  let concat = ConcatSource::new(vec![sms_minify, sms_rollup]);
 
   b.iter(|| {
     concat
@@ -88,7 +90,8 @@ fn benchmark_concat_generate_string_with_cache(b: &mut Bencher) {
     original_source: Some(HELLOWORLD_JS.to_string().into()),
     inner_source_map: Some(SourceMap::from_json(HELLOWORLD_JS_MAP).unwrap()),
     remove_original_source: false,
-  });
+  })
+  .boxed();
   let sms_rollup = SourceMapSource::new(SourceMapSourceOptions {
     value: BUNDLE_JS,
     name: "bundle.js",
@@ -96,8 +99,9 @@ fn benchmark_concat_generate_string_with_cache(b: &mut Bencher) {
     original_source: None,
     inner_source_map: None,
     remove_original_source: false,
-  });
-  let concat = ConcatSource::new([sms_minify, sms_rollup]);
+  })
+  .boxed();
+  let concat = ConcatSource::new(vec![sms_minify, sms_rollup]);
   let cached = CachedSource::new(concat);
 
   b.iter(|| {
@@ -116,7 +120,8 @@ fn benchmark_cached_source_hash(b: &mut Bencher) {
     original_source: Some(HELLOWORLD_JS.to_string().into()),
     inner_source_map: Some(SourceMap::from_json(HELLOWORLD_JS_MAP).unwrap()),
     remove_original_source: false,
-  });
+  })
+  .boxed();
   let sms_rollup = SourceMapSource::new(SourceMapSourceOptions {
     value: BUNDLE_JS,
     name: "bundle.js",
@@ -124,8 +129,9 @@ fn benchmark_cached_source_hash(b: &mut Bencher) {
     original_source: None,
     inner_source_map: None,
     remove_original_source: false,
-  });
-  let concat = ConcatSource::new([sms_minify, sms_rollup]);
+  })
+  .boxed();
+  let concat = ConcatSource::new(vec![sms_minify, sms_rollup]);
   let cached = CachedSource::new(concat).boxed();
 
   b.iter(|| {


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Add `ConcatSource::with_capacity` and make `ConcatSource::new` construct directly from pre-boxed sources, reducing repeated `add` calls and intermediate reallocations.
- Preallocate `ConcatSource` / `Vec` capacity in hot rendering paths, including concatenated module code generation, init fragments, JavaScript runtime rendering, chunk formats, CSS modules, banners, and source map comments.
- Avoid unnecessary source materialization in several checks by using `size()` and reuse boxed namespace object sources when appending to concat output.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
