### PR TITLE
fix(library): implement JsonpLibraryPlugin for `output.library.type: 'jsonp'`

### DIFF
--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -104,7 +104,7 @@ async fn render(
   let mut source = ConcatSource::default();
   source.add(RawStringSource::from(format!("{name}(")));
   source.add(render_source.source.clone());
-  source.add(RawStringSource::from_static(")"));
+  source.add(RawStringSource::from_static("\n)"));
   render_source.source = source.boxed();
   Ok(())
 }

--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -1,0 +1,158 @@
+use std::hash::Hash;
+
+use rspack_core::{
+  ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements, CompilationParams,
+  CompilerCompilation, Filename, LibraryName, LibraryNonUmdObject, LibraryOptions, LibraryType,
+  PathData, Plugin, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SourceType,
+  rspack_sources::{ConcatSource, RawStringSource, SourceExt},
+};
+use rspack_error::{Result, error_bail};
+use rspack_hash::RspackHash;
+use rspack_hook::{plugin, plugin_hook};
+use rspack_plugin_javascript::{
+  JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
+};
+
+use crate::utils::{COMMON_LIBRARY_NAME_MESSAGE, get_options_for_chunk};
+
+const PLUGIN_NAME: &str = "rspack.JsonpLibraryPlugin";
+
+#[derive(Debug)]
+struct JsonpLibraryPluginParsed<'a> {
+  name: &'a str,
+}
+
+#[plugin]
+#[derive(Debug)]
+pub struct JsonpLibraryPlugin {
+  library_type: LibraryType,
+}
+
+impl JsonpLibraryPlugin {
+  pub fn new(library_type: LibraryType) -> Self {
+    Self::new_inner(library_type)
+  }
+
+  fn parse_options<'a>(&self, library: &'a LibraryOptions) -> Result<JsonpLibraryPluginParsed<'a>> {
+    match &library.name {
+      Some(LibraryName::NonUmdObject(LibraryNonUmdObject::String(s))) => {
+        Ok(JsonpLibraryPluginParsed { name: s.as_str() })
+      }
+      _ => {
+        error_bail!("Jsonp library name must be a simple string. {COMMON_LIBRARY_NAME_MESSAGE}")
+      }
+    }
+  }
+
+  fn get_options_for_chunk<'a>(
+    &self,
+    compilation: &'a Compilation,
+    chunk_ukey: &'a ChunkUkey,
+  ) -> Result<Option<JsonpLibraryPluginParsed<'a>>> {
+    get_options_for_chunk(compilation, chunk_ukey)
+      .filter(|library| library.library_type == self.library_type)
+      .map(|library| self.parse_options(library))
+      .transpose()
+  }
+}
+
+#[plugin_hook(CompilerCompilation for JsonpLibraryPlugin)]
+async fn compilation(
+  &self,
+  compilation: &mut Compilation,
+  _params: &mut CompilationParams,
+) -> Result<()> {
+  let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
+  let mut hooks = hooks.write().await;
+  hooks.render.tap(render::new(self));
+  hooks.chunk_hash.tap(js_chunk_hash::new(self));
+  Ok(())
+}
+
+#[plugin_hook(JavascriptModulesRender for JsonpLibraryPlugin)]
+async fn render(
+  &self,
+  compilation: &Compilation,
+  chunk_ukey: &ChunkUkey,
+  render_source: &mut RenderSource,
+  _runtime_template: &RuntimeCodeTemplate<'_>,
+) -> Result<()> {
+  let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
+    return Ok(());
+  };
+  let chunk = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .expect_get(chunk_ukey);
+  let name = compilation
+    .get_path(
+      &Filename::from(options.name),
+      PathData::default()
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+        .chunk_hash_optional(chunk.rendered_hash(
+          &compilation.chunk_hashes_artifact,
+          compilation.options.output.hash_digest_length,
+        ))
+        .chunk_name_optional(chunk.name_for_filename_template())
+        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
+          &compilation.chunk_hashes_artifact,
+          &SourceType::JavaScript,
+          compilation.options.output.hash_digest_length,
+        )),
+    )
+    .await?;
+  let mut source = ConcatSource::default();
+  source.add(RawStringSource::from(format!("{name}(")));
+  source.add(render_source.source.clone());
+  source.add(RawStringSource::from_static(")"));
+  render_source.source = source.boxed();
+  Ok(())
+}
+
+#[plugin_hook(JavascriptModulesChunkHash for JsonpLibraryPlugin)]
+async fn js_chunk_hash(
+  &self,
+  compilation: &Compilation,
+  chunk_ukey: &ChunkUkey,
+  hasher: &mut RspackHash,
+) -> Result<()> {
+  let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
+    return Ok(());
+  };
+  PLUGIN_NAME.hash(hasher);
+  options.name.hash(hasher);
+  Ok(())
+}
+
+#[plugin_hook(CompilationAdditionalChunkRuntimeRequirements for JsonpLibraryPlugin)]
+async fn additional_chunk_runtime_requirements(
+  &self,
+  compilation: &Compilation,
+  chunk_ukey: &ChunkUkey,
+  runtime_requirements: &mut RuntimeGlobals,
+  _runtime_modules: &mut Vec<Box<dyn RuntimeModule>>,
+) -> Result<()> {
+  if self
+    .get_options_for_chunk(compilation, chunk_ukey)?
+    .is_none()
+  {
+    return Ok(());
+  }
+  runtime_requirements.insert(RuntimeGlobals::RETURN_EXPORTS_FROM_RUNTIME);
+  Ok(())
+}
+
+impl Plugin for JsonpLibraryPlugin {
+  fn name(&self) -> &'static str {
+    PLUGIN_NAME
+  }
+
+  fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {
+    ctx.compiler_hooks.compilation.tap(compilation::new(self));
+    ctx
+      .compilation_hooks
+      .additional_chunk_runtime_requirements
+      .tap(additional_chunk_runtime_requirements::new(self));
+    Ok(())
+  }
+}

