### PR TITLE
perf(core): use dense maps for module graph artifacts

### DIFF
--- a/crates/rspack_core/src/artifacts/exports_info_artifact.rs
+++ b/crates/rspack_core/src/artifacts/exports_info_artifact.rs
@@ -2,15 +2,15 @@ use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
 
 use crate::{
-  ArtifactExt, ExportsInfo, ExportsInfoData, ModuleIdentifier,
+  ArtifactExt, DenseExportsInfoMap, ExportsInfo, ExportsInfoData, ModuleIdentifier,
   incremental::{Incremental, IncrementalPasses},
-  module_graph::rollback,
+  module_graph::rollback::RollbackAtom,
 };
 
 #[derive(Debug, Default)]
 pub struct ExportsInfoArtifact {
   module_exports_info: IdentifierMap<ExportsInfo>,
-  exports_info_map: rollback::RollbackAtomMap<ExportsInfo, ExportsInfoData>,
+  exports_info_map: RollbackAtom<DenseExportsInfoMap<ExportsInfoData>>,
 }
 
 impl ArtifactExt for ExportsInfoArtifact {
@@ -101,15 +101,16 @@ impl ExportsInfoArtifact {
   }
 
   pub fn reset_all_exports_info_used(&mut self) {
-    self.exports_info_map.par_iter_mut().for_each(
-      |(_, exports_info): (&ExportsInfo, &mut ExportsInfoData)| {
+    self
+      .exports_info_map
+      .par_iter_mut()
+      .for_each(|(_, exports_info)| {
         for export_info in exports_info.exports_mut().values_mut() {
           export_info.set_has_use_info();
         }
         exports_info.side_effects_only_info_mut().set_has_use_info();
         exports_info.other_exports_info_mut().set_has_use_info();
-      },
-    );
+      });
   }
 }
 

--- a/crates/rspack_core/src/exports/dense_exports_info_map.rs
+++ b/crates/rspack_core/src/exports/dense_exports_info_map.rs
@@ -1,0 +1,132 @@
+use rayon::prelude::*;
+
+use super::ExportsInfo;
+
+#[derive(Debug, Clone)]
+pub(crate) struct DenseExportsInfoMap<V> {
+  offset: Option<u32>,
+  values: Vec<Option<V>>,
+}
+
+impl<V> Default for DenseExportsInfoMap<V> {
+  fn default() -> Self {
+    Self {
+      offset: None,
+      values: Vec::new(),
+    }
+  }
+}
+
+impl<V> DenseExportsInfoMap<V> {
+  #[inline]
+  pub fn insert(&mut self, key: ExportsInfo, value: V) -> Option<V> {
+    let index = self.ensure_index(key);
+    self.values[index].replace(value)
+  }
+
+  #[inline]
+  pub fn get(&self, key: &ExportsInfo) -> Option<&V> {
+    self
+      .index(*key)
+      .and_then(|index| self.values.get(index))
+      .and_then(Option::as_ref)
+  }
+
+  #[inline]
+  pub fn get_mut(&mut self, key: &ExportsInfo) -> Option<&mut V> {
+    self
+      .index(*key)
+      .and_then(|index| self.values.get_mut(index))
+      .and_then(Option::as_mut)
+  }
+
+  #[inline]
+  pub fn par_iter_mut(&mut self) -> impl ParallelIterator<Item = (ExportsInfo, &mut V)> + '_
+  where
+    V: Send,
+  {
+    let offset = self.offset.unwrap_or_default();
+    self
+      .values
+      .par_iter_mut()
+      .enumerate()
+      .filter_map(move |(index, value)| {
+        value
+          .as_mut()
+          .map(|value| (ExportsInfo::from_u32(offset + index as u32), value))
+      })
+  }
+
+  #[inline]
+  fn index(&self, key: ExportsInfo) -> Option<usize> {
+    let offset = self.offset?;
+    let key = key.as_u32();
+    if key < offset {
+      return None;
+    }
+    let index = (key - offset) as usize;
+    (index < self.values.len()).then_some(index)
+  }
+
+  #[inline]
+  fn ensure_index(&mut self, key: ExportsInfo) -> usize {
+    let key = key.as_u32();
+    let Some(offset) = self.offset else {
+      self.offset = Some(key);
+      self.values.resize_with(1, || None);
+      return 0;
+    };
+
+    if key < offset {
+      let additional = (offset - key) as usize;
+      let old_values = std::mem::take(&mut self.values);
+      self.values = Vec::with_capacity(additional + old_values.len());
+      self.values.resize_with(additional, || None);
+      self.values.extend(old_values);
+      self.offset = Some(key);
+      return 0;
+    }
+
+    let index = (key - offset) as usize;
+    if self.values.len() <= index {
+      self.values.resize_with(index + 1, || None);
+    }
+    index
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rayon::iter::ParallelIterator;
+
+  use super::{DenseExportsInfoMap, ExportsInfo};
+
+  #[test]
+  fn supports_sparse_and_shifted_exports_info_ids() {
+    let mut map = DenseExportsInfoMap::default();
+    let a = ExportsInfo::from_u32(10);
+    let b = ExportsInfo::from_u32(13);
+    let c = ExportsInfo::from_u32(8);
+
+    assert_eq!(map.insert(a, "a"), None);
+    assert_eq!(map.insert(b, "b"), None);
+    assert_eq!(map.insert(c, "c"), None);
+
+    assert_eq!(map.get(&a), Some(&"a"));
+    assert_eq!(map.get(&b), Some(&"b"));
+    assert_eq!(map.get(&c), Some(&"c"));
+    assert_eq!(map.get(&ExportsInfo::from_u32(9)), None);
+  }
+
+  #[test]
+  fn par_iter_mut_visits_existing_values() {
+    let mut map = DenseExportsInfoMap::default();
+    map.insert(ExportsInfo::from_u32(20), 1);
+    map.insert(ExportsInfo::from_u32(22), 3);
+
+    map.par_iter_mut().for_each(|(_, value)| *value += 1);
+
+    assert_eq!(map.get(&ExportsInfo::from_u32(20)), Some(&2));
+    assert_eq!(map.get(&ExportsInfo::from_u32(22)), Some(&4));
+  }
+}

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -18,6 +18,14 @@ impl ExportsInfo {
     Self(NEXT_EXPORTS_INFO_UKEY.fetch_add(1, Relaxed))
   }
 
+  pub fn as_u32(&self) -> u32 {
+    self.0
+  }
+
+  pub(crate) fn from_u32(id: u32) -> Self {
+    Self(id)
+  }
+
   pub fn as_data<'a>(&self, exports_info_artifact: &'a ExportsInfoArtifact) -> &'a ExportsInfoData {
     exports_info_artifact.get_exports_info_by_id(self)
   }

