### PR TITLE
fix(tree-shaking): handle nested pure function calls

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -8,10 +8,10 @@ use rustc_hash::FxHashSet;
 use swc_atoms::Atom;
 use swc_experimental_allocator::{CloneIn, atom::Atom as AstAtom};
 use swc_experimental_ecma_ast::{
-  ArrowExpr, BlockStmt, BlockStmtOrExpr, CallExpr, Class, ClassMember, CommentKind, Comments, Decl,
-  DefaultDecl, ExportSpecifier, Expr, ExprOrSpread, Function, GetSpan, ImportSpecifier, ModuleDecl,
-  ModuleExportName, ModuleItem, ObjectPatProp, Pat, Program, PropName, ScopeId, Span,
-  Span as AstSpan, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
+  ArrayLit, ArrowExpr, BlockStmt, BlockStmtOrExpr, CallExpr, Class, ClassMember, CommentKind,
+  Comments, Decl, DefaultDecl, ExportSpecifier, Expr, ExprOrSpread, Function, GetSpan,
+  ImportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, ObjectPatProp, Pat, Program, PropName,
+  ScopeId, Span, Span as AstSpan, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
 };
 use swc_experimental_ecma_utils::{ExprCtx, ExprExt};
 
@@ -922,6 +922,31 @@ fn is_pure_call_args(
   true
 }
 
+fn is_pure_array_lit<'a>(
+  parser: &mut JavascriptParser,
+  analyze_side_effects_free: bool,
+  array_lit: &'a ArrayLit,
+  unresolved_ctxt: ScopeId,
+  comments: &'a Comments<'a>,
+  mut callees: Option<&mut Vec<(Atom, Span)>>,
+) -> bool {
+  for elem in array_lit.elems.iter().flatten() {
+    if elem.spread.is_some()
+      || !is_pure_expression(
+        parser,
+        analyze_side_effects_free,
+        &elem.expr,
+        unresolved_ctxt,
+        comments,
+        callees.as_deref_mut(),
+      )
+    {
+      return false;
+    }
+  }
+  true
+}
+
 enum ExplicitSideEffectsFreeCallee {
   Direct,
   Deferred,
@@ -962,7 +987,17 @@ fn resolve_explicit_side_effects_free_callee(
     }
   }
 
-  if parser.get_variable_info(ident).is_some() || allow_unresolved_marked {
+  if let Some((declared_scope, is_free)) = parser
+    .get_variable_info(ident)
+    .map(|info| (info.declared_scope, info.is_free()))
+  {
+    if !is_free && declared_scope == parser.definitions {
+      return ExplicitSideEffectsFreeCallee::Direct;
+    }
+    return ExplicitSideEffectsFreeCallee::Invalid;
+  }
+
+  if allow_unresolved_marked {
     return ExplicitSideEffectsFreeCallee::Direct;
   }
 
@@ -1591,6 +1626,14 @@ pub fn is_pure_expression<'a>(
     }
 
     match expr {
+      Expr::Array(array_lit) => is_pure_array_lit(
+        parser,
+        analyze_side_effects_free,
+        array_lit,
+        unresolved_ctxt,
+        comments,
+        callees.as_deref_mut(),
+      ),
       Expr::Call(_) => is_pure_call_expr(
         parser,
         analyze_side_effects_free,

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/__snapshots__/esm.snap.txt
@@ -1,0 +1,8 @@
+```mjs title=main.mjs
+// ./index.js
+
+
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/decl.js
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/decl.js
@@ -1,0 +1,9 @@
+export function a(value, label) {
+  (globalThis.__PURE_FUNCTION_EDGE_CALLS__ ||= []).push(label);
+  return value;
+}
+
+export function b(label, value) {
+  (globalThis.__PURE_FUNCTION_EDGE_CALLS__ ||= []).push(label);
+  return value;
+}

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/index.js
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/index.js
@@ -1,0 +1,2 @@
+import "./pure-call-with-pure-call-array-arg";
+import "./pure-call-with-local-pure-call-arg";

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/pure-call-with-local-pure-call-arg.js
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/pure-call-with-local-pure-call-arg.js
@@ -1,0 +1,7 @@
+import { a, b } from "./decl";
+
+function foo() {
+  return 1;
+}
+
+a([b("PURE_NESTING_LOCAL_B_MARKER", foo())], "PURE_NESTING_LOCAL_A_MARKER");

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/pure-call-with-pure-call-array-arg.js
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/pure-call-with-pure-call-array-arg.js
@@ -1,0 +1,3 @@
+import { a, b } from "./decl";
+
+a([b("PURE_NESTING_ARRAY_B_MARKER")], "PURE_NESTING_ARRAY_A_MARKER");

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/rspack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /decl\.js$/,
+        parser: {
+          pureFunctions: ['a', 'b'],
+        },
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/test.config.js
+++ b/tests/rspack-test/esmOutputCases/basic/pure-functions-expression-nesting/test.config.js
@@ -1,0 +1,17 @@
+const removedMarkers = [
+  "PURE_NESTING_ARRAY_A_MARKER",
+  "PURE_NESTING_ARRAY_B_MARKER",
+  "PURE_NESTING_LOCAL_A_MARKER",
+  "PURE_NESTING_LOCAL_B_MARKER",
+];
+
+module.exports = {
+  snapshotContent(content) {
+    for (const marker of removedMarkers) {
+      if (content.includes(marker)) {
+        throw new Error(`Expected pure function marker ${marker} to be removed from ESM output`);
+      }
+    }
+    return content;
+  },
+};


### PR DESCRIPTION
## Summary

Fix `experiments.pureFunctions` purity analysis for array-literal arguments so nested marked pure calls can be removed, including `a([b()])` and `a([b(0, foo())])`.

Implementation is limited to `side_effects_parser_plugin.rs`:

- recurse through array elements with the existing `is_pure_expression` path so deferred pure callees are recorded
- keep configured pure-function callees limited to the current top-level binding instead of accepting shadowed/non-top-level bindings
- add an ESM output regression case whose snapshot guard fails if the `a`/`b` markers remain in generated output

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).