### PR TITLE
chore: release version 2.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "rspack"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "bitflags 2.11.1",
  "derive_more",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_allocator"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "mimalloc",
  "sftrace-setup",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_benchmark"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_api"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3733,21 +3733,21 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_build"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "napi-build",
 ]
 
 [[package]]
 name = "rspack_binding_builder"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_binding_api",
 ]
 
 [[package]]
 name = "rspack_binding_builder_macros"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_builder_testing"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "napi",
  "napi-derive",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_browserslist"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "browserslist-rs",
  "lightningcss",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "camino",
  "dashmap",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_macros"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_test"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "camino",
  "dashmap",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_collections"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "dashmap",
  "hashlink",
@@ -3847,7 +3847,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_core"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anymap3",
  "async-recursion",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_error"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anyhow",
  "miette",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_fs"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hash"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "base64-simd 0.8.0",
  "md4",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hook"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_error",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_ids"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "derive_more",
  "futures",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_javascript_compiler"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_lightningcss"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_preact_refresh"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_react_refresh"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_runner"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_swc"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "either",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_testing"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_location"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "itoa",
  "memchr",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros_test"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "napi",
  "oneshot",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi_macros"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_node"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "napi-derive",
  "rspack_binding_api",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_parallel"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rayon",
  "rspack_tasks",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_paths"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "camino",
  "dashmap",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_asset"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "mime_guess",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_banner"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "futures",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_case_sensitive"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "itertools 0.14.0",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_circular_dependencies"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_copy"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css_chunking"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "indexmap",
  "rspack_collections",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_devtool"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dll"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dynamic_entry"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "atomic_refcell",
  "derive_more",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ensure_chunk_conditions"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_entry"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_esm_library"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_externals"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "regex",
  "rspack_core",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_extract_css"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_hmr"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_html"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anyhow",
  "atomic_refcell",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ignore"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "derive_more",
  "futures",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_javascript"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4628,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_json"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lazy_compilation"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_library"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "futures",
  "regex",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lightning_css_minimizer"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "lightningcss",
  "parcel_sourcemap",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_limit_chunk_count"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_merge_duplicate_chunks"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rayon",
  "rspack_core",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_mf"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "camino",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_info_header"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_cacheable",
  "rspack_core",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_replacement"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "derive_more",
  "futures",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_no_emit_on_errors"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_progress"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "futures",
  "indicatif",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_real_content_hash"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "aho-corasick",
  "atomic_refcell",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_duplicate_modules"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rayon",
  "rspack_collections",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_empty_chunks"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsc"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsdoctor"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "atomic_refcell",
  "futures",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rslib"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rstest"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "camino",
  "cow-utils",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime_chunk"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "futures",
  "rspack_core",
@@ -4983,7 +4983,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_schemes"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_size_limits"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "derive_more",
  "futures",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_split_chunks"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "derive_more",
  "futures",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_sri"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_swc_js_minimizer"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "once_cell",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_wasm"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_worker"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_regex"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "napi",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "dyn-clone",
  "memchr",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_storage"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_import"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "heck",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_ts_collector"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "glob",
  "insta",
