### PR TITLE
perf: use mask intersects instead of flag iteration for scope globals

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -65,16 +65,10 @@ fn handle_scope_globals(
   runtime_requirements: &RuntimeGlobals,
   runtime_requirements_mut: &mut RuntimeGlobals,
 ) {
-  if runtime_requirements
-    .iter()
-    .any(|requirement| REQUIRE_SCOPE_GLOBALS.contains(requirement))
-  {
+  if runtime_requirements.intersects(*REQUIRE_SCOPE_GLOBALS) {
     runtime_requirements_mut.insert(RuntimeGlobals::REQUIRE_SCOPE);
   }
-  if runtime_requirements
-    .iter()
-    .any(|requirement| MODULE_GLOBALS.contains(requirement))
-  {
+  if runtime_requirements.intersects(*MODULE_GLOBALS) {
     runtime_requirements_mut.insert(RuntimeGlobals::MODULE);
   }
 }


### PR DESCRIPTION
### Why

`handle_scope_globals` runs once per module per runtime via the `runtime_requirement_in_module` hook (and again in `runtime_requirements_in_tree`). `RuntimeGlobals::iter()` walks all 78 defined flags on every call, showing up as ~14% self cost of the `runtime_requirements` stage benchmark in callgrind.

`REQUIRE_SCOPE_GLOBALS` / `MODULE_GLOBALS` are already union masks, so `.iter().any(|r| mask.contains(r))` is equivalent to a single bitwise `intersects(mask)`.

Expecting an improvement on the `runtime_requirements` benchmark; CodSpeed will verify.