--- a/crates/rspack_plugin_library/src/lib.rs
+++ b/crates/rspack_plugin_library/src/lib.rs
@@ -1,6 +1,7 @@
 mod amd_library_plugin;
 mod assign_library_plugin;
 mod export_property_library_plugin;
+mod jsonp_library_plugin;
 mod module_library_plugin;
 mod system_library_plugin;
 mod umd_library_plugin;
@@ -11,6 +12,7 @@ use std::path::PathBuf;
 pub use amd_library_plugin::AmdLibraryPlugin;
 pub use assign_library_plugin::*;
 pub use export_property_library_plugin::ExportPropertyLibraryPlugin;
+pub use jsonp_library_plugin::JsonpLibraryPlugin;
 use rspack_core::{BoxPlugin, PluginExt};
 use rspack_plugin_esm_library::EsmLibraryPlugin;
 use rspack_plugin_split_chunks::CacheGroup;
@@ -134,6 +136,11 @@ pub fn enable_library_plugin(
           .boxed(),
       );
       plugins.push(SystemLibraryPlugin::default().boxed());
+    }
+    "jsonp" => {
+      plugins
+        .push(ExportPropertyLibraryPlugin::new(library_type.clone(), ns_object_used, true).boxed());
+      plugins.push(JsonpLibraryPlugin::new(library_type).boxed());
     }
     _ => {}
   }

--- a/tests/rspack-test/configCases/library/jsonp-export/index.js
+++ b/tests/rspack-test/configCases/library/jsonp-export/index.js
@@ -1,0 +1,6 @@
+it("should pass only the exported property to jsonp callback", function () {
+	expect(global.__jsonpExportCapture).toBe(42);
+});
+
+export const answer = 42;
+export const other = "not exported";

--- a/tests/rspack-test/configCases/library/jsonp-export/rspack.config.js
+++ b/tests/rspack-test/configCases/library/jsonp-export/rspack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  output: {
+    library: {
+      type: 'jsonp',
+      name: 'MyJsonpCallback',
+      export: 'answer',
+    },
+  },
+};

--- a/tests/rspack-test/configCases/library/jsonp-export/test.config.js
+++ b/tests/rspack-test/configCases/library/jsonp-export/test.config.js
@@ -1,0 +1,11 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+  moduleScope(scope) {
+    scope.MyJsonpCallback = function (exports) {
+      global.__jsonpExportCapture = exports;
+    };
+  },
+  afterExecute() {
+    delete global.__jsonpExportCapture;
+  },
+};

--- a/tests/rspack-test/configCases/library/jsonp-invalid-name/errors.js
+++ b/tests/rspack-test/configCases/library/jsonp-invalid-name/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Jsonp library name must be a simple string/]
+];

