### PR TITLE
fix: remove webpackSource and webpackDefer magic comments

### DIFF
--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -25,8 +25,6 @@ pub enum RspackComment {
   ExcludeRegexp,
   Mode,
   Exports,
-  Defer,
-  Source,
 }
 
 impl RspackComment {
@@ -47,8 +45,6 @@ impl fmt::Display for RspackComment {
       Self::ExcludeRegexp => "Exclude",
       Self::Mode => "Mode",
       Self::Exports => "Exports",
-      Self::Defer => "Defer",
-      Self::Source => "Source",
     })
   }
 }
@@ -67,8 +63,6 @@ impl TryFrom<&str> for RspackComment {
       "Exclude" => Ok(Self::ExcludeRegexp),
       "Mode" => Ok(Self::Mode),
       "Exports" => Ok(Self::Exports),
-      "Defer" => Ok(Self::Defer),
-      "Source" => Ok(Self::Source),
       _ => Err(()),
     }
   }
@@ -249,20 +243,6 @@ impl RspackCommentMap {
     match self.0.get(&RspackComment::Exports).map(|item| &item.value) {
       Some(MagicCommentValue::String(value)) => Some(vec![value.clone()]),
       Some(MagicCommentValue::Array(value)) => Some(value.clone()),
-      _ => None,
-    }
-  }
-
-  pub fn get_defer(&self) -> Option<bool> {
-    match self.0.get(&RspackComment::Defer).map(|item| &item.value) {
-      Some(MagicCommentValue::Bool(value)) => Some(*value),
-      _ => None,
-    }
-  }
-
-  pub fn get_source(&self) -> Option<bool> {
-    match self.0.get(&RspackComment::Source).map(|item| &item.value) {
-      Some(MagicCommentValue::Bool(value)) => Some(*value),
       _ => None,
     }
   }
@@ -636,22 +616,6 @@ fn analyze_comments(
             continue;
           }
         }
