### PR TITLE
fix: wait for in-flight build before closing compiler

### DIFF
--- a/crates/rspack_binding_api/src/compiler.rs
+++ b/crates/rspack_binding_api/src/compiler.rs
@@ -1,11 +1,10 @@
 use std::{
+  future::Future,
   marker::PhantomPinned,
   ops::{Deref, DerefMut},
-  sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-  },
 };
+
+use tokio::sync::watch;
 
 type CompilerInner = rspack_core::Compiler;
 
@@ -32,31 +31,40 @@ impl DerefMut for Compiler {
   }
 }
 
-pub(crate) struct CompilerState(Arc<AtomicBool>);
+pub(crate) struct CompilerState(watch::Sender<bool>);
 
 impl CompilerState {
   pub(crate) fn init() -> Self {
-    Self(Arc::new(AtomicBool::new(false)))
+    Self(watch::Sender::new(false))
   }
 }
 
 impl CompilerState {
   pub(crate) fn running(&self) -> bool {
-    self.0.load(Ordering::Relaxed)
+    *self.0.borrow()
   }
 
   pub(crate) fn enter(&self) -> CompilerStateGuard {
-    self.0.store(true, Ordering::Relaxed);
+    self.0.send_replace(true);
     CompilerStateGuard(self.0.clone())
+  }
+
+  /// Resolves once no build/rebuild is in flight. Detached from `self` so callers
+  /// can await it without borrowing the compiler.
+  pub(crate) fn wait_idle(&self) -> impl Future<Output = ()> + Send + 'static {
+    let mut receiver = self.0.subscribe();
+    async move {
+      // `wait_for` checks the current value first, so an idle compiler resolves
+      // immediately. A closed channel means the compiler is dropped, hence idle.
+      let _ = receiver.wait_for(|running| !running).await;
+    }
   }
 }
 
-pub(crate) struct CompilerStateGuard(Arc<AtomicBool>);
-
-unsafe impl Send for CompilerStateGuard {}
+pub(crate) struct CompilerStateGuard(watch::Sender<bool>);
 
 impl Drop for CompilerStateGuard {
   fn drop(&mut self) {
-    self.0.store(false, Ordering::Relaxed);
+    self.0.send_replace(false);
   }
 }

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -436,7 +436,12 @@ impl JsCompiler {
     let compiler =
       unsafe { std::mem::transmute::<&Compiler, &'static Compiler>(&reference.compiler) };
 
+    let wait_idle = self.state.wait_idle();
     let spawn_future_result = env.spawn_future(async move {
+      // An in-flight build/rebuild still calls back into JS through compiler-scoped
+      // TSFNs; closing mid-build would release them and fail those calls. Wait until
+      // the compiler is idle before shutting down.
+      wait_idle.await;
       let result = compiler
         .close()
         .await


### PR DESCRIPTION
## Why

`MultiCompiler.test.js > multiCompilerCases/run-twice > "(run - watch)"` is flaky on CI (e.g. [this run](https://github.com/web-infra-dev/rspack/actions/runs/27398129557/job/80970603789)), failing with:

```
Rspack compiler has already been closed by `compiler.close()`. Do not call Rspack compiler APIs after close; create a new compiler instead.
```

Root cause: `JsCompiler::close` does not wait for an in-flight `build()`/`rebuild()`. It runs `Compiler::close()` and then releases all compiler-scoped TSFNs (introduced in #13565) while the build is still running on the tokio pool. The build's next native→JS call (`registerCompilerCompilationTaps` — non-skippable even in a bare config because of the built-in `JavascriptModulesPlugin`/stats plugins taps) hits the cleared TSFN slot and fails the whole build.

Timeline before (instrumented, ms):

```
60.8  [a] native close() invoked            ← build still in flight
61.4  [a] registerCompilerThisCompilationTaps   ← TSFN still alive, ok
61.8  [a] close resolved → all scoped TSFNs released
62.9  [a] registerCompilerCompilationTaps   ← hits released slot → error
65.0  [a] build callback: "has already been closed"
```

The race fires on every close-during-run; the test only fails when this error reaches `multiCompiler.run`'s callback before the sibling compiler's close completes (`MultiCompiler.close` waits for all compilers via `asyncLib.each`), which is why it only shows up on loaded CI runners.

## What

- `CompilerState`: `Arc<AtomicBool>` → `tokio::sync::watch` channel, adding an awaitable `wait_idle()`. The guard is still Drop-based, so the flag flips back even if the build future panics.
- `JsCompiler::close`: await `wait_idle()` before running `Compiler::close()`, so the TSFN release in the promise `finally` happens only after the in-flight build has finished.

This mirrors webpack's `Watching.close` semantics (which defers shutdown via `_done` while a compilation is running) for the bare `run()` path, where webpack needs no native resource teardown but rspack does.

Verified: a deterministic repro of the CI interleaving (delayed sibling close) fails before and passes after; `run-twice` ×10 loops, `MultiCompiler`/`Compiler`, `Watch.part1-3` and `nativeWatcher` suites all green.
