### PR TITLE
fix: preserve inline source content for transform sourcemaps

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -46,7 +46,10 @@ impl SourceMapGenConfig for SourceMapConfig {
   }
 
   fn inline_sources_content(&self, _: &FileName) -> bool {
-    self.source_map_kind.inline_sources_content()
+    // Ideally transform should keep the original source via `original_source`, but
+    // NormalModule historically wraps loader output with `WithoutOriginalOptions`.
+    // Keep the old behavior of carrying it through SWC's inline source content.
+    self.source_map_kind.source_map()
   }
 
   fn emit_columns(&self, _f: &FileName) -> bool {

--- a/tests/rspack-test/configCases/source-map/nosources/index.js
+++ b/tests/rspack-test/configCases/source-map/nosources/index.js
@@ -1,3 +1,5 @@
+require("./list.test");
+
 it("should not include sourcesContent if noSources option is used", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
@@ -5,4 +7,67 @@ it("should not include sourcesContent if noSources option is used", function() {
 	expect(map).not.toHaveProperty("sourcesContent");
 });
 
+it("should preserve test call original positions when noSources option is used", async function() {
+	var fs = require("fs");
+	var path = require("path");
+	var sourceMap = require("source-map");
+
+	var source = fs.readFileSync(__filename + ".map", "utf-8");
+	var generated = fs.readFileSync(__filename, "utf-8");
+	var testSource = fs.readFileSync(path.resolve(CONTEXT, "./list.test.ts"), "utf-8");
+	var map = JSON.parse(source);
+	var consumer = await new sourceMap.SourceMapConsumer(map);
+	var testSourceIndex = map.sources.indexOf("webpack:///./list.test.ts");
+	expect(testSourceIndex).toBeGreaterThanOrEqual(0);
+	expect(map).not.toHaveProperty("sourcesContent");
+
+	var cases = [
+		["test a", 3, 9],
+		["test a-1", 4, 5],
+		["test a-2", 9, 3],
+	];
+	for (var i = 0; i < cases.length; i++) {
+		var c = cases[i];
+		var actual = positionsFor(generated, c[0])
+			.map(function(position) {
+				return consumer.originalPositionFor(position);
+			})
+			.find(function(position) {
+				return /\/list\.test\.ts$/.test(position.source || "");
+			});
+		var expected = callSitePositionFor(testSource, c[0]);
+		expect(expected).toEqual({ line: c[1], column: c[2] });
+		expect(actual).toBeTruthy();
+		expect(actual.line).toBe(expected.line);
+		expect(actual.column).toBe(expected.column);
+	}
+});
+
 if (Math.random() < 0) require("./test.js");
+
+var positionFor = function(content, text) {
+	var lines = content.split(/\r?\n/);
+	for (var i = 0; i < lines.length; i++) {
+		var column = lines[i].indexOf(text);
+		if (column >= 0) return { line: i + 1, column };
+	}
+	return null;
+};
+
+var callSitePositionFor = function(content, text) {
+	var position = positionFor(content, text);
+	return { line: position.line, column: position.column - 1 };
+};
+
+var positionsFor = function(content, text) {
+	var positions = [];
+	var lines = content.split(/\r?\n/);
+	for (var i = 0; i < lines.length; i++) {
+		var column = lines[i].indexOf(text);
+		while (column >= 0) {
+			positions.push({ line: i + 1, column });
+			column = lines[i].indexOf(text, column + text.length);
+		}
+	}
+	return positions;
+};

--- a/tests/rspack-test/configCases/source-map/nosources/list.test.ts
+++ b/tests/rspack-test/configCases/source-map/nosources/list.test.ts
@@ -1,0 +1,19 @@
+// Emulate the rstest e2e/list fixture layout.
+
+describe('test a', () => {
+  it('test a-1', () => {
+    void 0;
+  });
+});
+
+it('test a-2', () => {
+  void 0;
+});
+
+function describe(_name: string, fn: () => void) {
+  fn();
+}
+
+function it(_name: string, fn: () => void) {
+  fn();
+}

--- a/tests/rspack-test/configCases/source-map/nosources/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/nosources/rspack.config.js
@@ -1,3 +1,5 @@
+const { rspack } = require('@rspack/core');
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   mode: 'development',
@@ -6,4 +8,25 @@ module.exports = {
     __filename: false,
   },
   devtool: 'nosources-source-map',
+  externals: ['source-map'],
+  externalsType: 'commonjs',
+  resolve: {
+    extensions: ['...', '.ts'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          detectSyntax: 'auto',
+        },
+      },
+    ],
+  },
+  plugins: [
+    new rspack.DefinePlugin({
+      CONTEXT: JSON.stringify(__dirname),
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary

- keep SWC source map generation inlining source content whenever a full source map is requested
- add a comment explaining why transform still relies on inline source content

## Context

Ideally the transform pipeline should preserve the original source through `original_source`. However, the NormalModule path has historically wrapped loader output with `SourceMapSource::WithoutOriginalOptions`, so the transform stage does not get the original source through that channel.

Because of that historical behavior, the combined SWC source map is also the place where transform source content is carried. This restores the old behavior of using `source_map_kind.source_map()` for `inline_sources_content`, instead of deriving it from the newer `nosources`-aware helper.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_javascript_compiler`

---
_by OpenAI Codex_