-        RspackComment::Defer => {
-          if let Some(value) = expr_to_bool(value) {
-            MagicCommentValue::Bool(value)
-          } else {
-            push_parse_warning("a boolean");
-            continue;
-          }
-        }
-        RspackComment::Source => {
-          if let Some(value) = expr_to_bool(value) {
-            MagicCommentValue::Bool(value)
-          } else {
-            push_parse_warning("a boolean");
-            continue;
-          }
-        }
         RspackComment::FetchPriority => {
           if let Some(priority) = expr_to_str(value)
             && matches!(priority.as_ref(), "low" | "high" | "auto")
@@ -935,14 +899,6 @@ mod tests_extract_magic_comment_object {
       Some(RspackComment::Mode)
     );
     assert_eq!(
-      parse_magic_comment_name("rspackDefer").map(|(comment, _)| comment),
-      Some(RspackComment::Defer)
-    );
-    assert_eq!(
-      parse_magic_comment_name("rspackSource").map(|(comment, _)| comment),
-      Some(RspackComment::Source)
-    );
-    assert_eq!(
       parse_magic_comment_name("rspackFetchPriority").map(|(comment, _)| comment),
       Some(RspackComment::FetchPriority)
     );
@@ -969,8 +925,6 @@ mod tests_extract_magic_comment_object {
         rspackPreload: true,
         rspackIgnore: true,
         rspackMode: "eager",
-        rspackDefer: true,
-        rspackSource: true,
         rspackFetchPriority: "high",
         rspackInclude: /\.js$/,
         rspackExclude: /\.test\.js$/,
@@ -984,8 +938,6 @@ mod tests_extract_magic_comment_object {
     assert_eq!(comments.get_preload().as_deref(), Some("true"));
     assert_eq!(comments.get_ignore(), Some(true));
     assert_eq!(comments.get_mode(), Some(&"eager".to_string()));
-    assert_eq!(comments.get_defer(), Some(true));
-    assert_eq!(comments.get_source(), Some(true));
     assert_eq!(comments.get_fetch_priority(), Some(&"high".to_string()));
     assert!(comments.get_include().is_some());
     assert!(comments.get_exclude().is_some());
@@ -1006,10 +958,6 @@ mod tests_extract_magic_comment_object {
         webpackPreload: true,
         webpackIgnore: false,
         rspackIgnore: true,
-        webpackDefer: false,
-        rspackDefer: true,
-        rspackSource: true,
-        webpackSource: false,
         rspackFetchPriority: "high",
         webpackFetchPriority: "low",
         webpackInclude: /\.jsx$/,
@@ -1026,21 +974,17 @@ mod tests_extract_magic_comment_object {
     assert_eq!(comments.get_prefetch().as_deref(), Some("true"));
     assert_eq!(comments.get_preload().as_deref(), Some("2"));
     assert_eq!(comments.get_ignore(), Some(true));
-    assert_eq!(comments.get_defer(), Some(true));
-    assert_eq!(comments.get_source(), Some(true));
     assert_eq!(comments.get_fetch_priority(), Some(&"high".to_string()));
     assert_eq!(comments.get_include().unwrap().source(), r#"\.js$"#);
     assert_eq!(comments.get_exclude().unwrap().source(), r#"\.test\.js$"#);
     assert_eq!(comments.get_exports(), Some(vec!["rspack".into()]));
-    assert_eq!(warnings.len(), 11);
+    assert_eq!(warnings.len(), 9);
     for webpack_name in [
       "webpackChunkName",
       "webpackMode",
       "webpackPrefetch",
       "webpackPreload",
       "webpackIgnore",
-      "webpackDefer",
-      "webpackSource",
       "webpackFetchPriority",
       "webpackInclude",
       "webpackExclude",

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -57,7 +57,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
   ) -> Option<bool> {
     parser.last_esm_import_order += 1;
     let attributes = import_decl.with.as_ref().map(|obj| get_attributes(obj));
-    let phase = get_import_phase(parser, import_decl.phase, None, None);
+    let phase = get_import_phase(parser, import_decl.phase);
     check_import_phase(parser, phase);
     let import_span = import_decl.span;
     let dependency = ESMImportSideEffectDependency::new(
@@ -94,7 +94,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     name: &Atom,
   ) -> Option<bool> {
     let is_create_require = is_create_require_import(parser, source, id);
-    let phase = get_import_phase(parser, statement.phase, None, None);
+    let phase = get_import_phase(parser, statement.phase);
     parser.tag_variable::<ESMSpecifierData>(
       name.clone(),
       ESM_SPECIFIER_TAG,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -370,12 +370,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
     }
 
     let syntax_phase = node.callee.as_import().expect("should be import").phase;
-    let phase = get_import_phase(
-      parser,
-      syntax_phase,
-      magic_comment_options.get_defer(),
-      magic_comment_options.get_source(),
-    );
+    let phase = get_import_phase(parser, syntax_phase);
     if phase.is_defer() && !parser.compiler_options.experiments.defer_import {
       parser.add_error(rspack_error::error!("deferImport is still an experimental feature. To continue using it, please enable 'experiments.deferImport'.").into());
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_phase.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_phase.rs
@@ -6,10 +6,8 @@ use crate::visitors::JavascriptParser;
 pub(super) fn get_import_phase(
   parser: &JavascriptParser,
   syntax_phase: AstImportPhase,
-  webpack_defer: Option<bool>,
-  webpack_source: Option<bool>,
 ) -> ImportPhase {
-  let phase_by_syntax = match syntax_phase {
+  match syntax_phase {
     AstImportPhase::Defer if parser.javascript_options.defer_import.unwrap_or_default() => {
       ImportPhase::Defer
     }
@@ -17,19 +15,5 @@ pub(super) fn get_import_phase(
       ImportPhase::Source
     }
     _ => ImportPhase::Evaluation,
-  };
-
-  if parser.javascript_options.defer_import.unwrap_or_default()
-    && matches!(webpack_defer, Some(true))
-  {
-    return ImportPhase::Defer;
   }
-
-  if parser.javascript_options.source_import.unwrap_or_default()
-    && matches!(webpack_source, Some(true))
-  {
-    return ImportPhase::Source;
-  }
-
-  phase_by_syntax
 }

--- a/tests/rspack-test/configCases/wasm/source-phase-universal/index.js
+++ b/tests/rspack-test/configCases/wasm/source-phase-universal/index.js
@@ -14,14 +14,13 @@ it("should allow to run a WebAssembly module (direct)", function() {
 	});
 });
 
-it("should allow to run a WebAssembly module using comment (direct)", function() {
-	return import(/* webpackSource: true */ "./wasm.wat?3")
-		.then(wasmModule => WebAssembly.instantiate(wasmModule))
-		.then(({ exports }) => {
-
-			const result = exports.add(exports.getNumber(), 2);
-			expect(result).toEqual(42);
-		});
+it("should ignore source phase magic comments", function() {
+	return import(
+		/* webpackSource: true, rspackSource: true */ "./wasm.wat?3"
+	).then(function(wasmModule) {
+		const result = wasmModule.add(wasmModule.getNumber(), 2);
+		expect(result).toEqual(42);
+	});
 });
 
 it("should allow to run the same WebAssembly module with source", function() {


### PR DESCRIPTION
## Summary

In https://github.com/web-infra-dev/rspack/pull/13864 we add `/* webpackSource: true */` and `/* webpackDefer: true */` magic comments support. However, after further consideration, we have decided to remove support for these two magic comments. Users should directly use `import.source()` and `import.defer()` instead of magic comments.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
