### PR TITLE
fix: handle cjs export assignment side effects

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -2,13 +2,14 @@ use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsPreset, AsVec},
 };
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  AsContextDependency, AsModuleDependency, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact,
   ExportsOfExportsSpec, ExportsSpec, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment, TemplateContext,
-  TemplateReplaceSource, UsedName, property_access,
+  ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment, SideEffectsStateArtifact,
+  TemplateContext, TemplateReplaceSource, UsedName, property_access,
 };
 use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
@@ -123,6 +124,17 @@ impl Dependency for CommonJsExportsDependency {
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
     rspack_core::AffectType::False
+  }
+
+  fn get_module_evaluation_side_effects_state(
+    &self,
+    _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
+    _side_effects_state_artifact: &SideEffectsStateArtifact,
+    _module_chain: &mut IdentifierSet,
+    _connection_state_cache: &mut IdentifierMap<ConnectionState>,
+  ) -> ConnectionState {
+    ConnectionState::Active(false)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -2,11 +2,13 @@ use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsPreset, AsVec},
 };
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, property_access_with_optional,
+  AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
+  TemplateReplaceSource, UsedName, property_access_with_optional,
 };
 use swc_atoms::Atom;
 
@@ -89,6 +91,17 @@ impl Dependency for CommonJsSelfReferenceDependency {
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
     rspack_core::AffectType::True
+  }
+
+  fn get_module_evaluation_side_effects_state(
+    &self,
+    _module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
+    _side_effects_state_artifact: &SideEffectsStateArtifact,
+    _module_chain: &mut IdentifierSet,
+    _connection_state_cache: &mut IdentifierMap<ConnectionState>,
+  ) -> ConnectionState {
+    ConnectionState::Active(false)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -6,12 +6,13 @@ use rspack_core::{
 use rspack_util::SpanExt;
 use rustc_hash::FxHashSet;
 use swc_atoms::Atom;
-use swc_experimental_allocator::{CloneIn, atom::Atom as AstAtom};
+use swc_experimental_allocator::{CloneIn, atom::Atom as AstAtom, wtf8::Wtf8};
 use swc_experimental_ecma_ast::{
-  ArrayLit, ArrowExpr, BlockStmt, BlockStmtOrExpr, CallExpr, Class, ClassMember, CommentKind,
-  Comments, Decl, DefaultDecl, ExportSpecifier, Expr, ExprOrSpread, Function, GetSpan,
-  ImportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, ObjectPatProp, Pat, Program, PropName,
-  Span, Span as AstSpan, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
+  ArrayLit, ArrowExpr, AssignExpr, AssignOp, BlockStmt, BlockStmtOrExpr, CallExpr, Class,
+  ClassMember, CommentKind, Comments, Decl, DefaultDecl, ExportSpecifier, Expr, ExprOrSpread,
+  Function, GetSpan, ImportSpecifier, Lit, MemberProp, ModuleDecl, ModuleExportName, ModuleItem,
+  ObjectPatProp, Pat, Program, PropName, SimpleAssignTarget, Span, Span as AstSpan, Stmt, VarDecl,
+  VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
 };
 use swc_experimental_ecma_utils::{ExprCtx, ExprExt};
 
@@ -1281,7 +1282,7 @@ impl SideEffectsParserPlugin {
           range,
           loc,
           String::from("Statement"),
-        ))
+        ));
       }
     };
 
@@ -1498,6 +1499,66 @@ pub fn is_pure_function<'a>(
   true
 }
 
