### PR TITLE
feat: support rspack magic comment prefix

### DIFF
--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -40,37 +40,105 @@ pub enum MagicCommentValue {
 }
 
 #[derive(Debug)]
-pub struct RspackCommentMap(FxHashMap<RspackComment, MagicCommentValue>);
+pub struct RspackCommentMap(FxHashMap<RspackComment, MagicCommentItem>);
 
 impl RspackCommentMap {
   fn new() -> Self {
     Self(Default::default())
   }
 
-  fn insert(&mut self, key: RspackComment, value: MagicCommentValue) {
+  fn insert(&mut self, key: RspackComment, value: MagicCommentItem) {
     self.0.insert(key, value);
   }
 
+  fn push_conflict_warning(
+    source: &str,
+    ignored_comment_name: &str,
+    preferred_comment_name: &str,
+    item: &MagicCommentItem,
+    warning_diagnostics: &mut Vec<Diagnostic>,
+  ) {
+    let mut error: Error = create_traceable_error(
+      "Magic comments conflict".into(),
+      format!(
+        "`{ignored_comment_name}` is ignored because `{preferred_comment_name}` is also specified. Prefer `{preferred_comment_name}`."
+      ),
+      source.to_owned(),
+      item.span,
+    );
+    error.severity = Severity::Warning;
+    error.hide_stack = Some(true);
+    warning_diagnostics.push(error.into())
+  }
+
+  fn insert_with_conflict_warning(
+    &mut self,
+    source: &str,
+    comment_name: MagicCommentName,
+    rspack_comment: RspackComment,
+    item: MagicCommentItem,
+    warning_diagnostics: &mut Vec<Diagnostic>,
+  ) {
+    if let Some(existing) = self.0.get_mut(&rspack_comment) {
+      match (existing.prefix, item.prefix) {
+        (MagicCommentPrefix::Rspack, MagicCommentPrefix::Webpack) => {
+          Self::push_conflict_warning(
+            source,
+            comment_name.prefixed_name(MagicCommentPrefix::Webpack),
+            comment_name.prefixed_name(MagicCommentPrefix::Rspack),
+            &item,
+            warning_diagnostics,
+          );
+        }
+        (MagicCommentPrefix::Webpack, MagicCommentPrefix::Rspack) => {
+          Self::push_conflict_warning(
+            source,
+            comment_name.prefixed_name(MagicCommentPrefix::Webpack),
+            comment_name.prefixed_name(MagicCommentPrefix::Rspack),
+            existing,
+            warning_diagnostics,
+          );
+          *existing = item;
+        }
+        _ => {
+          Self::push_conflict_warning(
+            source,
+            comment_name.prefixed_name(item.prefix),
+            comment_name.prefixed_name(existing.prefix),
+            &item,
+            warning_diagnostics,
+          );
+        }
+      }
+    } else {
+      self.insert(rspack_comment, item);
+    }
+  }
+
   pub fn get_ignore_value(&self) -> Option<&MagicCommentValue> {
-    self.0.get(&RspackComment::Ignore)
+    self.0.get(&RspackComment::Ignore).map(|item| &item.value)
   }
 
   pub fn get_mode(&self) -> Option<&String> {
-    match self.0.get(&RspackComment::Mode) {
+    match self.0.get(&RspackComment::Mode).map(|item| &item.value) {
       Some(MagicCommentValue::String(value)) => Some(value),
       _ => None,
     }
   }
 
   pub fn get_chunk_name(&self) -> Option<&String> {
-    match self.0.get(&RspackComment::ChunkName) {
+    match self
+      .0
+      .get(&RspackComment::ChunkName)
+      .map(|item| &item.value)
+    {
       Some(MagicCommentValue::String(value)) => Some(value),
       _ => None,
     }
   }
 
   pub fn get_prefetch(&self) -> Option<Cow<'_, str>> {
-    match self.0.get(&RspackComment::Prefetch) {
+    match self.0.get(&RspackComment::Prefetch).map(|item| &item.value) {
       Some(MagicCommentValue::Bool(true)) => Some(Cow::Borrowed("true")),
       Some(MagicCommentValue::Number(value)) => Some(Cow::Borrowed(value.as_str())),
       _ => None,
@@ -78,7 +146,7 @@ impl RspackCommentMap {
   }
 
   pub fn get_preload(&self) -> Option<Cow<'_, str>> {
-    match self.0.get(&RspackComment::Preload) {
+    match self.0.get(&RspackComment::Preload).map(|item| &item.value) {
       Some(MagicCommentValue::Bool(true)) => Some(Cow::Borrowed("true")),
       Some(MagicCommentValue::Number(value)) => Some(Cow::Borrowed(value.as_str())),
       _ => None,
@@ -86,14 +154,18 @@ impl RspackCommentMap {
   }
 
   pub fn get_ignore(&self) -> Option<bool> {
-    match self.0.get(&RspackComment::Ignore) {
+    match self.0.get(&RspackComment::Ignore).map(|item| &item.value) {
       Some(MagicCommentValue::Bool(value)) => Some(*value),
       _ => None,
     }
   }
 
   pub fn get_fetch_priority(&self) -> Option<&String> {
-    match self.0.get(&RspackComment::FetchPriority) {
+    match self
+      .0
+      .get(&RspackComment::FetchPriority)
+      .map(|item| &item.value)
+    {
       Some(MagicCommentValue::String(value)) => Some(value),
       _ => None,
     }
@@ -103,7 +175,7 @@ impl RspackCommentMap {
     self
       .0
       .get(&RspackComment::IncludeRegexp)
-      .and_then(|value| match value {
+      .and_then(|item| match &item.value {
         MagicCommentValue::RegExp { source, flags } => {
           Some(RspackRegex::with_flags(source, flags).unwrap_or_else(|_| {
             // test when capture
@@ -118,7 +190,7 @@ impl RspackCommentMap {
     self
       .0
       .get(&RspackComment::ExcludeRegexp)
-      .and_then(|value| match value {
+      .and_then(|item| match &item.value {
         MagicCommentValue::RegExp { source, flags } => {
           Some(RspackRegex::with_flags(source, flags).unwrap_or_else(|_| {
             // test when capture
@@ -130,7 +202,7 @@ impl RspackCommentMap {
   }
 
   pub fn get_exports(&self) -> Option<Vec<String>> {
-    match self.0.get(&RspackComment::Exports) {
+    match self.0.get(&RspackComment::Exports).map(|item| &item.value) {
       Some(MagicCommentValue::String(value)) => Some(vec![value.clone()]),
       Some(MagicCommentValue::Array(value)) => Some(value.clone()),
       _ => None,
@@ -138,21 +210,21 @@ impl RspackCommentMap {
   }
 
   pub fn get_defer(&self) -> Option<bool> {
-    match self.0.get(&RspackComment::Defer) {
+    match self.0.get(&RspackComment::Defer).map(|item| &item.value) {
       Some(MagicCommentValue::Bool(value)) => Some(*value),
       _ => None,
     }
   }
 
   pub fn get_source(&self) -> Option<bool> {
-    match self.0.get(&RspackComment::Source) {
+    match self.0.get(&RspackComment::Source).map(|item| &item.value) {
       Some(MagicCommentValue::Bool(value)) => Some(*value),
       _ => None,
     }
   }
 }
 
-fn add_magic_comment_warning(
+fn push_magic_comment_parse_warning(
   source: &str,
   comment_name: &str,
   comment_type: &str,
@@ -382,7 +454,7 @@ fn expr_to_exports(expr: &Expr) -> Option<MagicCommentValue> {
   Some(MagicCommentValue::Array(exports))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum MagicCommentName {
   ChunkName,
   Prefetch,
@@ -397,21 +469,241 @@ enum MagicCommentName {
   Exports,
 }
 
-fn magic_comment_name(name: &str) -> Option<MagicCommentName> {
+impl MagicCommentName {
+  fn prefixed_name(self, prefix: MagicCommentPrefix) -> &'static str {
+    match (self, prefix) {
+      (Self::ChunkName, MagicCommentPrefix::Rspack) => "rspackChunkName",
+      (Self::ChunkName, MagicCommentPrefix::Webpack) => "webpackChunkName",
+      (Self::Prefetch, MagicCommentPrefix::Rspack) => "rspackPrefetch",
+      (Self::Prefetch, MagicCommentPrefix::Webpack) => "webpackPrefetch",
+      (Self::Preload, MagicCommentPrefix::Rspack) => "rspackPreload",
+      (Self::Preload, MagicCommentPrefix::Webpack) => "webpackPreload",
+      (Self::Ignore, MagicCommentPrefix::Rspack) => "rspackIgnore",
+      (Self::Ignore, MagicCommentPrefix::Webpack) => "webpackIgnore",
+      (Self::Mode, MagicCommentPrefix::Rspack) => "rspackMode",
+      (Self::Mode, MagicCommentPrefix::Webpack) => "webpackMode",
+      (Self::Defer, MagicCommentPrefix::Rspack) => "rspackDefer",
+      (Self::Defer, MagicCommentPrefix::Webpack) => "webpackDefer",
+      (Self::Source, MagicCommentPrefix::Rspack) => "rspackSource",
+      (Self::Source, MagicCommentPrefix::Webpack) => "webpackSource",
+      (Self::FetchPriority, MagicCommentPrefix::Rspack) => "rspackFetchPriority",
+      (Self::FetchPriority, MagicCommentPrefix::Webpack) => "webpackFetchPriority",
+      (Self::Include, MagicCommentPrefix::Rspack) => "rspackInclude",
+      (Self::Include, MagicCommentPrefix::Webpack) => "webpackInclude",
+      (Self::Exclude, MagicCommentPrefix::Rspack) => "rspackExclude",
+      (Self::Exclude, MagicCommentPrefix::Webpack) => "webpackExclude",
+      (Self::Exports, MagicCommentPrefix::Rspack) => "rspackExports",
+      (Self::Exports, MagicCommentPrefix::Webpack) => "webpackExports",
+    }
+  }
+
+  fn rspack_comment(self) -> RspackComment {
+    match self {
+      Self::ChunkName => RspackComment::ChunkName,
+      Self::Prefetch => RspackComment::Prefetch,
+      Self::Preload => RspackComment::Preload,
+      Self::Ignore => RspackComment::Ignore,
+      Self::Mode => RspackComment::Mode,
+      Self::Defer => RspackComment::Defer,
+      Self::Source => RspackComment::Source,
+      Self::FetchPriority => RspackComment::FetchPriority,
+      Self::Include => RspackComment::IncludeRegexp,
+      Self::Exclude => RspackComment::ExcludeRegexp,
+      Self::Exports => RspackComment::Exports,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MagicCommentPrefix {
+  Rspack,
+  Webpack,
+}
+
+#[derive(Debug)]
+struct MagicCommentItem {
+  prefix: MagicCommentPrefix,
+  value: MagicCommentValue,
+  span: DependencyRange,
+}
+
+fn parse_magic_comment_name(name: &str) -> Option<(MagicCommentName, MagicCommentPrefix)> {
   match name {
-    "webpackChunkName" | "rspackChunkName" => Some(MagicCommentName::ChunkName),
-    "webpackPrefetch" | "rspackPrefetch" => Some(MagicCommentName::Prefetch),
-    "webpackPreload" | "rspackPreload" => Some(MagicCommentName::Preload),
-    "webpackIgnore" | "rspackIgnore" => Some(MagicCommentName::Ignore),
-    "webpackMode" | "rspackMode" => Some(MagicCommentName::Mode),
-    "webpackDefer" | "rspackDefer" => Some(MagicCommentName::Defer),
-    "webpackSource" | "rspackSource" => Some(MagicCommentName::Source),
-    "webpackFetchPriority" | "rspackFetchPriority" => Some(MagicCommentName::FetchPriority),
-    "webpackInclude" | "rspackInclude" => Some(MagicCommentName::Include),
-    "webpackExclude" | "rspackExclude" => Some(MagicCommentName::Exclude),
-    "webpackExports" | "rspackExports" => Some(MagicCommentName::Exports),
+    "rspackChunkName" => Some((MagicCommentName::ChunkName, MagicCommentPrefix::Rspack)),
+    "webpackChunkName" => Some((MagicCommentName::ChunkName, MagicCommentPrefix::Webpack)),
+    "rspackPrefetch" => Some((MagicCommentName::Prefetch, MagicCommentPrefix::Rspack)),
+    "webpackPrefetch" => Some((MagicCommentName::Prefetch, MagicCommentPrefix::Webpack)),
+    "rspackPreload" => Some((MagicCommentName::Preload, MagicCommentPrefix::Rspack)),
+    "webpackPreload" => Some((MagicCommentName::Preload, MagicCommentPrefix::Webpack)),
+    "rspackIgnore" => Some((MagicCommentName::Ignore, MagicCommentPrefix::Rspack)),
+    "webpackIgnore" => Some((MagicCommentName::Ignore, MagicCommentPrefix::Webpack)),
+    "rspackMode" => Some((MagicCommentName::Mode, MagicCommentPrefix::Rspack)),
+    "webpackMode" => Some((MagicCommentName::Mode, MagicCommentPrefix::Webpack)),
+    "rspackDefer" => Some((MagicCommentName::Defer, MagicCommentPrefix::Rspack)),
+    "webpackDefer" => Some((MagicCommentName::Defer, MagicCommentPrefix::Webpack)),
+    "rspackSource" => Some((MagicCommentName::Source, MagicCommentPrefix::Rspack)),
+    "webpackSource" => Some((MagicCommentName::Source, MagicCommentPrefix::Webpack)),
+    "rspackFetchPriority" => Some((MagicCommentName::FetchPriority, MagicCommentPrefix::Rspack)),
+    "webpackFetchPriority" => Some((MagicCommentName::FetchPriority, MagicCommentPrefix::Webpack)),
+    "rspackInclude" => Some((MagicCommentName::Include, MagicCommentPrefix::Rspack)),
+    "webpackInclude" => Some((MagicCommentName::Include, MagicCommentPrefix::Webpack)),
+    "rspackExclude" => Some((MagicCommentName::Exclude, MagicCommentPrefix::Rspack)),
+    "webpackExclude" => Some((MagicCommentName::Exclude, MagicCommentPrefix::Webpack)),
+    "rspackExports" => Some((MagicCommentName::Exports, MagicCommentPrefix::Rspack)),
+    "webpackExports" => Some((MagicCommentName::Exports, MagicCommentPrefix::Webpack)),
     _ => None,
   }
+}
+
+fn magic_comment_name(name: &str) -> Option<MagicCommentName> {
+  parse_magic_comment_name(name).map(|(name, _)| name)
+}
+
+fn parse_magic_comment_item(
+  source: &str,
+  comment_text: &str,
+  comment_span: Span,
+  error_span: Span,
+  comment_name: MagicCommentName,
+  prefix: MagicCommentPrefix,
+  value: &Expr,
+  warning_diagnostics: &mut Vec<Diagnostic>,
+) -> Option<(RspackComment, MagicCommentItem)> {
+  let item_name = comment_name.prefixed_name(prefix);
+  let received = raw_value(comment_text, value).unwrap_or_default();
+  let item_span = value_span_to_error_span(comment_span, value.span()).unwrap_or(error_span.into());
+  let mut push_parse_warning = |comment_type| {
+    push_magic_comment_parse_warning(
+      source,
+      item_name,
+      comment_type,
+      received,
+      warning_diagnostics,
+      item_span,
+    );
+  };
+
+  let value = match comment_name {
+    MagicCommentName::ChunkName => {
+      if let Some(value) = expr_to_str(value) {
+        MagicCommentValue::String(value.into_owned())
+      } else {
+        push_parse_warning("a string");
+        return None;
+      }
+    }
+    MagicCommentName::Prefetch => {
+      if let Some(value) = expr_to_order_str(comment_text, value) {
+        if value == "true" {
+          MagicCommentValue::Bool(true)
+        } else {
+          MagicCommentValue::Number(value.to_string())
+        }
+      } else {
+        push_parse_warning("true or a number");
+        return None;
+      }
+    }
+    MagicCommentName::Preload => {
+      if let Some(value) = expr_to_order_str(comment_text, value) {
+        if value == "true" {
+          MagicCommentValue::Bool(true)
+        } else {
+          MagicCommentValue::Number(value.to_string())
+        }
+      } else {
+        push_parse_warning("true or a number");
+        return None;
+      }
+    }
+    MagicCommentName::Ignore => {
+      if let Some(value) = expr_to_bool(value) {
+        MagicCommentValue::Bool(value)
+      } else {
+        let value =
+          expr_to_magic_comment_value(comment_text, value).unwrap_or(MagicCommentValue::Unknown);
+        push_parse_warning("a boolean");
+        value
+      }
+    }
+    MagicCommentName::Mode => {
+      if let Some(value) = expr_to_str(value) {
+        MagicCommentValue::String(value.into_owned())
+      } else {
+        push_parse_warning("a string");
+        return None;
+      }
+    }
+    MagicCommentName::Defer => {
+      if let Some(value) = expr_to_bool(value) {
+        MagicCommentValue::Bool(value)
+      } else {
+        push_parse_warning("a boolean");
+        return None;
+      }
+    }
+    MagicCommentName::Source => {
+      if let Some(value) = expr_to_bool(value) {
+        MagicCommentValue::Bool(value)
+      } else {
+        push_parse_warning("a boolean");
+        return None;
+      }
+    }
+    MagicCommentName::FetchPriority => {
+      if let Some(priority) = expr_to_str(value)
+        && matches!(priority.as_ref(), "low" | "high" | "auto")
+      {
+        MagicCommentValue::String(priority.into_owned())
+      } else {
+        push_parse_warning(r#""low", "high" or "auto""#);
+        return None;
+      }
+    }
+    MagicCommentName::Include => {
+      if let Some((regexp, flags)) = expr_to_regexp(value)
+        && RspackRegex::with_flags(regexp, flags).is_ok()
+      {
+        MagicCommentValue::RegExp {
+          source: regexp.to_string(),
+          flags: flags.to_string(),
+        }
+      } else {
+        push_parse_warning(r#"a regular expression"#);
+        return None;
+      }
+    }
+    MagicCommentName::Exclude => {
+      if let Some((regexp, flags)) = expr_to_regexp(value)
+        && RspackRegex::with_flags(regexp, flags).is_ok()
+      {
+        MagicCommentValue::RegExp {
+          source: regexp.to_string(),
+          flags: flags.to_string(),
+        }
+      } else {
+        push_parse_warning(r#"a regular expression"#);
+        return None;
+      }
+    }
+    MagicCommentName::Exports => {
+      if let Some(exports) = expr_to_exports(value) {
+        exports
+      } else {
+        push_parse_warning(r#"a string or an array of strings"#);
+        return None;
+      }
+    }
+  };
+
+  Some((
+    comment_name.rspack_comment(),
+    MagicCommentItem {
+      prefix,
+      value,
+      span: item_span,
+    },
+  ))
 }
 
 fn analyze_comments(
@@ -445,222 +737,39 @@ fn analyze_comments(
       let Prop::KeyValue(prop) = &**prop else {
         continue;
       };
-      if let Some(item_name) = prop_name_to_str(&prop.key) {
-        let value = &prop.value;
-        let received = raw_value(&comment.text, value).unwrap_or_default();
-        let error_span =
-          || value_span_to_error_span(comment.span, value.span()).unwrap_or(error_span.into());
-        match magic_comment_name(item_name.as_ref()) {
-          Some(MagicCommentName::ChunkName) => {
-            if let Some(value) = expr_to_str(value) {
-              result.insert(
-                RspackComment::ChunkName,
-                MagicCommentValue::String(value.into_owned()),
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "a string",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Prefetch) => {
-            if let Some(value) = expr_to_order_str(&comment.text, value) {
-              result.insert(
-                RspackComment::Prefetch,
-                if value == "true" {
-                  MagicCommentValue::Bool(true)
-                } else {
-                  MagicCommentValue::Number(value.to_string())
-                },
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "true or a number",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Preload) => {
-            if let Some(value) = expr_to_order_str(&comment.text, value) {
-              result.insert(
-                RspackComment::Preload,
-                if value == "true" {
-                  MagicCommentValue::Bool(true)
-                } else {
-                  MagicCommentValue::Number(value.to_string())
-                },
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "true or a number",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Ignore) => {
-            if let Some(value) = expr_to_bool(value) {
-              result.insert(RspackComment::Ignore, MagicCommentValue::Bool(value));
-              continue;
-            }
-            result.insert(
-              RspackComment::Ignore,
-              expr_to_magic_comment_value(&comment.text, value)
-                .unwrap_or(MagicCommentValue::Unknown),
-            );
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "a boolean",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Mode) => {
-            if let Some(value) = expr_to_str(value) {
-              result.insert(
-                RspackComment::Mode,
-                MagicCommentValue::String(value.into_owned()),
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "a string",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Defer) => {
-            if let Some(value) = expr_to_bool(value) {
-              result.insert(RspackComment::Defer, MagicCommentValue::Bool(value));
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "a boolean",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Source) => {
-            if let Some(value) = expr_to_bool(value) {
-              result.insert(RspackComment::Source, MagicCommentValue::Bool(value));
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              "a boolean",
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::FetchPriority) => {
-            if let Some(priority) = expr_to_str(value)
-              && matches!(priority.as_ref(), "low" | "high" | "auto")
-            {
-              result.insert(
-                RspackComment::FetchPriority,
-                MagicCommentValue::String(priority.into_owned()),
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              r#""low", "high" or "auto""#,
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Include) => {
-            if let Some((regexp, flags)) = expr_to_regexp(value)
-              && RspackRegex::with_flags(regexp, flags).is_ok()
-            {
-              result.insert(
-                RspackComment::IncludeRegexp,
-                MagicCommentValue::RegExp {
-                  source: regexp.to_string(),
-                  flags: flags.to_string(),
-                },
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              r#"a regular expression"#,
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Exclude) => {
-            if let Some((regexp, flags)) = expr_to_regexp(value)
-              && RspackRegex::with_flags(regexp, flags).is_ok()
-            {
-              result.insert(
-                RspackComment::ExcludeRegexp,
-                MagicCommentValue::RegExp {
-                  source: regexp.to_string(),
-                  flags: flags.to_string(),
-                },
-              );
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              r#"a regular expression"#,
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          Some(MagicCommentName::Exports) => {
-            if let Some(exports) = expr_to_exports(value) {
-              result.insert(RspackComment::Exports, exports);
-              continue;
-            }
-            add_magic_comment_warning(
-              source,
-              item_name.as_ref(),
-              r#"a string or an array of strings"#,
-              received,
-              warning_diagnostics,
-              error_span(),
-            );
-          }
-          _ => {}
-        }
-      }
+      let Some(item_name) = prop_name_to_str(&prop.key) else {
+        continue;
+      };
+      let Some((comment_name, prefix)) = parse_magic_comment_name(item_name.as_ref()) else {
+        continue;
+      };
+      let value = &prop.value;
+      let Some((rspack_comment, item)) = parse_magic_comment_item(
+        source,
+        &comment.text,
+        comment.span,
+        error_span,
+        comment_name,
+        prefix,
+        value,
+        warning_diagnostics,
+      ) else {
+        continue;
+      };
+      result.insert_with_conflict_warning(
+        source,
+        comment_name,
+        rspack_comment,
+        item,
+        warning_diagnostics,
+      );
     }
   }
 }
 
 #[cfg(test)]
 mod tests_extract_magic_comment_object {
-  use swc_core::{atoms::Atom, common::DUMMY_SP};
+  use swc_experimental_ecma_ast::DUMMY_SP;
 
   use super::*;
 
@@ -687,12 +796,14 @@ mod tests_extract_magic_comment_object {
   fn extract(raw: &str) -> (RspackCommentMap, Vec<Diagnostic>) {
     let mut result = RspackCommentMap::new();
     let mut warning_diagnostics = Vec::new();
+    let allocator = Allocator::new();
     analyze_comments(
+      &allocator,
       "",
       &[Comment {
         kind: CommentKind::Block,
         span: DUMMY_SP,
-        text: Atom::from(raw),
+        text: swc_experimental_allocator::atom::Atom::new_in(raw, &allocator),
       }],
       DUMMY_SP,
       &mut warning_diagnostics,

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -53,6 +53,27 @@ impl fmt::Display for RspackComment {
   }
 }
 
+impl TryFrom<&str> for RspackComment {
+  type Error = ();
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    match value {
+      "ChunkName" => Ok(Self::ChunkName),
+      "Prefetch" => Ok(Self::Prefetch),
+      "Preload" => Ok(Self::Preload),
+      "Ignore" => Ok(Self::Ignore),
+      "FetchPriority" => Ok(Self::FetchPriority),
+      "Include" => Ok(Self::IncludeRegexp),
+      "Exclude" => Ok(Self::ExcludeRegexp),
+      "Mode" => Ok(Self::Mode),
+      "Exports" => Ok(Self::Exports),
+      "Defer" => Ok(Self::Defer),
+      "Source" => Ok(Self::Source),
+      _ => Err(()),
+    }
+  }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum MagicCommentValue {
   Bool(bool),
@@ -500,31 +521,15 @@ struct MagicCommentItem {
 }
 
 fn parse_magic_comment_name(name: &str) -> Option<(RspackComment, MagicCommentPrefix)> {
-  match name {
-    "rspackChunkName" => Some((RspackComment::ChunkName, MagicCommentPrefix::Rspack)),
-    "webpackChunkName" => Some((RspackComment::ChunkName, MagicCommentPrefix::Webpack)),
-    "rspackPrefetch" => Some((RspackComment::Prefetch, MagicCommentPrefix::Rspack)),
-    "webpackPrefetch" => Some((RspackComment::Prefetch, MagicCommentPrefix::Webpack)),
-    "rspackPreload" => Some((RspackComment::Preload, MagicCommentPrefix::Rspack)),
-    "webpackPreload" => Some((RspackComment::Preload, MagicCommentPrefix::Webpack)),
-    "rspackIgnore" => Some((RspackComment::Ignore, MagicCommentPrefix::Rspack)),
-    "webpackIgnore" => Some((RspackComment::Ignore, MagicCommentPrefix::Webpack)),
-    "rspackMode" => Some((RspackComment::Mode, MagicCommentPrefix::Rspack)),
-    "webpackMode" => Some((RspackComment::Mode, MagicCommentPrefix::Webpack)),
-    "rspackDefer" => Some((RspackComment::Defer, MagicCommentPrefix::Rspack)),
-    "webpackDefer" => Some((RspackComment::Defer, MagicCommentPrefix::Webpack)),
-    "rspackSource" => Some((RspackComment::Source, MagicCommentPrefix::Rspack)),
-    "webpackSource" => Some((RspackComment::Source, MagicCommentPrefix::Webpack)),
-    "rspackFetchPriority" => Some((RspackComment::FetchPriority, MagicCommentPrefix::Rspack)),
-    "webpackFetchPriority" => Some((RspackComment::FetchPriority, MagicCommentPrefix::Webpack)),
-    "rspackInclude" => Some((RspackComment::IncludeRegexp, MagicCommentPrefix::Rspack)),
-    "webpackInclude" => Some((RspackComment::IncludeRegexp, MagicCommentPrefix::Webpack)),
-    "rspackExclude" => Some((RspackComment::ExcludeRegexp, MagicCommentPrefix::Rspack)),
-    "webpackExclude" => Some((RspackComment::ExcludeRegexp, MagicCommentPrefix::Webpack)),
-    "rspackExports" => Some((RspackComment::Exports, MagicCommentPrefix::Rspack)),
-    "webpackExports" => Some((RspackComment::Exports, MagicCommentPrefix::Webpack)),
-    _ => None,
-  }
+  let (name, prefix) = if let Some(name) = name.strip_prefix("rspack") {
+    (name, MagicCommentPrefix::Rspack)
+  } else if let Some(name) = name.strip_prefix("webpack") {
+    (name, MagicCommentPrefix::Webpack)
+  } else {
+    return None;
+  };
+
+  Some((RspackComment::try_from(name).ok()?, prefix))
 }
 
 fn analyze_comments(

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -523,150 +523,6 @@ fn parse_magic_comment_name(name: &str) -> Option<(RspackComment, MagicCommentPr
   }
 }
 
-fn parse_magic_comment_item(
-  source: &str,
-  comment_text: &str,
-  comment_span: Span,
-  error_span: Span,
-  rspack_comment: RspackComment,
-  prefix: MagicCommentPrefix,
-  value: &Expr,
-  warning_diagnostics: &mut Vec<Diagnostic>,
-) -> Option<MagicCommentItem> {
-  let item_name = rspack_comment.prefixed_name(prefix);
-  let received = raw_value(comment_text, value).unwrap_or_default();
-  let item_span = value_span_to_error_span(comment_span, value.span()).unwrap_or(error_span.into());
-  let mut push_parse_warning = |comment_type| {
-    push_magic_comment_parse_warning(
-      source,
-      item_name,
-      comment_type,
-      received,
-      warning_diagnostics,
-      item_span,
-    );
-  };
-
-  let value = match rspack_comment {
-    RspackComment::ChunkName => {
-      if let Some(value) = expr_to_str(value) {
-        MagicCommentValue::String(value.into_owned())
-      } else {
-        push_parse_warning("a string");
-        return None;
-      }
-    }
-    RspackComment::Prefetch => {
-      if let Some(value) = expr_to_order_str(comment_text, value) {
-        if value == "true" {
-          MagicCommentValue::Bool(true)
-        } else {
-          MagicCommentValue::Number(value.to_string())
-        }
-      } else {
-        push_parse_warning("true or a number");
-        return None;
-      }
-    }
-    RspackComment::Preload => {
-      if let Some(value) = expr_to_order_str(comment_text, value) {
-        if value == "true" {
-          MagicCommentValue::Bool(true)
-        } else {
-          MagicCommentValue::Number(value.to_string())
-        }
-      } else {
-        push_parse_warning("true or a number");
-        return None;
-      }
-    }
-    RspackComment::Ignore => {
-      if let Some(value) = expr_to_bool(value) {
-        MagicCommentValue::Bool(value)
-      } else {
-        let value =
-          expr_to_magic_comment_value(comment_text, value).unwrap_or(MagicCommentValue::Unknown);
-        push_parse_warning("a boolean");
-        value
-      }
-    }
-    RspackComment::Mode => {
-      if let Some(value) = expr_to_str(value) {
-        MagicCommentValue::String(value.into_owned())
-      } else {
-        push_parse_warning("a string");
-        return None;
-      }
-    }
-    RspackComment::Defer => {
-      if let Some(value) = expr_to_bool(value) {
-        MagicCommentValue::Bool(value)
-      } else {
-        push_parse_warning("a boolean");
-        return None;
-      }
-    }
-    RspackComment::Source => {
-      if let Some(value) = expr_to_bool(value) {
-        MagicCommentValue::Bool(value)
-      } else {
-        push_parse_warning("a boolean");
-        return None;
-      }
-    }
-    RspackComment::FetchPriority => {
-      if let Some(priority) = expr_to_str(value)
-        && matches!(priority.as_ref(), "low" | "high" | "auto")
-      {
-        MagicCommentValue::String(priority.into_owned())
-      } else {
-        push_parse_warning(r#""low", "high" or "auto""#);
-        return None;
-      }
-    }
-    RspackComment::IncludeRegexp => {
-      if let Some((regexp, flags)) = expr_to_regexp(value)
-        && RspackRegex::with_flags(regexp, flags).is_ok()
-      {
-        MagicCommentValue::RegExp {
-          source: regexp.to_string(),
-          flags: flags.to_string(),
-        }
-      } else {
-        push_parse_warning(r#"a regular expression"#);
-        return None;
-      }
-    }
-    RspackComment::ExcludeRegexp => {
-      if let Some((regexp, flags)) = expr_to_regexp(value)
-        && RspackRegex::with_flags(regexp, flags).is_ok()
-      {
-        MagicCommentValue::RegExp {
-          source: regexp.to_string(),
-          flags: flags.to_string(),
-        }
-      } else {
-        push_parse_warning(r#"a regular expression"#);
-        return None;
-      }
-    }
-    RspackComment::Exports => {
-      if let Some(exports) = expr_to_exports(value) {
-        exports
-      } else {
-        push_parse_warning(r#"a string or an array of strings"#);
-        return None;
-      }
-    }
-  };
-
-  Some(MagicCommentItem {
-    prefix,
-    value,
-    span: item_span,
-  })
-}
-
 fn analyze_comments(
   allocator: &Allocator,
   source: &str,
@@ -705,17 +561,137 @@ fn analyze_comments(
         continue;
       };
       let value = &prop.value;
-      let Some(item) = parse_magic_comment_item(
-        source,
-        &comment.text,
-        comment.span,
-        error_span,
-        rspack_comment,
+      let item_name = rspack_comment.prefixed_name(prefix);
+      let received = raw_value(&comment.text, value).unwrap_or_default();
+      let item_span =
+        value_span_to_error_span(comment.span, value.span()).unwrap_or(error_span.into());
+      let mut push_parse_warning = |comment_type| {
+        push_magic_comment_parse_warning(
+          source,
+          item_name,
+          comment_type,
+          received,
+          warning_diagnostics,
+          item_span,
+        );
+      };
+
+      let value = match rspack_comment {
+        RspackComment::ChunkName => {
+          if let Some(value) = expr_to_str(value) {
+            MagicCommentValue::String(value.into_owned())
+          } else {
+            push_parse_warning("a string");
+            continue;
+          }
+        }
+        RspackComment::Prefetch => {
+          if let Some(value) = expr_to_order_str(&comment.text, value) {
+            if value == "true" {
+              MagicCommentValue::Bool(true)
+            } else {
+              MagicCommentValue::Number(value.to_string())
+            }
+          } else {
+            push_parse_warning("true or a number");
+            continue;
+          }
+        }
+        RspackComment::Preload => {
+          if let Some(value) = expr_to_order_str(&comment.text, value) {
+            if value == "true" {
+              MagicCommentValue::Bool(true)
+            } else {
+              MagicCommentValue::Number(value.to_string())
+            }
+          } else {
+            push_parse_warning("true or a number");
+            continue;
+          }
+        }
+        RspackComment::Ignore => {
+          if let Some(value) = expr_to_bool(value) {
+            MagicCommentValue::Bool(value)
+          } else {
+            let value = expr_to_magic_comment_value(&comment.text, value)
+              .unwrap_or(MagicCommentValue::Unknown);
+            push_parse_warning("a boolean");
+            value
+          }
+        }
+        RspackComment::Mode => {
+          if let Some(value) = expr_to_str(value) {
+            MagicCommentValue::String(value.into_owned())
+          } else {
+            push_parse_warning("a string");
+            continue;
+          }
+        }
+        RspackComment::Defer => {
+          if let Some(value) = expr_to_bool(value) {
+            MagicCommentValue::Bool(value)
+          } else {
+            push_parse_warning("a boolean");
+            continue;
+          }
+        }
+        RspackComment::Source => {
+          if let Some(value) = expr_to_bool(value) {
+            MagicCommentValue::Bool(value)
+          } else {
+            push_parse_warning("a boolean");
+            continue;
+          }
+        }
+        RspackComment::FetchPriority => {
+          if let Some(priority) = expr_to_str(value)
+            && matches!(priority.as_ref(), "low" | "high" | "auto")
+          {
+            MagicCommentValue::String(priority.into_owned())
+          } else {
+            push_parse_warning(r#""low", "high" or "auto""#);
+            continue;
+          }
+        }
+        RspackComment::IncludeRegexp => {
+          if let Some((regexp, flags)) = expr_to_regexp(value)
+            && RspackRegex::with_flags(regexp, flags).is_ok()
+          {
+            MagicCommentValue::RegExp {
+              source: regexp.to_string(),
+              flags: flags.to_string(),
+            }
+          } else {
+            push_parse_warning(r#"a regular expression"#);
+            continue;
+          }
+        }
+        RspackComment::ExcludeRegexp => {
+          if let Some((regexp, flags)) = expr_to_regexp(value)
+            && RspackRegex::with_flags(regexp, flags).is_ok()
+          {
+            MagicCommentValue::RegExp {
+              source: regexp.to_string(),
+              flags: flags.to_string(),
+            }
+          } else {
+            push_parse_warning(r#"a regular expression"#);
+            continue;
+          }
+        }
+        RspackComment::Exports => {
+          if let Some(exports) = expr_to_exports(value) {
+            exports
+          } else {
+            push_parse_warning(r#"a string or an array of strings"#);
+            continue;
+          }
+        }
+      };
+      let item = MagicCommentItem {
         prefix,
         value,
-        warning_diagnostics,
-      ) else {
-        continue;
+        span: item_span,
       };
       result.insert_with_conflict_warning(source, rspack_comment, item, warning_diagnostics);
     }

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -1053,6 +1053,112 @@ mod tests_extract_magic_comment_object {
   }
 
   #[test]
+  fn test_rspack_prefixed_magic_comments_override_webpack_prefixed_comments() {
+    let (comments, warnings) = extract(
+      r#"
+        webpackChunkName: "webpack-chunk",
+        rspackChunkName: "rspack-chunk",
+        rspackMode: "eager",
+        webpackMode: "lazy",
+        webpackPrefetch: 1,
+        rspackPrefetch: true,
+        rspackPreload: 2,
+        webpackPreload: true,
+        webpackIgnore: false,
+        rspackIgnore: true,
+        webpackDefer: false,
+        rspackDefer: true,
+        rspackSource: true,
+        webpackSource: false,
+        rspackFetchPriority: "high",
+        webpackFetchPriority: "low",
+        webpackInclude: /\.jsx$/,
+        rspackInclude: /\.js$/,
+        rspackExclude: /\.test\.js$/,
+        webpackExclude: /\.spec\.js$/,
+        webpackExports: ["webpack"],
+        rspackExports: ["rspack"]
+      "#,
+    );
+
+    assert_eq!(comments.get_chunk_name(), Some(&"rspack-chunk".to_string()));
+    assert_eq!(comments.get_mode(), Some(&"eager".to_string()));
+    assert_eq!(comments.get_prefetch().as_deref(), Some("true"));
+    assert_eq!(comments.get_preload().as_deref(), Some("2"));
+    assert_eq!(comments.get_ignore(), Some(true));
+    assert_eq!(comments.get_defer(), Some(true));
+    assert_eq!(comments.get_source(), Some(true));
+    assert_eq!(comments.get_fetch_priority(), Some(&"high".to_string()));
+    assert_eq!(comments.get_include().unwrap().source(), r#"\.js$"#);
+    assert_eq!(comments.get_exclude().unwrap().source(), r#"\.test\.js$"#);
+    assert_eq!(comments.get_exports(), Some(vec!["rspack".into()]));
+    assert_eq!(warnings.len(), 11);
+    for webpack_name in [
+      "webpackChunkName",
+      "webpackMode",
+      "webpackPrefetch",
+      "webpackPreload",
+      "webpackIgnore",
+      "webpackDefer",
+      "webpackSource",
+      "webpackFetchPriority",
+      "webpackInclude",
+      "webpackExclude",
+      "webpackExports",
+    ] {
+      assert!(
+        warnings.iter().any(|warning| warning
+          .message
+          .contains(&format!("`{webpack_name}` is ignored"))),
+        "missing conflict warning for {webpack_name}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_rspack_prefixed_magic_comments_override_webpack_prefixed_comments_in_any_order() {
+    let (comments, warnings) = extract(
+      r#"
+        rspackChunkName: "rspack-chunk",
+        webpackChunkName: "webpack-chunk"
+      "#,
+    );
+
+    assert_eq!(comments.get_chunk_name(), Some(&"rspack-chunk".to_string()));
+    assert_eq!(warnings.len(), 1);
+    assert!(
+      warnings[0]
+        .message
+        .contains("`webpackChunkName` is ignored")
+    );
+  }
+
+  #[test]
+  fn test_repeated_magic_comments_with_same_prefix_keep_first_value() {
+    let (comments, warnings) = extract(
+      r#"
+        webpackChunkName: "first-webpack-chunk",
+        webpackChunkName: "second-webpack-chunk",
+        rspackMode: "eager",
+        rspackMode: "lazy"
+      "#,
+    );
+
+    assert_eq!(
+      comments.get_chunk_name(),
+      Some(&"first-webpack-chunk".to_string())
+    );
+    assert_eq!(comments.get_mode(), Some(&"eager".to_string()));
+    assert_eq!(warnings.len(), 2);
+    assert!(
+      warnings[0]
+        .message
+        .contains("`webpackChunkName` is ignored")
+    );
+    assert!(warnings[1].message.contains("`rspackMode` is ignored"));
+  }
+
+  #[test]
   fn test_extract_magic_comment_object() {
     test_extract_string();
     test_extract_number();

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 use rspack_core::DependencyRange;
 use rspack_error::{Diagnostic, Error, Severity};
@@ -30,31 +30,26 @@ pub enum RspackComment {
 }
 
 impl RspackComment {
-  fn prefixed_name(self, prefix: MagicCommentPrefix) -> &'static str {
-    match (self, prefix) {
-      (Self::ChunkName, MagicCommentPrefix::Rspack) => "rspackChunkName",
-      (Self::ChunkName, MagicCommentPrefix::Webpack) => "webpackChunkName",
-      (Self::Prefetch, MagicCommentPrefix::Rspack) => "rspackPrefetch",
-      (Self::Prefetch, MagicCommentPrefix::Webpack) => "webpackPrefetch",
-      (Self::Preload, MagicCommentPrefix::Rspack) => "rspackPreload",
-      (Self::Preload, MagicCommentPrefix::Webpack) => "webpackPreload",
-      (Self::Ignore, MagicCommentPrefix::Rspack) => "rspackIgnore",
-      (Self::Ignore, MagicCommentPrefix::Webpack) => "webpackIgnore",
-      (Self::Mode, MagicCommentPrefix::Rspack) => "rspackMode",
-      (Self::Mode, MagicCommentPrefix::Webpack) => "webpackMode",
-      (Self::Defer, MagicCommentPrefix::Rspack) => "rspackDefer",
-      (Self::Defer, MagicCommentPrefix::Webpack) => "webpackDefer",
-      (Self::Source, MagicCommentPrefix::Rspack) => "rspackSource",
-      (Self::Source, MagicCommentPrefix::Webpack) => "webpackSource",
-      (Self::FetchPriority, MagicCommentPrefix::Rspack) => "rspackFetchPriority",
-      (Self::FetchPriority, MagicCommentPrefix::Webpack) => "webpackFetchPriority",
-      (Self::IncludeRegexp, MagicCommentPrefix::Rspack) => "rspackInclude",
-      (Self::IncludeRegexp, MagicCommentPrefix::Webpack) => "webpackInclude",
-      (Self::ExcludeRegexp, MagicCommentPrefix::Rspack) => "rspackExclude",
-      (Self::ExcludeRegexp, MagicCommentPrefix::Webpack) => "webpackExclude",
-      (Self::Exports, MagicCommentPrefix::Rspack) => "rspackExports",
-      (Self::Exports, MagicCommentPrefix::Webpack) => "webpackExports",
-    }
+  fn prefixed_name(self, prefix: MagicCommentPrefix) -> String {
+    format!("{prefix}{self}")
+  }
+}
+
+impl fmt::Display for RspackComment {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(match self {
+      Self::ChunkName => "ChunkName",
+      Self::Prefetch => "Prefetch",
+      Self::Preload => "Preload",
+      Self::Ignore => "Ignore",
+      Self::FetchPriority => "FetchPriority",
+      Self::IncludeRegexp => "Include",
+      Self::ExcludeRegexp => "Exclude",
+      Self::Mode => "Mode",
+      Self::Exports => "Exports",
+      Self::Defer => "Defer",
+      Self::Source => "Source",
+    })
   }
 }
 
@@ -82,8 +77,8 @@ impl RspackCommentMap {
 
   fn push_conflict_warning(
     source: &str,
-    ignored_comment_name: &str,
-    preferred_comment_name: &str,
+    ignored_comment_name: impl fmt::Display,
+    preferred_comment_name: impl fmt::Display,
     item: &MagicCommentItem,
     warning_diagnostics: &mut Vec<Diagnostic>,
   ) {
@@ -254,7 +249,7 @@ impl RspackCommentMap {
 
 fn push_magic_comment_parse_warning(
   source: &str,
-  comment_name: &str,
+  comment_name: impl fmt::Display,
   comment_type: &str,
   received: &str,
   warning_diagnostics: &mut Vec<Diagnostic>,
@@ -488,6 +483,15 @@ enum MagicCommentPrefix {
   Webpack,
 }
 
+impl fmt::Display for MagicCommentPrefix {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(match self {
+      Self::Rspack => "rspack",
+      Self::Webpack => "webpack",
+    })
+  }
+}
+
 #[derive(Debug)]
 struct MagicCommentItem {
   prefix: MagicCommentPrefix,
@@ -565,7 +569,7 @@ fn analyze_comments(
       let received = raw_value(&comment.text, value).unwrap_or_default();
       let item_span =
         value_span_to_error_span(comment.span, value.span()).unwrap_or(error_span.into());
-      let mut push_parse_warning = |comment_type| {
+      let push_parse_warning = |comment_type| {
         push_magic_comment_parse_warning(
           source,
           item_name,

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -29,6 +29,35 @@ pub enum RspackComment {
   Source,
 }
 
+impl RspackComment {
+  fn prefixed_name(self, prefix: MagicCommentPrefix) -> &'static str {
+    match (self, prefix) {
+      (Self::ChunkName, MagicCommentPrefix::Rspack) => "rspackChunkName",
+      (Self::ChunkName, MagicCommentPrefix::Webpack) => "webpackChunkName",
+      (Self::Prefetch, MagicCommentPrefix::Rspack) => "rspackPrefetch",
+      (Self::Prefetch, MagicCommentPrefix::Webpack) => "webpackPrefetch",
+      (Self::Preload, MagicCommentPrefix::Rspack) => "rspackPreload",
+      (Self::Preload, MagicCommentPrefix::Webpack) => "webpackPreload",
+      (Self::Ignore, MagicCommentPrefix::Rspack) => "rspackIgnore",
+      (Self::Ignore, MagicCommentPrefix::Webpack) => "webpackIgnore",
+      (Self::Mode, MagicCommentPrefix::Rspack) => "rspackMode",
+      (Self::Mode, MagicCommentPrefix::Webpack) => "webpackMode",
+      (Self::Defer, MagicCommentPrefix::Rspack) => "rspackDefer",
+      (Self::Defer, MagicCommentPrefix::Webpack) => "webpackDefer",
+      (Self::Source, MagicCommentPrefix::Rspack) => "rspackSource",
+      (Self::Source, MagicCommentPrefix::Webpack) => "webpackSource",
+      (Self::FetchPriority, MagicCommentPrefix::Rspack) => "rspackFetchPriority",
+      (Self::FetchPriority, MagicCommentPrefix::Webpack) => "webpackFetchPriority",
+      (Self::IncludeRegexp, MagicCommentPrefix::Rspack) => "rspackInclude",
+      (Self::IncludeRegexp, MagicCommentPrefix::Webpack) => "webpackInclude",
+      (Self::ExcludeRegexp, MagicCommentPrefix::Rspack) => "rspackExclude",
+      (Self::ExcludeRegexp, MagicCommentPrefix::Webpack) => "webpackExclude",
+      (Self::Exports, MagicCommentPrefix::Rspack) => "rspackExports",
+      (Self::Exports, MagicCommentPrefix::Webpack) => "webpackExports",
+    }
+  }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum MagicCommentValue {
   Bool(bool),
@@ -74,7 +103,6 @@ impl RspackCommentMap {
   fn insert_with_conflict_warning(
     &mut self,
     source: &str,
-    comment_name: MagicCommentName,
     rspack_comment: RspackComment,
     item: MagicCommentItem,
     warning_diagnostics: &mut Vec<Diagnostic>,
@@ -84,8 +112,8 @@ impl RspackCommentMap {
         (MagicCommentPrefix::Rspack, MagicCommentPrefix::Webpack) => {
           Self::push_conflict_warning(
             source,
-            comment_name.prefixed_name(MagicCommentPrefix::Webpack),
-            comment_name.prefixed_name(MagicCommentPrefix::Rspack),
+            rspack_comment.prefixed_name(MagicCommentPrefix::Webpack),
+            rspack_comment.prefixed_name(MagicCommentPrefix::Rspack),
             &item,
             warning_diagnostics,
           );
@@ -93,8 +121,8 @@ impl RspackCommentMap {
         (MagicCommentPrefix::Webpack, MagicCommentPrefix::Rspack) => {
           Self::push_conflict_warning(
             source,
-            comment_name.prefixed_name(MagicCommentPrefix::Webpack),
-            comment_name.prefixed_name(MagicCommentPrefix::Rspack),
+            rspack_comment.prefixed_name(MagicCommentPrefix::Webpack),
+            rspack_comment.prefixed_name(MagicCommentPrefix::Rspack),
             existing,
             warning_diagnostics,
           );
@@ -103,8 +131,8 @@ impl RspackCommentMap {
         _ => {
           Self::push_conflict_warning(
             source,
-            comment_name.prefixed_name(item.prefix),
-            comment_name.prefixed_name(existing.prefix),
+            rspack_comment.prefixed_name(item.prefix),
+            rspack_comment.prefixed_name(existing.prefix),
             &item,
             warning_diagnostics,
           );
@@ -454,66 +482,6 @@ fn expr_to_exports(expr: &Expr) -> Option<MagicCommentValue> {
   Some(MagicCommentValue::Array(exports))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum MagicCommentName {
-  ChunkName,
-  Prefetch,
-  Preload,
-  Ignore,
-  Mode,
-  Defer,
-  Source,
-  FetchPriority,
-  Include,
-  Exclude,
-  Exports,
-}
-
-impl MagicCommentName {
-  fn prefixed_name(self, prefix: MagicCommentPrefix) -> &'static str {
-    match (self, prefix) {
-      (Self::ChunkName, MagicCommentPrefix::Rspack) => "rspackChunkName",
-      (Self::ChunkName, MagicCommentPrefix::Webpack) => "webpackChunkName",
-      (Self::Prefetch, MagicCommentPrefix::Rspack) => "rspackPrefetch",
-      (Self::Prefetch, MagicCommentPrefix::Webpack) => "webpackPrefetch",
-      (Self::Preload, MagicCommentPrefix::Rspack) => "rspackPreload",
-      (Self::Preload, MagicCommentPrefix::Webpack) => "webpackPreload",
-      (Self::Ignore, MagicCommentPrefix::Rspack) => "rspackIgnore",
-      (Self::Ignore, MagicCommentPrefix::Webpack) => "webpackIgnore",
-      (Self::Mode, MagicCommentPrefix::Rspack) => "rspackMode",
-      (Self::Mode, MagicCommentPrefix::Webpack) => "webpackMode",
-      (Self::Defer, MagicCommentPrefix::Rspack) => "rspackDefer",
-      (Self::Defer, MagicCommentPrefix::Webpack) => "webpackDefer",
-      (Self::Source, MagicCommentPrefix::Rspack) => "rspackSource",
-      (Self::Source, MagicCommentPrefix::Webpack) => "webpackSource",
-      (Self::FetchPriority, MagicCommentPrefix::Rspack) => "rspackFetchPriority",
-      (Self::FetchPriority, MagicCommentPrefix::Webpack) => "webpackFetchPriority",
-      (Self::Include, MagicCommentPrefix::Rspack) => "rspackInclude",
-      (Self::Include, MagicCommentPrefix::Webpack) => "webpackInclude",
-      (Self::Exclude, MagicCommentPrefix::Rspack) => "rspackExclude",
-      (Self::Exclude, MagicCommentPrefix::Webpack) => "webpackExclude",
-      (Self::Exports, MagicCommentPrefix::Rspack) => "rspackExports",
-      (Self::Exports, MagicCommentPrefix::Webpack) => "webpackExports",
-    }
-  }
-
-  fn rspack_comment(self) -> RspackComment {
-    match self {
-      Self::ChunkName => RspackComment::ChunkName,
-      Self::Prefetch => RspackComment::Prefetch,
-      Self::Preload => RspackComment::Preload,
-      Self::Ignore => RspackComment::Ignore,
-      Self::Mode => RspackComment::Mode,
-      Self::Defer => RspackComment::Defer,
-      Self::Source => RspackComment::Source,
-      Self::FetchPriority => RspackComment::FetchPriority,
-      Self::Include => RspackComment::IncludeRegexp,
-      Self::Exclude => RspackComment::ExcludeRegexp,
-      Self::Exports => RspackComment::Exports,
-    }
-  }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MagicCommentPrefix {
   Rspack,
@@ -527,36 +495,32 @@ struct MagicCommentItem {
   span: DependencyRange,
 }
 
-fn parse_magic_comment_name(name: &str) -> Option<(MagicCommentName, MagicCommentPrefix)> {
+fn parse_magic_comment_name(name: &str) -> Option<(RspackComment, MagicCommentPrefix)> {
   match name {
-    "rspackChunkName" => Some((MagicCommentName::ChunkName, MagicCommentPrefix::Rspack)),
-    "webpackChunkName" => Some((MagicCommentName::ChunkName, MagicCommentPrefix::Webpack)),
-    "rspackPrefetch" => Some((MagicCommentName::Prefetch, MagicCommentPrefix::Rspack)),
-    "webpackPrefetch" => Some((MagicCommentName::Prefetch, MagicCommentPrefix::Webpack)),
-    "rspackPreload" => Some((MagicCommentName::Preload, MagicCommentPrefix::Rspack)),
-    "webpackPreload" => Some((MagicCommentName::Preload, MagicCommentPrefix::Webpack)),
-    "rspackIgnore" => Some((MagicCommentName::Ignore, MagicCommentPrefix::Rspack)),
-    "webpackIgnore" => Some((MagicCommentName::Ignore, MagicCommentPrefix::Webpack)),
-    "rspackMode" => Some((MagicCommentName::Mode, MagicCommentPrefix::Rspack)),
-    "webpackMode" => Some((MagicCommentName::Mode, MagicCommentPrefix::Webpack)),
-    "rspackDefer" => Some((MagicCommentName::Defer, MagicCommentPrefix::Rspack)),
-    "webpackDefer" => Some((MagicCommentName::Defer, MagicCommentPrefix::Webpack)),
-    "rspackSource" => Some((MagicCommentName::Source, MagicCommentPrefix::Rspack)),
-    "webpackSource" => Some((MagicCommentName::Source, MagicCommentPrefix::Webpack)),
-    "rspackFetchPriority" => Some((MagicCommentName::FetchPriority, MagicCommentPrefix::Rspack)),
-    "webpackFetchPriority" => Some((MagicCommentName::FetchPriority, MagicCommentPrefix::Webpack)),
-    "rspackInclude" => Some((MagicCommentName::Include, MagicCommentPrefix::Rspack)),
-    "webpackInclude" => Some((MagicCommentName::Include, MagicCommentPrefix::Webpack)),
-    "rspackExclude" => Some((MagicCommentName::Exclude, MagicCommentPrefix::Rspack)),
-    "webpackExclude" => Some((MagicCommentName::Exclude, MagicCommentPrefix::Webpack)),
-    "rspackExports" => Some((MagicCommentName::Exports, MagicCommentPrefix::Rspack)),
-    "webpackExports" => Some((MagicCommentName::Exports, MagicCommentPrefix::Webpack)),
+    "rspackChunkName" => Some((RspackComment::ChunkName, MagicCommentPrefix::Rspack)),
+    "webpackChunkName" => Some((RspackComment::ChunkName, MagicCommentPrefix::Webpack)),
+    "rspackPrefetch" => Some((RspackComment::Prefetch, MagicCommentPrefix::Rspack)),
+    "webpackPrefetch" => Some((RspackComment::Prefetch, MagicCommentPrefix::Webpack)),
+    "rspackPreload" => Some((RspackComment::Preload, MagicCommentPrefix::Rspack)),
+    "webpackPreload" => Some((RspackComment::Preload, MagicCommentPrefix::Webpack)),
+    "rspackIgnore" => Some((RspackComment::Ignore, MagicCommentPrefix::Rspack)),
+    "webpackIgnore" => Some((RspackComment::Ignore, MagicCommentPrefix::Webpack)),
+    "rspackMode" => Some((RspackComment::Mode, MagicCommentPrefix::Rspack)),
+    "webpackMode" => Some((RspackComment::Mode, MagicCommentPrefix::Webpack)),
+    "rspackDefer" => Some((RspackComment::Defer, MagicCommentPrefix::Rspack)),
+    "webpackDefer" => Some((RspackComment::Defer, MagicCommentPrefix::Webpack)),
+    "rspackSource" => Some((RspackComment::Source, MagicCommentPrefix::Rspack)),
+    "webpackSource" => Some((RspackComment::Source, MagicCommentPrefix::Webpack)),
+    "rspackFetchPriority" => Some((RspackComment::FetchPriority, MagicCommentPrefix::Rspack)),
+    "webpackFetchPriority" => Some((RspackComment::FetchPriority, MagicCommentPrefix::Webpack)),
+    "rspackInclude" => Some((RspackComment::IncludeRegexp, MagicCommentPrefix::Rspack)),
+    "webpackInclude" => Some((RspackComment::IncludeRegexp, MagicCommentPrefix::Webpack)),
+    "rspackExclude" => Some((RspackComment::ExcludeRegexp, MagicCommentPrefix::Rspack)),
+    "webpackExclude" => Some((RspackComment::ExcludeRegexp, MagicCommentPrefix::Webpack)),
+    "rspackExports" => Some((RspackComment::Exports, MagicCommentPrefix::Rspack)),
+    "webpackExports" => Some((RspackComment::Exports, MagicCommentPrefix::Webpack)),
     _ => None,
   }
-}
-
-fn magic_comment_name(name: &str) -> Option<MagicCommentName> {
-  parse_magic_comment_name(name).map(|(name, _)| name)
 }
 
 fn parse_magic_comment_item(
@@ -564,12 +528,12 @@ fn parse_magic_comment_item(
   comment_text: &str,
   comment_span: Span,
   error_span: Span,
-  comment_name: MagicCommentName,
+  rspack_comment: RspackComment,
   prefix: MagicCommentPrefix,
   value: &Expr,
   warning_diagnostics: &mut Vec<Diagnostic>,
-) -> Option<(RspackComment, MagicCommentItem)> {
-  let item_name = comment_name.prefixed_name(prefix);
+) -> Option<MagicCommentItem> {
+  let item_name = rspack_comment.prefixed_name(prefix);
   let received = raw_value(comment_text, value).unwrap_or_default();
   let item_span = value_span_to_error_span(comment_span, value.span()).unwrap_or(error_span.into());
   let mut push_parse_warning = |comment_type| {
@@ -583,8 +547,8 @@ fn parse_magic_comment_item(
     );
   };
 
-  let value = match comment_name {
-    MagicCommentName::ChunkName => {
+  let value = match rspack_comment {
+    RspackComment::ChunkName => {
       if let Some(value) = expr_to_str(value) {
         MagicCommentValue::String(value.into_owned())
       } else {
@@ -592,7 +556,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Prefetch => {
+    RspackComment::Prefetch => {
       if let Some(value) = expr_to_order_str(comment_text, value) {
         if value == "true" {
           MagicCommentValue::Bool(true)
@@ -604,7 +568,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Preload => {
+    RspackComment::Preload => {
       if let Some(value) = expr_to_order_str(comment_text, value) {
         if value == "true" {
           MagicCommentValue::Bool(true)
@@ -616,7 +580,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Ignore => {
+    RspackComment::Ignore => {
       if let Some(value) = expr_to_bool(value) {
         MagicCommentValue::Bool(value)
       } else {
@@ -626,7 +590,7 @@ fn parse_magic_comment_item(
         value
       }
     }
-    MagicCommentName::Mode => {
+    RspackComment::Mode => {
       if let Some(value) = expr_to_str(value) {
         MagicCommentValue::String(value.into_owned())
       } else {
@@ -634,7 +598,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Defer => {
+    RspackComment::Defer => {
       if let Some(value) = expr_to_bool(value) {
         MagicCommentValue::Bool(value)
       } else {
@@ -642,7 +606,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Source => {
+    RspackComment::Source => {
       if let Some(value) = expr_to_bool(value) {
         MagicCommentValue::Bool(value)
       } else {
@@ -650,7 +614,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::FetchPriority => {
+    RspackComment::FetchPriority => {
       if let Some(priority) = expr_to_str(value)
         && matches!(priority.as_ref(), "low" | "high" | "auto")
       {
@@ -660,7 +624,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Include => {
+    RspackComment::IncludeRegexp => {
       if let Some((regexp, flags)) = expr_to_regexp(value)
         && RspackRegex::with_flags(regexp, flags).is_ok()
       {
@@ -673,7 +637,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Exclude => {
+    RspackComment::ExcludeRegexp => {
       if let Some((regexp, flags)) = expr_to_regexp(value)
         && RspackRegex::with_flags(regexp, flags).is_ok()
       {
@@ -686,7 +650,7 @@ fn parse_magic_comment_item(
         return None;
       }
     }
-    MagicCommentName::Exports => {
+    RspackComment::Exports => {
       if let Some(exports) = expr_to_exports(value) {
         exports
       } else {
@@ -696,14 +660,11 @@ fn parse_magic_comment_item(
     }
   };
 
-  Some((
-    comment_name.rspack_comment(),
-    MagicCommentItem {
-      prefix,
-      value,
-      span: item_span,
-    },
-  ))
+  Some(MagicCommentItem {
+    prefix,
+    value,
+    span: item_span,
+  })
 }
 
 fn analyze_comments(
@@ -740,29 +701,23 @@ fn analyze_comments(
       let Some(item_name) = prop_name_to_str(&prop.key) else {
         continue;
       };
-      let Some((comment_name, prefix)) = parse_magic_comment_name(item_name.as_ref()) else {
+      let Some((rspack_comment, prefix)) = parse_magic_comment_name(item_name.as_ref()) else {
         continue;
       };
       let value = &prop.value;
-      let Some((rspack_comment, item)) = parse_magic_comment_item(
+      let Some(item) = parse_magic_comment_item(
         source,
         &comment.text,
         comment.span,
         error_span,
-        comment_name,
+        rspack_comment,
         prefix,
         value,
         warning_diagnostics,
       ) else {
         continue;
       };
-      result.insert_with_conflict_warning(
-        source,
-        comment_name,
-        rspack_comment,
-        item,
-        warning_diagnostics,
-      );
+      result.insert_with_conflict_warning(source, rspack_comment, item, warning_diagnostics);
     }
   }
 }
@@ -975,48 +930,48 @@ mod tests_extract_magic_comment_object {
   #[test]
   fn test_rspack_magic_comment_name_aliases() {
     assert_eq!(
-      magic_comment_name("rspackChunkName"),
-      Some(MagicCommentName::ChunkName)
+      parse_magic_comment_name("rspackChunkName").map(|(comment, _)| comment),
+      Some(RspackComment::ChunkName)
     );
     assert_eq!(
-      magic_comment_name("rspackPrefetch"),
-      Some(MagicCommentName::Prefetch)
+      parse_magic_comment_name("rspackPrefetch").map(|(comment, _)| comment),
+      Some(RspackComment::Prefetch)
     );
     assert_eq!(
-      magic_comment_name("rspackPreload"),
-      Some(MagicCommentName::Preload)
+      parse_magic_comment_name("rspackPreload").map(|(comment, _)| comment),
+      Some(RspackComment::Preload)
     );
     assert_eq!(
-      magic_comment_name("rspackIgnore"),
-      Some(MagicCommentName::Ignore)
+      parse_magic_comment_name("rspackIgnore").map(|(comment, _)| comment),
+      Some(RspackComment::Ignore)
     );
     assert_eq!(
-      magic_comment_name("rspackMode"),
-      Some(MagicCommentName::Mode)
+      parse_magic_comment_name("rspackMode").map(|(comment, _)| comment),
+      Some(RspackComment::Mode)
     );
     assert_eq!(
-      magic_comment_name("rspackDefer"),
-      Some(MagicCommentName::Defer)
+      parse_magic_comment_name("rspackDefer").map(|(comment, _)| comment),
+      Some(RspackComment::Defer)
     );
     assert_eq!(
-      magic_comment_name("rspackSource"),
-      Some(MagicCommentName::Source)
+      parse_magic_comment_name("rspackSource").map(|(comment, _)| comment),
+      Some(RspackComment::Source)
     );
     assert_eq!(
-      magic_comment_name("rspackFetchPriority"),
-      Some(MagicCommentName::FetchPriority)
+      parse_magic_comment_name("rspackFetchPriority").map(|(comment, _)| comment),
+      Some(RspackComment::FetchPriority)
     );
     assert_eq!(
-      magic_comment_name("rspackInclude"),
-      Some(MagicCommentName::Include)
+      parse_magic_comment_name("rspackInclude").map(|(comment, _)| comment),
+      Some(RspackComment::IncludeRegexp)
     );
     assert_eq!(
-      magic_comment_name("rspackExclude"),
-      Some(MagicCommentName::Exclude)
+      parse_magic_comment_name("rspackExclude").map(|(comment, _)| comment),
+      Some(RspackComment::ExcludeRegexp)
     );
     assert_eq!(
-      magic_comment_name("rspackExports"),
-      Some(MagicCommentName::Exports)
+      parse_magic_comment_name("rspackExports").map(|(comment, _)| comment),
+      Some(RspackComment::Exports)
     );
   }
 

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -382,6 +382,38 @@ fn expr_to_exports(expr: &Expr) -> Option<MagicCommentValue> {
   Some(MagicCommentValue::Array(exports))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MagicCommentName {
+  ChunkName,
+  Prefetch,
+  Preload,
+  Ignore,
+  Mode,
+  Defer,
+  Source,
+  FetchPriority,
+  Include,
+  Exclude,
+  Exports,
+}
+
+fn magic_comment_name(name: &str) -> Option<MagicCommentName> {
+  match name {
+    "webpackChunkName" | "rspackChunkName" => Some(MagicCommentName::ChunkName),
+    "webpackPrefetch" | "rspackPrefetch" => Some(MagicCommentName::Prefetch),
+    "webpackPreload" | "rspackPreload" => Some(MagicCommentName::Preload),
+    "webpackIgnore" | "rspackIgnore" => Some(MagicCommentName::Ignore),
+    "webpackMode" | "rspackMode" => Some(MagicCommentName::Mode),
+    "webpackDefer" | "rspackDefer" => Some(MagicCommentName::Defer),
+    "webpackSource" | "rspackSource" => Some(MagicCommentName::Source),
+    "webpackFetchPriority" | "rspackFetchPriority" => Some(MagicCommentName::FetchPriority),
+    "webpackInclude" | "rspackInclude" => Some(MagicCommentName::Include),
+    "webpackExclude" | "rspackExclude" => Some(MagicCommentName::Exclude),
+    "webpackExports" | "rspackExports" => Some(MagicCommentName::Exports),
+    _ => None,
+  }
+}
+
 fn analyze_comments(
   allocator: &Allocator,
   source: &str,
@@ -418,8 +450,8 @@ fn analyze_comments(
         let received = raw_value(&comment.text, value).unwrap_or_default();
         let error_span =
           || value_span_to_error_span(comment.span, value.span()).unwrap_or(error_span.into());
-        match item_name.as_ref() {
-          "webpackChunkName" => {
+        match magic_comment_name(item_name.as_ref()) {
+          Some(MagicCommentName::ChunkName) => {
             if let Some(value) = expr_to_str(value) {
               result.insert(
                 RspackComment::ChunkName,
@@ -436,7 +468,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackPrefetch" => {
+          Some(MagicCommentName::Prefetch) => {
             if let Some(value) = expr_to_order_str(&comment.text, value) {
               result.insert(
                 RspackComment::Prefetch,
@@ -457,7 +489,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackPreload" => {
+          Some(MagicCommentName::Preload) => {
             if let Some(value) = expr_to_order_str(&comment.text, value) {
               result.insert(
                 RspackComment::Preload,
@@ -478,7 +510,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackIgnore" => {
+          Some(MagicCommentName::Ignore) => {
             if let Some(value) = expr_to_bool(value) {
               result.insert(RspackComment::Ignore, MagicCommentValue::Bool(value));
               continue;
@@ -497,7 +529,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackMode" => {
+          Some(MagicCommentName::Mode) => {
             if let Some(value) = expr_to_str(value) {
               result.insert(
                 RspackComment::Mode,
@@ -514,7 +546,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackDefer" => {
+          Some(MagicCommentName::Defer) => {
             if let Some(value) = expr_to_bool(value) {
               result.insert(RspackComment::Defer, MagicCommentValue::Bool(value));
               continue;
@@ -528,7 +560,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackSource" => {
+          Some(MagicCommentName::Source) => {
             if let Some(value) = expr_to_bool(value) {
               result.insert(RspackComment::Source, MagicCommentValue::Bool(value));
               continue;
@@ -542,7 +574,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackFetchPriority" => {
+          Some(MagicCommentName::FetchPriority) => {
             if let Some(priority) = expr_to_str(value)
               && matches!(priority.as_ref(), "low" | "high" | "auto")
             {
@@ -561,7 +593,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackInclude" => {
+          Some(MagicCommentName::Include) => {
             if let Some((regexp, flags)) = expr_to_regexp(value)
               && RspackRegex::with_flags(regexp, flags).is_ok()
             {
@@ -583,7 +615,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackExclude" => {
+          Some(MagicCommentName::Exclude) => {
             if let Some((regexp, flags)) = expr_to_regexp(value)
               && RspackRegex::with_flags(regexp, flags).is_ok()
             {
@@ -605,7 +637,7 @@ fn analyze_comments(
               error_span(),
             );
           }
-          "webpackExports" => {
+          Some(MagicCommentName::Exports) => {
             if let Some(exports) = expr_to_exports(value) {
               result.insert(RspackComment::Exports, exports);
               continue;
@@ -628,6 +660,8 @@ fn analyze_comments(
 
 #[cfg(test)]
 mod tests_extract_magic_comment_object {
+  use swc_core::{atoms::Atom, common::DUMMY_SP};
+
   use super::*;
 
   fn with_value<R>(raw: &str, name: &str, f: impl FnOnce(&Expr<'_>) -> Option<R>) -> Option<R> {
@@ -648,6 +682,23 @@ mod tests_extract_magic_comment_object {
       }
     }
     None
+  }
+
+  fn extract(raw: &str) -> (RspackCommentMap, Vec<Diagnostic>) {
+    let mut result = RspackCommentMap::new();
+    let mut warning_diagnostics = Vec::new();
+    analyze_comments(
+      "",
+      &[Comment {
+        kind: CommentKind::Block,
+        span: DUMMY_SP,
+        text: Atom::from(raw),
+      }],
+      DUMMY_SP,
+      &mut warning_diagnostics,
+      &mut result,
+    );
+    (result, warning_diagnostics)
   }
 
   fn try_match_string(raw: &str) -> Option<(String, String)> {
@@ -808,6 +859,86 @@ mod tests_extract_magic_comment_object {
         String::new()
       ))
     );
+  }
+
+  #[test]
+  fn test_rspack_magic_comment_name_aliases() {
+    assert_eq!(
+      magic_comment_name("rspackChunkName"),
+      Some(MagicCommentName::ChunkName)
+    );
+    assert_eq!(
+      magic_comment_name("rspackPrefetch"),
+      Some(MagicCommentName::Prefetch)
+    );
+    assert_eq!(
+      magic_comment_name("rspackPreload"),
+      Some(MagicCommentName::Preload)
+    );
+    assert_eq!(
+      magic_comment_name("rspackIgnore"),
+      Some(MagicCommentName::Ignore)
+    );
+    assert_eq!(
+      magic_comment_name("rspackMode"),
+      Some(MagicCommentName::Mode)
+    );
+    assert_eq!(
+      magic_comment_name("rspackDefer"),
+      Some(MagicCommentName::Defer)
+    );
+    assert_eq!(
+      magic_comment_name("rspackSource"),
+      Some(MagicCommentName::Source)
+    );
+    assert_eq!(
+      magic_comment_name("rspackFetchPriority"),
+      Some(MagicCommentName::FetchPriority)
+    );
+    assert_eq!(
+      magic_comment_name("rspackInclude"),
+      Some(MagicCommentName::Include)
+    );
+    assert_eq!(
+      magic_comment_name("rspackExclude"),
+      Some(MagicCommentName::Exclude)
+    );
+    assert_eq!(
+      magic_comment_name("rspackExports"),
+      Some(MagicCommentName::Exports)
+    );
+  }
+
+  #[test]
+  fn test_extract_rspack_prefixed_magic_comments() {
+    let (comments, warnings) = extract(
+      r#"
+        rspackChunkName: "chunk",
+        rspackPrefetch: 1,
+        rspackPreload: true,
+        rspackIgnore: true,
+        rspackMode: "eager",
+        rspackDefer: true,
+        rspackSource: true,
+        rspackFetchPriority: "high",
+        rspackInclude: /\.js$/,
+        rspackExclude: /\.test\.js$/,
+        rspackExports: ["a", "b"]
+      "#,
+    );
+
+    assert!(warnings.is_empty());
+    assert_eq!(comments.get_chunk_name(), Some(&"chunk".to_string()));
+    assert_eq!(comments.get_prefetch().as_deref(), Some("1"));
+    assert_eq!(comments.get_preload().as_deref(), Some("true"));
+    assert_eq!(comments.get_ignore(), Some(true));
+    assert_eq!(comments.get_mode(), Some(&"eager".to_string()));
+    assert_eq!(comments.get_defer(), Some(true));
+    assert_eq!(comments.get_source(), Some(true));
+    assert_eq!(comments.get_fetch_priority(), Some(&"high".to_string()));
+    assert!(comments.get_include().is_some());
+    assert!(comments.get_exclude().is_some());
+    assert_eq!(comments.get_exports(), Some(vec!["a".into(), "b".into()]));
   }
 
   #[test]

--- a/tests/rspack-test/configCases/context-modules/context-options/index.js
+++ b/tests/rspack-test/configCases/context-modules/context-options/index.js
@@ -6,12 +6,24 @@ async function loadModuleWithExclude(name) {
 	return import(/* webpackExclude: /module-b\.js$/ */ "./dir/" + name);
 }
 
+async function loadModuleWithRspackExclude(name) {
+	return import(/* rspackExclude: /module-b\.js$/ */ "./dir/" + name);
+}
+
 async function loadModuleWithInclude(name) {
 	return import(/* webpackInclude: /module-b\.js$/ */ "./dir/" + name);
 }
 
+async function loadModuleWithRspackInclude(name) {
+	return import(/* rspackInclude: /module-b\.js$/ */ "./dir/" + name);
+}
+
 async function loadModuleWithMode(name) {
 	return import(/* webpackMode: "eager" */ "./dir/" + name);
+}
+
+async function loadModuleWithRspackMode(name) {
+	return import(/* rspackMode: "eager" */ "./dir/" + name);
 }
 
 it("should work when no options", async () => {
@@ -26,14 +38,32 @@ it("should work with exclude", async () => {
 	expect((await loadModuleWithExclude("module-c.js")).default).toBe("c");
 });
 
+it("should work with rspack exclude", async () => {
+	expect((await loadModuleWithRspackExclude("module-a.js")).default).toBe("a");
+	await expect(loadModuleWithRspackExclude("module-b.js")).rejects.toThrow("Cannot find module './module-b.js'");
+	expect((await loadModuleWithRspackExclude("module-c.js")).default).toBe("c");
+});
+
 it("should work with include", async () => {
 	await expect(loadModuleWithInclude("module-a.js")).rejects.toThrow("Cannot find module './module-a.js'");
 	expect((await loadModuleWithInclude("module-b.js")).default).toBe("b");
 	await expect(loadModuleWithInclude("module-c.js")).rejects.toThrow("Cannot find module './module-c.js'");
 });
 
+it("should work with rspack include", async () => {
+	await expect(loadModuleWithRspackInclude("module-a.js")).rejects.toThrow("Cannot find module './module-a.js'");
+	expect((await loadModuleWithRspackInclude("module-b.js")).default).toBe("b");
+	await expect(loadModuleWithRspackInclude("module-c.js")).rejects.toThrow("Cannot find module './module-c.js'");
+});
+
 it("should work with mode", async () => {
 	expect((await loadModuleWithMode("module-a.js")).default).toBe("a");
 	expect((await loadModuleWithMode("module-b.js")).default).toBe("b");
 	expect((await loadModuleWithMode("module-c.js")).default).toBe("c");
+});
+
+it("should work with rspack mode", async () => {
+	expect((await loadModuleWithRspackMode("module-a.js")).default).toBe("a");
+	expect((await loadModuleWithRspackMode("module-b.js")).default).toBe("b");
+	expect((await loadModuleWithRspackMode("module-c.js")).default).toBe("c");
 });

--- a/tests/rspack-test/configCases/parsing/import-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/import-ignore/index.js
@@ -5,4 +5,6 @@ it("should be able to ignore import()", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle1.js"), "utf-8");
 	expect(source).toMatch(`import(/* webpackIgnore: true */ "./other2.js")`);
 	expect(source).not.toMatch(`import(/* webpackIgnore: false */ "./other3.js")`);
+	expect(source).toMatch(`import(/* rspackIgnore: true */ "./other2.js")`);
+	expect(source).not.toMatch(`import(/* rspackIgnore: false */ "./other3.js")`);
 });

--- a/tests/rspack-test/configCases/parsing/import-ignore/other.js
+++ b/tests/rspack-test/configCases/parsing/import-ignore/other.js
@@ -1,2 +1,4 @@
 import(/* webpackIgnore: true */ "./other2.js");
 import(/* webpackIgnore: false */ "./other3.js");
+import(/* rspackIgnore: true */ "./other2.js");
+import(/* rspackIgnore: false */ "./other3.js");

--- a/tests/rspack-test/configCases/parsing/magic-comment-conflict/conflict.js
+++ b/tests/rspack-test/configCases/parsing/magic-comment-conflict/conflict.js
@@ -1,0 +1,1 @@
+export default "conflict";

--- a/tests/rspack-test/configCases/parsing/magic-comment-conflict/duplicate.js
+++ b/tests/rspack-test/configCases/parsing/magic-comment-conflict/duplicate.js
@@ -1,0 +1,1 @@
+export default "duplicate";

--- a/tests/rspack-test/configCases/parsing/magic-comment-conflict/index.js
+++ b/tests/rspack-test/configCases/parsing/magic-comment-conflict/index.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+
+it("should prefer rspack-prefixed magic comments over webpack-prefixed ones", async () => {
+	const { default: value } = await import(
+		/* webpackChunkName: "webpack-prefix-ignored", rspackChunkName: "rspack-prefix-wins" */ "./conflict"
+	);
+
+	expect(value).toBe("conflict");
+	const files = fs.readdirSync(__dirname);
+	expect(files).toContain("rspack-prefix-wins.js");
+	expect(files).not.toContain("webpack-prefix-ignored.js");
+});
+
+it("should keep the first magic comment when the same prefixed comment repeats", async () => {
+	const { default: value } = await import(
+		/* webpackChunkName: "first-duplicate-wins", webpackChunkName: "second-duplicate-ignored" */ "./duplicate"
+	);
+
+	expect(value).toBe("duplicate");
+	const files = fs.readdirSync(__dirname);
+	expect(files).toContain("first-duplicate-wins.js");
+	expect(files).not.toContain("second-duplicate-ignored.js");
+});

--- a/tests/rspack-test/configCases/parsing/magic-comment-conflict/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/magic-comment-conflict/rspack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  output: {
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    chunkIds: 'named',
+  },
+};

--- a/tests/rspack-test/configCases/parsing/magic-comment-conflict/warnings.js
+++ b/tests/rspack-test/configCases/parsing/magic-comment-conflict/warnings.js
@@ -1,0 +1,8 @@
+module.exports = [
+	[
+		/`webpackChunkName` is ignored because `rspackChunkName` is also specified/
+	],
+	[
+		/`webpackChunkName` is ignored because `webpackChunkName` is also specified/
+	]
+];

--- a/tests/rspack-test/configCases/parsing/require-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/require-ignore/index.js
@@ -5,4 +5,6 @@ it("should be able to ignore require()", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle1.js"), "utf-8");
 	expect(source).toMatch(`require(/* webpackIgnore: true */ "./other2.js")`);
 	expect(source).not.toMatch(`require(/* webpackIgnore: false */ "./other3.js")`);
+	expect(source).toMatch(`require(/* rspackIgnore: true */ "./other2.js")`);
+	expect(source).not.toMatch(`require(/* rspackIgnore: false */ "./other3.js")`);
 });

--- a/tests/rspack-test/configCases/parsing/require-ignore/other.js
+++ b/tests/rspack-test/configCases/parsing/require-ignore/other.js
@@ -1,2 +1,4 @@
 require(/* webpackIgnore: true */ "./other2.js");
 require(/* webpackIgnore: false */ "./other3.js");
+require(/* rspackIgnore: true */ "./other2.js");
+require(/* rspackIgnore: false */ "./other3.js");

--- a/tests/rspack-test/configCases/parsing/require-resolve-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-ignore/index.js
@@ -6,4 +6,7 @@ it("should be able to ignore require.resolve()", () => {
 	expect(source).toMatch(`require.resolve(/* webpackIgnore: true */ "./non-exists")`);
 	expect(source).toMatch(`createRequire(import.meta.url).resolve(/* webpackIgnore: true */ "./non-exists")`);
 	expect(source).toMatch(`require.resolve(/* webpackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`require.resolve(/* rspackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`createRequire(import.meta.url).resolve(/* rspackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`require.resolve(/* rspackIgnore: true */ "./non-exists")`);
 });

--- a/tests/rspack-test/configCases/parsing/require-resolve-ignore/other.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-ignore/other.js
@@ -4,5 +4,15 @@ const resolve = require.resolve(/* webpackIgnore: true */ "./non-exists");
 const createRequireResolve1 = createRequire(import.meta.url).resolve(/* webpackIgnore: true */ "./non-exists");
 const require = createRequire(import.meta.url);
 const createRequireResolve2 = require.resolve(/* webpackIgnore: true */ "./non-exists");
+const rspackResolve = require.resolve(/* rspackIgnore: true */ "./non-exists");
+const rspackCreateRequireResolve1 = createRequire(import.meta.url).resolve(/* rspackIgnore: true */ "./non-exists");
+const rspackCreateRequireResolve2 = require.resolve(/* rspackIgnore: true */ "./non-exists");
 
-export { resolve, createRequireResolve1, createRequireResolve2 }
+export {
+	resolve,
+	createRequireResolve1,
+	createRequireResolve2,
+	rspackResolve,
+	rspackCreateRequireResolve1,
+	rspackCreateRequireResolve2,
+}

--- a/tests/rspack-test/configCases/parsing/url-ignore/index.js
+++ b/tests/rspack-test/configCases/parsing/url-ignore/index.js
@@ -28,4 +28,9 @@ it('should ignore', function() {
   expect(url10.toString()).toBe(window.location.href);
   const url11 = new URL(/* webpackIgnore: true */ ...args);
   expect(url11.pathname.endsWith('file3.css')).toBe(true);
+  const url12 = new URL(/* rspackIgnore: true */ 'file12.css', import.meta.url);
+  expect(url12.pathname.endsWith('file12.css')).toBe(true);
+  expect(url12.pathname.includes('/public/')).toBe(false);
+  const url13 = new URL(/* rspackIgnore: false */ 'file2.css', import.meta.url);
+  expect(/\/public\/.+\.css/.test(url13.pathname)).toBe(true);
 });

--- a/tests/rspack-test/configCases/worker/worker-webpack-chunk-name/index.js
+++ b/tests/rspack-test/configCases/worker/worker-webpack-chunk-name/index.js
@@ -1,12 +1,16 @@
 import * as fs from "node:fs";
 import { Worker } from "worker_threads";
 
-it("worker webpackChunkName comments should works", async () => {
+it("worker webpackChunkName and rspackChunkName comments should works", async () => {
 	new Worker(new URL(/* webpackChunkName: "chunk-url" */ "./a", import.meta.url));
 	new Worker(/* webpackChunkName: "chunk-worker" */ new URL("./a", import.meta.url));
+	new Worker(new URL(/* rspackChunkName: "rspack-chunk-url" */ "./a", import.meta.url));
+	new Worker(/* rspackChunkName: "rspack-chunk-worker" */ new URL("./a", import.meta.url));
 	new Worker(new URL("./a", import.meta.url), { name: "chunk-arg2" });
 	const files = await fs.promises.readdir(__dirname);
 	expect(files).toContain("chunk-url.bundle0.js");
 	expect(files).toContain("chunk-worker.bundle0.js");
+	expect(files).toContain("rspack-chunk-url.bundle0.js");
+	expect(files).toContain("rspack-chunk-worker.bundle0.js");
 	expect(files).toContain("chunk-arg2.bundle0.js");
 });

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -109,6 +109,8 @@ import(`./locale/${language}.json`).then((module) => {
 
 Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. For a full list of these magic comments see the code below followed by an explanation of what these comments do.
 
+Rspack also supports `rspack`-prefixed aliases for these magic comments. For example, `rspackIgnore` is equivalent to `webpackIgnore`, and `rspackChunkName` is equivalent to `webpackChunkName`.
+
 ```js
 // Single target
 import(
@@ -149,6 +151,14 @@ import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
 });
 ```
 
+You can also use the equivalent `rspackIgnore` comment:
+
+```js
+import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
 `webpackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `webpackIgnore: true` comment:
 
 ```js
@@ -157,6 +167,9 @@ const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack will ignore this URL and preserve the original module identifier
 const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+
+// `rspackIgnore` is also supported
+const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -107,7 +107,7 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. In Rspack projects, prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
+Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. Starting from Rspack 2.0.7, Rspack projects should prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
 
 ```js
 // Single target

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -131,7 +131,7 @@ import(
 );
 ```
 
-##### webpackIgnore
+##### rspackIgnore / webpackIgnore \{#webpackignore}
 
 - **Type:** `boolean`
 
@@ -170,7 +170,7 @@ const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
-##### webpackMode
+##### rspackMode / webpackMode \{#webpackmode}
 
 - **Type:** `"eager" | "lazy" | "weak" | "lazy-once"`
 - **Default:** `'lazy'`
@@ -182,7 +182,7 @@ Different modes for resolving dynamic imports can be specified. The following op
 - `'eager'`: Generates no extra chunk. All modules are included in the current chunk and no additional network requests are made. A Promise is still returned but is already resolved. In contrast to a static import, the module isn't executed until the call to `import()` is made.
 - `'weak'`: Tries to load the module if the module function has already been loaded in some other way (e.g. another chunk imported it or a script containing the module was loaded). A Promise is still returned, but only successfully resolves if the chunks are already on the client. If the module is not available, the Promise is rejected. A network request will never be performed. This is useful for universal rendering when required chunks are always manually served in initial requests (embedded within the page), but not in cases where app navigation will trigger an import not initially served.
 
-##### webpackPrefetch
+##### rspackPrefetch / webpackPrefetch \{#webpackprefetch}
 
 - **Type:**
   - `number`: chunk prefetch priority
@@ -190,7 +190,7 @@ Different modes for resolving dynamic imports can be specified. The following op
 
 Tells the browser that the resource is probably needed for some navigation in the future, see [Prefetching/Preloading modules](/guide/optimization/code-splitting#prefetchingpreloading-modules) for more details.
 
-##### webpackPreload
+##### rspackPreload / webpackPreload \{#webpackpreload}
 
 - **Type:**
   - `number`: chunk preload priority
@@ -198,13 +198,13 @@ Tells the browser that the resource is probably needed for some navigation in th
 
 Tells the browser that the resource might be needed during the current navigation, , see [Prefetching/Preloading modules](/guide/optimization/code-splitting#prefetchingpreloading-modules) for more details.
 
-##### webpackChunkName
+##### rspackChunkName / webpackChunkName \{#webpackchunkname}
 
 - **Type:**: `string`
 
 A name for the new chunk.
 
-##### webpackFetchPriority
+##### rspackFetchPriority / webpackFetchPriority \{#webpackfetchpriority}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -212,7 +212,7 @@ A name for the new chunk.
 
 Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) for specific dynamic imports. It's also possible to set a global default value for all dynamic imports by using the `module.parser.javascript.dynamicImportFetchPriority` option.
 
-##### webpackInclude
+##### rspackInclude / webpackInclude \{#webpackinclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -220,7 +220,7 @@ Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImage
 
 A regular expression that will be matched against during import resolution. Only modules that match **will be bundled**.
 
-##### webpackExclude
+##### rspackExclude / webpackExclude \{#webpackexclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -229,10 +229,10 @@ A regular expression that will be matched against during import resolution. Only
 A regular expression that will be matched against during import resolution. Any module that matches **will not be bundled**.
 
 :::info
-Note that `webpackInclude` and `webpackExclude` options do not interfere with the prefix. eg: `./locale`.
+Note that `rspackInclude` and `rspackExclude` options do not interfere with the prefix. The equivalent `webpackInclude` and `webpackExclude` comments are also supported for compatibility. eg: `./locale`.
 :::
 
-##### webpackExports
+##### rspackExports / webpackExports \{#webpackexports}
 
 <ApiMeta addedVersion="1.0.0" />
 

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -107,7 +107,7 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. Starting from Rspack 2.0.7, Rspack projects should prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
+Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. **Since Rspack 2.0.7**, prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
 
 ```js
 // Single target

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -107,28 +107,26 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. For a full list of these magic comments see the code below followed by an explanation of what these comments do.
-
-Rspack also supports `rspack`-prefixed aliases for these magic comments. For example, `rspackIgnore` is equivalent to `webpackIgnore`, and `rspackChunkName` is equivalent to `webpackChunkName`.
+Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. In Rspack projects, prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
 
 ```js
 // Single target
 import(
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackExports: ["default", "named"] */
-  /* webpackFetchPriority: "high" */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackExports: ["default", "named"] */
+  /* rspackFetchPriority: "high" */
   'module'
 );
 
 // Multiple possible targets
 import(
-  /* webpackInclude: /\.json$/ */
-  /* webpackExclude: /\.noimport\.json$/ */
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackPrefetch: true */
-  /* webpackPreload: true */
+  /* rspackInclude: /\.json$/ */
+  /* rspackExclude: /\.noimport\.json$/ */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackPrefetch: true */
+  /* rspackPreload: true */
   `./locale/${language}`
 );
 ```
@@ -146,30 +144,30 @@ When set to `true`, Rspack will skip analysis and bundling processing for the dy
 This is particularly useful for dynamically loading ESM third-party libraries from external CDNs, for example:
 
 ```js
-import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
-  console.log(React.version); // 19.0.0
-});
-```
-
-You can also use the equivalent `rspackIgnore` comment:
-
-```js
 import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
   console.log(React.version); // 19.0.0
 });
 ```
 
-`webpackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `webpackIgnore: true` comment:
+The equivalent `webpackIgnore` comment is also supported:
+
+```js
+import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
+`rspackIgnore` also applies to the `new URL()` syntax. By default, Rspack will parse module identifiers in `new URL()` and bundle the referenced module into the build output. When you need Rspack to skip processing a particular `new URL()`, you can add the `rspackIgnore: true` comment:
 
 ```js
 // Rspack will process this URL and bundle './index.css' into the build output
 const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack will ignore this URL and preserve the original module identifier
-const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 
-// `rspackIgnore` is also supported
-const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
+// `webpackIgnore` is also supported
+const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,11 +134,11 @@ export default {
 };
 ```
 
-Note that only the `webpackIgnore` and `rspackIgnore` comments are supported at the moment:
+Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. Prefer `rspackIgnore` in Rspack projects; `webpackIgnore` remains supported for compatibility:
 
 ```js
-const x = require(/* webpackIgnore: true */ 'x');
-const y = require(/* rspackIgnore: true */ 'y');
+const x = require(/* rspackIgnore: true */ 'x');
+const y = require(/* webpackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,10 +134,11 @@ export default {
 };
 ```
 
-Note that only `webpackIgnore` comment is supported at the moment:
+Note that only the `webpackIgnore` and `rspackIgnore` comments are supported at the moment:
 
 ```js
 const x = require(/* webpackIgnore: true */ 'x');
+const y = require(/* rspackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,7 +134,7 @@ export default {
 };
 ```
 
-Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. Starting from Rspack 2.0.7, prefer `rspackIgnore` in Rspack projects; `webpackIgnore` remains supported for compatibility:
+Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. **Since Rspack 2.0.7**, prefer `rspackIgnore`; `webpackIgnore` remains supported for compatibility:
 
 ```js
 const x = require(/* rspackIgnore: true */ 'x');

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,7 +134,7 @@ export default {
 };
 ```
 
-Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. Prefer `rspackIgnore` in Rspack projects; `webpackIgnore` remains supported for compatibility:
+Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. Starting from Rspack 2.0.7, prefer `rspackIgnore` in Rspack projects; `webpackIgnore` remains supported for compatibility:
 
 ```js
 const x = require(/* rspackIgnore: true */ 'x');

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -107,27 +107,25 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。有关这些魔法注释的完整列表，请参见下面的代码，以及对这些注释功能的解释。
-
-Rspack 也支持带有 `rspack` 前缀的等价魔法注释。例如，`rspackIgnore` 等价于 `webpackIgnore`，`rspackChunkName` 等价于 `webpackChunkName`。
+通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。在 Rspack 项目中，推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
 
 ```js
 // 单个模块
 import(
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackFetchPriority: "high" */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackFetchPriority: "high" */
   'module'
 );
 
 // 多个可能模块
 import(
-  /* webpackInclude: /\.json$/ */
-  /* webpackExclude: /\.noimport\.json$/ */
-  /* webpackChunkName: "my-chunk-name" */
-  /* webpackMode: "lazy" */
-  /* webpackPrefetch: true */
-  /* webpackPreload: true */
+  /* rspackInclude: /\.json$/ */
+  /* rspackExclude: /\.noimport\.json$/ */
+  /* rspackChunkName: "my-chunk-name" */
+  /* rspackMode: "lazy" */
+  /* rspackPrefetch: true */
+  /* rspackPreload: true */
   `./locale/${language}`
 );
 ```
@@ -145,30 +143,30 @@ import(
 这在需要从外部 CDN 动态加载 ESM 格式的第三方库时特别有用，例如：
 
 ```js
-import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
-  console.log(React.version); // 19.0.0
-});
-```
-
-你也可以使用等价的 `rspackIgnore` 注释：
-
-```js
 import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
   console.log(React.version); // 19.0.0
 });
 ```
 
-`webpackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `webpackIgnore: true` 注释：
+也支持等价的 `webpackIgnore` 注释：
+
+```js
+import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
+`rspackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `rspackIgnore: true` 注释：
 
 ```js
 // Rspack 会处理这个 URL，将 './index.css' 打包到构建产物中
 const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack 会忽略这个 URL，保持原始的模块标识符
-const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 
-// 同样支持 `rspackIgnore`
-const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
+// 同样支持 `webpackIgnore`
+const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -107,7 +107,7 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。在 Rspack 项目中，推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
+通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。从 Rspack 2.0.7 开始，Rspack 项目中推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
 
 ```js
 // 单个模块

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -109,6 +109,8 @@ import(`./locale/${language}.json`).then((module) => {
 
 通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。有关这些魔法注释的完整列表，请参见下面的代码，以及对这些注释功能的解释。
 
+Rspack 也支持带有 `rspack` 前缀的等价魔法注释。例如，`rspackIgnore` 等价于 `webpackIgnore`，`rspackChunkName` 等价于 `webpackChunkName`。
+
 ```js
 // 单个模块
 import(
@@ -148,6 +150,14 @@ import('https://esm.sh/react' /* webpackIgnore: true */).then((React) => {
 });
 ```
 
+你也可以使用等价的 `rspackIgnore` 注释：
+
+```js
+import('https://esm.sh/react' /* rspackIgnore: true */).then((React) => {
+  console.log(React.version); // 19.0.0
+});
+```
+
 `webpackIgnore` 同样适用于 `new URL()` 语法。默认情况下，Rspack 会解析 `new URL()` 中的模块标识符，并将其引用的模块打包到构建产物中。当你需要 Rspack 跳过某个 `new URL()` 的处理时，可以添加 `webpackIgnore: true` 注释：
 
 ```js
@@ -156,6 +166,9 @@ const url1 = new URL('./index.css', import.meta.url);
 
 // Rspack 会忽略这个 URL，保持原始的模块标识符
 const url2 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
+
+// 同样支持 `rspackIgnore`
+const url3 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 ```
 
 ##### webpackMode

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -107,7 +107,7 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。从 Rspack 2.0.7 开始，Rspack 项目中推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
+通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。**从 Rspack 2.0.7 开始**，推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
 
 ```js
 // 单个模块

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -130,7 +130,7 @@ import(
 );
 ```
 
-##### webpackIgnore
+##### rspackIgnore / webpackIgnore \{#webpackignore}
 
 - **类型：** `boolean`
 
@@ -169,7 +169,7 @@ const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
-##### webpackMode
+##### rspackMode / webpackMode \{#webpackmode}
 
 - **类型：** `"eager" | "lazy" | "weak" | "lazy-once"`
 - **默认值：** `'lazy'`
@@ -181,7 +181,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 - `'eager'`：不会生成额外的 chunk。所有的模块都被当前的 chunk 引入，并且没有额外的网络请求。但是仍会返回一个 resolved 状态的 Promise。与静态导入相比，在调用 `import()` 完成之前，该模块不会被执行。
 - `'weak'`：尝试加载模块，如果该模块函数已经以其他方式加载，（即另一个 chunk 导入过此模块，或包含模块的脚本被加载）。仍会返回 Promise， 但是只有在客户端上已经有该 chunk 时才会成功解析。如果该模块不可用，则返回 rejected 状态的 Promise，且网络请求永远都不会执行。当需要的 chunks 始终在（嵌入在页面中的）初始请求中手动提供，而不是在应用程序导航在最初没有提供的模块导入的情况下触发，这对于通用渲染（SSR）是非常有用的。
 
-##### webpackPrefetch
+##### rspackPrefetch / webpackPrefetch \{#webpackprefetch}
 
 - **类型：**
   - `number`: 预取优先级
@@ -189,7 +189,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 告诉浏览器将来可能需要该资源来进行某些导航跳转，详情请查看[预取/预载模块](/guide/optimization/code-splitting#prefetchingpreloading-模块)。
 
-##### webpackPreload
+##### rspackPreload / webpackPreload \{#webpackpreload}
 
 - **类型：**
   - `number`: 预载优先级
@@ -197,13 +197,13 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 告诉浏览器在当前导航期间可能需要该资源，详情请查看[预取/预载模块](/guide/optimization/code-splitting#prefetchingpreloading-模块)。
 
-##### webpackChunkName
+##### rspackChunkName / webpackChunkName \{#webpackchunkname}
 
 - **类型：**: `string`
 
 指定新 chunk 的名称。
 
-##### webpackFetchPriority
+##### rspackFetchPriority / webpackFetchPriority \{#webpackfetchpriority}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -211,7 +211,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 为指定的动态导入设置 [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority)。也可以通过使用 `module.parser.javascript.dynamicImportFetchPriority` 选项为所有动态导入设置全局默认值。
 
-##### webpackInclude
+##### rspackInclude / webpackInclude \{#webpackinclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -219,7 +219,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 在导入解析时匹配的正则表达式。只有匹配的模块**才会被打包**。
 
-##### webpackExclude
+##### rspackExclude / webpackExclude \{#webpackexclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -228,10 +228,10 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 在导入解析时匹配的正则表达式。只有匹配的模块**不会被打包**。
 
 :::info
-请注意，`webpackInclude` 和 `webpackExclude` 选项不会影响前缀。例如：`./locale`。
+请注意，`rspackInclude` 和 `rspackExclude` 选项不会影响前缀。等价的 `webpackInclude` 和 `webpackExclude` 注释也会被兼容支持。例如：`./locale`。
 :::
 
-##### webpackExports
+##### rspackExports / webpackExports \{#webpackexports}
 
 <ApiMeta addedVersion="1.0.0" />
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,7 +134,7 @@ export default {
 };
 ```
 
-目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。Rspack 项目中推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
+目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。从 Rspack 2.0.7 开始，Rspack 项目中推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
 
 ```js
 const x = require(/* rspackIgnore: true */ 'x');

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,11 +134,11 @@ export default {
 };
 ```
 
-目前仅支持 `webpackIgnore` 和 `rspackIgnore` 注释：
+目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。Rspack 项目中推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
 
 ```js
-const x = require(/* webpackIgnore: true */ 'x');
-const y = require(/* rspackIgnore: true */ 'y');
+const x = require(/* rspackIgnore: true */ 'x');
+const y = require(/* webpackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,7 +134,7 @@ export default {
 };
 ```
 
-目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。从 Rspack 2.0.7 开始，Rspack 项目中推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
+目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。**从 Rspack 2.0.7 开始**，推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
 
 ```js
 const x = require(/* rspackIgnore: true */ 'x');

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,10 +134,11 @@ export default {
 };
 ```
 
-目前仅支持 `webpackIgnore` 注释：
+目前仅支持 `webpackIgnore` 和 `rspackIgnore` 注释：
 
 ```js
 const x = require(/* webpackIgnore: true */ 'x');
+const y = require(/* rspackIgnore: true */ 'y');
 ```
 
 ### javascript.dynamicImportMode


### PR DESCRIPTION
## Summary

Support `rspack*` magic comment names as aliases for the existing `webpack*` names, including `rspackIgnore`, `rspackChunkName`, `rspackInclude`, `rspackExclude`, and related options.

Added parallel config cases for the `rspack` prefix across import/require ignore handling, URL ignore handling, context module options, and worker chunk names.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).