### PR TITLE
feat(watcher): port watchpack safeTime/mtime-accuracy to native watcher

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -473,6 +473,13 @@ export declare class NativeWatcher {
    */
   close(): Promise<void>
   pause(): void
+  /**
+   * Collect the full file/context time tables, mirroring watchpack's
+   * `collectTimeInfoEntries`. Called synchronously from JS after an aggregated
+   * event (or from `getInfo()`) to populate `compiler.fileTimestamps` /
+   * `contextTimestamps`.
+   */
+  getTimeInfo(): NativeTimeInfo
 }
 
 export declare class NativeWatchResult {
@@ -1562,6 +1569,16 @@ export interface JsTap {
   stage: number
 }
 
+/**
+ * watchpack-style time info for a single path, surfaced to webpack as a
+ * `FileSystemInfoEntry`. `timestamp` is absent for directory (context)
+ * entries, whose value is a derived `safe_time` only.
+ */
+export interface JsTimeInfoEntry {
+  safeTime: number
+  timestamp?: number
+}
+
 export interface JsVirtualFile {
   path: string
   content: string
@@ -1780,6 +1797,15 @@ export interface NapiResolveOptions {
    * Default `false`
    */
   enablePnp?: boolean
+}
+
+/**
+ * The full `fileTimeInfoEntries` / `contextTimeInfoEntries` snapshot, mirroring
+ * watchpack's `collectTimeInfoEntries` output.
+ */
+export interface NativeTimeInfo {
+  fileTimeInfoEntries: Record<string, JsTimeInfoEntry>
+  contextTimeInfoEntries: Record<string, JsTimeInfoEntry>
 }
 
 export interface NativeWatcherOptions {

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -1,5 +1,6 @@
 use std::{
   boxed::Box,
+  collections::HashMap,
   path::{Path, PathBuf},
   time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -42,6 +43,23 @@ pub struct NativeWatcherOptions {
 pub struct NativeWatchResult {
   pub changed_files: Vec<String>,
   pub removed_files: Vec<String>,
+}
+
+/// watchpack-style time info for a single path, surfaced to webpack as a
+/// `FileSystemInfoEntry`. `timestamp` is absent for directory (context)
+/// entries, whose value is a derived `safe_time` only.
+#[napi(object)]
+pub struct JsTimeInfoEntry {
+  pub safe_time: f64,
+  pub timestamp: Option<f64>,
+}
+
+/// The full `fileTimeInfoEntries` / `contextTimeInfoEntries` snapshot, mirroring
+/// watchpack's `collectTimeInfoEntries` output.
+#[napi(object)]
+pub struct NativeTimeInfo {
+  pub file_time_info_entries: HashMap<String, JsTimeInfoEntry>,
+  pub context_time_info_entries: HashMap<String, JsTimeInfoEntry>,
 }
 
 #[napi]
@@ -156,6 +174,43 @@ impl NativeWatcher {
       .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
     Ok(())
+  }
+
+  /// Collect the full file/context time tables, mirroring watchpack's
+  /// `collectTimeInfoEntries`. Called synchronously from JS after an aggregated
+  /// event (or from `getInfo()`) to populate `compiler.fileTimestamps` /
+  /// `contextTimestamps`.
+  #[napi]
+  pub fn get_time_info(&self) -> NativeTimeInfo {
+    let (files, contexts) = self.watcher.collect_time_info();
+    let file_time_info_entries = files
+      .into_iter()
+      .map(|(path, entry)| {
+        (
+          path,
+          JsTimeInfoEntry {
+            safe_time: entry.safe_time as f64,
+            timestamp: Some(entry.timestamp as f64),
+          },
+        )
+      })
+      .collect();
+    let context_time_info_entries = contexts
+      .into_iter()
+      .map(|(path, safe_time)| {
+        (
+          path,
+          JsTimeInfoEntry {
+            safe_time: safe_time as f64,
+            timestamp: None,
+          },
+        )
+      })
+      .collect();
+    NativeTimeInfo {
+      file_time_info_entries,
+      context_time_info_entries,
+    }
   }
 }
 

--- a/crates/rspack_watcher/src/lib.rs
+++ b/crates/rspack_watcher/src/lib.rs
@@ -4,6 +4,7 @@ mod executor;
 mod ignored;
 mod paths;
 mod scanner;
+mod time_info;
 mod trigger;
 
 use std::{sync::Arc, time::SystemTime};
@@ -17,6 +18,7 @@ use rspack_error::Result;
 use rspack_paths::ArcPath;
 use rspack_util::fx_hash::FxHashSet as HashSet;
 use scanner::Scanner;
+pub use time_info::{TimeInfoEntry, TimeInfoTables};
 use tokio::sync::mpsc;
 use trigger::Trigger;
 
@@ -164,6 +166,14 @@ impl FsWatcher {
     }
   }
 
+  /// Collect the full webpack-shaped time tables for all watched files and
+  /// directories. Mirrors watchpack's `collectTimeInfoEntries`; consumed via
+  /// the napi `getTimeInfo()` to populate `fileTimeInfoEntries` /
+  /// `contextTimeInfoEntries`.
+  pub fn collect_time_info(&self) -> TimeInfoTables {
+    self.path_manager.collect_time_info()
+  }
+
   /// Pauses the file system watcher, stopping the execution of the event loop.
   pub fn pause(&self) -> Result<()> {
     self.executor.pause();
@@ -224,7 +234,22 @@ impl FsWatcher {
         .metadata()
         .and_then(|m| m.modified().or_else(|_| m.created()))
       {
-        self.path_manager.set_file_mtime_if_absent(path, mtime);
+        self
+          .path_manager
+          .set_file_mtime_if_absent(path.clone(), mtime);
+        // Seed the watchpack-style time entry for newly-added files so the
+        // first `getTimeInfo()` already carries their conservative safe_time.
+        self.path_manager.set_initial_file_time(path, mtime);
+      }
+    }
+
+    let dirs: Vec<_> = accessor.directories().1.iter().map(|p| p.clone()).collect();
+    for path in dirs {
+      if let Ok(mtime) = path
+        .metadata()
+        .and_then(|m| m.modified().or_else(|_| m.created()))
+      {
+        self.path_manager.set_initial_dir_time(path, mtime);
       }
     }
   }

--- a/crates/rspack_watcher/src/paths.rs
+++ b/crates/rspack_watcher/src/paths.rs
@@ -671,7 +671,9 @@ mod tests {
     let t2 = SystemTime::now() - Duration::from_secs(10);
     pm.set_event_file_time(&path, t1);
     let s1 = file_safe_time(&pm, &path).expect("entry after first event");
-    sleep(Duration::from_millis(5));
+    // 50ms comfortably exceeds the ~15.6ms SystemTime granularity on Windows
+    // so `now_millis()` reliably advances between the two events.
+    sleep(Duration::from_millis(50));
     pm.set_event_file_time(&path, t2);
     let s2 = file_safe_time(&pm, &path).expect("entry after second event");
 
@@ -739,11 +741,21 @@ mod tests {
   /// descendant file's `safe_time`.
   #[test]
   fn collect_time_info_aggregates_child_safe_times_to_dir() {
-    use std::{path::Path, time::SystemTime};
+    use std::time::SystemTime;
 
     let pm = PathManager::default();
-    let dir = ArcPath::from(Path::new("/project/src"));
-    let file = ArcPath::from(Path::new("/project/src/nested/a.js"));
+    // Build from an absolute temp-dir base: a Unix-style "/project" path is
+    // NOT absolute on Windows, so `update()` would relativize the directory
+    // (join cwd) and the file's parent chain would no longer match it.
+    let base = std::env::temp_dir();
+    let dir = ArcPath::from(base.join("rspack_wt_agg_src").as_path());
+    let file = ArcPath::from(
+      base
+        .join("rspack_wt_agg_src")
+        .join("nested")
+        .join("a.js")
+        .as_path(),
+    );
 
     // Register the directory so it is an aggregation target.
     pm.update(

--- a/crates/rspack_watcher/src/paths.rs
+++ b/crates/rspack_watcher/src/paths.rs
@@ -1,10 +1,14 @@
-use std::{fmt::Debug, ops::Deref, path::PathBuf, time::SystemTime};
+use std::{collections::HashMap, fmt::Debug, ops::Deref, path::PathBuf, time::SystemTime};
 
 use dashmap::setref::multiple::RefMulti;
 use rspack_error::Result;
 use rspack_paths::{ArcPath, ArcPathDashMap, ArcPathDashSet};
 
 use super::FsWatcherIgnored;
+use crate::time_info::{
+  TimeInfoEntry, TimeInfoTables, ensure_fs_accuracy, fixup_entry_accuracy, fs_accuracy,
+  initial_entry, now_millis, system_time_to_millis,
+};
 
 /// An iterator that chains together references to all files, directories, and missing paths
 /// stored in the [`PathTracker`]. This allows iteration over all registered paths as a single sequence.
@@ -190,6 +194,14 @@ pub(crate) struct PathManager {
   /// Used to filter stale FSEvents that arrive for files not actually modified.
   /// See: https://gist.github.com/stormslowly/ed758500de6f23211fd63b39eba5ed07
   file_mtimes: ArcPathDashMap<SystemTime>,
+  /// watchpack-style `{ safe_time, timestamp, accuracy }` time info per file,
+  /// surfaced to webpack as `fileTimeInfoEntries`. See [`crate::time_info`].
+  file_entries: ArcPathDashMap<TimeInfoEntry>,
+  /// Directory-level time info, surfaced as `contextTimeInfoEntries`. Holds the
+  /// directory's own change time; the value exposed to webpack additionally
+  /// aggregates the `safe_time` of every registered child file (see
+  /// [`PathManager::collect_time_info`]).
+  dir_entries: ArcPathDashMap<TimeInfoEntry>,
 }
 
 impl PathManager {
@@ -201,6 +213,8 @@ impl PathManager {
       missing: PathTracker::default(),
       ignored,
       file_mtimes: ArcPathDashMap::default(),
+      file_entries: ArcPathDashMap::default(),
+      dir_entries: ArcPathDashMap::default(),
     }
   }
 
@@ -241,6 +255,117 @@ impl PathManager {
     self.file_mtimes.remove(path);
   }
 
+  /// Record an initial-scan time entry for a file, mirroring watchpack
+  /// `setFileTime(initial=true)`. Only set if absent: a live event may have
+  /// already advanced the entry across watch cycles and must not be clobbered
+  /// by a re-stat (same reasoning as [`Self::set_file_mtime_if_absent`]).
+  pub fn set_initial_file_time(&self, path: ArcPath, mtime: SystemTime) {
+    self
+      .file_entries
+      .entry(path)
+      .or_insert_with(|| initial_entry(system_time_to_millis(mtime)));
+  }
+
+  /// Record an initial-scan time entry for a directory (using its mtime as the
+  /// birthtime), mirroring watchpack `setDirectory(initial=true)`.
+  pub fn set_initial_dir_time(&self, path: ArcPath, mtime: SystemTime) {
+    self
+      .dir_entries
+      .entry(path)
+      .or_insert_with(|| initial_entry(system_time_to_millis(mtime)));
+  }
+
+  /// Record a real-time change for a file, mirroring watchpack
+  /// `setFileTime(initial=false)`: `safe_time = now`, `accuracy = 0`. Skips the
+  /// update for an attribute-only change — the same mtime already sitting
+  /// outside the accuracy window, which cannot hide a content change.
+  pub fn set_event_file_time(&self, path: &ArcPath, mtime: SystemTime) {
+    let mtime_ms = system_time_to_millis(mtime);
+    ensure_fs_accuracy(mtime_ms);
+    let now = now_millis();
+    // Read-and-drop the guard before inserting: DashMap would deadlock if a
+    // read ref into the same shard were held across a write.
+    let skip = {
+      if let Some(old) = self.file_entries.get(path) {
+        old.timestamp == mtime_ms && mtime_ms + fs_accuracy() < now
+      } else {
+        false
+      }
+    };
+    if skip {
+      return;
+    }
+    self.file_entries.insert(
+      path.clone(),
+      TimeInfoEntry {
+        safe_time: now,
+        timestamp: mtime_ms,
+        accuracy: 0,
+      },
+    );
+  }
+
+  /// Bump a directory's change time to now when an event is associated with it,
+  /// but only for registered directories. Captures directory-level changes
+  /// (a child added/removed) that a remaining child file's entry can't reflect.
+  pub fn touch_dir_if_registered(&self, path: &ArcPath) {
+    if !self.directories.all.contains(path) {
+      return;
+    }
+    let now = now_millis();
+    self.dir_entries.insert(
+      path.clone(),
+      TimeInfoEntry {
+        safe_time: now,
+        timestamp: now,
+        accuracy: 0,
+      },
+    );
+  }
+
+  /// Collect the full webpack-shaped time tables, mirroring watchpack's
+  /// `collectTimeInfoEntries`. Returns `(file_entries, context_entries)` where
+  /// each entry's accuracy is tightened on read ([`fixup_entry_accuracy`]) and a
+  /// directory's `safe_time` is the max of its own change time and the
+  /// `safe_time` of every registered descendant file.
+  pub fn collect_time_info(&self) -> TimeInfoTables {
+    let accuracy = fs_accuracy();
+
+    // Seed directory aggregates with each directory's own change time.
+    let mut dir_times: HashMap<ArcPath, u64> = HashMap::new();
+    for dir in self.dir_entries.iter() {
+      let mut entry = *dir.value();
+      fixup_entry_accuracy(&mut entry, accuracy);
+      dir_times.insert(dir.key().clone(), entry.safe_time);
+    }
+
+    let mut files = Vec::with_capacity(self.file_entries.len());
+    for file in self.file_entries.iter() {
+      let mut entry = *file.value();
+      fixup_entry_accuracy(&mut entry, accuracy);
+      let path = file.key();
+      files.push((path.to_string_lossy().to_string(), entry));
+
+      // Bubble this file's safe_time up to every registered ancestor directory.
+      let mut current = path.parent();
+      while let Some(parent) = current {
+        let parent_arc = ArcPath::from(parent);
+        if self.directories.all.contains(&parent_arc) {
+          let slot = dir_times.entry(parent_arc).or_insert(0);
+          *slot = (*slot).max(entry.safe_time);
+        }
+        current = parent.parent();
+      }
+    }
+
+    let contexts = dir_times
+      .into_iter()
+      .map(|(dir, safe_time)| (dir.to_string_lossy().to_string(), safe_time))
+      .collect();
+
+    (files, contexts)
+  }
+
   /// Check if a file's mtime has changed from the stored baseline.
   /// Returns `true` if the event should pass through (mtime changed or no baseline).
   /// Returns `false` if the event should be suppressed (mtime unchanged = stale).
@@ -262,6 +387,7 @@ impl PathManager {
         if current_mtime != *baseline {
           drop(baseline);
           self.file_mtimes.insert(path.clone(), current_mtime);
+          self.set_event_file_time(path, current_mtime);
           true
         } else {
           false
@@ -269,6 +395,7 @@ impl PathManager {
       }
       None => {
         self.file_mtimes.insert(path.clone(), current_mtime);
+        self.set_event_file_time(path, current_mtime);
         true
       }
     }
@@ -292,6 +419,11 @@ impl PathManager {
     let removed_files: Vec<ArcPath> = self.files.removed.iter().map(|p| p.clone()).collect();
     for path in &removed_files {
       self.remove_file_mtime(path);
+      self.file_entries.remove(path);
+    }
+    let removed_dirs: Vec<ArcPath> = self.directories.removed.iter().map(|p| p.clone()).collect();
+    for path in &removed_dirs {
+      self.dir_entries.remove(path);
     }
 
     Ok(())
@@ -502,6 +634,132 @@ mod tests {
       pm.file_mtimes.get(&path).map(|v| *v),
       Some(post_write_mtime),
       "has_mtime_changed should advance the baseline on a real change",
+    );
+  }
+
+  /// Read a file's collected `safe_time`, or `None` if it has no entry.
+  fn file_safe_time(pm: &PathManager, path: &ArcPath) -> Option<u64> {
+    let key = path.to_string_lossy().to_string();
+    let (files, _) = pm.collect_time_info();
+    files
+      .into_iter()
+      .find(|(p, _)| *p == key)
+      .map(|(_, e)| e.safe_time)
+  }
+
+  /// Read a directory's collected `safe_time`, or `None` if it has no entry.
+  fn dir_safe_time(pm: &PathManager, path: &ArcPath) -> Option<u64> {
+    let key = path.to_string_lossy().to_string();
+    let (_, dirs) = pm.collect_time_info();
+    dirs.into_iter().find(|(p, _)| *p == key).map(|(_, t)| t)
+  }
+
+  /// Ports watchpack "setFileTime without initial triggers change": a real-time
+  /// event with a different mtime must advance `safe_time` to ~now.
+  #[test]
+  fn set_event_advances_safe_time_on_real_change() {
+    use std::{
+      path::Path,
+      thread::sleep,
+      time::{Duration, SystemTime},
+    };
+
+    let pm = PathManager::default();
+    let path = ArcPath::from(Path::new("/x/file.js"));
+
+    let t1 = SystemTime::now() - Duration::from_secs(20);
+    let t2 = SystemTime::now() - Duration::from_secs(10);
+    pm.set_event_file_time(&path, t1);
+    let s1 = file_safe_time(&pm, &path).expect("entry after first event");
+    sleep(Duration::from_millis(5));
+    pm.set_event_file_time(&path, t2);
+    let s2 = file_safe_time(&pm, &path).expect("entry after second event");
+
+    assert!(
+      s2 > s1,
+      "a real change must advance safe_time ({s1} -> {s2})"
+    );
+  }
+
+  /// Ports watchpack "setFileTime skips when timestamp is unchanged and old is
+  /// stable": a repeated event carrying the same, already-stable mtime is an
+  /// attribute-only change and must not advance `safe_time`.
+  #[test]
+  fn set_event_skips_attribute_only_change() {
+    use std::{
+      path::Path,
+      thread::sleep,
+      time::{Duration, SystemTime},
+    };
+
+    let pm = PathManager::default();
+    let path = ArcPath::from(Path::new("/x/stable.js"));
+
+    // An mtime well outside any plausible accuracy window (<= 2000ms).
+    let stable = SystemTime::now() - Duration::from_secs(10);
+    pm.set_event_file_time(&path, stable);
+    let s1 = file_safe_time(&pm, &path).expect("entry after first event");
+    sleep(Duration::from_millis(5));
+    pm.set_event_file_time(&path, stable);
+    let s2 = file_safe_time(&pm, &path).expect("entry after second event");
+
+    assert_eq!(
+      s1, s2,
+      "attribute-only change (same stable mtime) must not advance safe_time",
+    );
+  }
+
+  /// `set_initial_file_time` must not clobber an entry a live event already
+  /// advanced — mirrors the if-absent contract of the mtime baseline.
+  #[test]
+  fn set_initial_does_not_overwrite_event_entry() {
+    use std::{
+      path::Path,
+      time::{Duration, SystemTime},
+    };
+
+    let pm = PathManager::default();
+    let path = ArcPath::from(Path::new("/x/live.js"));
+
+    pm.set_event_file_time(&path, SystemTime::now() - Duration::from_secs(1));
+    let after_event = file_safe_time(&pm, &path).expect("entry after event");
+
+    // A later initial re-scan with an ancient mtime must be a no-op.
+    pm.set_initial_file_time(path.clone(), SystemTime::now() - Duration::from_secs(100));
+    let after_initial = file_safe_time(&pm, &path).expect("entry still present");
+
+    assert_eq!(
+      after_event, after_initial,
+      "initial scan must not overwrite a live event entry",
+    );
+  }
+
+  /// Ports watchpack's directory aggregation in `collectTimeInfoEntries`: a
+  /// registered directory's `safe_time` is the max of every registered
+  /// descendant file's `safe_time`.
+  #[test]
+  fn collect_time_info_aggregates_child_safe_times_to_dir() {
+    use std::{path::Path, time::SystemTime};
+
+    let pm = PathManager::default();
+    let dir = ArcPath::from(Path::new("/project/src"));
+    let file = ArcPath::from(Path::new("/project/src/nested/a.js"));
+
+    // Register the directory so it is an aggregation target.
+    pm.update(
+      (std::iter::empty(), std::iter::empty()),
+      (std::iter::once(dir.clone()), std::iter::empty()),
+      (std::iter::empty(), std::iter::empty()),
+    )
+    .expect("register dir");
+
+    pm.set_event_file_time(&file, SystemTime::now());
+    let file_st = file_safe_time(&pm, &file).expect("file entry");
+    let dir_st = dir_safe_time(&pm, &dir).expect("dir entry aggregated from child");
+
+    assert!(
+      dir_st >= file_st,
+      "dir safe_time ({dir_st}) must be >= descendant file safe_time ({file_st})",
     );
   }
 }

--- a/crates/rspack_watcher/src/time_info.rs
+++ b/crates/rspack_watcher/src/time_info.rs
@@ -1,0 +1,212 @@
+//! Port of watchpack's `safeTime` / mtime-accuracy mechanism.
+//!
+//! The reference implementation lives in watchpack's `lib/DirectoryWatcher.js`
+//! (`FS_ACCURACY`, `ensureFsAccuracy`, `fixupEntryAccuracy`, `setFileTime`).
+//!
+//! Why this exists: a raw filesystem `mtime` is not enough to answer "did this
+//! file change at or after time T". Filesystems quantize mtime to a coarse
+//! resolution (1ms .. 2s depending on the FS), and the moment we observe an
+//! event the content may still be settling. `safeTime` is the conservative
+//! point in time *after which reading the file is guaranteed to be stable*; it
+//! is intentionally biased to be larger than the raw mtime so the downstream
+//! `startTime <= safeTime` comparison never silently drops a real change.
+//! `accuracy` records how much padding was baked into `safeTime` so it can be
+//! tightened later once the filesystem proves to be more precise.
+
+use std::{
+  sync::atomic::{AtomicU64, Ordering},
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+/// Worst-case filesystem mtime resolution, in milliseconds.
+///
+/// Mirrors watchpack's module-global `FS_ACCURACY`. It starts pessimistic
+/// (2000ms, the coarsest mtime granularity seen in the wild, e.g. FAT) and only
+/// ever ratchets *down* as observed mtimes prove the filesystem records
+/// timestamps more finely. Process-global and monotonically non-increasing.
+static FS_ACCURACY: AtomicU64 = AtomicU64::new(2000);
+
+/// Current value of [`FS_ACCURACY`].
+pub(crate) fn fs_accuracy() -> u64 {
+  FS_ACCURACY.load(Ordering::Relaxed)
+}
+
+/// Narrow [`FS_ACCURACY`] based on the divisibility of an observed mtime,
+/// mirroring watchpack's `ensureFsAccuracy`. A non-zero remainder at a given
+/// granularity proves the filesystem keeps timestamps at least that finely.
+///
+/// watchpack's finest branch (`mtime % 1 !== 0 -> 1`) only fires for
+/// non-integer (sub-millisecond) mtimes; we operate on integer milliseconds, so
+/// the finest resolution reachable here is 10ms, governed by `mtime % 10`.
+pub(crate) fn ensure_fs_accuracy(mtime: u64) {
+  if mtime == 0 {
+    return;
+  }
+  let target = if !mtime.is_multiple_of(10) {
+    10
+  } else if !mtime.is_multiple_of(100) {
+    100
+  } else if !mtime.is_multiple_of(1000) {
+    1000
+  } else {
+    // Whole second: tells us nothing finer than what we already assume.
+    return;
+  };
+
+  // One-way ratchet: only ever decrease, and stay correct under concurrent
+  // events with a compare-and-swap loop.
+  let mut cur = FS_ACCURACY.load(Ordering::Relaxed);
+  while target < cur {
+    match FS_ACCURACY.compare_exchange_weak(cur, target, Ordering::Relaxed, Ordering::Relaxed) {
+      Ok(_) => break,
+      Err(actual) => cur = actual,
+    }
+  }
+}
+
+/// Per-path time information, mirroring watchpack's `Entry`.
+///
+/// - `safe_time`: the point in time after which reading is safe to be unchanged.
+/// - `timestamp`: the raw observed mtime, compared against other timestamps.
+/// - `accuracy`: how much padding is currently baked into `safe_time`.
+///
+/// All values are integer milliseconds since the Unix epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeInfoEntry {
+  pub safe_time: u64,
+  pub timestamp: u64,
+  pub accuracy: u64,
+}
+
+/// The webpack-shaped time tables: `(file_entries, context_entries)`. Each file
+/// entry is a full [`TimeInfoEntry`]; each context (directory) entry carries
+/// only a derived `safe_time`.
+pub type TimeInfoTables = (Vec<(String, TimeInfoEntry)>, Vec<(String, u64)>);
+
+/// Tighten an entry whose padding exceeds the current [`FS_ACCURACY`], mirroring
+/// watchpack's `fixupEntryAccuracy`. Because `FS_ACCURACY` only decreases, an
+/// entry created early is over-padded once the filesystem is later proven finer;
+/// this removes the old padding and re-applies the current (smaller) one,
+/// pulling `safe_time` earlier (more accurate). Idempotent.
+pub(crate) fn fixup_entry_accuracy(entry: &mut TimeInfoEntry, accuracy: u64) {
+  if entry.accuracy > accuracy {
+    // `saturating_sub` guards the synthetic test case where `accuracy` exceeds
+    // `safe_time`; for real epoch-millisecond entries `safe_time` always
+    // dominates the <= 2000ms padding.
+    entry.safe_time = entry.safe_time.saturating_sub(entry.accuracy) + accuracy;
+    entry.accuracy = accuracy;
+  }
+}
+
+/// Build an initial-scan entry, mirroring watchpack `setFileTime(initial=true)`.
+///
+/// `safe_time = min(now, mtime) + FS_ACCURACY`: the `min` clamps future-stamped
+/// files (clock skew) and the `+ accuracy` padding absorbs the filesystem's
+/// mtime granularity. `accuracy` records the padding so it can be reclaimed.
+pub(crate) fn initial_entry(mtime: u64) -> TimeInfoEntry {
+  ensure_fs_accuracy(mtime);
+  let accuracy = fs_accuracy();
+  TimeInfoEntry {
+    safe_time: now_millis().min(mtime) + accuracy,
+    timestamp: mtime,
+    accuracy,
+  }
+}
+
+/// Convert a [`SystemTime`] to integer milliseconds since the Unix epoch.
+pub(crate) fn system_time_to_millis(time: SystemTime) -> u64 {
+  time
+    .duration_since(UNIX_EPOCH)
+    .map_or(0, |d| d.as_millis() as u64)
+}
+
+/// Current wall-clock time in milliseconds since the Unix epoch.
+pub(crate) fn now_millis() -> u64 {
+  system_time_to_millis(SystemTime::now())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // FS_ACCURACY is process-global and monotonically decreasing; tests must not
+  // assume its absolute value (other tests may have ratcheted it down). They
+  // assert relative behavior instead.
+
+  #[test]
+  fn ensure_fs_accuracy_only_decreases() {
+    // A sub-100ms mtime proves <= 10ms resolution (governed by `% 10`).
+    ensure_fs_accuracy(1_700_000_000_123);
+    let after = fs_accuracy();
+    assert!(after <= 10, "sub-10ms mtime must drop accuracy to <= 10");
+
+    // A whole-second mtime must NOT raise it back up.
+    ensure_fs_accuracy(1_700_000_000_000);
+    assert_eq!(
+      fs_accuracy(),
+      after,
+      "whole-second mtime must not change it"
+    );
+  }
+
+  #[test]
+  fn ensure_fs_accuracy_ladder() {
+    // Verify the ladder mapping in isolation by reasoning about the target,
+    // independent of the shared global. 1230 -> %10==0, %100!=0 -> 100.
+    // We can only observe the global, so just assert it never exceeds the
+    // coarsest target a given mtime implies.
+    ensure_fs_accuracy(1230); // implies <= 100
+    assert!(fs_accuracy() <= 100);
+  }
+
+  #[test]
+  fn fixup_reclaims_overpadding() {
+    // Mirrors watchpack "fixupEntryAccuracy adjusts entries whose accuracy
+    // exceeds FS_ACCURACY": seed {safeTime:100000, accuracy:100000}, fixup to
+    // accuracy=2000 gives safeTime = 100000 - 100000 + 2000 = 2000.
+    let mut entry = TimeInfoEntry {
+      safe_time: 100_000,
+      timestamp: 100_000,
+      accuracy: 100_000,
+    };
+    fixup_entry_accuracy(&mut entry, 2000);
+    assert_eq!(entry.accuracy, 2000);
+    assert_eq!(entry.safe_time, 2000);
+    // getTimes() would report max(safe_time, timestamp) = 100000.
+    assert_eq!(entry.safe_time.max(entry.timestamp), 100_000);
+  }
+
+  #[test]
+  fn fixup_is_noop_when_already_tight() {
+    let mut entry = TimeInfoEntry {
+      safe_time: 5000,
+      timestamp: 4000,
+      accuracy: 10,
+    };
+    let before = entry;
+    fixup_entry_accuracy(&mut entry, 2000); // accuracy 10 < 2000 -> no change
+    assert_eq!(entry, before);
+  }
+
+  #[test]
+  fn initial_entry_pads_with_accuracy() {
+    // safe_time = min(now, mtime) + accuracy. With an old mtime, min picks
+    // mtime, so safe_time = mtime + accuracy and accuracy is recorded.
+    let mtime = 1_000_000u64;
+    let entry = initial_entry(mtime);
+    assert_eq!(entry.timestamp, mtime);
+    assert_eq!(entry.safe_time, mtime + entry.accuracy);
+    assert!(entry.accuracy > 0);
+  }
+
+  #[test]
+  fn initial_entry_clamps_future_mtime() {
+    // A far-future mtime must be clamped to `now` so safe_time stays sane.
+    let future = now_millis() + 1_000_000_000;
+    let entry = initial_entry(future);
+    assert!(
+      entry.safe_time <= now_millis() + entry.accuracy + 1000,
+      "future mtime must be clamped to now"
+    );
+  }
+}

--- a/crates/rspack_watcher/src/trigger.rs
+++ b/crates/rspack_watcher/src/trigger.rs
@@ -128,6 +128,12 @@ impl Trigger {
 
     let finder = self.finder();
     let associated_event = finder.find_associated_event(path, kind);
+    // Record directory-level change times for any registered directory touched
+    // by this event (parent directories included), so `contextTimeInfoEntries`
+    // reflects directory-level changes such as a child being added or removed.
+    for (associated_path, _) in &associated_event {
+      self.path_manager.touch_dir_if_registered(associated_path);
+    }
     self.trigger_events(associated_event);
   }
   /// Helper to construct a `DependencyFinder` for the current path register state.

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -36,6 +36,26 @@ const toJsWatcherIgnored = (
   return undefined;
 };
 
+/**
+ * Convert the native `{ safeTime, timestamp }` snapshot into the
+ * `Map<string, FileSystemInfoEntry>` webpack expects. The native layer leaves
+ * `timestamp` absent for directory (context) entries; normalize null to
+ * undefined so the value matches `FileSystemInfoEntry`.
+ */
+const toTimeInfoMap = (
+  entries: Record<string, { safeTime: number; timestamp?: number | null }>,
+): Map<string, FileSystemInfoEntry> => {
+  const map = new Map<string, FileSystemInfoEntry>();
+  for (const path in entries) {
+    const entry = entries[path];
+    map.set(path, {
+      safeTime: entry.safeTime,
+      timestamp: entry.timestamp ?? undefined,
+    });
+  }
+  return map;
+};
+
 export default class NativeWatchFileSystem implements WatchFileSystem {
   #inner: binding.NativeWatcher | undefined;
   #isFirstWatch = true;
@@ -120,11 +140,11 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
             fs.purge?.(item);
           }
         }
-        // TODO: add fileTimeInfoEntries and contextTimeInfoEntries
+        const timeInfo = nativeWatcher.getTimeInfo();
         callback(
           err,
-          new Map(),
-          new Map(),
+          toTimeInfoMap(timeInfo.fileTimeInfoEntries),
+          toTimeInfoMap(timeInfo.contextTimeInfoEntries),
           new Set(changedFiles),
           new Set(removedFiles),
         );
@@ -155,13 +175,18 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
       },
 
       getInfo() {
-        // This is a placeholder implementation.
-        // TODO: The actual implementation should return the current state of the watcher.
+        // changes/removals are only known at aggregate time (via the callback);
+        // on this non-event-driven query path we surface the full time tables
+        // (what compiler.fileTimestamps/contextTimestamps need) and leave the
+        // change/removal sets empty.
+        const timeInfo = nativeWatcher.getTimeInfo();
         return {
-          changes: new Set(),
-          removals: new Set(),
-          fileTimeInfoEntries: new Map(),
-          contextTimeInfoEntries: new Map(),
+          changes: new Set<string>(),
+          removals: new Set<string>(),
+          fileTimeInfoEntries: toTimeInfoMap(timeInfo.fileTimeInfoEntries),
+          contextTimeInfoEntries: toTimeInfoMap(
+            timeInfo.contextTimeInfoEntries,
+          ),
         };
       },
     };


### PR DESCRIPTION
## Why

The native watcher returned empty `fileTimeInfoEntries` / `contextTimeInfoEntries` (left as a `// TODO`), so `compiler.fileTimestamps` / `contextTimestamps` were empty. Persistent-cache snapshot validation then degrades to "trust the changedFiles set only", which can miss or over-invalidate across processes — the JS (watchpack) path does populate these via `collectTimeInfoEntries`, so this closes a parity gap.

## What

Port watchpack's `safeTime` / mtime-accuracy mechanism into `rspack_watcher`:

- `FS_ACCURACY` global (2000ms, monotonically ratchets down) + `ensureFsAccuracy` resolution detection
- per-entry `{ safe_time, timestamp, accuracy }` with the initial-scan regime (`min(now, mtime) + FS_ACCURACY`) and the real-time regime (`now`, accuracy `0`), including the attribute-only within-window skip
- `fixupEntryAccuracy` lazy tightening on read + directory `safe_time` aggregated from descendant files
- expose via napi `getTimeInfo()`; `NativeWatchFileSystem` now fills both maps and `getInfo()`

`accuracy` is kept internal — rspack's `FileSystemInfoEntry` exposes only `{ safeTime, timestamp }`, matching webpack's public contract.

### Before / After

```
// Before
callback(err, new Map(), new Map(), changed, removed); // TODO

// After
const timeInfo = nativeWatcher.getTimeInfo();
callback(err, toTimeInfoMap(timeInfo.fileTimeInfoEntries),
         toTimeInfoMap(timeInfo.contextTimeInfoEntries), changed, removed);
```

## Test

- `cargo test -p rspack_watcher` — ported watchpack safeTime characterization tests (FS_ACCURACY ladder, fixup, initial/event regimes, within-window skip, dir aggregation)
- watchpack `DirectoryWatcherExtra` suite green (reference parity)
- `NativeWatcher.part1/2/3` JS suites green (230 cases)

> Draft: opened to produce a canary for rstest native-watcher stress testing.
