### PR TITLE
perf(sources): use scoped bump allocation for sourcemap scratch data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5133,6 +5133,7 @@ dependencies = [
 name = "rspack_sources"
 version = "0.100.6"
 dependencies = [
+ "bumpalo",
  "dyn-clone",
  "memchr",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ atomic_refcell  = { version = "0.1.14", default-features = false }
 base64-simd     = { version = "0.8.0", default-features = false, features = ["alloc"] }
 bitflags        = { version = "2.11.1", default-features = false }
 browserslist-rs = { version = "0.19.0", default-features = false }
+bumpalo         = { version = "3.20.3", default-features = false }
 bytes           = { version = "1.11.1", default-features = false }
 camino          = { version = "1.2.2", default-features = false }
 cargo_toml      = { version = "0.22.3", default-features = false }

--- a/crates/rspack_sources/Cargo.toml
+++ b/crates/rspack_sources/Cargo.toml
@@ -17,6 +17,7 @@ codspeed         = []
 rspack_cacheable = ["dep:rkyv"]
 
 [dependencies]
+bumpalo           = { workspace = true, features = ["collections"] }
 dyn-clone         = { workspace = true }
 memchr            = { workspace = true, features = ["std"] }
 rkyv              = { workspace = true, optional = true }

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -12,7 +12,7 @@ use crate::{
   decoder::MappingsDecoder,
   encoder::create_encoder,
   linear_map::LinearMap,
-  object_pool::ObjectPool,
+  object_pool::{ObjectPool, Pooled},
   source::{Mapping, OriginalLocation},
   source_content_lines::SourceContentLines,
   with_utf16::WithUtf16,
@@ -856,8 +856,8 @@ fn stream_chunks_of_source_map_lines_full<'a>(
 
 #[derive(Debug)]
 struct SourceMapLineData<'a> {
-  pub mappings_data: Vec<i64>,
-  pub chunks: Vec<TextSpan<'a>>,
+  pub mappings_data: Pooled<'a, i64>,
+  pub chunks: Pooled<'a, TextSpan<'a>>,
 }
 
 type InnerSourceIndexValueMapping<'a> = LinearMap<(Cow<'a, str>, Option<&'a Arc<str>>)>;
@@ -894,7 +894,8 @@ pub fn stream_chunks_of_combined_source_map<'a>(
   let inner_name_index_mapping: RefCell<LinearMap<i64>> = RefCell::new(LinearMap::default());
   let inner_name_index_value_mapping: RefCell<LinearMap<Cow<str>>> =
     RefCell::new(LinearMap::default());
-  let inner_source_map_line_data: RefCell<Vec<SourceMapLineData>> = RefCell::new(Vec::new());
+  let inner_source_map_line_data: RefCell<Pooled<'a, SourceMapLineData<'a>>> =
+    RefCell::new(object_pool.pull_vec(0));
 
   let find_inner_mapping = |line: i64, column: i64| -> Option<u32> {
     let inner_source_map_line_data = inner_source_map_line_data.borrow();
@@ -1240,8 +1241,8 @@ pub fn stream_chunks_of_combined_source_map<'a>(
                 .reserve(mapping_generated_line_len - inner_source_map_line_data_len + 1);
               while inner_source_map_line_data.len() <= mapping_generated_line_len {
                 inner_source_map_line_data.push(SourceMapLineData {
-                  mappings_data: Default::default(),
-                  chunks: vec![],
+                  mappings_data: object_pool.pull_vec(0),
+                  chunks: object_pool.pull_vec(0),
                 });
               }
             }
@@ -1322,6 +1323,7 @@ pub fn stream_and_get_source_and_map<'a>(
   on_source: OnSource<'_, 'a>,
   on_name: OnName<'_, 'a>,
 ) -> (GeneratedInfo, Option<SourceMap>) {
+  let _allocation_scope = object_pool.scope();
   let mut mappings_encoder = create_encoder(options.columns);
   let mut sources: Vec<String> = Vec::new();
   let mut sources_content: Vec<Arc<str>> = Vec::new();

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -23,6 +23,7 @@ pub fn get_map<'a>(
   chunks: &'a dyn Chunks,
   options: &MapOptions,
 ) -> Option<SourceMap> {
+  let _allocation_scope = object_pool.scope();
   let mut mappings_encoder = create_encoder(options.columns);
   let mut sources: Vec<String> = Vec::new();
   let mut sources_content: Vec<Arc<str>> = Vec::new();

--- a/crates/rspack_sources/src/object_pool.rs
+++ b/crates/rspack_sources/src/object_pool.rs
@@ -1,86 +1,143 @@
-use std::{cell::RefCell, collections::BTreeMap};
+use std::cell::{Cell, UnsafeCell};
 
-// Vector pooling minimum capacity threshold
-// Recommended threshold: 64
-// Reasons:
-// 1. Memory consideration: 64 * 8 bytes = 512 bytes, a reasonable memory block size
-// 2. Allocation cost: Allocations smaller than 512 bytes are usually fast, pooling benefits are limited
-// 3. Cache friendly: 512 bytes can typically utilize CPU cache well
-// 4. Empirical value: 64 is a proven balance point in real projects
-const MIN_POOL_CAPACITY: usize = 64;
+use bumpalo::{Bump, collections::Vec as BumpVec};
 
-/// A memory pool for reusing `T` allocations to reduce memory allocation overhead.
-#[derive(Default, Debug)]
+/// A scoped bump allocator for temporary source-map scratch storage.
+///
+/// `ObjectPool` is reused through thread-local storage by devtool/minimizer code.
+/// Each top-level source-map generation enters an allocation scope, allocates
+/// UTF-16 byte-index scratch vectors from the bump arena, and resets the arena
+/// when the outermost scope exits. Direct unscoped `pull` calls fall back to an
+/// owned `Vec` so public helper usage stays safe even without a scope.
+#[derive(Debug)]
 pub struct ObjectPool {
-  objects: RefCell<BTreeMap<usize, Vec<Vec<usize>>>>,
+  bump: UnsafeCell<Bump>,
+  active_scopes: Cell<usize>,
+}
+
+impl Default for ObjectPool {
+  fn default() -> Self {
+    Self {
+      bump: UnsafeCell::new(Bump::new()),
+      active_scopes: Cell::new(0),
+    }
+  }
 }
 
 impl ObjectPool {
-  /// Retrieves a reusable `T` from the pool with at least the requested capacity.
-  pub fn pull<'a>(&'a self, requested_capacity: usize) -> Pooled<'a> {
-    if requested_capacity < MIN_POOL_CAPACITY || self.objects.borrow().is_empty() {
-      return Pooled::new(self, Vec::with_capacity(requested_capacity));
+  /// Enter a temporary allocation scope.
+  ///
+  /// Nested scopes share the same arena. The arena is reset only after the
+  /// outermost scope exits, so temporary allocations remain valid for the whole
+  /// source-map streaming call that created them.
+  pub(crate) fn scope(&self) -> Scope<'_> {
+    let depth = self.active_scopes.get();
+    if depth == 0 {
+      self.reset();
     }
-    let mut objects = self.objects.borrow_mut();
-    if let Some((_, bucket)) = objects.range_mut(requested_capacity..).next() {
-      if let Some(mut object) = bucket.pop() {
-        object.clear();
-        return Pooled::new(self, object);
-      }
-    }
-    Pooled::new(self, Vec::with_capacity(requested_capacity))
+    self.active_scopes.set(depth + 1);
+    Scope { pool: self }
   }
 
-  /// Returns a `T` to the pool for future reuse.
-  fn return_to_pool(&self, object: Vec<usize>) {
-    if object.capacity() < MIN_POOL_CAPACITY {
-      return;
+  /// Retrieves temporary `usize` scratch storage with at least the requested capacity.
+  pub fn pull<'a>(&'a self, requested_capacity: usize) -> Pooled<'a> {
+    if self.active_scopes.get() == 0 {
+      return Pooled::new_heap(requested_capacity);
     }
-    let mut objects = self.objects.borrow_mut();
-    let cap = object.capacity();
-    let bucket = objects.entry(cap).or_default();
-    bucket.push(object);
+
+    Pooled::new_in(requested_capacity, self.bump())
+  }
+
+  #[inline]
+  fn bump(&self) -> &Bump {
+    #[allow(unsafe_code)]
+    // SAFETY: `Bump` allocation only requires shared access. `ObjectPool` is
+    // intentionally `!Sync` because it contains `Cell`/`UnsafeCell`, so shared
+    // references are not used concurrently across threads.
+    unsafe {
+      &*self.bump.get()
+    }
+  }
+
+  #[inline]
+  fn reset(&self) {
+    #[allow(unsafe_code)]
+    // SAFETY: `reset` is called only when `active_scopes == 0`, before a new
+    // scope starts or after the outermost scope exits. All bump-backed
+    // `Pooled` values created by internal streaming code have been dropped at
+    // that point.
+    unsafe {
+      (&mut *self.bump.get()).reset();
+    }
   }
 }
 
-/// A smart pointer that holds a pooled object and automatically returns it to the pool when dropped.
-///
-/// `Pooled<T>` implements RAII (Resource Acquisition Is Initialization) pattern to manage
-/// pooled objects lifecycle. When the `Pooled` instance is dropped, the contained object
-/// is automatically returned to its associated pool for future reuse.
+/// Guard for an [`ObjectPool`] temporary allocation scope.
+pub(crate) struct Scope<'pool> {
+  pool: &'pool ObjectPool,
+}
+
+impl Drop for Scope<'_> {
+  fn drop(&mut self) {
+    let depth = self.pool.active_scopes.get();
+    debug_assert!(depth > 0);
+    let next_depth = depth.saturating_sub(1);
+    self.pool.active_scopes.set(next_depth);
+    if next_depth == 0 {
+      self.pool.reset();
+    }
+  }
+}
+
+/// Temporary `usize` scratch storage.
 #[derive(Debug)]
 pub struct Pooled<'object_pool> {
