### PR TITLE
chore(benchmark): cap walltime benchmark threads

### DIFF
--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -37,6 +37,8 @@ jobs:
   bench-rust:
     name: 'Bench Rust ${{ inputs.measurement }}'
     runs-on: ${{ fromJSON(inputs.runner) }}
+    env:
+      BENCH_MODE: ${{ inputs.measurement }}
     defaults:
       run:
         shell: bash
@@ -90,7 +92,6 @@ jobs:
         timeout-minutes: 30
         env:
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
-          RAYON_NUM_THREADS: 1
           CODSPEED_EXPERIMENTAL_FAIR_SCHED: true
         with:
           mode: simulation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,7 @@ dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
  "mimalloc",
+ "rayon",
  "rspack",
  "rspack_cacheable",
  "rspack_collections",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:rs": "cargo test --workspace --exclude rspack_binding_api --exclude rspack_node --exclude rspack_binding_builder --exclude rspack_binding_builder_macros --exclude rspack_binding_builder_testing --exclude rspack_binding_build --exclude rspack_napi --exclude rspack_watcher -- --nocapture",
     "bench:ci": "pnpm run bench:prepare && pnpm run bench:rust && pnpm --filter bench run bench",
     "bench:rust": "RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run",
-    "bench:rust:local": "mkdir -p /tmp/rspack-codspeed-valgrind-tmp && TMPDIR=/tmp/rspack-codspeed-valgrind-tmp RAYON_NUM_THREADS=1 RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases codspeed run -m simulation -- cargo codspeed run -m simulation",
+    "bench:rust:local": "mkdir -p /tmp/rspack-codspeed-valgrind-tmp && TMPDIR=/tmp/rspack-codspeed-valgrind-tmp BENCH_MODE=simulation RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases codspeed run -m simulation -- cargo codspeed run -m simulation",
     "bench:prepare": "node ./scripts/bench/setup.mjs"
   },
   "engines": {

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 criterion = { workspace = true }
+rayon     = { workspace = true }
 tokio     = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/xtask/benchmark/README.md
+++ b/xtask/benchmark/README.md
@@ -20,7 +20,11 @@ upstream `threejs/src` input ten times. This larger input is registered only by
 the isolated `walltime` benchmark target, so regular simulation runs keep using
 the smaller default benchmark set. The `threejs-10x` walltime benchmark writes
 outputs through the native filesystem instead of the in-memory filesystem used
-by the regular bundle benchmarks.
+by the regular bundle benchmarks. Rust benchmark concurrency is selected with
+`BENCH_MODE=simulation|walltime` (default: `simulation`). Walltime bundle
+benchmarks use `BENCH_MODE=walltime`, which caps machine-size-dependent
+parallelism at up to 16 threads for each of Tokio workers, Tokio blocking tasks,
+and Rayon.
 
 ## Run in CI mode
 
@@ -77,14 +81,14 @@ pnpm run bench:rust:local -- --bench rspack_sources
 The script expands to:
 
 ```bash
-mkdir -p /tmp/rspack-codspeed-valgrind-tmp && TMPDIR=/tmp/rspack-codspeed-valgrind-tmp RAYON_NUM_THREADS=1 RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases codspeed run -m simulation -- cargo codspeed run -m simulation
+mkdir -p /tmp/rspack-codspeed-valgrind-tmp && TMPDIR=/tmp/rspack-codspeed-valgrind-tmp BENCH_MODE=simulation RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases codspeed run -m simulation -- cargo codspeed run -m simulation
 ```
 
 This command:
 
 - Creates a stable temporary directory for CodSpeed and Valgrind files
 - Sets `TMPDIR` so the temporary files are written to that directory
-- Sets `RAYON_NUM_THREADS=1` to match the single-threaded CI simulation environment
+- Sets `BENCH_MODE=simulation` to match the single-threaded CI simulation environment
 - Sets `RSPACK_BENCHCASES_DIR` to the prepared benchmark fixtures
 - Wraps `cargo codspeed run -m simulation` in `codspeed run -m simulation` so local runs use the CodSpeed runner environment instead of only checking benchmarks
 

--- a/xtask/benchmark/benches/benches.rs
+++ b/xtask/benchmark/benches/benches.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use rspack_core::configure_rayon_current_thread_for_codspeed;
 
 mod groups;
 // Keep these registered case entrypoints in a dedicated short source path:
@@ -13,14 +12,14 @@ mod cases;
 #[path = "../stages/mod.rs"]
 mod stages;
 
-fn configure_rayon_for_codspeed(_: &mut Criterion) {
-  configure_rayon_current_thread_for_codspeed();
+fn configure_rayon_for_benchmark(_: &mut Criterion) {
+  rspack_benchmark::configure_rayon_for_benchmark();
 }
 
-criterion_group!(codspeed_setup, configure_rayon_for_codspeed);
+criterion_group!(benchmark_setup, configure_rayon_for_benchmark);
 
 criterion_main!(
-  codspeed_setup,
+  benchmark_setup,
   cases::build_chunk_graph::case,
   cases::build_module_graph::case,
   cases::module_graph_api::case,

--- a/xtask/benchmark/benches/rspack_sources.rs
+++ b/xtask/benchmark/benches/rspack_sources.rs
@@ -1,12 +1,17 @@
 #![allow(clippy::unwrap_used)]
 
-use criterion::{criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 #[path = "groups/rspack_sources.rs"]
 mod rspack_sources;
 
+fn configure_rayon_for_benchmark(_: &mut Criterion) {
+  rspack_benchmark::configure_rayon_for_benchmark();
+}
+
+criterion_group!(benchmark_setup, configure_rayon_for_benchmark);
 criterion_group!(
   rspack_sources_benches,
   rspack_sources::rspack_sources_benchmark
 );
-criterion_main!(rspack_sources_benches);
+criterion_main!(benchmark_setup, rspack_sources_benches);

--- a/xtask/benchmark/benches/walltime.rs
+++ b/xtask/benchmark/benches/walltime.rs
@@ -3,7 +3,6 @@
 use std::{fs, io::ErrorKind, path::PathBuf, sync::Arc};
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use rspack_core::configure_rayon_current_thread_for_codspeed;
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
 
 use crate::groups::{
@@ -17,8 +16,8 @@ use crate::groups::{
 #[path = "walltime_groups/mod.rs"]
 mod groups;
 
-fn configure_rayon_for_codspeed(_: &mut Criterion) {
-  configure_rayon_current_thread_for_codspeed();
+fn configure_rayon_for_benchmark(_: &mut Criterion) {
+  rspack_benchmark::configure_rayon_for_benchmark();
 }
 
 fn threejs_10x_bundle_benchmark(c: &mut Criterion) {
@@ -88,6 +87,6 @@ impl Drop for NativeOutputCleanup {
   }
 }
 
-criterion_group!(codspeed_setup, configure_rayon_for_codspeed);
+criterion_group!(benchmark_setup, configure_rayon_for_benchmark);
 criterion_group!(walltime_benches, threejs_10x_bundle_benchmark);
-criterion_main!(codspeed_setup, walltime_benches);
+criterion_main!(benchmark_setup, walltime_benches);

--- a/xtask/benchmark/src/lib.rs
+++ b/xtask/benchmark/src/lib.rs
@@ -2,10 +2,52 @@
 
 #[cfg(target_family = "wasm")]
 use std::alloc::System;
-use std::alloc::{GlobalAlloc, Layout};
+use std::{
+  alloc::{GlobalAlloc, Layout},
+  sync::Once,
+};
 
 pub use criterion::*;
 use tokio::runtime::{Builder, Runtime};
+
+const ENV_BENCH_MODE: &str = "BENCH_MODE";
+const SIMULATION_BENCHMARK_BLOCKING_THREADS: usize = 8;
+const SIMULATION_BENCHMARK_RAYON_THREADS: usize = 1;
+const WALLTIME_BENCHMARK_THREAD_LIMIT: usize = 16;
+
+static RAYON_FOR_BENCHMARK: Once = Once::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BenchMode {
+  Simulation,
+  Walltime,
+}
+
+impl BenchMode {
+  fn current() -> Self {
+    match std::env::var(ENV_BENCH_MODE).as_deref() {
+      Ok("walltime") => Self::Walltime,
+      Ok("simulation") | Err(_) => Self::Simulation,
+      Ok(value) => {
+        panic!("{ENV_BENCH_MODE} must be either \"simulation\" or \"walltime\", got \"{value}\"")
+      }
+    }
+  }
+
+  fn blocking_threads(self) -> usize {
+    match self {
+      Self::Simulation => SIMULATION_BENCHMARK_BLOCKING_THREADS,
+      Self::Walltime => walltime_benchmark_thread_count(),
+    }
+  }
+
+  fn rayon_threads(self) -> usize {
+    match self {
+      Self::Simulation => SIMULATION_BENCHMARK_RAYON_THREADS,
+      Self::Walltime => walltime_benchmark_thread_count(),
+    }
+  }
+}
 
 #[global_allocator]
 #[cfg(not(target_family = "wasm"))]
@@ -60,11 +102,45 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   }
 }
 
+fn build_multi_thread_tokio_rt(worker_threads: usize, blocking_threads: usize) -> Runtime {
+  let mut builder = Builder::new_multi_thread();
+  builder
+    .worker_threads(worker_threads)
+    .max_blocking_threads(blocking_threads)
+    .build()
+    .expect("should not fail to build tokio runtime")
+}
+
+fn walltime_benchmark_thread_count() -> usize {
+  std::thread::available_parallelism().map_or(WALLTIME_BENCHMARK_THREAD_LIMIT, |cpu| {
+    cpu.get().min(WALLTIME_BENCHMARK_THREAD_LIMIT)
+  })
+}
+
+pub fn configure_rayon_for_benchmark() {
+  RAYON_FOR_BENCHMARK.call_once(|| {
+    rayon::ThreadPoolBuilder::new()
+      .use_current_thread()
+      .num_threads(BenchMode::current().rayon_threads())
+      .build_global()
+      .expect("rayon global thread pool should be configured before rayon is used");
+  });
+}
+
 pub fn build_tokio_rt() -> Runtime {
+  let bench_mode = BenchMode::current();
+
+  if bench_mode == BenchMode::Walltime {
+    return build_multi_thread_tokio_rt(
+      walltime_benchmark_thread_count(),
+      bench_mode.blocking_threads(),
+    );
+  }
+
   #[cfg(codspeed)]
   {
     return Builder::new_current_thread()
-      .max_blocking_threads(8)
+      .max_blocking_threads(bench_mode.blocking_threads())
       .build()
       .expect("should not fail to build tokio runtime");
   }
@@ -75,10 +151,6 @@ pub fn build_tokio_rt() -> Runtime {
     .get();
   #[cfg(not(codspeed))]
   {
-    Builder::new_multi_thread()
-      .worker_threads(cpu_num.min(4))
-      .max_blocking_threads(8)
-      .build()
-      .expect("should not fail to build tokio runtime")
+    build_multi_thread_tokio_rt(cpu_num.min(4), bench_mode.blocking_threads())
   }
 }


### PR DESCRIPTION
## What changed

- Use a single `BENCH_MODE=simulation|walltime` switch for Rust benchmark concurrency instead of `TOKIO_WORKER_THREADS`, `RSPACK_BLOCKING_THREADS`, or `RAYON_NUM_THREADS`.
- Set `BENCH_MODE` from the reusable benchmark workflow's `measurement` input.
- In `BENCH_MODE=walltime`, cap Tokio worker threads, Tokio blocking threads, and Rayon threads at `min(available_parallelism, 16)`.
- In `BENCH_MODE=simulation`, keep the CodSpeed current-thread Tokio runtime and configure Rayon to one thread.
- Apply the shared Rayon benchmark setup to `benches`, `rspack_sources`, and `walltime`, and update docs/local benchmark scripts.

## Why

Walltime benchmarks run on physical runners, so unrestricted machine-size-dependent parallelism can make results harder to compare across runner sizes. Using `BENCH_MODE` keeps the concurrency policy tied to the benchmark measurement mode directly.

## Validation

- `git diff --check`
- `cargo check -p rspack_benchmark --benches --profile codspeed --locked`
- `RUSTFLAGS="--cfg=codspeed" cargo check -p rspack_benchmark --benches --profile codspeed --locked`
