### PR TITLE
refactor(devtool): propagate source map kind to generators

### DIFF
--- a/crates/rspack/src/builder/builder_context.rs
+++ b/crates/rspack/src/builder/builder_context.rs
@@ -185,8 +185,7 @@ impl BuilderContext {
         plugins.push(
           rspack_plugin_devtool::SourceMapDevToolModuleOptionsPlugin::new(
             rspack_plugin_devtool::SourceMapDevToolModuleOptionsPluginOptions {
-              module: options.module,
-              cheap: !options.columns,
+              source_map_kind: options.module_source_map_kind(),
             },
           )
           .boxed(),
@@ -197,8 +196,7 @@ impl BuilderContext {
         plugins.push(
           rspack_plugin_devtool::SourceMapDevToolModuleOptionsPlugin::new(
             rspack_plugin_devtool::SourceMapDevToolModuleOptionsPluginOptions {
-              module: options.module,
-              cheap: !options.columns,
+              source_map_kind: options.module_source_map_kind(),
             },
           )
           .boxed(),

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/mod.rs
@@ -652,8 +652,7 @@ impl<'a> BuiltinPlugin<'a> {
             .into();
         plugins.push(
           SourceMapDevToolModuleOptionsPlugin::new(SourceMapDevToolModuleOptionsPluginOptions {
-            module: options.module,
-            cheap: !options.columns,
+            source_map_kind: options.module_source_map_kind(),
           })
           .boxed(),
         );
@@ -666,8 +665,7 @@ impl<'a> BuiltinPlugin<'a> {
             .into();
         plugins.push(
           SourceMapDevToolModuleOptionsPlugin::new(SourceMapDevToolModuleOptionsPluginOptions {
-            module: options.module,
-            cheap: !options.columns,
+            source_map_kind: options.module_source_map_kind(),
           })
           .boxed(),
         );

--- a/crates/rspack_javascript_compiler/src/compiler/minify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/minify.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rspack_error::BatchErrors;
-use rspack_util::swc::minify_file_comments;
+use rspack_util::{source_map::SourceMapKind, swc::minify_file_comments};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 pub use swc_core::base::BoolOrDataConfig;
@@ -79,6 +79,8 @@ impl JavaScriptCompiler {
             })
           })
           .expect("should have source map config");
+        let source_map_kind = SourceMapKind::from_enabled(source_map.enabled())
+          .with_sources_content(opts.inline_sources_content);
 
         let mut min_opts = MinifyOptions {
           compress: opts
@@ -181,9 +183,7 @@ impl JavaScriptCompiler {
           source_map: self.cm.clone(),
           target,
           source_map_config: SourceMapConfig {
-            enable: source_map.enabled(),
-            inline_sources_content: opts.inline_sources_content,
-            emit_columns: true,
+            source_map_kind,
             names: Default::default(),
           },
           input_source_map: None,

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -81,7 +81,7 @@ impl JavaScriptCompiler {
     } = options;
     let mut src_map_buf = vec![];
 
-    if source_map_config.source_map_kind.enabled() {
+    if source_map_config.source_map_kind.source_map() {
       let mut v = IdentCollector {
         names: Default::default(),
       };
@@ -100,7 +100,7 @@ impl JavaScriptCompiler {
           &mut buf,
           source_map_config
             .source_map_kind
-            .enabled()
+            .source_map()
             .then_some(&mut src_map_buf),
         );
 
@@ -127,7 +127,7 @@ impl JavaScriptCompiler {
       unsafe { String::from_utf8_unchecked(buf) }
     };
 
-    let map = if source_map_config.source_map_kind.enabled() {
+    let map = if source_map_config.source_map_kind.source_map() {
       let combined_source_map =
         source_map.build_source_map(&src_map_buf, input_source_map.cloned(), source_map_config);
 

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rspack_error::Result;
 use rspack_sources::{Mapping, OriginalLocation, encode_mappings};
+use rspack_util::source_map::SourceMapKind;
 use rustc_hash::FxHashMap;
 use swc_core::{
   base::sourcemap,
@@ -24,9 +25,7 @@ use super::{JavaScriptCompiler, TransformOutput};
 
 #[derive(Default, Clone, Debug)]
 pub struct SourceMapConfig {
-  pub enable: bool,
-  pub inline_sources_content: bool,
-  pub emit_columns: bool,
+  pub source_map_kind: SourceMapKind,
   pub names: FxHashMap<BytePos, Atom>,
 }
 
@@ -41,11 +40,11 @@ impl SourceMapGenConfig for SourceMapConfig {
   }
 
   fn inline_sources_content(&self, _: &FileName) -> bool {
-    self.inline_sources_content
+    self.source_map_kind.inline_sources_content()
   }
 
   fn emit_columns(&self, _f: &FileName) -> bool {
-    self.emit_columns
+    self.source_map_kind.emit_columns()
   }
 
   fn name_for_bytepos(&self, pos: BytePos) -> Option<&str> {
@@ -82,7 +81,7 @@ impl JavaScriptCompiler {
     } = options;
     let mut src_map_buf = vec![];
 
-    if source_map_config.enable {
+    if source_map_config.source_map_kind.enabled() {
       let mut v = IdentCollector {
         names: Default::default(),
       };
@@ -99,7 +98,10 @@ impl JavaScriptCompiler {
           source_map.clone(),
           "\n",
           &mut buf,
-          source_map_config.enable.then_some(&mut src_map_buf),
+          source_map_config
+            .source_map_kind
+            .enabled()
+            .then_some(&mut src_map_buf),
         );
 
         w.preamble(preamble)?;
@@ -125,7 +127,7 @@ impl JavaScriptCompiler {
       unsafe { String::from_utf8_unchecked(buf) }
     };
 
-    let map = if source_map_config.enable {
+    let map = if source_map_config.source_map_kind.enabled() {
       let combined_source_map =
         source_map.build_source_map(&src_map_buf, input_source_map.cloned(), source_map_config);
 
@@ -182,7 +184,7 @@ struct IdentCollector {
   pub names: FxHashMap<BytePos, Atom>,
 }
 
-impl Visit for IdentCollector {
+impl Vist for IdentCollector {
   noop_visit_type!();
 
   fn visit_ident(&mut self, ident: &Ident) {

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -29,6 +29,12 @@ pub struct SourceMapConfig {
   pub names: FxHashMap<BytePos, Atom>,
 }
 
+impl SourceMapConfig {
+  pub fn enabled(&self) -> bool {
+    self.source_map_kind.source_map()
+  }
+}
+
 impl SourceMapGenConfig for SourceMapConfig {
   fn file_name_to_source(&self, f: &FileName) -> String {
     let f = f.to_string();
@@ -81,7 +87,7 @@ impl JavaScriptCompiler {
     } = options;
     let mut src_map_buf = vec![];
 
-    if source_map_config.source_map_kind.source_map() {
+    if source_map_config.enabled() {
       let mut v = IdentCollector {
         names: Default::default(),
       };
@@ -98,10 +104,7 @@ impl JavaScriptCompiler {
           source_map.clone(),
           "\n",
           &mut buf,
-          source_map_config
-            .source_map_kind
-            .source_map()
-            .then_some(&mut src_map_buf),
+          source_map_config.enabled().then_some(&mut src_map_buf),
         );
 
         w.preamble(preamble)?;
@@ -127,7 +130,7 @@ impl JavaScriptCompiler {
       unsafe { String::from_utf8_unchecked(buf) }
     };
 
-    let map = if source_map_config.source_map_kind.source_map() {
+    let map = if source_map_config.enabled() {
       let combined_source_map =
         source_map.build_source_map(&src_map_buf, input_source_map.cloned(), source_map_config);
 

--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -184,7 +184,7 @@ struct IdentCollector {
   pub names: FxHashMap<BytePos, Atom>,
 }
 
-impl Vist for IdentCollector {
+impl Visit for IdentCollector {
   noop_visit_type!();
 
   fn visit_ident(&mut self, ident: &Ident) {

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -320,7 +320,7 @@ impl<'a> JavaScriptTransformer<'a> {
     let minify = built_input.minify;
     let source_map_config = SourceMapConfig {
       enable: source_map_kind.source_map(),
-      inline_sources_content: source_map_kind.source_map(),
+      inline_sources_content: source_map_kind.source_map() && !source_map_kind.no_sources(),
       emit_columns: !source_map_kind.cheap(),
       names: Default::default(),
     };

--- a/crates/rspack_javascript_compiler/src/compiler/transform.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/transform.rs
@@ -319,9 +319,7 @@ impl<'a> JavaScriptTransformer<'a> {
     };
     let minify = built_input.minify;
     let source_map_config = SourceMapConfig {
-      enable: source_map_kind.source_map(),
-      inline_sources_content: source_map_kind.source_map() && !source_map_kind.no_sources(),
-      emit_columns: !source_map_kind.cheap(),
+      source_map_kind,
       names: Default::default(),
     };
 

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_module_options_plugin.rs
@@ -8,20 +8,18 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_util::source_map::SourceMapKind;
 
 pub struct SourceMapDevToolModuleOptionsPluginOptions {
-  pub module: bool,
-  pub cheap: bool,
+  pub source_map_kind: SourceMapKind,
 }
 
 #[plugin]
 #[derive(Debug)]
 pub struct SourceMapDevToolModuleOptionsPlugin {
-  module: bool,
-  cheap: bool,
+  source_map_kind: SourceMapKind,
 }
 
 impl SourceMapDevToolModuleOptionsPlugin {
   pub fn new(options: SourceMapDevToolModuleOptionsPluginOptions) -> Self {
-    Self::new_inner(options.module, options.cheap)
+    Self::new_inner(options.source_map_kind)
   }
 }
 
@@ -32,15 +30,7 @@ async fn build_module(
   _compilation_id: CompilationId,
   module: &mut BoxModule,
 ) -> Result<()> {
-  if self.module {
-    module.set_source_map_kind(SourceMapKind::SourceMap);
-  } else {
-    module.set_source_map_kind(SourceMapKind::SimpleSourceMap);
-  }
-  if self.cheap {
-    let current_kind = *module.get_source_map_kind();
-    module.set_source_map_kind(current_kind | SourceMapKind::Cheap)
-  }
+  module.set_source_map_kind(self.source_map_kind);
   Ok(())
 }
 
@@ -55,15 +45,7 @@ async fn runtime_module(
   let Some(runtime_module) = runtime_modules.get_mut(module_identifier) else {
     return Ok(());
   };
-  if self.module {
-    runtime_module.set_source_map_kind(SourceMapKind::SourceMap);
-  } else {
-    runtime_module.set_source_map_kind(SourceMapKind::SimpleSourceMap);
-  }
-  if self.cheap {
-    let current_kind = *runtime_module.get_source_map_kind();
-    runtime_module.set_source_map_kind(current_kind | SourceMapKind::Cheap)
-  }
+  runtime_module.set_source_map_kind(self.source_map_kind);
   Ok(())
 }
 

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -192,18 +192,10 @@ pub struct SourceMapDevToolPluginOptions {
 
 impl SourceMapDevToolPluginOptions {
   pub fn module_source_map_kind(&self) -> SourceMapKind {
-    let mut source_map_kind = if self.module {
-      SourceMapKind::SourceMap
-    } else {
-      SourceMapKind::SimpleSourceMap
-    };
-    if !self.columns {
-      source_map_kind |= SourceMapKind::Cheap;
-    }
-    if self.no_sources {
-      source_map_kind |= SourceMapKind::NoSources;
-    }
-    source_map_kind
+    SourceMapKind::from_module(self.module)
+      .with_cheap(!self.columns)
+      .with_no_sources(self.no_sources)
+      .with_inline(self.filename.is_none())
   }
 }
 

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -27,6 +27,7 @@ use rspack_util::{
   fx_hash::FxIndexMap,
   identifier::make_paths_absolute,
   node_path::NodePath,
+  source_map::SourceMapKind,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use sugar_path::SugarPath;
@@ -187,6 +188,23 @@ pub struct SourceMapDevToolPluginOptions {
   pub include: Option<AssetConditions>,
   pub exclude: Option<AssetConditions>,
   pub debug_ids: bool,
+}
+
+impl SourceMapDevToolPluginOptions {
+  pub fn module_source_map_kind(&self) -> SourceMapKind {
+    let mut source_map_kind = if self.module {
+      SourceMapKind::SourceMap
+    } else {
+      SourceMapKind::SimpleSourceMap
+    };
+    if !self.columns {
+      source_map_kind |= SourceMapKind::Cheap;
+    }
+    if self.no_sources {
+      source_map_kind |= SourceMapKind::NoSources;
+    }
+    source_map_kind
+  }
 }
 
 enum SourceMappingUrlComment {

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -613,9 +613,16 @@ impl Plugin for RsdoctorPlugin {
       .after_process_assets
       .tap(after_process_assets::new(self));
 
+    let mut source_map_kind = if self.options.source_map_features.module {
+      rspack_util::source_map::SourceMapKind::SourceMap
+    } else {
+      rspack_util::source_map::SourceMapKind::SimpleSourceMap
+    };
+    if self.options.source_map_features.cheap {
+      source_map_kind |= rspack_util::source_map::SourceMapKind::Cheap;
+    }
     SourceMapDevToolModuleOptionsPlugin::new(SourceMapDevToolModuleOptionsPluginOptions {
-      cheap: self.options.source_map_features.cheap,
-      module: self.options.source_map_features.module,
+      source_map_kind,
     })
     .apply(ctx)?;
 

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -18,7 +18,10 @@ use rspack_plugin_devtool::{
 };
 #[cfg(allocative)]
 use rspack_util::allocative;
-use rspack_util::fx_hash::{FxDashMap, FxHashSet};
+use rspack_util::{
+  fx_hash::{FxDashMap, FxHashSet},
+  source_map::SourceMapKind,
+};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::{
@@ -613,16 +616,9 @@ impl Plugin for RsdoctorPlugin {
       .after_process_assets
       .tap(after_process_assets::new(self));
 
-    let mut source_map_kind = if self.options.source_map_features.module {
-      rspack_util::source_map::SourceMapKind::SourceMap
-    } else {
-      rspack_util::source_map::SourceMapKind::SimpleSourceMap
-    };
-    if self.options.source_map_features.cheap {
-      source_map_kind |= rspack_util::source_map::SourceMapKind::Cheap;
-    }
     SourceMapDevToolModuleOptionsPlugin::new(SourceMapDevToolModuleOptionsPluginOptions {
-      source_map_kind,
+      source_map_kind: SourceMapKind::from_module(self.options.source_map_features.module)
+        .with_cheap(self.options.source_map_features.cheap),
     })
     .apply(ctx)?;
 

--- a/crates/rspack_util/src/source_map.rs
+++ b/crates/rspack_util/src/source_map.rs
@@ -10,6 +10,7 @@ bitflags! {
       const SourceMap = 1 << 0;
       const SimpleSourceMap = 1 << 1;
       const Cheap = 1 << 2;
+      const NoSources = 1 << 3;
   }
 }
 
@@ -34,6 +35,10 @@ impl SourceMapKind {
 
   pub fn cheap(&self) -> bool {
     self.contains(SourceMapKind::Cheap)
+  }
+
+  pub fn no_sources(&self) -> bool {
+    self.contains(SourceMapKind::NoSources)
   }
 }
 

--- a/crates/rspack_util/src/source_map.rs
+++ b/crates/rspack_util/src/source_map.rs
@@ -22,21 +22,13 @@ impl Default for SourceMapKind {
 }
 
 impl SourceMapKind {
-  pub fn new_enabled() -> Self {
-    SourceMapKind::SourceMap
-  }
-
   pub fn new_inline() -> Self {
-    SourceMapKind::new_enabled().with_inline(true)
-  }
-
-  pub fn new_simple() -> Self {
-    SourceMapKind::SimpleSourceMap
+    SourceMapKind::SourceMap.with_inline(true)
   }
 
   pub fn from_enabled(enabled: bool) -> Self {
     if enabled {
-      SourceMapKind::new_enabled()
+      SourceMapKind::SourceMap
     } else {
       SourceMapKind::empty()
     }
@@ -44,9 +36,9 @@ impl SourceMapKind {
 
   pub fn from_module(module: bool) -> Self {
     if module {
-      SourceMapKind::new_enabled()
+      SourceMapKind::SourceMap
     } else {
-      SourceMapKind::new_simple()
+      SourceMapKind::SimpleSourceMap
     }
   }
 

--- a/crates/rspack_util/src/source_map.rs
+++ b/crates/rspack_util/src/source_map.rs
@@ -22,10 +22,6 @@ impl Default for SourceMapKind {
 }
 
 impl SourceMapKind {
-  pub fn new_inline() -> Self {
-    SourceMapKind::SourceMap.with_inline(true)
-  }
-
   pub fn from_enabled(enabled: bool) -> Self {
     if enabled {
       SourceMapKind::SourceMap

--- a/crates/rspack_util/src/source_map.rs
+++ b/crates/rspack_util/src/source_map.rs
@@ -11,6 +11,7 @@ bitflags! {
       const SimpleSourceMap = 1 << 1;
       const Cheap = 1 << 2;
       const NoSources = 1 << 3;
+      const Inline = 1 << 4;
   }
 }
 
@@ -21,8 +22,61 @@ impl Default for SourceMapKind {
 }
 
 impl SourceMapKind {
+  pub fn new_enabled() -> Self {
+    SourceMapKind::SourceMap
+  }
+
+  pub fn new_inline() -> Self {
+    SourceMapKind::new_enabled().with_inline(true)
+  }
+
+  pub fn new_simple() -> Self {
+    SourceMapKind::SimpleSourceMap
+  }
+
+  pub fn from_enabled(enabled: bool) -> Self {
+    if enabled {
+      SourceMapKind::new_enabled()
+    } else {
+      SourceMapKind::empty()
+    }
+  }
+
+  pub fn from_module(module: bool) -> Self {
+    if module {
+      SourceMapKind::new_enabled()
+    } else {
+      SourceMapKind::new_simple()
+    }
+  }
+
+  pub fn with_cheap(mut self, cheap: bool) -> Self {
+    if cheap {
+      self |= SourceMapKind::Cheap;
+    }
+    self
+  }
+
+  pub fn with_no_sources(mut self, no_sources: bool) -> Self {
+    if no_sources {
+      self |= SourceMapKind::NoSources;
+    }
+    self
+  }
+
+  pub fn with_sources_content(self, sources_content: bool) -> Self {
+    self.with_no_sources(!sources_content)
+  }
+
+  pub fn with_inline(mut self, inline: bool) -> Self {
+    if inline {
+      self |= SourceMapKind::Inline;
+    }
+    self
+  }
+
   pub fn enabled(&self) -> bool {
-    !self.is_empty()
+    self.source_map() || self.simple_source_map()
   }
 
   pub fn source_map(&self) -> bool {
@@ -39,6 +93,18 @@ impl SourceMapKind {
 
   pub fn no_sources(&self) -> bool {
     self.contains(SourceMapKind::NoSources)
+  }
+
+  pub fn inline(&self) -> bool {
+    self.contains(SourceMapKind::Inline)
+  }
+
+  pub fn inline_sources_content(&self) -> bool {
+    self.source_map() && !self.no_sources()
+  }
+
+  pub fn emit_columns(&self) -> bool {
+    !self.cheap()
   }
 }
 


### PR DESCRIPTION
## Summary

- Refactor `SourceMapDevToolModuleOptionsPlugin` to pass the complete `SourceMapKind` to module and runtime module setup instead of only `module` / `cheap` booleans.
- Add `NoSources` and `Inline` metadata plus chainable helpers on `SourceMapKind`, so generators can read sourcemap-related configuration directly, including `noSources`.
- Let JavaScript sourcemap printing consume `SourceMapKind` as the shared config source for `sourcesContent` and column emission behavior.

This is primarily a refactor to make sourcemap options available to generators such as the CSS generator, rather than a user-facing behavior change by itself.

## Related links

- None

## Testing

- `cargo fmt --all`
- `cargo check -p rspack_javascript_compiler -p rspack_plugin_devtool -p rspack_plugin_rsdoctor -p rspack_binding_api`
- `cargo check -p rspack_plugin_devtool -p rspack_plugin_rsdoctor`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).