+fn is_common_js_export_assignment(parser: &mut JavascriptParser, expr: &AssignExpr) -> bool {
+  if parser.is_esm || !parser.is_top_level_scope() {
+    return false;
+  }
+
+  if !matches!(expr.op, AssignOp::Assign) {
+    return false;
+  }
+
+  let Some(SimpleAssignTarget::Member(member)) = expr.left.as_simple() else {
+    return false;
+  };
+
+  match &member.obj {
+    Expr::Ident(ident) => {
+      if ident.sym == "exports" {
+        let property_is_side_effect_free = match &member.prop {
+          MemberProp::Ident(ident) => ident.sym != "__proto__",
+          MemberProp::Computed(computed) => match &computed.expr {
+            Expr::Lit(lit) => match &**lit {
+              Lit::Str(str) => str.value.as_wtf8() != Wtf8::from_str("__proto__"),
+              _ => false,
+            },
+            _ => false,
+          },
+          MemberProp::PrivateName(_) => false,
+        };
+        if !property_is_side_effect_free {
+          return false;
+        }
+        return parser
+          .get_variable_info(&Atom::from("exports"))
+          .is_none_or(|info| info.is_free());
+      }
+      if ident.sym != "module" {
+        return false;
+      }
+      let property_is_exports = match &member.prop {
+        MemberProp::Ident(ident) => ident.sym == "exports",
+        MemberProp::Computed(computed) => match &computed.expr {
+          Expr::Lit(lit) => match &**lit {
+            Lit::Str(str) => str.value.as_wtf8() == Wtf8::from_str("exports"),
+            _ => false,
+          },
+          _ => false,
+        },
+        MemberProp::PrivateName(_) => false,
+      };
+      property_is_exports
+        && parser
+          .get_variable_info(&Atom::from("module"))
+          .is_none_or(|info| info.is_free())
+    }
+    // `module.exports.foo = ...` reads the current `module.exports` object. It
+    // may have been replaced with an accessor-bearing object, so only direct
+    // `module.exports = ...` is treated as a side-effect-free export assignment.
+    _ => false,
+  }
+}
+
 #[inline(never)]
 pub fn is_pure_expression<'a>(
   parser: &mut JavascriptParser,
@@ -1518,6 +1579,17 @@ pub fn is_pure_expression<'a>(
     }
 
     match expr {
+      Expr::Assign(assign_expr)
+        if callees.is_some() && is_common_js_export_assignment(parser, assign_expr) =>
+      {
+        is_pure_expression(
+          parser,
+          analyze_side_effects_free,
+          &assign_expr.right,
+          comments,
+          callees,
+        )
+      }
       Expr::Array(array_lit) => is_pure_array_lit(
         parser,
         analyze_side_effects_free,

--- a/tests/rspack-test/configCases/entry/depend-on-bug/node_modules/isomorphic-fetch.js
+++ b/tests/rspack-test/configCases/entry/depend-on-bug/node_modules/isomorphic-fetch.js
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = "isomorphic-fetch";

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/b.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/b.js.txt
@@ -2,7 +2,9 @@ import { __webpack_require__ } from "./runtime~0.js";
 
 __webpack_require__.add({
 917(module) {
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = 'b'
+
 
 },
 });

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/e.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/e.js.txt
@@ -6,13 +6,14 @@ module.exports = 'bar'
 
 },
 });
+
+
+
+
+
 const bar = __webpack_require__("100");
 var bar_default = /*#__PURE__*/__webpack_require__.n(bar);
 var bar_default_0 = bar_default();
-
-
-
-
 
 var e_foo = (/* inlined export .foo */"foo");
 export { bar_default_0 as bar, e_foo as foo };

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/g.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/g.js.txt
@@ -7,11 +7,12 @@ module.exports = 'foo'
 
 },
 });
+
+
+
+
 const foo = __webpack_require__("547");
 var foo_default = /*#__PURE__*/__webpack_require__.n(foo);
 var foo_default_0 = foo_default();
-
-
-
 
 export { foo_default_0 as foo };

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/b.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/b.js.txt
@@ -2,7 +2,9 @@ import { __rspack_context } from "./runtime~0.js";
 
 __rspack_context.m.add({
 917(module) {
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = 'b'
+
 
 },
 });

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/e.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/e.js.txt
@@ -6,13 +6,14 @@ module.exports = 'bar'
 
 },
 });
+
+
+
+
+
 const bar = __rspack_context.r("100");
 var bar_default = /*#__PURE__*/__rspack_context.n(bar);
 var bar_default_0 = bar_default();
-
-
-
-
 
 var e_foo = (/* inlined export .foo */"foo");
 export { bar_default_0 as bar, e_foo as foo };

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/g.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/g.js.txt
@@ -7,11 +7,12 @@ module.exports = 'foo'
 
 },
 });
+
+
+
+
 const foo = __rspack_context.r("547");
 var foo_default = /*#__PURE__*/__rspack_context.n(foo);
 var foo_default_0 = foo_default();
-
-
-
 
 export { foo_default_0 as foo };

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/b.cjs
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/b.cjs
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = 'b'

--- a/tests/rspack-test/configCases/module/iife-inner-strict/foo.cjs
+++ b/tests/rspack-test/configCases/module/iife-inner-strict/foo.cjs
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = 42;

--- a/tests/rspack-test/configCases/output-module/iife-inner-strict/foo.cjs
+++ b/tests/rspack-test/configCases/output-module/iife-inner-strict/foo.cjs
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = 42;

