### PR TITLE
docs: document source phase imports

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -147,7 +147,7 @@ import defer * as __rspack_external_jquery from 'jquery';
 
 ## experiments.sourceImport
 
-<ApiMeta stability={Stability.Experimental} />
+<ApiMeta stability={Stability.Experimental} addedVersion="2.0.8" />
 
 - **Type:** `boolean`
 - **Default:** `false`

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -2,7 +2,7 @@
 description: 'In minor releases, Rspack may change the APIs of experimental features'
 ---
 
-import { ApiMeta } from '../../../components/ApiMeta';
+import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import WebpackLicense from '@components/WebpackLicense';
 import PropertyType from '@components/PropertyType';
 
@@ -143,6 +143,48 @@ This is because `defer import` syntax is not yet supported by any runtime. In th
 import defer * as __rspack_external_jquery from 'jquery';
 ```
 
+:::
+
+## experiments.sourceImport
+
+<ApiMeta stability={Stability.Experimental} />
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Enables support for the TC39 [Source Phase Imports](https://github.com/tc39/proposal-source-phase-imports) proposal.
+
+Source phase imports let you import a module before it is evaluated. In Rspack, this support is currently designed for WebAssembly modules: importing a `.wasm` module in the source phase returns a compiled [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module), so you can instantiate it yourself, instantiate it more than once with different imports, or transfer it to a worker.
+
+Enable `experiments.sourceImport`:
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    sourceImport: true,
+  },
+};
+```
+
+You can use the static source-phase syntax:
+
+```js
+import source wasmModule from './module.wasm';
+
+const instance = await WebAssembly.instantiate(wasmModule, {
+  // imports...
+});
+```
+
+Or the dynamic syntax:
+
+```js
+const wasmModule = await import.source('./module.wasm');
+const instance = await WebAssembly.instantiate(wasmModule);
+```
+
+:::note
+For a normal WebAssembly import, Rspack instantiates the module and exposes its exports. For a source phase import, Rspack returns the compiled `WebAssembly.Module` instead, and your code is responsible for calling `WebAssembly.instantiate`.
 :::
 
 ## experiments.futureDefaults

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -329,7 +329,7 @@ export default {
 
 ## rules[].phase
 
-<ApiMeta stability={Stability.Experimental} />
+<ApiMeta stability={Stability.Experimental} addedVersion="2.0.8" />
 
 - **Type:** [`Condition`](#condition)
 - **Default:** `undefined`

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -327,6 +327,51 @@ export default {
 };
 ```
 
+## rules[].phase
+
+<ApiMeta stability={Stability.Experimental} />
+
+- **Type:** [`Condition`](#condition)
+- **Default:** `undefined`
+
+Matches modules by the import phase of the dependency that introduced the module.
+
+The value passed to the condition is one of:
+
+- `evaluation`: normal imports such as `import`, `import()`, `require()`, and other dependencies without a special import phase
+- `defer`: `import defer` and `import.defer()` dependencies when [`experiments.deferImport`](/config/experiments#experimentsdeferimport) is enabled
+- `source`: `import source` and `import.source()` dependencies when [`experiments.sourceImport`](/config/experiments#experimentssourceimport) is enabled
+
+This is useful when the same resource needs different loaders, parser options, or module types depending on how it is imported.
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    deferImport: true,
+    sourceImport: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /module\.js$/,
+        phase: 'evaluation',
+        loader: './evaluation-loader.js',
+      },
+      {
+        test: /module\.js$/,
+        phase: 'defer',
+        loader: './defer-loader.js',
+      },
+      {
+        test: /module\.js$/,
+        phase: 'source',
+        loader: './source-loader.js',
+      },
+    ],
+  },
+};
+```
+
 ## rules[].scheme
 
 - **Type:** [`Condition`](#condition)

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -2,7 +2,7 @@
 description: '在 minor release 中，Rspack 可能对这些实验性特性的 public API 做一些调整，并在更新日志中对这些变动进行详细的说明。'
 ---
 
-import { ApiMeta } from '../../../components/ApiMeta';
+import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import WebpackLicense from '@components/WebpackLicense';
 import PropertyType from '@components/PropertyType';
 import { Table } from '@builtIns';
@@ -144,6 +144,48 @@ import * as __rspack_external_jquery from 'jquery';
 import defer * as __rspack_external_jquery from 'jquery';
 ```
 
+:::
+
+## experiments.sourceImport
+
+<ApiMeta stability={Stability.Experimental} />
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+开启对 TC39 [Source Phase Imports](https://github.com/tc39/proposal-source-phase-imports) 提案的支持。
+
+Source phase import 允许在模块执行前导入模块。Rspack 当前主要面向 WebAssembly 模块提供该能力：以 source phase 导入 `.wasm` 模块时，返回的是编译后的 [`WebAssembly.Module`](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module)，你可以自行实例化它、使用不同 imports 多次实例化，或将它传递给 worker。
+
+启用 `experiments.sourceImport`：
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    sourceImport: true,
+  },
+};
+```
+
+你可以使用静态的 source-phase 语法：
+
+```js
+import source wasmModule from './module.wasm';
+
+const instance = await WebAssembly.instantiate(wasmModule, {
+  // imports...
+});
+```
+
+也可以使用动态语法：
+
+```js
+const wasmModule = await import.source('./module.wasm');
+const instance = await WebAssembly.instantiate(wasmModule);
+```
+
+:::note
+普通 WebAssembly 导入会由 Rspack 实例化模块并暴露其导出；source phase 导入会返回编译后的 `WebAssembly.Module`，需要你的代码自行调用 `WebAssembly.instantiate`。
 :::
 
 ## experiments.futureDefaults

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -148,7 +148,7 @@ import defer * as __rspack_external_jquery from 'jquery';
 
 ## experiments.sourceImport
 
-<ApiMeta stability={Stability.Experimental} />
+<ApiMeta stability={Stability.Experimental} addedVersion="2.0.8" />
 
 - **类型：** `boolean`
 - **默认值：** `false`

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -327,6 +327,51 @@ export default {
 };
 ```
 
+## rules[].phase
+
+<ApiMeta stability={Stability.Experimental} />
+
+- **类型：** [`Condition`](#condition)
+- **默认值：** `undefined`
+
+根据引入当前模块的依赖所处的 import phase 来匹配模块。
+
+传给 condition 的值可能是：
+
+- `evaluation`：普通的 `import`、`import()`、`require()`，以及其他没有特殊 import phase 的依赖
+- `defer`：启用 [`experiments.deferImport`](/config/experiments#experimentsdeferimport) 后的 `import defer` 和 `import.defer()` 依赖
+- `source`：启用 [`experiments.sourceImport`](/config/experiments#experimentssourceimport) 后的 `import source` 和 `import.source()` 依赖
+
+当同一个资源需要根据导入方式应用不同 Loader、parser 选项或模块类型时，可以使用该条件。
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    deferImport: true,
+    sourceImport: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /module\.js$/,
+        phase: 'evaluation',
+        loader: './evaluation-loader.js',
+      },
+      {
+        test: /module\.js$/,
+        phase: 'defer',
+        loader: './defer-loader.js',
+      },
+      {
+        test: /module\.js$/,
+        phase: 'source',
+        loader: './source-loader.js',
+      },
+    ],
+  },
+};
+```
+
 ## rules[].scheme
 
 - **类型：** [`Condition`](#condition)

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -329,7 +329,7 @@ export default {
 
 ## rules[].phase
 
-<ApiMeta stability={Stability.Experimental} />
+<ApiMeta stability={Stability.Experimental} addedVersion="2.0.8" />
 
 - **类型：** [`Condition`](#condition)
 - **默认值：** `undefined`


### PR DESCRIPTION
## Summary

This PR documents the source phase import support added for WebAssembly modules. It adds `experiments.sourceImport` usage examples for static `import source` and dynamic `import.source()`, and documents `module.rules[].phase` so users can match modules by `evaluation`, `defer`, or `source` import phases.

## Related links

- https://github.com/web-infra-dev/rspack/pull/13864
- https://github.com/webpack/webpack.js.org/pull/8157

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
