### PR TITLE
fix(real-content-hash): use a collision-resistant sentinel for content hashes

### DIFF
--- a/crates/rspack_binding_api/src/path_data.rs
+++ b/crates/rspack_binding_api/src/path_data.rs
@@ -52,6 +52,7 @@ impl JsPathData {
       runtime: self.runtime.as_deref(),
       url: self.url.as_deref(),
       id: self.id.as_deref(),
+      real_content_hash: false,
     }
   }
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1202,6 +1202,7 @@ impl Compilation {
     if data.hash.is_none() {
       data.hash = self.get_hash();
     }
+    data.real_content_hash = self.options.optimization.real_content_hash;
     let path = filename.render(data, Some(info)).await?;
     Ok(path)
   }
@@ -1213,8 +1214,9 @@ impl Compilation {
   pub async fn get_asset_path_with_info(
     &self,
     filename: &Filename,
-    data: PathData<'_>,
+    mut data: PathData<'_>,
   ) -> Result<(String, AssetInfo)> {
+    data.real_content_hash = self.options.optimization.real_content_hash;
     let mut info = AssetInfo::default();
     let path = filename.render(data, Some(&mut info)).await?;
     Ok((path, info))

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -194,6 +194,32 @@ pub fn has_content_hash_placeholder(template: &str) -> bool {
   false
 }
 
+// realContentHash sentinel (#8474): while realContentHash is on, `[contenthash]`
+// renders as this token instead of the raw hash, so RealContentHashPlugin rewrites
+// only real insertion sites, never source data that merely looks like a hash.
+// Charset is `[A-Za-z0-9_]`: filename-safe and minify-stable inside string literals.
+const CONTENT_HASH_SENTINEL_PREFIX: &str = "__rspackRealCH_";
+const CONTENT_HASH_SENTINEL_SUFFIX: &str = "_HClaeRkcapsr__";
+
+/// `<prefix><digest>_<len><suffix>`: digest keeps it unique per hash; len carries the
+/// requested `[contenthash:len]` so the plugin can truncate the real hash to match.
+pub fn content_hash_sentinel(digest: &str, len: usize) -> String {
+  format!("{CONTENT_HASH_SENTINEL_PREFIX}{digest}_{len}{CONTENT_HASH_SENTINEL_SUFFIX}")
+}
+
+pub fn is_content_hash_sentinel(s: &str) -> bool {
+  s.starts_with(CONTENT_HASH_SENTINEL_PREFIX) && s.ends_with(CONTENT_HASH_SENTINEL_SUFFIX)
+}
+
+pub fn parse_content_hash_sentinel_len(s: &str) -> Option<usize> {
+  s.strip_prefix(CONTENT_HASH_SENTINEL_PREFIX)?
+    .strip_suffix(CONTENT_HASH_SENTINEL_SUFFIX)?
+    .rsplit_once('_')?
+    .1
+    .parse::<usize>()
+    .ok()
+}
+
 fn render_template(
   template: Cow<str>,
   options: PathData,
@@ -298,19 +324,28 @@ fn render_template(
       asset_info.version = content_hash.to_string();
     }
     t = t.map(|t| {
-      t.replace_all_with_len(CONTENT_HASH_PLACEHOLDER, |len, need_base64| {
-        let content: Cow<str> = if need_base64 {
-          base64::encode_to_string(content_hash).into()
-        } else {
-          content_hash.into()
-        };
-        let content = content.map(|s| s[..hash_len(s, len)].into());
-        if let Some(asset_info) = asset_info.as_mut() {
-          asset_info.set_immutable(Some(true));
-          asset_info.set_content_hash(content.to_string());
-        }
-        content
-      })
+      t.replace_all_with_len(
+        CONTENT_HASH_PLACEHOLDER,
+        |len: Option<usize>, need_base64: bool| {
+          let content: Cow<str> = if is_content_hash_sentinel(content_hash) {
+            content_hash.into() // already a sentinel (runtime chunk-filename ref) — don't re-wrap
+          } else if options.real_content_hash && !need_base64 {
+            content_hash_sentinel(content_hash, hash_len(content_hash, len)).into()
+          } else if need_base64 {
+            let s = base64::encode_to_string(content_hash);
+            s[..hash_len(&s, len)].to_string().into()
+          } else {
+            content_hash[..hash_len(content_hash, len)]
+              .to_string()
+              .into()
+          };
+          if let Some(asset_info) = asset_info.as_mut() {
+            asset_info.set_immutable(Some(true));
+            asset_info.set_content_hash(content.to_string());
+          }
+          content
+        },
+      )
     });
   }
   // chunk-level

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -233,6 +233,9 @@ pub struct PathData<'a> {
   pub runtime: Option<&'a str>,
   pub url: Option<&'a str>,
   pub id: Option<&'a str>,
+  /// When set, `[contenthash]` renders as a collision-resistant sentinel (#8474);
+  /// the compilation path helpers set it from `optimization.realContentHash`.
+  pub real_content_hash: bool,
 }
 
 static MATCH_ID_REGEX: LazyLock<Regex> =
@@ -309,6 +312,11 @@ impl<'a> PathData<'a> {
 
   pub fn content_hash_optional(mut self, v: Option<&'a str>) -> Self {
     self.content_hash = v;
+    self
+  }
+
+  pub fn real_content_hash(mut self, v: bool) -> Self {
+    self.real_content_hash = v;
     self
   }
 

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -214,7 +214,10 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
                 }
                 let new_hash = hasher.digest(&compilation.options.output.hash_digest);
 
-                new_hash.rendered(old_hash.len()).to_string()
+                // old_hash may be a sentinel (#8474): truncate to the length it encodes
+                let len =
+                  rspack_core::parse_content_hash_sentinel_len(&old_hash).unwrap_or(old_hash.len());
+                new_hash.rendered(len).to_string()
               };
 
               Ok((old_hash.clone(), new_hash))

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -238,9 +238,20 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
             &self.source_type,
             compilation.options.output.hash_digest_length,
           )
