### PR TITLE
docs: document split chunks options

### DIFF
--- a/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
@@ -383,6 +383,36 @@ Like `maxSize`, `maxInitialSize` can be applied globally (`splitChunks.maxInitia
 
 The difference between `maxInitialSize` and `maxSize` is that `maxInitialSize` will only affect initial load chunks.
 
+### splitChunks.fallbackCacheGroup
+
+- **Type:**
+
+```ts
+type FallbackCacheGroup = {
+  chunks?: 'initial' | 'async' | 'all' | RegExp | ((chunk: Chunk) => boolean);
+  minSize?: number;
+  maxSize?: number;
+  maxAsyncSize?: number;
+  maxInitialSize?: number;
+  automaticNameDelimiter?: string;
+};
+```
+
+Configures options for modules that are not selected by any cache group. The fallback cache group uses the same sizing behavior as the corresponding global `splitChunks` options, but only for the remaining modules after cache group matching.
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      fallbackCacheGroup: {
+        minSize: 10_000,
+        maxSize: 50_000,
+      },
+    },
+  },
+};
+```
+
 ### splitChunks.automaticNameDelimiter
 
 - **Type:** `string`
@@ -664,6 +694,27 @@ If the setting of reuseExistingChunk is set to `false`, then the module B in chu
 - **Types:** `string | RegExp`
 
 Allows to assign modules to a cache group by module type.
+
+#### splitChunks.cacheGroups.\{cacheGroup\}.layer
+
+- **Type:** `string | RegExp | ((layer?: string) => boolean)`
+
+Assigns modules to a cache group by module layer. This is useful when [entry](/config/entry#entrydescriptionlayer) or [rule](/config/module-rules#ruleslayer) layers are used to separate modern, legacy, server, or client code paths.
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        modern: {
+          layer: 'modern',
+          chunks: 'all',
+        },
+      },
+    },
+  },
+};
+```
 
 ## FAQ
 

--- a/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
@@ -381,6 +381,36 @@ Rspack 在处理 `maxSize` 时会基于路径派生出的确定性 key 对模块
 
 `maxInitialSize` 和 `maxSize` 的区别在于 `maxInitialSize` 仅会影响初始加载 chunks。
 
+### splitChunks.fallbackCacheGroup
+
+- **类型：**
+
+```ts
+type FallbackCacheGroup = {
+  chunks?: 'initial' | 'async' | 'all' | RegExp | ((chunk: Chunk) => boolean);
+  minSize?: number;
+  maxSize?: number;
+  maxAsyncSize?: number;
+  maxInitialSize?: number;
+  automaticNameDelimiter?: string;
+};
+```
+
+用于配置未被任何 cache group 选中的模块。fallback cache group 的体积相关行为与对应的全局 `splitChunks` 选项一致，但只作用于 cache group 匹配完成后剩余的模块。
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      fallbackCacheGroup: {
+        minSize: 10_000,
+        maxSize: 50_000,
+      },
+    },
+  },
+};
+```
+
 ### splitChunks.automaticNameDelimiter
 
 - **类型：** `string`
@@ -658,6 +688,27 @@ cacheGroup: {
 - **Types:** `string | RegExp`
 
 允许模块根据模块类型分配给 cache group
+
+#### splitChunks.cacheGroups.\{cacheGroup\}.layer
+
+- **类型：** `string | RegExp | ((layer?: string) => boolean)`
+
+根据模块 layer 将模块分配给 cache group。当你通过 [entry](/config/entry#entrydescriptionlayer) 或 [rule](/config/module-rules#ruleslayer) 的 layer 区分 modern、legacy、server、client 等代码路径时，这个选项会很有用。
+
+```js title="rspack.config.mjs"
+export default {
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        modern: {
+          layer: 'modern',
+          chunks: 'all',
+        },
+      },
+    },
+  },
+};
+```
 
 ## 常见问题 {#faq}
 


### PR DESCRIPTION
## Summary

Document missing SplitChunksPlugin options in both English and Chinese docs. This adds `splitChunks.fallbackCacheGroup` and `splitChunks.cacheGroups.{cacheGroup}.layer`, including their supported types and examples.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).