### PR TITLE
chore: bump swc exp from 0.10.0 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6748,8 +6748,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_allocator"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2f721d492c92c8332eee8c4592b1b21c26834091eafffd5d3bdfd1cc4a1e3e"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "bumpalo",
 ]
@@ -6757,8 +6756,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ast_macros"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e89cb54ca71ef6c9f0fe709d9da7719f5bdf81ac4a8a3b09b65400f688c772"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6768,8 +6766,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_ast"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445b40eeb93dd39c456bb7cbb851e03ea8c3d9e993c8d66fcb213cc04bb8da6d"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "num-bigint",
  "oxc_index",
@@ -6781,8 +6778,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_parser"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b3bfe6dbc29699a817a8c378f267981d0706a877f2b1d327f7a42de627e14b"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6799,8 +6795,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_semantic"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089fdfd22524d1d14cb63597f1c8cc41ba8c8897cbb251d162ce1af140240e17"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "oxc_index",
  "rustc-hash",
@@ -6812,8 +6807,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_transforms_base"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921d3d345279efbdd45e21a450ae02300d49b9f0584e230fd1662165654ecb04"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -6824,8 +6818,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_utils"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0a7b14822f7f6cadaf47a6cde8f744b565a3e9276536ee61f3dec7bc361c9a"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_semantic",
@@ -6834,8 +6827,7 @@ dependencies = [
 [[package]]
 name = "swc_experimental_ecma_visit"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a22172b1422e9283ff568d896c405682f7d8c64ef652895d73f99e7f4dc7a2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
 dependencies = [
  "swc_experimental_ecma_ast",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6747,18 +6747,18 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_allocator"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd93ae305f9f5085206a10c1e19cff6cbfe28cb4277e2c3685befc873e0e42f"
+checksum = "0e2f721d492c92c8332eee8c4592b1b21c26834091eafffd5d3bdfd1cc4a1e3e"
 dependencies = [
  "bumpalo",
 ]
 
 [[package]]
 name = "swc_experimental_ast_macros"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35273dbac918d1cf6cd5bf012c38c063de497ef86cbab5facac49f700416c58"
+checksum = "f8e89cb54ca71ef6c9f0fe709d9da7719f5bdf81ac4a8a3b09b65400f688c772"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6767,9 +6767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_ast"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688d404991fc047897053686edce6813828547baf944f0b13965e5a1a23a4ab6"
+checksum = "445b40eeb93dd39c456bb7cbb851e03ea8c3d9e993c8d66fcb213cc04bb8da6d"
 dependencies = [
  "num-bigint",
  "oxc_index",
@@ -6780,9 +6780,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_parser"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c38b4aca8e8f0302b7a2386969c4841bc2c77a5a00b8e9f6555637f2a9a88ca"
+checksum = "71b3bfe6dbc29699a817a8c378f267981d0706a877f2b1d327f7a42de627e14b"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6798,9 +6798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_semantic"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400f28300bd3773b1d12949630d1d7ed11c2fba7563ebce398a66637c982243"
+checksum = "089fdfd22524d1d14cb63597f1c8cc41ba8c8897cbb251d162ce1af140240e17"
 dependencies = [
  "oxc_index",
  "rustc-hash",
@@ -6811,9 +6811,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_transforms_base"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ede829a5614a83445ebdd16b3cdf5231de37033de8cdee4aa6d7820a428d5f"
+checksum = "921d3d345279efbdd45e21a450ae02300d49b9f0584e230fd1662165654ecb04"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -6823,9 +6823,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_utils"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314c6b37e60420e02d1cd033d8c58c9cf870b3d91a0ba25dcc22d6962c57820f"
+checksum = "1e0a7b14822f7f6cadaf47a6cde8f744b565a3e9276536ee61f3dec7bc361c9a"
 dependencies = [
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_semantic",
@@ -6833,9 +6833,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_visit"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40460e57394716158c078c022a5d3911e486aebeeae09829319500832295f686"
+checksum = "f6a22172b1422e9283ff568d896c405682f7d8c64ef652895d73f99e7f4dc7a2"
 dependencies = [
  "swc_experimental_ecma_ast",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,9 +1830,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2042,7 +2047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "rayon",
  "serde",
  "serde_core",
@@ -3477,7 +3482,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck 0.8.0",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta 0.3.0",
@@ -6747,16 +6752,19 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_allocator"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
+ "allocator-api2",
  "bumpalo",
+ "hashbrown 0.17.1",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "swc_experimental_ast_macros"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6765,8 +6773,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_ast"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "num-bigint",
  "oxc_index",
@@ -6777,8 +6785,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_parser"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6794,8 +6802,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_semantic"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "oxc_index",
  "rustc-hash",
@@ -6806,8 +6814,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_transforms_base"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -6817,8 +6825,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_utils"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_semantic",
@@ -6826,8 +6834,8 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_visit"
-version = "0.10.1"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=99850ee53fffa9a95c83232fed4049d9a63c7775#99850ee53fffa9a95c83232fed4049d9a63c7775"
+version = "0.10.2"
+source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
 dependencies = [
  "swc_experimental_ecma_ast",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6752,8 +6752,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_allocator"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de30cc8c479b5fe7fa85ee814f5d2dd50908e596e5c2523c56a26aaa2b3e9c1"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -6763,8 +6764,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ast_macros"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08b8a40e179bac304f73b897bb266b1f871f51ec2c33d7e2bd34759cd2aeb995"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6773,8 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_ast"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fe7ec66f486afe1dd25601306b4026d4eda6dc250012d26e72d5a6c4f083cb"
 dependencies = [
  "num-bigint",
  "oxc_index",
@@ -6785,8 +6788,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_parser"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c74202893ebbcffd2c59150ef13a231137c919669ca20bab37baef9719ba779"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6802,8 +6806,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_semantic"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f92087f9cf030ee823e4dd43c2dbe34c2893c350f085cb4bec161c3460d7bd"
 dependencies = [
  "oxc_index",
  "rustc-hash",
@@ -6814,8 +6819,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_transforms_base"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d70f2e94eac530d788d24adcca35552815f9f6575717c0067e921f91fffa7c5"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -6825,8 +6831,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_utils"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d4620c8e29665bbd21e286087b3b8dd4927ac34e3531453eb24e6286a88c61"
 dependencies = [
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_semantic",
@@ -6834,8 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_ecma_visit"
-version = "0.10.2"
-source = "git+https://github.com/CPunisher/swc-experimental.git?rev=aa5472ced0c6c9ba944b30637bed8d8e508eae41#aa5472ced0c6c9ba944b30637bed8d8e508eae41"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb1fd897c8d956850c73bf457591c11c0a6054c32b54306ff99a9a9026483b1"
 dependencies = [
  "swc_experimental_ecma_ast",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,12 +143,12 @@ swc_html_minifier   = { version = "55.0.0", default-features = false }
 swc_plugin_runner   = { version = "29.0.0", default-features = false }
 swc_typescript      = { version = "30.0.0", default-features = false }
 
-swc_experimental_allocator            = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
-swc_experimental_ecma_ast             = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
-swc_experimental_ecma_parser          = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
-swc_experimental_ecma_semantic        = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
-swc_experimental_ecma_transforms_base = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
-swc_experimental_ecma_utils           = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
+swc_experimental_allocator            = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
+swc_experimental_ecma_ast             = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
+swc_experimental_ecma_parser          = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
+swc_experimental_ecma_semantic        = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
+swc_experimental_ecma_transforms_base = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
+swc_experimental_ecma_utils           = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,12 +143,12 @@ swc_html_minifier   = { version = "55.0.0", default-features = false }
 swc_plugin_runner   = { version = "29.0.0", default-features = false }
 swc_typescript      = { version = "30.0.0", default-features = false }
 
-swc_experimental_allocator            = { version = "0.10.0", default-features = false }
-swc_experimental_ecma_ast             = { version = "0.10.0", default-features = false }
-swc_experimental_ecma_parser          = { version = "0.10.0", default-features = false }
-swc_experimental_ecma_semantic        = { version = "0.10.0", default-features = false }
-swc_experimental_ecma_transforms_base = { version = "0.10.0", default-features = false }
-swc_experimental_ecma_utils           = { version = "0.10.0", default-features = false }
+swc_experimental_allocator            = { version = "0.10.1", default-features = false }
+swc_experimental_ecma_ast             = { version = "0.10.1", default-features = false }
+swc_experimental_ecma_parser          = { version = "0.10.1", default-features = false }
+swc_experimental_ecma_semantic        = { version = "0.10.1", default-features = false }
+swc_experimental_ecma_transforms_base = { version = "0.10.1", default-features = false }
+swc_experimental_ecma_utils           = { version = "0.10.1", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,12 +143,12 @@ swc_html_minifier   = { version = "55.0.0", default-features = false }
 swc_plugin_runner   = { version = "29.0.0", default-features = false }
 swc_typescript      = { version = "30.0.0", default-features = false }
 
-swc_experimental_allocator            = { version = "0.10.1", default-features = false }
-swc_experimental_ecma_ast             = { version = "0.10.1", default-features = false }
-swc_experimental_ecma_parser          = { version = "0.10.1", default-features = false }
-swc_experimental_ecma_semantic        = { version = "0.10.1", default-features = false }
-swc_experimental_ecma_transforms_base = { version = "0.10.1", default-features = false }
-swc_experimental_ecma_utils           = { version = "0.10.1", default-features = false }
+swc_experimental_allocator            = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
+swc_experimental_ecma_ast             = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
+swc_experimental_ecma_parser          = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
+swc_experimental_ecma_semantic        = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
+swc_experimental_ecma_transforms_base = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
+swc_experimental_ecma_utils           = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "99850ee53fffa9a95c83232fed4049d9a63c7775", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,12 +143,12 @@ swc_html_minifier   = { version = "55.0.0", default-features = false }
 swc_plugin_runner   = { version = "29.0.0", default-features = false }
 swc_typescript      = { version = "30.0.0", default-features = false }
 
-swc_experimental_allocator            = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
-swc_experimental_ecma_ast             = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
-swc_experimental_ecma_parser          = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
-swc_experimental_ecma_semantic        = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
-swc_experimental_ecma_transforms_base = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
-swc_experimental_ecma_utils           = { git = "https://github.com/CPunisher/swc-experimental.git", rev = "aa5472ced0c6c9ba944b30637bed8d8e508eae41", default-features = false }
+swc_experimental_allocator            = { version = "0.11.0", default-features = false }
+swc_experimental_ecma_ast             = { version = "0.11.0", default-features = false }
+swc_experimental_ecma_parser          = { version = "0.11.0", default-features = false }
+swc_experimental_ecma_semantic        = { version = "0.11.0", default-features = false }
+swc_experimental_ecma_transforms_base = { version = "0.11.0", default-features = false }
+swc_experimental_ecma_utils           = { version = "0.11.0", default-features = false }
 
 rspack_dojang = { version = "0.1.11", default-features = false }
 tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -242,7 +242,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       .unwrap_or(false);
 
     let allocator = Allocator::new();
-    let mut comments = Comments::default();
+    let mut comments = Comments::new_in(&allocator);
     let parser_lexer = Lexer::new(
       &allocator,
       Syntax::Es(EsSyntax {

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -178,7 +178,7 @@ fn parse_benchmark_program(
 ) -> PreparedScanDependenciesProgram {
   let source_text = Box::leak(source_text.to_string().into_boxed_str());
   let allocator = Box::leak(Box::new(Allocator::default()));
-  let comments = Box::leak(Box::new(Comments::default()));
+  let comments = Box::leak(Box::new(Comments::new_in(allocator)));
   let parser_lexer = Lexer::new(
     allocator,
     Syntax::Es(EsSyntax {


### PR DESCRIPTION
## Summary

See: https://github.com/CPunisher/swc-experimental/compare/v0.10.0...v0.11.0

- Performance optimization
  - `ArenaVec` is now 24 bytes compared to original 32 bytes, which is achieved with `len: u32` and `cap: u32`
  - Introduce `ArenaHashSet` and `ArenaHashMap`, and put nearly everything during parsing to the arena (such as `Capturing::tokens`, `Comments`).
  - Avoid unnecessary copy from source to arena by `.alloc_str`

- Correctness improvment
  - Add conformance tests of parsing, transforming, semantic to make sure swc exp produces same results as `swc_core` 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
