### PR TITLE
chore: add scope hoisting regression for for-init references

### DIFF
--- a/tests/rspack-test/configCases/scope-hoisting/for-var-decl-init-reference/generate.js
+++ b/tests/rspack-test/configCases/scope-hoisting/for-var-decl-init-reference/generate.js
@@ -1,0 +1,9 @@
+const lightColorCount = 5;
+
+export default function generate() {
+	let total = 0;
+	for (let i = lightColorCount; i > 0; i -= 1) {
+		total += i;
+	}
+	return total;
+}

--- a/tests/rspack-test/configCases/scope-hoisting/for-var-decl-init-reference/index.js
+++ b/tests/rspack-test/configCases/scope-hoisting/for-var-decl-init-reference/index.js
@@ -1,0 +1,5 @@
+import generate from "./generate";
+
+it("should preserve references in for statement variable initializers", () => {
+	expect(generate()).toBe(15);
+});

--- a/tests/rspack-test/configCases/scope-hoisting/for-var-decl-init-reference/rspack.config.js
+++ b/tests/rspack-test/configCases/scope-hoisting/for-var-decl-init-reference/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  optimization: {
+    concatenateModules: true,
+    minimize: false,
+  },
+};


### PR DESCRIPTION
## Summary

Add a scope-hoisting regression case for references used in `for` statement variable initializers.

This covers a case like:

```js
for (let i = lightColorCount; i > 0; i -= 1) {}
```

where `lightColorCount` must keep the same scope identity as the top-level binding during module concatenation renaming.

## Verification

Fails with swc_experimental 0.9.2
Passes on current main with swc_experimental 0.10.0

## Related links

https://github.com/web-infra-dev/rspack/pull/14347

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
