### PR TITLE
docs: update magic comment version and anchors

### DIFF
--- a/website/cspell.config.cjs
+++ b/website/cspell.config.cjs
@@ -21,6 +21,12 @@ module.exports = {
     'rspack.mp3',
     'doc_build',
   ],
+  ignoreRegExpList: [
+    // Ignore markdown anchors such as [modifyRspackConfig](#modifyrspackconfig).
+    '#.*?\\)',
+    // Ignore custom anchor declarations such as ## createRspack \{#createrspack}.
+    '\\\\\\{#[^}]+\\}',
+  ],
   flagWords: banWords,
   caseSensitive: true,
   allowCompoundWords: true,

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -107,7 +107,11 @@ import(`./locale/${language}.json`).then((module) => {
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-Inline comments to make features work. By adding comments to the import, we can do things such as specify chunk name or select different loading modes. **Since Rspack 2.0.7**, prefer the `rspack`-prefixed magic comments shown below. The corresponding `webpack`-prefixed comments are also supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
+Inline comments can specify chunk names, loading modes, and other import behavior.
+
+:::tip
+Since Rspack 2.1.0, prefer the `rspack`-prefixed magic comments below. The equivalent `webpack`-prefixed comments remain supported for compatibility, for example `webpackIgnore` is equivalent to `rspackIgnore`.
+:::
 
 ```js
 // Single target
@@ -131,7 +135,7 @@ import(
 );
 ```
 
-##### rspackIgnore / webpackIgnore \{#webpackignore}
+##### rspackIgnore / webpackIgnore \{#rspackignore}
 
 - **Type:** `boolean`
 
@@ -170,7 +174,7 @@ const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
-##### rspackMode / webpackMode \{#webpackmode}
+##### rspackMode / webpackMode \{#rspackmode}
 
 - **Type:** `"eager" | "lazy" | "weak" | "lazy-once"`
 - **Default:** `'lazy'`
@@ -182,7 +186,7 @@ Different modes for resolving dynamic imports can be specified. The following op
 - `'eager'`: Generates no extra chunk. All modules are included in the current chunk and no additional network requests are made. A Promise is still returned but is already resolved. In contrast to a static import, the module isn't executed until the call to `import()` is made.
 - `'weak'`: Tries to load the module if the module function has already been loaded in some other way (e.g. another chunk imported it or a script containing the module was loaded). A Promise is still returned, but only successfully resolves if the chunks are already on the client. If the module is not available, the Promise is rejected. A network request will never be performed. This is useful for universal rendering when required chunks are always manually served in initial requests (embedded within the page), but not in cases where app navigation will trigger an import not initially served.
 
-##### rspackPrefetch / webpackPrefetch \{#webpackprefetch}
+##### rspackPrefetch / webpackPrefetch \{#rspackprefetch}
 
 - **Type:**
   - `number`: chunk prefetch priority
@@ -190,7 +194,7 @@ Different modes for resolving dynamic imports can be specified. The following op
 
 Tells the browser that the resource is probably needed for some navigation in the future, see [Prefetching/Preloading modules](/guide/optimization/code-splitting#prefetchingpreloading-modules) for more details.
 
-##### rspackPreload / webpackPreload \{#webpackpreload}
+##### rspackPreload / webpackPreload \{#rspackpreload}
 
 - **Type:**
   - `number`: chunk preload priority
@@ -198,13 +202,13 @@ Tells the browser that the resource is probably needed for some navigation in th
 
 Tells the browser that the resource might be needed during the current navigation, , see [Prefetching/Preloading modules](/guide/optimization/code-splitting#prefetchingpreloading-modules) for more details.
 
-##### rspackChunkName / webpackChunkName \{#webpackchunkname}
+##### rspackChunkName / webpackChunkName \{#rspackchunkname}
 
 - **Type:**: `string`
 
 A name for the new chunk.
 
-##### rspackFetchPriority / webpackFetchPriority \{#webpackfetchpriority}
+##### rspackFetchPriority / webpackFetchPriority \{#rspackfetchpriority}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -212,7 +216,7 @@ A name for the new chunk.
 
 Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority) for specific dynamic imports. It's also possible to set a global default value for all dynamic imports by using the `module.parser.javascript.dynamicImportFetchPriority` option.
 
-##### rspackInclude / webpackInclude \{#webpackinclude}
+##### rspackInclude / webpackInclude \{#rspackinclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -220,7 +224,7 @@ Set [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImage
 
 A regular expression that will be matched against during import resolution. Only modules that match **will be bundled**.
 
-##### rspackExclude / webpackExclude \{#webpackexclude}
+##### rspackExclude / webpackExclude \{#rspackexclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -232,7 +236,7 @@ A regular expression that will be matched against during import resolution. Any 
 Note that `rspackInclude` and `rspackExclude` options do not interfere with the prefix. The equivalent `webpackInclude` and `webpackExclude` comments are also supported for compatibility. eg: `./locale`.
 :::
 
-##### rspackExports / webpackExports \{#webpackexports}
+##### rspackExports / webpackExports \{#rspackexports}
 
 <ApiMeta addedVersion="1.0.0" />
 

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -134,7 +134,11 @@ export default {
 };
 ```
 
-Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment. **Since Rspack 2.0.7**, prefer `rspackIgnore`; `webpackIgnore` remains supported for compatibility:
+Note that only the `rspackIgnore` and `webpackIgnore` comments are supported at the moment.
+
+:::tip
+Since Rspack 2.1.0, prefer `rspackIgnore`. `webpackIgnore` remains supported for compatibility.
+:::
 
 ```js
 const x = require(/* rspackIgnore: true */ 'x');
@@ -148,7 +152,7 @@ const y = require(/* webpackIgnore: true */ 'y');
   defaultValueList={[{ defaultValue: "'lazy'" }]}
 />
 
-Specifies global mode for dynamic import, see [`webpackMode`](/api/runtime-api/module-methods#webpackmode) for more details.
+Specifies global mode for dynamic import, see [`rspackMode`](/api/runtime-api/module-methods#rspackmode) for more details.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -169,7 +173,7 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-Specifies global prefetch for dynamic import, see [`webpackPrefetch`](/api/runtime-api/module-methods#webpackprefetch) for more details.
+Specifies global prefetch for dynamic import, see [`rspackPrefetch`](/api/runtime-api/module-methods#rspackprefetch) for more details.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -190,7 +194,7 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-Specifies global preload for dynamic import, see [`webpackPreload`](/api/runtime-api/module-methods#webpackpreload) for more details.
+Specifies global preload for dynamic import, see [`rspackPreload`](/api/runtime-api/module-methods#rspackpreload) for more details.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -213,7 +217,7 @@ export default {
   defaultValueList={[{ defaultValue: "'auto'" }]}
 />
 
-Specifies global `fetchPriority` for dynamic import, see [`webpackFetchPriority`](/api/runtime-api/module-methods#webpackfetchpriority) for more details.
+Specifies global `fetchPriority` for dynamic import, see [`rspackFetchPriority`](/api/runtime-api/module-methods#rspackfetchpriority) for more details.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -103,11 +103,15 @@ import(`./locale/${language}.json`).then((module) => {
 });
 ```
 
-#### Magic comments
+#### 魔法注释 \{#magic-comments}
 
 <ApiMeta specific={['Rspack', 'Webpack']} />
 
-通过向 import 语句添加注释，我们可以实现「指定 chunk 名称」或「设置加载模式」等操作。**从 Rspack 2.0.7 开始**，推荐使用下面展示的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释也会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
+通过向 import 语句添加注释，可以指定 chunk 名称、加载模式等行为。
+
+:::tip
+从 Rspack 2.1.0 开始，推荐使用下方的 `rspack` 前缀魔法注释。对应的 `webpack` 前缀注释仍会被兼容支持，例如 `webpackIgnore` 等价于 `rspackIgnore`。
+:::
 
 ```js
 // 单个模块
@@ -130,7 +134,7 @@ import(
 );
 ```
 
-##### rspackIgnore / webpackIgnore \{#webpackignore}
+##### rspackIgnore / webpackIgnore \{#rspackignore}
 
 - **类型：** `boolean`
 
@@ -169,7 +173,7 @@ const url2 = new URL(/* rspackIgnore: true */ './index.css', import.meta.url);
 const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 ```
 
-##### rspackMode / webpackMode \{#webpackmode}
+##### rspackMode / webpackMode \{#rspackmode}
 
 - **类型：** `"eager" | "lazy" | "weak" | "lazy-once"`
 - **默认值：** `'lazy'`
@@ -181,7 +185,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 - `'eager'`：不会生成额外的 chunk。所有的模块都被当前的 chunk 引入，并且没有额外的网络请求。但是仍会返回一个 resolved 状态的 Promise。与静态导入相比，在调用 `import()` 完成之前，该模块不会被执行。
 - `'weak'`：尝试加载模块，如果该模块函数已经以其他方式加载，（即另一个 chunk 导入过此模块，或包含模块的脚本被加载）。仍会返回 Promise， 但是只有在客户端上已经有该 chunk 时才会成功解析。如果该模块不可用，则返回 rejected 状态的 Promise，且网络请求永远都不会执行。当需要的 chunks 始终在（嵌入在页面中的）初始请求中手动提供，而不是在应用程序导航在最初没有提供的模块导入的情况下触发，这对于通用渲染（SSR）是非常有用的。
 
-##### rspackPrefetch / webpackPrefetch \{#webpackprefetch}
+##### rspackPrefetch / webpackPrefetch \{#rspackprefetch}
 
 - **类型：**
   - `number`: 预取优先级
@@ -189,7 +193,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 告诉浏览器将来可能需要该资源来进行某些导航跳转，详情请查看[预取/预载模块](/guide/optimization/code-splitting#prefetchingpreloading-模块)。
 
-##### rspackPreload / webpackPreload \{#webpackpreload}
+##### rspackPreload / webpackPreload \{#rspackpreload}
 
 - **类型：**
   - `number`: 预载优先级
@@ -197,13 +201,13 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 告诉浏览器在当前导航期间可能需要该资源，详情请查看[预取/预载模块](/guide/optimization/code-splitting#prefetchingpreloading-模块)。
 
-##### rspackChunkName / webpackChunkName \{#webpackchunkname}
+##### rspackChunkName / webpackChunkName \{#rspackchunkname}
 
 - **类型：**: `string`
 
 指定新 chunk 的名称。
 
-##### rspackFetchPriority / webpackFetchPriority \{#webpackfetchpriority}
+##### rspackFetchPriority / webpackFetchPriority \{#rspackfetchpriority}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -211,7 +215,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 为指定的动态导入设置 [`fetchPriority`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority)。也可以通过使用 `module.parser.javascript.dynamicImportFetchPriority` 选项为所有动态导入设置全局默认值。
 
-##### rspackInclude / webpackInclude \{#webpackinclude}
+##### rspackInclude / webpackInclude \{#rspackinclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -219,7 +223,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 
 在导入解析时匹配的正则表达式。只有匹配的模块**才会被打包**。
 
-##### rspackExclude / webpackExclude \{#webpackexclude}
+##### rspackExclude / webpackExclude \{#rspackexclude}
 
 <ApiMeta addedVersion="1.0.0" />
 
@@ -231,7 +235,7 @@ const url3 = new URL(/* webpackIgnore: true */ './index.css', import.meta.url);
 请注意，`rspackInclude` 和 `rspackExclude` 选项不会影响前缀。等价的 `webpackInclude` 和 `webpackExclude` 注释也会被兼容支持。例如：`./locale`。
 :::
 
-##### rspackExports / webpackExports \{#webpackexports}
+##### rspackExports / webpackExports \{#rspackexports}
 
 <ApiMeta addedVersion="1.0.0" />
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -134,7 +134,11 @@ export default {
 };
 ```
 
-目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。**从 Rspack 2.0.7 开始**，推荐使用 `rspackIgnore`；`webpackIgnore` 仍会被兼容支持：
+目前仅支持 `rspackIgnore` 和 `webpackIgnore` 注释。
+
+:::tip
+从 Rspack 2.1.0 开始，推荐使用 `rspackIgnore`。`webpackIgnore` 仍会被兼容支持。
+:::
 
 ```js
 const x = require(/* rspackIgnore: true */ 'x');
@@ -148,7 +152,7 @@ const y = require(/* webpackIgnore: true */ 'y');
   defaultValueList={[{ defaultValue: "'lazy'" }]}
 />
 
-指定动态导入的全局模式，详见[`webpackMode`](/api/runtime-api/module-methods#webpackmode)。
+指定动态导入的全局模式，详见 [`rspackMode`](/api/runtime-api/module-methods#rspackmode)。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -169,7 +173,7 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-指定动态导入的全局 prefetch，详见[`webpackPrefetch`](/api/runtime-api/module-methods#webpackprefetch)。
+指定动态导入的全局 prefetch，详见 [`rspackPrefetch`](/api/runtime-api/module-methods#rspackprefetch)。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -190,7 +194,7 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-指定动态导入的全局 preload，详见[`webpackPreload`](/api/runtime-api/module-methods#webpackpreload)。
+指定动态导入的全局 preload，详见 [`rspackPreload`](/api/runtime-api/module-methods#rspackpreload)。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -213,7 +217,7 @@ export default {
   defaultValueList={[{ defaultValue: "'auto'" }]}
 />
 
-指定动态导入的全局 `fetchPriority`，详见[`webpackFetchPriority`](/api/runtime-api/module-methods#webpackfetchpriority)。
+指定动态导入的全局 `fetchPriority`，详见 [`rspackFetchPriority`](/api/runtime-api/module-methods#rspackfetchpriority)。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR updates the magic comment docs to prefer `rspack`-prefixed comments from Rspack 2.1.0, moves the compatibility guidance into tip blocks, localizes the Chinese magic comments heading while preserving its anchor, and changes related magic comment anchors and links to use the `rspack` prefix.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).