### PR TITLE
perf(module-graph): store dependencies in dense map

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -114,7 +114,7 @@ impl Occasion for MakeOccasion {
     for (dep_id, dep) in mg.dependencies() {
       if let Some(info) = FactorizeInfo::get_from(dep) {
         if !info.is_success() {
-          make_failed_dependencies.insert(*dep_id);
+          make_failed_dependencies.insert(dep_id);
         }
         let resource = dep_id.into();
         file_dep.add_files(&resource, info.file_dependencies());

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -112,7 +112,7 @@ pub(crate) struct ModuleGraphData {
     rollback::RollbackMap<ModuleIdentifier, BoxModule, BuildHasherDefault<IdentifierHasher>>,
 
   /// Dependencies indexed by `DependencyId`.
-  dependencies: HashMap<DependencyId, BoxDependency>,
+  dependencies: rollback::DenseDependencyIdMap<BoxDependency>,
   /// AsyncDependenciesBlocks indexed by `AsyncDependenciesBlockIdentifier`.
   blocks: AsyncDependenciesBlockIdentifierMap<Box<AsyncDependenciesBlock>>,
 
@@ -610,7 +610,7 @@ impl ModuleGraph {
     &self.inner.blocks
   }
 
-  pub fn dependencies(&self) -> impl Iterator<Item = (&DependencyId, &BoxDependency)> {
+  pub fn dependencies(&self) -> impl Iterator<Item = (DependencyId, &BoxDependency)> {
     self.inner.dependencies.iter()
   }
 

--- a/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_map.rs
@@ -1,0 +1,93 @@
+use crate::DependencyId;
+
+#[derive(Debug, Clone)]
+pub struct DenseDependencyIdMap<V> {
+  values: Vec<Option<V>>,
+}
+
+impl<V> Default for DenseDependencyIdMap<V> {
+  fn default() -> Self {
+    Self { values: Vec::new() }
+  }
+}
+
+impl<V> DenseDependencyIdMap<V> {
+  #[inline]
+  pub fn insert(&mut self, key: DependencyId, value: V) -> Option<V> {
+    let index = key.as_u32() as usize;
+    if self.values.len() <= index {
+      self.values.resize_with(index + 1, || None);
+    }
+    self.values[index].replace(value)
+  }
+
+  #[inline]
+  pub fn remove(&mut self, key: &DependencyId) -> Option<V> {
+    self
+      .values
+      .get_mut(key.as_u32() as usize)
+      .and_then(Option::take)
+  }
+
+  #[inline]
+  pub fn get(&self, key: &DependencyId) -> Option<&V> {
+    self
+      .values
+      .get(key.as_u32() as usize)
+      .and_then(Option::as_ref)
+  }
+
+  #[inline]
+  pub fn get_mut(&mut self, key: &DependencyId) -> Option<&mut V> {
+    self
+      .values
+      .get_mut(key.as_u32() as usize)
+      .and_then(Option::as_mut)
+  }
+
+  #[inline]
+  pub fn clear(&mut self) {
+    self.values.clear();
+  }
+
+  #[inline]
+  pub fn iter(&self) -> impl Iterator<Item = (DependencyId, &V)> {
+    self.values.iter().enumerate().filter_map(|(index, value)| {
+      value
+        .as_ref()
+        .map(|value| (DependencyId::from(index as u32), value))
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::{DependencyId, module_graph::rollback::DenseDependencyIdMap};
+
+  #[test]
+  fn supports_sparse_dependency_ids() {
+    let mut map = DenseDependencyIdMap::default();
+    let a = DependencyId::from(1);
+    let b = DependencyId::from(8);
+
+    assert_eq!(map.insert(b, "b"), None);
+    assert_eq!(map.insert(a, "a"), None);
+
+    assert_eq!(map.get(&a), Some(&"a"));
+    assert_eq!(map.get(&b), Some(&"b"));
+    assert_eq!(map.get(&DependencyId::from(3)), None);
+
+    assert_eq!(map.iter().collect::<Vec<_>>(), vec![(a, &"a"), (b, &"b")]);
+  }
+
+  #[test]
+  fn remove_returns_existing_value() {
+    let mut map = DenseDependencyIdMap::default();
+    let id = DependencyId::from(2);
+
+    map.insert(id, 1);
+    assert_eq!(map.remove(&id), Some(1));
+    assert_eq!(map.get(&id), None);
+    assert_eq!(map.remove(&id), None);
+  }
+}

--- a/crates/rspack_core/src/module_graph/rollback/mod.rs
+++ b/crates/rspack_core/src/module_graph/rollback/mod.rs
@@ -1,5 +1,7 @@
 pub mod atom;
 pub use atom::*;
+pub mod dense_dependency_id_map;
+pub use dense_dependency_id_map::*;
 pub mod dense_dependency_id_overlay_map;
 pub use dense_dependency_id_overlay_map::*;
 pub mod map;

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -558,7 +558,7 @@ async fn optimize_dependencies(
       .filter(|(_, dep)| dep.dependency_type() == &DependencyType::RstestMockModuleId)
       .filter_map(|(dep_id, _)| {
         module_graph
-          .module_identifier_by_dependency_id(dep_id)
+          .module_identifier_by_dependency_id(&dep_id)
           .copied()
       })
       .collect()

--- a/xtask/benchmark/benches/groups/module_graph_api.rs
+++ b/xtask/benchmark/benches/groups/module_graph_api.rs
@@ -79,7 +79,7 @@ pub fn module_graph_api_benchmark_inner(c: &mut Criterion) {
     let module_graph = compiler.compilation.get_module_graph();
     module_graph
       .dependencies()
-      .map(|(dependency_id, _)| *dependency_id)
+      .map(|(dependency_id, _)| dependency_id)
       .collect::<Vec<_>>()
   };
   let module_ids = {


### PR DESCRIPTION
## What changed

- Added `DenseDependencyIdMap`, a vector-backed map keyed directly by `DependencyId`.
- Switched `ModuleGraphData.dependencies` from a hash map to `DenseDependencyIdMap<BoxDependency>`.
- Updated the few dependency iterator call sites for the owned `DependencyId` iterator shape.

## Why

`DependencyId` is a dense numeric key, so dependency lookup in the module graph can avoid hash-map overhead and use direct index access instead.

## Scope

This PR now only keeps the dependency storage dense-map change. Other previously proposed dense-map conversions and dependency-storage splitting changes were removed.

## Validation

- `cargo test -p rspack_core module_graph::rollback::dense_dependency_id_map --lib`
- `cargo check -p rspack_core`
- `cargo fmt --all --check`