### PR TITLE
perf: force DFA automaton for real content hash scanning

### DIFF
--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aho-corasick    = { workspace = true }
+aho-corasick    = { workspace = true, features = ["std", "perf-literal"] }
 atomic_refcell  = { workspace = true }
 derive_more     = { workspace = true, features = ["debug"] }
 indexmap        = { workspace = true }

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aho-corasick    = { workspace = true, features = ["std", "perf-literal"] }
+aho-corasick    = { workspace = true }
 atomic_refcell  = { workspace = true }
 derive_more     = { workspace = true, features = ["debug"] }
 indexmap        = { workspace = true }

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -107,10 +107,11 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   // the default automaton scanning with the slower contiguous NFA. Total
   // pattern bytes bound the DFA size; beyond the cap fall back to the default
   // automaton so pathological hash counts don't pay the DFA build cost
+  const DFA_PATTERN_BYTES_CAP: usize = 128 * 1024;
   let total_pattern_bytes: usize = hash_to_asset_names.keys().map(|s| s.len()).sum();
   let hash_ac = AhoCorasick::builder()
     .match_kind(MatchKind::LeftmostLongest)
-    .kind((total_pattern_bytes <= 128 * 1024).then_some(AhoCorasickKind::DFA))
+    .kind((total_pattern_bytes <= DFA_PATTERN_BYTES_CAP).then_some(AhoCorasickKind::DFA))
     .build(hash_to_asset_names.keys().map(|s| s.as_bytes()))
     .expect("Invalid patterns");
   logger.time_end(start);

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use aho_corasick::{AhoCorasick, MatchKind};
+use aho_corasick::{AhoCorasick, AhoCorasickKind, MatchKind};
 use atomic_refcell::AtomicRefCell;
 use derive_more::Debug;
 pub use drive::*;
@@ -103,8 +103,14 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   // use LeftmostLongest here:
   // e.g. 4afc|4afcbe match xxx.4afcbe-4afc.js -> xxx.[4afc]be-[4afc].js
   //      4afcbe|4afc match xxx.4afcbe-4afc.js -> xxx.[4afcbe]-[4afc].js
+  // force the DFA: hex hash patterns defeat the literal prefilters, leaving
+  // the default automaton scanning with the slower contiguous NFA. Total
+  // pattern bytes bound the DFA size; beyond the cap fall back to the default
+  // automaton so pathological hash counts don't pay the DFA build cost
+  let total_pattern_bytes: usize = hash_to_asset_names.keys().map(|s| s.len()).sum();
   let hash_ac = AhoCorasick::builder()
     .match_kind(MatchKind::LeftmostLongest)
+    .kind((total_pattern_bytes <= 128 * 1024).then_some(AhoCorasickKind::DFA))
     .build(hash_to_asset_names.keys().map(|s| s.as_bytes()))
     .expect("Invalid patterns");
   logger.time_end(start);


### PR DESCRIPTION
**Why:** Callgrind on `main` shows the hash scan (`aho_corasick::automaton::try_find_fwd`) at ~73% self cost of the `real_content_hash` stage benchmark. The scan runs on a contiguous NFA because aho-corasick's automatic kind selection is too conservative for this workload: it only attempts a DFA for sets of **≤ 100 patterns** (`build_auto`, aho-corasick 1.1.4), using pattern count as a crude proxy for DFA memory and ignoring actual pattern bytes. Content-hash sets are exactly the case this proxy misjudges — many but tiny patterns: the stage benchmark alone carries 300 distinct 8-char hashes (verified by probing `AhoCorasick::kind()` inside the benchmark: auto picks `ContiguousNFA` at 300 patterns, and flips DFA→NFA exactly between 100 and 101 patterns), yet the DFA it refuses to build costs only 257 KiB. The hex pattern set also defeats the literal prefilters, so the scan walks the NFA byte by byte.

**What:**
- Replace the upstream count-based gate with a size-based one: force `AhoCorasickKind::DFA` for the hash scan whenever total pattern bytes ≤ 128 KiB, falling back to the default automaton beyond that so pathological hash sets don't pay the DFA build cost.
- Make the previously-implicit `std`/`perf-literal` features explicit (feature unification already enabled them transitively).

**Memory impact** (measured via `AhoCorasick::memory_usage()`):

Benchmark case — 300 × 8-char hashes (`[contenthash:8]`, 2400 pattern bytes): forced DFA **257 KiB** vs auto ContiguousNFA 38 KiB (6.7×). Noise next to the asset sources the compilation already holds in memory.

Worst case — pattern set saturating the 128 KiB cap:

| hash length | patterns | forced DFA (mem / build) | auto ContiguousNFA (mem / build) | mem ratio |
|---|---|---|---|---|
| 8 chars (`[contenthash:8]`) | 16384 | 10.78 MiB / 36 ms | 1.12 MiB / 8 ms | 9.6× |
| 16 chars | 8192 | 13.65 MiB / 32 ms | 1.34 MiB / 6 ms | 10.2× |
| 20 chars (webpack full default) | 6553 | 14.19 MiB / 30 ms | 1.38 MiB / 6 ms | 10.3× |
| 32 chars | 4096 | 14.96 MiB / 35 ms | 1.44 MiB / 5 ms | 10.4× |
| 64 chars | 2048 | 15.54 MiB / 34 ms | 1.48 MiB / 5 ms | 10.5× |

Even fully saturated, the DFA tops out at ~15 MiB with a one-off ~35 ms build — and hitting the cap requires tens of thousands of content-hashed assets, where this stays a small fraction of compilation memory.

**Expectation:** the `real_content_hash` benchmark should improve substantially; CodSpeed on this PR verifies.