@@ -5221,14 +5221,14 @@ dependencies = [
 
 [[package]]
 name = "rspack_tasks"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rspack_tools"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "clap",
  "itertools 0.14.0",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "chrono",
  "rspack_tracing_perfetto",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing_perfetto"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "bytes",
  "micromegas-perfetto",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_util"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "anyhow",
  "base64-simd 0.8.0",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_watcher"
-version = "0.100.6"
+version = "0.100.7"
 dependencies = [
  "cow-utils",
  "dashmap",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_workspace"
-version = "0.100.6"
+version = "0.100.7"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition       = "2024"
 homepage      = "https://rspack.rs/"
 license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
-version       = "0.100.6"
+version       = "0.100.7"
 
 [workspace.metadata.dylint]
 libraries = [{ path = "linting/*" }]
@@ -157,92 +157,92 @@ wasmtime      = { version = "36.0.7", default-features = false }
 
 
 # all rspack workspace dependencies
-rspack                                 = { version = "=0.100.6", path = "crates/rspack", default-features = false }
-rspack_allocator                       = { version = "=0.100.6", path = "crates/rspack_allocator", default-features = false }
-rspack_binding_api                     = { version = "=0.100.6", path = "crates/rspack_binding_api", default-features = false }
-rspack_binding_build                   = { version = "=0.100.6", path = "crates/rspack_binding_build", default-features = false }
-rspack_binding_builder                 = { version = "=0.100.6", path = "crates/rspack_binding_builder", default-features = false }
-rspack_binding_builder_macros          = { version = "=0.100.6", path = "crates/rspack_binding_builder_macros", default-features = false }
-rspack_browserslist                    = { version = "=0.100.6", path = "crates/rspack_browserslist", default-features = false }
-rspack_cacheable                       = { version = "=0.100.6", path = "crates/rspack_cacheable", default-features = false }
-rspack_cacheable_macros                = { version = "=0.100.6", path = "crates/rspack_cacheable_macros", default-features = false }
-rspack_collections                     = { version = "=0.100.6", path = "crates/rspack_collections", default-features = false }
-rspack_core                            = { version = "=0.100.6", path = "crates/rspack_core", default-features = false }
-rspack_error                           = { version = "=0.100.6", path = "crates/rspack_error", default-features = false }
-rspack_fs                              = { version = "=0.100.6", path = "crates/rspack_fs", default-features = false }
-rspack_hash                            = { version = "=0.100.6", path = "crates/rspack_hash", default-features = false }
-rspack_hook                            = { version = "=0.100.6", path = "crates/rspack_hook", default-features = false }
-rspack_ids                             = { version = "=0.100.6", path = "crates/rspack_ids", default-features = false }
-rspack_javascript_compiler             = { version = "=0.100.6", path = "crates/rspack_javascript_compiler", default-features = false }
-rspack_loader_lightningcss             = { version = "=0.100.6", path = "crates/rspack_loader_lightningcss", default-features = false }
-rspack_loader_preact_refresh           = { version = "=0.100.6", path = "crates/rspack_loader_preact_refresh", default-features = false }
-rspack_loader_react_refresh            = { version = "=0.100.6", path = "crates/rspack_loader_react_refresh", default-features = false }
-rspack_loader_runner                   = { version = "=0.100.6", path = "crates/rspack_loader_runner", default-features = false }
-rspack_loader_swc                      = { version = "=0.100.6", path = "crates/rspack_loader_swc", default-features = false }
-rspack_loader_testing                  = { version = "=0.100.6", path = "crates/rspack_loader_testing", default-features = false }
-rspack_location                        = { version = "=0.100.6", path = "crates/rspack_location", default-features = false }
-rspack_macros                          = { version = "=0.100.6", path = "crates/rspack_macros", default-features = false }
-rspack_napi                            = { version = "=0.100.6", path = "crates/rspack_napi", default-features = false }
-rspack_napi_macros                     = { version = "=0.100.6", path = "crates/rspack_napi_macros", default-features = false }
-rspack_parallel                        = { version = "=0.100.6", path = "crates/rspack_parallel", default-features = false }
-rspack_paths                           = { version = "=0.100.6", path = "crates/rspack_paths", default-features = false }
-rspack_plugin_asset                    = { version = "=0.100.6", path = "crates/rspack_plugin_asset", default-features = false }
-rspack_plugin_banner                   = { version = "=0.100.6", path = "crates/rspack_plugin_banner", default-features = false }
-rspack_plugin_case_sensitive           = { version = "=0.100.6", path = "crates/rspack_plugin_case_sensitive", default-features = false }
-rspack_plugin_circular_dependencies    = { version = "=0.100.6", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
-rspack_plugin_copy                     = { version = "=0.100.6", path = "crates/rspack_plugin_copy", default-features = false }
-rspack_plugin_css                      = { version = "=0.100.6", path = "crates/rspack_plugin_css", default-features = false }
-rspack_plugin_css_chunking             = { version = "=0.100.6", path = "crates/rspack_plugin_css_chunking", default-features = false }
-rspack_plugin_devtool                  = { version = "=0.100.6", path = "crates/rspack_plugin_devtool", default-features = false }
-rspack_plugin_dll                      = { version = "=0.100.6", path = "crates/rspack_plugin_dll", default-features = false }
-rspack_plugin_dynamic_entry            = { version = "=0.100.6", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
-rspack_plugin_ensure_chunk_conditions  = { version = "=0.100.6", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
-rspack_plugin_entry                    = { version = "=0.100.6", path = "crates/rspack_plugin_entry", default-features = false }
-rspack_plugin_esm_library              = { version = "=0.100.6", path = "crates/rspack_plugin_esm_library", default-features = false }
-rspack_plugin_externals                = { version = "=0.100.6", path = "crates/rspack_plugin_externals", default-features = false }
-rspack_plugin_extract_css              = { version = "=0.100.6", path = "crates/rspack_plugin_extract_css", default-features = false }
-rspack_plugin_hmr                      = { version = "=0.100.6", path = "crates/rspack_plugin_hmr", default-features = false }
-rspack_plugin_html                     = { version = "=0.100.6", path = "crates/rspack_plugin_html", default-features = false }
-rspack_plugin_ignore                   = { version = "=0.100.6", path = "crates/rspack_plugin_ignore", default-features = false }
-rspack_plugin_javascript               = { version = "=0.100.6", path = "crates/rspack_plugin_javascript", default-features = false }
-rspack_plugin_json                     = { version = "=0.100.6", path = "crates/rspack_plugin_json", default-features = false }
-rspack_plugin_lazy_compilation         = { version = "=0.100.6", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
-rspack_plugin_library                  = { version = "=0.100.6", path = "crates/rspack_plugin_library", default-features = false }
-rspack_plugin_lightning_css_minimizer  = { version = "=0.100.6", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
-rspack_plugin_limit_chunk_count        = { version = "=0.100.6", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
-rspack_plugin_merge_duplicate_chunks   = { version = "=0.100.6", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
-rspack_plugin_mf                       = { version = "=0.100.6", path = "crates/rspack_plugin_mf", default-features = false }
-rspack_plugin_module_info_header       = { version = "=0.100.6", path = "crates/rspack_plugin_module_info_header", default-features = false }
-rspack_plugin_module_replacement       = { version = "=0.100.6", path = "crates/rspack_plugin_module_replacement", default-features = false }
-rspack_plugin_no_emit_on_errors        = { version = "=0.100.6", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
-rspack_plugin_progress                 = { version = "=0.100.6", path = "crates/rspack_plugin_progress", default-features = false }
-rspack_plugin_real_content_hash        = { version = "=0.100.6", path = "crates/rspack_plugin_real_content_hash", default-features = false }
-rspack_plugin_remove_duplicate_modules = { version = "=0.100.6", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
-rspack_plugin_remove_empty_chunks      = { version = "=0.100.6", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
-rspack_plugin_rsc                      = { version = "=0.100.6", path = "crates/rspack_plugin_rsc", default-features = false }
-rspack_plugin_rsdoctor                 = { version = "=0.100.6", path = "crates/rspack_plugin_rsdoctor", default-features = false }
-rspack_plugin_rslib                    = { version = "=0.100.6", path = "crates/rspack_plugin_rslib", default-features = false }
-rspack_plugin_rstest                   = { version = "=0.100.6", path = "crates/rspack_plugin_rstest", default-features = false }
-rspack_plugin_runtime                  = { version = "=0.100.6", path = "crates/rspack_plugin_runtime", default-features = false }
-rspack_plugin_runtime_chunk            = { version = "=0.100.6", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
-rspack_plugin_schemes                  = { version = "=0.100.6", path = "crates/rspack_plugin_schemes", default-features = false }
-rspack_plugin_size_limits              = { version = "=0.100.6", path = "crates/rspack_plugin_size_limits", default-features = false }
-rspack_plugin_split_chunks             = { version = "=0.100.6", path = "crates/rspack_plugin_split_chunks", default-features = false }
-rspack_plugin_sri                      = { version = "=0.100.6", path = "crates/rspack_plugin_sri", default-features = false }
-rspack_plugin_swc_js_minimizer         = { version = "=0.100.6", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
-rspack_plugin_wasm                     = { version = "=0.100.6", path = "crates/rspack_plugin_wasm", default-features = false }
-rspack_plugin_worker                   = { version = "=0.100.6", path = "crates/rspack_plugin_worker", default-features = false }
-rspack_regex                           = { version = "=0.100.6", path = "crates/rspack_regex", default-features = false }
-rspack_sources                         = { version = "=0.100.6", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
-rspack_storage                         = { version = "=0.100.6", path = "crates/rspack_storage", default-features = false }
-rspack_swc_plugin_import               = { version = "=0.100.6", path = "crates/swc_plugin_import", default-features = false }
-rspack_swc_plugin_ts_collector         = { version = "=0.100.6", path = "crates/swc_plugin_ts_collector", default-features = false }
-rspack_tasks                           = { version = "=0.100.6", path = "crates/rspack_tasks", default-features = false }
-rspack_tracing                         = { version = "=0.100.6", path = "crates/rspack_tracing", default-features = false }
-rspack_tracing_perfetto                = { version = "=0.100.6", path = "crates/rspack_tracing_perfetto", default-features = false }
-rspack_util                            = { version = "=0.100.6", path = "crates/rspack_util", default-features = false }
-rspack_watcher                         = { version = "=0.100.6", path = "crates/rspack_watcher", default-features = false }
-rspack_workspace                       = { version = "=0.100.6", path = "crates/rspack_workspace", default-features = false }
+rspack                                 = { version = "=0.100.7", path = "crates/rspack", default-features = false }
+rspack_allocator                       = { version = "=0.100.7", path = "crates/rspack_allocator", default-features = false }
+rspack_binding_api                     = { version = "=0.100.7", path = "crates/rspack_binding_api", default-features = false }
+rspack_binding_build                   = { version = "=0.100.7", path = "crates/rspack_binding_build", default-features = false }
+rspack_binding_builder                 = { version = "=0.100.7", path = "crates/rspack_binding_builder", default-features = false }
+rspack_binding_builder_macros          = { version = "=0.100.7", path = "crates/rspack_binding_builder_macros", default-features = false }
+rspack_browserslist                    = { version = "=0.100.7", path = "crates/rspack_browserslist", default-features = false }
+rspack_cacheable                       = { version = "=0.100.7", path = "crates/rspack_cacheable", default-features = false }
+rspack_cacheable_macros                = { version = "=0.100.7", path = "crates/rspack_cacheable_macros", default-features = false }
+rspack_collections                     = { version = "=0.100.7", path = "crates/rspack_collections", default-features = false }
+rspack_core                            = { version = "=0.100.7", path = "crates/rspack_core", default-features = false }
+rspack_error                           = { version = "=0.100.7", path = "crates/rspack_error", default-features = false }
+rspack_fs                              = { version = "=0.100.7", path = "crates/rspack_fs", default-features = false }
+rspack_hash                            = { version = "=0.100.7", path = "crates/rspack_hash", default-features = false }
+rspack_hook                            = { version = "=0.100.7", path = "crates/rspack_hook", default-features = false }
+rspack_ids                             = { version = "=0.100.7", path = "crates/rspack_ids", default-features = false }
+rspack_javascript_compiler             = { version = "=0.100.7", path = "crates/rspack_javascript_compiler", default-features = false }
+rspack_loader_lightningcss             = { version = "=0.100.7", path = "crates/rspack_loader_lightningcss", default-features = false }
+rspack_loader_preact_refresh           = { version = "=0.100.7", path = "crates/rspack_loader_preact_refresh", default-features = false }
+rspack_loader_react_refresh            = { version = "=0.100.7", path = "crates/rspack_loader_react_refresh", default-features = false }
+rspack_loader_runner                   = { version = "=0.100.7", path = "crates/rspack_loader_runner", default-features = false }
+rspack_loader_swc                      = { version = "=0.100.7", path = "crates/rspack_loader_swc", default-features = false }
+rspack_loader_testing                  = { version = "=0.100.7", path = "crates/rspack_loader_testing", default-features = false }
+rspack_location                        = { version = "=0.100.7", path = "crates/rspack_location", default-features = false }
+rspack_macros                          = { version = "=0.100.7", path = "crates/rspack_macros", default-features = false }
+rspack_napi                            = { version = "=0.100.7", path = "crates/rspack_napi", default-features = false }
+rspack_napi_macros                     = { version = "=0.100.7", path = "crates/rspack_napi_macros", default-features = false }
+rspack_parallel                        = { version = "=0.100.7", path = "crates/rspack_parallel", default-features = false }
+rspack_paths                           = { version = "=0.100.7", path = "crates/rspack_paths", default-features = false }
+rspack_plugin_asset                    = { version = "=0.100.7", path = "crates/rspack_plugin_asset", default-features = false }
+rspack_plugin_banner                   = { version = "=0.100.7", path = "crates/rspack_plugin_banner", default-features = false }
+rspack_plugin_case_sensitive           = { version = "=0.100.7", path = "crates/rspack_plugin_case_sensitive", default-features = false }
+rspack_plugin_circular_dependencies    = { version = "=0.100.7", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
+rspack_plugin_copy                     = { version = "=0.100.7", path = "crates/rspack_plugin_copy", default-features = false }
+rspack_plugin_css                      = { version = "=0.100.7", path = "crates/rspack_plugin_css", default-features = false }
+rspack_plugin_css_chunking             = { version = "=0.100.7", path = "crates/rspack_plugin_css_chunking", default-features = false }
+rspack_plugin_devtool                  = { version = "=0.100.7", path = "crates/rspack_plugin_devtool", default-features = false }
+rspack_plugin_dll                      = { version = "=0.100.7", path = "crates/rspack_plugin_dll", default-features = false }
+rspack_plugin_dynamic_entry            = { version = "=0.100.7", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
+rspack_plugin_ensure_chunk_conditions  = { version = "=0.100.7", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
+rspack_plugin_entry                    = { version = "=0.100.7", path = "crates/rspack_plugin_entry", default-features = false }
+rspack_plugin_esm_library              = { version = "=0.100.7", path = "crates/rspack_plugin_esm_library", default-features = false }
+rspack_plugin_externals                = { version = "=0.100.7", path = "crates/rspack_plugin_externals", default-features = false }
+rspack_plugin_extract_css              = { version = "=0.100.7", path = "crates/rspack_plugin_extract_css", default-features = false }
+rspack_plugin_hmr                      = { version = "=0.100.7", path = "crates/rspack_plugin_hmr", default-features = false }
+rspack_plugin_html                     = { version = "=0.100.7", path = "crates/rspack_plugin_html", default-features = false }
+rspack_plugin_ignore                   = { version = "=0.100.7", path = "crates/rspack_plugin_ignore", default-features = false }
+rspack_plugin_javascript               = { version = "=0.100.7", path = "crates/rspack_plugin_javascript", default-features = false }
+rspack_plugin_json                     = { version = "=0.100.7", path = "crates/rspack_plugin_json", default-features = false }
+rspack_plugin_lazy_compilation         = { version = "=0.100.7", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
+rspack_plugin_library                  = { version = "=0.100.7", path = "crates/rspack_plugin_library", default-features = false }
+rspack_plugin_lightning_css_minimizer  = { version = "=0.100.7", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
+rspack_plugin_limit_chunk_count        = { version = "=0.100.7", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
+rspack_plugin_merge_duplicate_chunks   = { version = "=0.100.7", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
+rspack_plugin_mf                       = { version = "=0.100.7", path = "crates/rspack_plugin_mf", default-features = false }
+rspack_plugin_module_info_header       = { version = "=0.100.7", path = "crates/rspack_plugin_module_info_header", default-features = false }
+rspack_plugin_module_replacement       = { version = "=0.100.7", path = "crates/rspack_plugin_module_replacement", default-features = false }
+rspack_plugin_no_emit_on_errors        = { version = "=0.100.7", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
+rspack_plugin_progress                 = { version = "=0.100.7", path = "crates/rspack_plugin_progress", default-features = false }
+rspack_plugin_real_content_hash        = { version = "=0.100.7", path = "crates/rspack_plugin_real_content_hash", default-features = false }
+rspack_plugin_remove_duplicate_modules = { version = "=0.100.7", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
+rspack_plugin_remove_empty_chunks      = { version = "=0.100.7", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
+rspack_plugin_rsc                      = { version = "=0.100.7", path = "crates/rspack_plugin_rsc", default-features = false }
+rspack_plugin_rsdoctor                 = { version = "=0.100.7", path = "crates/rspack_plugin_rsdoctor", default-features = false }
+rspack_plugin_rslib                    = { version = "=0.100.7", path = "crates/rspack_plugin_rslib", default-features = false }
+rspack_plugin_rstest                   = { version = "=0.100.7", path = "crates/rspack_plugin_rstest", default-features = false }
+rspack_plugin_runtime                  = { version = "=0.100.7", path = "crates/rspack_plugin_runtime", default-features = false }
+rspack_plugin_runtime_chunk            = { version = "=0.100.7", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
+rspack_plugin_schemes                  = { version = "=0.100.7", path = "crates/rspack_plugin_schemes", default-features = false }
+rspack_plugin_size_limits              = { version = "=0.100.7", path = "crates/rspack_plugin_size_limits", default-features = false }
+rspack_plugin_split_chunks             = { version = "=0.100.7", path = "crates/rspack_plugin_split_chunks", default-features = false }
+rspack_plugin_sri                      = { version = "=0.100.7", path = "crates/rspack_plugin_sri", default-features = false }
+rspack_plugin_swc_js_minimizer         = { version = "=0.100.7", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
+rspack_plugin_wasm                     = { version = "=0.100.7", path = "crates/rspack_plugin_wasm", default-features = false }
+rspack_plugin_worker                   = { version = "=0.100.7", path = "crates/rspack_plugin_worker", default-features = false }
+rspack_regex                           = { version = "=0.100.7", path = "crates/rspack_regex", default-features = false }
+rspack_sources                         = { version = "=0.100.7", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
+rspack_storage                         = { version = "=0.100.7", path = "crates/rspack_storage", default-features = false }
+rspack_swc_plugin_import               = { version = "=0.100.7", path = "crates/swc_plugin_import", default-features = false }
+rspack_swc_plugin_ts_collector         = { version = "=0.100.7", path = "crates/swc_plugin_ts_collector", default-features = false }
+rspack_tasks                           = { version = "=0.100.7", path = "crates/rspack_tasks", default-features = false }
+rspack_tracing                         = { version = "=0.100.7", path = "crates/rspack_tracing", default-features = false }
+rspack_tracing_perfetto                = { version = "=0.100.7", path = "crates/rspack_tracing_perfetto", default-features = false }
+rspack_util                            = { version = "=0.100.7", path = "crates/rspack_util", default-features = false }
+rspack_watcher                         = { version = "=0.100.7", path = "crates/rspack_watcher", default-features = false }
+rspack_workspace                       = { version = "=0.100.7", path = "crates/rspack_workspace", default-features = false }
 
 
 [workspace.metadata.release]

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -6,10 +6,10 @@ pub const fn rspack_swc_core_version() -> &'static str {
 
 /// The version of the JavaScript `@rspack/core` package.
 pub const fn rspack_pkg_version() -> &'static str {
-  "2.0.6"
+  "2.0.7"
 }
 
 /// The version of the Rust workspace in the root `Cargo.toml` of the repository.
 pub const fn rspack_workspace_version() -> &'static str {
-  "0.100.6"
+  "0.100.7"
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-gnu",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-gnu.node",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-musl",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-musl.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-musl",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-musl.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-arm64-msvc",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-arm64-msvc.node",

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-ia32-msvc",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-ia32-msvc.node",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/browser",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Rspack for running in the browser. This is still in early stage and may not follow the semver.",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Test tools for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",


### PR DESCRIPTION
## Release Information

- Released By: intellild
- Release Date: 2026-06-10
- JavaScript Packages Version: 2.0.7
- Rust Crates Version: 0.100.7

---
_by OpenAI Codex_