### PR TITLE
chore: move rust bench simulation runner to exclusive host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/bench-rust.yml
     with:
       target: x86_64-unknown-linux-gnu
-      runner: '"ubuntu-22.04"'
+      runner: '"physical-1-exclusive"'
 
   bench-rust-walltime:
     name: Rust Bench Walltime


### PR DESCRIPTION
## Summary

Move the Rust bench simulation job to `physical-1-exclusive` so it uses the same exclusive physical runner class as the walltime bench.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
