### PR TITLE
perf(core): compact factorize info

### DIFF
--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -170,8 +170,7 @@ impl BuildModuleGraphArtifact {
         self
           .missing_dependencies
           .remove_files(&resource_id, factorize_info.missing_dependencies());
-        // related_dep_ids will contain dep_id it self
-        factorize_info.related_dep_ids().to_vec()
+        factorize_info.related_dep_ids_for_revoke(*dep_id)
       } else {
         vec![*dep_id]
       };

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -135,17 +135,17 @@ impl BuildModuleGraphArtifact {
         if let Some(file_dependencies) = info.file_dependencies() {
           self
             .file_dependencies
-            .remove_files(&resource_id, file_dependencies);
+            .remove_file_paths(&resource_id, file_dependencies);
         }
         if let Some(context_dependencies) = info.context_dependencies() {
           self
             .context_dependencies
-            .remove_files(&resource_id, context_dependencies);
+            .remove_file_paths(&resource_id, context_dependencies);
         }
         if let Some(missing_dependencies) = info.missing_dependencies() {
           self
             .missing_dependencies
-            .remove_files(&resource_id, missing_dependencies);
+            .remove_file_paths(&resource_id, missing_dependencies);
         }
       }
       self.affected_dependencies.mark_as_remove(&dep_id);
@@ -170,17 +170,17 @@ impl BuildModuleGraphArtifact {
         if let Some(file_dependencies) = factorize_info.file_dependencies() {
           self
             .file_dependencies
-            .remove_files(&resource_id, file_dependencies);
+            .remove_file_paths(&resource_id, file_dependencies);
         }
         if let Some(context_dependencies) = factorize_info.context_dependencies() {
           self
             .context_dependencies
-            .remove_files(&resource_id, context_dependencies);
+            .remove_file_paths(&resource_id, context_dependencies);
         }
         if let Some(missing_dependencies) = factorize_info.missing_dependencies() {
           self
             .missing_dependencies
-            .remove_files(&resource_id, missing_dependencies);
+            .remove_file_paths(&resource_id, missing_dependencies);
         }
         factorize_info.related_dep_ids_for_revoke(*dep_id)
       } else {

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -132,15 +132,21 @@ impl BuildModuleGraphArtifact {
       let dep = mg.dependency_by_id_mut(&dep_id);
       if let Some(info) = FactorizeInfo::revoke(dep) {
         let resource_id = ResourceId::from(dep_id);
-        self
-          .file_dependencies
-          .remove_files(&resource_id, info.file_dependencies());
-        self
-          .context_dependencies
-          .remove_files(&resource_id, info.context_dependencies());
-        self
-          .missing_dependencies
-          .remove_files(&resource_id, info.missing_dependencies());
+        if let Some(file_dependencies) = info.file_dependencies() {
+          self
+            .file_dependencies
+            .remove_files(&resource_id, file_dependencies);
+        }
+        if let Some(context_dependencies) = info.context_dependencies() {
+          self
+            .context_dependencies
+            .remove_files(&resource_id, context_dependencies);
+        }
+        if let Some(missing_dependencies) = info.missing_dependencies() {
+          self
+            .missing_dependencies
+            .remove_files(&resource_id, missing_dependencies);
+        }
       }
       self.affected_dependencies.mark_as_remove(&dep_id);
     }
@@ -161,15 +167,21 @@ impl BuildModuleGraphArtifact {
     let revoke_dep_ids =
       if let Some(factorize_info) = FactorizeInfo::revoke(mg.dependency_by_id_mut(dep_id)) {
         let resource_id = ResourceId::from(dep_id);
-        self
-          .file_dependencies
-          .remove_files(&resource_id, factorize_info.file_dependencies());
-        self
-          .context_dependencies
-          .remove_files(&resource_id, factorize_info.context_dependencies());
-        self
-          .missing_dependencies
-          .remove_files(&resource_id, factorize_info.missing_dependencies());
+        if let Some(file_dependencies) = factorize_info.file_dependencies() {
+          self
+            .file_dependencies
+            .remove_files(&resource_id, file_dependencies);
+        }
+        if let Some(context_dependencies) = factorize_info.context_dependencies() {
+          self
+            .context_dependencies
+            .remove_files(&resource_id, context_dependencies);
+        }
+        if let Some(missing_dependencies) = factorize_info.missing_dependencies() {
+          self
+            .missing_dependencies
+            .remove_files(&resource_id, missing_dependencies);
+        }
         factorize_info.related_dep_ids_for_revoke(*dep_id)
       } else {
         vec![*dep_id]

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -117,9 +117,15 @@ impl Occasion for MakeOccasion {
           make_failed_dependencies.insert(*dep_id);
         }
         let resource = dep_id.into();
-        file_dep.add_files(&resource, info.file_dependencies());
-        context_dep.add_files(&resource, info.context_dependencies());
-        missing_dep.add_files(&resource, info.missing_dependencies());
+        if let Some(file_dependencies) = info.file_dependencies() {
+          file_dep.add_files(&resource, file_dependencies);
+        }
+        if let Some(context_dependencies) = info.context_dependencies() {
+          context_dep.add_files(&resource, context_dependencies);
+        }
+        if let Some(missing_dependencies) = info.missing_dependencies() {
+          missing_dep.add_files(&resource, missing_dependencies);
+        }
       }
     }
 

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -118,13 +118,13 @@ impl Occasion for MakeOccasion {
         }
         let resource = dep_id.into();
         if let Some(file_dependencies) = info.file_dependencies() {
-          file_dep.add_files(&resource, file_dependencies);
+          file_dep.add_file_paths(&resource, file_dependencies);
         }
         if let Some(context_dependencies) = info.context_dependencies() {
-          context_dep.add_files(&resource, context_dependencies);
+          context_dep.add_file_paths(&resource, context_dependencies);
         }
         if let Some(missing_dependencies) = info.missing_dependencies() {
-          missing_dep.add_files(&resource, missing_dependencies);
+          missing_dep.add_file_paths(&resource, missing_dependencies);
         }
       }
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -110,13 +110,18 @@ impl Task<TaskContext> for FactorizeTask {
       }
     };
 
