### PR TITLE
perf(core): avoid parsing concatenated module refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,5 +198,8 @@ rstack-examples/
 .aider
 .codex
 
+# ignore known coding support frameworks
+.codegraph/
+
 # rstest event report files
 /*-report.txt

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1441,7 +1441,7 @@ impl Module for ConcatenatedModule {
         let mut refs = vec![];
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
-          if !ConcatenationScope::is_module_reference(name.as_str()) {
+          if !ConcatenationScope::has_module_reference_prefix(name.as_str()) {
             continue;
           }
           if let Some(match_info) = info.module_references.get(name) {
@@ -1452,6 +1452,19 @@ impl Module for ConcatenatedModule {
               match_info,
               build_meta.strict_esm_module,
             ));
+          } else if let Some(stripped_name) =
+            ConcatenationScope::strip_module_reference_property_access_suffix(name.as_str())
+          {
+            let stripped_name = Atom::from(stripped_name);
+            if let Some(match_info) = info.module_references.get(&stripped_name) {
+              let referenced_info_id = &references_info[match_info.index].0;
+              refs.push((
+                reference.clone(),
+                referenced_info_id,
+                match_info,
+                build_meta.strict_esm_module,
+              ));
+            }
           }
         }
 

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -50,11 +50,12 @@ use crate::{
   ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta, ImportedByDeferModulesArtifact,
   InitFragment, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT,
-  ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
-  SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set,
-  filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
+  ModuleIdentifier, ModuleLayer, ModuleReferenceOptions, ModuleStaticCache, ModuleType,
+  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
+  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
+  escape_identifier, fast_set, filter_runtime, find_target, get_runtime_key,
+  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
+  module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -314,6 +315,7 @@ pub struct ConcatenatedModuleInfo {
   pub idents: Vec<ConcatenatedModuleIdent>,
   pub all_used_names: HashSet<Atom>,
   pub binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>>,
+  pub module_references: HashMap<Atom, ModuleReferenceOptions>,
 
   pub public_path_auto_replacement: Option<bool>,
   pub static_url_replacement: bool,
@@ -1439,52 +1441,33 @@ impl Module for ConcatenatedModule {
         let mut refs = vec![];
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
-          let match_result = ConcatenationScope::match_module_reference(name.as_str());
-          if let Some(match_info) = match_result {
+          if let Some(match_info) = info.module_references.get(name) {
             let referenced_info_id = &references_info[match_info.index].0;
             refs.push((
               reference.clone(),
               referenced_info_id,
-              match_info
-                .ids
-                .into_iter()
-                .map(|item| Atom::from(item.as_str()))
-                .collect::<Vec<_>>(),
-              match_info.call,
-              !match_info.direct_import,
-              match_info.deferred_import,
+              match_info,
               build_meta.strict_esm_module,
-              match_info.asi_safe,
             ));
           }
         }
 
         let mut changes = vec![];
-        for (
-          reference_ident,
-          referenced_info_id,
-          export_name,
-          call,
-          call_context,
-          deferred_import,
-          strict_esm_module,
-          asi_safe,
-        ) in refs
-        {
+        for (reference_ident, referenced_info_id, match_info, strict_esm_module) in refs {
           let final_name = Self::get_final_name(
             compilation.get_module_graph(),
             &compilation.module_graph_cache_artifact,
             &compilation.exports_info_artifact,
             &compilation.module_static_cache,
             referenced_info_id,
-            export_name,
+            match_info.ids.clone(),
             &module_to_info_map,
             runtime,
-            deferred_import,
-            call,
-            call_context,
+            match_info.deferred_import,
+            match_info.call,
+            !match_info.direct_import,
             strict_esm_module,
-            asi_safe,
+            match_info.asi_safe,
             &context,
           );
 

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1441,6 +1441,9 @@ impl Module for ConcatenatedModule {
         let mut refs = vec![];
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
+          if !ConcatenationScope::is_module_reference(name.as_str()) {
+            continue;
+          }
           if let Some(match_info) = info.module_references.get(name) {
             let referenced_info_id = &references_info[match_info.index].0;
             refs.push((

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -222,6 +222,10 @@ impl ConcatenationScope {
     })
   }
 
+  pub fn is_module_reference(name: &str) -> bool {
+    name.starts_with(MODULE_REFERENCE_PREFIX)
+  }
+
   pub fn is_module_concatenated(&self, module: &ModuleIdentifier) -> bool {
     matches!(
       self.modules_map.get(module).expect("should have module"),
@@ -373,5 +377,15 @@ mod tests {
     assert!(
       ConcatenationScope::match_module_reference("__rspack_module_ref1_ns_asiSafe2__").is_none()
     );
+  }
+
+  #[test]
+  fn is_module_reference_checks_prefix() {
+    assert!(ConcatenationScope::is_module_reference(
+      "__rspack_module_ref1_0__"
+    ));
+    assert!(!ConcatenationScope::is_module_reference(
+      "__webpack_module_ref1_0__"
+    ));
   }
 }

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -307,6 +307,53 @@ mod tests {
   }
 
   #[test]
+  fn create_module_reference_preserves_option_branches() {
+    let (mut scope, referenced_module_id) = create_test_scope(7);
+    let options_cases = vec![
+      ModuleReferenceOptions::default(),
+      ModuleReferenceOptions {
+        ids: vec![Atom::from("named")],
+        direct_import: true,
+        asi_safe: Some(true),
+        ..Default::default()
+      },
+      ModuleReferenceOptions {
+        ids: vec![Atom::from("default"), Atom::from("named")],
+        call: true,
+        deferred_import: true,
+        asi_safe: Some(false),
+        ..Default::default()
+      },
+    ];
+
+    for options in options_cases {
+      let module_ref = scope.create_module_reference(&referenced_module_id, options.clone());
+      let module_ref_identifier = module_ref
+        .strip_suffix(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX)
+        .expect("should include module reference property access suffix");
+      let expected = ModuleReferenceOptions {
+        index: 7,
+        ..options
+      };
+
+      let stored = scope
+        .refs
+        .get(&referenced_module_id)
+        .and_then(|refs| refs.get(&module_ref))
+        .expect("should store created module reference");
+      assert_module_reference_options_eq(stored, &expected);
+
+      let lookup_key = Atom::from(module_ref_identifier);
+      let lookup = scope
+        .current_module
+        .module_references
+        .get(&lookup_key)
+        .expect("should store created module reference lookup");
+      assert_module_reference_options_eq(lookup, &expected);
+    }
+  }
+
+  #[test]
   fn match_module_reference_accepts_identifier_without_property_access_suffix() {
     let parsed = ConcatenationScope::match_module_reference(
       "__rspack_module_ref3_ns_call_directImport_deferredImport_asiSafe1__",

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, LazyLock};
 use anymap::CloneAny;
 use rspack_collections::IdentifierIndexMap;
 use rspack_util::{
-  fx_hash::{FxIndexMap, FxIndexSet},
+  fx_hash::{FxHashMap, FxIndexMap, FxIndexSet},
   itoa,
 };
 use swc_core::atoms::Atom;
@@ -19,7 +19,7 @@ pub const DEFAULT_EXPORT: &str = "__rspack_default_export";
 const MODULE_REFERENCE_PREFIX: &str = "__rspack_module_ref";
 const MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX: &str = "._";
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModuleReferenceOptions {
   pub ids: Vec<Atom>,
   pub call: bool,
@@ -36,6 +36,7 @@ pub struct ConcatenationScope {
   pub modules_map: Arc<IdentifierIndexMap<ModuleInfo>>,
   pub data: anymap::Map<dyn CloneAny + Send + Sync>,
   pub refs: IdentifierIndexMap<FxIndexMap<String, ModuleReferenceOptions>>,
+  pub module_reference_by_options: IdentifierIndexMap<FxHashMap<ModuleReferenceOptions, String>>,
   pub dyn_refs: IdentifierIndexMap<FxIndexSet<(String, Atom)>>,
   pub re_exports: IdentifierIndexMap<Vec<ExportMode>>,
 }
@@ -53,6 +54,7 @@ impl ConcatenationScope {
       modules_map,
       data: Default::default(),
       refs: IdentifierIndexMap::default(),
+      module_reference_by_options: IdentifierIndexMap::default(),
       dyn_refs: Default::default(),
       re_exports: Default::default(),
     }
@@ -130,6 +132,14 @@ impl ConcatenationScope {
 
     options.index = info.index();
 
+    if let Some(module_ref) = self
+      .module_reference_by_options
+      .get(module)
+      .and_then(|references| references.get(&options))
+    {
+      return module_ref.clone();
+    }
+
     let mut index_buffer = itoa::Buffer::new();
     let index_str = index_buffer.format(options.index);
     let mut reference_index_buffer = itoa::Buffer::new();
@@ -155,7 +165,12 @@ impl ConcatenationScope {
     module_ref.push_str(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX);
 
     let entry = self.refs.entry(*module).or_default();
-    entry.insert(module_ref.clone(), options);
+    entry.insert(module_ref.clone(), options.clone());
+    self
+      .module_reference_by_options
+      .entry(*module)
+      .or_default()
+      .insert(options, module_ref.clone());
 
     module_ref
   }
@@ -312,6 +327,31 @@ mod tests {
       .get(&lookup_key)
       .expect("should store created module reference lookup");
     assert_module_reference_options_eq(lookup, &expected);
+  }
+
+  #[test]
+  fn create_module_reference_reuses_same_options() {
+    let (mut scope, referenced_module_id) = create_test_scope(7);
+    let options = ModuleReferenceOptions {
+      ids: vec![Atom::from("default")],
+      direct_import: true,
+      ..Default::default()
+    };
+
+    let first_ref = scope.create_module_reference(&referenced_module_id, options.clone());
+    let second_ref = scope.create_module_reference(&referenced_module_id, options.clone());
+    assert_eq!(first_ref, second_ref);
+    assert_eq!(scope.current_module.module_references.len(), 1);
+
+    let different_ref = scope.create_module_reference(
+      &referenced_module_id,
+      ModuleReferenceOptions {
+        call: true,
+        ..options
+      },
+    );
+    assert_ne!(first_ref, different_ref);
+    assert_eq!(scope.current_module.module_references.len(), 2);
   }
 
   #[test]

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -121,39 +121,39 @@ impl ConcatenationScope {
   pub fn create_module_reference(
     &mut self,
     module: &ModuleIdentifier,
-    options: ModuleReferenceOptions,
+    mut options: ModuleReferenceOptions,
   ) -> String {
     let info = self
       .modules_map
       .get(module)
       .expect("should have module info");
 
-    let export_data = if !options.ids.is_empty() {
-      hex::encode(serde_json::to_string(&options.ids).expect("should serialize to json string"))
-    } else {
-      "ns".to_string()
-    };
+    options.index = info.index();
 
     let mut index_buffer = itoa::Buffer::new();
-    let index_str = index_buffer.format(info.index());
-    let mut module_ref = String::with_capacity(index_str.len() + export_data.len() + 64);
-    module_ref.push_str("__rspack_module_ref");
-    module_ref.push_str(index_str);
-    module_ref.push('_');
-    module_ref.push_str(&export_data);
-    if options.call {
-      module_ref.push_str("_call");
-    }
-    if options.direct_import {
-      module_ref.push_str("_directImport");
-    }
-    if options.deferred_import {
-      module_ref.push_str("_deferredImport");
-    }
-    if let Some(asi_safe) = options.asi_safe {
-      module_ref.push_str(if asi_safe { "_asiSafe1" } else { "_asiSafe0" });
-    }
-    module_ref.push_str("__._");
+    let index_str = index_buffer.format(options.index);
+    let mut reference_index_buffer = itoa::Buffer::new();
+    let reference_index_str =
+      reference_index_buffer.format(self.current_module.module_references.len());
+    let mut module_ref_identifier =
+      String::with_capacity(index_str.len() + reference_index_str.len() + 32);
+    module_ref_identifier.push_str(MODULE_REFERENCE_PREFIX);
+    module_ref_identifier.push_str(index_str);
+    module_ref_identifier.push('_');
+    module_ref_identifier.push_str(reference_index_str);
+    module_ref_identifier.push_str("__");
+
+    self
+      .current_module
+      .module_references
+      .insert(Atom::from(module_ref_identifier.as_str()), options.clone());
+
+    let mut module_ref = String::with_capacity(
+      module_ref_identifier.len() + MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX.len(),
+    );
+    module_ref.push_str(&module_ref_identifier);
+    module_ref.push_str(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX);
+
     let entry = self.refs.entry(*module).or_default();
     entry.insert(module_ref.clone(), options);
 
@@ -269,7 +269,7 @@ mod tests {
   }
 
   #[test]
-  fn create_module_reference_round_trips_through_matcher() {
+  fn create_module_reference_stores_lookup_and_legacy_refs() {
     let (mut scope, referenced_module_id) = create_test_scope(7);
     let options = ModuleReferenceOptions {
       ids: vec![Atom::from("default"), Atom::from("named")],
@@ -281,21 +281,29 @@ mod tests {
     };
 
     let module_ref = scope.create_module_reference(&referenced_module_id, options.clone());
+    assert!(module_ref.ends_with(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX));
+    let module_ref_identifier = module_ref
+      .strip_suffix(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX)
+      .expect("should include module reference property access suffix");
+    let expected = ModuleReferenceOptions {
+      index: 7,
+      ..options
+    };
 
     let stored = scope
       .refs
       .get(&referenced_module_id)
       .and_then(|refs| refs.get(&module_ref))
       .expect("should store created module reference");
-    assert_module_reference_options_eq(stored, &options);
+    assert_module_reference_options_eq(stored, &expected);
 
-    let parsed = ConcatenationScope::match_module_reference(&module_ref)
-      .expect("should parse full module reference");
-    let expected = ModuleReferenceOptions {
-      index: 7,
-      ..options
-    };
-    assert_module_reference_options_eq(&parsed, &expected);
+    let lookup_key = Atom::from(module_ref_identifier);
+    let lookup = scope
+      .current_module
+      .module_references
+      .get(&lookup_key)
+      .expect("should store created module reference lookup");
+    assert_module_reference_options_eq(lookup, &expected);
   }
 
   #[test]

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -222,8 +222,12 @@ impl ConcatenationScope {
     })
   }
 
-  pub fn is_module_reference(name: &str) -> bool {
+  pub fn has_module_reference_prefix(name: &str) -> bool {
     name.starts_with(MODULE_REFERENCE_PREFIX)
+  }
+
+  pub fn strip_module_reference_property_access_suffix(name: &str) -> Option<&str> {
+    name.strip_suffix(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX)
   }
 
   pub fn is_module_concatenated(&self, module: &ModuleIdentifier) -> bool {
@@ -380,12 +384,26 @@ mod tests {
   }
 
   #[test]
-  fn is_module_reference_checks_prefix() {
-    assert!(ConcatenationScope::is_module_reference(
+  fn has_module_reference_prefix_checks_prefix() {
+    assert!(ConcatenationScope::has_module_reference_prefix(
       "__rspack_module_ref1_0__"
     ));
-    assert!(!ConcatenationScope::is_module_reference(
+    assert!(!ConcatenationScope::has_module_reference_prefix(
       "__webpack_module_ref1_0__"
     ));
+  }
+
+  #[test]
+  fn strip_module_reference_property_access_suffix_strips_full_reference_suffix() {
+    assert_eq!(
+      ConcatenationScope::strip_module_reference_property_access_suffix(
+        "__rspack_module_ref1_0__._"
+      ),
+      Some("__rspack_module_ref1_0__")
+    );
+    assert_eq!(
+      ConcatenationScope::strip_module_reference_property_access_suffix("__rspack_module_ref1_0__"),
+      None
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Store concatenation module reference options in `ConcatenatedModuleInfo` when references are created.
- Replace hot-path JSON/hex module reference parsing with a direct lookup during concatenated module code generation.
- Keep the existing `ConcatenationScope.refs` data for ESM library linking compatibility.
- Add `.codegraph/` to `.gitignore`.

## Module reference format

Before this change, `create_module_reference` encoded the target export information into the generated identifier itself:

```text
__rspack_module_ref{module_index}_{hex(json(ids))}[_call][_directImport][_deferredImport][_asiSafe0|_asiSafe1]__._
```

The replacement pass later had to recover the same `ModuleReferenceOptions` by parsing the identifier, hex-decoding the export payload, JSON-deserializing `ids`, and then parsing each flag suffix.

After this change, the generated reference only carries a compact identity:

```text
__rspack_module_ref{module_index}_{local_ref_index}__._
```

The actual `ModuleReferenceOptions` are stored structurally when the reference is created:

- `current_module.module_references` stores the options by the generated identifier without the trailing `._`.
- `ConcatenationScope.refs` is still populated with the full generated reference string for the existing ESM library linking path.

So `ids`, `call`, `direct_import`, `deferred_import`, `asi_safe`, and the resolved target module index are no longer serialized into the identifier. They remain in `ModuleReferenceOptions` and are read back directly during concatenated module code generation.

## Algorithmic rationale

The previous algorithm treated the generated identifier as both an identity and a serialized payload. That made every replacement in `concatenate_module_code_generation` pay the cost of reconstructing data that was already known at reference creation time:

1. parse the module reference string,
2. decode hex,
3. deserialize JSON into a fresh `ids` vector,
4. parse boolean flag suffixes,
5. convert parsed strings back into `Atom`s before calling `get_final_name`.

This is unnecessary work on the hot path. The new algorithm separates identity from metadata:

1. `create_module_reference` assigns a per-current-module `local_ref_index` and emits a short stable identifier.
2. The full `ModuleReferenceOptions` are stored once in the current `ConcatenatedModuleInfo`.
3. The replacement pass performs a direct lookup from the generated symbol to the stored options.
4. `ids.clone()` happens only once, immediately before `get_final_name`, because `get_final_name` still owns the export-name vector.

The lookup is safe because these module reference symbols are generated by `ConcatenationScope::create_module_reference`; they are not user-authored identifiers. The existing `refs` map remains unchanged at the API level for the ESM library linker, so this avoids changing the cross-plugin contract while removing JSON/hex parsing from the core replacement path.

Benchmark (`BENCH_MODE=walltime cargo codspeed run -m walltime -p rspack_benchmark --bench benches rust@concatenate_module_code_generation`):

- Baseline: `9.4164 ms`
- After run 1: `9.2599 ms`
- After run 2: `9.2028 ms`

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Verification:

- `cargo test -p rspack_core concatenation_scope`
- `cargo test -p rspack_plugin_esm_library`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test -t "concatenate"`
- `pnpm run test -t "scope-hoisting"`
- `pnpm run test -t "esmOutputCases/dynamic-import"`
- `pnpm run test -t "esmOutputCases/externals"`
- `pnpm run test -t "defer-import"`
- `cargo fmt --all --check`