--- a/tests/rspack-test/configCases/output-module/iife-innter-strict/foo.cjs
+++ b/tests/rspack-test/configCases/output-module/iife-innter-strict/foo.cjs
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = 42;

--- a/tests/rspack-test/configCases/output/pathinfo-verbose/index.js
+++ b/tests/rspack-test/configCases/output/pathinfo-verbose/index.js
@@ -3,25 +3,17 @@ it("should add all modules headers info above modules", () => {
   const path = require("path")
   const content = fs.readFileSync(path.join(__dirname, "sut.js"), "utf-8");
 
-  if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
-    expect(content).toContain(`
+  const runtimeRequirements = content.includes("__rspack_context.r")
+    ? "__rspack_context.r, __rspack_context.n, __rspack_context"
+    : "__webpack_require__.n, __webpack_require__, __webpack_require__";
+  expect(content).toContain(`
 /*!****************!*\\
   !*** ./sut.js ***!
   \\****************/
 /*! namespace exports */
-/*! runtime requirements: __rspack_context.r, __rspack_context */
+/*! runtime requirements: ${runtimeRequirements} */
 /*! Statement with side_effects in source code at ./sut.js:3:1-29 */
     `.trim())
-  } else {
-    expect(content).toContain(`
-/*!****************!*\\
-  !*** ./sut.js ***!
-  \\****************/
-/*! namespace exports */
-/*! runtime requirements: __webpack_require__, __webpack_require__ */
-/*! Statement with side_effects in source code at ./sut.js:3:1-29 */
-    `.trim())
-  }
 
   expect(content).toContain(`
 /*!****************!*\\
@@ -29,35 +21,5 @@ it("should add all modules headers info above modules", () => {
   \\****************/
 /*! unknown exports (runtime-defined) */
 /*! runtime requirements: module */
-/*! Statement with side_effects in source code at ./cjs.js:1:1-3:2 */    
     `.trim())
-
-  if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
-    expect(content).toContain(`
-/*!*****************!*\\
-  !*** ./util.js ***!
-  \\*****************/
-/*! namespace exports */
-/*! export default [not provided] [unused] [provision prevents renaming] */
-/*! export message [provided] [used in sut] [inlined to ("hello")] */
-/*! export secret [maybe provided (runtime-defined)] [used in sut] [provision prevents renaming] -> ./cjs.js secret */
-/*! other exports [maybe provided (runtime-defined)] [unused] -> ./cjs.js */
-/*! runtime requirements: __rspack_exports, __rspack_context.r, __rspack_context.o, __rspack_context.n, __rspack_context.d, __rspack_context */
-`.trim())
-  } else {
-    expect(content).toContain(`
-/*!*****************!*\\
-  !*** ./util.js ***!
-  \\*****************/
-/*! namespace exports */
-/*! export default [not provided] [unused] [provision prevents renaming] */
-/*! export message [provided] [used in sut] [inlined to ("hello")] */
-/*! export secret [maybe provided (runtime-defined)] [used in sut] [provision prevents renaming] -> ./cjs.js secret */
-/*! other exports [maybe provided (runtime-defined)] [unused] -> ./cjs.js */
-/*! runtime requirements: __webpack_require__.o, __webpack_require__.n, __webpack_require__.d, __webpack_require__, __webpack_require__, __webpack_exports__ */
-`.trim())
-  }
-
-
-
 })

--- a/tests/rspack-test/configCases/output/pathinfo/index.js
+++ b/tests/rspack-test/configCases/output/pathinfo/index.js
@@ -4,6 +4,5 @@ it("should add all modules headers info above modules", () => {
     const content = fs.readFileSync(path.join(__dirname, "sut.js"), "utf-8");
 
     expect(content).toContain(`!*** ./sut.js ***!`)
-    expect(content).toContain(`!*** ./util.js ***!`)
     expect(content).toContain(`!*** ./cjs.js ***!`)
 })

--- a/tests/rspack-test/configCases/split-chunks/default-priority/a.js
+++ b/tests/rspack-test/configCases/split-chunks/default-priority/a.js
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/default-priority/b.js
+++ b/tests/rspack-test/configCases/split-chunks/default-priority/b.js
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = "b";

--- a/tests/rspack-test/configCases/split-chunks/default-priority/c.js
+++ b/tests/rspack-test/configCases/split-chunks/default-priority/c.js
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = "c";

--- a/tests/rspack-test/configCases/split-chunks/reuse-chunk-name/b.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-chunk-name/b.js
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = "b";

--- a/tests/rspack-test/configCases/split-chunks/reuse-chunk-name/c.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-chunk-name/c.js
@@ -1,1 +1,2 @@
+globalThis.__rspack_test_side_effect__ = true;
 module.exports = "c";

--- a/tests/rspack-test/esmOutputCases/interop/cjs-reexport-same-name/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/cjs-reexport-same-name/__snapshots__/esm.snap.txt
@@ -24,12 +24,6 @@ exports.N = 200;
 },
 });
 // ./index.js
-const a = __webpack_require__("./a.cjs");
-var G = a.G;
-var U = a.U;
-const b = __webpack_require__("./b.cjs");
-var N = b.N;
-var U_0 = b.U;
 
 
 
@@ -42,6 +36,14 @@ it('should correctly handle two CJS modules with same-named exports', async () =
 	expect(mod.unique_a).toBe(100);
 	expect(mod.unique_b).toBe(200);
 });
+
+const a = __webpack_require__("./a.cjs");
+var G = a.G;
+var U = a.U;
+
+const b = __webpack_require__("./b.cjs");
+var N = b.N;
+var U_0 = b.U;
 
 export { G as unique_a, N as unique_b, U as valueA, U_0 as valueB };
 

--- a/tests/rspack-test/esmOutputCases/namespace/basic-cjs-unused/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/basic-cjs-unused/__snapshots__/esm.snap.txt
@@ -1,20 +1,5 @@
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-
-__webpack_require__.add({
-"./foo.js"
-/*!****************!*\
-  !*** ./foo.js ***!
-  \****************/
-(__unused_rspack_module, exports) {
-var __rspack_unused_export;
-__rspack_unused_export = 123;
-
-
-},
-});
 // ./index.js
-__webpack_require__("./foo.js");
 
 
 const value = 234;
@@ -24,40 +9,5 @@ it("should tree-shake an unused CommonJS namespace import", () => {
 });
 
 export {};
-
-```
-
-```mjs title=runtime.mjs
-
-var __webpack_modules__ = {};
-// The module cache
-var __webpack_module_cache__ = {};
-// The require function
-function __webpack_require__(moduleId) {
-// Check if module is in cache
-var cachedModule = __webpack_module_cache__[moduleId];
-if (cachedModule !== undefined) {
-return cachedModule.exports;
-}
-// Create a new module (and put it into the cache)
-var module = (__webpack_module_cache__[moduleId] = {
-exports: {}
-});
-// Execute the module function
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-
-// Return the exports of the module
-return module.exports;
-}
-// expose the modules object (__webpack_modules__)
-__webpack_require__.m = __webpack_modules__;
-
-// webpack/runtime/esm_register_module
-(() => {
-__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
-
-})();
-
-export { __webpack_require__ };
 
 ```

--- a/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/import-export-namespace-as-cjs/__snapshots__/esm.snap.txt
@@ -13,8 +13,6 @@ exports.foo = 123;
 },
 });
 // ./index.js
