### PR TITLE
chore: move rust bench simulation runner to exclusive host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
     uses: ./.github/workflows/bench-rust.yml
     with:
       target: x86_64-unknown-linux-gnu
-      runner: '"ubuntu-22.04"'
+      measurement: simulation
+      runner: '"physical-1-exclusive"'
 
   bench-rust-walltime:
     name: Rust Bench Walltime


### PR DESCRIPTION
## Summary

Move the Rust bench simulation job to `physical-1-exclusive`. The simulation measurement is now explicit at the call site and uses the exclusive physical runner.

## Related links

Supersedes #14315, which was closed after GitHub kept stale head/check metadata after force-push retries.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
