### PR TITLE
test: run walltime bench on CodSpeed macro runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
       target: x86_64-unknown-linux-gnu
       measurement: walltime
       bench_target: walltime
-      runner: '"physical-1-exclusive"'
+      # Walltime measurements should run on CodSpeed-managed macro runners.
+      runner: '"codspeed-macro"'
 
   test-windows:
     name: Test Windows


### PR DESCRIPTION
## Summary
- Switch the Rust walltime benchmark CI job from the physical exclusive runner to the CodSpeed macro runner label.
- Add a short workflow comment explaining that walltime measurements should run on CodSpeed-managed macro runners.

## Validation
- `pnpm exec prettier --check .github/workflows/ci.yml`
- Triggered the CI workflow multiple times and inspected the `Rust Bench Walltime / Bench Rust walltime` job logs.
- For the 10 additional variance runs, I used temporary branches with empty commits that have the same tree as this PR commit, so they would not cancel each other via the CI workflow concurrency group. The walltime jobs completed successfully; the remaining non-walltime work was canceled afterward and the temporary branches were removed.

## Walltime stability check
All walltime jobs ran successfully on CodSpeed macro runner machines.

### Initial 3 PR-branch runs

| CI run | CodSpeed run hash | threejs-10x-development | threejs-10x-production-sourcemap |
| --- | --- | ---: | ---: |
| [26998342250](https://github.com/web-infra-dev/rspack/actions/runs/26998342250) | `e2597d713363d97c1a63d108138471384c503991908cc48e7cf0ee0bd569ac10` | 732.93 ms | 1381.80 ms |
| [26999348185](https://github.com/web-infra-dev/rspack/actions/runs/26999348185) | `1021353803f350ce5c5c0fbdd698c3a3700f7d31b45c2eca632d42769f9c50b8` | 731.77 ms | 1382.90 ms |
| [27000335550](https://github.com/web-infra-dev/rspack/actions/runs/27000335550) | `6df7f88abf87f0866921eff05b62cfbe15ee97ca7208d734a20188ba8caa1fa3` | 735.93 ms | 1372.80 ms |

### 10 additional variance runs

| # | CI run | CodSpeed run hash | threejs-10x-development | threejs-10x-production-sourcemap |
| --- | --- | --- | ---: | ---: |
| 01 | [27006635354](https://github.com/web-infra-dev/rspack/actions/runs/27006635354) | `801fb7672f9d02d2b7b1782c55ef44a11daff0bd032ea60413ed18fdad7c13be` | 728.58 ms | 1386.30 ms |
| 02 | [27006644885](https://github.com/web-infra-dev/rspack/actions/runs/27006644885) | `62ad39e2e929d628edd29593165a584fb28dedd1f6257a4f28e83662df935c00` | 734.44 ms | 1378.30 ms |
| 03 | [27006654268](https://github.com/web-infra-dev/rspack/actions/runs/27006654268) | `ead0b9222adee140bccffd38adb05bb15dcd71661b508fc03b836ac5396528db` | 734.59 ms | 1379.00 ms |
| 04 | [27006674793](https://github.com/web-infra-dev/rspack/actions/runs/27006674793) | `4345fbd2efb39315eda487e5731b3ca27d05e062df52abe10924c735cabd4690` | 734.80 ms | 1387.80 ms |
| 05 | [27006683002](https://github.com/web-infra-dev/rspack/actions/runs/27006683002) | `a71690a86e5eaefe037f39ab26e3315350510041e9d22fd2733bdf592e41eb50` | 735.37 ms | 1377.20 ms |
| 06 | [27006695952](https://github.com/web-infra-dev/rspack/actions/runs/27006695952) | `f24d8087d0f9422fa52c4774a9da83095cc5d0de8d1c127bf5fc03c898ee9307` | 731.31 ms | 1379.70 ms |
| 07 | [27006703713](https://github.com/web-infra-dev/rspack/actions/runs/27006703713) | `9545e555899a2840c7134d611b2a46d70f60ce753372f13d2820dcf6ea1fbf0a` | 733.45 ms | 1382.00 ms |
| 08 | [27006718198](https://github.com/web-infra-dev/rspack/actions/runs/27006718198) | `042fc8b429bfd0dddd6917ca495e3d8bce2f8c0353e8137cc1968bef405088ea` | 730.41 ms | 1387.30 ms |
| 09 | [27006724042](https://github.com/web-infra-dev/rspack/actions/runs/27006724042) | `7076d17e6c94e406eaed34f15615e7c0244797ea94ef0bc53e04e1bc76b1e4e9` | 733.95 ms | 1395.30 ms |
| 10 | [27006744361](https://github.com/web-infra-dev/rspack/actions/runs/27006744361) | `3890890b777bf21e4122fcd0ee3dc21a536a3a53df6cace3d8dda3a6d2624d75` | 734.66 ms | 1378.00 ms |

### Variance summary

- 10 additional runs:
  - `threejs-10x-development`: mean 733.16 ms, sd 2.27 ms, CV 0.309%, min 728.58 ms, max 735.37 ms, spread 0.926%.
  - `threejs-10x-production-sourcemap`: mean 1383.09 ms, sd 5.89 ms, CV 0.426%, min 1377.20 ms, max 1395.30 ms, spread 1.309%.
- 13 total runs:
  - `threejs-10x-development`: mean 733.25 ms, sd 2.16 ms, CV 0.294%, min 728.58 ms, max 735.93 ms, spread 1.002%.
  - `threejs-10x-production-sourcemap`: mean 1382.18 ms, sd 5.84 ms, CV 0.422%, min 1372.80 ms, max 1395.30 ms, spread 1.628%.

Conclusion: the walltime benchmark remained stable across the additional CodSpeed macro-runner executions.
