### PR TITLE
docs: add Remotion to ecosystem

### DIFF
--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -123,6 +123,15 @@ Rspack team and Nx team have collaborated to provide the [Rspack Nx plugin](http
 
 Re.Pack v5 uses Rspack and React Native community CLI's plugin system to allow you to bundle your application using Rspack and easily switch from Metro.
 
+### Remotion
+
+<Tag color="geekblue">Video framework</Tag>
+<Tag color="purple">React</Tag>
+
+[Remotion](https://www.remotion.dev/) is a React-based framework for creating videos programmatically.
+
+The [`@remotion/bundler`](https://www.remotion.dev/docs/bundle#rspack) package can use Rspack to bundle Remotion projects.
+
 ### Shakapacker
 
 <Tag color="geekblue">Build tool</Tag>

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -114,6 +114,14 @@ Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://nx.dev/nx-a
 
 Re.Pack v5 使用 Rspack 和 React Native 社区 CLI 的插件系统，允许你使用 Rspack 打包你的应用，并轻松切换到 Metro。
 
+### Remotion
+
+<Tag color="geekblue">视频框架</Tag> <Tag color="purple">React</Tag>
+
+[Remotion](https://www.remotion.dev/) 是一个基于 React 的视频创作框架，可以用代码以编程方式生成视频。
+
+[`@remotion/bundler`](https://www.remotion.dev/docs/bundle#rspack) 可以使用 Rspack 打包 Remotion 项目。
+
 ### Shakapacker
 
 <Tag color="geekblue">构建工具</Tag> <Tag color="purple">Rails</Tag>


### PR DESCRIPTION
## Summary

This PR adds Remotion to the Ecosystem docs so users can find the Remotion integration and its Rspack-powered bundling support through `@remotion/bundler`.

## Related links

https://www.remotion.dev/docs/bundle#rspack

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).