--- a/crates/rspack_core/src/exports/mod.rs
+++ b/crates/rspack_core/src/exports/mod.rs
@@ -1,3 +1,4 @@
+mod dense_exports_info_map;
 mod export_info;
 mod export_info_getter;
 mod export_info_setter;
@@ -8,6 +9,7 @@ mod referenced_export;
 mod target;
 mod utils;
 
+pub(crate) use dense_exports_info_map::*;
 pub use export_info::*;
 pub use exports_info::*;
 pub use referenced_export::*;

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -133,9 +133,9 @@ pub(crate) struct ModuleGraphData {
   ///     assert_eq!(parents_info.module, parent_module_id);
   ///   })
   /// ```
-  dependency_id_to_parents: HashMap<DependencyId, DependencyParents>,
+  dependency_id_to_parents: rollback::DenseDependencyIdMap<DependencyParents>,
   // TODO try move condition as connection field
-  connection_to_condition: HashMap<DependencyId, DependencyCondition>,
+  connection_to_condition: rollback::DenseDependencyIdMap<DependencyCondition>,
 
   /************************** Modified by Seal Phase **********************/
   /// ModuleGraphModule indexed by `ModuleIdentifier`.
@@ -149,7 +149,7 @@ pub(crate) struct ModuleGraphData {
 
   /***************** only Modified during Seal Phase ********************/
   // setting here https://github.com/web-infra-dev/rspack/blob/9ae2f0f3be22370197cd9ed3308982f84f2bb738/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs#L318
-  dep_meta_map: HashMap<DependencyId, DependencyExtraMeta>,
+  dep_meta_map: rollback::DenseDependencyIdMap<DependencyExtraMeta>,
 }
 impl ModuleGraphData {
   fn checkpoint(&mut self) {


### PR DESCRIPTION
### Summary
- use dense storage for module graph dependency id maps
- store exports info artifact data in an offset dense map keyed by `ExportsInfo`
- keep rollback checkpoint/reset behavior through existing rollback wrappers

### Tests
- `cargo test -p rspack_core dense_exports_info_map`
- `cargo check -p rspack_core`