### PR TITLE
perf(core): reduce memcpy overhead

### DIFF
--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -223,7 +223,7 @@ pub(crate) async fn code_generation_modules(
           }
         }
 
-        (job.module, job.runtimes, codegen_res)
+        (job.module, job.runtimes, codegen_res.map(Box::new))
       })
     })
   })
@@ -235,7 +235,7 @@ pub(crate) async fn code_generation_modules(
 
   for (module, runtimes, codegen_res) in results {
     let codegen_res = match codegen_res {
-      Ok(codegen_res) => codegen_res,
+      Ok(codegen_res) => *codegen_res,
       Err(err) => {
         let mut diagnostic = Diagnostic::from(err);
         diagnostic.module_identifier = Some(module);

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1004,18 +1004,15 @@ impl Module for ConcatenatedModule {
 
     let tmp = rspack_parallel::scope::<_, Result<_>>(|token| {
       arc_map.iter().for_each(|(id, info)| {
-        if !matches!(info, ModuleInfo::Concatenated(_)) {
-          return;
-        }
-
-        let module_to_info_map = arc_map.clone();
+        let module_to_info_map =
+          matches!(info, ModuleInfo::Concatenated(_)).then(|| arc_map.clone());
         let s = unsafe { token.used((&self, &compilation, runtime, id, info)) };
         s.spawn(|(module, compilation, runtime, id, info)| async move {
           let concatenation_scope = if let ModuleInfo::Concatenated(info) = info {
             let info = info.as_ref();
             Some(ConcatenationScope::new(
               module.id,
-              module_to_info_map,
+              module_to_info_map.expect("should have module_to_info_map for concatenated module"),
               ConcatenatedModuleInfo {
                 index: info.index,
                 module: info.module,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1004,21 +1004,31 @@ impl Module for ConcatenatedModule {
 
     let tmp = rspack_parallel::scope::<_, Result<_>>(|token| {
       arc_map.iter().for_each(|(id, info)| {
-        let concatenation_scope = if let ModuleInfo::Concatenated(info) = &info {
-          let concatenation_scope =
-            ConcatenationScope::new(self.id, arc_map.clone(), info.as_ref().clone());
+        if !matches!(info, ModuleInfo::Concatenated(_)) {
+          return;
+        }
 
-          Some(concatenation_scope)
-        } else {
-          None
-        };
-
+        let module_to_info_map = arc_map.clone();
         let s = unsafe { token.used((&self, &compilation, runtime, id, info)) };
         s.spawn(|(module, compilation, runtime, id, info)| async move {
+          let concatenation_scope = if let ModuleInfo::Concatenated(info) = info {
+            let info = info.as_ref();
+            Some(ConcatenationScope::new(
+              module.id,
+              module_to_info_map,
+              ConcatenatedModuleInfo {
+                index: info.index,
+                module: info.module,
+                ..Default::default()
+              },
+            ))
+          } else {
+            None
+          };
           let updated_module_info = module
             .analyze_module(compilation, info, runtime, concatenation_scope)
             .await?;
-          Ok((*id, updated_module_info))
+          Ok((*id, Box::new(updated_module_info)))
         });
       })
     })
@@ -1035,7 +1045,7 @@ impl Module for ConcatenatedModule {
     let mut module_to_info_map = Arc::into_inner(arc_map).expect("reference count should be one");
 
     for (id, module_info) in updated_pairs {
-      module_to_info_map.insert(id, module_info);
+      module_to_info_map.insert(id, *module_info);
     }
 
     let mut top_level_declarations: HashSet<Atom> = HashSet::default();

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -660,6 +660,7 @@ impl Module for NormalModule {
 
     let module_graph = compilation.get_module_graph();
     for source_type in self.source_types(module_graph) {
+      let in_concatenation = concatenation_scope.is_some();
       let generation_result = self
         .parser_and_generator
         .generate(
@@ -677,7 +678,11 @@ impl Module for NormalModule {
           },
         )
         .await?;
-      code_generation_result.add(*source_type, CachedSource::new(generation_result).boxed());
+      if in_concatenation {
+        code_generation_result.add(*source_type, generation_result);
+      } else {
+        code_generation_result.add(*source_type, CachedSource::new(generation_result).boxed());
+      }
     }
     code_generation_result.concatenation_scope = std::mem::take(concatenation_scope);
     Ok(code_generation_result)


### PR DESCRIPTION
## What changed

- Avoid wrapping concatenation analysis code generation output in `CachedSource` so source materialization does less redundant copying.
- Box `CodeGenerationResult` at the async scope return boundary before it is collected on the main path.
- Keep the earlier concatenated module async move reduction in the same PR branch.

## Why

Callgrind on the threejs production bundle showed `memcpy`/`memmove` cost coming partly from large code generation results crossing async boundaries and from redundant source wrappers in module concatenation analysis. These changes keep behavior the same while reducing unnecessary movement/copying on that path.

## Impact

Local callgrind validation on threejs production showed the current PR branch reducing `__memcpy_avx_unaligned_erms` Ir from `24,390,572` to `24,027,278`, a `1.4895%` reduction. This is below the original 3% target, but it is the smallest positive set verified so far; broader attempted async boxing and init-fragment fast paths were measured and not kept.

## Checks

- `cargo check -p rspack_core`
- `cargo check -p rspack_core -p rspack_plugin_javascript`
- Local callgrind harness for threejs production bundle