### PR TITLE
fix: apply global `overrideStrict` for ContextModule

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -272,13 +272,26 @@ impl ContextModule {
     resolve_dependencies: ResolveContextModuleDependencies,
     options: ContextModuleOptions,
   ) -> Self {
+    Self::new_with_strict(resolve_dependencies, options, None)
+  }
+
+  pub(crate) fn new_with_strict(
+    resolve_dependencies: ResolveContextModuleDependencies,
+    options: ContextModuleOptions,
+    strict: Option<bool>,
+  ) -> Self {
+    let mut build_info = BuildInfo::default();
+    if let Some(strict) = strict {
+      build_info.strict = strict;
+    }
+
     Self {
       dependencies: Vec::new(),
       blocks: Vec::new(),
       identifier: create_identifier(&options, None),
       options,
       factory_meta: None,
-      build_info: Default::default(),
+      build_info,
       build_meta: BuildMeta {
         exports_type: BuildMetaExportsType::Default,
         default_object: BuildMetaDefaultObject::RedirectWarn,

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -14,11 +14,12 @@ use tracing::instrument;
 use crate::{
   BoxDependency, CompilationId, ContextElementDependency, ContextModule, ContextModuleOptions,
   ContextModulePattern, DependencyCategory, DependencyId, DependencyType, GlobMatchOptions,
-  ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, ResolveArgs,
-  ResolveContextModuleDependencies, ResolveInnerOptions, ResolveOptionsWithDependencyType,
-  ResolveResult, Resolver, ResolverFactory, SharedPluginDriver, escape_glob_pattern,
-  extract_glob_base_dir, glob_match_normalized_with_explicit_dot, normalize_path_separators,
-  normalize_path_separators_for_path, resolve, unescape_glob_path, walk_dir,
+  ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult, OverrideStrict,
+  ResolveArgs, ResolveContextModuleDependencies, ResolveInnerOptions,
+  ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory, SharedPluginDriver,
+  escape_glob_pattern, extract_glob_base_dir, glob_match_normalized_with_explicit_dot,
+  normalize_path_separators, normalize_path_separators_for_path, resolve, unescape_glob_path,
+  walk_dir,
 };
 
 #[derive(Debug)]
@@ -216,6 +217,7 @@ impl ContextModuleFactory {
     before_resolve_data: Box<BeforeResolveData>,
   ) -> Result<(ModuleFactoryResult, Option<ContextModuleOptions>)> {
     let plugin_driver = &self.plugin_driver;
+    let strict = self.global_override_strict();
     let dependency = data.dependencies[0]
       .as_context_dependency()
       .expect("should be context dependency");
@@ -311,7 +313,12 @@ impl ContextModuleFactory {
           context_options: dependency_options,
           type_prefix: dependency.type_prefix(),
         };
-        let module = ContextModule::new(self.resolve_dependencies.clone(), options.clone()).boxed();
+        let module = ContextModule::new_with_strict(
+          self.resolve_dependencies.clone(),
+          options.clone(),
+          strict,
+        )
+        .boxed();
         (module, Some(options))
       }
       Ok(ResolveResult::Ignored) => {
@@ -330,7 +337,12 @@ impl ContextModuleFactory {
           context_options: dependency_options,
           type_prefix: dependency.type_prefix(),
         };
-        let module = ContextModule::new(self.resolve_dependencies.clone(), options.clone()).boxed();
+        let module = ContextModule::new_with_strict(
+          self.resolve_dependencies.clone(),
+          options.clone(),
+          strict,
+        )
+        .boxed();
         (module, Some(options))
       }
       Err(err) => {
@@ -396,15 +408,29 @@ impl ContextModuleFactory {
         context_module_options.context_options.pattern = after_resolve_data.pattern.clone();
         context_module_options.context_options.recursive = after_resolve_data.recursive;
 
-        let module = ContextModule::new(
+        let module = ContextModule::new_with_strict(
           after_resolve_data.resolve_dependencies,
           context_module_options.clone(),
+          self.global_override_strict(),
         )
         .boxed();
 
         Ok(Some(ModuleFactoryResult::new_with_module(module)))
       }
     }
+  }
+
+  fn global_override_strict(&self) -> Option<bool> {
+    self
+      .plugin_driver
+      .options
+      .module
+      .parser
+      .as_ref()
+      .and_then(|parser| parser.get("javascript"))
+      .and_then(|parser| parser.get_javascript())
+      .and_then(|options| options.override_strict)
+      .map(|strict| matches!(strict, OverrideStrict::Strict))
   }
 }
 

--- a/tests/rspack-test/configCases/parsing/override-strict-context-module/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/override-strict-context-module/rspack.config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+  mode: 'production',
+  entry: ['./strict'],
+  module: {
+    parser: {
+      javascript: {
+        overrideStrict: 'strict',
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/parsing/override-strict-context-module/strict.js
+++ b/tests/rspack-test/configCases/parsing/override-strict-context-module/strict.js
@@ -1,0 +1,16 @@
+import fs from "fs";
+
+it("should import", async () => {
+	const n = "a.js";
+	const { default: a1 } = await import(`./sub/${n}`);
+	expect(typeof a1).toBe("function");
+});
+
+it("should not have iife for entry module when modules strict is different", () => {
+	const code = fs.readFileSync(__filename, "utf-8");
+	const iifeComment = [
+		"This entry needs to be wrapped in an IIFE",
+		"because it needs to be in strict mode."
+	].join(" ");
+	expect(code).not.toMatch(iifeComment);
+});

--- a/tests/rspack-test/configCases/parsing/override-strict-context-module/sub/a.js
+++ b/tests/rspack-test/configCases/parsing/override-strict-context-module/sub/a.js
@@ -1,0 +1,1 @@
+export default function () {}


### PR DESCRIPTION
## Summary

- Port webpack/webpack#21142 to make ContextModule respect the global `module.parser.javascript.overrideStrict` option.
- Apply the global override when creating Rspack `ContextModule`s instead of forcing every context module to `strict: true`.
- Add the upstream webpack config case for `parsing/override-strict-context-module`, with only `webpack.config.js` renamed to `rspack.config.js`.

## Upstream PR

- https://github.com/webpack/webpack/pull/21142
- Upstream title: `fix: apply global overrideStrict for ContextModule`
- This supersedes the earlier Rspack PR approach that was blocked while the webpack-side change was not merged.

## Related

- Replaces #9675. GitHub cannot reopen #9675 after the head branch was force-pushed/recreated, so this PR uses the updated branch as a replacement.

## Test Plan

- [x] `pnpm run build:binding:dev`
- [x] `cd tests/rspack-test && pnpm run test -t "configCases/parsing/override-strict"`
