### PR TITLE
feat: support parsing createRequire from module

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2476,6 +2476,7 @@ export interface RawJavascriptParserOptions {
   overrideStrict?: string
   importMeta?: string
   commonjsMagicComments?: boolean
+  createRequire?: boolean | string
 commonjs?: boolean | { exports?: boolean | 'skipInEsm' }
 deferImport?: boolean
 sourceImport?: boolean

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -47,10 +47,11 @@ use rspack_core::{
   CssModuleGeneratorOptions, CssModuleParserOptions, CssParserOptions, DynamicImportMode,
   EntryDescription, EntryOptions, EntryRuntime, Environment, Experiments, ExternalItem,
   ExternalType, Filename, GeneratorOptions, GeneratorOptionsMap, ImportMeta,
-  JavascriptParserCommonjsExportsOption, JavascriptParserCommonjsOptions, JavascriptParserOptions,
-  JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName,
-  LibraryNonUmdObject, LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules,
-  ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
+  JavascriptParserCommonjsExportsOption, JavascriptParserCommonjsOptions,
+  JavascriptParserCreateRequire, JavascriptParserOptions, JavascriptParserOrder,
+  JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName, LibraryNonUmdObject,
+  LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions,
+  ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
   NodeGlobalOption, NodeOption, Optimization, OutputOptions, ParseOption, ParserOptions,
   ParserOptionsMap, PathInfo, PublicPath, Resolve, RuleSetCondition, RuleSetLogicalConditions,
   SideEffectOption, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType,
@@ -1744,6 +1745,9 @@ impl ModuleOptionsBuilder {
           }),
           import_dynamic: Some(true),
           commonjs_magic_comments: Some(false),
+          create_require: target_properties.node.filter(|node| *node).map(|_| {
+            JavascriptParserCreateRequire::Enabled("createRequire from module".to_string())
+          }),
           jsx: Some(false),
           ..Default::default()
         }),

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1708,6 +1708,7 @@ CompilerOptions {
                             commonjs_magic_comments: Some(
                                 false,
                             ),
+                            create_require: None,
                             jsx: Some(
                                 false,
                             ),

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -20,11 +20,11 @@ use rspack_core::{
   CssModuleParserOptions, CssParserImport, CssParserImportContext, CssParserOptions,
   DescriptionData, DynamicImportFetchPriority, DynamicImportMode, ExportPresenceMode, FuncUseCtx,
   GeneratorOptions, GeneratorOptionsMap, ImportMeta, JavascriptParserCommonjsExportsOption,
-  JavascriptParserCommonjsOptions, JavascriptParserOptions, JavascriptParserOrder,
-  JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, ModuleNoParseRule,
-  ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions, ModuleRule, ModuleRuleEffect,
-  ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, OverrideStrict, ParseOption,
-  ParserOptions, ParserOptionsMap, TypeReexportPresenceMode,
+  JavascriptParserCommonjsOptions, JavascriptParserCreateRequire, JavascriptParserOptions,
+  JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions,
+  ModuleNoParseRule, ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions, ModuleRule,
+  ModuleRuleEffect, ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, OverrideStrict,
+  ParseOption, ParserOptions, ParserOptionsMap, TypeReexportPresenceMode,
 };
 use rspack_error::error;
 use rspack_regex::RspackRegex;
@@ -299,6 +299,8 @@ pub struct RawJavascriptParserOptions {
   pub override_strict: Option<String>,
   pub import_meta: Option<String>,
   pub commonjs_magic_comments: Option<bool>,
+  #[napi(ts_type = "boolean | string")]
+  pub create_require: Option<Either<bool, String>>,
   #[napi(ts_type = "boolean | { exports?: boolean | 'skipInEsm' }")]
   pub commonjs: Option<Either<bool, RawJavascriptParserCommonjsOptions>>,
   pub defer_import: Option<bool>,
@@ -413,6 +415,15 @@ impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
       }),
       import_dynamic: value.import_dynamic,
       commonjs_magic_comments: value.commonjs_magic_comments,
+      create_require: value
+        .create_require
+        .map(|create_require| match create_require {
+          Either::A(true) => {
+            JavascriptParserCreateRequire::Enabled("createRequire from module".to_string())
+          }
+          Either::A(false) => JavascriptParserCreateRequire::Disabled,
+          Either::B(value) => JavascriptParserCreateRequire::Enabled(value),
+        }),
       jsx: value.jsx,
       defer_import: value.defer_import,
       source_import: value.source_import,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -433,7 +433,7 @@ mod tests {
   use super::*;
   use crate::{
     AssetGeneratorOptions, AssetParserDataUrl, AssetParserDataUrlOptions, AssetParserOptions,
-    CssGeneratorOptions, CssParserOptions, JavascriptParserOptions,
+    CssGeneratorOptions, CssParserOptions, JavascriptParserCreateRequire, JavascriptParserOptions,
   };
 
   #[test]
@@ -613,6 +613,28 @@ mod tests {
     assert_eq!(parser_options.named_exports, Some(true));
     assert_eq!(generator_options.exports_only, Some(false));
     assert_eq!(generator_options.es_module, Some(true));
+  }
+
+  #[test]
+  fn merge_explicit_disabled_create_require_into_global_parser_options() {
+    let global = ParserOptions::Javascript(JavascriptParserOptions {
+      create_require: Some(JavascriptParserCreateRequire::Enabled(
+        "createRequire from module".to_string(),
+      )),
+      ..Default::default()
+    });
+    let local = ParserOptions::JavascriptAuto(JavascriptParserOptions {
+      create_require: Some(JavascriptParserCreateRequire::Disabled),
+      ..Default::default()
+    });
+
+    let resolved = merge_parser_options_with_local(Some(&global), Some(&local))
+      .expect("merged parser options should exist");
+
+    let options = resolved
+      .get_javascript()
+      .expect("javascript parser options should be resolved");
+    assert!(!options.is_create_require_enabled());
   }
 
   #[test]

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -333,11 +333,38 @@ pub struct JavascriptParserOptions {
   pub commonjs: Option<JavascriptParserCommonjsOptions>,
   pub import_dynamic: Option<bool>,
   pub commonjs_magic_comments: Option<bool>,
+  pub create_require: Option<JavascriptParserCreateRequire>,
   pub jsx: Option<bool>,
   pub defer_import: Option<bool>,
   pub source_import: Option<bool>,
   pub import_meta_resolve: Option<bool>,
   pub side_effects_free: Option<Vec<String>>,
+}
+
+impl JavascriptParserOptions {
+  pub fn create_require_option(&self) -> Option<&str> {
+    match self.create_require.as_ref()? {
+      JavascriptParserCreateRequire::Disabled => None,
+      JavascriptParserCreateRequire::Enabled(option) => Some(option),
+    }
+  }
+
+  pub fn is_create_require_enabled(&self) -> bool {
+    self.create_require_option().is_some()
+  }
+}
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub enum JavascriptParserCreateRequire {
+  Disabled,
+  Enabled(String),
+}
+
+impl MergeFrom for JavascriptParserCreateRequire {
+  fn merge_from(self, other: &Self) -> Self {
+    other.clone()
+  }
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -3,14 +3,15 @@ use rspack_cacheable::{
   with::{AsCacheable, AsOption, AsVec},
 };
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  AsContextDependency, Context, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyCondition, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport,
   FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ReferencedSpecifier,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource, create_exports_object_referenced,
-  create_referenced_exports_by_referenced_specifiers,
+  ResourceIdentifier, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  create_exports_object_referenced, create_referenced_exports_by_referenced_specifiers,
 };
 
+use super::create_resource_identifier_for_contextual_commonjs_dependency;
 use crate::dependency::{
   DependencyBranchGuard, DependencyBranchGuards, compose_dependency_condition,
 };
@@ -28,6 +29,8 @@ pub struct CommonJsRequireDependency {
   referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
   #[cacheable(with=AsOption<AsCacheable>)]
   branch_guards: Option<Box<DependencyBranchGuards>>,
+  context: Option<Context>,
+  resource_identifier: ResourceIdentifier,
   factorize_info: FactorizeInfo,
 }
 
@@ -49,7 +52,38 @@ impl CommonJsRequireDependency {
       loc,
       referenced_specifiers,
       branch_guards: None,
+      context: None,
+      resource_identifier: Default::default(),
       factorize_info: Default::default(),
+    }
+  }
+
+  pub fn new_contextual(
+    request: String,
+    range: DependencyRange,
+    range_expr: Option<DependencyRange>,
+    optional: bool,
+    context: Context,
+    loc: Option<DependencyLocation>,
+    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
+  ) -> Self {
+    let resource_identifier = create_resource_identifier_for_contextual_commonjs_dependency(
+      "cjs require",
+      &context,
+      &request,
+    )
+    .into();
+    Self {
+      context: Some(context),
+      resource_identifier,
+      ..Self::new(
+        request,
+        range,
+        range_expr,
+        optional,
+        loc,
+        referenced_specifiers,
+      )
     }
   }
 
@@ -78,6 +112,17 @@ impl Dependency for CommonJsRequireDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::CjsRequire
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    self.context.as_ref()
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    self
+      .context
+      .as_ref()
+      .map(|_| self.resource_identifier.as_str())
   }
 
   fn range(&self) -> Option<DependencyRange> {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
@@ -37,6 +37,21 @@ pub use require_resolve_dependency::{RequireResolveDependency, RequireResolveDep
 pub use require_resolve_header_dependency::{
   RequireResolveHeaderDependency, RequireResolveHeaderDependencyTemplate,
 };
+use rspack_core::Context;
+
+pub(super) fn create_resource_identifier_for_contextual_commonjs_dependency(
+  dep_type: &str,
+  context: &Context,
+  request: &str,
+) -> String {
+  let mut identifier = String::with_capacity(dep_type.len() + context.len() + request.len() + 2);
+  identifier.push_str(dep_type);
+  identifier.push('|');
+  identifier.push_str(context);
+  identifier.push('|');
+  identifier.push_str(request);
+  identifier
+}
 
 static OBJECT_PROTOTYPE_METHODS: &[&str] = &[
   "constructor",

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,10 +1,13 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Context, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ResourceIdentifier, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource,
 };
+
+use super::create_resource_identifier_for_contextual_commonjs_dependency;
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -14,6 +17,8 @@ pub struct RequireResolveDependency {
   pub weak: bool,
   range: DependencyRange,
   optional: bool,
+  context: Option<Context>,
+  resource_identifier: ResourceIdentifier,
   factorize_info: FactorizeInfo,
 }
 
@@ -25,7 +30,29 @@ impl RequireResolveDependency {
       weak,
       optional,
       id: DependencyId::new(),
+      context: None,
+      resource_identifier: Default::default(),
       factorize_info: Default::default(),
+    }
+  }
+
+  pub fn new_contextual(
+    request: String,
+    range: DependencyRange,
+    weak: bool,
+    optional: bool,
+    context: Context,
+  ) -> Self {
+    let resource_identifier = create_resource_identifier_for_contextual_commonjs_dependency(
+      "require.resolve",
+      &context,
+      &request,
+    )
+    .into();
+    Self {
+      context: Some(context),
+      resource_identifier,
+      ..Self::new(request, range, weak, optional)
     }
   }
 }