-    let factorize_info = FactorizeInfo::new(
-      create_data.diagnostics,
+    let related_dep_ids = if create_data.dependencies.len() > 1 {
       create_data
         .dependencies
         .iter()
         .map(|dep| *dep.id())
-        .collect(),
+        .collect()
+    } else {
+      Vec::new()
+    };
+    let factorize_info = FactorizeInfo::new(
+      create_data.diagnostics,
+      related_dep_ids,
       create_data.file_dependencies,
       create_data.context_dependencies,
       create_data.missing_dependencies,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -168,15 +168,21 @@ impl Task<TaskContext> for FactorizeResultTask {
         .insert(*dependencies[0].id());
     }
     let resource_id = ResourceId::from(*dependencies[0].id());
-    artifact
-      .file_dependencies
-      .add_files(&resource_id, factorize_info.file_dependencies());
-    artifact
-      .context_dependencies
-      .add_files(&resource_id, factorize_info.context_dependencies());
-    artifact
-      .missing_dependencies
-      .add_files(&resource_id, factorize_info.missing_dependencies());
+    if let Some(file_dependencies) = factorize_info.file_dependencies() {
+      artifact
+        .file_dependencies
+        .add_files(&resource_id, file_dependencies);
+    }
+    if let Some(context_dependencies) = factorize_info.context_dependencies() {
+      artifact
+        .context_dependencies
+        .add_files(&resource_id, context_dependencies);
+    }
+    if let Some(missing_dependencies) = factorize_info.missing_dependencies() {
+      artifact
+        .missing_dependencies
+        .add_files(&resource_id, missing_dependencies);
+    }
 
     for dep in &mut dependencies {
       // Some dependencies do not come from the process_dependencies task,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -171,17 +171,17 @@ impl Task<TaskContext> for FactorizeResultTask {
     if let Some(file_dependencies) = factorize_info.file_dependencies() {
       artifact
         .file_dependencies
-        .add_files(&resource_id, file_dependencies);
+        .add_file_paths(&resource_id, file_dependencies);
     }
     if let Some(context_dependencies) = factorize_info.context_dependencies() {
       artifact
         .context_dependencies
-        .add_files(&resource_id, context_dependencies);
+        .add_file_paths(&resource_id, context_dependencies);
     }
     if let Some(missing_dependencies) = factorize_info.missing_dependencies() {
       artifact
         .missing_dependencies
-        .add_files(&resource_id, missing_dependencies);
+        .add_file_paths(&resource_id, missing_dependencies);
     }
 
     for dep in &mut dependencies {

--- a/crates/rspack_core/src/dependency/factorize_info.rs
+++ b/crates/rspack_core/src/dependency/factorize_info.rs
@@ -1,27 +1,30 @@
-use std::sync::LazyLock;
-
 use rspack_cacheable::cacheable;
 use rspack_error::Diagnostic;
 use rspack_paths::ArcPathSet;
 
 use super::{BoxDependency, DependencyId};
 
-static EMPTY_ARC_PATH_SET: LazyLock<ArcPathSet> = LazyLock::new(ArcPathSet::default);
-
 #[cacheable]
 #[derive(Debug, Clone, Default)]
 pub struct FactorizeInfo {
+  /// Whether this value came from a factorization result.
+  ///
+  /// A default value is also stored on secondary dependencies after their
+  /// factorization group's info has been moved to the first dependency; keep
+  /// this flag so revocation can preserve the previous "no related ids"
+  /// behavior for those defaults while still representing the common
+  /// single-dependency result without storing its id.
+  has_info: bool,
   /// Dependencies resolved by the same factorization task.
   ///
-  /// `None` represents a default placeholder, while `Some([])` represents the
-  /// overwhelmingly common "only this dependency" case. Callers that revoke a
-  /// dependency already know the owner dependency id and can use that id for
-  /// this single-dependency case without storing it in every hot dependency.
-  related_dep_ids: Option<Box<[DependencyId]>>,
+  /// Empty represents the overwhelmingly common "only this dependency" case.
+  /// Callers that revoke a dependency already know the owner dependency id and
+  /// can use that id without storing it in every hot dependency.
+  related_dep_ids: Vec<DependencyId>,
   file_dependencies: Option<Box<ArcPathSet>>,
   context_dependencies: Option<Box<ArcPathSet>>,
   missing_dependencies: Option<Box<ArcPathSet>>,
-  diagnostics: Option<Box<[Diagnostic]>>,
+  diagnostics: Vec<Diagnostic>,
 }
 
 impl FactorizeInfo {
@@ -32,20 +35,19 @@ impl FactorizeInfo {
     context_dependencies: ArcPathSet,
     missing_dependencies: ArcPathSet,
   ) -> Self {
-    let related_dep_ids = Some(if related_dep_ids.len() > 1 {
-      related_dep_ids.into_boxed_slice()
-    } else {
-      Box::default()
-    });
-
     Self {
-      related_dep_ids,
+      has_info: true,
+      related_dep_ids: if related_dep_ids.len() > 1 {
+        related_dep_ids
+      } else {
+        Vec::new()
+      },
       file_dependencies: (!file_dependencies.is_empty()).then_some(Box::new(file_dependencies)),
       context_dependencies: (!context_dependencies.is_empty())
         .then_some(Box::new(context_dependencies)),
       missing_dependencies: (!missing_dependencies.is_empty())
         .then_some(Box::new(missing_dependencies)),
-      diagnostics: (!diagnostics.is_empty()).then_some(diagnostics.into_boxed_slice()),
+      diagnostics,
     }
   }
 
@@ -70,56 +72,37 @@ impl FactorizeInfo {
   }
 
   pub fn is_success(&self) -> bool {
-    self.diagnostics.is_none()
+    self.diagnostics.is_empty()
   }
 
   pub fn related_dep_ids(&self) -> &[DependencyId] {
-    self
-      .related_dep_ids
-      .as_ref()
-      .map_or(&[], |related_dep_ids| related_dep_ids.as_ref())
+    &self.related_dep_ids
   }
 
   pub fn related_dep_ids_for_revoke(&self, dep_id: DependencyId) -> Vec<DependencyId> {
-    match &self.related_dep_ids {
-      Some(related_dep_ids) if !related_dep_ids.is_empty() => related_dep_ids.to_vec(),
-      Some(_) => vec![dep_id],
-      None => vec![],
+    if !self.related_dep_ids.is_empty() {
+      self.related_dep_ids.clone()
+    } else if self.has_info {
+      vec![dep_id]
+    } else {
+      vec![]
     }
   }
 
-  pub fn file_dependencies(&self) -> &ArcPathSet {
-    self
-      .file_dependencies
-      .as_ref()
-      .map_or(&EMPTY_ARC_PATH_SET, |file_dependencies| {
-        file_dependencies.as_ref()
-      })
+  pub fn file_dependencies(&self) -> Option<&ArcPathSet> {
+    self.file_dependencies.as_deref()
   }
 
-  pub fn context_dependencies(&self) -> &ArcPathSet {
-    self
-      .context_dependencies
-      .as_ref()
-      .map_or(&EMPTY_ARC_PATH_SET, |context_dependencies| {
-        context_dependencies.as_ref()
-      })
+  pub fn context_dependencies(&self) -> Option<&ArcPathSet> {
+    self.context_dependencies.as_deref()
   }
 
-  pub fn missing_dependencies(&self) -> &ArcPathSet {
-    self
-      .missing_dependencies
-      .as_ref()
-      .map_or(&EMPTY_ARC_PATH_SET, |missing_dependencies| {
-        missing_dependencies.as_ref()
-      })
+  pub fn missing_dependencies(&self) -> Option<&ArcPathSet> {
+    self.missing_dependencies.as_deref()
   }
 
   pub fn diagnostics(&self) -> &[Diagnostic] {
-    self
-      .diagnostics
-      .as_ref()
-      .map_or(&[], |diagnostics| diagnostics.as_ref())
+    &self.diagnostics
   }
 }
 

--- a/crates/rspack_core/src/dependency/factorize_info.rs
+++ b/crates/rspack_core/src/dependency/factorize_info.rs
@@ -11,18 +11,12 @@ static EMPTY_ARC_PATH_SET: LazyLock<ArcPathSet> = LazyLock::new(ArcPathSet::defa
 #[cacheable]
 #[derive(Debug, Clone, Default)]
 pub struct FactorizeInfo {
-  /// Whether this value came from a factorization result.
-  ///
-  /// A default value is also stored on secondary dependencies after their
-  /// factorization group's info has been moved to the first dependency; keep
-  /// this flag so revocation can preserve the previous "no related ids"
-  /// behavior for those defaults.
-  has_info: bool,
   /// Dependencies resolved by the same factorization task.
   ///
-  /// `None` represents the overwhelmingly common "only this dependency" case.
-  /// Callers that revoke a dependency already know the owner dependency id and
-  /// can use that id when this field is absent.
+  /// `None` represents a default placeholder, while `Some([])` represents the
+  /// overwhelmingly common "only this dependency" case. Callers that revoke a
+  /// dependency already know the owner dependency id and can use that id for
+  /// this single-dependency case without storing it in every hot dependency.
   related_dep_ids: Option<Box<[DependencyId]>>,
   file_dependencies: Option<Box<ArcPathSet>>,
   context_dependencies: Option<Box<ArcPathSet>>,
@@ -38,9 +32,14 @@ impl FactorizeInfo {
     context_dependencies: ArcPathSet,
     missing_dependencies: ArcPathSet,
   ) -> Self {
+    let related_dep_ids = Some(if related_dep_ids.len() > 1 {
+      related_dep_ids.into_boxed_slice()
+    } else {
+      Box::default()
+    });
+
     Self {
-      has_info: true,
-      related_dep_ids: (related_dep_ids.len() > 1).then_some(related_dep_ids.into_boxed_slice()),
+      related_dep_ids,
       file_dependencies: (!file_dependencies.is_empty()).then_some(Box::new(file_dependencies)),
       context_dependencies: (!context_dependencies.is_empty())
         .then_some(Box::new(context_dependencies)),
@@ -82,13 +81,10 @@ impl FactorizeInfo {
   }
 
   pub fn related_dep_ids_for_revoke(&self, dep_id: DependencyId) -> Vec<DependencyId> {
-    let related_dep_ids = self.related_dep_ids();
-    if !related_dep_ids.is_empty() {
-      related_dep_ids.to_vec()
-    } else if self.has_info {
-      vec![dep_id]
-    } else {
-      vec![]
+    match &self.related_dep_ids {
+      Some(related_dep_ids) if !related_dep_ids.is_empty() => related_dep_ids.to_vec(),
+      Some(_) => vec![dep_id],
+      None => vec![],
     }
   }
 

--- a/crates/rspack_core/src/dependency/factorize_info.rs
+++ b/crates/rspack_core/src/dependency/factorize_info.rs
@@ -1,6 +1,11 @@
-use rspack_cacheable::cacheable;
+use std::sync::Arc;
+
+use rspack_cacheable::{
+  cacheable,
+  with::{AsCacheable, AsOption, AsVec},
+};
 use rspack_error::Diagnostic;
-use rspack_paths::ArcPathSet;
+use rspack_paths::{ArcPath, ArcPathSet};
 
 use super::{BoxDependency, DependencyId};
 
@@ -20,11 +25,23 @@ pub struct FactorizeInfo {
   /// Empty represents the overwhelmingly common "only this dependency" case.
   /// Callers that revoke a dependency already know the owner dependency id and
   /// can use that id without storing it in every hot dependency.
-  related_dep_ids: Vec<DependencyId>,
-  file_dependencies: Option<Box<ArcPathSet>>,
-  context_dependencies: Option<Box<ArcPathSet>>,
-  missing_dependencies: Option<Box<ArcPathSet>>,
+  #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
+  related_dep_ids: Option<Arc<[DependencyId]>>,
+  #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
+  file_dependencies: Option<Arc<[ArcPath]>>,
+  #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
+  context_dependencies: Option<Arc<[ArcPath]>>,
+  #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
+  missing_dependencies: Option<Arc<[ArcPath]>>,
   diagnostics: Vec<Diagnostic>,
+}
+
+fn compact_path_set(paths: ArcPathSet) -> Option<Arc<[ArcPath]>> {
+  if paths.is_empty() {
+    None
+  } else {
+    Some(paths.into_iter().collect::<Vec<_>>().into())
+  }
 }
 
 impl FactorizeInfo {
@@ -38,15 +55,13 @@ impl FactorizeInfo {
     Self {
       has_info: true,
       related_dep_ids: if related_dep_ids.len() > 1 {
-        related_dep_ids
+        Some(related_dep_ids.into())
       } else {
-        Vec::new()
+        None
       },
-      file_dependencies: (!file_dependencies.is_empty()).then_some(Box::new(file_dependencies)),
-      context_dependencies: (!context_dependencies.is_empty())
-        .then_some(Box::new(context_dependencies)),
-      missing_dependencies: (!missing_dependencies.is_empty())
-        .then_some(Box::new(missing_dependencies)),
+      file_dependencies: compact_path_set(file_dependencies),
+      context_dependencies: compact_path_set(context_dependencies),
+      missing_dependencies: compact_path_set(missing_dependencies),
       diagnostics,
     }
   }
@@ -76,12 +91,12 @@ impl FactorizeInfo {
   }
 
   pub fn related_dep_ids(&self) -> &[DependencyId] {
-    &self.related_dep_ids
+    self.related_dep_ids.as_deref().unwrap_or_default()
   }
 
   pub fn related_dep_ids_for_revoke(&self, dep_id: DependencyId) -> Vec<DependencyId> {
-    if !self.related_dep_ids.is_empty() {
-      self.related_dep_ids.clone()
+    if let Some(related_dep_ids) = &self.related_dep_ids {
+      related_dep_ids.to_vec()
     } else if self.has_info {
       vec![dep_id]
     } else {
@@ -89,15 +104,15 @@ impl FactorizeInfo {
     }
   }
 
-  pub fn file_dependencies(&self) -> Option<&ArcPathSet> {
+  pub fn file_dependencies(&self) -> Option<&[ArcPath]> {
     self.file_dependencies.as_deref()
   }
 
-  pub fn context_dependencies(&self) -> Option<&ArcPathSet> {
+  pub fn context_dependencies(&self) -> Option<&[ArcPath]> {
     self.context_dependencies.as_deref()
   }
 
-  pub fn missing_dependencies(&self) -> Option<&ArcPathSet> {
+  pub fn missing_dependencies(&self) -> Option<&[ArcPath]> {
     self.missing_dependencies.as_deref()
   }
 

--- a/crates/rspack_core/src/dependency/factorize_info.rs
+++ b/crates/rspack_core/src/dependency/factorize_info.rs
@@ -1,17 +1,33 @@
+use std::sync::LazyLock;
+
 use rspack_cacheable::cacheable;
 use rspack_error::Diagnostic;
 use rspack_paths::ArcPathSet;
 
 use super::{BoxDependency, DependencyId};
 
+static EMPTY_ARC_PATH_SET: LazyLock<ArcPathSet> = LazyLock::new(ArcPathSet::default);
+
 #[cacheable]
 #[derive(Debug, Clone, Default)]
 pub struct FactorizeInfo {
-  related_dep_ids: Vec<DependencyId>,
-  file_dependencies: ArcPathSet,
-  context_dependencies: ArcPathSet,
-  missing_dependencies: ArcPathSet,
-  diagnostics: Vec<Diagnostic>,
+  /// Whether this value came from a factorization result.
+  ///
+  /// A default value is also stored on secondary dependencies after their
+  /// factorization group's info has been moved to the first dependency; keep
+  /// this flag so revocation can preserve the previous "no related ids"
+  /// behavior for those defaults.
+  has_info: bool,
+  /// Dependencies resolved by the same factorization task.
+  ///
+  /// `None` represents the overwhelmingly common "only this dependency" case.
+  /// Callers that revoke a dependency already know the owner dependency id and
+  /// can use that id when this field is absent.
+  related_dep_ids: Option<Box<[DependencyId]>>,
+  file_dependencies: Option<Box<ArcPathSet>>,
+  context_dependencies: Option<Box<ArcPathSet>>,
+  missing_dependencies: Option<Box<ArcPathSet>>,
+  diagnostics: Option<Box<[Diagnostic]>>,
 }
 
 impl FactorizeInfo {
@@ -23,11 +39,14 @@ impl FactorizeInfo {
     missing_dependencies: ArcPathSet,
   ) -> Self {
     Self {
-      related_dep_ids,
-      file_dependencies,
-      context_dependencies,
-      missing_dependencies,
-      diagnostics,
+      has_info: true,
+      related_dep_ids: (related_dep_ids.len() > 1).then_some(related_dep_ids.into_boxed_slice()),
+      file_dependencies: (!file_dependencies.is_empty()).then_some(Box::new(file_dependencies)),
+      context_dependencies: (!context_dependencies.is_empty())
+        .then_some(Box::new(context_dependencies)),
+      missing_dependencies: (!missing_dependencies.is_empty())
+        .then_some(Box::new(missing_dependencies)),
+      diagnostics: (!diagnostics.is_empty()).then_some(diagnostics.into_boxed_slice()),
     }
   }
 
@@ -52,26 +71,104 @@ impl FactorizeInfo {
   }
 
   pub fn is_success(&self) -> bool {
-    self.diagnostics.is_empty()
+    self.diagnostics.is_none()
   }
 
   pub fn related_dep_ids(&self) -> &[DependencyId] {
-    &self.related_dep_ids
+    self
+      .related_dep_ids
+      .as_ref()
+      .map_or(&[], |related_dep_ids| related_dep_ids.as_ref())
+  }
+
+  pub fn related_dep_ids_for_revoke(&self, dep_id: DependencyId) -> Vec<DependencyId> {
+    let related_dep_ids = self.related_dep_ids();
+    if !related_dep_ids.is_empty() {
+      related_dep_ids.to_vec()
+    } else if self.has_info {
+      vec![dep_id]
+    } else {
+      vec![]
+    }
   }
 
   pub fn file_dependencies(&self) -> &ArcPathSet {
-    &self.file_dependencies
+    self
+      .file_dependencies
+      .as_ref()
+      .map_or(&EMPTY_ARC_PATH_SET, |file_dependencies| {
+        file_dependencies.as_ref()
+      })
   }
 
   pub fn context_dependencies(&self) -> &ArcPathSet {
-    &self.context_dependencies
+    self
+      .context_dependencies
+      .as_ref()
+      .map_or(&EMPTY_ARC_PATH_SET, |context_dependencies| {
+        context_dependencies.as_ref()
+      })
   }
 
   pub fn missing_dependencies(&self) -> &ArcPathSet {
-    &self.missing_dependencies
+    self
+      .missing_dependencies
+      .as_ref()
+      .map_or(&EMPTY_ARC_PATH_SET, |missing_dependencies| {
+        missing_dependencies.as_ref()
+      })
   }
 
   pub fn diagnostics(&self) -> &[Diagnostic] {
-    &self.diagnostics
+    self
+      .diagnostics
+      .as_ref()
+      .map_or(&[], |diagnostics| diagnostics.as_ref())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn default_info_has_no_related_dependencies_for_revoke() {
+    let dep_id = DependencyId::from(1);
+    assert!(
+      FactorizeInfo::default()
+        .related_dep_ids_for_revoke(dep_id)
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn single_dependency_info_uses_owner_for_revoke_without_storing_id() {
+    let dep_id = DependencyId::from(1);
+    let info = FactorizeInfo::new(
+      vec![],
+      vec![dep_id],
+      Default::default(),
+      Default::default(),
+      Default::default(),
+    );
+
+    assert!(info.related_dep_ids().is_empty());
+    assert_eq!(info.related_dep_ids_for_revoke(dep_id), vec![dep_id]);
+  }
+
+  #[test]
+  fn multiple_dependency_info_keeps_related_ids_for_revoke() {
+    let first = DependencyId::from(1);
+    let second = DependencyId::from(2);
+    let info = FactorizeInfo::new(
+      vec![],
+      vec![first, second],
+      Default::default(),
+      Default::default(),
+      Default::default(),
+    );
+
+    assert_eq!(info.related_dep_ids(), &[first, second]);
+    assert_eq!(info.related_dep_ids_for_revoke(first), vec![first, second]);
   }
 }

--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -53,17 +53,47 @@ pub struct FileCounter {
 }
 
 impl FileCounter {
+  #[inline]
+  fn add_file(&mut self, resource_id: &ResourceId, path: &ArcPath) {
+    let list = self.inner.entry(path.clone()).or_default();
+    if list.is_empty() {
+      self.incremental_info.mark_as_add(path);
+    }
+    // multiple additions are allowed without additional checks to see if the addition was successful
+    list.insert(resource_id);
+  }
+
+  #[inline]
+  fn remove_file(&mut self, resource_id: &ResourceId, path: &ArcPath) {
+    let Some(list) = self.inner.get_mut(path) else {
+      panic!("unable to remove untracked file {}", path.to_string_lossy());
+    };
+    if !list.remove(resource_id) {
+      panic!(
+        "unable to remove path '{}' with resource_id '{:?}', it has not been added.",
+        path.to_string_lossy(),
+        resource_id,
+      )
+    }
+    if list.is_empty() {
+      self.incremental_info.mark_as_remove(path);
+      self.inner.remove(path);
+    }
+  }
+
   /// Add batch [`PathBuf`] to counter
   ///
   /// It will add resource_id at the PathBuf in inner hashmap
   pub fn add_files(&mut self, resource_id: &ResourceId, paths: &ArcPathSet) {
     for path in paths {
-      let list = self.inner.entry(path.clone()).or_default();
-      if list.is_empty() {
-        self.incremental_info.mark_as_add(path);
-      }
-      // multiple additions are allowed without additional checks to see if the addition was successful
-      list.insert(resource_id);
+      self.add_file(resource_id, path);
+    }
+  }
+
+  /// Add compact batch of paths to counter.
+  pub fn add_file_paths(&mut self, resource_id: &ResourceId, paths: &[ArcPath]) {
+    for path in paths {
+      self.add_file(resource_id, path);
     }
   }
 
@@ -75,20 +105,14 @@ impl FileCounter {
   /// If PathBuf does not exist, panic will occur.
   pub fn remove_files(&mut self, resource_id: &ResourceId, paths: &ArcPathSet) {
     for path in paths {
-      let Some(list) = self.inner.get_mut(path) else {
-        panic!("unable to remove untracked file {}", path.to_string_lossy());
-      };
-      if !list.remove(resource_id) {
-        panic!(
-          "unable to remove path '{}' with resource_id '{:?}', it has not been added.",
-          path.to_string_lossy(),
-          resource_id,
-        )
-      }
-      if list.is_empty() {
-        self.incremental_info.mark_as_remove(path);
-        self.inner.remove(path);
-      }
+      self.remove_file(resource_id, path);
+    }
+  }
+
+  /// Remove compact batch of paths from counter.
+  pub fn remove_file_paths(&mut self, resource_id: &ResourceId, paths: &[ArcPath]) {
+    for path in paths {
+      self.remove_file(resource_id, path);
     }
   }
 
@@ -239,6 +263,23 @@ mod test {
     counter.remove_files(&resource_2, &file_list_a);
     assert_eq!(counter.added_files().count(), 0);
     assert_eq!(counter.removed_files().count(), 1);
+  }
+
+  #[test]
+  fn file_counter_supports_compact_path_slices() {
+    let mut counter = FileCounter::default();
+    let file_a = ArcPath::from(std::path::PathBuf::from("/a"));
+    let file_b = ArcPath::from(std::path::PathBuf::from("/b"));
+    let file_list = vec![file_a, file_b];
+    let resource = ResourceId::Module("A".into());
+
+    counter.add_file_paths(&resource, &file_list);
+    assert_eq!(counter.files().count(), 2);
+    assert_eq!(counter.added_files().count(), 2);
+
+    counter.remove_file_paths(&resource, &file_list);
+    assert_eq!(counter.files().count(), 0);
+    assert_eq!(counter.removed_files().count(), 0);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Compact `FactorizeInfo` for successful/common cases by storing optional compact shared slices for related dependency ids and factorize path dependencies instead of always retaining inline `Vec`/`HashSet` metadata.
- Avoid storing or transiently collecting the related dependency id list for the common single-dependency factorization result; `related_dep_ids_for_revoke` uses the owner dependency id while preserving default/secondary dependency behavior.
- Convert factorize file/context/missing dependency sets into compact shared path slices after factorization, so retained info no longer keeps `HashSet` bucket storage. `FileCounter` now has slice-based add/remove helpers for these compact paths.
- This targets the module graph dependency hot path: `FactorizeInfo` is embedded in module/context dependencies, which are high-cardinality objects. Reducing its inline footprint and retained path-set buckets should reduce memory across large compilations.

Benchmark notes:

- Local size probe: `FactorizeInfo` is 96 bytes on this branch versus 144 bytes on `origin/main`, and retained factorize path dependencies no longer keep `HashSet` buckets.
- Ecosystem Benchmark for this tree: weighted RSS across reported cases is 16,329 MiB → 16,032 MiB (`-1.82%`); 16 cases improved by at least 1% RSS, 5 regressed.
- The same Ecosystem run completed successfully with no threshold-exceeded footer.
- CodSpeed reports: “Merging this PR will not alter performance” for this tree, with one small regression and one small improvement reported in simulation mode.

Checks run locally:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p rspack_core`
- `cargo test -p rspack_core --lib factorize_info -- --nocapture`
- `cargo test -p rspack_core --lib file_counter -- --nocapture`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test:unit` was attempted after the builds, but failed locally due the OS watcher limit (`ENOSPC`) in native watcher tests.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
