### PR TITLE
feat: support rspack magic comment prefix

### DIFF
--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -357,6 +357,34 @@ fn expr_to_exports(expr: &Expr) -> Option<MagicCommentValue> {
   Some(MagicCommentValue::Array(exports))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MagicCommentName {
+  ChunkName,
+  Prefetch,
+  Preload,
+  Ignore,
+  Mode,
+  FetchPriority,
+  Include,
+  Exclude,
+  Exports,
+}
+
+fn magic_comment_name(name: &str) -> Option<MagicCommentName> {
+  match name {
+    "webpackChunkName" | "rspackChunkName" => Some(MagicCommentName::ChunkName),
+    "webpackPrefetch" | "rspackPrefetch" => Some(MagicCommentName::Prefetch),
+    "webpackPreload" | "rspackPreload" => Some(MagicCommentName::Preload),
+    "webpackIgnore" | "rspackIgnore" => Some(MagicCommentName::Ignore),
+    "webpackMode" | "rspackMode" => Some(MagicCommentName::Mode),
+    "webpackFetchPriority" | "rspackFetchPriority" => Some(MagicCommentName::FetchPriority),
+    "webpackInclude" | "rspackInclude" => Some(MagicCommentName::Include),
+    "webpackExclude" | "rspackExclude" => Some(MagicCommentName::Exclude),
+    "webpackExports" | "rspackExports" => Some(MagicCommentName::Exports),
+    _ => None,
+  }
+}
+
 fn analyze_comments(
   source: &str,
   comments: &[Comment],
@@ -393,8 +421,8 @@ fn analyze_comments(
         let received = raw_value(&comment.text, value).unwrap_or_default();
         let error_span =
           || value_span_to_error_span(comment.span, value.span()).unwrap_or(error_span.into());
-        match item_name.as_ref() {
-          "webpackChunkName" => {
+        match magic_comment_name(item_name.as_ref()) {
+          Some(MagicCommentName::ChunkName) => {
             if let Some(value) = expr_to_str(value) {
               result.insert(
                 RspackComment::ChunkName,
@@ -411,7 +439,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackPrefetch" => {
+          Some(MagicCommentName::Prefetch) => {
             if let Some(value) = expr_to_order_str(&comment.text, value) {
               result.insert(
                 RspackComment::Prefetch,
@@ -432,7 +460,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackPreload" => {
+          Some(MagicCommentName::Preload) => {
             if let Some(value) = expr_to_order_str(&comment.text, value) {
               result.insert(
                 RspackComment::Preload,
@@ -453,7 +481,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackIgnore" => {
+          Some(MagicCommentName::Ignore) => {
             if let Some(value) = expr_to_bool(value) {
               result.insert(RspackComment::Ignore, MagicCommentValue::Bool(value));
               continue;
@@ -472,7 +500,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackMode" => {
+          Some(MagicCommentName::Mode) => {
             if let Some(value) = expr_to_str(value) {
               result.insert(
                 RspackComment::Mode,
@@ -489,7 +517,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackFetchPriority" => {
+          Some(MagicCommentName::FetchPriority) => {
             if let Some(priority) = expr_to_str(value)
               && matches!(priority.as_ref(), "low" | "high" | "auto")
             {
@@ -508,7 +536,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackInclude" => {
+          Some(MagicCommentName::Include) => {
             if let Some((regexp, flags)) = expr_to_regexp(value)
               && RspackRegex::with_flags(regexp, flags).is_ok()
             {
@@ -530,7 +558,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackExclude" => {
+          Some(MagicCommentName::Exclude) => {
             if let Some((regexp, flags)) = expr_to_regexp(value)
               && RspackRegex::with_flags(regexp, flags).is_ok()
             {
@@ -552,7 +580,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackExports" => {
+          Some(MagicCommentName::Exports) => {
             if let Some(exports) = expr_to_exports(value) {
               result.insert(RspackComment::Exports, exports);
               continue;
@@ -575,6 +603,8 @@ fn analyze_comments(
 
 #[cfg(test)]
 mod tests_extract_magic_comment_object {
+  use swc_core::{atoms::Atom, common::DUMMY_SP};
+
   use super::*;
 
   fn find_value(raw: &str, name: &str) -> Option<Box<Expr>> {
@@ -594,6 +624,23 @@ mod tests_extract_magic_comment_object {
       }
     }
     None
+  }
+
+  fn extract(raw: &str) -> (RspackCommentMap, Vec<Diagnostic>) {
+    let mut result = RspackCommentMap::new();
+    let mut warning_diagnostics = Vec::new();
+    analyze_comments(
+      "",
+      &[Comment {
+        kind: CommentKind::Block,
+        span: DUMMY_SP,
+        text: Atom::from(raw),
+      }],
+      DUMMY_SP,
+      &mut warning_diagnostics,
+      &mut result,
+    );
+    (result, warning_diagnostics)
   }
 
   fn try_match_string(raw: &str) -> Option<(String, String)> {
@@ -751,6 +798,74 @@ mod tests_extract_magic_comment_object {
         String::new()
       ))
     );
+  }
+
+  #[test]
+  fn test_rspack_magic_comment_name_aliases() {
+    assert_eq!(
+      magic_comment_name("rspackChunkName"),
+      Some(MagicCommentName::ChunkName)
+    );
+    assert_eq!(
+      magic_comment_name("rspackPrefetch"),
+      Some(MagicCommentName::Prefetch)
+    );
+    assert_eq!(
+      magic_comment_name("rspackPreload"),
+      Some(MagicCommentName::Preload)
+    );
+    assert_eq!(
+      magic_comment_name("rspackIgnore"),
+      Some(MagicCommentName::Ignore)
+    );
+    assert_eq!(
+      magic_comment_name("rspackMode"),
+      Some(MagicCommentName::Mode)
+    );
+    assert_eq!(
+      magic_comment_name("rspackFetchPriority"),
+      Some(MagicCommentName::FetchPriority)
+    );
+    assert_eq!(
+      magic_comment_name("rspackInclude"),
+      Some(MagicCommentName::Include)
+    );
+    assert_eq!(
+      magic_comment_name("rspackExclude"),
+      Some(MagicCommentName::Exclude)
+    );
+    assert_eq!(
+      magic_comment_name("rspackExports"),
+      Some(MagicCommentName::Exports)
+    );
+  }
+
+  #[test]
+  fn test_extract_rspack_prefixed_magic_comments() {
+    let (comments, warnings) = extract(
+      r#"
+        rspackChunkName: "chunk",
+        rspackPrefetch: 1,
+        rspackPreload: true,
+        rspackIgnore: true,
+        rspackMode: "eager",
+        rspackFetchPriority: "high",
+        rspackInclude: /\.js$/,
+        rspackExclude: /\.test\.js$/,
+        rspackExports: ["a", "b"]
+      "#,
+    );
+
+    assert!(warnings.is_empty());
+    assert_eq!(comments.get_chunk_name(), Some(&"chunk".to_string()));
+    assert_eq!(comments.get_prefetch().as_deref(), Some("1"));
+    assert_eq!(comments.get_preload().as_deref(), Some("true"));
+    assert_eq!(comments.get_ignore(), Some(true));
+    assert_eq!(comments.get_mode(), Some(&"eager".to_string()));
+    assert_eq!(comments.get_fetch_priority(), Some(&"high".to_string()));
+    assert!(comments.get_include().is_some());
+    assert!(comments.get_exclude().is_some());
+    assert_eq!(comments.get_exports(), Some(vec!["a".into(), "b".into()]));
   }
 
   #[test]

--- a/tests/rspack-test/configCases/context-modules/context-options/index.js
+++ b/tests/rspack-test/configCases/context-modules/context-options/index.js
@@ -6,12 +6,24 @@ async function loadModuleWithExclude(name) {
 	return import(/* webpackExclude: /module-b\.js$/ */ "./dir/" + name);
 }
 
+async function loadModuleWithRspackExclude(name) {
+	return import(/* rspackExclude: /module-b\.js$/ */ "./dir/" + name);
+}
+
 async function loadModuleWithInclude(name) {
 	return import(/* webpackInclude: /module-b\.js$/ */ "./dir/" + name);
 }
 
+async function loadModuleWithRspackInclude(name) {
+	return import(/* rspackInclude: /module-b\.js$/ */ "./dir/" + name);
+}
+
 async function loadModuleWithMode(name) {
 	return import(/* webpackMode: "eager" */ "./dir/" + name);
+}
+
+async function loadModuleWithRspackMode(name) {
+	return import(/* rspackMode: "eager" */ "./dir/" + name);
 }
 
 it("should work when no options", async () => {
@@ -26,14 +38,32 @@ it("should work with exclude", async () => {
 	expect((await loadModuleWithExclude("module-c.js")).default).toBe("c");
 });
 
+it("should work with rspack exclude", async () => {
+	expect((await loadModuleWithRspackExclude("module-a.js")).default).toBe("a");
+	await expect(loadModuleWithRspackExclude("module-b.js")).rejects.toThrow("Cannot find module './module-b.js'");
+	expect((await loadModuleWithRspackExclude("module-c.js")).default).toBe("c");
+});
+
 it("should work with include", async () => {
 	await expect(loadModuleWithInclude("module-a.js")).rejects.toThrow("Cannot find module './module-a.js'");
 	expect((await loadModuleWithInclude("module-b.js")).default).toBe("b");
 	await expect(loadModuleWithInclude("module-c.js")).rejects.toThrow("Cannot find module './module-c.js'");
 });
 
+it("should work with rspack include", async () => {
+	await expect(loadModuleWithRspackInclude("module-a.js")).rejects.toThrow("Cannot find module './module-a.js'");
+	expect((await loadModuleWithRspackInclude("module-b.js")).default).toBe("b");
+	await expect(loadModuleWithRspackInclude("module-c.js")).rejects.toThrow("Cannot find module './module-c.js'");
+});
+
 it("should work with mode", async () => {
 	expect((await loadModuleWithMode("module-a.js")).default).toBe("a");
 	expect((await loadModuleWithMode("module-b.js")).default).toBe("b");
 	expect((await loadModuleWithMode("module-c.js")).default).toBe("c");
+});
+
+it("should work with rspack mode", async () => {
+	expect((await loadModuleWithRspackMode("module-a.js")).default).toBe("a");
+	expect((await loadModuleWithRspackMode("module-b.js")).default).toBe("b");
+	expect((await loadModuleWithRspackMode("module-c.js")).default).toBe("c");
 });

--- a/tests/rspack-test/configCases/parsing/import-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/import-ignore/index.js
@@ -5,4 +5,6 @@ it("should be able to ignore import()", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle1.js"), "utf-8");
 	expect(source).toMatch(`import(/* webpackIgnore: true */ "./other2.js")`);
 	expect(source).not.toMatch(`import(/* webpackIgnore: false */ "./other3.js")`);
+	expect(source).toMatch(`import(/* rspackIgnore: true */ "./other2.js")`);
+	expect(source).not.toMatch(`import(/* rspackIgnore: false */ "./other3.js")`);
 });

--- a/tests/rspack-test/configCases/parsing/import-ignore/other.js
+++ b/tests/rspack-test/configCases/parsing/import-ignore/other.js
@@ -1,2 +1,4 @@
 import(/* webpackIgnore: true */ "./other2.js");
 import(/* webpackIgnore: false */ "./other3.js");
+import(/* rspackIgnore: true */ "./other2.js");
+import(/* rspackIgnore: false */ "./other3.js");

--- a/tests/rspack-test/configCases/parsing/require-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/require-ignore/index.js
@@ -5,4 +5,6 @@ it("should be able to ignore require()", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle1.js"), "utf-8");
 	expect(source).toMatch(`require(/* webpackIgnore: true */ "./other2.js")`);
 	expect(source).not.toMatch(`require(/* webpackIgnore: false */ "./other3.js")`);
+	expect(source).toMatch(`require(/* rspackIgnore: true */ "./other2.js")`);
+	expect(source).not.toMatch(`require(/* rspackIgnore: false */ "./other3.js")`);
 });

--- a/tests/rspack-test/configCases/parsing/require-ignore/other.js
+++ b/tests/rspack-test/configCases/parsing/require-ignore/other.js
@@ -1,2 +1,4 @@
 require(/* webpackIgnore: true */ "./other2.js");
 require(/* webpackIgnore: false */ "./other3.js");
+require(/* rspackIgnore: true */ "./other2.js");
+require(/* rspackIgnore: false */ "./other3.js");

--- a/tests/rspack-test/configCases/parsing/require-resolve-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-ignore/index.js
@@ -6,4 +6,7 @@ it("should be able to ignore require.resolve()", () => {
 	expect(source).toMatch(`require.resolve(/* webpackIgnore: true */ "./non-exists")`);
 	expect(source).toMatch(`createRequire(import.meta.url).resolve(/* webpackIgnore: true */ "./non-exists")`);
 	expect(source).toMatch(`require.resolve(/* webpackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`require.resolve(/* rspackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`createRequire(import.meta.url).resolve(/* rspackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`require.resolve(/* rspackIgnore: true */ "./non-exists")`);
 });

--- a/tests/rspack-test/configCases/parsing/require-resolve-ignore/other.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-ignore/other.js
@@ -4,5 +4,15 @@ const resolve = require.resolve(/* webpackIgnore: true */ "./non-exists");
 const createRequireResolve1 = createRequire(import.meta.url).resolve(/* webpackIgnore: true */ "./non-exists");
 const require = createRequire(import.meta.url);
 const createRequireResolve2 = require.resolve(/* webpackIgnore: true */ "./non-exists");
+const rspackResolve = require.resolve(/* rspackIgnore: true */ "./non-exists");
+const rspackCreateRequireResolve1 = createRequire(import.meta.url).resolve(/* rspackIgnore: true */ "./non-exists");
+const rspackCreateRequireResolve2 = require.resolve(/* rspackIgnore: true */ "./non-exists");
 
-export { resolve, createRequireResolve1, createRequireResolve2 }
+export {
+	resolve,
+	createRequireResolve1,
+	createRequireResolve2,
+	rspackResolve,
+	rspackCreateRequireResolve1,
+	rspackCreateRequireResolve2,
+}

--- a/tests/rspack-test/configCases/parsing/url-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/url-ignore/index.js
@@ -28,4 +28,9 @@ it('should ignore', function() {
   expect(url10.toString()).toBe(window.location.href);
   const url11 = new URL(/* webpackIgnore: true */ ...args);
   expect(url11.pathname.endsWith('file3.css')).toBe(true);
+  const url12 = new URL(/* rspackIgnore: true */ 'file12.css', import.meta.url);
+  expect(url12.pathname.endsWith('file12.css')).toBe(true);
+  expect(url12.pathname.includes('/public/')).toBe(false);
+  const url13 = new URL(/* rspackIgnore: false */ 'file2.css', import.meta.url);
+  expect(/\/public\/.+\.css/.test(url13.pathname)).toBe(true);
 });

--- a/tests/rspack-test/configCases/worker/worker-webpack-chunk-name/index.js
+++ b/tests/rspack-test/configCases/worker/worker-webpack-chunk-name/index.js
@@ -1,12 +1,16 @@
 import * as fs from "node:fs";
 import { Worker } from "worker_threads";
 
-it("worker webpackChunkName comments should works", async () => {
+it("worker webpackChunkName and rspackChunkName comments should works", async () => {
 	new Worker(new URL(/* webpackChunkName: "chunk-url" */ "./a", import.meta.url));
 	new Worker(/* webpackChunkName: "chunk-worker" */ new URL("./a", import.meta.url));
+	new Worker(new URL(/* rspackChunkName: "rspack-chunk-url" */ "./a", import.meta.url));
+	new Worker(/* rspackChunkName: "rspack-chunk-worker" */ new URL("./a", import.meta.url));
 	new Worker(new URL("./a", import.meta.url), { name: "chunk-arg2" });
 	const files = await fs.promises.readdir(__dirname);
 	expect(files).toContain("chunk-url.bundle0.js");
 	expect(files).toContain("chunk-worker.bundle0.js");
+	expect(files).toContain("rspack-chunk-url.bundle0.js");
+	expect(files).toContain("rspack-chunk-worker.bundle0.js");
 	expect(files).toContain("chunk-arg2.bundle0.js");
 });

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -109,6 +109,8 @@ import(`./locale/${language}.json`).then((module) => {
 
 Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. For a full list of these magic comments see the code below followed by an explanation of what these comments do.
 
+Rspack also supports `rspack`-prefixed aliases for these magic comments. For example, `rspackIgnore` is equivalent to `webpackIgnore`, and `rspackChunkName` is equivalent to `webpackChunkName`.
+
 ```js
 // Single target
 import(
@@ -149,6 +151,14 @@ import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
 });
 ```
 
+You can also use the equivalent `rspackIgnore` comment:
+
+```js
+import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
 `webpackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `webpackIgnore: true` comment:
 
 ```js
@@ -157,6 +167,9 @@ const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack will ignore this URL and preserve the original module identifier
 const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+
+// `rspackIgnore` is also supported
+const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -131,7 +131,7 @@ import(
 );
 ```
 
-##### webpackIgnore
+##### rspackIgnore / webpackIgnore \{#webpackignore}
 
 - **Type:** `boolean`
 
@@ -170,7 +170,7 @@ const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
-##### webpackMode
+##### rspackMode / webpackMode \{#webpackmode}
 
 - **Type:** `"eager" | "lazy" | "weak" | "lazy-once"`
 - **Default:** `'lazy'`
@@ -182,7 +182,7 @@ Different modes for resolving dynamic imports can be specified. The following op
 - `'eager'`: Generates no extra chunk. All modules are included in the current chunk and no additional network requests are made. A Promise is still returned but is already resolved. In contrast to a static import, the module isn't executed until the call to `import()` is made.
 - `'weak'`: Tries to load the module if the module function has already been loaded in some other way (e.g. another chunk imported it or a script containing the module was loaded). A Promise is still returned, but only successfully resolves if the chunks are already on the client. If the module is not available, the Promise is rejected. A network request will never be performed. This is useful for universal rendering when required chunks are always manually served in initial requests (embedded within the page), but not in cases where app navigation will trigger an import not initially served.
 
-##### webpackPrefetch
+##### rspackPrefetch / webpackPrefetch \{#webpackprefetch}
 
 - **Type:**
   - `number`: chunk prefetch priority
@@ -190,7 +190,7 @@ Different modes for resolving dynamic imports can be specified. The following op
 
 Tells the browser that the resource is probably needed for some navigation in the future, see [Prefetching/Preloading modules](/guide/optimization/code-splitting#prefetchingpreloading-modules) for more details.
 
-##### webpackPreload
+##### rspackPreload / webpackPreload \{#webpackpreload}
 
 - **Type:**
   - `number`: chunk preload priority
@@ -198,13 +198,13 @@ Tells the browser that the resource is probably needed for some navigation in th
 
 Tells the browser that the resource might be needed during the current navigation, , see [Prefetching/Preloading modules](/guide/optimization/code-splitting#prefetchingpreloading-modules) for more details.
 
-##### webpackChunkName
+##### rspackChunkName / webpackChunkName \{#webpackchunkname}
 
 - **Type:**: `string`
 
 A name for the new chunk.
 
-##### webpackFetchPriority
+##### rspackFetchPriority / webpackFetchPriority \{#webpackfetchpriority}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -212,7 +212,7 @@ A name for the new chunk.
 
 Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) for specific dynamic imports. It's also possible to set a global default value for all dynamic imports by using the `module.parser.javascript.dynamicImportFetchPriority` option.
 
-##### webpackInclude
+##### rspackInclude / webpackInclude \{#webpackinclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -220,7 +220,7 @@ Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImage
 
 A regular expression that will be matched against during import resolution. Only modules that match **will be bundled**.
 
-##### webpackExclude
+##### rspackExclude / webpackExclude \{#webpackexclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -229,10 +229,10 @@ A regular expression that will be matched against during import resolution. Only
 A regular expression that will be matched against during import resolution. Any module that matches **will not be bundled**.
 
 :::info
-Note that `webpackInclude` and `webpackExclude` options do not interfere with the prefix. eg: `./locale`.
+Note that `rspackInclude` and `rspackExclude` options do not interfere with the prefix. The equivalent `webpackInclude` and `webpackExclude` comments are also supported for compatibility. eg: `./locale`.
 :::
 
-##### webpackExports
+##### rspackExports / webpackExports \{#webpackexports}
 
 <ApiMeta addedVersion="1.0.0" />
 

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -107,28 +107,26 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. For a full list of these magic comments see the code below followed by an explanation of what these comments do.
-
-Rspack also supports `rspack`-prefixed aliases for these magic comments. For example, `rspackIgnore` is equivalent to `webpackIgnore`, and `rspackChunkName` is equivalent to `webpackChunkName`.
+Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. In Rspack projects, prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
 
 ```js
 // Single target
 import(
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackExports: ["default", "named"] */
-  /* webpackFetchPriority: "high" */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackExports: ["default", "named"] */
+  /* rspackFetchPriority: "high" */
   'module'
 );
 
 // Multiple possible targets
 import(
-  /* webpackInclude: /\.json$/ */
-  /* webpackExclude: /\.noimport\.json$/ */
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackPrefetch: true */
-  /* webpackPreload: true */
+  /* rspackInclude: /\.json$/ */
+  /* rspackExclude: /\.noimport\.json$/ */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackPrefetch: true */
+  /* rspackPreload: true */
   `./locale/${language}`
 );
 ```
@@ -146,30 +144,30 @@ When set to `true`, Rspack will skip analysis and bundling processing for the dy
 This is particularly useful for dynamically loading ESM third-party libraries from external CDNs, for example:
 
 ```js
-import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
-  console.log(React.version); // 19.0.0
-});
-```
-
-You can also use the equivalent `rspackIgnore` comment:
-
-```js
 import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
   console.log(React.version); // 19.0.0
 });
 ```
 
-`webpackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `webpackIgnore: true` comment:
+The equivalent `webpackIgnore` comment is also supported:
+
+```js
+import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
+`rspackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `rspackIgnore: true` comment:
 
 ```js
 // Rspack will process this URL and bundle './index.css' into the build output
 const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack will ignore this URL and preserve the original module identifier
-const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 
-// `rspackIgnore` is also supported
-const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
+// `webpackIgnore` is also supported
+const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,11 +134,11 @@ export default {
 };
 ```
 
-Note that only the `webpackIgnore` and `rspackIgnore` comments are supported at the moment:
+Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. Prefer `rspackIgnore` in Rspack projects; `webpackIgnore` remains supported for compatibility:
 
 ```js
-const x = require(/* webpackIgnore: true */ 'x');
-const y = require(/* rspackIgnore: true */ 'y');
+const x = require(/* rspackIgnore: true */ 'x');
+const y = require(/* webpackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,10 +134,11 @@ export default {
 };
 ```
 
-Note that only `webpackIgnore` comment is supported at the moment:
+Note that only the `webpackIgnore` and `rspackIgnore` comments are supported at the moment:
 
 ```js
 const x = require(/* webpackIgnore: true */ 'x');
+const y = require(/* rspackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -107,27 +107,25 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。有关这些魔法注释的完整列表，请参见下面的代码，以及对这些注释功能的解释。
-
-Rspack 也支持带有 `rspack` 前缀的等价魔法注释。例如，`rspackIgnore` 等价于 `webpackIgnore`，`rspackChunkName` 等价于 `webpackChunkName`。
+通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。在 Rspack 项目中，推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
 
 ```js
 // 单个模块
 import(
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackFetchPriority: "high" */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackFetchPriority: "high" */
   'module'
 );
 
 // 多个可能模块
 import(
-  /* webpackInclude: /\.json$/ */
-  /* webpackExclude: /\.noimport\.json$/ */
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackPrefetch: true */
-  /* webpackPreload: true */
+  /* rspackInclude: /\.json$/ */
+  /* rspackExclude: /\.noimport\.json$/ */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackPrefetch: true */
+  /* rspackPreload: true */
   `./locale/${language}`
 );
 ```
@@ -145,30 +143,30 @@ import(
 这在需要从外部 CDN 动态加载 ESM 格式的第三方库时特别有用，例如：
 
 ```js
-import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
-  console.log(React.version); // 19.0.0
-});
-```
-
-你也可以使用等价的 `rspackIgnore` 注释：
-
-```js
 import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
   console.log(React.version); // 19.0.0
 });
 ```
 
-`webpackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `webpackIgnore: true` 注释：
+也支持等价的 `webpackIgnore` 注释：
+
+```js
+import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
+`rspackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `rspackIgnore: true` 注释：
 
 ```js
 // Rspack 会处理这个 URL，将 './index.css' 打包到构建产物中
 const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack 会忽略这个 URL，保持原始的模块标识符
-const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 
-// 同样支持 `rspackIgnore`
-const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
+// 同样支持 `webpackIgnore`
+const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -109,6 +109,8 @@ import(`./locale/${language}.json`).then((module) => {
 
 通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。有关这些魔法注释的完整列表，请参见下面的代码，以及对这些注释功能的解释。
 
+Rspack 也支持带有 `rspack` 前缀的等价魔法注释。例如，`rspackIgnore` 等价于 `webpackIgnore`，`rspackChunkName` 等价于 `webpackChunkName`。
+
 ```js
 // 单个模块
 import(
@@ -148,6 +150,14 @@ import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
 });
 ```
 
+你也可以使用等价的 `rspackIgnore` 注释：
+
+```js
+import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
 `webpackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `webpackIgnore: true` 注释：
 
 ```js
@@ -156,6 +166,9 @@ const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack 会忽略这个 URL，保持原始的模块标识符
 const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+
+// 同样支持 `rspackIgnore`
+const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -130,7 +130,7 @@ import(
 );
 ```
 
-##### webpackIgnore
+##### rspackIgnore / webpackIgnore \{#webpackignore}
 
 - **类型：** `boolean`
 
@@ -169,7 +169,7 @@ const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
-##### webpackMode
+##### rspackMode / webpackMode \{#webpackmode}
 
 - **类型：** `"eager" | "lazy" | "weak" | "lazy-once"`
 - **默认值：** `'lazy'`
@@ -181,7 +181,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 - `'eager'`：不会生成额外的 chunk。所有的模块都被当前的 chunk 引入，并且没有额外的网络请求。但是仍会返回一个 resolved 状态的 Promise。与静态导入相比，在调用 `import()` 完成之前，该模块不会被执行。
 - `'weak'`：尝试加载模块，如果该模块函数已经以其他方式加载，（即另一个 chunk 导入过此模块，或包含模块的脚本被加载）。仍会返回 Promise， 但是只有在客户端上已经有该 chunk 时才会成功解析。如果该模块不可用，则返回 rejected 状态的 Promise，且网络请求永远都不会执行。当需要的 chunks 始终在（嵌入在页面中的）初始请求中手动提供，而不是在应用程序导航在最初没有提供的模块导入的情况下触发，这对于通用渲染（SSR）是非常有用的。
 
-##### webpackPrefetch
+##### rspackPrefetch / webpackPrefetch \{#webpackprefetch}
 
 - **类型：**
   - `number`: 预取优先级
@@ -189,7 +189,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 告诉浏览器将来可能需要该资源来进行某些导航跳转，详情请查看[预取/预载模块](/guide/optimization/code-splitting#prefetchingpreloading-模块)。
 
-##### webpackPreload
+##### rspackPreload / webpackPreload \{#webpackpreload}
 
 - **类型：**
   - `number`: 预载优先级
@@ -197,13 +197,13 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 告诉浏览器在当前导航期间可能需要该资源，详情请查看[预取/预载模块](/guide/optimization/code-splitting#prefetchingpreloading-模块)。
 
-##### webpackChunkName
+##### rspackChunkName / webpackChunkName \{#webpackchunkname}
 
 - **类型：**: `string`
 
 指定新 chunk 的名称。
 
-##### webpackFetchPriority
+##### rspackFetchPriority / webpackFetchPriority \{#webpackfetchpriority}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -211,7 +211,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 为指定的动态导入设置 [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority)。也可以通过使用 `module.parser.javascript.dynamicImportFetchPriority` 选项为所有动态导入设置全局默认值。
 
-##### webpackInclude
+##### rspackInclude / webpackInclude \{#webpackinclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -219,7 +219,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 在导入解析时匹配的正则表达式。只有匹配的模块**才会被打包**。
 
-##### webpackExclude
+##### rspackExclude / webpackExclude \{#webpackexclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -228,10 +228,10 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 在导入解析时匹配的正则表达式。只有匹配的模块**不会被打包**。
 
 :::info
-请注意，`webpackInclude` 和 `webpackExclude` 选项不会影响前缀。例如：`./locale`。
+请注意，`rspackInclude` 和 `rspackExclude` 选项不会影响前缀。等价的 `webpackInclude` 和 `webpackExclude` 注释也会被兼容支持。例如：`./locale`。
 :::
 
-##### webpackExports
+##### rspackExports / webpackExports \{#webpackexports}
 
 <ApiMeta addedVersion="1.0.0" />
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,11 +134,11 @@ export default {
 };
 ```
 
-目前仅支持 `webpackIgnore` 和 `rspackIgnore` 注释：
+目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。Rspack 项目中推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
 
 ```js
-const x = require(/* webpackIgnore: true */ 'x');
-const y = require(/* rspackIgnore: true */ 'y');
+const x = require(/* rspackIgnore: true */ 'x');
+const y = require(/* webpackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,10 +134,11 @@ export default {
 };
 ```
 
-目前仅支持 `webpackIgnore` 注释：
+目前仅支持 `webpackIgnore` 和 `rspackIgnore` 注释：
 
 ```js
 const x = require(/* webpackIgnore: true */ 'x');
+const y = require(/* rspackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode


### PR DESCRIPTION
## Summary

Support `rspack*` magic comment names as aliases for the existing `webpack*` names, including `rspackIgnore`, `rspackChunkName`, `rspackInclude`, `rspackExclude`, and related options.

Added parallel config cases for the `rspack` prefix across import/require ignore handling, URL ignore handling, context module options, and worker chunk names.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).