--- a/tests/rspack-test/configCases/library/jsonp-invalid-name/index.js
+++ b/tests/rspack-test/configCases/library/jsonp-invalid-name/index.js
@@ -1,0 +1,3 @@
+it("should error", function () {
+	throw new Error("should not be executed");
+});

--- a/tests/rspack-test/configCases/library/jsonp-invalid-name/rspack.config.js
+++ b/tests/rspack-test/configCases/library/jsonp-invalid-name/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  output: {
+    library: {
+      type: 'jsonp',
+      name: ['not', 'a', 'string'],
+    },
+  },
+};

--- a/tests/rspack-test/configCases/library/jsonp/index.js
+++ b/tests/rspack-test/configCases/library/jsonp/index.js
@@ -3,7 +3,7 @@ it("should wrap output in jsonp callback", function () {
 	var source = fs.readFileSync(__filename, "utf-8");
 
 	expect(source.startsWith("MyJsonpCallback(")).toBe(true);
-	expect(source).toMatch("return __webpack_exports__");
+	expect(source).toContain("return __webpack_exports__");
 });
 
 it("should pass exports to jsonp callback", function () {

--- a/tests/rspack-test/configCases/library/jsonp/index.js
+++ b/tests/rspack-test/configCases/library/jsonp/index.js
@@ -1,0 +1,14 @@
+it("should wrap output in jsonp callback", function () {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source.startsWith("MyJsonpCallback(")).toBe(true);
+	expect(source).toMatch("return __webpack_exports__");
+});
+
+it("should pass exports to jsonp callback", function () {
+	expect(global.__jsonpCapture).toBeDefined();
+	expect(global.__jsonpCapture.answer).toBe(42);
+});
+
+export const answer = 42;

--- a/tests/rspack-test/configCases/library/jsonp/rspack.config.js
+++ b/tests/rspack-test/configCases/library/jsonp/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  output: {
+    library: {
+      type: 'jsonp',
+      name: 'MyJsonpCallback',
+    },
+  },
+};

--- a/tests/rspack-test/configCases/library/jsonp/test.config.js
+++ b/tests/rspack-test/configCases/library/jsonp/test.config.js
@@ -1,0 +1,11 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+  moduleScope(scope) {
+    scope.MyJsonpCallback = function (exports) {
+      global.__jsonpCapture = exports;
+    };
+  },
+  afterExecute() {
+    delete global.__jsonpCapture;
+  },
+};


### PR DESCRIPTION
## Summary

- Implement `JsonpLibraryPlugin` for `output.library.type: 'jsonp'`, matching webpack's [`JsonpLibraryPlugin`](https://github.com/webpack/webpack/blob/main/lib/library/JsonpLibraryPlugin.js) behavior
- Register `ExportPropertyLibraryPlugin` alongside it (matching webpack's `enableExportProperty()`) so `library.export` works with jsonp
- Add test cases for basic wrapping, export property integration, and invalid name validation

## Context

The `jsonp` library type is [documented as supported](https://rspack.rs/config/output#other-types) and accepted in configuration, but `enable_library_plugin` had no match arm for `"jsonp"` — it fell through to the empty `_ => {}` default, silently producing an unwrapped IIFE instead of the expected `callbackName(source)` output.

This breaks microfrontend systems that rely on the JSONP callback wrapper for plugin loading (e.g. OpenShift dynamic plugins using `@openshift/dynamic-plugin-sdk-webpack`).

**Upstream reference:**
- [webpack `JsonpLibraryPlugin`](https://github.com/webpack/webpack/blob/main/lib/library/JsonpLibraryPlugin.js)
- [webpack `EnableLibraryPlugin` jsonp registration](https://github.com/webpack/webpack/blob/main/lib/library/EnableLibraryPlugin.js#L282-L290)

## Validation

- [x] Added `configCases/library/jsonp` — verifies output starts with `callbackName(` and contains `return __webpack_exports__`; verifies the callback receives exports via `test.config.js` `moduleScope`
- [x] Added `configCases/library/jsonp-export` — verifies `library.export` passes only the named export to the callback (exercises `ExportPropertyLibraryPlugin` integration)
- [x] Added `configCases/library/jsonp-invalid-name` — verifies array name produces error matching `/Jsonp library name must be a simple string/`
- [x] All 54 existing library tests continue to pass (zero regressions)
- [x] `cargo clippy` clean, `lint:js` clean

## Related links

Fixes https://github.com/web-infra-dev/rspack/issues/14277

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
