### PR TITLE
chore(ci): use mini runner for lint workflow

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: Lint and format
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 


### PR DESCRIPTION
## Summary

This PR moves the `Lint and format` workflow job onto the same lightweight CI runner expression introduced in #14363. It uses `CI_LINUX_MINI_RUNNER` with an `ubuntu-latest` fallback, so forks without the self-hosted mini runner can still run the check.

## Related links

https://github.com/web-infra-dev/rspack/pull/14363

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).