### PR TITLE
test: add build meta css fields

### DIFF
--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -858,6 +858,8 @@ impl From<JsBuildMeta> for BuildMeta {
       strict_esm_module: strict_esm_module.unwrap_or_default(),
       has_top_level_await: has_top_level_await.unwrap_or_default(),
       esm: esm.unwrap_or_default(),
+      is_css_module: false,
+      need_id_in_concatenation: false,
       exports_type,
       default_object,
       side_effect_free,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -409,6 +409,8 @@ pub struct BuildMeta {
   // same as is_async https://github.com/webpack/webpack/blob/3919c844eca394d73ca930e4fc5506fb86e2b094/lib/Module.js#L107
   pub has_top_level_await: bool,
   pub esm: bool,
+  pub is_css_module: bool,
+  pub need_id_in_concatenation: bool,
   pub exports_type: BuildMetaExportsType,
   pub default_object: BuildMetaDefaultObject,
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
@@ -62,7 +62,7 @@ __rspack_async_done();
 },
 "./wasm.wasm"(module, exports, __webpack_require__) {
 var __rspack_instantiate__ = function ([rspack_import_0, rspack_import_1]) {
-return __webpack_require__.v(exports, module.id, "a6713fea1064f4d3" , {
+return __webpack_require__.v(exports, module.id, "59e423082e604bb6" , {
 "./module": {
 "getNumber": rspack_import_0.getNumber
 },
@@ -78,7 +78,7 @@ __webpack_require__.a(module, async function (__rspack_load_async_deps, __rspack
 
     var __rspack_async_deps = __rspack_load_async_deps([rspack_import_0, rspack_import_1]);
     var [rspack_import_0, rspack_import_1] = __rspack_async_deps.then ? (await __rspack_async_deps)() : __rspack_async_deps;
-    await __webpack_require__.v(exports, module.id, "a6713fea1064f4d3" , {
+    await __webpack_require__.v(exports, module.id, "59e423082e604bb6" , {
 "./module": {
 "getNumber": rspack_import_0.getNumber
 },

--- a/tests/rspack-test/builtinCases/plugin-wasm/v128/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/v128/__snapshots__/output.snap.txt
@@ -15,7 +15,7 @@ __rspack_async_done();
 
 },
 "./v128.wasm"(module, exports, __webpack_require__) {
-module.exports = __webpack_require__.v(exports, module.id, "a32782c316f3bc9b" );
+module.exports = __webpack_require__.v(exports, module.id, "5d92a1394828be63" );
 
 },
 

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 5494176960333ddb,
+			      hash: feddfe48d0d4e576,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 2574529075ccb8c5,
+			  hash: e3239eec35f7debc,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (7762259ba9d01658)
+Rspack compiled successfully (15f204d08502aa31)

--- a/tests/rspack-test/statsOutputCases/wasm-explorer-examples-sync/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/wasm-explorer-examples-sync/__snapshots__/stats.txt
@@ -1,17 +1,17 @@
 assets by path *.wasm xx KiB
-  asset 5b1cf9eabe97b5fa.module.wasm xx bytes [emitted] [immutable]
-  asset d6fb27cc8ba95963.module.wasm xx bytes [emitted] [immutable]
-  asset dd6d2a216fd153df.module.wasm xx bytes [emitted] [immutable]
-  asset 1b3ca18da9ba7585.module.wasm xx bytes [emitted] [immutable]
-  asset d570402154524085.module.wasm xx bytes [emitted] [immutable]
-  asset 41d0d47cfd218be6.module.wasm xx bytes [emitted] [immutable]
+  asset 7090e28ebb84fdd8.module.wasm xx bytes [emitted] [immutable]
+  asset 977bb0cc74309149.module.wasm xx bytes [emitted] [immutable]
+  asset 717bac786f333ac8.module.wasm xx bytes [emitted] [immutable]
+  asset 4a4b2b7db243bbe2.module.wasm xx bytes [emitted] [immutable]
+  asset 52984547ebee2c67.module.wasm xx bytes [emitted] [immutable]
+  asset 00084e490b41b700.module.wasm xx bytes [emitted] [immutable]
 assets by path *.js xx KiB
   asset bundle.js xx KiB [emitted] (name: main)
   asset 549.bundle.js xx KiB [emitted]
   asset 440.bundle.js xx bytes [emitted] (id hint: vendors)
 chunk (runtime: main) 440.bundle.js (id hint: vendors) xx bytes [rendered] split chunk (cache group: defaultVendors)
   ./node_modules/env.js xx bytes [built] [code generated]
-chunk (runtime: main) 1b3ca18da9ba7585.module.wasm, 41d0d47cfd218be6.module.wasm, 549.bundle.js, 5b1cf9eabe97b5fa.module.wasm, d570402154524085.module.wasm, d6fb27cc8ba95963.module.wasm, dd6d2a216fd153df.module.wasm xx KiB (javascript) xx KiB (wasm) [rendered]
+chunk (runtime: main) 00084e490b41b700.module.wasm, 4a4b2b7db243bbe2.module.wasm, 52984547ebee2c67.module.wasm, 549.bundle.js, 7090e28ebb84fdd8.module.wasm, 717bac786f333ac8.module.wasm, 977bb0cc74309149.module.wasm xx KiB (javascript) xx KiB (wasm) [rendered]
   ./Q_rsqrt.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]
   ./duff.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]
   ./fact.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]


### PR DESCRIPTION
`is_css_module` and `need_id_in_concatenation` is required for css export type "style" HMR with concatenation

## Summary

- Add `is_css_module` and `need_id_in_concatenation` fields to `BuildMeta`.
- Default the new fields to `false` when converting `JsBuildMeta` from bindings.
- Update hash-sensitive wasm/stats snapshots affected by the `BuildMeta` hash shape change.

## Related Links

https://github.com/webpack/webpack/pull/20911

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm --filter @rspack/binding test`
- `pnpm --filter @rspack/cli test`
- `pnpm --filter @rspack/tests test -t plugin-wasm --maxConcurrency 2`
- `pnpm --filter @rspack/tests test -t statsAPICases-statsAPICases/exports --maxConcurrency 2`
- `pnpm --filter @rspack/tests test -t auxiliary-files-test --maxConcurrency 2`
- `pnpm --filter @rspack/tests test -t wasm-explorer-examples-sync --maxConcurrency 2`

Note: full `pnpm --filter @rspack/tests test --maxConcurrency 2` still hit unrelated local failures in `Config.part3.test.js` (`require/module-require` JavaScript scope panic) and `HotSnapshot.hottest.js` (`worker/update-in-worker` did not complete all hot steps). Native watcher timeout during broad `exports` snapshot update was ignored per local project guidance.

---
_by OpenAI Codex_