### PR TITLE
chore: bind walltime bench to dedicated CPUs test

### DIFF
--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -118,14 +118,15 @@ jobs:
         with:
           mode: walltime
           run: |
+            sync; echo 1 > /proc/sys/vm/drop_caches
             if [ -n "${{ inputs.bench_target }}" ]; then
               bench_args=(--bench "${{ inputs.bench_target }}")
               if [ -n "${{ inputs.bench_filter }}" ]; then
                 bench_args+=("${{ inputs.bench_filter }}")
               fi
-              RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run "${bench_args[@]}"
+              taskset -c 176-191 env RSPACK_BENCHCASES_DIR=$PWD/.bench/rspack-benchcases cargo codspeed run "${bench_args[@]}"
             else
-              pnpm run bench:rust
+              taskset -c 176-191 pnpm run bench:rust
             fi
           token: ${{ secrets.CODSPEED_TOKEN }}
           runner-version: 4.13.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       runner: '"ubuntu-22.04"'
 
   # add some comment
+  # add another comment
   bench-rust-walltime:
     name: Rust Bench Walltime
     needs: [check-changed]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       target: x86_64-unknown-linux-gnu
       runner: '"ubuntu-22.04"'
 
+  # add some comment
   bench-rust-walltime:
     name: Rust Bench Walltime
     needs: [check-changed]


### PR DESCRIPTION
bind walltime bench to dedicated CPUs