### PR TITLE
chore(ci): use mini runner to offload lightweight CI jobs

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Rust Test Required Check
     needs: [rust_tests]
     if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Log
         run: echo ${{ needs.*.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   check-changed:
-    runs-on: rspack-ubuntu-22.04-mini
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     name: Check Source Changed
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed == 'true' }}
@@ -192,7 +192,7 @@ jobs:
         check-cache,
       ]
     if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Log
         run: echo ${{ join(needs.*.result, ',') }}

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-changed:
-    runs-on: rspack-ubuntu-22.04-mini
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     name: Check Source Changed
     outputs:
       code_changed: ${{ steps.filter.outputs.code_changed == 'true' }}
@@ -194,7 +194,7 @@ jobs:
         check-changed,
       ]
     if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Log
         run: echo ${{ join(needs.*.result, ',') }}


### PR DESCRIPTION
## Why

Lightweight jobs (required-check aggregations that only run `echo`, and `paths-filter` checks) don't need a full-size GitHub-hosted runner. Moving them to the self-hosted mini runner offloads CI tasks from GitHub-hosted runners and reduces queueing in the critical CI path.

All of them now use the new `CI_LINUX_MINI_RUNNER` repo variable, falling back to `ubuntu-latest` when the variable is not set, so forks without the self-hosted runner still work:

```yaml
runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
```

This also fixes the previously hardcoded `rspack-ubuntu-22.04-mini` in the two `check-changed` jobs, which would queue forever on forks.