@@ -42,6 +69,17 @@ impl Dependency for RequireResolveDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::RequireResolve
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    self.context.as_ref()
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    self
+      .context
+      .as_ref()
+      .map(|_| self.resource_identifier.as_str())
   }
 
   fn range(&self) -> Option<DependencyRange> {

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AsModuleDependency, ContextDependency, ContextOptions, Dependency, DependencyCategory,
+  AsModuleDependency, Context, ContextDependency, ContextOptions, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportsInfoArtifact, FactorizeInfo, ModuleGraph,
   ModuleGraphCacheArtifact, ReferencedSpecifier, ResourceIdentifier, TemplateContext,
@@ -19,6 +19,7 @@ pub struct CommonJsRequireContextDependency {
   loc: DependencyLocation,
   range: DependencyRange,
   value_range: Option<DependencyRange>,
+  context: Option<Context>,
   resource_identifier: ResourceIdentifier,
   options: ContextOptions,
   optional: bool,
@@ -33,12 +34,17 @@ impl CommonJsRequireContextDependency {
     range: DependencyRange,
     value_range: Option<DependencyRange>,
     optional: bool,
+    context: Option<Context>,
   ) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
+    let resource_identifier = create_resource_identifier_for_context_dependency(
+      context.as_ref().map(|c| c.as_str()),
+      &options,
+    );
     Self {
       loc,
       range,
       value_range,
+      context,
       options,
       resource_identifier,
       optional,
@@ -50,8 +56,10 @@ impl CommonJsRequireContextDependency {
 
   pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
     self.options.referenced_specifiers = Some(referenced_specifiers);
-    self.resource_identifier =
-      create_resource_identifier_for_context_dependency(None, &self.options);
+    self.resource_identifier = create_resource_identifier_for_context_dependency(
+      self.context.as_ref().map(|c| c.as_str()),
+      &self.options,
+    );
   }
 }
 
@@ -67,6 +75,10 @@ impl Dependency for CommonJsRequireContextDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::CommonJSRequireContext
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    self.context.as_ref()
   }
 
   fn range(&self) -> Option<DependencyRange> {
@@ -104,7 +116,7 @@ impl ContextDependency for CommonJsRequireContextDependency {
   }
 
   fn get_context(&self) -> Option<&str> {
-    None
+    self.context.as_ref().map(|c| c.as_str())
   }
 
   fn resource_identifier(&self) -> &str {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
@@ -1,9 +1,10 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
-  AffectType, AsModuleDependency, ContextDependency, ContextOptions, ContextTypePrefix, Dependency,
-  DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, FactorizeInfo, ModuleGraph,
-  ModuleGraphCacheArtifact, ResourceIdentifier, TemplateContext, TemplateReplaceSource,
+  AffectType, AsModuleDependency, Context, ContextDependency, ContextOptions, ContextTypePrefix,
+  Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact, FactorizeInfo,
+  ModuleGraph, ModuleGraphCacheArtifact, ResourceIdentifier, TemplateContext,
+  TemplateReplaceSource,
 };
 use rspack_error::Diagnostic;
 
@@ -15,6 +16,7 @@ pub struct RequireResolveContextDependency {
   id: DependencyId,
   options: ContextOptions,
   range: DependencyRange,
+  context: Option<Context>,
   resource_identifier: ResourceIdentifier,
   optional: bool,
   critical: Option<Diagnostic>,
@@ -22,12 +24,21 @@ pub struct RequireResolveContextDependency {
 }
 
 impl RequireResolveContextDependency {
-  pub fn new(options: ContextOptions, range: DependencyRange, optional: bool) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
+  pub fn new(
+    options: ContextOptions,
+    range: DependencyRange,
+    optional: bool,
+    context: Option<Context>,
+  ) -> Self {
+    let resource_identifier = create_resource_identifier_for_context_dependency(
+      context.as_ref().map(|c| c.as_str()),
+      &options,
+    );
     Self {
       id: DependencyId::new(),
       options,
       range,
+      context,
       resource_identifier,
       optional,
       critical: None,
@@ -48,6 +59,10 @@ impl Dependency for RequireResolveContextDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::RequireResolveContext
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    self.context.as_ref()
   }
 
   fn range(&self) -> Option<DependencyRange> {
@@ -81,7 +96,7 @@ impl ContextDependency for RequireResolveContextDependency {
   }
 
   fn get_context(&self) -> Option<&str> {
-    None
+    self.context.as_ref().map(|c| c.as_str())
   }
 
   fn resource_identifier(&self) -> &str {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -1,16 +1,26 @@
+#[cfg(windows)]
+use std::path::Path;
+
 use rspack_core::{
-  ConstDependency, ContextDependency, ContextMode, ContextModulePattern, ContextOptions,
-  DependencyCategory, DependencyRange, DependencyType, ReferencedSpecifier,
+  ConstDependency, Context, ContextDependency, ContextMode, ContextModulePattern, ContextOptions,
+  DependencyCategory, DependencyRange, DependencyType, ModuleType, ReferencedSpecifier,
+  RuntimeGlobals, RuntimeRequirementsDependency,
 };
 use rspack_error::{Diagnostic, Severity};
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, json_stringify_str};
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
-  AssignExpr, CallExpr, Callee, Expr, ExprOrSpread, GetSpan, Ident, MemberExpr, NewExpr, Span,
-  UnaryExpr, VarDeclarator,
+  AssignExpr, AssignOp, CallExpr, Callee, Expr, ExprOrSpread, GetSpan, Ident, Lit, MemberExpr,
+  MemberProp, NewExpr, Span, UnaryExpr, UnaryOp, VarDeclarator,
 };
+use url::Url;
 
-use super::JavascriptParserPlugin;
+use super::{
+  JavascriptParserPlugin,
+  esm_import_dependency_parser_plugin::{ESM_SPECIFIER_TAG, ESMSpecifierData},
+  get_url_request,
+  url_plugin::is_meta_url,
+};
 use crate::{
   dependency::{
     CommonJsFullRequireDependency, CommonJsRequireContextDependency, CommonJsRequireDependency,
@@ -20,13 +30,28 @@ use crate::{
   magic_comment::try_extract_magic_comment,
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{
-    CallHooksName, JavascriptParser, TagInfoData, VariableDeclaration, VariableDeclarationKind,
-    context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
-    get_non_optional_part,
+    CallHooksName, ExportedVariableInfo, JavascriptParser, TagInfoData, VariableDeclaration,
+    VariableDeclarationKind, VariableInfo, VariableInfoFlags, context_reg_exp,
+    create_context_dependency, create_traceable_error, expr_name, get_non_optional_part,
   },
 };
 
 const COMMONJS_REQUIRE_TAG: &str = "commonjs require";
+pub const CREATE_REQUIRE_SPECIFIER_TAG: &str = "createRequire";
+pub const CREATE_REQUIRE_EVALUATED_TAG: &str = "\0createRequire";
+pub const CREATED_REQUIRE_IDENTIFIER_TAG: &str = "createRequire()";
+
+#[derive(Clone)]
+pub struct CreatedRequireTagData {
+  pub(crate) context: Context,
+  pub(crate) side_effects: String,
+}
+
+struct CreateRequireArgument {
+  value: String,
+  context: Context,
+  replace_argument: bool,
+}
 
 #[derive(Debug, Default)]
 pub struct RequireReferencesState {
@@ -89,9 +114,905 @@ struct RequireDependencyLocator {
   dep_type: DependencyType,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct RequireTagData {
   require_span: Span,
+}
+
+#[inline(never)]
+pub fn is_create_require_import(
+  parser: &JavascriptParser,
+  source: &Atom,
+  export_name: Option<&Atom>,
+) -> bool {
+  let Some(specifier) = create_require_import_specifier(parser, source) else {
+    return false;
+  };
+  export_name.is_some_and(|export_name| export_name == &specifier)
+}
+
+#[inline(never)]
+fn create_require_import_specifier(parser: &JavascriptParser, source: &Atom) -> Option<Atom> {
+  let option = parser.javascript_options.create_require_option()?;
+  let (specifier, module) = option.split_once(" from ")?;
+  (!specifier.is_empty()
+    && !module.is_empty()
+    && (source.as_ref() == module || (module == "module" && source.as_ref() == "node:module")))
+    .then(|| specifier.into())
+}
+
+#[inline(never)]
+pub fn tag_create_require(parser: &mut JavascriptParser, name: Atom) {
+  parser.tag_variable_without_data(name, CREATE_REQUIRE_SPECIFIER_TAG);
+}
+
+#[inline(never)]
+fn is_current_create_require_tag(parser: &JavascriptParser) -> bool {
+  parser.current_tag_info.is_some_and(|tag_info| {
+    parser.definitions_db.expect_get_tag_info(tag_info).tag == CREATE_REQUIRE_SPECIFIER_TAG
+  })
+}
+
+#[inline(never)]
+pub fn is_create_require_specifier(parser: &mut JavascriptParser, name: &Atom) -> bool {
+  let Some(variable_info) = parser.get_variable_info(name) else {
+    return false;
+  };
+  let mut tag_info_id = variable_info.tag_info;
+  while let Some(id) = tag_info_id {
+    let tag_info = parser.definitions_db.expect_get_tag_info(id);
+    if tag_info.tag == CREATE_REQUIRE_SPECIFIER_TAG {
+      return true;
+    }
+    tag_info_id = tag_info.next;
+  }
+  false
+}
+
+#[cold]
+#[inline(never)]
+fn should_handle_create_require_specifier(parser: &JavascriptParser, for_name: &str) -> bool {
+  for_name == CREATE_REQUIRE_EVALUATED_TAG
+    || (for_name == CREATE_REQUIRE_SPECIFIER_TAG && is_current_create_require_tag(parser))
+}
+
+#[cold]
+#[inline(never)]
+fn should_handle_create_require_call(
+  parser: &mut JavascriptParser,
+  for_name: &str,
+  callee: Option<&Expr>,
+) -> bool {
+  should_handle_create_require_specifier(parser, for_name)
+    || callee.is_some_and(|callee| is_create_require_namespace_member(parser, callee))
+}
+
+#[cold]
+#[inline(never)]
+fn is_evaluated_create_require(parser: &mut JavascriptParser, expr: &Expr) -> bool {
+  let evaluated = parser.evaluate_expression(expr);
+  evaluated.is_identifier() && evaluated.identifier() == CREATE_REQUIRE_EVALUATED_TAG
+}
+
+#[cold]
+#[inline(never)]
+pub(crate) fn is_create_require_namespace_member(
+  parser: &mut JavascriptParser,
+  expr: &Expr,
+) -> bool {
+  let Some(member_expr) = expr.as_member() else {
+    return false;
+  };
+  let Some(namespace) = member_expr.obj.as_ident() else {
+    return false;
+  };
+  let Some(settings) =
+    parser.get_tag_data::<ESMSpecifierData>(&Atom::from(namespace.sym.as_str()), ESM_SPECIFIER_TAG)
+  else {
+    return false;
+  };
+  let namespace_import = settings.namespace_import;
+  let source = settings.source.clone();
+  let Some(member) = static_member_name(member_expr) else {
+    return false;
+  };
+  namespace_import
+    && create_require_import_specifier(parser, &source).is_some_and(|specifier| member == specifier)
+}
+
+#[cold]
+#[inline(never)]
+fn is_create_require_namespace_member_param(
+  parser: &JavascriptParser,
+  property: &str,
+  param: &BasicEvaluatedExpression,
+) -> bool {
+  if !param.is_identifier() {
+    return false;
+  }
+  let ExportedVariableInfo::VariableInfo(variable) = param.root_info() else {
+    return false;
+  };
+  let Some(settings) =
+    parser.get_variable_tag_data::<ESMSpecifierData>(*variable, ESM_SPECIFIER_TAG)
+  else {
+    return false;
+  };
+  settings.namespace_import
+    && create_require_import_specifier(parser, &settings.source)
+      .is_some_and(|specifier| property == specifier.as_ref())
+}
+
+#[cold]
+#[inline(never)]
+fn static_member_name(member_expr: &MemberExpr) -> Option<Atom> {
+  match &member_expr.prop {
+    MemberProp::Ident(ident) => Some(Atom::from(ident.sym.as_str())),
+    MemberProp::Computed(computed) => match &computed.expr {
+      Expr::Lit(lit) => match &**lit {
+        Lit::Str(str) => Some(Atom::from(str.value.as_wtf8().to_string_lossy().as_ref())),
+        _ => None,
+      },
+      _ => None,
+    },
+    MemberProp::PrivateName(_) => None,
+  }
+}
+
+#[cold]
+#[inline(never)]
+fn has_invalid_or_encoded_separator(value: &str) -> bool {
+  let bytes = value.as_bytes();
+  let mut index = 0;
+  while index + 2 < bytes.len() {
+    if bytes[index] == b'%' {
+      let hi = bytes[index + 1].to_ascii_lowercase();
+      let lo = bytes[index + 2].to_ascii_lowercase();
+      if !hi.is_ascii_hexdigit() || !lo.is_ascii_hexdigit() {
+        return true;
+      }
+      if hi == b'2' && lo == b'f' || cfg!(windows) && hi == b'5' && lo == b'c' {
+        return true;
+      }
+      index += 3;
+    } else {
+      index += 1;
+    }
+  }
+  (bytes.len().saturating_sub(index) == 1 || bytes.len().saturating_sub(index) == 2)
+    && bytes[index] == b'%'
+}
+
+#[cold]
+#[inline(never)]
+fn file_url_to_path(value: &str) -> Option<(String, bool)> {
+  let parsed = Url::parse(value).ok()?;
+  if parsed.scheme() != "file" || has_invalid_or_encoded_separator(parsed.path()) {
+    return None;
+  }
+  let is_directory_request = parsed.path().ends_with('/');
+  let path = parsed
+    .to_file_path()
+    .ok()
+    .and_then(|path| path.into_os_string().into_string().ok())?;
+  Some((path, is_directory_request))
+}
+
+#[cold]
+#[inline(never)]
+fn create_require_context_from_path(value: &str) -> Option<Context> {
+  #[cfg(not(windows))]
+  {
+    let (path, is_directory_request) = if let Some(path) = file_url_to_path(value) {
+      path
+    } else {
+      if !value.starts_with('/') {
+        return None;
+      }
+      (value.to_string(), value.ends_with('/'))
+    };
+    let context = if is_directory_request {
+      let context = path.trim_end_matches('/');
+      if context.is_empty() { "/" } else { context }
+    } else {
+      dirname(&path)?
+    };
+    Some(Context::new(context.into()))
+  }
+
+  #[cfg(windows)]
+  {
+    let (path, is_directory_request) = if let Some(path) = file_url_to_path(value) {
+      path
+    } else {
+      if !Path::new(value).is_absolute() {
+        return None;
+      }
+      (
+        value.to_string(),
+        value.ends_with('/') || value.ends_with('\\'),
+      )
+    };
+    let path = Path::new(&path);
+    let context = if is_directory_request {
+      path
+    } else {
+      path.parent()?
+    };
+    let context = if context.parent().is_none() {
+      context.to_string_lossy().to_string()
+    } else {
+      context
+        .to_string_lossy()
+        .trim_end_matches(['/', '\\'])
+        .to_string()
+    };
+    Some(Context::new(context.into()))
+  }
+}
+
+#[cfg(not(windows))]
+#[cold]
+#[inline(never)]
+fn dirname(path: &str) -> Option<&str> {
+  let path = path.trim_end_matches('/');
+  path
+    .rfind('/')
+    .map(|idx| if idx == 0 { "/" } else { &path[..idx] })
+}
+
+#[cold]
+#[inline(never)]
+fn evaluate_create_require_argument(parser: &mut JavascriptParser, arg: &Expr) -> Option<String> {
+  let evaluated = parser.evaluate_expression(arg);
+  if let Some(value) = evaluated.as_string() {
+    return Some(value);
+  }
+
+  let new_expr = arg.as_new()?;
+  if new_expr.callee.as_ident()?.sym.as_str() != "URL"
+    || parser.get_variable_info(&Atom::from("URL")).is_some()
+  {
+    return None;
+  }
+  if let Some(args) = &new_expr.args
+    && !args.is_empty()
+    && args[0].spread.is_none()
+    && let Some(value) = parser.evaluate_expression(&args[0].expr).as_string()
+    && value.starts_with("file:/")
+  {
+    if let Some(base) = args.get(1)
+      && !is_valid_ignored_url_base_arg(parser, base)
+    {
+      return None;
+    }
+    return file_url_to_path(&value).map(|(path, _)| path);
+  }
+  let (request, _, _) = get_url_request(parser, new_expr)?;
+  if request.starts_with("//") {
+    let mut value = String::with_capacity("file:".len() + request.len());
+    value.push_str("file:");
+    value.push_str(&request);
+    return Some(value);
+  }
+  if request.starts_with("file:/") {
+    return file_url_to_path(&request).map(|(path, _)| path);
+  }
+  if !request.starts_with("file:")
+    && request
+      .find([':', '/', '?', '#'])
+      .is_some_and(|idx| request.as_bytes()[idx] == b':')
+  {
+    return None;
+  }
+  let request_path = request.split(['?', '#']).next()?;
+  if has_invalid_or_encoded_separator(request_path) {
+    return None;
+  }
+  let url = Url::from_file_path(parser.resource_data.resource())
+    .ok()?
+    .join(&request)
+    .ok()?;
+  if url.scheme() != "file" {
+    return None;
+  }
+  file_url_to_path(url.as_str()).map(|(path, _)| path)
+}
+
+#[cold]
+#[inline(never)]
+fn ignored_url_args_are_side_effect_free_from(
+  parser: &mut JavascriptParser,
+  args: &[ExprOrSpread],
+  start: usize,
+) -> bool {
+  args
+    .iter()
+    .skip(start)
+    .all(|arg| arg.spread.is_none() && is_side_effect_free_ignored_url_arg(parser, &arg.expr))
+}
+
+#[cold]
+#[inline(never)]
+fn is_side_effect_free_ignored_url_arg(parser: &mut JavascriptParser, expr: &Expr) -> bool {
+  match expr {
+    Expr::Lit(_) => true,
+    Expr::Ident(ident) => {
+      ident.sym.as_str() == "undefined"
+        && parser.get_variable_info(&Atom::from("undefined")).is_none()
+    }
+    Expr::Unary(unary) if unary.op == UnaryOp::Void => {
+      is_side_effect_free_ignored_url_arg(parser, &unary.arg)
+    }
+    _ => false,
+  }
+}
+
+#[cold]
+#[inline(never)]
+fn parse_create_require_argument(
+  parser: &mut JavascriptParser,
+  call_expr: &CallExpr,
+  emit_warning: bool,
+) -> Option<CreateRequireArgument> {
+  parse_create_require_argument_from_args(parser, &call_expr.args, call_expr.span, emit_warning)
+}
+
+#[cold]
+#[inline(never)]
+fn parse_create_require_argument_from_args(
+  parser: &mut JavascriptParser,
+  args: &[ExprOrSpread],
+  span: Span,
+  emit_warning: bool,
+) -> Option<CreateRequireArgument> {
+  if args.is_empty() {
+    if emit_warning {
+      add_create_require_warning(parser, "module.createRequire requires one argument.", span);
+    }
+    return None;
+  }
+
+  if let Some(spread) = args[0].spread {
+    if emit_warning {
+      add_create_require_warning(
+        parser,
+        "module.createRequire does not support spread arguments.",
+        spread,
+      );
+    }
+    return None;
+  }
+
+  let arg = &args[0].expr;
+  let Some(value) = evaluate_create_require_argument(parser, arg) else {
+    if emit_warning {
+      add_create_require_warning(
+        parser,
+        "module.createRequire failed parsing argument.",
+        arg.span(),
+      );
+    }
+    return None;
+  };
+  let context = create_require_context_from_path(&value);
+  if context.is_none() && emit_warning {
+    add_create_require_warning(
+      parser,
+      "module.createRequire supports only file URLs and absolute paths.",
+      arg.span(),
+    );
+  }
+  Some(CreateRequireArgument {
+    value,
+    context: context?,
+    replace_argument: should_replace_create_require_argument(parser, arg),
+  })
+}
+
+#[cold]
+#[inline(never)]
+fn parse_create_require_new_argument(
+  parser: &mut JavascriptParser,
+  new_expr: &NewExpr,
+  emit_warning: bool,
+) -> Option<CreateRequireArgument> {
+  let args = new_expr.args.as_deref().unwrap_or_default();
+  parse_create_require_argument_from_args(parser, args, new_expr.span, emit_warning)
+}
+
+#[inline(never)]
+fn should_replace_create_require_argument(parser: &mut JavascriptParser, arg: &Expr) -> bool {
+  let Some(new_expr) = arg.as_new() else {
+    return true;
+  };
+  if new_expr
+    .callee
+    .as_ident()
+    .is_some_and(|ident| ident.sym.as_str() == "URL")
+    && parser.get_variable_info(&Atom::from("URL")).is_none()
+  {
+    let is_absolute_file_url = is_absolute_file_url_constructor_arg(parser, arg);
+    let start = if is_absolute_file_url { 1 } else { 2 };
+    let Some(args) = &new_expr.args else {
+      return true;
+    };
+    if is_absolute_file_url
+      && let Some(base) = args.get(1)
+      && !is_valid_ignored_url_base_arg(parser, base)
+    {
+      return false;
+    }
+    ignored_url_args_are_side_effect_free_from(parser, args, start)
+  } else {
+    true
+  }
+}
+
+#[inline(never)]
+fn is_valid_ignored_url_base_arg(parser: &mut JavascriptParser, base: &ExprOrSpread) -> bool {
+  if base.spread.is_some() {
+    return false;
+  }
+  if let Expr::Ident(ident) = &base.expr
+    && ident.sym.as_str() == "undefined"
+    && parser.get_variable_info(&Atom::from("undefined")).is_none()
+  {
+    return true;
+  }
+  if let Expr::Unary(unary) = &base.expr
+    && unary.op == UnaryOp::Void
+    && is_side_effect_free_ignored_url_arg(parser, &unary.arg)
+  {
+    return true;
+  }
+  parser
+    .evaluate_expression(&base.expr)
+    .as_string()
+    .is_some_and(|base| Url::parse(&base).is_ok())
+}
+
+#[inline(never)]
+fn is_absolute_file_url_constructor_arg(parser: &mut JavascriptParser, arg: &Expr) -> bool {
+  let Some(new_expr) = arg.as_new() else {
+    return false;
+  };
+  if new_expr
+    .callee
+    .as_ident()
+    .is_none_or(|ident| ident.sym.as_str() != "URL")
+    || parser.get_variable_info(&Atom::from("URL")).is_some()
+  {
+    return false;
+  };
+  let Some(args) = &new_expr.args else {
+    return false;
+  };
+  args
+    .first()
+    .filter(|arg| arg.spread.is_none())
+    .and_then(|arg| parser.evaluate_expression(&arg.expr).as_string())
+    .is_some_and(|value| value.starts_with("file:/"))
+}
+
+#[inline(never)]
+fn walk_create_require_callee(parser: &mut JavascriptParser, call_expr: &CallExpr) {
+  if let Callee::Expr(callee) = &call_expr.callee {
+    parser.walk_expression(callee);
+  }
+}
+
+fn walk_create_require_ignored_args(parser: &mut JavascriptParser, call_expr: &CallExpr) {
+  if call_expr.args.len() > 1 {
+    parser.walk_expr_or_spread(&call_expr.args[1..]);
+  }
+}
+
+#[inline(never)]
+fn is_unbound_url_constructor(parser: &mut JavascriptParser, callee: &Expr) -> bool {
+  callee
+    .as_ident()
+    .is_some_and(|ident| ident.sym.as_str() == "URL")
+    && parser.get_variable_info(&Atom::from("URL")).is_none()
+}
+
+#[inline(never)]
+fn walk_create_require_argument_side_effects(parser: &mut JavascriptParser, arg: &Expr) {
+  let Some(new_expr) = arg.as_new() else {
+    return;
+  };
+  if !is_unbound_url_constructor(parser, &new_expr.callee) {
+    return;
+  };
+  let Some(args) = &new_expr.args else {
+    return;
+  };
+  if args.len() > 1 {
+    parser.walk_expr_or_spread(&args[1..]);
+  }
+}
+
+#[inline(never)]
+fn source_for_span(parser: &JavascriptParser, span: Span) -> Option<String> {
+  parser
+    .source()
+    .get(span.real_lo() as usize..span.real_hi() as usize)
+    .map(str::to_string)
+}
+
+#[inline(never)]
+fn push_side_effect(side_effects: &mut String, source: &str) {
+  if !side_effects.is_empty() {
+    side_effects.push_str(", ");
+  }
+  side_effects.push_str(source);
+}
+
+#[inline(never)]
+fn push_spread_side_effect(side_effects: &mut String, source: &str) {
+  if !side_effects.is_empty() {
+    side_effects.push_str(", ");
+  }
+  side_effects.push_str("[...(");
+  side_effects.push_str(source);
+  side_effects.push_str(")]");
+}
+
+#[inline(never)]
+fn side_effects_with_suffix(side_effects: &str, suffix: &str) -> Box<str> {
+  let mut replacement = String::with_capacity(side_effects.len() + suffix.len() + 3);
+  replacement.push('(');
+  replacement.push_str(side_effects);
+  replacement.push_str(", ");
+  replacement.push_str(suffix);
+  replacement.into_boxed_str()
+}
+
+#[inline(never)]
+fn create_require_url_arg_side_effects(parser: &mut JavascriptParser, arg: &Expr) -> String {
+  let Some(new_expr) = arg.as_new() else {
+    return String::new();
+  };
+  if !is_unbound_url_constructor(parser, &new_expr.callee) {
+    return String::new();
+  };
+  let Some(args) = &new_expr.args else {
+    return String::new();
+  };
+  let start = if is_absolute_file_url_constructor_arg(parser, arg) {
+    1
+  } else {
+    2
+  };
+  let mut side_effects = String::new();
+  for arg in args.iter().skip(start) {
+    let Some(source) = source_for_span(parser, arg.expr.span()) else {
+      continue;
+    };
+    if arg.spread.is_some() {
+      push_spread_side_effect(&mut side_effects, &source);
+    } else if !is_side_effect_free_ignored_url_arg(parser, &arg.expr)
+      && !arg
+        .expr
+        .as_member()
+        .is_some_and(|expr| is_meta_url(parser, expr))
+    {
+      push_side_effect(&mut side_effects, &source);
+    }
+  }
+  side_effects
+}
+
+#[inline(never)]
+fn create_require_unsupported_member_replacement(side_effects: &str) -> Box<str> {
+  if side_effects.is_empty() {
+    "undefined".into()
+  } else {
+    side_effects_with_suffix(side_effects, "undefined)")
+  }
+}
+
+#[inline(never)]
+fn wrap_span_with_side_effects(parser: &mut JavascriptParser, span: Span, side_effects: &str) {
+  if side_effects.is_empty() {
+    return;
+  }
+  parser.add_presentational_dependency(Box::new(ConstDependency::new(
+    (span.real_lo(), span.real_lo()).into(),
+    side_effects_with_suffix(side_effects, ""),
+  )));
+  parser.add_presentational_dependency(Box::new(ConstDependency::new(
+    (span.real_hi(), span.real_hi()).into(),
+    ")".into(),
+  )));
+}
+
+#[inline(never)]
+fn create_require_extra_arg_side_effects(
+  parser: &JavascriptParser,
+  args: &[ExprOrSpread],
+) -> String {
+  let mut side_effects = String::new();
+  for arg in args.iter().skip(1) {
+    let Some(source) = source_for_span(parser, arg.expr.span()) else {
+      continue;
+    };
+    if arg.spread.is_some() {
+      push_spread_side_effect(&mut side_effects, &source);
+    } else {
+      push_side_effect(&mut side_effects, &source);
+    }
+  }
+  side_effects
+}
+
+#[inline(never)]
+fn create_require_args_side_effects(
+  parser: &mut JavascriptParser,
+  args: &[ExprOrSpread],
+  argument: &CreateRequireArgument,
+) -> String {
+  let mut side_effects = if argument.replace_argument {
+    String::new()
+  } else {
+    create_require_url_arg_side_effects(parser, &args[0].expr)
+  };
+  let extra_side_effects = create_require_extra_arg_side_effects(parser, args);
+  if !extra_side_effects.is_empty() {
+    push_side_effect(&mut side_effects, &extra_side_effects);
+  }
+  side_effects
+}
+
+#[inline(never)]
+fn evaluate_created_require<'a>(
+  parser: &mut JavascriptParser,
+  range: Span,
+  args: &[ExprOrSpread],
+  argument: CreateRequireArgument,
+) -> BasicEvaluatedExpression<'a> {
+  let side_effects = create_require_args_side_effects(parser, args, &argument);
+  let has_side_effects = !side_effects.is_empty();
+  let evaluated_name = Atom::from(range.real_lo().to_string());
+  parser.tag_variable(
+    evaluated_name.clone(),
+    CREATED_REQUIRE_IDENTIFIER_TAG,
+    Some(CreatedRequireTagData {
+      context: argument.context,
+      side_effects,
+    }),
+  );
+  let mut evaluated = BasicEvaluatedExpression::with_range(range.real_lo(), range.real_hi());
+  evaluated.set_identifier(
+    evaluated_name.clone(),
+    ExportedVariableInfo::Name(evaluated_name),
+    None,
+    None,
+    None,
+  );
+  evaluated.set_side_effects(has_side_effects);
+  evaluated.set_truthy();
+  evaluated
+}
+
+#[inline(never)]
+pub(crate) fn evaluate_create_require_new_expression<'a>(
+  parser: &mut JavascriptParser,
+  for_name: &str,
+  callee: Option<&Expr>,
+  expr: &'a NewExpr,
+) -> Option<BasicEvaluatedExpression<'a>> {
+  if !should_handle_create_require_call(parser, for_name, callee) {
+    return None;
+  }
+  let argument = parse_create_require_new_argument(parser, expr, false)?;
+  Some(evaluate_created_require(
+    parser,
+    expr.span,
+    expr.args.as_deref().unwrap_or_default(),
+    argument,
+  ))
+}
+
+#[inline(never)]
+fn evaluate_create_require_call_expression<'a>(
+  parser: &mut JavascriptParser,
+  expr: &'a CallExpr,
+) -> Option<BasicEvaluatedExpression<'a>> {
+  let argument = parse_create_require_argument(parser, expr, false)?;
+  Some(evaluate_created_require(
+    parser, expr.span, &expr.args, argument,
+  ))
+}
+
+#[inline(never)]
+fn current_created_require_side_effects(parser: &mut JavascriptParser) -> String {
+  parser
+    .current_tag_info
+    .and_then(|tag_info| {
+      parser
+        .definitions_db
+        .expect_get_tag_info(tag_info)
+        .data
+        .clone()
+    })
+    .map(CreatedRequireTagData::downcast)
+    .map(|data| data.side_effects)
+    .unwrap_or_default()
+}
+
+#[inline(never)]
+fn wrap_created_require_with_side_effects(parser: &mut JavascriptParser, span: Span) {
+  let side_effects = current_created_require_side_effects(parser);
+  wrap_span_with_side_effects(parser, span, &side_effects);
+}
+
+#[cold]
+#[inline(never)]
+fn add_create_require_warning(parser: &mut JavascriptParser, message: &str, span: Span) {
+  let mut error = create_traceable_error(
+    "Unsupported feature".into(),
+    message.to_string(),
+    parser.source.to_string(),
+    span.into(),
+  );
+  error.severity = Severity::Warning;
+  error.hide_stack = Some(true);
+  parser.add_warning(error.into());
+}
+
+#[cold]
+#[inline(never)]
+fn add_unsupported_create_require_member_warning(parser: &mut JavascriptParser, span: Span) {
+  add_create_require_warning(
+    parser,
+    "The accessed createRequire() member is not supported by Rspack.",
+    span,
+  );
+}
+
+#[cold]
+#[inline(never)]
+fn tag_created_require_declarator(
+  parser: &mut JavascriptParser,
+  binding: &Ident,
+  args: &[ExprOrSpread],
+  argument: CreateRequireArgument,
+) {
+  let CreateRequireArgument {
+    value,
+    context,
+    replace_argument,
+  } = argument;
+  let binding_name = Atom::from(binding.sym.as_str());
+  parser.define_variable(binding_name.clone());
+  parser.tag_variable(
+    binding_name,
+    CREATED_REQUIRE_IDENTIFIER_TAG,
+    Some(CreatedRequireTagData {
+      context,
+      side_effects: String::new(),
+    }),
+  );
+  if replace_argument {
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      args[0].expr.span().into(),
+      json_stringify_str(&value).into(),
+    )));
+  } else {
+    walk_create_require_argument_side_effects(parser, &args[0].expr);
+  }
+  parser.walk_expr_or_spread(&args[1..]);
+}
+
+fn clear_create_require_tag(parser: &mut JavascriptParser, name: &Atom) {
+  if let Some(declared_scope) = parser
+    .get_variable_info(name)
+    .map(|info| info.declared_scope)
+  {
+    let info = VariableInfo::create(
+      &mut parser.definitions_db,
+      declared_scope,
+      None,
+      VariableInfoFlags::NORMAL,
+      None,
+    );
+    parser
+      .definitions_db
+      .set(declared_scope, name.clone(), info);
+  }
+}
+
+#[inline(never)]
+fn add_require_cache_dependency(parser: &mut JavascriptParser, range: DependencyRange) {
+  parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::new(
+    range,
+    RuntimeGlobals::MODULE_CACHE,
+  )));
+}
+
+#[inline(never)]
+fn require_cache_range(member_expr: &MemberExpr, member_ranges: &[Span], members: &[Atom]) -> Span {
+  if members.len() > 1 {
+    member_ranges[1]
+  } else {
+    member_expr.span()
+  }
+}
+
+#[inline(never)]
+fn handle_created_require_member(
+  parser: &mut JavascriptParser,
+  member_span: Span,
+  cache_range: Span,
+  members: &[Atom],
+  unsupported_replacement: Box<str>,
+) {
+  if members
+    .first()
+    .is_some_and(|member| member.as_ref() == "cache")
+  {
+    add_require_cache_dependency(parser, cache_range.into());
+  } else {
+    add_unsupported_create_require_member_warning(parser, member_span);
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      member_span.into(),
+      unsupported_replacement,
+    )));
+  }
+}
+
+#[inline(never)]
+fn current_created_require_context(parser: &JavascriptParser) -> Option<Context> {
+  parser
+    .current_tag_info
+    .and_then(|tag_info| {
+      parser
+        .definitions_db
+        .expect_get_tag_info(tag_info)
+        .data
+        .clone()
+    })
+    .map(CreatedRequireTagData::downcast)
+    .map(|data| data.context)
+}
+
+#[cold]
+#[inline(never)]
+fn walk_unsupported_create_require_resolve(
+  parser: &mut JavascriptParser,
+  inner_call_expr: &CallExpr,
+  call_expr: &CallExpr,
+) {
+  walk_create_require_callee(parser, inner_call_expr);
+  if inner_call_expr.args.len() == 1 && inner_call_expr.args[0].spread.is_none() {
+    let arg = &inner_call_expr.args[0].expr;
+    if let Some(value) = evaluate_create_require_argument(parser, arg) {
+      if should_replace_create_require_argument(parser, arg) {
+        parser.add_presentational_dependency(Box::new(ConstDependency::new(
+          arg.span().into(),
+          json_stringify_str(&value).into(),
+        )));
+      } else {
+        walk_create_require_argument_side_effects(parser, arg);
+      }
+    } else if let Some(new_expr) = arg.as_new()
+      && is_unbound_url_constructor(parser, &new_expr.callee)
+      && let Some(args) = new_expr.args.as_ref()
+      && args.len() > 2
+    {
+      if get_url_request(parser, new_expr).is_some() {
+        parser.walk_expr_or_spread(&args[2..]);
+      } else {
+        parser.walk_expr_or_spread(args);
+      }
+    } else {
+      parser.walk_expression(arg);
+    }
+  } else {
+    parser.walk_expr_or_spread(&inner_call_expr.args);
+  }
+  parser.walk_expr_or_spread(&call_expr.args);
 }
 
 fn tag_commonjs_require_referenced(
@@ -120,6 +1041,7 @@ fn create_commonjs_require_context_dependency(
   call_expr: &CallExpr,
   arg_expr: &Expr,
   referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
+  request_context: Option<rspack_core::Context>,
 ) -> CommonJsRequireContextDependency {
   let result = create_context_dependency(param, parser);
 
@@ -147,6 +1069,7 @@ fn create_commonjs_require_context_dependency(
     range,
     Some(arg_expr.span().into()),
     parser.in_try,
+    request_context,
   );
   *dep.critical_mut() = result.critical;
   dep
@@ -157,6 +1080,7 @@ fn create_require_resolve_context_dependency(
   param: &BasicEvaluatedExpression,
   range: DependencyRange,
   weak: bool,
+  request_context: Option<rspack_core::Context>,
 ) -> RequireResolveContextDependency {
   let start = range.start;
   let end = range.end;
@@ -179,10 +1103,14 @@ fn create_require_resolve_context_dependency(
     end,
     ..Default::default()
   };
-  RequireResolveContextDependency::new(options, range, parser.in_try)
+  RequireResolveContextDependency::new(options, range, parser.in_try, request_context)
 }
 
 pub(crate) fn is_require_call_expr(parser: &mut JavascriptParser, call: &CallExpr) -> bool {
+  if !should_parse_commonjs_require(parser) {
+    return false;
+  }
+
   if call.args.len() != 1 {
     return false;
   }
@@ -208,6 +1136,13 @@ pub(crate) fn is_require_call_expr(parser: &mut JavascriptParser, call: &CallExp
   }
 
   false
+}
+
+fn should_parse_commonjs_require(parser: &JavascriptParser) -> bool {
+  matches!(
+    parser.module_type,
+    ModuleType::JsAuto | ModuleType::JsDynamic
+  )
 }
 
 enum CallOrNewExpr<'a> {
@@ -278,7 +1213,13 @@ impl CommonJsImportsParserPlugin {
     true
   }
 
-  fn process_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr, weak: bool) {
+  fn process_resolve(
+    &self,
+    parser: &mut JavascriptParser,
+    call_expr: &CallExpr,
+    weak: bool,
+    request_context: Option<Context>,
+  ) {
     if call_expr.args.len() != 1 {
       return;
     }
@@ -301,17 +1242,34 @@ impl CommonJsImportsParserPlugin {
 
     if param.is_conditional() {
       for option in param.options() {
-        if !self.process_resolve_item(parser, option, weak) {
-          self.process_resolve_context(parser, option, weak);
+        if !self.process_resolve_item(parser, option, weak, request_context.clone()) {
+          self.process_resolve_context(parser, option, weak, request_context.clone());
         }
       }
       parser.add_dependency(require_resolve_header_dependency);
     } else {
-      if !self.process_resolve_item(parser, &param, weak) {
-        self.process_resolve_context(parser, &param, weak);
+      if !self.process_resolve_item(parser, &param, weak, request_context.clone()) {
+        self.process_resolve_context(parser, &param, weak, request_context);
       }
       parser.add_dependency(require_resolve_header_dependency);
     }
+  }
+
+  fn process_created_require_resolve_call(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: &CallExpr,
+  ) -> Option<bool> {
+    if expr.args.len() != 1 || expr.args[0].spread.is_some() {
+      parser.walk_expr_or_spread(&expr.args);
+      return Some(true);
+    }
+    if matches!(parser.javascript_options.require_resolve, Some(false)) {
+      parser.walk_expr_or_spread(&expr.args);
+      return Some(true);
+    }
+    self.process_resolve(parser, expr, false, current_created_require_context(parser));
+    Some(true)
   }
 
   fn process_resolve_item(
@@ -319,14 +1277,25 @@ impl CommonJsImportsParserPlugin {
     parser: &mut JavascriptParser,
     param: &BasicEvaluatedExpression,
     weak: bool,
+    request_context: Option<rspack_core::Context>,
   ) -> bool {
     if param.is_string() {
-      parser.add_dependency(Box::new(RequireResolveDependency::new(
-        param.string().clone(),
-        param.range().into(),
-        weak,
-        parser.in_try,
-      )));
+      if let Some(context) = request_context {
+        parser.add_dependency(Box::new(RequireResolveDependency::new_contextual(
+          param.string().clone(),
+          param.range().into(),
+          weak,
+          parser.in_try,
+          context,
+        )));
+      } else {
+        parser.add_dependency(Box::new(RequireResolveDependency::new(
+          param.string().clone(),
+          param.range().into(),
+          weak,
+          parser.in_try,
+        )));
+      }
 
       return true;
     }
@@ -339,8 +1308,15 @@ impl CommonJsImportsParserPlugin {
     parser: &mut JavascriptParser,
     param: &BasicEvaluatedExpression,
     weak: bool,
+    request_context: Option<rspack_core::Context>,
   ) {
-    let dep = create_require_resolve_context_dependency(parser, param, param.range().into(), weak);
+    let dep = create_require_resolve_context_dependency(
+      parser,
+      param,
+      param.range().into(),
+      weak,
+      request_context,
+    );
 
     parser.add_dependency(Box::new(dep));
   }
@@ -391,6 +1367,7 @@ impl CommonJsImportsParserPlugin {
     parser: &mut JavascriptParser,
     span: Span,
     param: &BasicEvaluatedExpression,
+    request_context: Option<Context>,
   ) -> Option<bool> {
     param.is_string().then(|| {
       let (start, end) = param.range();
@@ -408,14 +1385,26 @@ impl CommonJsImportsParserPlugin {
             });
             refs
           });
-      let dep = CommonJsRequireDependency::new(
-        param.string().clone(),
-        range_expr,
-        Some(span.into()),
-        parser.in_try,
-        loc,
-        referenced_specifiers,
-      );
+      let dep: Box<dyn rspack_core::Dependency> = if let Some(context) = request_context {
+        Box::new(CommonJsRequireDependency::new_contextual(
+          param.string().clone(),
+          range_expr,
+          Some(span.into()),
+          parser.in_try,
+          context,
+          loc,
+          referenced_specifiers,
+        ))
+      } else {
+        Box::new(CommonJsRequireDependency::new(
+          param.string().clone(),
+          range_expr,
+          Some(span.into()),
+          parser.in_try,
+          loc,
+          referenced_specifiers,
+        ))
+      };
       let dep_idx = parser.next_dependency_idx();
       if let Some(require_references) = parser.common_js_require_references.get_require_mut(&span) {
         require_references.dep_locator = Some(RequireDependencyLocator {
@@ -424,7 +1413,7 @@ impl CommonJsImportsParserPlugin {
           dep_type: DependencyType::CjsRequire,
         });
       }
-      parser.add_dependency(Box::new(dep));
+      parser.add_dependency(dep);
       true
     })
   }
@@ -434,6 +1423,7 @@ impl CommonJsImportsParserPlugin {
     parser: &mut JavascriptParser,
     call_expr: &CallExpr,
     param: &BasicEvaluatedExpression,
+    request_context: Option<Context>,
   ) -> Option<bool> {
     let Some(argument_expr) = call_expr.args.first().map(|expr| &expr.expr) else {
       unreachable!("ensure require includes arguments")
@@ -455,6 +1445,7 @@ impl CommonJsImportsParserPlugin {
       call_expr,
       argument_expr,
       referenced_specifiers,
+      request_context,
     );
     let dep_idx = parser.next_dependency_idx();
     if let Some(require_references) = parser
@@ -471,11 +1462,19 @@ impl CommonJsImportsParserPlugin {
     Some(true)
   }
 
-  fn require_handler(&self, parser: &mut JavascriptParser, expr: CallOrNewExpr) -> Option<bool> {
+  fn require_handler(
+    &self,
+    parser: &mut JavascriptParser,
+    expr: CallOrNewExpr,
+    request_context: Option<Context>,
+  ) -> Option<bool> {
     let callee = expr.callee()?;
     let args = expr.args()?;
 
     if args.len() != 1 {
+      return None;
+    }
+    if args[0].spread.is_some() {
       return None;
     }
 
@@ -500,7 +1499,10 @@ impl CommonJsImportsParserPlugin {
     if param.is_conditional() {
       let mut is_expression = false;
       for p in param.options() {
-        if self.process_require_item(parser, expr.span(), p).is_none() {
+        if self
+          .process_require_item(parser, expr.span(), p, request_context.clone())
+          .is_none()
+        {
           is_expression = true;
         }
       }
@@ -530,11 +1532,11 @@ impl CommonJsImportsParserPlugin {
     }
 
     if self
-      .process_require_item(parser, expr.span(), &param)
+      .process_require_item(parser, expr.span(), &param, request_context.clone())
       .is_none()
       && let CallOrNewExpr::Call(call_expr) = expr
     {
-      self.process_require_context(parser, call_expr, &param);
+      self.process_require_context(parser, call_expr, &param, request_context);
     } else {
       let range: DependencyRange = callee.span().into();
       let loc = parser.to_dependency_location(range);
@@ -547,6 +1549,7 @@ impl CommonJsImportsParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     ident: &Ident,
+    request_context: Option<Context>,
   ) -> Option<bool> {
     if parser.javascript_options.require_as_expression == Some(false) {
       return None;
@@ -572,6 +1575,7 @@ impl CommonJsImportsParserPlugin {
       span.into(),
       None,
       parser.in_try,
+      request_context,
     );
     let is_renaming_require = parser
       .is_renaming
@@ -603,6 +1607,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     parser: &mut JavascriptParser<'p>,
     expr: &Expr,
   ) -> Option<bool> {
+    if !should_parse_commonjs_require(parser) {
+      return None;
+    }
+
     if let Some(call) = expr.as_call()
       && is_require_call_expr(parser, call)
     {
@@ -627,6 +1635,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     declarator: &VarDeclarator,
     declaration: VariableDeclaration<'_>,
   ) -> Option<bool> {
+    if !should_parse_commonjs_require(parser) {
+      return None;
+    }
+
     if declaration.kind() != VariableDeclarationKind::Var
       && let Some(init) = &declarator.init
       && let Some(call) = init.as_call()
@@ -640,13 +1652,100 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     None
   }
 
+  fn declarator(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    declarator: &VarDeclarator,
+    _stmt: VariableDeclaration<'_>,
+  ) -> Option<bool> {
+    if !parser.javascript_options.is_create_require_enabled() {
+      return None;
+    }
+
+    let init = declarator.init.as_ref()?;
+    if let Some(init) = init.as_ident()
+      && let Some(context) = parser
+        .get_tag_data::<CreatedRequireTagData>(
+          &Atom::from(init.sym.as_str()),
+          CREATED_REQUIRE_IDENTIFIER_TAG,
+        )
+        .map(|data| data.context.clone())
+      && let Some(binding) = declarator.name.as_ident()
+    {
+      let name = Atom::from(binding.id.sym.as_str());
+      parser.define_variable(name.clone());
+      parser.tag_variable(
+        name,
+        CREATED_REQUIRE_IDENTIFIER_TAG,
+        Some(CreatedRequireTagData {
+          context,
+          side_effects: String::new(),
+        }),
+      );
+      return Some(true);
+    }
+
+    if let Some(init) = init.as_ident()
+      && is_create_require_specifier(parser, &Atom::from(init.sym.as_str()))
+      && let Some(binding) = declarator.name.as_ident()
+    {
+      let name = Atom::from(binding.id.sym.as_str());
+      parser.define_variable(name.clone());
+      tag_create_require(parser, name);
+    }
+
+    let binding = declarator.name.as_ident()?;
+
+    if is_create_require_namespace_member(parser, init) {
+      let name = Atom::from(binding.id.sym.as_str());
+      parser.define_variable(name.clone());
+      tag_create_require(parser, name);
+    }
+
+    if let Some(call) = init.as_call()
+      && let Some(callee) = call.callee.as_expr()
+      && (is_evaluated_create_require(parser, callee)
+        || is_create_require_namespace_member(parser, callee))
+      && let Some(argument) = parse_create_require_argument(parser, call, false)
+    {
+      tag_created_require_declarator(parser, &binding.id, &call.args, argument);
+      walk_create_require_callee(parser, call);
+      return Some(true);
+    }
+
+    if let Some(init) = init.as_new()
+      && (is_evaluated_create_require(parser, &init.callee)
+        || is_create_require_namespace_member(parser, &init.callee))
+      && let Some(argument) = parse_create_require_new_argument(parser, init, false)
+      && let Some(args) = init.args.as_deref()
+    {
+      tag_created_require_declarator(parser, &binding.id, args, argument);
+      parser.walk_expression(&init.callee);
+      return Some(true);
+    }
+
+    if parser
+      .get_tag_data::<CreatedRequireTagData>(
+        &Atom::from(binding.id.sym.as_str()),
+        CREATED_REQUIRE_IDENTIFIER_TAG,
+      )
+      .is_some()
+    {
+      parser.define_variable(Atom::from(binding.id.sym.as_str()));
+      parser.walk_expression(init);
+      return Some(true);
+    }
+
+    None
+  }
+
   fn identifier(
     &self,
     parser: &mut JavascriptParser<'p>,
     ident: &Ident,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == COMMONJS_REQUIRE_TAG {
+    if for_name == COMMONJS_REQUIRE_TAG && should_parse_commonjs_require(parser) {
       let tag_info = parser
         .definitions_db
         .expect_get_tag_info(parser.current_tag_info?);
@@ -671,8 +1770,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       return Some(true);
     }
 
-    if for_name == expr_name::REQUIRE {
-      return self.require_as_expression_handler(parser, ident);
+    if for_name == expr_name::REQUIRE && should_parse_commonjs_require(parser) {
+      return self.require_as_expression_handler(parser, ident, None);
+    }
+
+    if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      let context = current_created_require_context(parser);
+      return self.require_as_expression_handler(parser, ident, context);
     }
 
     None
@@ -685,9 +1789,20 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     for_name: &str,
     members: &[Atom],
     members_optionals: &[bool],
-    _member_ranges: &[Span],
+    member_ranges: &[Span],
   ) -> Option<bool> {
-    if for_name != COMMONJS_REQUIRE_TAG {
+    if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      handle_created_require_member(
+        parser,
+        _expr.span(),
+        require_cache_range(_expr, member_ranges, members),
+        members,
+        "undefined".into(),
+      );
+      return Some(true);
+    }
+
+    if for_name != COMMONJS_REQUIRE_TAG || !should_parse_commonjs_require(parser) {
       return None;
     }
     let tag_info = parser
@@ -711,7 +1826,27 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     members_optionals: &[bool],
     _member_ranges: &[Span],
   ) -> Option<bool> {
-    if for_name != COMMONJS_REQUIRE_TAG {
+    if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      let ids = get_non_optional_part(members, members_optionals);
+      if members.is_empty() {
+        wrap_created_require_with_side_effects(parser, expr.span());
+        return self.require_handler(
+          parser,
+          CallOrNewExpr::Call(expr),
+          current_created_require_context(parser),
+        );
+      }
+      if members.len() == 1 && members[0].as_ref() == "resolve" {
+        return self.process_created_require_resolve_call(parser, expr);
+      }
+      if ids.len() != members.len() {
+        parser.walk_expr_or_spread(&expr.args);
+        return Some(true);
+      }
+      return None;
+    }
+
+    if for_name != COMMONJS_REQUIRE_TAG || !should_parse_commonjs_require(parser) {
       return None;
     }
     let tag_info = parser
@@ -735,8 +1870,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     Some(true)
   }
 
-  fn can_rename(&self, _parser: &mut JavascriptParser<'p>, for_name: &str) -> Option<bool> {
-    if for_name == expr_name::REQUIRE {
+  fn can_rename(&self, parser: &mut JavascriptParser<'p>, for_name: &str) -> Option<bool> {
+    if (for_name == expr_name::REQUIRE && should_parse_commonjs_require(parser))
+      || for_name == CREATED_REQUIRE_IDENTIFIER_TAG
+    {
       Some(true)
     } else {
       None
@@ -744,7 +1881,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
   }
 
   fn rename(&self, parser: &mut JavascriptParser<'p>, expr: &Expr, for_name: &str) -> Option<bool> {
-    if for_name == expr_name::REQUIRE {
+    if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      if let Some(ident) = expr.as_ident() {
+        let context = current_created_require_context(parser);
+        self.require_as_expression_handler(parser, ident, context)?;
+      }
+      parser.walk_expression(expr);
+      Some(false)
+    } else if for_name == expr_name::REQUIRE && should_parse_commonjs_require(parser) {
       if parser.javascript_options.require_alias.unwrap_or_default() {
         parser.add_presentational_dependency(Box::new(ConstDependency::new(
           expr.span().into(),
@@ -765,13 +1909,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
 
   fn evaluate_typeof(
     &self,
-    _parser: &mut JavascriptParser<'p>,
+    parser: &mut JavascriptParser<'p>,
     expr: &'a UnaryExpr<'a>,
     for_name: &str,
   ) -> Option<BasicEvaluatedExpression<'a>> {
-    (for_name == expr_name::REQUIRE
-      || for_name == expr_name::REQUIRE_RESOLVE
-      || for_name == expr_name::REQUIRE_RESOLVE_WEAK)
+    ((should_parse_commonjs_require(parser)
+      && (for_name == expr_name::REQUIRE
+        || for_name == expr_name::REQUIRE_RESOLVE
+        || for_name == expr_name::REQUIRE_RESOLVE_WEAK))
+      || should_handle_create_require_specifier(parser, for_name)
+      || for_name == CREATED_REQUIRE_IDENTIFIER_TAG)
       .then(|| {
         eval::evaluate_to_string(
           "function".to_string(),
@@ -783,35 +1930,88 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
 
   fn evaluate_identifier(
     &self,
-    _parser: &mut JavascriptParser<'p>,
+    parser: &mut JavascriptParser<'p>,
     for_name: &str,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {
     match for_name {
-      expr_name::REQUIRE => Some(eval::evaluate_to_identifier(
-        expr_name::REQUIRE.into(),
-        expr_name::REQUIRE.into(),
-        Some(true),
-        start,
-        end,
-      )),
-      expr_name::REQUIRE_RESOLVE => Some(eval::evaluate_to_identifier(
-        expr_name::REQUIRE_RESOLVE.into(),
-        expr_name::REQUIRE_RESOLVE.into(),
-        Some(true),
-        start,
-        end,
-      )),
-      expr_name::REQUIRE_RESOLVE_WEAK => Some(eval::evaluate_to_identifier(
-        expr_name::REQUIRE_RESOLVE_WEAK.into(),
-        expr_name::REQUIRE_RESOLVE_WEAK.into(),
+      expr_name::REQUIRE if should_parse_commonjs_require(parser) => {
+        Some(eval::evaluate_to_identifier(
+          expr_name::REQUIRE.into(),
+          expr_name::REQUIRE.into(),
+          Some(true),
+          start,
+          end,
+        ))
+      }
+      expr_name::REQUIRE_RESOLVE if should_parse_commonjs_require(parser) => {
+        Some(eval::evaluate_to_identifier(
+          expr_name::REQUIRE_RESOLVE.into(),
+          expr_name::REQUIRE_RESOLVE.into(),
+          Some(true),
+          start,
+          end,
+        ))
+      }
+      expr_name::REQUIRE_RESOLVE_WEAK if should_parse_commonjs_require(parser) => {
+        Some(eval::evaluate_to_identifier(
+          expr_name::REQUIRE_RESOLVE_WEAK.into(),
+          expr_name::REQUIRE_RESOLVE_WEAK.into(),
+          Some(true),
+          start,
+          end,
+        ))
+      }
+      CREATE_REQUIRE_SPECIFIER_TAG if is_current_create_require_tag(parser) => {
+        Some(eval::evaluate_to_identifier(
+          CREATE_REQUIRE_EVALUATED_TAG.into(),
+          CREATE_REQUIRE_EVALUATED_TAG.into(),
+          Some(true),
+          start,
+          end,
+        ))
+      }
+      CREATE_REQUIRE_EVALUATED_TAG => Some(eval::evaluate_to_identifier(
+        CREATE_REQUIRE_EVALUATED_TAG.into(),
+        CREATE_REQUIRE_EVALUATED_TAG.into(),
         Some(true),
         start,
         end,
       )),
       _ => None,
     }
+  }
+
+  fn evaluate_call_expression(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    for_name: &str,
+    expr: &'a CallExpr<'a>,
+  ) -> Option<BasicEvaluatedExpression<'a>>
+  where
+    'p: 'a,
+  {
+    if !should_handle_create_require_call(parser, for_name, expr.callee.as_expr()) {
+      return None;
+    }
+    evaluate_create_require_call_expression(parser, expr)
+  }
+
+  fn evaluate_call_expression_member(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    property: &str,
+    expr: &'a CallExpr<'a>,
+    param: BasicEvaluatedExpression<'a>,
+  ) -> Option<BasicEvaluatedExpression<'a>>
+  where
+    'p: 'a,
+  {
+    if !is_create_require_namespace_member_param(parser, property, &param) {
+      return None;
+    }
+    evaluate_create_require_call_expression(parser, expr)
   }
 
   fn r#typeof(
@@ -821,9 +2021,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     for_name: &str,
   ) -> Option<bool> {
     // same as webpack/tagRequireExpression
-    if for_name == expr_name::REQUIRE
-      || for_name == expr_name::REQUIRE_RESOLVE
-      || for_name == expr_name::REQUIRE_RESOLVE_WEAK
+    if (should_parse_commonjs_require(parser)
+      && (for_name == expr_name::REQUIRE
+        || for_name == expr_name::REQUIRE_RESOLVE
+        || for_name == expr_name::REQUIRE_RESOLVE_WEAK))
+      || should_handle_create_require_specifier(parser, for_name)
+      || for_name == CREATED_REQUIRE_IDENTIFIER_TAG
     {
       parser.add_presentational_dependency(Box::new(ConstDependency::new(
         expr.span.into(),
@@ -841,24 +2044,49 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     call_expr: &CallExpr,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE {
-      self.require_handler(parser, CallOrNewExpr::Call(call_expr))
-    } else if for_name == expr_name::REQUIRE_RESOLVE {
+    if (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
+      && should_parse_commonjs_require(parser)
+    {
+      self.require_handler(parser, CallOrNewExpr::Call(call_expr), None)
+    } else if should_handle_create_require_call(parser, for_name, call_expr.callee.as_expr()) {
+      if let Some(argument) = parse_create_require_argument(parser, call_expr, true) {
+        if argument.replace_argument {
+          parser.add_presentational_dependency(Box::new(ConstDependency::new(
+            call_expr.args[0].expr.span().into(),
+            json_stringify_str(&argument.value).into(),
+          )));
+        } else {
+          walk_create_require_argument_side_effects(parser, &call_expr.args[0].expr);
+        }
+        walk_create_require_callee(parser, call_expr);
+        walk_create_require_ignored_args(parser, call_expr);
+        Some(true)
+      } else {
+        None
+      }
+    } else if for_name == expr_name::REQUIRE_RESOLVE && should_parse_commonjs_require(parser) {
       if matches!(parser.javascript_options.require_resolve, Some(false))
         || !Self::should_process_resolve(parser, call_expr)
       {
         return None;
       }
 
-      self.process_resolve(parser, call_expr, false);
+      self.process_resolve(parser, call_expr, false, None);
       Some(true)
-    } else if for_name == expr_name::REQUIRE_RESOLVE_WEAK {
+    } else if for_name == expr_name::REQUIRE_RESOLVE_WEAK && should_parse_commonjs_require(parser) {
       if !Self::should_process_resolve(parser, call_expr) {
         return None;
       }
 
-      self.process_resolve(parser, call_expr, true);
+      self.process_resolve(parser, call_expr, true, None);
       Some(true)
+    } else if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      wrap_created_require_with_side_effects(parser, call_expr.span());
+      self.require_handler(
+        parser,
+        CallOrNewExpr::Call(call_expr),
+        current_created_require_context(parser),
+      )
     } else {
       None
     }
@@ -870,8 +2098,17 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     new_expr: &NewExpr,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE {
-      self.require_handler(parser, CallOrNewExpr::New(new_expr))
+    if (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
+      && should_parse_commonjs_require(parser)
+    {
+      self.require_handler(parser, CallOrNewExpr::New(new_expr), None)
+    } else if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      wrap_created_require_with_side_effects(parser, new_expr.span);
+      self.require_handler(
+        parser,
+        CallOrNewExpr::New(new_expr),
+        current_created_require_context(parser),
+      )
     } else {
       None
     }
@@ -884,11 +2121,35 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     callee_members: &[Atom],
     call_expr: &CallExpr,
     members: &[Atom],
-    _member_ranges: &[Span],
+    member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
     if callee_members.is_empty()
+      && should_handle_create_require_specifier(parser, for_name)
+      && let Some(argument) = parse_create_require_argument(parser, call_expr, false)
+    {
+      let side_effects = create_require_args_side_effects(parser, &call_expr.args, &argument);
+      let unsupported_replacement = create_require_unsupported_member_replacement(&side_effects);
+      handle_created_require_member(
+        parser,
+        member_expr.span(),
+        require_cache_range(member_expr, member_ranges, members),
+        members,
+        unsupported_replacement,
+      );
+      if members
+        .first()
+        .is_some_and(|member| member.as_ref() == "cache")
+      {
+        wrap_span_with_side_effects(parser, member_expr.span(), &side_effects);
+      }
+      walk_create_require_ignored_args(parser, call_expr);
+      return Some(true);
+    }
+
+    if callee_members.is_empty()
       && (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
+      && should_parse_commonjs_require(parser)
       && let Some(dep) = self.chain_handler(parser, member_expr, call_expr, members, false)
     {
       parser.add_dependency(Box::new(dep));
@@ -904,11 +2165,62 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     callee_members: &[Atom],
     inner_call_expr: &CallExpr,
     members: &[Atom],
-    _member_ranges: &[Span],
+    member_ranges: &[Span],
     for_name: &str,
   ) -> Option<bool> {
     if callee_members.is_empty()
+      && should_handle_create_require_specifier(parser, for_name)
+      && members.len() == 1
+      && members[0].as_ref() == "resolve"
+    {
+      if matches!(parser.javascript_options.require_resolve, Some(false))
+        || call_expr.args.len() != 1
+        || call_expr.args[0].spread.is_some()
+      {
+        walk_unsupported_create_require_resolve(parser, inner_call_expr, call_expr);
+        return Some(true);
+      }
+      let argument = parse_create_require_argument(parser, inner_call_expr, false)?;
+      let side_effects = create_require_args_side_effects(parser, &inner_call_expr.args, &argument);
+      wrap_span_with_side_effects(parser, call_expr.span(), &side_effects);
+      let context = argument.context;
+      walk_create_require_ignored_args(parser, inner_call_expr);
+      self.process_resolve(parser, call_expr, false, Some(context));
+      return Some(true);
+    }
+
+    if callee_members.is_empty()
+      && should_handle_create_require_specifier(parser, for_name)
+      && let Some(argument) = parse_create_require_argument(parser, inner_call_expr, false)
+    {
+      let side_effects = create_require_args_side_effects(parser, &inner_call_expr.args, &argument);
+      let unsupported_replacement = create_require_unsupported_member_replacement(&side_effects);
+      let member_span = call_expr.callee.span();
+      handle_created_require_member(
+        parser,
+        member_span,
+        require_cache_range(
+          call_expr.callee.as_expr()?.as_member()?,
+          member_ranges,
+          members,
+        ),
+        members,
+        unsupported_replacement,
+      );
+      if members
+        .first()
+        .is_some_and(|member| member.as_ref() == "cache")
+      {
+        wrap_span_with_side_effects(parser, member_span, &side_effects);
+      }
+      walk_create_require_ignored_args(parser, inner_call_expr);
+      parser.walk_expr_or_spread(&call_expr.args);
+      return Some(true);
+    }
+
+    if callee_members.is_empty()
       && (for_name == expr_name::REQUIRE || for_name == expr_name::MODULE_REQUIRE)
+      && should_parse_commonjs_require(parser)
       && let Some(callee) = call_expr.callee.as_expr()
       && let Some(member) = callee.as_member()
       && let Some(dep) = self.chain_handler(parser, member, inner_call_expr, members, true)
@@ -923,14 +2235,26 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
   fn assign(
     &self,
     parser: &mut JavascriptParser<'p>,
-    _expr: &AssignExpr,
+    expr: &AssignExpr,
+    ident: &Ident,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == expr_name::REQUIRE {
+    if for_name == expr_name::REQUIRE && should_parse_commonjs_require(parser) {
       parser.add_presentational_dependency(Box::new(ConstDependency::new(
         (0, 0).into(),
         "var require;".into(),
       )));
+      return Some(true);
+    }
+
+    if for_name == CREATED_REQUIRE_IDENTIFIER_TAG
+      || for_name == CREATE_REQUIRE_SPECIFIER_TAG
+      || for_name == CREATE_REQUIRE_EVALUATED_TAG
+    {
+      if matches!(expr.op, AssignOp::OrAssign | AssignOp::NullishAssign) {
+        return Some(true);
+      }
+      clear_create_require_tag(parser, &Atom::from(ident.sym.as_str()));
       return Some(true);
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -306,10 +306,11 @@ impl<'p: 'a, 'a> JavascriptParserPlugin<'p, 'a> for JavaScriptParserPluginDrive 
     &self,
     parser: &mut JavascriptParser<'p>,
     expr: &AssignExpr,
+    ident: &Ident,
     for_name: &str,
   ) -> Option<bool> {
     for plugin in self.plugins_for(JavascriptParserPluginHook::Assign) {
-      let res = plugin.assign(parser, expr, for_name);
+      let res = plugin.assign(parser, expr, ident, for_name);
       // `SyncBailHook`
       if res.is_some() {
         return res;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -8,7 +8,9 @@ use swc_experimental_ecma_ast::{
 };
 
 use super::{
-  InnerGraphParserPlugin, JavascriptParserPlugin, import_phase::get_import_phase,
+  InnerGraphParserPlugin, JavascriptParserPlugin,
+  common_js_imports_parse_plugin::{is_create_require_import, tag_create_require},
+  import_phase::get_import_phase,
   inner_graph::state::InnerGraphUsageOperation,
 };
 use crate::{
@@ -91,6 +93,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     id: Option<&Atom>,
     name: &Atom,
   ) -> Option<bool> {
+    let is_create_require = is_create_require_import(parser, source, id);
     let phase = get_import_phase(parser, statement.phase, None, None);
     parser.tag_variable::<ESMSpecifierData>(
       name.clone(),
@@ -105,6 +108,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
         attributes: statement.with.as_ref().map(|obj| get_attributes(obj)),
       }),
     );
+    if is_create_require {
+      tag_create_require(parser, name.clone());
+    }
     Some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -880,6 +880,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     expr: &AssignExpr,
+    _ident: &Ident,
     for_name: &str,
   ) -> Option<bool> {
     if !parser.inner_graph.is_enabled() || for_name != TOP_LEVEL_SYMBOL {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -44,7 +44,12 @@ pub(crate) use self::{
   },
   api_plugin::APIPlugin,
   common_js_exports_parse_plugin::CommonJsExportsParserPlugin,
-  common_js_imports_parse_plugin::{CommonJsImportsParserPlugin, RequireReferencesState},
+  common_js_imports_parse_plugin::{
+    CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
+    CommonJsImportsParserPlugin, CreatedRequireTagData, RequireReferencesState,
+    evaluate_create_require_new_expression, is_create_require_namespace_member,
+    is_create_require_specifier,
+  },
   common_js_plugin::CommonJsPlugin,
   compatibility_plugin::CompatibilityPlugin,
   r#const::ConstPlugin,
@@ -67,7 +72,7 @@ pub(crate) use self::{
   require_context_dependency_parser_plugin::RequireContextDependencyParserPlugin,
   require_ensure_dependencies_block_parse_plugin::RequireEnsureDependenciesBlockParserPlugin,
   side_effects_parser_plugin::SideEffectsParserPlugin,
-  url_plugin::URLPlugin,
+  url_plugin::{URLPlugin, get_url_request},
   use_strict_plugin::UseStrictPlugin,
   worker_plugin::WorkerPlugin,
 };

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -552,6 +552,7 @@ Please annotate your `impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ...` block
     &self,
     _parser: &mut JavascriptParser<'p>,
     _expr: &AssignExpr,
+    _ident: &Ident,
     _for_name: &str,
   ) -> Option<bool> {
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -156,6 +156,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
     }
 
     if let Some((request, start, end)) = get_url_request(parser, expr) {
+      if request.starts_with("//") {
+        if args.len() == 2 {
+          parser.walk_expression(&args[1].expr);
+          return Some(true);
+        }
+        return None;
+      }
       let dep = URLDependency::new(
         request.into(),
         expr.span.into(),

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_call_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_call_expr.rs
@@ -1,7 +1,14 @@
+use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{CallExpr, Callee, MemberProp};
 
 use super::BasicEvaluatedExpression;
-use crate::{parser_plugin::JavascriptParserPlugin, visitors::JavascriptParser};
+use crate::{
+  parser_plugin::{
+    CREATE_REQUIRE_EVALUATED_TAG, JavascriptParserPlugin, is_create_require_namespace_member,
+    is_create_require_specifier,
+  },
+  visitors::{CallHooksName, JavascriptParser},
+};
 
 #[inline]
 pub fn eval_call_expression<'parser: 'a, 'a>(
@@ -11,16 +18,37 @@ pub fn eval_call_expression<'parser: 'a, 'a>(
   let drive = parser.plugin_drive.clone();
   match &expr.callee {
     Callee::Expr(callee_expr) => {
-      if let Some(ident) = callee_expr.as_ident()
-        && let Some(evaluated) = drive.evaluate_call_expression(parser, ident.sym.as_str(), expr)
-      {
-        return Some(evaluated);
+      if let Some(ident) = callee_expr.as_ident() {
+        let is_create_require = parser.javascript_options.is_create_require_enabled()
+          && is_create_require_specifier(parser, &Atom::from(ident.sym.as_str()));
+        let evaluated = if is_create_require {
+          Atom::from(ident.sym.as_str()).call_hooks_name(parser, |parser, for_name| {
+            drive.evaluate_call_expression(parser, for_name, expr)
+          })
+        } else if parser.javascript_options.is_create_require_enabled() {
+          let evaluated = parser.evaluate_expression(callee_expr);
+          if evaluated.is_identifier() && evaluated.identifier() == CREATE_REQUIRE_EVALUATED_TAG {
+            drive.evaluate_call_expression(parser, CREATE_REQUIRE_EVALUATED_TAG, expr)
+          } else {
+            drive.evaluate_call_expression(parser, ident.sym.as_str(), expr)
+          }
+        } else {
+          drive.evaluate_call_expression(parser, ident.sym.as_str(), expr)
+        };
+        if evaluated.is_some() {
+          return evaluated;
+        }
       }
       if let Some(member) = callee_expr.as_member()
         && let MemberProp::Ident(ident) = &member.prop
       {
         let param = parser.evaluate_expression(&member.obj);
         return drive.evaluate_call_expression_member(parser, ident.sym.as_str(), expr, param);
+      }
+      if parser.javascript_options.is_create_require_enabled()
+        && is_create_require_namespace_member(parser, callee_expr)
+      {
+        return drive.evaluate_call_expression(parser, "", expr);
       }
       None
     }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -3,8 +3,10 @@ use swc_experimental_ecma_ast::{Expr, MemberExpr};
 
 use super::BasicEvaluatedExpression;
 use crate::{
-  parser_plugin::JavascriptParserPlugin,
-  visitors::{AllowedMemberTypes, ExprRef, JavascriptParser, MemberExpressionInfo},
+  parser_plugin::{CREATED_REQUIRE_IDENTIFIER_TAG, CreatedRequireTagData, JavascriptParserPlugin},
+  visitors::{
+    AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
+  },
 };
 
 pub fn eval_member_expression<'parser: 'a, 'a>(
@@ -16,6 +18,14 @@ pub fn eval_member_expression<'parser: 'a, 'a>(
   let ret = if let Some(MemberExpressionInfo::Expression(info)) =
     parser.get_member_expression_info(ExprRef::Member(member), AllowedMemberTypes::Expression)
   {
+    let is_created_require_member = parser.javascript_options.is_create_require_enabled()
+      && matches!(
+        info.root_info,
+        ExportedVariableInfo::VariableInfo(id)
+          if parser
+            .get_variable_tag_data::<CreatedRequireTagData>(id, CREATED_REQUIRE_IDENTIFIER_TAG)
+            .is_some()
+      );
     drive
       .evaluate_identifier(
         parser,
@@ -23,6 +33,7 @@ pub fn eval_member_expression<'parser: 'a, 'a>(
         member.span.real_lo(),
         member.span.real_hi(),
       )
+      .filter(|_| !is_created_require_member)
       .or_else(|| drive.evaluate(parser, expr))
       .or_else(|| {
         // TODO: fallback with `evaluateDefinedIdentifier`

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -3,14 +3,37 @@ use swc_atoms::Atom;
 use swc_experimental_ecma_ast::NewExpr;
 
 use super::BasicEvaluatedExpression;
-use crate::{utils::eval, visitors::JavascriptParser};
+use crate::{
+  parser_plugin::{evaluate_create_require_new_expression, is_create_require_specifier},
+  utils::eval,
+  visitors::{CallHooksName, JavascriptParser},
+};
 
 #[inline]
 pub fn eval_new_expression<'a>(
   scanner: &mut JavascriptParser,
   expr: &'a NewExpr,
 ) -> Option<BasicEvaluatedExpression<'a>> {
-  let ident = expr.callee.as_ident()?;
+  let ident = expr.callee.as_ident();
+  if scanner.javascript_options.is_create_require_enabled() {
+    if let Some(ident) = ident {
+      let ident_name = Atom::from(ident.sym.as_str());
+      if is_create_require_specifier(scanner, &ident_name) {
+        let evaluated = ident_name.call_hooks_name(scanner, |scanner, for_name| {
+          evaluate_create_require_new_expression(scanner, for_name, Some(&expr.callee), expr)
+        });
+        if evaluated.is_some() {
+          return evaluated;
+        }
+      }
+    } else if expr.callee.as_member().is_some()
+      && let Some(evaluated) =
+        evaluate_create_require_new_expression(scanner, "", Some(&expr.callee), expr)
+    {
+      return Some(evaluated);
+    }
+  }
+  let ident = ident?;
   if ident.sym.as_str() != "RegExp" {
     // FIXME: call hooks
     return None;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -502,8 +502,11 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(parser_plugin::AMDParserPlugin));
     }
 
-    if module_type.is_js_auto() || module_type.is_js_dynamic() {
+    if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {
       plugins.push(Box::new(parser_plugin::CommonJsImportsParserPlugin));
+    }
+
+    if module_type.is_js_auto() || module_type.is_js_dynamic() {
       plugins.push(Box::new(parser_plugin::CommonJsPlugin));
       let commonjs_exports = javascript_options
         .commonjs
@@ -965,7 +968,7 @@ impl<'parser> JavascriptParser<'parser> {
     tag: &'static str,
     data: Option<Data>,
   ) {
-    self.tag_variable_impl(name, tag, data, None);
+    self.tag_variable_impl(name, tag, data.map(TagInfoData::into_any), None);
   }
 
   pub fn tag_variable_with_flags<Data: TagInfoData>(
@@ -975,18 +978,21 @@ impl<'parser> JavascriptParser<'parser> {
     data: Option<Data>,
     flags: VariableInfoFlags,
   ) {
-    self.tag_variable_impl(name, tag, data, Some(flags));
+    self.tag_variable_impl(name, tag, data.map(TagInfoData::into_any), Some(flags));
   }
 
-  fn tag_variable_impl<Data: TagInfoData>(
+  pub fn tag_variable_without_data(&mut self, name: Atom, tag: &'static str) {
+    self.tag_variable_impl(name, tag, None, None);
+  }
+
+  fn tag_variable_impl(
     &mut self,
     name: Atom,
     tag: &'static str,
-    data: Option<Data>,
+    data: Option<Box<dyn anymap::CloneAny>>,
     flags: Option<VariableInfoFlags>,
   ) {
     let flags = flags.unwrap_or(VariableInfoFlags::TAGGED);
-    let data = data.map(|data| TagInfoData::into_any(data));
     let new_info = if let Some(old_info_id) = self.definitions_db.get(self.definitions, &name) {
       let old_info = self.definitions_db.expect_get_variable(old_info_id);
       if let Some(old_tag_info) = old_info.tag_info {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -5,17 +5,17 @@ use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_allocator::{Allocator, CloneIn};
 use swc_experimental_ecma_ast::{
-  ArrayLit, ArrayPat, ArrowExpr, AssignExpr, AssignPat, AssignTarget, AssignTargetPat, AwaitExpr,
-  BinExpr, BinaryOp, BlockStmt, BlockStmtOrExpr, CallExpr, Callee, CatchClause, Class, ClassExpr,
-  ClassMember, CondExpr, DefaultDecl, DoWhileStmt, ExportDefaultDecl, Expr, ExprOrSpread, ExprStmt,
-  FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetSpan, GetterProp, Ident, IdentName,
-  IfStmt, JSXAttr, JSXAttrOrSpread, JSXAttrValue, JSXElement, JSXElementChild, JSXElementName,
-  JSXExpr, JSXExprContainer, JSXFragment, JSXMemberExpr, JSXNamespacedName, JSXObject,
-  KeyValueProp, LabeledStmt, Lit, MemberExpr, MemberProp, MetaPropExpr, ModuleDecl, ModuleItem,
-  NewExpr, ObjectLit, ObjectPat, ObjectPatProp, OptCall, OptChainExpr, Param, Pat, Prop, PropName,
-  PropOrSpread, RestPat, ReturnStmt, SeqExpr, SetterProp, SimpleAssignTarget, Stmt, SwitchCase,
-  SwitchStmt, TaggedTpl, ThisExpr, ThrowStmt, Tpl, TryStmt, UnaryExpr, UnaryOp, UpdateExpr,
-  VarDeclOrExpr, WhileStmt, WithStmt, YieldExpr,
+  ArrayLit, ArrayPat, ArrowExpr, AssignExpr, AssignOp, AssignPat, AssignTarget, AssignTargetPat,
+  AwaitExpr, BinExpr, BinaryOp, BlockStmt, BlockStmtOrExpr, CallExpr, Callee, CatchClause, Class,
+  ClassExpr, ClassMember, CondExpr, DefaultDecl, DoWhileStmt, ExportDefaultDecl, Expr,
+  ExprOrSpread, ExprStmt, FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetSpan,
+  GetterProp, Ident, IdentName, IfStmt, JSXAttr, JSXAttrOrSpread, JSXAttrValue, JSXElement,
+  JSXElementChild, JSXElementName, JSXExpr, JSXExprContainer, JSXFragment, JSXMemberExpr,
+  JSXNamespacedName, JSXObject, KeyValueProp, LabeledStmt, Lit, MemberExpr, MemberProp,
+  MetaPropExpr, ModuleDecl, ModuleItem, NewExpr, ObjectLit, ObjectPat, ObjectPatProp, OptCall,
+  OptChainExpr, Param, Pat, Prop, PropName, PropOrSpread, RestPat, ReturnStmt, SeqExpr, SetterProp,
+  SimpleAssignTarget, Stmt, SwitchCase, SwitchStmt, TaggedTpl, ThisExpr, ThrowStmt, Tpl, TryStmt,
+  UnaryExpr, UnaryOp, UpdateExpr, VarDeclOrExpr, WhileStmt, WithStmt, YieldExpr,
 };
 
 use super::{
@@ -25,12 +25,22 @@ use super::{
 };
 use crate::{
   dependency::{DependencyBranchGuard, ESMImportSpecifierDependency, ESMImportedBooleanGuardNode},
-  parser_plugin::JavascriptParserPlugin,
+  parser_plugin::{
+    CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
+    CreatedRequireTagData, JavascriptParserPlugin, is_create_require_namespace_member,
+  },
   visitors::{
-    AtomMembers, ExportedVariableInfo, ExprRef, VariableDeclaration,
-    dependency::parser::ExtractedMemberExpressionChainData, get_non_optional_part,
+    AtomMembers, ExportedVariableInfo, ExprRef, VariableDeclaration, VariableInfo,
+    VariableInfoFlags, dependency::parser::ExtractedMemberExpressionChainData,
+    get_non_optional_part,
   },
 };
+
+fn is_create_require_tag(tag: &str, include_create_require_fn: bool) -> bool {
+  tag == CREATED_REQUIRE_IDENTIFIER_TAG
+    || (include_create_require_fn
+      && (tag == CREATE_REQUIRE_SPECIFIER_TAG || tag == CREATE_REQUIRE_EVALUATED_TAG))
+}
 
 fn warp_ident_to_pat<'a>(ident: &Ident<'a>, allocator: &'a Allocator) -> Pat<'a> {
   Pat::Ident(allocator.boxed(ident.clone_in(allocator).into_binding(allocator)))
@@ -575,6 +585,9 @@ impl JavascriptParser<'_> {
     self.in_block_scope(false, |this| {
       this.walk_for_head(&stmt.left);
       this.walk_expression(&stmt.right);
+      if this.javascript_options.is_create_require_enabled() {
+        this.clear_created_require_tags_in_for_head(&stmt.left);
+      }
       if let Some(body) = stmt.body.as_block() {
         let prev = this.prev_statement;
         this.block_pre_walk_statements(&body.stmts);
@@ -590,6 +603,9 @@ impl JavascriptParser<'_> {
     self.in_block_scope(false, |this| {
       this.walk_for_head(&stmt.left);
       this.walk_expression(&stmt.right);
+      if this.javascript_options.is_create_require_enabled() {
+        this.clear_created_require_tags_in_for_head(&stmt.left);
+      }
       if let Some(body) = stmt.body.as_block() {
         let prev = this.prev_statement;
         this.block_pre_walk_statements(&body.stmts);
@@ -613,30 +629,68 @@ impl JavascriptParser<'_> {
         self.block_pre_walk_variable_declaration(decl);
         self.walk_variable_declaration(decl);
       }
-      ForHead::Pat(pat) => self.walk_pattern(pat),
+      ForHead::Pat(pat) => {
+        self.walk_pattern(pat);
+      }
+    }
+  }
+
+  fn clear_created_require_tags_in_for_head(&mut self, for_head: &ForHead) {
+    if let ForHead::Pat(pat) = for_head {
+      self.clear_created_require_tags_in_pattern(pat);
     }
   }
 
   fn walk_variable_declaration(&mut self, decl: VariableDeclaration<'_>) {
     let drive = self.plugin_drive.clone();
     for declarator in decl.declarators() {
+      if self.javascript_options.is_create_require_enabled()
+        && let Some(init) = declarator.init.as_ref()
+        && let Some(assign) = init.as_assign()
+        && assign.op == AssignOp::Assign
+        && let AssignTarget::Simple(simple) = &assign.left
+        && let Some(target) = simple.as_ident()
+        && let Some(binding) = declarator.name.as_ident()
+        && self
+          .try_walk_created_require_assignment(assign, &target.id)
+          .unwrap_or_default()
+      {
+        self.copy_create_require_assignment_result(
+          Atom::from(binding.id.sym.as_str()),
+          &Atom::from(target.id.sym.as_str()),
+        );
+        continue;
+      }
       if let Some(init) = declarator.init.as_ref()
         && let Some(renamed_identifier) = self.get_rename_identifier(init)
         && let Some(ident) = declarator.name.as_ident()
-        && drive
-          .can_rename(self, &renamed_identifier)
-          .unwrap_or_default()
       {
-        if !drive
-          .rename(self, init, &renamed_identifier)
-          .unwrap_or_default()
+        if self.javascript_options.is_create_require_enabled()
+          && renamed_identifier == CREATE_REQUIRE_EVALUATED_TAG
+          && !matches!(init, Expr::Call(_) | Expr::New(_))
         {
           self.set_variable(
             Atom::from(ident.id.sym.as_str()),
-            ExportedVariableInfo::Name(renamed_identifier.clone()),
+            ExportedVariableInfo::Name(renamed_identifier),
           );
+          self.walk_expression(init);
+          continue;
         }
-        continue;
+        if drive
+          .can_rename(self, &renamed_identifier)
+          .unwrap_or_default()
+        {
+          if !drive
+            .rename(self, init, &renamed_identifier)
+            .unwrap_or_default()
+          {
+            self.set_variable(
+              Atom::from(ident.id.sym.as_str()),
+              ExportedVariableInfo::Name(renamed_identifier.clone()),
+            );
+          }
+          continue;
+        }
       }
       if !drive.declarator(self, declarator, decl).unwrap_or_default() {
         self.walk_pattern(&declarator.name);
@@ -698,7 +752,194 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_update_expression(&mut self, expr: &UpdateExpr) {
-    self.walk_expression(&expr.arg)
+    if !self.javascript_options.is_create_require_enabled() {
+      self.walk_expression(&expr.arg);
+      return;
+    }
+    let updated_ident = expr
+      .arg
+      .as_ident()
+      .map(|ident| Atom::from(ident.sym.as_str()));
+    if let Some(name) = &updated_ident {
+      self.clear_create_require_tag(name);
+    }
+    self.walk_expression(&expr.arg);
+    if let Some(name) = &updated_ident {
+      self.clear_create_require_tag(name);
+    }
+  }
+
+  fn clear_create_require_tag(&mut self, name: &Atom) {
+    if let Some(variable_info) = self.get_variable_info(name) {
+      let declared_scope = variable_info.declared_scope;
+      let should_clear_name = variable_info.name.as_ref().is_some_and(|name| {
+        name == CREATED_REQUIRE_IDENTIFIER_TAG
+          || name == CREATE_REQUIRE_SPECIFIER_TAG
+          || name == CREATE_REQUIRE_EVALUATED_TAG
+      });
+      let mut should_clear = should_clear_name;
+      let mut tag_info_id = variable_info.tag_info;
+      while let Some(id) = tag_info_id {
+        let tag_info = self.definitions_db.expect_get_tag_info(id);
+        if tag_info.tag == CREATED_REQUIRE_IDENTIFIER_TAG
+          || tag_info.tag == CREATE_REQUIRE_SPECIFIER_TAG
+          || tag_info.tag == CREATE_REQUIRE_EVALUATED_TAG
+        {
+          should_clear = true;
+          break;
+        }
+        tag_info_id = tag_info.next;
+      }
+      if should_clear {
+        let info = VariableInfo::create(
+          &mut self.definitions_db,
+          declared_scope,
+          None,
+          VariableInfoFlags::NORMAL,
+          None,
+        );
+        self.definitions_db.set(declared_scope, name.clone(), info);
+      }
+    }
+  }
+
+  fn has_create_require_tag(&mut self, name: &Atom, include_create_require_fn: bool) -> bool {
+    let Some(variable_info) = self.get_variable_info(name) else {
+      return false;
+    };
+    if variable_info
+      .name
+      .as_ref()
+      .is_some_and(|name| is_create_require_tag(name, include_create_require_fn))
+    {
+      return true;
+    }
+    let mut tag_info_id = variable_info.tag_info;
+    while let Some(id) = tag_info_id {
+      let tag_info = self.definitions_db.expect_get_tag_info(id);
+      if is_create_require_tag(tag_info.tag, include_create_require_fn) {
+        return true;
+      }
+      tag_info_id = tag_info.next;
+    }
+    false
+  }
+
+  fn clear_created_require_tags_in_pattern(&mut self, pat: &Pat) {
+    match pat {
+      Pat::Ident(ident) => {
+        self.clear_create_require_tag(&Atom::from(ident.id.sym.as_str()));
+      }
+      Pat::Array(array) => array
+        .elems
+        .iter()
+        .flatten()
+        .for_each(|ele| self.clear_created_require_tags_in_pattern(ele)),
+      Pat::Assign(assign) => self.clear_created_require_tags_in_pattern(&assign.left),
+      Pat::Object(obj) => {
+        for prop in &obj.props {
+          match prop {
+            ObjectPatProp::KeyValue(kv) => self.clear_created_require_tags_in_pattern(&kv.value),
+            ObjectPatProp::Assign(assign) => {
+              self.clear_create_require_tag(&Atom::from(assign.key.id.sym.as_str()));
+            }
+            ObjectPatProp::Rest(rest) => self.clear_created_require_tags_in_pattern(&rest.arg),
+          }
+        }
+      }
+      Pat::Rest(rest) => self.clear_created_require_tags_in_pattern(&rest.arg),
+      Pat::Expr(_) | Pat::Invalid(_) => (),
+    }
+  }
+
+  #[cold]
+  #[inline(never)]
+  fn try_walk_created_require_assignment(
+    &mut self,
+    expr: &AssignExpr,
+    ident: &Ident,
+  ) -> Option<bool> {
+    let ident_name = Atom::from(ident.sym.as_str());
+    if matches!(expr.op, AssignOp::OrAssign | AssignOp::NullishAssign)
+      && self.has_create_require_tag(&ident_name, true)
+    {
+      return Some(true);
+    }
+    if expr.op != AssignOp::Assign {
+      return None;
+    }
+    if let Some(variable) = expr.right.as_ident().and_then(|rhs| {
+      let rhs_name = Atom::from(rhs.sym.as_str());
+      self
+        .has_create_require_tag(&rhs_name, false)
+        .then(|| self.get_variable_info(&rhs_name).map(|info| info.id()))
+        .flatten()
+    }) {
+      self.set_variable(
+        ident_name.clone(),
+        ExportedVariableInfo::VariableInfo(variable),
+      );
+      return Some(true);
+    }
+    if let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
+      && let Some(context) = self
+        .get_tag_data::<CreatedRequireTagData>(&rename_identifier, CREATED_REQUIRE_IDENTIFIER_TAG)
+        .map(|data| data.context.clone())
+    {
+      self.tag_variable(
+        ident_name.clone(),
+        CREATED_REQUIRE_IDENTIFIER_TAG,
+        Some(CreatedRequireTagData {
+          context,
+          side_effects: String::new(),
+        }),
+      );
+      if !expr.right.is_ident() {
+        self.walk_expression(&expr.right);
+      }
+      return Some(true);
+    }
+    if is_create_require_namespace_member(self, &expr.right) {
+      self.tag_variable_without_data(ident_name.clone(), CREATE_REQUIRE_SPECIFIER_TAG);
+      self.walk_expression(&expr.right);
+      return Some(true);
+    }
+    if let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
+      && rename_identifier == CREATE_REQUIRE_EVALUATED_TAG
+    {
+      self.set_variable(ident_name, ExportedVariableInfo::Name(rename_identifier));
+      self.walk_expression(&expr.right);
+      return Some(true);
+    }
+    None
+  }
+
+  fn copy_create_require_assignment_result(&mut self, binding: Atom, target: &Atom) {
+    if let Some(context) = self
+      .get_tag_data::<CreatedRequireTagData>(target, CREATED_REQUIRE_IDENTIFIER_TAG)
+      .map(|data| data.context.clone())
+    {
+      self.tag_variable(
+        binding,
+        CREATED_REQUIRE_IDENTIFIER_TAG,
+        Some(CreatedRequireTagData {
+          context,
+          side_effects: String::new(),
+        }),
+      );
+    } else if let Some(info) = self.get_variable_info(target)
+      && info
+        .name
+        .as_ref()
+        .is_some_and(|name| name == CREATE_REQUIRE_EVALUATED_TAG)
+    {
+      self.set_variable(
+        binding,
+        ExportedVariableInfo::Name(CREATE_REQUIRE_EVALUATED_TAG.into()),
+      );
+    } else if self.has_create_require_tag(target, true) {
+      self.tag_variable_without_data(binding, CREATE_REQUIRE_SPECIFIER_TAG);
+    }
   }
 
   fn walk_unary_expression(&mut self, expr: &UnaryExpr) {
@@ -1575,7 +1816,15 @@ impl JavascriptParser<'_> {
     if let AssignTarget::Simple(simple) = &expr.left
       && let Some(ident) = simple.as_ident()
     {
-      if let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
+      if self.javascript_options.is_create_require_enabled()
+        && self
+          .try_walk_created_require_assignment(expr, &ident.id)
+          .unwrap_or_default()
+      {
+        return;
+      }
+      if expr.op == AssignOp::Assign
+        && let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
         && rename_identifier
           .call_hooks_name(self, |this, for_name| drive.can_rename(this, for_name))
           .unwrap_or_default()
@@ -1594,12 +1843,21 @@ impl JavascriptParser<'_> {
         }
         return;
       }
-      self.walk_expression(&expr.right);
+      if !self.javascript_options.is_create_require_enabled()
+        || !expr
+          .right
+          .as_ident()
+          .is_some_and(|rhs| self.has_create_require_tag(&Atom::from(rhs.sym.as_str()), false))
+      {
+        self.walk_expression(&expr.right);
+      }
       self.enter_pattern(
         PatRef::Owned(warp_ident_to_pat(&ident.id, self.ast.allocator)),
         |this, ident| {
           if !Atom::from(ident.sym.as_str())
-            .call_hooks_name(this, |this, for_name| drive.assign(this, expr, for_name))
+            .call_hooks_name(this, |this, for_name| {
+              drive.assign(this, expr, ident, for_name)
+            })
             .unwrap_or_default()
           {
             // webpack use `walk_expression`, `walk_expression` just walk down the ast, so it's ok to use `walk_identifier`
@@ -1611,7 +1869,9 @@ impl JavascriptParser<'_> {
       self.walk_expression(&expr.right);
       self.enter_assign_target_pattern(pat, |this: &mut JavascriptParser<'_>, ident| {
         if !Atom::from(ident.sym.as_str())
-          .call_hooks_name(this, |this, for_name| drive.assign(this, expr, for_name))
+          .call_hooks_name(this, |this, for_name| {
+            drive.assign(this, expr, ident, for_name)
+          })
           .unwrap_or_default()
         {
           this.define_variable(Atom::from(ident.sym.as_str()));

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -605,6 +605,7 @@ function getRawJavascriptParserOptions(
     commonjs: parser.commonjs,
     importDynamic: parser.importDynamic,
     commonjsMagicComments: parser.commonjsMagicComments,
+    createRequire: parser.createRequire,
     typeReexportsPresence: parser.typeReexportsPresence,
     jsx: parser.jsx,
     deferImport: parser.deferImport,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -271,10 +271,12 @@ const applyJavascriptParserOptionsDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    targetProperties,
   }: {
     deferImport?: boolean;
     sourceImport?: boolean;
     outputModule: RspackOptionsNormalized['output']['module'];
+    targetProperties: false | TargetProperties;
   },
 ) => {
   D(parserOptions, 'dynamicImportMode', 'lazy');
@@ -300,6 +302,11 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'deferImport', deferImport);
   D(parserOptions, 'sourceImport', sourceImport);
   D(parserOptions, 'importMetaResolve', false);
+  D(
+    parserOptions,
+    'createRequire',
+    Boolean(targetProperties && targetProperties.node),
+  );
 };
 
 const applyCssGeneratorOptionsDefaults = (
@@ -413,6 +420,7 @@ const applyModuleDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    targetProperties,
   });
 
   F(module.parser, JSON_MODULE_TYPE, () => ({}));

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1270,6 +1270,12 @@ export type JavascriptParserOptions = {
    */
   commonjsMagicComments?: boolean;
 
+  /**
+   * Enable or disable parsing `import { createRequire } from "module"` and evaluating createRequire().
+   * @default true for Node-like targets, false otherwise
+   */
+  createRequire?: boolean | string;
+
   /** Whether to tolerant exportsPresence for type reexport */
   typeReexportsPresence?: 'no-tolerant' | 'tolerant' | 'tolerant-no-check';
 

--- a/tests/rspack-test/configCases/asset-modules/protocol-relative-url-args/index.js
+++ b/tests/rspack-test/configCases/asset-modules/protocol-relative-url-args/index.js
@@ -1,0 +1,13 @@
+it("should walk ignored protocol-relative URL arguments", async () => {
+	const exactUrl = new URL("//cdn.example.com/exact.png", import.meta.url);
+	expect(exactUrl.href).toBe("file://cdn.example.com/exact.png");
+
+	globalThis.protocolRelativeUrlSideEffect = false;
+	new URL(
+		"//cdn.example.com/a.png",
+		import.meta.url,
+		(globalThis.protocolRelativeUrlPromise = import("./side"))
+	);
+	await globalThis.protocolRelativeUrlPromise;
+	expect(globalThis.protocolRelativeUrlSideEffect).toBe(true);
+});

--- a/tests/rspack-test/configCases/asset-modules/protocol-relative-url-args/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/protocol-relative-url-args/rspack.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  mode: 'development',
+  target: 'web',
+};

--- a/tests/rspack-test/configCases/asset-modules/protocol-relative-url-args/side.js
+++ b/tests/rspack-test/configCases/asset-modules/protocol-relative-url-args/side.js
@@ -1,0 +1,1 @@
+globalThis.protocolRelativeUrlSideEffect = true;

--- a/tests/rspack-test/configCases/require/module-require-disable-resolve/a.js
+++ b/tests/rspack-test/configCases/require/module-require-disable-resolve/a.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/rspack-test/configCases/require/module-require-disable-resolve/async-context.js
+++ b/tests/rspack-test/configCases/require/module-require-disable-resolve/async-context.js
@@ -1,0 +1,1 @@
+export const marker = "__rspackCreateRequireUnsupportedResolveContextDependency";

--- a/tests/rspack-test/configCases/require/module-require-disable-resolve/async-url-context.js
+++ b/tests/rspack-test/configCases/require/module-require-disable-resolve/async-url-context.js
@@ -1,0 +1,1 @@
+export const marker = "__rspackCreateRequireUnsupportedResolveUrlDependency";

--- a/tests/rspack-test/configCases/require/module-require-disable-resolve/foo/a.js
+++ b/tests/rspack-test/configCases/require/module-require-disable-resolve/foo/a.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/rspack-test/configCases/require/module-require-disable-resolve/index.js
+++ b/tests/rspack-test/configCases/require/module-require-disable-resolve/index.js
@@ -1,0 +1,50 @@
+import { createRequire as _createRequire } from "module";
+import fs from "fs";
+import path from "path";
+
+it("should preserve created require resolve when requireResolve is disabled", () => {
+	const require = _createRequire(import.meta.url);
+	const resolved = require.resolve("./a");
+	expect(resolved.endsWith("a.js")).toBe(true);
+	expect(resolved).not.toBe("./a.js");
+
+	const directResolved = _createRequire(import.meta.url).resolve("./a");
+	expect(directResolved.endsWith("a.js")).toBe(true);
+	expect(directResolved).not.toBe("./a.js");
+
+	const directResolvedWithUrl = _createRequire(
+		new URL("./foo/c.js", import.meta.url)
+	).resolve("./a");
+	expect(directResolvedWithUrl).toMatch(/[\\/]foo[\\/]a\.js$/);
+	expect(directResolvedWithUrl).not.toBe("./a.js");
+});
+
+it("should keep preserved createRequire argument dependencies", () => {
+	try {
+		_createRequire(import("./async-context")).resolve("./a", {});
+	} catch {}
+
+	let dynamicUrlBaseExtraEvaluated = false;
+	try {
+		_createRequire(
+			new URL(
+				"./foo/c.js",
+				import("./async-url-context"),
+				(dynamicUrlBaseExtraEvaluated = true)
+			)
+		).resolve("./a", {});
+	} catch {}
+	expect(dynamicUrlBaseExtraEvaluated).toBe(true);
+
+	const emittedSource = fs
+		.readdirSync(path.dirname(__filename))
+		.filter(file => file.endsWith(".js"))
+		.map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
+		.join("\n");
+	expect(
+		emittedSource.includes("__rspackCreateRequireUnsupportedResolveContextDependency")
+	).toBe(true);
+	expect(
+		emittedSource.includes("__rspackCreateRequireUnsupportedResolveUrlDependency")
+	).toBe(true);
+});

--- a/tests/rspack-test/configCases/require/module-require-disable-resolve/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require-disable-resolve/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  module: {
+    parser: {
+      javascript: {
+        createRequire: true,
+        requireResolve: false,
+      },
+    },
+  },
+  optimization: {
+    moduleIds: 'named',
+  },
+};

--- a/tests/rspack-test/configCases/require/module-require-escape/escaped/c.js
+++ b/tests/rspack-test/configCases/require/module-require-escape/escaped/c.js
@@ -1,0 +1,2 @@
+module.exports = "escaped-context";
+

--- a/tests/rspack-test/configCases/require/module-require-escape/index.js
+++ b/tests/rspack-test/configCases/require/module-require-escape/index.js
@@ -1,0 +1,10 @@
+import { createRequire } from "module";
+
+it("should preserve context dependencies when created require escapes", () => {
+	const escapedRequire = createRequire(new URL("./escaped/c.js", import.meta.url));
+	function register(value) {
+		globalThis.__rspackEscapedRequire = value;
+	}
+	register(escapedRequire);
+	expect(typeof globalThis.__rspackEscapedRequire).toBe("function");
+});

--- a/tests/rspack-test/configCases/require/module-require-escape/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require-escape/rspack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+};

--- a/tests/rspack-test/configCases/require/module-require-escape/warnings.js
+++ b/tests/rspack-test/configCases/require/module-require-escape/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	/require function is used in a way in which dependencies cannot be statically extracted/
+];

--- a/tests/rspack-test/configCases/require/module-require-posix-file-url-host/index.js
+++ b/tests/rspack-test/configCases/require/module-require-posix-file-url-host/index.js
@@ -1,0 +1,6 @@
+import { createRequire as _createRequire } from "module";
+
+it("should not parse non-local createRequire file URL hosts", () => {
+	expect(() => _createRequire("file://example.com/project/foo.js")("./a")).toThrow();
+	expect(() => _createRequire(new URL("//example.com/project/foo.js", import.meta.url))("./a")).toThrow();
+});

--- a/tests/rspack-test/configCases/require/module-require-posix-file-url-host/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require-posix-file-url-host/rspack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+};

--- a/tests/rspack-test/configCases/require/module-require-posix-file-url-host/test.filter.js
+++ b/tests/rspack-test/configCases/require/module-require-posix-file-url-host/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function filter() {
+	return process.platform !== "win32";
+};

--- a/tests/rspack-test/configCases/require/module-require-posix-file-url-host/warnings.js
+++ b/tests/rspack-test/configCases/require/module-require-posix-file-url-host/warnings.js
@@ -1,0 +1,4 @@
+module.exports = [
+	/module\.createRequire supports only file URLs and absolute paths/,
+	/module\.createRequire supports only file URLs and absolute paths/
+];

--- a/tests/rspack-test/configCases/require/module-require/esm.mjs
+++ b/tests/rspack-test/configCases/require/module-require/esm.mjs
@@ -1,0 +1,10 @@
+import { createRequire } from "module";
+import { createRequire as nodeCreateRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const nodeRequire = nodeCreateRequire(new URL("./foo/c.js", import.meta.url));
+
+export const required = require("./a");
+export const directRequired = createRequire(import.meta.url)("./c");
+export const resolved = require.resolve("./b");
+export const nodeRequired = nodeRequire("./a");

--- a/tests/rspack-test/configCases/require/module-require/flag.js
+++ b/tests/rspack-test/configCases/require/module-require/flag.js
@@ -1,0 +1,1 @@
+export const unusedBranchEnabled = false;

--- a/tests/rspack-test/configCases/require/module-require/foo bar/a.js
+++ b/tests/rspack-test/configCases/require/module-require/foo bar/a.js
@@ -1,0 +1,1 @@
+module.exports = "space";

--- a/tests/rspack-test/configCases/require/module-require/foo/aliased-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/aliased-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackAliasedCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/assigned-alias-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/assigned-alias-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackAssignedAliasCreatedRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/assigned-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/assigned-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackAssignedCreatedRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/direct-extra-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/direct-extra-only.js
@@ -1,0 +1,2 @@
+globalThis.__rspackDirectExtraCreateRequire = true;
+module.exports = "__rspackDirectExtraCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/ignored-extra-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/ignored-extra-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackIgnoredExtraCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/loop-key-rhs-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/loop-key-rhs-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackLoopKeyRhsCreatedRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/loop-rhs-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/loop-rhs-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackLoopRhsCreatedRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/namespace-alias-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/namespace-alias-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackAliasNamespaceCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/namespace-constructed-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/namespace-constructed-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackConstructedNamespaceCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/namespace-direct-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/namespace-direct-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackDirectNamespaceCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/namespace-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/namespace-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackNamespaceCreateRequire";

--- a/tests/rspack-test/configCases/require/module-require/foo/optional-resolve-only.js
+++ b/tests/rspack-test/configCases/require/module-require/foo/optional-resolve-only.js
@@ -1,0 +1,1 @@
+module.exports = "__rspackOptionalResolveOnly";

--- a/tests/rspack-test/configCases/require/module-require/guarded-unused.js
+++ b/tests/rspack-test/configCases/require/module-require/guarded-unused.js
@@ -1,0 +1,2 @@
+globalThis.__rspackCreateRequireGuardedUnused = true;
+throw new Error("unreachable");

--- a/tests/rspack-test/configCases/require/module-require/index.js
+++ b/tests/rspack-test/configCases/require/module-require/index.js
@@ -1,45 +1,606 @@
 import { createRequire as _createRequire } from "module";
 import { createRequire as __createRequire, builtinModules } from "module";
+import { createRequire as nodeCreateRequire } from "node:module";
+import * as moduleNs from "module";
+import * as esm from "./esm.mjs";
+import { unusedBranchEnabled } from "./flag.js";
+import "./posix-backslash.generated.js";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
 
 it("should evaluate require/createRequire", () => {
 	expect(
 		(function () { return typeof _createRequire; }).toString()
-	).toBe('function() { return "function"; }');
+	).toBe("function () { return 'function'; }");
 	expect(
 		(function () { if (typeof _createRequire); }).toString()
-	).toBe('function() { if (true); }');
+	).toBe("function () { if (true); }");
 	const require = __createRequire(import.meta.url);
 	expect(
 		(function () { return typeof require; }).toString()
-	).toBe('function() { return "function"; }');
+	).toBe("function () { return 'function'; }");
 	expect(
 		(function () { if (typeof require); }).toString()
-	).toBe('function() { if (true); }');
+	).toBe("function () { if (true); }");
+	const evaluatedCreateRequireEffects = [];
+	if (
+		_createRequire(
+			import.meta.url,
+			evaluatedCreateRequireEffects.push("evaluated-extra")
+		)
+	) {
+		evaluatedCreateRequireEffects.push("body");
+	}
+	expect(evaluatedCreateRequireEffects).toEqual(["evaluated-extra", "body"]);
+});
+
+it("should not parse unbound createRequire identifiers", () => {
+	expect(
+		(function () { return typeof createRequire; }).toString()
+	).toBe("function () { return typeof createRequire; }");
+	expect(() => createRequire(import.meta.url)("./a")).toThrow(ReferenceError);
 });
 
 it("should create require", () => {
 	const require = _createRequire(import.meta.url);
 	expect(require("./a")).toBe(1);
+	expect(new require("./a")).toEqual({});
 	expect(_createRequire(import.meta.url)("./c")).toBe(3);
+	_createRequire(import.meta.url)("./c");
+	const __rspack_create_require = request => request;
+	expect(__rspack_create_require("./a")).toBe("./a");
+	var varRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	expect(varRequire("./a")).toBe(4);
+	expect(new varRequire("./a")).toEqual({});
 });
 
 it("should resolve using created require", () => {
 	const require = _createRequire(import.meta.url);
 	expect(require.resolve("./b")).toBe("./b.js");
 	expect(_createRequire(import.meta.url).resolve("./b")).toBe("./b.js");
+	const resolveSideEffects = [];
+	expect(
+		_createRequire(
+			new URL(
+				"./foo/c.js",
+				import.meta.url,
+				resolveSideEffects.push("resolve-url-extra")
+			),
+			resolveSideEffects.push("resolve-extra")
+		).resolve("./a")
+	).toMatch(/[\\/]foo[\\/]a\.js$/);
+	expect(resolveSideEffects).toEqual(["resolve-url-extra", "resolve-extra"]);
+});
+
+it("should preserve optional created require members", () => {
+	const require = _createRequire(import.meta.url);
+	expect(require?.resolve("./b")).toMatch(/[\\/]b\.js$/);
+	expect(require?.cache).toBe(_createRequire(import.meta.url).cache);
+	const cacheRequire = _createRequire(import.meta.url);
+	expect(cacheRequire?.cache).toBe(_createRequire(import.meta.url).cache);
+	const fooRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	expect(fooRequire?.resolve("./optional-resolve-only")).toMatch(
+		/[\\/]optional-resolve-only\.js$/
+	);
+	const emittedSource = fs
+		.readdirSync(path.dirname(__filename))
+		.filter(file => file.endsWith(".js"))
+		.map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
+		.join("\n");
+	expect(emittedSource.includes("__rspackOptionalResolveOnly")).toBe(true);
 });
 
 it("should provide require.cache", () => {
 	const _require = _createRequire(import.meta.url);
 	expect(require.cache).toBe(_require.cache);
 	expect(require.cache).toBe(_createRequire(import.meta.url).cache);
+	const cacheMemberExtraEffects = [];
+	expect(
+		_createRequire(
+			import.meta.url,
+			cacheMemberExtraEffects.push("cache-member-extra")
+		).cache
+	).toBe(require.cache);
+	expect(cacheMemberExtraEffects).toEqual(["cache-member-extra"]);
+	expect(_require.cache.__rspackMissingCreateRequireCacheEntry).toBe(undefined);
+	expect(_require.cache["__rspackMissingCreateRequireCacheEntry"]).toBe(
+		undefined
+	);
 });
 
 it("should provide dependency context", () => {
 	const _require = _createRequire(new URL("./foo/c.js", import.meta.url));
 	expect(_require("./a")).toBe(4);
+	const createRequireAlias = _createRequire;
+	const aliasRequire = createRequireAlias(new URL("./foo/c.js", import.meta.url));
+	expect(aliasRequire("./aliased-only")).toBe("__rspackAliasedCreateRequire");
+	let assignedCreateRequireAlias;
+	assignedCreateRequireAlias = _createRequire;
+	const assignedAliasRequire = assignedCreateRequireAlias(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(assignedAliasRequire("./aliased-only")).toBe(
+		"__rspackAliasedCreateRequire"
+	);
+	const namespaceRequire = moduleNs.createRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(namespaceRequire("./namespace-only")).toBe(
+		"__rspackNamespaceCreateRequire"
+	);
+	expect(
+		moduleNs.createRequire(new URL("./foo/c.js", import.meta.url))(
+			"./namespace-direct-only"
+		)
+	).toBe("__rspackDirectNamespaceCreateRequire");
+	expect(
+		moduleNs["createRequire"](new URL("./foo/c.js", import.meta.url))(
+			"./namespace-direct-only"
+		)
+	).toBe("__rspackDirectNamespaceCreateRequire");
+	const namespaceCreateRequire = moduleNs.createRequire;
+	const namespaceAliasRequire = namespaceCreateRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(namespaceAliasRequire("./namespace-alias-only")).toBe(
+		"__rspackAliasNamespaceCreateRequire"
+	);
+	let assignedNamespaceCreateRequire;
+	assignedNamespaceCreateRequire = moduleNs.createRequire;
+	const assignedNamespaceAliasRequire = assignedNamespaceCreateRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(assignedNamespaceAliasRequire("./namespace-alias-only")).toBe(
+		"__rspackAliasNamespaceCreateRequire"
+	);
 	const _require1 = _createRequire(new URL("./foo/", import.meta.url));
 	expect(_require1("./c")).toBe(5);
+	expect(
+		_createRequire(new URL("./foo/?v=1#hash", import.meta.url))("./c")
+	).toBe(5);
+	expect(_createRequire(new URL("file:a.js", import.meta.url))("./b")).toBe(2);
+	expect(_createRequire(new URL("./foo/..", import.meta.url))("./a")).toBe(1);
+	expect(_createRequire(new URL("./foo/c.js", import.meta.url))("./a")).toBe(4);
+	expect(new _createRequire(new URL("./foo/c.js", import.meta.url))("./a")).toBe(
+		4
+	);
+	const constructedRequire = new _createRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(constructedRequire("./a")).toBe(4);
+	const namespaceConstructedRequire = new moduleNs.createRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(namespaceConstructedRequire("./namespace-constructed-only")).toBe(
+		"__rspackConstructedNamespaceCreateRequire"
+	);
+	expect(
+		new moduleNs.createRequire(new URL("./foo/c.js", import.meta.url))(
+			"./namespace-constructed-only"
+		)
+	).toBe("__rspackConstructedNamespaceCreateRequire");
+	let namespaceConstructedRequireEffects = 0;
+	expect(
+		new moduleNs.createRequire(
+			new URL(
+				"./foo/c.js",
+				import.meta.url,
+				namespaceConstructedRequireEffects++
+			),
+			namespaceConstructedRequireEffects++
+		)("./a")
+	).toBe(4);
+	expect(namespaceConstructedRequireEffects).toBe(2);
+	let constructedRequireEffects = 0;
+	expect(
+		new _createRequire(
+			new URL(
+				"./foo/c.js",
+				import.meta.url,
+				constructedRequireEffects++
+			),
+			constructedRequireEffects++
+		)("./a")
+	).toBe(4);
+	expect(constructedRequireEffects).toBe(2);
+	expect(
+		_createRequire(new URL("./foo/c.js", import.meta.url), undefined)(
+			"./ignored-extra-only"
+		)
+	).toBe("__rspackIgnoredExtraCreateRequire");
+	const ignoredExtraEffects = [];
+	expect(
+		_createRequire(
+			new URL("./foo/c.js", import.meta.url),
+			ignoredExtraEffects.push("extra")
+		)("./ignored-extra-only")
+	).toBe("__rspackIgnoredExtraCreateRequire");
+	expect(ignoredExtraEffects).toEqual(["extra"]);
+	const directExtraEffects = [];
+	expect(
+		_createRequire(
+			new URL("./foo/c.js", import.meta.url),
+			directExtraEffects.push("direct-extra")
+		)("./direct-extra-only")
+	).toBe("__rspackDirectExtraCreateRequire");
+	expect(directExtraEffects).toEqual(["direct-extra"]);
+	expect(globalThis.__rspackDirectExtraCreateRequire).toBe(true);
+	const directSpreadExtraEffects = [];
+	expect(
+		_createRequire(
+			new URL("./foo/c.js", import.meta.url),
+			...[directSpreadExtraEffects.push("direct-spread-extra")]
+		)("./direct-extra-only")
+	).toBe("__rspackDirectExtraCreateRequire");
+	expect(directSpreadExtraEffects).toEqual(["direct-spread-extra"]);
+	const directUrlExtraEffects = [];
+	expect(
+		_createRequire(
+			new URL(
+				"./foo/c.js",
+				import.meta.url,
+				directUrlExtraEffects.push("direct-url-extra")
+			)
+		)("./direct-extra-only")
+	).toBe("__rspackDirectExtraCreateRequire");
+	expect(directUrlExtraEffects).toEqual(["direct-url-extra"]);
+	const directUrlSpreadExtraEffects = [];
+	expect(
+		_createRequire(
+			new URL(
+				"./foo/c.js",
+				import.meta.url,
+				...[directUrlSpreadExtraEffects.push("direct-url-spread-extra")]
+			)
+		)("./direct-extra-only")
+	).toBe("__rspackDirectExtraCreateRequire");
+	expect(directUrlSpreadExtraEffects).toEqual(["direct-url-spread-extra"]);
+	const emittedSourceWithDirectExtra = fs
+		.readdirSync(path.dirname(__filename))
+		.filter(file => file.endsWith(".js"))
+		.map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
+		.join("\n");
+	expect(
+		emittedSourceWithDirectExtra.includes("__rspackDirectExtraCreateRequire")
+	).toBe(true);
+	expect(
+		_createRequire(new URL("./foo/c.js", import.meta.url, undefined))(
+			"./ignored-extra-only"
+		)
+	).toBe("__rspackIgnoredExtraCreateRequire");
+	const ignoredUrlExtraEffects = [];
+	const requireWithUrlExtra = _createRequire(
+		new URL(
+			"./foo/c.js",
+			import.meta.url,
+			ignoredUrlExtraEffects.push("url-extra")
+		)
+	);
+	expect(requireWithUrlExtra("./ignored-extra-only")).toBe(
+		"__rspackIgnoredExtraCreateRequire"
+	);
+	expect(ignoredUrlExtraEffects).toEqual(["url-extra"]);
+	if (process.platform !== "win32") {
+		const ignoredAbsoluteUrlBaseEffects = [];
+		const absoluteUrlBaseRequire = _createRequire(
+			new URL(
+				"file:///tmp/rspack-create-require.js",
+				(ignoredAbsoluteUrlBaseEffects.push("absolute-url-base"),
+				"file:///tmp/base.js")
+			)
+		);
+		expect(typeof absoluteUrlBaseRequire).toBe("function");
+		expect(ignoredAbsoluteUrlBaseEffects).toEqual(["absolute-url-base"]);
+	}
+	const nodeRequire = nodeCreateRequire(new URL("./foo/c.js", import.meta.url));
+	expect(nodeRequire("./a")).toBe(4);
+});
+
+it("should drop inactive branch dependencies of created require", () => {
+	const require = _createRequire(import.meta.url);
+	if (unusedBranchEnabled) {
+		require("./guarded-unused.js");
+	}
+
+	const unusedMarker = "__rspackCreateRequire" + "GuardedUnused";
+	const emittedSource = fs
+		.readdirSync(path.dirname(__filename))
+		.filter(file => file.endsWith(".js"))
+		.map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
+		.join("\n");
+	expect(globalThis[unusedMarker]).toBe(undefined);
+	expect(emittedSource.includes(unusedMarker)).toBe(false);
+});
+
+it("should not parse relative createRequire filename", () => {
+	expect(() => _createRequire("./foo/c.js")("./a")).toThrow(/absolute path|file URL/);
+	expect(() => _createRequire("./foo/c.js").resolve("./a")).toThrow(/absolute path|file URL/);
+});
+
+it("should not decode encoded separators in createRequire file URLs", () => {
+	expect(() => _createRequire("file:///project/foo%2Fbar.js")("./a")).toThrow();
+	if (process.platform === "win32") {
+		expect(() =>
+			_createRequire(
+				new URL(
+					/* webpackIgnore: true */ "./foo%5Cbar/a.js",
+					import.meta.url
+				)
+			)("./a")
+		).toThrow();
+	} else {
+		expect(
+			_createRequire(
+				new URL(
+					/* webpackIgnore: true */ "./foo%5Cbar/a.js",
+					import.meta.url
+				)
+			)("./a")
+		).toBe("backslash");
+	}
+});
+
+it("should decode normal file URL escapes in createRequire paths", () => {
+	const escapedRequire = _createRequire(new URL("./foo%20bar/a.js", import.meta.url));
+	expect(escapedRequire("./a")).toBe("space");
+});
+
+it("should preserve createRequire binding for unsupported uses", async () => {
+	const createRequire = _createRequire;
+	const require = _createRequire(import.meta.url);
+	expect(() => createRequire("./foo/c.js")).toThrow(/absolute path|file URL/);
+	expect(() => _createRequire(...import.meta.url)("./a")).toThrow(/absolute path|file URL/);
+	expect(() => _createRequire(import.meta.url)(..."./a")).toThrow();
+	expect(() => _createRequire(import.meta.url).resolve()).toThrow();
+	const URLCtor = globalThis["URL"];
+	const httpsUrl = new URLCtor("https:" + "//example.com/foo/c.js", import.meta.url);
+	const dataUrl = new URLCtor("data:" + "text/javascript,export default 1", import.meta.url);
+	expect(() => _createRequire(httpsUrl)("./a")).toThrow();
+	expect(() => _createRequire(dataUrl)("./a")).toThrow();
+	let extraUrlArgEvaluated = false;
+	try {
+		_createRequire(new URL("./foo/c.js", import.meta.url, (extraUrlArgEvaluated = true)))("./a");
+	} catch {}
+	expect(extraUrlArgEvaluated).toBe(true);
+	let resolveExtraUrlArgEvaluated = false;
+	try {
+		_createRequire(
+			new URL("./foo/c.js", import.meta.url, (resolveExtraUrlArgEvaluated = true))
+		).resolve("./a", {});
+	} catch {}
+	expect(resolveExtraUrlArgEvaluated).toBe(true);
+	expect(() =>
+		_createRequire(new URL("file:///tmp/rspack-create-require.js", null))("./a")
+	).toThrow();
+	expect(
+		(function () { return require.resolve(..."./b"); }).toString()
+	).toContain("...");
+	globalThis.unsupportedCreateRequireMemberArg = false;
+	let unsupportedMemberUrlArgEvaluated = false;
+	let unsupportedMemberArgPromise;
+	try {
+		_createRequire(
+			new URL("./foo/c.js", import.meta.url, (unsupportedMemberUrlArgEvaluated = true))
+		).main(unsupportedMemberArgPromise = import("./unsupported-member-arg"));
+	} catch {}
+	expect(unsupportedMemberUrlArgEvaluated).toBe(true);
+	await unsupportedMemberArgPromise;
+	expect(globalThis.unsupportedCreateRequireMemberArg).toBe(true);
+});
+
+it("should not hoist var createRequire bindings before initialization", () => {
+	expect(() => {
+		hoistedRequire("./a");
+		var hoistedRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	}).toThrow();
+});
+
+it("should not tag lexical createRequire bindings before initialization", () => {
+	expect(() => {
+		lexicalRequire("./a");
+		const lexicalRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	}).toThrow();
+
+	expect(() => {
+		const before = sameDeclarationRequire("./a"), sameDeclarationRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+		return before;
+	}).toThrow();
+
+	const initializedRequire = _createRequire(new URL("./foo/c.js", import.meta.url)), after = initializedRequire("./a");
+	expect(after).toBe(4);
+});
+
+it("should clear shadowed created require bindings with unsupported initializers", () => {
+	const req = _createRequire(new URL("./foo/c.js", import.meta.url));
+	expect(req("./a")).toBe(4);
+	expect(() => {
+		const req = _createRequire("./foo/c.js");
+		return req("./a");
+	}).toThrow(/absolute path|file URL/);
+});
+
+it("should stop parsing reassigned created require bindings", () => {
+	let mutableCreateRequire = _createRequire;
+	mutableCreateRequire = () => request => request;
+	const mutableCreateRequireResult = mutableCreateRequire(import.meta.url);
+	expect(mutableCreateRequireResult("./a")).toBe("./a");
+	let updatedCreateRequire = _createRequire;
+	updatedCreateRequire++;
+	expect(() => updatedCreateRequire(import.meta.url)("./a")).toThrow();
+	let loopCreateRequire = _createRequire;
+	for (loopCreateRequire of [() => request => request]) {}
+	expect(loopCreateRequire(import.meta.url)("./a")).toBe("./a");
+	let logicalCreateRequire = _createRequire;
+	logicalCreateRequire ||= require("./guarded-unused.js");
+	const logicalCreatedRequire = logicalCreateRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(logicalCreatedRequire("./a")).toBe(4);
+	let logicalCreateRequireWithMissingRhs = _createRequire;
+	logicalCreateRequireWithMissingRhs ||= require("./missing-logical-create-require-alias.js");
+	expect(
+		logicalCreateRequireWithMissingRhs(
+			new URL("./foo/c.js", import.meta.url)
+		)("./a")
+	).toBe(4);
+	let nullishCreateRequire = _createRequire;
+	nullishCreateRequire ??= require("./guarded-unused.js");
+	const nullishCreatedRequire = nullishCreateRequire(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(nullishCreatedRequire("./a")).toBe(4);
+	let nullishCreateRequireWithMissingRhs = _createRequire;
+	nullishCreateRequireWithMissingRhs ??= require("./missing-nullish-create-require-alias.js");
+	expect(
+		nullishCreateRequireWithMissingRhs(
+			new URL("./foo/c.js", import.meta.url)
+		)("./a")
+	).toBe(4);
+
+	let mutableRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	mutableRequire = request => request;
+	expect(mutableRequire("./a")).toBe("./a");
+	let require = _createRequire(new URL("./foo/c.js", import.meta.url));
+	require = request => request;
+	expect(require("./a")).toBe("./a");
+	let outerRequire = _createRequire(import.meta.url);
+	function useReassignedOuterRequire() {
+		outerRequire = request => request;
+		return outerRequire("./a");
+	}
+	expect(useReassignedOuterRequire()).toBe("./a");
+	let blockReassignedOuterRequire = _createRequire(import.meta.url);
+	function useBlockReassignedOuterRequire() {
+		{
+			blockReassignedOuterRequire = request => request;
+		}
+		return blockReassignedOuterRequire("./a");
+	}
+	expect(useBlockReassignedOuterRequire()).toBe("./a");
+
+	let logicalOrRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	logicalOrRequire ||= require("./guarded-unused.js");
+	expect(logicalOrRequire("./a")).toBe(4);
+
+	let nullishRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	nullishRequire ??= require("./guarded-unused.js");
+	expect(nullishRequire("./a")).toBe(4);
+
+	let logicalAndRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	logicalAndRequire &&= request => request;
+	expect(logicalAndRequire("./a")).toBe("./a");
+
+	let destructuredRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	({ destructuredRequire } = { destructuredRequire: request => request });
+	expect(destructuredRequire("./a")).toBe("./a");
+
+	let updatedRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	updatedRequire++;
+	expect(() => updatedRequire("./a")).toThrow();
+
+	let loopRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	for (loopRequire of [request => request]) {}
+	expect(loopRequire("./a")).toBe("./a");
+
+	let loopRhsRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	for (loopRhsRequire of [loopRhsRequire("./loop-rhs-only")]) {}
+	expect(loopRhsRequire).toBe("__rspackLoopRhsCreatedRequire");
+
+	let loopKeyRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	for (loopKeyRequire in { "./a": true }) {}
+	expect(() => loopKeyRequire("./a")).toThrow();
+
+	let loopKeyRhsRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	for (loopKeyRhsRequire in {
+		[loopKeyRhsRequire("./loop-key-rhs-only")]: true
+	}) {}
+	expect(loopKeyRhsRequire).toBe("__rspackLoopKeyRhsCreatedRequire");
+});
+
+it("should preserve createRequire results used as values", () => {
+	let assignedRequire;
+	assignedRequire = _createRequire(new URL("./foo/c.js", import.meta.url));
+	expect(assignedRequire("./a")).toBe(4);
+	expect(assignedRequire("./assigned-only")).toBe("__rspackAssignedCreatedRequire");
+	let assignedExpressionRequire;
+	const assignedExpressionAlias = (assignedExpressionRequire = _createRequire(
+		new URL("./foo/c.js", import.meta.url)
+	));
+	expect(assignedExpressionAlias("./assigned-only")).toBe(
+		"__rspackAssignedCreatedRequire"
+	);
+	expect(assignedExpressionRequire("./assigned-only")).toBe(
+		"__rspackAssignedCreatedRequire"
+	);
+	const aliasedRequire = assignedRequire;
+	expect(aliasedRequire("./a")).toBe(4);
+	let assignedAliasRequire;
+	assignedAliasRequire = assignedRequire;
+	expect(assignedAliasRequire("./assigned-alias-only")).toBe(
+		"__rspackAssignedAliasCreatedRequire"
+	);
+	let compoundAliasRequire = request => request;
+	compoundAliasRequire += assignedRequire;
+	expect(() => compoundAliasRequire("./a")).toThrow();
+	let assignedCallCreateRequireAlias;
+	assignedCallCreateRequireAlias = _createRequire;
+	const copiedAssignedCallCreateRequireAlias = assignedCallCreateRequireAlias;
+	expect(
+		copiedAssignedCallCreateRequireAlias(
+			new URL("./foo/c.js", import.meta.url)
+		)("./aliased-only")
+	).toBe("__rspackAliasedCreateRequire");
+	let assignedCallRequire;
+	assignedCallRequire = assignedCallCreateRequireAlias(
+		new URL("./foo/c.js", import.meta.url)
+	);
+	expect(assignedCallRequire("./aliased-only")).toBe(
+		"__rspackAliasedCreateRequire"
+	);
+	let assignedCallRequireEffects = 0;
+	let assignedCallRequireWithEffects;
+	assignedCallRequireWithEffects = assignedCallCreateRequireAlias(
+		new URL(
+			"./foo/c.js",
+			import.meta.url,
+			assignedCallRequireEffects++
+		),
+		assignedCallRequireEffects++
+	);
+	expect(assignedCallRequireEffects).toBe(2);
+	expect(assignedCallRequireWithEffects("./a")).toBe(4);
+	expect(assignedCallRequireWithEffects("./a")).toBe(4);
+	expect(assignedCallRequireEffects).toBe(2);
+	let assignedExpressionRequireEffects = 0;
+	let assignedExpressionRequireWithEffects;
+	const assignedExpressionAliasWithEffects =
+		(assignedExpressionRequireWithEffects = assignedCallCreateRequireAlias(
+			new URL(
+				"./foo/c.js",
+				import.meta.url,
+				assignedExpressionRequireEffects++
+			),
+			assignedExpressionRequireEffects++
+		));
+	expect(assignedExpressionRequireEffects).toBe(2);
+	expect(assignedExpressionAliasWithEffects("./a")).toBe(4);
+	expect(assignedExpressionRequireWithEffects("./a")).toBe(4);
+	expect(assignedExpressionRequireEffects).toBe(2);
+
+	const emittedSource = fs
+		.readdirSync(path.dirname(__filename))
+		.filter(file => file.endsWith(".js"))
+		.map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
+		.join("\n");
+	expect(emittedSource.includes("__rspackAssignedCreatedRequire")).toBe(true);
+	expect(emittedSource.includes("__rspackAssignedAliasCreatedRequire")).toBe(
+		true
+	);
+});
+
+it("should not parse URL object as CommonJS require request", () => {
+	expect(() => require(new URL("./a.js", import.meta.url))).toThrow();
 });
 
 it("should add warning on using as expression", () => {
@@ -51,8 +612,25 @@ it("should add warning on using as expression", () => {
 it("should add warning on using require.main", () => {
 	let _require = _createRequire(new URL("./foo/c.js", import.meta.url));
 	expect(_require.main).toBe(undefined);
+	expect(_require?.main).toBe(undefined);
+	const unsupportedMemberExtraEffects = [];
+	expect(
+		_createRequire(
+			import.meta.url,
+			unsupportedMemberExtraEffects.push("unsupported-member-extra")
+		).main
+	).toBe(undefined);
+	expect(unsupportedMemberExtraEffects).toEqual(["unsupported-member-extra"]);
+	expect(_createRequire(import.meta.url).resolve).toBe(undefined);
 });
 
 it("should import Node.js module", () => {
 	expect(Array.isArray(builtinModules)).toBe(true);
+});
+
+it("should create require in ESM modules", () => {
+	expect(esm.required).toBe(1);
+	expect(esm.directRequired).toBe(3);
+	expect(esm.resolved).toBe("./b.js");
+	expect(esm.nodeRequired).toBe(4);
 });

--- a/tests/rspack-test/configCases/require/module-require/posix-backslash.js
+++ b/tests/rspack-test/configCases/require/module-require/posix-backslash.js
@@ -1,0 +1,1 @@
+module.exports = "posix-backslash";

--- a/tests/rspack-test/configCases/require/module-require/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require/rspack.config.js
@@ -1,7 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+if (process.platform !== 'win32') {
+  const fixtureDir = path.join(__dirname, 'foo\\bar');
+  fs.mkdirSync(fixtureDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(fixtureDir, 'a.js'),
+    'module.exports = "backslash";\n',
+  );
+}
+
+fs.writeFileSync(
+  path.join(__dirname, 'posix-backslash.generated.js'),
+  `import { createRequire as _createRequire } from "module";
+
+it("should create require from absolute file URL object", () => {
+\texpect(_createRequire(new URL(${JSON.stringify(pathToFileURL(path.join(__dirname, 'foo/c.js')).href)}))("./a")).toBe(4);
+});
+
+it("should create require from absolute file URL object with ignored base", () => {
+\texpect(_createRequire(new URL(${JSON.stringify(pathToFileURL(path.join(__dirname, 'foo/c.js')).href)}, undefined))("./a")).toBe(4);
+});
+
+it("should normalize direct file URL dot segments", () => {
+\texpect(_createRequire(${JSON.stringify(`${pathToFileURL(`${__dirname}${path.sep}`).href}foo/..`)})("./a")).toBe(1);
+});
+
+it("should accept normalized file URL object spellings", () => {
+\texpect(_createRequire(new URL(${JSON.stringify(pathToFileURL(path.join(__dirname, 'foo/c.js')).href.replace('file:///', 'file:/'))}, import.meta.url))("./a")).toBe(4);
+});
+` +
+    (process.platform === 'win32'
+      ? '\n'
+      : `
+
+it("should treat POSIX absolute paths ending in backslash as files", () => {
+\texpect(_createRequire(__dirname + "/foo\\\\")("./posix-backslash")).toBe(
+\t\t"posix-backslash"
+\t);
+});
+`),
+);
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   target: 'node',
   optimization: {
+    inlineExports: true,
     moduleIds: 'named',
   },
 };

--- a/tests/rspack-test/configCases/require/module-require/test.filter.js
+++ b/tests/rspack-test/configCases/require/module-require/test.filter.js
@@ -1,2 +1,0 @@
-
-module.exports = () => "TODO: support parsing createRequire in CommonJsImportsParserPlugin"

--- a/tests/rspack-test/configCases/require/module-require/unsupported-member-arg.js
+++ b/tests/rspack-test/configCases/require/module-require/unsupported-member-arg.js
@@ -1,0 +1,1 @@
+globalThis.unsupportedCreateRequireMemberArg = true;

--- a/tests/rspack-test/configCases/require/module-require/warnings.js
+++ b/tests/rspack-test/configCases/require/module-require/warnings.js
@@ -1,4 +1,27 @@
-module.exports = [
-	/require function is used in a way in which dependencies cannot be statically extracted/,
-	/createRequire\(\)\.main is not supported by webpack/
+const warnings = [
+	/module\.createRequire supports only file URLs and absolute paths/,
+	/module\.createRequire supports only file URLs and absolute paths/,
+	/module\.createRequire supports only file URLs and absolute paths/,
+	/module\.createRequire supports only file URLs and absolute paths/,
+	/module\.createRequire supports only file URLs and absolute paths/,
+	/module\.createRequire failed parsing argument/,
+	/module\.createRequire failed parsing argument/,
+	/module\.createRequire failed parsing argument/,
+	/module\.createRequire failed parsing argument/,
+	/module\.createRequire does not support spread arguments/,
+	/the request of a dependency is an expression/,
+	/The accessed createRequire\(\) member is not supported by Rspack/,
+	/The accessed createRequire\(\) member is not supported by Rspack/,
+	/The accessed createRequire\(\) member is not supported by Rspack/,
+	/The accessed createRequire\(\) member is not supported by Rspack/,
+	/The accessed createRequire\(\) member is not supported by Rspack/
 ];
+
+if (process.platform === "win32") {
+	warnings.push(
+		/module\.createRequire failed parsing argument/,
+		/module\.createRequire failed parsing argument/
+	);
+}
+
+module.exports = warnings;

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -295,6 +295,7 @@ module.exports = {
 			      },
 			      javascript: Object {
 			        commonjs: true,
+			        createRequire: false,
 			        deferImport: false,
 			        dynamicImportMode: lazy,
 			        dynamicImportPrefetch: false,

--- a/tests/rspack-test/defaultsCases/target_/electron-main.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-main.js
@@ -37,6 +37,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/electron-preload.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-preload.js
@@ -35,6 +35,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/node.js
+++ b/tests/rspack-test/defaultsCases/target_/node.js
@@ -32,6 +32,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/nwjs.js
+++ b/tests/rspack-test/defaultsCases/target_/nwjs.js
@@ -31,6 +31,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/node-commonjs-helper-name-collision/rspack.config.js
@@ -2,4 +2,11 @@ module.exports = {
   externals: {
     fs: 'node-commonjs fs',
   },
+  module: {
+    parser: {
+      javascript: {
+        createRequire: false,
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary

### What

- Port webpack's `module.createRequire` parser support.
- Add `module.parser.javascript.createRequire` and enable it by default for Node-like targets.
- Support created require calls, `require.resolve`, `require.cache`, dependency context from `import.meta.url` / `new URL(...)`, and unsupported member warnings.

### Why

- Allows `import { createRequire } from "module"` to behave like webpack in bundled Node-target code.
- Ensures dependencies created from `createRequire(new URL(..., import.meta.url))` resolve relative to the provided URL context.

### How

- Tag `createRequire` imports and created require bindings in the JavaScript parser.
- Thread request context through CommonJS require/resolve dependencies and context dependencies.
- Include request context in dependency resource identifiers so same-request dependencies from different contexts do not get merged.
- Re-enable and update `configCases/require/module-require` as regression coverage.

## Related links

- https://github.com/webpack/webpack/pull/15579

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Testing

- `PATH=/Users/bytedance/.nvm/versions/node/v22.21.1/bin:$PATH cargo check -p rspack_plugin_javascript`
- `PATH=/Users/bytedance/.nvm/versions/node/v22.21.1/bin:$PATH pnpm run build:binding:dev`
- `PATH=/Users/bytedance/.nvm/versions/node/v22.21.1/bin:$PATH pnpm run build:js`
- `PATH=/Users/bytedance/.nvm/versions/node/v22.21.1/bin:$PATH pnpm run test -t "configCases/require/module-require"`