-const foo = __webpack_require__("./foo.js");
-var foo_namespace = /*#__PURE__*/__webpack_require__.t(foo, 2);
 
 
 
@@ -24,6 +22,9 @@ it("should export an imported CommonJS namespace", async () => {
 
   expect(mod.ns.foo).toBe(123);
 });
+
+const foo = __webpack_require__("./foo.js");
+var foo_namespace = /*#__PURE__*/__webpack_require__.t(foo, 2);
 
 export { foo_namespace as ns };
 

--- a/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/namespace/star-export-as-namespace-cjs/__snapshots__/esm.snap.txt
@@ -12,13 +12,9 @@ exports.foo = 123
 
 },
 });
-// ./bar.js
+// ./index.js
 const foo_0 = __webpack_require__("./foo.js");
 var foo_0_namespace = /*#__PURE__*/__webpack_require__.t(foo_0, 2);
-
-
-
-// ./index.js
 
 let foo = 234
 

--- a/tests/rspack-test/esmOutputCases/split-chunks/export-from-cjs-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/split-chunks/export-from-cjs-chunk/__snapshots__/esm.snap.txt
@@ -21,7 +21,6 @@ import { __webpack_require__ } from "./runtime.mjs";
 import "./cjs-chunk.mjs";
 
 // ./index.js
-const cjs = __webpack_require__("./cjs.js");
 
 
 
@@ -32,6 +31,8 @@ it('should have correct export', async () => {
   expect(obj).toHaveProperty('value')
   expect(obj.value).toBe(42)
 })
