### PR TITLE
perf: reduce compilation hash overhead

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -2,7 +2,6 @@ use std::{cmp::Ordering, fmt::Debug, hash::Hash};
 
 use itertools::Itertools;
 use rayon::prelude::*;
-use rspack_collections::IdentifierSet;
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
@@ -736,21 +735,26 @@ impl Chunk {
 
   pub fn update_hash(&self, hasher: &mut RspackHash, compilation: &Compilation) {
     self.id().hash(hasher);
-    let runtime_modules = compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_chunk_runtime_modules_iterable(&self.ukey)
-      .copied()
-      .collect::<IdentifierSet>();
+    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+    let has_runtime_modules = chunk_graph.has_chunk_runtime_modules(&self.ukey);
+    let module_identifiers = if has_runtime_modules {
+      let mut module_identifiers = chunk_graph
+        .get_chunk_modules_identifier(&self.ukey)
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+      let runtime_modules = chunk_graph
+        .get_chunk_runtime_modules_iterable(&self.ukey)
+        .copied()
+        .collect::<Vec<_>>();
+      module_identifiers.retain(|module_identifier| !runtime_modules.contains(module_identifier));
+      module_identifiers.sort_unstable_by_key(|m| m.as_str());
+      module_identifiers
+    } else {
+      chunk_graph.get_ordered_chunk_modules_identifier(&self.ukey)
+    };
 
-    for module_identifier in compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_ordered_chunk_modules_identifier(&self.ukey)
-    {
-      if runtime_modules.contains(&module_identifier) {
-        continue;
-      }
+    for module_identifier in module_identifiers {
       if let Some(hash) = compilation
         .code_generation_results
         .get_hash(&module_identifier, Some(&self.runtime))
@@ -759,27 +763,25 @@ impl Chunk {
       }
     }
 
-    for (runtime_module_identifier, _) in compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_chunk_runtime_modules_in_order(&self.ukey, compilation)
-    {
-      let hash = compilation
-        .runtime_modules_hash
-        .get(runtime_module_identifier)
-        .unwrap_or_else(|| {
-          panic!(
-            "Runtime module ({runtime_module_identifier}) should have hash result when updating chunk hash."
-          );
-        });
-      hash.hash(hasher);
+    if has_runtime_modules {
+      for (runtime_module_identifier, _) in
+        chunk_graph.get_chunk_runtime_modules_in_order(&self.ukey, compilation)
+      {
+        let hash = compilation
+          .runtime_modules_hash
+          .get(runtime_module_identifier)
+          .unwrap_or_else(|| {
+            panic!(
+              "Runtime module ({runtime_module_identifier}) should have hash result when updating chunk hash."
+            );
+          });
+        hash.hash(hasher);
+      }
     }
 
     "entry".hash(hasher);
-    for (module, chunk_group) in compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .get_chunk_entry_modules_with_chunk_group_iterable(&self.ukey)
+    for (module, chunk_group) in
+      chunk_graph.get_chunk_entry_modules_with_chunk_group_iterable(&self.ukey)
     {
       ChunkGraph::get_module_id(&compilation.module_ids_artifact, *module).hash(hasher);
       if let Some(chunk_group) = compilation

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -46,35 +46,43 @@ pub async fn create_hash(
   // possible to depend on full hash, but for library type commonjs/module, it's possible to
   // have non-runtime chunks depend on full hash, the library format plugin is using
   // dependent_full_hash hook to declare it.
-  let mut full_hash_chunks: FxHashSet<_> = compilation
-    .build_chunk_graph_artifact
-    .chunk_by_ukey
-    .keys()
-    .copied()
-    .collect::<Vec<_>>()
-    .into_par_iter()
-    .try_fold(
-      FxHashSet::default,
-      |mut local_set, chunk_ukey| -> Result<FxHashSet<_>> {
-        let mut chunk_dependent_full_hash = false;
-        plugin_driver.compilation_hooks.dependent_full_hash.call(
-          compilation,
-          &chunk_ukey,
-          &mut chunk_dependent_full_hash,
-        )?;
-        if chunk_dependent_full_hash {
-          local_set.insert(chunk_ukey);
-        }
-        Ok(local_set)
-      },
-    )
-    .try_reduce(
-      FxHashSet::default,
-      |mut acc, local_set| -> Result<FxHashSet<_>> {
-        acc.extend(local_set);
-        Ok(acc)
-      },
-    )?;
+  let mut full_hash_chunks: FxHashSet<_> = if plugin_driver
+    .compilation_hooks
+    .dependent_full_hash
+    .is_empty()
+  {
+    FxHashSet::default()
+  } else {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .keys()
+      .copied()
+      .collect::<Vec<_>>()
+      .into_par_iter()
+      .try_fold(
+        FxHashSet::default,
+        |mut local_set, chunk_ukey| -> Result<FxHashSet<_>> {
+          let mut chunk_dependent_full_hash = false;
+          plugin_driver.compilation_hooks.dependent_full_hash.call(
+            compilation,
+            &chunk_ukey,
+            &mut chunk_dependent_full_hash,
+          )?;
+          if chunk_dependent_full_hash {
+            local_set.insert(chunk_ukey);
+          }
+          Ok(local_set)
+        },
+      )
+      .try_reduce(
+        FxHashSet::default,
+        |mut acc, local_set| -> Result<FxHashSet<_>> {
+          acc.extend(local_set);
+          Ok(acc)
+        },
+      )?
+  };
   if !full_hash_chunks.is_empty()
     && let Some(diagnostic) = compilation.incremental.disable_passes(
       IncrementalPasses::CHUNKS_HASHES,
@@ -163,28 +171,33 @@ pub async fn create_hash(
 
   // create hash for runtime modules in other chunks
   let compilation_ref = &*compilation;
-  let other_chunk_runtime_module_hashes = rspack_parallel::scope::<_, Result<_>>(|token| {
-    other_chunks
+  let other_chunk_runtime_module_hashes = {
+    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+    if other_chunks
       .iter()
-      .flat_map(|chunk| {
-        compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .get_chunk_runtime_modules_iterable(chunk)
+      .any(|chunk| chunk_graph.has_chunk_runtime_modules(chunk))
+    {
+      rspack_parallel::scope::<_, Result<_>>(|token| {
+        other_chunks
+          .iter()
+          .flat_map(|chunk| chunk_graph.get_chunk_runtime_modules_iterable(chunk))
+          .for_each(|runtime_module_identifier| {
+            let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
+            s.spawn(|(compilation, runtime_module_identifier)| async {
+              let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
+              let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+              Ok((*runtime_module_identifier, digest))
+            });
+          })
       })
-      .for_each(|runtime_module_identifier| {
-        let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
-        s.spawn(|(compilation, runtime_module_identifier)| async {
-          let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
-          let digest = runtime_module.get_runtime_hash(compilation, None).await?;
-          Ok((*runtime_module_identifier, digest))
-        });
-      })
-  })
-  .await
-  .into_iter()
-  .map(|res| res.to_rspack_result())
-  .collect::<Result<Vec<_>>>()?;
+      .await
+      .into_iter()
+      .map(|res| res.to_rspack_result())
+      .collect::<Result<Vec<_>>>()?
+    } else {
+      Vec::new()
+    }
+  };
 
   for res in other_chunk_runtime_module_hashes {
     let (runtime_module_identifier, digest) = res?;
@@ -195,11 +208,12 @@ pub async fn create_hash(
 
   // create hash for other chunks
   let compilation_ref = &*compilation;
+  let plugin_driver_ref = &plugin_driver;
   let other_chunks_hash_results = rspack_parallel::scope::<_, Result<_>>(|token| {
     for chunk in other_chunks {
-      let s = unsafe { token.used((compilation_ref, chunk, plugin_driver.clone())) };
+      let s = unsafe { token.used((compilation_ref, chunk, plugin_driver_ref)) };
       s.spawn(|(compilation, chunk, plugin_driver)| async move {
-        let hash_result = process_chunk_hash(compilation, *chunk, &plugin_driver).await?;
+        let hash_result = process_chunk_hash(compilation, *chunk, plugin_driver).await?;
         Ok((*chunk, hash_result))
       });
     }
@@ -270,11 +284,12 @@ pub async fn create_hash(
     if has_full_hash_modules {
       full_hash_chunks.insert(chunk_ukey);
     }
-    let referenced_by = runtime_chunks_map
-      .get(&chunk_ukey)
-      .expect("should in runtime_chunks_map")
-      .0
-      .clone();
+    let referenced_by = std::mem::take(
+      &mut runtime_chunks_map
+        .get_mut(&chunk_ukey)
+        .expect("should in runtime_chunks_map")
+        .0,
+    );
     for other in referenced_by {
       if has_full_hash_modules {
         for runtime_module in compilation
@@ -342,24 +357,27 @@ pub async fn create_hash(
   let start = logger.time("hashing: hash runtime chunks");
   for runtime_chunk_ukey in runtime_chunks {
     let compilation_ref = &*compilation;
-    let runtime_module_hashes = rspack_parallel::scope::<_, Result<_>>(|token| {
-      compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_chunk_runtime_modules_iterable(&runtime_chunk_ukey)
-        .for_each(|runtime_module_identifier| {
-          let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
-          s.spawn(|(compilation, runtime_module_identifier)| async {
-            let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
-            let digest = runtime_module.get_runtime_hash(compilation, None).await?;
-            Ok((*runtime_module_identifier, digest))
-          });
-        })
-    })
-    .await
-    .into_iter()
-    .map(|res| res.to_rspack_result())
-    .collect::<Result<Vec<_>>>()?;
+    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+    let runtime_module_hashes = if chunk_graph.has_chunk_runtime_modules(&runtime_chunk_ukey) {
+      rspack_parallel::scope::<_, Result<_>>(|token| {
+        chunk_graph
+          .get_chunk_runtime_modules_iterable(&runtime_chunk_ukey)
+          .for_each(|runtime_module_identifier| {
+            let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
+            s.spawn(|(compilation, runtime_module_identifier)| async {
+              let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
+              let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+              Ok((*runtime_module_identifier, digest))
+            });
+          })
+      })
+      .await
+      .into_iter()
+      .map(|res| res.to_rspack_result())
+      .collect::<Result<Vec<_>>>()?
+    } else {
+      Vec::new()
+    };
 
     for res in runtime_module_hashes {
       let (mid, digest) = res?;
@@ -389,21 +407,21 @@ pub async fn create_hash(
   compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey
-    .values()
-    .sorted_unstable_by_key(|chunk| chunk.ukey())
-    .for_each(|chunk| {
-      if let Some(hash) = chunk.hash(&compilation.chunk_hashes_artifact) {
-        hash.hash(&mut compilation_hasher);
-      }
-      if let Some(content_hashes) = chunk.content_hash(&compilation.chunk_hashes_artifact) {
-        content_hashes
-          .iter()
-          .sorted_unstable_by_key(|(source_type, _)| *source_type)
-          .for_each(|(source_type, content_hash)| {
-            source_type.hash(&mut compilation_hasher);
-            content_hash.hash(&mut compilation_hasher);
-          });
-      }
+    .keys()
+    .sorted_unstable()
+    .for_each(|chunk_ukey| {
+      let Some(chunk_hashes) = compilation.chunk_hashes_artifact.get(chunk_ukey) else {
+        return;
+      };
+      chunk_hashes.hash().hash(&mut compilation_hasher);
+      chunk_hashes
+        .content_hash()
+        .iter()
+        .sorted_unstable_by_key(|(source_type, _)| *source_type)
+        .for_each(|(source_type, content_hash)| {
+          source_type.hash(&mut compilation_hasher);
+          content_hash.hash(&mut compilation_hasher);
+        });
     });
   compilation.hot_index.hash(&mut compilation_hasher);
   compilation.hash = Some(compilation_hasher.digest(&compilation.options.output.hash_digest));
@@ -477,6 +495,11 @@ pub async fn create_hash(
 
 #[instrument(skip_all)]
 pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> Result<()> {
+  if compilation.runtime_modules.is_empty() {
+    compilation.runtime_modules_code_generation_source = Default::default();
+    return Ok(());
+  }
+
   let compilation_ref = &*compilation;
   let results = rspack_parallel::scope::<_, Result<_>>(|token| {
     compilation
@@ -493,13 +516,14 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
               concatenation_scope: None,
               runtime_template: &mut runtime_template,
             };
-            let result = runtime_module
+            let mut result = runtime_module
               .code_generation(&mut code_generation_context)
               .await?;
             let source = result
-              .get(&SourceType::Runtime)
+              .inner
+              .remove(&SourceType::Runtime)
               .expect("should have source");
-            Ok((*runtime_module_identifier, source.clone()))
+            Ok((*runtime_module_identifier, source))
           },
         )
       })
@@ -510,12 +534,16 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
   .collect::<Result<Vec<_>>>()?;
 
   let mut runtime_module_sources = IdentifierMap::<BoxSource>::default();
+  runtime_module_sources.reserve(results.len());
   for result in results {
     let (runtime_module_identifier, source) = result?;
     runtime_module_sources.insert(runtime_module_identifier, source);
   }
 
   compilation.runtime_modules_code_generation_source = runtime_module_sources;
+  compilation
+    .code_generated_modules
+    .reserve(compilation.runtime_modules.len());
   compilation
     .code_generated_modules
     .extend(compilation.runtime_modules.keys().copied());


### PR DESCRIPTION
## Summary

Reduce compilation hash overhead in the existing create-hash path without moving work out of CodSpeed measurement.

- In `Chunk::update_hash`, keep the common no-runtime-module path on the existing `get_ordered_chunk_modules_identifier` helper, preserving the previous ordered-module behavior.
- For chunks with runtime modules, collect module identifiers directly, filter the small runtime-module list before sorting, then sort the remaining normal module identifiers by `as_str()`. This preserves the previous hash input order while avoiding runtime-module items in the normal-module sort path only when runtime modules exist.
- In `Chunk::update_hash`, skip ordered runtime-module hashing entirely for chunks that have no runtime modules.
- For chunks with runtime modules, use the small runtime-module `Vec` for filtering instead of building an `IdentifierSet`; runtime modules are normally few and there is no threshold/cache.
- Skip the per-chunk `dependent_full_hash` scan when the hook has no taps/interceptors.
- Before hashing runtime modules in non-runtime chunks, skip the `rspack_parallel::scope` entirely when none of those chunks have runtime modules. This avoids the previous zero-spawn scope path.
- Before hashing runtime modules in each runtime chunk, skip the `rspack_parallel::scope` when that runtime chunk has no runtime modules.
- When spawning non-runtime chunk hashing tasks, pass `&SharedPluginDriver` through `rspack_parallel::scope` instead of cloning the shared plugin driver once per chunk task.
- Consume runtime chunk `referenced_by` lists with `std::mem::take` instead of cloning them while topologically processing runtime chunks.
- For full-hash aggregation, sort `ChunkUkey` keys directly and read `ChunkHashesArtifact` once per key instead of sorting `Chunk` values and performing separate hash/content-hash artifact lookups through `Chunk` accessors.
- In runtime-module code generation, skip the empty-runtime-module path and reserve the runtime source map / generated-module set before filling them.
- Preserve deterministic chunk/module order, missing-hash behavior, runtime-module hashing, entry hashing, JS/CSS content-hash behavior, and error-path state updates.

## Scope Notes

- Final diff touches only `crates/rspack_core/src/chunk.rs` and `crates/rspack_core/src/compilation/create_hash/mod.rs`.
- No `chunk_graph_chunk.rs` / `chunk_graph_module.rs` changes.
- No JS/CSS plugin changes remain.
- No separate `ChunkHashingArtifact`.
- No `ChunkHashesArtifact::prepare_ordered_modules` cache or ordered-module precomputation remains.
- No unexplained threshold and no content-hash folding fast paths.
- No CodSpeed benchmark timing manipulation remains.

## Target Benchmarks

- `rust@create_chunk_hashes`: target >= 10%
- `rust@create_full_hash`: target >= 10%

## Validation

- CI-only validation per optimization workflow; no local benchmark/build/test run.
- Local pre-push checks: `cargo fmt --package rspack_core` and `git diff --check`.
- Current pushed head: `965040bc49b0079079cbf93c81cc9fe278466406`.
- Subagent correctness review for this head found no correctness issues. It confirmed the new runtime-module codegen empty-path and reserve calls preserve stale-source clearing, error behavior, and `code_generated_modules` semantics; it also confirmed the underlying map/set reserve calls are valid for `IdentifierMap`/`IdentifierSet`.
- CI/CodSpeed pending for current head.

Previous CodSpeed result for `ad1730b` did not meet the target: `rust@create_full_hash -2.06%` and no >=10% `rust@create_chunk_hashes` result was reported. This head keeps the scoped create-hash changes and adds a measured-path runtime-module codegen allocation fast path for the next CodSpeed run.