-          .map(|hash| match hash_len_map.get("[contenthash]") {
-            Some(hash_len) => hash[..*hash_len].to_string(),
-            None => hash.to_string(),
+          .map(|hash| {
+            if compilation.options.optimization.real_content_hash {
+              // sentinel for issue #8474 — matches the chunk's own filename
+              let len = hash_len_map
+                .get("[contenthash]")
+                .copied()
+                .unwrap_or(hash.len());
+              rspack_core::content_hash_sentinel(hash, len)
+            } else {
+              match hash_len_map.get("[contenthash]") {
+                Some(hash_len) => hash[..*hash_len].to_string(),
+                None => hash.to_string(),
+              }
+            }
           })
         },
         &chunks,
@@ -320,13 +331,20 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
           .content_hash(&compilation.chunk_hashes_artifact)
           .and_then(|content_hash| content_hash.get(&self.source_type))
           .map(|i| {
-            let hash = unquoted_stringify(
-              chunk.id(),
-              i.rendered(compilation.options.output.hash_digest_length),
-            );
-            match hash_len_map.get("[contenthash]") {
-              Some(hash_len) => hash[..*hash_len].to_string(),
-              None => hash,
+            let digest = i.rendered(compilation.options.output.hash_digest_length);
+            if compilation.options.optimization.real_content_hash {
+              // sentinel (#8474) — matches the chunk's own filename
+              let len = hash_len_map
+                .get("[contenthash]")
+                .copied()
+                .unwrap_or(digest.len());
+              rspack_core::content_hash_sentinel(digest, len)
+            } else {
+              let hash = unquoted_stringify(chunk.id(), digest);
+              match hash_len_map.get("[contenthash]") {
+                Some(hash_len) => hash[..*hash_len].to_string(),
+                None => hash,
+              }
             }
           });
         let full_hash = match hash_len_map


### PR DESCRIPTION
## Why

`optimization.realContentHash` rewrites each asset's placeholder content hash to the hash of its final bytes. To fix up references it does a **global string replace** of every old hash across all asset contents (`crates/rspack_plugin_real_content_hash`). A content hash is just a hex string, so any source data that merely *equals* a chunk's hash is rewritten too — silently corrupting the output, with no error.

This is #8474 (webpack/webpack#14058 shares the same root cause).

**Before** — a chunk whose data contains `…content-hash=64857983…` (where `64857983` coincidentally equals another chunk's content hash) becomes `…content-hash=b72bccbd…` after realContentHash. The data is corrupted.

**After** — the data is preserved; legitimate filename references are still rewritten.

## What

While `realContentHash` is enabled, render `[contenthash]` as a collision-resistant **sentinel** (`__rspackRealCH_<digest>_<N>_…`) at every real insertion site instead of the raw hash, and have `RealContentHashPlugin` replace only those sentinels.

Key invariant: `AssetInfo.content_hash` (the plugin's search set) is only ever written in `filename.rs::render_template`, reached solely through the two `*_with_info` compilation path helpers. Gating those makes the search set **provably composed of sentinels only**, so no raw source byte sequence can collide with it.

- `options/output.rs` — add `PathData.real_content_hash`
- `options/filename.rs` — sentinel helpers + `[contenthash]` render branch (emit sentinel / pass through if already one)
- `compilation/mod.rs` — set the flag in `get_path_with_info` / `get_asset_path_with_info`
- `runtime_module/get_chunk_filename.rs` — runtime chunk-map references emit the matching sentinel (static + dynamic)
- `plugin_real_content_hash/lib.rs` — truncate the real hash to the length encoded in the sentinel

Gated by `optimization.realContentHash`; output is byte-identical when there is no collision.

## Verification

- Deterministic standalone repro: data preserved with the fix, corrupted without it.
- `rstest` base suite: 5900 passed / 0 failed.
- `cargo test` workspace: 0 failures.

## TODO (draft)

- [ ] In-suite regression test. The deterministic repro needs a two-pass build to learn the colliding hash, which doesn't fit the single-build `configCases` harness; exploring a short-hash + de Bruijn fixture instead.