-  object: Option<Vec<usize>>,
-  pool: &'object_pool ObjectPool,
+  inner: PooledInner<'object_pool>,
+}
+
+#[derive(Debug)]
+enum PooledInner<'object_pool> {
+  Bump(BumpVec<'object_pool, usize>),
+  Heap(Vec<usize>),
 }
 
 impl<'object_pool> Pooled<'object_pool> {
-  fn new(pool: &'object_pool ObjectPool, object: Vec<usize>) -> Self {
-    Pooled {
-      object: Some(object),
-      pool,
+  fn new_in(capacity: usize, bump: &'object_pool Bump) -> Self {
+    Self {
+      inner: PooledInner::Bump(BumpVec::with_capacity_in(capacity, bump)),
     }
   }
 
-  pub fn as_mut(&mut self) -> &mut Vec<usize> {
-    self.object.as_mut().unwrap()
+  fn new_heap(capacity: usize) -> Self {
+    Self {
+      inner: PooledInner::Heap(Vec::with_capacity(capacity)),
+    }
   }
 
-  pub fn as_ref(&self) -> &Vec<usize> {
-    self.object.as_ref().unwrap()
+  pub fn as_mut(&mut self) -> &mut [usize] {
+    match &mut self.inner {
+      PooledInner::Bump(vec) => vec.as_mut_slice(),
+      PooledInner::Heap(vec) => vec.as_mut_slice(),
+    }
   }
-}
 
-impl Drop for Pooled<'_> {
-  fn drop(&mut self) {
-    if let Some(object) = self.object.take() {
-      self.pool.return_to_pool(object);
+  pub fn as_ref(&self) -> &[usize] {
+    match &self.inner {
+      PooledInner::Bump(vec) => vec.as_slice(),
+      PooledInner::Heap(vec) => vec.as_slice(),
+    }
+  }
+
+  pub fn push(&mut self, value: usize) {
+    match &mut self.inner {
+      PooledInner::Bump(vec) => vec.push(value),
+      PooledInner::Heap(vec) => vec.push(value),
     }
   }
 }
 
 impl std::ops::Deref for Pooled<'_> {
-  type Target = Vec<usize>;
+  type Target = [usize];
 
   fn deref(&self) -> &Self::Target {
     self.as_ref()

--- a/crates/rspack_sources/src/object_pool.rs
+++ b/crates/rspack_sources/src/object_pool.rs
@@ -41,6 +41,11 @@ impl ObjectPool {
 
   /// Retrieves temporary `usize` scratch storage with at least the requested capacity.
   pub fn pull<'a>(&'a self, requested_capacity: usize) -> Pooled<'a> {
+    self.pull_vec(requested_capacity)
+  }
+
+  /// Retrieves temporary scratch storage with at least the requested capacity.
+  pub(crate) fn pull_vec<'a, T>(&'a self, requested_capacity: usize) -> Pooled<'a, T> {
     if self.active_scopes.get() == 0 {
       return Pooled::new_heap(requested_capacity);
     }
@@ -89,19 +94,19 @@ impl Drop for Scope<'_> {
   }
 }
 
-/// Temporary `usize` scratch storage.
+/// Temporary scratch storage.
 #[derive(Debug)]
-pub struct Pooled<'object_pool> {
-  inner: PooledInner<'object_pool>,
+pub struct Pooled<'object_pool, T = usize> {
+  inner: PooledInner<'object_pool, T>,
 }
 
 #[derive(Debug)]
-enum PooledInner<'object_pool> {
-  Bump(BumpVec<'object_pool, usize>),
-  Heap(Vec<usize>),
+enum PooledInner<'object_pool, T> {
+  Bump(BumpVec<'object_pool, T>),
+  Heap(Vec<T>),
 }
 
-impl<'object_pool> Pooled<'object_pool> {
+impl<'object_pool, T> Pooled<'object_pool, T> {
   fn new_in(capacity: usize, bump: &'object_pool Bump) -> Self {
     Self {
       inner: PooledInner::Bump(BumpVec::with_capacity_in(capacity, bump)),
@@ -114,37 +119,44 @@ impl<'object_pool> Pooled<'object_pool> {
     }
   }
 
-  pub fn as_mut(&mut self) -> &mut [usize] {
+  pub fn as_mut(&mut self) -> &mut [T] {
     match &mut self.inner {
       PooledInner::Bump(vec) => vec.as_mut_slice(),
       PooledInner::Heap(vec) => vec.as_mut_slice(),
     }
   }
 
-  pub fn as_ref(&self) -> &[usize] {
+  pub fn as_ref(&self) -> &[T] {
     match &self.inner {
       PooledInner::Bump(vec) => vec.as_slice(),
       PooledInner::Heap(vec) => vec.as_slice(),
     }
   }
 
-  pub fn push(&mut self, value: usize) {
+  pub fn push(&mut self, value: T) {
     match &mut self.inner {
       PooledInner::Bump(vec) => vec.push(value),
       PooledInner::Heap(vec) => vec.push(value),
     }
   }
+
+  pub fn reserve(&mut self, additional: usize) {
+    match &mut self.inner {
+      PooledInner::Bump(vec) => vec.reserve(additional),
+      PooledInner::Heap(vec) => vec.reserve(additional),
+    }
+  }
 }
 
-impl std::ops::Deref for Pooled<'_> {
-  type Target = [usize];
+impl<T> std::ops::Deref for Pooled<'_, T> {
+  type Target = [T];
 
   fn deref(&self) -> &Self::Target {
     self.as_ref()
   }
 }
 
-impl std::ops::DerefMut for Pooled<'_> {
+impl<T> std::ops::DerefMut for Pooled<'_, T> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     self.as_mut()
   }


### PR DESCRIPTION
## Summary

- Replaces `rspack_sources`' scratch `ObjectPool` Vec bucket reuse with a scoped bump arena for temporary UTF-16 byte-index buffers used during source-map generation.
- Generalizes the temporary `Pooled` storage wrapper so selected non-escaping scratch vectors can use the same scoped arena.
- Bump-allocates combined source-map merge line data (`mappings_data` and `chunks`) and adds a scope around `stream_and_get_source_and_map` for cached-source map generation.
- Keeps returned `SourceMap` data and other escaping objects on ordinary owned storage, with a heap `Vec` fallback for unscoped public `pull` calls.

Performance notes:

- CodSpeed for HEAD `778c613`: overall **not alter performance**.
  - Improved: `sources@concat_source_add_few` +2.17%.
  - Regressed: `js@collect imported identifiers` -2.36%; this is a JavaScript tinybench over module graph bindings, not a `rspack_sources`/bump allocator path touched by this PR.
- Local `rspack_sources` Criterion benches:
  - `sources@complex_replace_source_map`: 19.026 ms -> 18.625 ms, about 2.1% faster.
  - `sources@complex_replace_source_map_cached_source_stream_chunks`: 4.8257 ms -> 4.8387 ms, no statistically significant change.
  - `sources@repetitive_react_components_map`: 2.0753 ms -> 2.0726 ms, effectively unchanged/slightly faster.
  - `sources@concat_generate_string_with_cache`: 17.024 µs -> 17.172 µs, within noise threshold.
  - `sources@concat_generate_string`: 39.437 µs -> 39.687 µs, within noise threshold.

Additional bump allocation experiments that were tried and rejected locally:

- Bump-backed full/cheap source-map `lines` collection regressed `sources@repetitive_react_components_map` by about 3%.
- Bump-backed temporary `LinearMap` index remaps regressed `sources@complex_replace_source_map` by about 6.4% and cached stream chunks by about 4.8%.
- Bump-backed `SourceContentLines` line storage regressed `sources@complex_replace_source_map` to about 20.33 ms.

Checks run:

- `cargo test -p rspack_sources --lib --tests`
- `cargo test -p rspack_sources --features rspack_cacheable`
- `cargo fmt --all --check`
- `pnpm run lint:rs`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test:unit`
- `pnpm run test:rs`
- `pnpm run test:type`
- `pnpm run test:e2e`
- `pnpm run test:hot`
- `pnpm run build:cli:dev:browser`
- `pnpm run test:e2e-browser`
- `pnpm --filter bench run bench`

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
