### PR TITLE
chore: bind walltime bench to dedicated CPUs

### DIFF
--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -122,9 +122,9 @@ jobs:
               if [ -n "${{ inputs.bench_filter }}" ]; then
                 bench_args+=("${{ inputs.bench_filter }}")
               fi
-              RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run "${bench_args[@]}"
+              taskset -c 300-315 env RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run "${bench_args[@]}"
             else
-              pnpm run bench:rust
+              taskset -c 300-315 pnpm run bench:rust
             fi
           token: ${{ secrets.CODSPEED_TOKEN }}
           runner-version: 4.13.0


### PR DESCRIPTION
## Summary

Bind the CodSpeed walltime Rust benchmark run commands to CPUs `300-315` using `taskset`.

## Why

This keeps the walltime benchmark workload on a dedicated CPU range for more controlled measurements on the self-hosted runner.

## Impact

Only the `walltime` CodSpeed benchmark path in `.github/workflows/bench-rust.yml` is affected. Simulation benchmarks are unchanged.

## Validation

- Commit hooks ran lint-staged/prettier for the workflow file during commit.
- Not run: full CI locally, because this is a GitHub Actions workflow-only change.