### PR TITLE
refactor: split module graph dependency storage

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -93,7 +93,7 @@ impl BuildChunkGraphArtifact {
           .module_graph_module_by_identifier(&module)
           .expect("should have module");
         module
-          .all_dependencies()
+          .module_dependencies()
           .iter()
           .filter(|dep_id| {
             module_graph

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -116,12 +116,12 @@ impl BuildModuleGraphArtifact {
       .remove_files(&resource_id, &build_info.build_dependencies);
     self.make_failed_module.remove(module_identifier);
 
-    // clean incoming & all_dependencies(outgoing) factorize info
+    // clean incoming & module_dependencies(outgoing) factorize info
     let mgm = mg
       .module_graph_module_by_identifier(module_identifier)
       .expect("should have mgm");
     let dep_ids = mgm
-      .all_dependencies()
+      .module_dependencies()
       .iter()
       .copied()
       .chain(mgm.incoming_connections().clone())

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -140,7 +140,7 @@ pub async fn recovery_module_graph(
     })
     .with_max_len(1)
     .consume(|node| {
-      let mgm = node.mgm.into_owned();
+      let mut mgm = node.mgm.into_owned();
       let module = node.module.into_owned();
       for (index_in_block, (dep, parent_block)) in node.dependencies.into_iter().enumerate() {
         let dep = dep.into_owned();
@@ -167,6 +167,18 @@ pub async fn recovery_module_graph(
         module_to_lazy_make
           .update_module_lazy_dependencies(module.identifier(), Some(lazy_info.into_owned()));
       }
+      mgm.set_code_generation_dependencies(
+        module
+          .get_code_generation_dependencies()
+          .map(|deps| deps.to_vec())
+          .unwrap_or_default(),
+      );
+      mgm.set_presentational_dependencies(
+        module
+          .get_presentational_dependencies()
+          .map(|deps| deps.to_vec())
+          .unwrap_or_default(),
+      );
       mg.add_module_graph_module(mgm);
       mg.add_module(module);
     });

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -2349,21 +2349,17 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     self.prepared_connection_map = all_modules
       .par_iter()
       .map(|module| {
-        let all_dependencies = mg
+        let module_dependencies = mg
           .module_graph_module_by_identifier(module)
-          .map(|mgm| mgm.all_dependencies())
+          .map(|mgm| mgm.module_dependencies())
           .unwrap_or_default();
-        let dependency_count = all_dependencies.len();
+        let dependency_count = module_dependencies.len();
 
         let mut ordered_deps = Vec::new();
         let mut unordered_deps = Vec::with_capacity(dependency_count);
-        for dep_id in all_dependencies {
+        for dep_id in module_dependencies {
           let dep = mg.dependency_by_id(dep_id);
-          let module_dep = dep.as_module_dependency();
-          if module_dep.is_none() && dep.as_context_dependency().is_none() {
-            continue;
-          }
-          if matches!(module_dep.map(|d| d.weak()), Some(true)) {
+          if matches!(dep.as_module_dependency().map(|d| d.weak()), Some(true)) {
             continue;
           }
           let Some(connection) = mg.connection_by_dependency_id(dep_id) else {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -142,6 +142,7 @@ impl Task<TaskContext> for BuildResultTask {
     let mut lazy_dependencies = LazyDependencies::default();
     let mut queue = VecDeque::new();
     let mut all_dependencies = vec![];
+    let mut module_dependencies = vec![];
     let mut handle_block = |dependencies: Vec<BoxDependency>,
                             blocks: Vec<Box<AsyncDependenciesBlock>>,
                             current_block: Option<Box<AsyncDependenciesBlock>>|
@@ -155,6 +156,11 @@ impl Task<TaskContext> for BuildResultTask {
           module.add_dependency_id(dependency_id);
         }
         all_dependencies.push(dependency_id);
+        if dependency.as_module_dependency().is_some()
+          || dependency.as_context_dependency().is_some()
+        {
+          module_dependencies.push(dependency_id);
+        }
         module_graph.set_parents(
           dependency_id,
           DependencyParents {
@@ -183,6 +189,21 @@ impl Task<TaskContext> for BuildResultTask {
     {
       let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
       mgm.all_dependencies_mut().clone_from(&all_dependencies);
+      mgm
+        .module_dependencies_mut()
+        .clone_from(&module_dependencies);
+      mgm.set_code_generation_dependencies(
+        module
+          .get_code_generation_dependencies()
+          .map(|deps| deps.to_vec())
+          .unwrap_or_default(),
+      );
+      mgm.set_presentational_dependencies(
+        module
+          .get_presentational_dependencies()
+          .map(|deps| deps.to_vec())
+          .unwrap_or_default(),
+      );
     }
 
     let module_identifier = module.identifier();
@@ -195,7 +216,7 @@ impl Task<TaskContext> for BuildResultTask {
       let lazy_dependency_ids = lazy_dependencies
         .all_lazy_dependencies()
         .collect::<FxHashSet<_>>();
-      all_dependencies.retain(|dep| !lazy_dependency_ids.contains(dep));
+      module_dependencies.retain(|dep| !lazy_dependency_ids.contains(dep));
 
       if let Some(HasLazyDependencies::Pending(pending_forwarded_ids)) = context
         .artifact
@@ -213,13 +234,13 @@ impl Task<TaskContext> for BuildResultTask {
         tasks.push(Box::new(task));
       }
 
-      all_dependencies
+      module_dependencies
     } else {
       context
         .artifact
         .module_to_lazy_make
         .update_module_lazy_dependencies(module_identifier, None);
-      all_dependencies
+      module_dependencies
     };
 
     tasks.push(Box::new(ProcessDependenciesTask {

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -94,10 +94,13 @@ pub async fn code_generation(compilation: &mut Compilation, modules: IdentifierS
   let mut no_codegen_dependencies_modules = IdentifierSet::default();
   let mut has_codegen_dependencies_modules = IdentifierSet::default();
   for module_identifier in modules {
-    let module = module_graph
+    module_graph
       .module_by_identifier(&module_identifier)
       .expect("should have module");
-    if module.get_code_generation_dependencies().is_none() {
+    if module_graph
+      .get_code_generation_dependencies(&module_identifier)
+      .is_none()
+    {
       no_codegen_dependencies_modules.insert(module_identifier);
     } else {
       has_codegen_dependencies_modules.insert(module_identifier);

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -734,7 +734,13 @@ pub fn module_update_hash(
   chunk_graph
     .get_module_graph_hash(module, compilation, runtime)
     .dyn_hash(hasher);
-  if let Some(deps) = module.get_presentational_dependencies() {
+  let module_graph = compilation.get_module_graph();
+  if let Some(deps) = module_graph.get_presentational_dependencies(&module.identifier()) {
+    for dep in deps {
+      dep.update_hash(hasher, compilation, runtime);
+    }
+  } else if let Some(deps) = module.get_presentational_dependencies() {
+    // Fallback for modules constructed outside the make module graph path.
     for dep in deps {
       dep.update_hash(hasher, compilation, runtime);
     }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -23,8 +23,8 @@ mod connection;
 pub use connection::*;
 
 use crate::{
-  BoxDependency, BoxModule, DependencyCondition, DependencyId, ExportsInfoArtifact,
-  ModuleIdentifier,
+  BoxDependency, BoxDependencyTemplate, BoxModule, BoxModuleDependency, DependencyCondition,
+  DependencyId, ExportsInfoArtifact, ModuleIdentifier,
 };
 
 // TODO Here request can be used Atom
@@ -327,6 +327,7 @@ impl ModuleGraph {
       mgm.remove_outgoing_connection(dep_id);
       if force {
         mgm.all_dependencies_mut().retain(|id| id != dep_id);
+        mgm.module_dependencies_mut().retain(|id| id != dep_id);
       }
     }
     // remove incoming from module graph module
@@ -614,6 +615,36 @@ impl ModuleGraph {
     self.inner.dependencies.iter()
   }
 
+  pub fn get_module_dependencies(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<&[DependencyId]> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(|mgm| mgm.module_dependencies())
+      .filter(|deps| !deps.is_empty())
+  }
+
+  pub fn get_code_generation_dependencies(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<&[BoxModuleDependency]> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(|mgm| mgm.code_generation_dependencies())
+      .filter(|deps| !deps.is_empty())
+  }
+
+  pub fn get_presentational_dependencies(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<&[BoxDependencyTemplate]> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(|mgm| mgm.presentational_dependencies())
+      .filter(|deps| !deps.is_empty())
+  }
+
   pub fn add_dependency(&mut self, dependency: BoxDependency) {
     self.inner.dependencies.insert(*dependency.id(), dependency);
   }
@@ -797,7 +828,7 @@ impl ModuleGraph {
     self
       .module_graph_module_by_identifier(module_identifier)
       .map(|m| {
-        m.all_dependencies()
+        m.module_dependencies()
           .iter()
           .filter_map(|dep_id| self.connection_by_dependency_id(dep_id))
       })
@@ -812,7 +843,7 @@ impl ModuleGraph {
     self
       .module_graph_module_by_identifier(module_identifier)
       .map(|m| {
-        m.all_dependencies()
+        m.module_dependencies()
           .iter()
           .filter(|dep_id| self.connection_by_dependency_id(dep_id).is_some())
       })

--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -3,7 +3,9 @@ use std::fmt;
 use rspack_cacheable::{cacheable, with::Skip};
 use rustc_hash::FxHashSet;
 
-use crate::{DependencyId, ModuleIdentifier, ModuleIssuer};
+use crate::{
+  BoxDependencyTemplate, BoxModuleDependency, DependencyId, ModuleIdentifier, ModuleIssuer,
+};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -50,6 +52,14 @@ pub struct ModuleGraphModule {
   // an quick way to get a module's all dependencies (including its blocks' dependencies)
   // and it is ordered by dependency creation order
   all_dependencies: Vec<DependencyId>,
+  // dependency ids that participate in module graph edges / factorization.
+  // Kept separately from presentational/code-generation-only dependencies to avoid
+  // repeatedly downcasting every dependency in graph traversals.
+  module_dependencies: Vec<DependencyId>,
+  #[cacheable(with=Skip)]
+  presentational_dependencies: Vec<BoxDependencyTemplate>,
+  #[cacheable(with=Skip)]
+  code_generation_dependencies: Vec<BoxModuleDependency>,
   pub(crate) pre_order_index: Option<u32>,
   pub post_order_index: Option<u32>,
   pub depth: Option<usize>,
@@ -65,6 +75,9 @@ impl ModuleGraphModule {
       // exec_order: usize::MAX,
       module_identifier,
       all_dependencies: Default::default(),
+      module_dependencies: Default::default(),
+      presentational_dependencies: Default::default(),
+      code_generation_dependencies: Default::default(),
       pre_order_index: None,
       post_order_index: None,
       depth: None,
@@ -102,6 +115,30 @@ impl ModuleGraphModule {
 
   pub(crate) fn all_dependencies_mut(&mut self) -> &mut Vec<DependencyId> {
     &mut self.all_dependencies
+  }
+
+  pub fn module_dependencies(&self) -> &[DependencyId] {
+    &self.module_dependencies
+  }
+
+  pub(crate) fn module_dependencies_mut(&mut self) -> &mut Vec<DependencyId> {
+    &mut self.module_dependencies
+  }
+
+  pub fn presentational_dependencies(&self) -> &[BoxDependencyTemplate] {
+    &self.presentational_dependencies
+  }
+
+  pub fn set_presentational_dependencies(&mut self, deps: Vec<BoxDependencyTemplate>) {
+    self.presentational_dependencies = deps;
+  }
+
+  pub fn code_generation_dependencies(&self) -> &[BoxModuleDependency] {
+    &self.code_generation_dependencies
+  }
+
+  pub fn set_code_generation_dependencies(&mut self, deps: Vec<BoxModuleDependency>) {
+    self.code_generation_dependencies = deps;
   }
 
   pub fn set_issuer_if_unset(&mut self, issuer: Option<ModuleIdentifier>) {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -296,7 +296,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
           }
         });
 
-        if let Some(dependencies) = module.get_presentational_dependencies() {
+        if let Some(dependencies) = module_graph
+          .get_presentational_dependencies(&module.identifier())
+          .or_else(|| module.get_presentational_dependencies())
+        {
           dependencies.iter().for_each(|dependency| {
             if let Some(template) = dependency
               .dependency_template()

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -374,7 +374,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         self.source_dependency(compilation, dependency_id, &mut source, &mut context)
       });
 
-      if let Some(dependencies) = module.get_presentational_dependencies() {
+      if let Some(dependencies) = compilation
+        .get_module_graph()
+        .get_presentational_dependencies(&module.identifier())
+        .or_else(|| module.get_presentational_dependencies())
+      {
         dependencies.iter().for_each(|dependency| {
           if let Some(template) = dependency
             .dependency_template()
@@ -415,7 +419,10 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       return Some("Module is not an ECMAScript module".into());
     }
 
-    if let Some(deps) = module.get_presentational_dependencies() {
+    if let Some(deps) = _mg
+      .get_presentational_dependencies(&module.identifier())
+      .or_else(|| module.get_presentational_dependencies())
+    {
       if !deps.iter().any(|dep| {
         // https://github.com/webpack/webpack/blob/b9fb99c63ca433b24233e0bbc9ce336b47872c08/lib/javascript/JavascriptGenerator.js#L65-L74
         dep

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1376,11 +1376,13 @@ async fn create_concatenated_module(
       .map(|id| id.to_string()),
     layer: root_module.get_layer().cloned(),
     resolve_options: root_module.get_resolve_options(),
-    code_generation_dependencies: root_module
-      .get_code_generation_dependencies()
+    code_generation_dependencies: module_graph
+      .get_code_generation_dependencies(&root_module_id)
+      .or_else(|| root_module.get_code_generation_dependencies())
       .map(|deps| deps.to_vec()),
-    presentational_dependencies: root_module
-      .get_presentational_dependencies()
+    presentational_dependencies: module_graph
+      .get_presentational_dependencies(&root_module_id)
+      .or_else(|| root_module.get_presentational_dependencies())
       .map(|deps| deps.to_vec()),
     context: Some(compilation.options.context.clone()),
     side_effect_connection_state: root_module.get_side_effects_connection_state(
@@ -1551,7 +1553,19 @@ fn add_concatenated_module(
   let mut chunk_graph = std::mem::take(&mut compilation.build_chunk_graph_artifact.chunk_graph);
   let module_graph = compilation.get_module_graph_mut();
 
-  let module_graph_module = ModuleGraphModule::new(new_module.identifier());
+  let mut module_graph_module = ModuleGraphModule::new(new_module.identifier());
+  module_graph_module.set_code_generation_dependencies(
+    new_module
+      .get_code_generation_dependencies()
+      .map(|deps| deps.to_vec())
+      .unwrap_or_default(),
+  );
+  module_graph_module.set_presentational_dependencies(
+    new_module
+      .get_presentational_dependencies()
+      .map(|deps| deps.to_vec())
+      .unwrap_or_default(),
+  );
   module_graph.add_module_graph_module(module_graph_module);
   ModuleGraph::clone_module_attributes(compilation, &root_module_id, &new_module.identifier());
   // integrate


### PR DESCRIPTION
## Summary

- Store module, presentational, and code generation dependencies separately on `ModuleGraphModule`.
- Populate the separated dependency storage during module build, persistent cache recovery, and module concatenation.
- Use the separated module graph accessors in code generation, hashing, chunk graph, and JS/CSS generation paths to reduce repeated `as_*` conversions.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace`
- `cargo test -p rspack_core module_graph --lib`
- `pnpm run test:rs`
- `pnpm run build:binding:dev`
- `pnpm run test:unit`