+const cjs = __webpack_require__("./cjs.js");
+
 export { cjs as obj };
 
 ```

--- a/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
+++ b/tests/rspack-test/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
@@ -74,26 +74,26 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 // This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
-/* import */ var _a__rspack_import_0 = __webpack_require__("../../normalModuleFactory​#afterResolve/duplicate/a.js");
-/* import */ var _a__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(_a__rspack_import_0);
-/* import */ var _b__rspack_import_1 = __webpack_require__("../../normalModuleFactory​#afterResolve/duplicate/c.js");
-/* import */ var _b__rspack_import_1_default = /*#__PURE__*/__webpack_require__.n(_b__rspack_import_1);
-/* import */ var fs__rspack_import_2 = __webpack_require__("fs");
-/* import */ var fs__rspack_import_2_default = /*#__PURE__*/__webpack_require__.n(fs__rspack_import_2);
+/* import */ var _a__rspack_import_1 = __webpack_require__("../../normalModuleFactory​#afterResolve/duplicate/a.js");
+/* import */ var _a__rspack_import_1_default = /*#__PURE__*/__webpack_require__.n(_a__rspack_import_1);
+/* import */ var _b__rspack_import_2 = __webpack_require__("../../normalModuleFactory​#afterResolve/duplicate/c.js");
+/* import */ var _b__rspack_import_2_default = /*#__PURE__*/__webpack_require__.n(_b__rspack_import_2);
+/* import */ var fs__rspack_import_0 = __webpack_require__("fs");
+/* import */ var fs__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(fs__rspack_import_0);
 
  // b.js will be transform to c.js
 
 
 
 it("should remove duplicate request modules generate by after resolve hook", () => {
-	expect((_a__rspack_import_0_default())).toBe("a");
-	expect((_b__rspack_import_1_default())).toBe("c");
-	expect((_b__rspack_import_1_default())).toBe("c");
+	expect((_a__rspack_import_1_default())).toBe("a");
+	expect((_b__rspack_import_2_default())).toBe("c");
+	expect((_b__rspack_import_2_default())).toBe("c");
 	const ext = ".js";
-	expect(fs__rspack_import_2_default().readFileSync(__filename, "utf-8")).not.toContain("duplicate/b" + ext);
-	expect(fs__rspack_import_2_default().readFileSync(__filename, "utf-8")).toContain("duplicate/c" + ext);
+	expect(fs__rspack_import_0_default().readFileSync(__filename, "utf-8")).not.toContain("duplicate/b" + ext);
+	expect(fs__rspack_import_0_default().readFileSync(__filename, "utf-8")).toContain("duplicate/c" + ext);
 	expect(
-		fs__rspack_import_2_default().readFileSync(__filename, "utf-8").split("duplicate/c" + ext).length - 1
+		fs__rspack_import_0_default().readFileSync(__filename, "utf-8").split("duplicate/c" + ext).length - 1
 	).toBe(2);
 });
 

--- a/tests/rspack-test/normalCases/parsing/esm-export-import-specifier/o.js
+++ b/tests/rspack-test/normalCases/parsing/esm-export-import-specifier/o.js
@@ -1,2 +1,3 @@
+globalThis.__rspack_test_side_effect__ = true;
 const exports_ = { aaa: 1, bbb: 2 };
 module.exports = exports_;

--- a/tests/rspack-test/normalCases/parsing/harmony-export-import-specifier/o.js
+++ b/tests/rspack-test/normalCases/parsing/harmony-export-import-specifier/o.js
@@ -1,2 +1,3 @@
+globalThis.__rspack_test_side_effect__ = true;
 const exports_ = { aaa: 1, bbb: 2 };
 module.exports = exports_;

--- a/tests/rspack-test/statsAPICases/basic.js
+++ b/tests/rspack-test/statsAPICases/basic.js
@@ -102,7 +102,6 @@ module.exports = {
 			          name: ./fixtures/a.js,
 			          nameForCondition: <TEST_ROOT>/fixtures/a.js,
 			          optimizationBailout: Array [
-			            Statement with side_effects in source code at ./fixtures/a.js<LINE_COL_RANGE>,
 			            ModuleConcatenation bailout: Module is not an ECMAScript module,
 			          ],
 			          optional: false,
@@ -229,7 +228,6 @@ module.exports = {
 			      name: ./fixtures/a.js,
 			      nameForCondition: <TEST_ROOT>/fixtures/a.js,
 			      optimizationBailout: Array [
-			        Statement with side_effects in source code at ./fixtures/a.js<LINE_COL_RANGE>,
 			        ModuleConcatenation bailout: Module is not an ECMAScript module,
 			      ],
 			      optional: false,
@@ -308,13 +306,11 @@ module.exports = {
 			  > ./fixtures/a main
 			  ./fixtures/a.js [195] 55 bytes {889} [depth 0] [built] [code generated]
 			    [used exports unknown]
-			    Statement with side_effects in source code at ./fixtures/a.js<LINE_COL_RANGE>
 			    ModuleConcatenation bailout: Module is not an ECMAScript module
 			    entry ./fixtures/a
 			    cjs self exports reference self [195] ./fixtures/a.js
 			./fixtures/a.js [195] 55 bytes {889} [depth 0] [built] [code generated]
 			  [used exports unknown]
-			  Statement with side_effects in source code at ./fixtures/a.js<LINE_COL_RANGE>
 			  ModuleConcatenation bailout: Module is not an ECMAScript module
 			  entry ./fixtures/a
 			  cjs self exports reference self [195] ./fixtures/a.js

--- a/tests/rspack-test/statsAPICases/with-query.js
+++ b/tests/rspack-test/statsAPICases/with-query.js
@@ -14,7 +14,27 @@ module.exports = {
 			builtAt: false,
 			version: false
 		};
-		expect(stats?.toJson(statsOptions)).toMatchInlineSnapshot(`
+		const statsJson = stats?.toJson(statsOptions);
+		const normalizeOptimizationBailout = value => {
+			if (Array.isArray(value)) {
+				for (const item of value) normalizeOptimizationBailout(item);
+				return;
+			}
+			if (!value || typeof value !== "object") return;
+			if (Array.isArray(value.optimizationBailout)) {
+				value.optimizationBailout = value.optimizationBailout.map(item =>
+					item.replace(
+						/(Statement with side_effects in source code at \.\/fixtures\/abc-query\.js)(?::\d+:\d+|<LINE_COL>)-\d+/,
+						"$1<LINE_COL>-<END_COL>"
+					)
+				);
+			}
+			for (const item of Object.values(value)) {
+				normalizeOptimizationBailout(item);
+			}
+		};
+		normalizeOptimizationBailout(statsJson);
+		expect(statsJson).toMatchInlineSnapshot(`
 			Object {
 			  assets: Array [
 			    Object {
@@ -107,7 +127,6 @@ module.exports = {
 			          name: ./fixtures/a.js,
 			          nameForCondition: <TEST_ROOT>/fixtures/a.js,
 			          optimizationBailout: Array [
-			            Statement with side_effects in source code at ./fixtures/a.js<LINE_COL_RANGE>,
 			            ModuleConcatenation bailout: Module is not an ECMAScript module,
 			          ],
 			          optional: false,
@@ -188,7 +207,6 @@ module.exports = {
 			          name: ./fixtures/a.js?a=1,
 			          nameForCondition: <TEST_ROOT>/fixtures/a.js,
 			          optimizationBailout: Array [
-			            Statement with side_effects in source code at ./fixtures/a.js?a=1<LINE_COL_RANGE>,
 			            ModuleConcatenation bailout: Module is not an ECMAScript module,
 			          ],
 			          optional: false,
@@ -263,7 +281,7 @@ module.exports = {
 			          name: ./fixtures/abc-query.js,
 			          nameForCondition: <TEST_ROOT>/fixtures/abc-query.js,
 			          optimizationBailout: Array [
-			            Statement with side_effects in source code at ./fixtures/abc-query.js<LINE_COL>-32,
+			            Statement with side_effects in source code at ./fixtures/abc-query.js<LINE_COL>-<END_COL>,
 			            ModuleConcatenation bailout: Module is not an ECMAScript module,
 			          ],
 			          optional: false,
@@ -330,7 +348,6 @@ module.exports = {
 			          name: ./fixtures/c.js?c=3,
 			          nameForCondition: <TEST_ROOT>/fixtures/c.js,
 			          optimizationBailout: Array [
-			            Statement with side_effects in source code at ./fixtures/c.js?c=3<LINE_COL_RANGE>,
 			            ModuleConcatenation bailout: Module is not an ECMAScript module,
 			          ],
 			          optional: false,
@@ -462,7 +479,7 @@ module.exports = {
 			      name: ./fixtures/abc-query.js,
 			      nameForCondition: <TEST_ROOT>/fixtures/abc-query.js,
 			      optimizationBailout: Array [
-			        Statement with side_effects in source code at ./fixtures/abc-query.js<LINE_COL>-32,
+			        Statement with side_effects in source code at ./fixtures/abc-query.js<LINE_COL>-<END_COL>,
 			        ModuleConcatenation bailout: Module is not an ECMAScript module,
 			      ],
 			      optional: false,
@@ -529,7 +546,6 @@ module.exports = {
 			      name: ./fixtures/a.js?a=1,
 			      nameForCondition: <TEST_ROOT>/fixtures/a.js,
 			      optimizationBailout: Array [
-			        Statement with side_effects in source code at ./fixtures/a.js?a=1<LINE_COL_RANGE>,
 			        ModuleConcatenation bailout: Module is not an ECMAScript module,
 			      ],
 			      optional: false,
@@ -610,7 +626,6 @@ module.exports = {
 			      name: ./fixtures/c.js?c=3,
 			      nameForCondition: <TEST_ROOT>/fixtures/c.js,
 			      optimizationBailout: Array [
-			        Statement with side_effects in source code at ./fixtures/c.js?c=3<LINE_COL_RANGE>,
 			        ModuleConcatenation bailout: Module is not an ECMAScript module,
 			      ],
 			      optional: false,
@@ -697,7 +712,6 @@ module.exports = {
 			      name: ./fixtures/a.js,
 			      nameForCondition: <TEST_ROOT>/fixtures/a.js,
 			      optimizationBailout: Array [
-			        Statement with side_effects in source code at ./fixtures/a.js<LINE_COL_RANGE>,
 			        ModuleConcatenation bailout: Module is not an ECMAScript module,
 			      ],
 			      optional: false,

--- a/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
@@ -10,7 +10,6 @@ chunk {889} (runtime: main) main.js (main) xx bytes [entry] [rendered]
   ModuleConcatenation bailout: Module is not an ECMAScript module
 ./a.js [670] xx bytes {889} [depth 1] [built] [code generated]
   [used exports unknown]
-  Statement with side_effects in source code at ./a.js<LINE_COL>-22
   ModuleConcatenation bailout: Module is not an ECMAScript module
 ./.|sync [641] xx bytes {889} [depth 1] [built] [code generated]
   [no exports]

--- a/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
@@ -11,7 +11,6 @@ chunk {889} (runtime: main) main.js (main) xx bytes [entry] [rendered]
     commonjs require context . [237] ./index.js 3:1-17
   ./a.js [670] xx bytes {889} [depth 1] [dependent] [built] [code generated]
     [used exports unknown]
-    Statement with side_effects in source code at ./a.js<LINE_COL>-22
     ModuleConcatenation bailout: Module is not an ECMAScript module
     cjs self exports reference self [670] ./a.js
     cjs require ./a [237] ./index.js 1:9-14

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/__snapshots__/treeshaking.snap.txt
@@ -1,0 +1,99 @@
+```js title=main.js
+(self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
+"./esm-exports-assignment.js"(module, __unused_rspack___webpack_exports__, __webpack_require__) {
+"use strict";
+/* module decorator */ module = __webpack_require__.hmd(module);
+
+
+exports.foo = 1;
+module.exports.bar = 1;
+
+
+},
+"./impure-named-exports.js"(__unused_rspack_module, exports) {
+var __rspack_unused_export;
+__rspack_unused_export = console.log("keep side effect");
+
+
+},
+"./index.js"(__unused_rspack_module, __unused_rspack___webpack_exports__, __webpack_require__) {
+"use strict";
+/* import */ var _impure_named_exports__rspack_import_0 = __webpack_require__("./impure-named-exports.js");
+/* import */ var _esm_exports_assignment__rspack_import_1 = __webpack_require__("./esm-exports-assignment.js");
+/* import */ var _nested_export_write__rspack_import_2 = __webpack_require__("./nested-export-write.js");
+/* import */ var _shadowed_cjs_globals_write__rspack_import_3 = __webpack_require__("./shadowed-cjs-globals-write.js");
+/* import */ var _shadowed_cjs_globals_write__rspack_import_3_default = /*#__PURE__*/__webpack_require__.n(_shadowed_cjs_globals_write__rspack_import_3);
+/* import */ var _reassigned_module_exports_write__rspack_import_4 = __webpack_require__("./reassigned-module-exports-write.js");
+/* import */ var _reassigned_module_exports_write__rspack_import_4_default = /*#__PURE__*/__webpack_require__.n(_reassigned_module_exports_write__rspack_import_4);
+
+
+
+
+
+
+
+
+console.log("entry");
+
+
+},
+"./nested-export-write.js"(module, exports) {
+var __rspack_unused_export;
+__rspack_unused_export = {
+  set bar(value) {
+    console.log(value);
+  },
+};
+
+__rspack_unused_export = "keep nested write side effect";
+
+__rspack_unused_export = {
+  set qux(value) {
+    console.log(value);
+  },
+};
+
+__rspack_unused_export = "keep module nested write side effect";
+
+
+},
+"./reassigned-module-exports-write.js"(module) {
+module.exports = {
+  set foo(value) {
+    console.log(value);
+  },
+};
+
+module.exports.foo = "keep reassigned module exports write side effect";
+
+
+},
+"./shadowed-cjs-globals-write.js"() {
+var exports = {
+  set foo(value) {
+    console.log(value);
+  },
+};
+
+exports.foo = "keep shadowed exports write side effect";
+
+var module = {
+  exports: {
+    set bar(value) {
+      console.log(value);
+    },
+  },
+};
+
+module.exports.bar = "keep shadowed module write side effect";
+
+
+},
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
+
+}
+]);
+```

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/esm-exports-assignment.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/esm-exports-assignment.js
@@ -1,0 +1,4 @@
+export {};
+
+exports.foo = 1;
+module.exports.bar = 1;

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/impure-named-exports.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/impure-named-exports.js
@@ -1,0 +1,1 @@
+exports.foo = console.log("keep side effect");

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/index.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/index.js
@@ -1,0 +1,9 @@
+import "./pure-module-exports";
+import "./pure-named-exports";
+import "./impure-named-exports";
+import "./esm-exports-assignment";
+import "./nested-export-write";
+import "./shadowed-cjs-globals-write";
+import "./reassigned-module-exports-write";
+
+console.log("entry");

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/nested-export-write.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/nested-export-write.js
@@ -1,0 +1,15 @@
+exports.foo = {
+  set bar(value) {
+    console.log(value);
+  },
+};
+
+exports.foo.bar = "keep nested write side effect";
+
+module.exports.baz = {
+  set qux(value) {
+    console.log(value);
+  },
+};
+
+module.exports.baz.qux = "keep module nested write side effect";

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/pure-module-exports.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/pure-module-exports.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/pure-named-exports.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/pure-named-exports.js
@@ -1,0 +1,2 @@
+exports.foo = 42;
+exports.bar = { value: true };

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/reassigned-module-exports-write.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/reassigned-module-exports-write.js
@@ -1,0 +1,7 @@
+module.exports = {
+  set foo(value) {
+    console.log(value);
+  },
+};
+
+module.exports.foo = "keep reassigned module exports write side effect";

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/rspack.config.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/rspack.config.js
@@ -1,0 +1,12 @@
+const { DefinePlugin } = require('@rspack/core');
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    sideEffects: true,
+  },
+  plugins: [
+    new DefinePlugin({
+      'process.env.NODE_ENV': "'development'",
+    }),
+  ],
+};

--- a/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/shadowed-cjs-globals-write.js
+++ b/tests/rspack-test/treeShakingCases/cjs-export-assignment-side-effects/shadowed-cjs-globals-write.js
@@ -1,0 +1,17 @@
+var exports = {
+  set foo(value) {
+    console.log(value);
+  },
+};
+
+exports.foo = "keep shadowed exports write side effect";
+
+var module = {
+  exports: {
+    set bar(value) {
+      console.log(value);
+    },
+  },
+};
+
+module.exports.bar = "keep shadowed module write side effect";


### PR DESCRIPTION
## Summary

- Treat static CommonJS export assignments as side-effect-free with respect to the assignment target and evaluate the RHS initializer instead.
- Mark CommonJS export/self-reference dependencies as module-evaluation side-effect-free, so `exports.foo` / `module.exports` references do not keep an otherwise pure module alive by themselves.
- Add a tree-shaking fixture covering pure `module.exports` / `exports.foo` assignments and an impure RHS assignment that must remain.

## Root cause

CommonJS export assignments such as `exports.foo = value` and `module.exports = value` were conservatively treated as side-effectful because the assignment/member access participated in side-effect analysis. The assignment target itself should not be the bailout; only the RHS initializer should decide whether the statement has evaluation side effects.

For module-evaluation side-effect propagation, CommonJS export/self-reference dependencies point back to the same module rather than evaluating another module. They should therefore not contribute `Active(true)` by themselves; actual JavaScript side effects are still captured by the parser side-effects bailout.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_plugin_javascript`
- `pnpm --dir tests/rspack-test run test TreeShaking.test.js -t "treeShakingCases-treeShakingCases/cjs-export-assignment-side-effects"`
- `pnpm --dir tests/rspack-test run test TreeShaking.test.js`