### PR TITLE
feat: support drop inactive branch dependencies for member expr

### DIFF
--- a/crates/rspack_core/src/dependency/dependency_location.rs
+++ b/crates/rspack_core/src/dependency/dependency_location.rs
@@ -8,8 +8,8 @@ use rspack_util::SpanExt;
 #[cacheable]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default)]
 pub struct DependencyRange {
-  pub end: u32,
   pub start: u32,
+  pub end: u32,
 }
 
 impl From<(u32, u32)> for DependencyRange {
@@ -41,6 +41,6 @@ impl From<swc_experimental_ecma_ast::Span> for DependencyRange {
 
 impl DependencyRange {
   pub fn new(start: u32, end: u32) -> Self {
-    DependencyRange { end, start }
+    DependencyRange { start, end }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
@@ -1,7 +1,4 @@
-use rspack_cacheable::{
-  cacheable,
-  with::{AsCacheable, AsVec},
-};
+use rspack_cacheable::{cacheable, with::AsCacheable};
 use rspack_core::{
   ConnectionState, Dependency, DependencyCondition, DependencyConditionFn, DependencyId,
   EvaluatedInlinableValue, ExportsInfoArtifact, ModuleGraph, ModuleGraphCacheArtifact,
@@ -9,93 +6,49 @@ use rspack_core::{
 };
 
 use super::{CommonJsRequireDependency, ESMImportSpecifierDependency, ImportDependency};
+use crate::utils::eval::DependencyData;
 
 #[cacheable]
 #[derive(Debug, Clone)]
-pub enum DependencyBranchGuard {
-  ESMImportedBoolean {
-    dependency_id: DependencyId,
-    expected: bool,
-  },
-  ESMImportedBooleanExpression {
-    #[cacheable(with=AsVec<AsCacheable>)]
-    nodes: Vec<ESMImportedBooleanGuardNode>,
-    root: u32,
-  },
-}
+pub struct DependencyBranchGuard(#[cacheable(with=AsCacheable)] DependencyData);
 
-#[cacheable]
-#[derive(Debug, Clone)]
-pub enum ESMImportedBooleanGuardNode {
-  Constant(bool),
-  ESMImportedBoolean {
-    dependency_id: DependencyId,
-    expected: bool,
-  },
-  All {
-    left: u32,
-    right: u32,
-  },
-  Any {
-    left: u32,
-    right: u32,
-  },
-}
-
-#[cacheable]
-#[derive(Debug, Clone, Default)]
-pub struct DependencyBranchGuards {
-  // Multiple entries are accumulated from nested branch guards, so the top-level list is conjunctive.
-  // A single entry may contain its own expression tree for compound tests like `a && b` or `a || b`.
-  #[cacheable(with=AsVec<AsCacheable>)]
-  guards: Vec<DependencyBranchGuard>,
-}
-
-impl DependencyBranchGuards {
-  pub fn extend(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
-    self.guards.extend(guards);
+impl DependencyBranchGuard {
+  pub fn new(data: DependencyData) -> Self {
+    Self(data)
   }
 
-  fn is_empty(&self) -> bool {
-    self.guards.is_empty()
+  pub fn and(self, other: DependencyBranchGuard) -> Self {
+    Self(self.0.and(other.0))
   }
 
-  fn iter(&self) -> impl Iterator<Item = &DependencyBranchGuard> {
-    self.guards.iter()
-  }
-}
-
-pub fn set_dependency_branch_guards(dep: &mut dyn Dependency, guards: &[DependencyBranchGuard]) {
-  if guards.is_empty() {
-    return;
-  }
-
-  if let Some(dep) = dep.downcast_mut::<CommonJsRequireDependency>() {
-    dep.add_branch_guards(guards.iter().cloned());
-  } else if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
-    dep.add_branch_guards(guards.iter().cloned());
-  } else if let Some(dep) = dep.downcast_mut::<ImportDependency>() {
-    dep.add_branch_guards(guards.iter().cloned());
+  pub fn bind_dependency(&self, dep: &mut dyn Dependency) {
+    if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
+      dep.set_branch_guard(self.clone());
+    } else if let Some(dep) = dep.downcast_mut::<ImportDependency>() {
+      dep.set_branch_guard(self.clone());
+    } else if let Some(dep) = dep.downcast_mut::<CommonJsRequireDependency>() {
+      dep.set_branch_guard(self.clone());
+    }
   }
 }
 
 pub fn compose_dependency_condition(
   base: Option<DependencyCondition>,
-  branch_guards: Option<&DependencyBranchGuards>,
+  branch_guard: Option<&DependencyBranchGuard>,
 ) -> Option<DependencyCondition> {
-  let Some(branch_guards) = branch_guards.filter(|guards| !guards.is_empty()) else {
+  let Some(branch_guard) = branch_guard else {
     return base;
   };
 
   Some(DependencyCondition::new(BranchGuardDependencyCondition {
     base,
-    branch_guards: branch_guards.clone(),
+    branch_guard: branch_guard.clone(),
   }))
 }
 
 struct BranchGuardDependencyCondition {
   base: Option<DependencyCondition>,
-  branch_guards: DependencyBranchGuards,
+  branch_guard: DependencyBranchGuard,
 }
 
 impl DependencyConditionFn for BranchGuardDependencyCondition {
@@ -108,13 +61,16 @@ impl DependencyConditionFn for BranchGuardDependencyCondition {
     side_effects_state_artifact: &SideEffectsStateArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
   ) -> ConnectionState {
-    for condition in self.branch_guards.iter() {
-      if matches!(
-        resolve_branch_guard(condition, runtime, module_graph, exports_info_artifact),
-        Some(false)
-      ) {
-        return ConnectionState::Active(false);
-      }
+    if matches!(
+      resolve_branch_guard(
+        &self.branch_guard,
+        runtime,
+        module_graph,
+        exports_info_artifact
+      ),
+      Some(false)
+    ) {
+      return ConnectionState::Active(false);
     }
 
     if let Some(condition) = &self.base {
@@ -138,103 +94,55 @@ fn resolve_branch_guard(
   module_graph: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> Option<bool> {
-  match condition {
-    DependencyBranchGuard::ESMImportedBoolean {
-      dependency_id,
-      expected,
-    } => resolve_esm_imported_boolean_guard(
-      dependency_id,
-      *expected,
-      runtime,
-      module_graph,
-      exports_info_artifact,
-    ),
-    DependencyBranchGuard::ESMImportedBooleanExpression { nodes, root } => {
-      resolve_esm_imported_boolean_guard_expression(
-        nodes,
-        *root,
-        runtime,
-        module_graph,
-        exports_info_artifact,
-      )
-    }
-  }
+  resolve_dependency_data(&condition.0, runtime, module_graph, exports_info_artifact)
 }
 
-fn resolve_esm_imported_boolean_guard_expression(
-  nodes: &[ESMImportedBooleanGuardNode],
-  root: u32,
+fn resolve_dependency_data(
+  data: &DependencyData,
   runtime: Option<&RuntimeSpec>,
   module_graph: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> Option<bool> {
-  let node = nodes.get(root as usize)?;
-  match node {
-    ESMImportedBooleanGuardNode::Constant(value) => Some(*value),
-    ESMImportedBooleanGuardNode::ESMImportedBoolean {
+  match data {
+    DependencyData::Dependency(dependency_id) => resolve_esm_imported_boolean_guard(
       dependency_id,
-      expected,
-    } => resolve_esm_imported_boolean_guard(
-      dependency_id,
-      *expected,
       runtime,
       module_graph,
       exports_info_artifact,
     ),
-    ESMImportedBooleanGuardNode::All { left, right } => {
-      let left = resolve_esm_imported_boolean_guard_expression(
-        nodes,
-        *left,
-        runtime,
-        module_graph,
-        exports_info_artifact,
-      );
-      if matches!(left, Some(false)) {
-        return Some(false);
-      }
-      let right = resolve_esm_imported_boolean_guard_expression(
-        nodes,
-        *right,
-        runtime,
-        module_graph,
-        exports_info_artifact,
-      );
-      match (left, right) {
-        (Some(true), Some(true)) => Some(true),
-        (Some(false), _) | (_, Some(false)) => Some(false),
-        _ => None,
-      }
-    }
-    ESMImportedBooleanGuardNode::Any { left, right } => {
-      let left = resolve_esm_imported_boolean_guard_expression(
-        nodes,
-        *left,
-        runtime,
-        module_graph,
-        exports_info_artifact,
-      );
+    DependencyData::Or(left, right) => {
+      let left = resolve_dependency_data(left, runtime, module_graph, exports_info_artifact);
       if matches!(left, Some(true)) {
         return Some(true);
       }
-      let right = resolve_esm_imported_boolean_guard_expression(
-        nodes,
-        *right,
-        runtime,
-        module_graph,
-        exports_info_artifact,
-      );
+      let right = resolve_dependency_data(right, runtime, module_graph, exports_info_artifact);
       match (left, right) {
         (Some(true), _) | (_, Some(true)) => Some(true),
         (Some(false), Some(false)) => Some(false),
         _ => None,
       }
     }
+    DependencyData::And(left, right) => {
+      let left = resolve_dependency_data(left, runtime, module_graph, exports_info_artifact);
+      if matches!(left, Some(false)) {
+        return Some(false);
+      }
+      let right = resolve_dependency_data(right, runtime, module_graph, exports_info_artifact);
+      match (left, right) {
+        (Some(true), Some(true)) => Some(true),
+        (Some(false), _) | (_, Some(false)) => Some(false),
+        _ => None,
+      }
+    }
+    DependencyData::Not(data) => {
+      resolve_dependency_data(data, runtime, module_graph, exports_info_artifact)
+        .map(|value| !value)
+    }
   }
 }
 
 fn resolve_esm_imported_boolean_guard(
   dependency_id: &DependencyId,
-  expected: bool,
   runtime: Option<&RuntimeSpec>,
   module_graph: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
@@ -255,7 +163,7 @@ fn resolve_esm_imported_boolean_guard(
   };
 
   match inlined.inlined_value() {
-    EvaluatedInlinableValue::Boolean(value) => Some(*value == expected),
+    EvaluatedInlinableValue::Boolean(value) => Some(*value),
     _ => None,
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
@@ -17,10 +17,6 @@ impl DependencyBranchGuard {
     Self(data)
   }
 
-  pub fn and(self, other: DependencyBranchGuard) -> Self {
-    Self(self.0.and(other.0))
-  }
-
   pub fn bind_dependency(&self, dep: &mut dyn Dependency) {
     if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
       dep.set_branch_guard(self.clone());

--- a/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
@@ -21,6 +21,10 @@ impl DependencyBranchGuard {
     self.0
   }
 
+  pub fn and(self, other: DependencyBranchGuard) -> Self {
+    Self(self.0.and(other.0))
+  }
+
   pub fn bind_dependency(&self, dep: &mut dyn Dependency) {
     if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
       dep.set_branch_guard(self.clone());

--- a/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
@@ -17,6 +17,10 @@ impl DependencyBranchGuard {
     Self(data)
   }
 
+  pub fn into_inner(self) -> DependencyData {
+    self.0
+  }
+
   pub fn bind_dependency(&self, dep: &mut dyn Dependency) {
     if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
       dep.set_branch_guard(self.clone());

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -12,9 +12,7 @@ use rspack_core::{
 };
 
 use super::create_resource_identifier_for_contextual_commonjs_dependency;
-use crate::dependency::{
-  DependencyBranchGuard, DependencyBranchGuards, compose_dependency_condition,
-};
+use crate::dependency::{DependencyBranchGuard, compose_dependency_condition};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -28,7 +26,7 @@ pub struct CommonJsRequireDependency {
   #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
   referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
   #[cacheable(with=AsOption<AsCacheable>)]
-  branch_guards: Option<Box<DependencyBranchGuards>>,
+  branch_guard: Option<DependencyBranchGuard>,
   context: Option<Context>,
   resource_identifier: ResourceIdentifier,
   factorize_info: FactorizeInfo,
@@ -51,7 +49,7 @@ impl CommonJsRequireDependency {
       range_expr,
       loc,
       referenced_specifiers,
-      branch_guards: None,
+      branch_guard: None,
       context: None,
       resource_identifier: Default::default(),
       factorize_info: Default::default(),
@@ -91,8 +89,8 @@ impl CommonJsRequireDependency {
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 
-  pub fn add_branch_guards(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
-    self.branch_guards.get_or_insert_default().extend(guards);
+  pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
+    self.branch_guard = Some(guard);
   }
 }
 
@@ -176,7 +174,7 @@ impl ModuleDependency for CommonJsRequireDependency {
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
-    compose_dependency_condition(None, self.branch_guards.as_deref())
+    compose_dependency_condition(None, self.branch_guard.as_ref())
   }
 
   fn factorize_info(&self) -> &FactorizeInfo {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -90,7 +90,10 @@ impl CommonJsRequireDependency {
   }
 
   pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
-    self.branch_guard = Some(guard);
+    self.branch_guard = Some(match self.branch_guard.take() {
+      Some(old_guard) => old_guard.and(guard),
+      None => guard,
+    });
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -24,7 +24,7 @@ use super::{
 };
 use crate::{
   connection_active_inline_value_for_esm_import_specifier, connection_active_used_by_exports,
-  dependency::{DependencyBranchGuard, DependencyBranchGuards, compose_dependency_condition},
+  dependency::{DependencyBranchGuard, compose_dependency_condition},
   is_export_inlined,
   visitors::DestructuringAssignmentProperties,
 };
@@ -47,7 +47,7 @@ pub struct ESMImportSpecifierDependency {
   direct_import: bool,
   used_by_exports: Option<UsedByExports>,
   #[cacheable(with=AsOption<AsCacheable>)]
-  branch_guards: Option<Box<DependencyBranchGuards>>,
+  branch_guard: Option<DependencyBranchGuard>,
   #[cacheable(with=AsOption<AsCacheable>)]
   referenced_properties_in_destructuring: Option<DestructuringAssignmentProperties>,
   resource_identifier: ResourceIdentifier,
@@ -95,7 +95,7 @@ impl ESMImportSpecifierDependency {
       direct_import,
       export_presence_mode,
       used_by_exports: None,
-      branch_guards: None,
+      branch_guard: None,
       evaluated_in_operator: false,
       namespace_object_as_context: false,
       ns_access,
@@ -173,8 +173,8 @@ impl ESMImportSpecifierDependency {
     self.used_by_exports = used_by_exports;
   }
 
-  pub fn add_branch_guards(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
-    self.branch_guards.get_or_insert_default().extend(guards);
+  pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
+    self.branch_guard = Some(guard);
   }
 }
 
@@ -352,7 +352,7 @@ impl ModuleDependency for ESMImportSpecifierDependency {
       Some(DependencyCondition::new(
         ESMImportSpecifierDependencyCondition,
       )),
-      self.branch_guards.as_deref(),
+      self.branch_guard.as_ref(),
     )
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -174,7 +174,10 @@ impl ESMImportSpecifierDependency {
   }
 
   pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
-    self.branch_guard = Some(guard);
+    self.branch_guard = Some(match self.branch_guard.take() {
+      Some(old_guard) => old_guard.and(guard),
+      None => guard,
+    });
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -13,9 +13,7 @@ use rspack_core::{
 use swc_atoms::Atom;
 
 use super::create_resource_identifier_for_esm_dependency;
-use crate::dependency::{
-  DependencyBranchGuard, DependencyBranchGuards, compose_dependency_condition,
-};
+use crate::dependency::{DependencyBranchGuard, compose_dependency_condition};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -33,7 +31,7 @@ pub struct ImportDependency {
   factorize_info: FactorizeInfo,
   optional: bool,
   #[cacheable(with=AsOption<AsCacheable>)]
-  branch_guards: Option<Box<DependencyBranchGuards>>,
+  branch_guard: Option<DependencyBranchGuard>,
 }
 
 impl ImportDependency {
@@ -59,7 +57,7 @@ impl ImportDependency {
       factorize_info: Default::default(),
       optional,
       comments,
-      branch_guards: None,
+      branch_guard: None,
     }
   }
 
@@ -67,8 +65,8 @@ impl ImportDependency {
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 
-  pub fn add_branch_guards(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
-    self.branch_guards.get_or_insert_default().extend(guards);
+  pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
+    self.branch_guard = Some(guard);
   }
 }
 
@@ -164,7 +162,7 @@ impl ModuleDependency for ImportDependency {
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
-    compose_dependency_condition(None, self.branch_guards.as_deref())
+    compose_dependency_condition(None, self.branch_guard.as_ref())
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -66,7 +66,10 @@ impl ImportDependency {
   }
 
   pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
-    self.branch_guard = Some(guard);
+    self.branch_guard = Some(match self.branch_guard.take() {
+      Some(old_guard) => old_guard.and(guard),
+      None => guard,
+    });
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_plugin.rs
@@ -140,6 +140,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for AMDParserPlugin {
     &self,
     _parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -278,6 +278,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<eval::BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -1932,6 +1932,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
@@ -15,6 +15,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsPlugin {
     &self,
     _parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/mod.rs
@@ -95,6 +95,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ConstPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/parser.rs
@@ -103,6 +103,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for DefineParserPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -11,8 +11,8 @@ use crate::{
   utils::eval::BasicEvaluatedExpression,
   visitors::{
     ClassDeclOrExpr, DestructuringAssignmentProperty, ExportDefaultDeclaration,
-    ExportDefaultExpression, ExportImport, ExportLocal, ExportedVariableInfo, JavascriptParser,
-    Statement, VariableDeclaration,
+    ExportDefaultExpression, ExportImport, ExportLocal, ExportedVariableInfo,
+    ExpressionExpressionInfo, JavascriptParser, Statement, VariableDeclaration,
   },
 };
 
@@ -595,11 +595,12 @@ impl<'p: 'a, 'a> JavascriptParserPlugin<'p, 'a> for JavaScriptParserPluginDrive 
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    member_expr_info: Option<&ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {
     for plugin in self.plugins_for(JavascriptParserPluginHook::EvaluateIdentifier) {
-      let res = plugin.evaluate_identifier(parser, for_name, start, end);
+      let res = plugin.evaluate_identifier(parser, for_name, member_expr_info, start, end);
       // `SyncBailHook`
       if res.is_some() {
         return res;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  ConstDependency, DependencyRange, DependencyType, ExportPresenceMode, ImportAttributes,
-  ImportPhase,
+  ConstDependency, Dependency, DependencyRange, DependencyType, ExportPresenceMode,
+  ImportAttributes, ImportPhase,
 };
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
@@ -15,10 +15,13 @@ use super::{
 };
 use crate::{
   dependency::{ESMImportSideEffectDependency, ESMImportSpecifierDependency},
-  utils::object_properties::get_attributes,
+  utils::{
+    eval::{BasicEvaluatedExpression, DependencyData},
+    object_properties::get_attributes,
+  },
   visitors::{
-    AllowedMemberTypes, AtomMembers, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo,
-    TagInfoData, get_non_optional_member_chain_from_expr,
+    AllowedMemberTypes, AtomMembers, ExportedVariableInfo, ExpressionExpressionInfo,
+    JavascriptParser, MemberExpressionInfo, TagInfoData, get_non_optional_member_chain_from_expr,
     get_non_optional_member_chain_from_member, get_non_optional_part,
   },
 };
@@ -26,6 +29,27 @@ use crate::{
 pub struct ESMImportDependencyParserPlugin;
 
 pub const ESM_SPECIFIER_TAG: &str = "_identifier__esm_specifier_tag__";
+
+fn is_esm_specifier_reference(
+  parser: &mut JavascriptParser,
+  for_name: &str,
+  member_expr_info: Option<&ExpressionExpressionInfo>,
+) -> bool {
+  if for_name == ESM_SPECIFIER_TAG {
+    return true;
+  }
+
+  let Some(member_expr_info) = member_expr_info else {
+    return false;
+  };
+  let ExportedVariableInfo::VariableInfo(root_info_id) = &member_expr_info.root_info else {
+    return false;
+  };
+
+  parser
+    .get_variable_tag_data::<ESMSpecifierData>(*root_info_id, ESM_SPECIFIER_TAG)
+    .is_some()
+}
 
 fn check_import_phase(parser: &mut JavascriptParser, phase: ImportPhase) {
   if !parser.compiler_options.experiments.defer_import && phase == ImportPhase::Defer {
@@ -159,7 +183,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       source_order,
       parser.in_short_hand,
       !parser.is_asi_position(expr.span_lo()),
-      expr_span.into(),
+      range,
       ids.into_vec(),
       parser.in_tagged_template_tag,
       direct_import,
@@ -172,8 +196,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     );
     dep.evaluated_in_operator = true;
 
+    let dep_id = *dep.id();
     let dep_idx = parser.next_dependency_idx();
     parser.add_dependency(Box::new(dep));
+
+    if let Some(in_guard) = parser.dependencies_in_branch_guard.as_mut() {
+      in_guard.insert(range, dep_id);
+    }
 
     InnerGraphParserPlugin::on_usage(
       parser,
@@ -225,7 +254,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       settings.source_order,
       parser.in_short_hand,
       !parser.is_asi_position(ident.span_lo()),
-      DependencyRange::from(ident.span),
+      range,
       settings.ids.into_vec(),
       parser.in_tagged_template_tag,
       true,
@@ -236,8 +265,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       settings.attributes,
       loc,
     );
+    let dep_id = *dep.id();
     let dep_idx = parser.next_dependency_idx();
     parser.add_dependency(Box::new(dep));
+
+    if let Some(in_guard) = parser.dependencies_in_branch_guard.as_mut() {
+      in_guard.insert(range, dep_id);
+    }
 
     InnerGraphParserPlugin::on_usage(
       parser,
@@ -280,6 +314,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     let mut ids = settings.ids;
     ids.extend(non_optional_members.iter().cloned());
     let direct_import = members.is_empty();
+    let range = DependencyRange::from(span);
     let ns_access = settings.namespace_import && !ids.is_empty();
     let mut dep = ESMImportSpecifierDependency::new(
       settings.source,
@@ -287,7 +322,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       settings.source_order,
       false,
       !parser.is_asi_position(call_expr.span_lo()),
-      span.into(),
+      range,
       ids.into_vec(),
       true,
       direct_import,
@@ -298,15 +333,20 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       None,
       settings.phase,
       settings.attributes,
-      parser.to_dependency_location(DependencyRange::from(call_expr.callee.span())),
+      parser.to_dependency_location(range),
     );
     dep.namespace_object_as_context = parser
       .javascript_options
       .strict_this_context_on_imports
       .unwrap_or(false)
       && !direct_import;
+    let dep_id = *dep.id();
     let dep_idx = parser.next_dependency_idx();
     parser.add_dependency(Box::new(dep));
+
+    if let Some(in_guard) = parser.dependencies_in_branch_guard.as_mut() {
+      in_guard.insert(range, dep_id);
+    }
 
     InnerGraphParserPlugin::on_usage(
       parser,
@@ -346,6 +386,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     };
     let mut ids = settings.ids;
     ids.extend(non_optional_members.iter().cloned());
+    let range = DependencyRange::from(span);
     let ns_access = settings.namespace_import && !ids.is_empty();
     let referenced_properties_in_destructuring = parser
       .destructuring_assignment_properties
@@ -357,7 +398,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       settings.source_order,
       false,
       !parser.is_asi_position(member_expr.span_lo()),
-      span.into(),
+      range,
       ids.into_vec(),
       false,
       false, // x.xx()
@@ -366,10 +407,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       referenced_properties_in_destructuring,
       settings.phase,
       settings.attributes,
-      parser.to_dependency_location(DependencyRange::from(span)),
+      parser.to_dependency_location(range),
     );
+    let dep_id = *dep.id();
     let dep_idx = parser.next_dependency_idx();
     parser.add_dependency(Box::new(dep));
+
+    if let Some(in_guard) = parser.dependencies_in_branch_guard.as_mut() {
+      in_guard.insert(range, dep_id);
+    }
 
     InnerGraphParserPlugin::on_usage(
       parser,
@@ -377,5 +423,24 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     );
 
     Some(true)
+  }
+
+  fn evaluate_identifier(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    for_name: &str,
+    member_expr_info: Option<&ExpressionExpressionInfo>,
+    start: u32,
+    end: u32,
+  ) -> Option<BasicEvaluatedExpression<'p>> {
+    if is_esm_specifier_reference(parser, for_name, member_expr_info)
+      && let Some(deps_in_guard) = &parser.dependencies_in_branch_guard
+      && let Some(dep) = deps_in_guard.get(&DependencyRange::new(start, end))
+    {
+      let mut res = BasicEvaluatedExpression::with_range(start, end);
+      res.set_dependency(DependencyData::Dependency(*dep));
+      return Some(res);
+    }
+    None
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -138,6 +138,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ModuleHotReplacementParserPlugin
     &self,
     _parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {
@@ -206,6 +207,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPl
     &self,
     _parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -432,6 +432,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaContextDependencyParse
     &self,
     _parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -241,6 +241,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<eval::BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -56,6 +56,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ConstValuePlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -717,6 +717,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -166,8 +166,8 @@ use crate::{
   utils::eval::BasicEvaluatedExpression,
   visitors::{
     ClassDeclOrExpr, DestructuringAssignmentProperty, ExportDefaultDeclaration,
-    ExportDefaultExpression, ExportImport, ExportLocal, ExportedVariableInfo, JavascriptParser,
-    Statement, VariableDeclaration,
+    ExportDefaultExpression, ExportImport, ExportLocal, ExportedVariableInfo,
+    ExpressionExpressionInfo, JavascriptParser, Statement, VariableDeclaration,
   },
 };
 
@@ -320,6 +320,7 @@ Please annotate your `impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ...` block
     &self,
     _parser: &mut JavascriptParser<'p>,
     _for_name: &str,
+    _member_expr_info: Option<&ExpressionExpressionInfo>,
     _start: u32,
     _end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -2,10 +2,7 @@ use rspack_core::DependencyRange;
 use rspack_util::SpanExt;
 use swc_experimental_ecma_ast::{BinExpr, BinaryOp, GetSpan};
 
-use crate::{
-  utils::eval::{BasicEvaluatedExpression, DependencyData},
-  visitors::JavascriptParser,
-};
+use crate::{utils::eval::BasicEvaluatedExpression, visitors::JavascriptParser};
 
 #[inline]
 fn handle_template_string_compare<'a>(

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -2,7 +2,10 @@ use rspack_core::DependencyRange;
 use rspack_util::SpanExt;
 use swc_experimental_ecma_ast::{BinExpr, BinaryOp, GetSpan};
 
-use crate::{utils::eval::BasicEvaluatedExpression, visitors::JavascriptParser};
+use crate::{
+  utils::eval::{BasicEvaluatedExpression, DependencyData},
+  visitors::JavascriptParser,
+};
 
 #[inline]
 fn handle_template_string_compare<'a>(
@@ -173,7 +176,7 @@ fn handle_nullish_coalescing<'parser: 'a, 'a>(
 
 #[inline(always)]
 fn handle_logical_or<'parser: 'a, 'a>(
-  left: BasicEvaluatedExpression<'a>,
+  mut left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr<'a>,
   scanner: &mut JavascriptParser<'parser>,
 ) -> Option<BasicEvaluatedExpression<'a>> {
@@ -192,13 +195,29 @@ fn handle_logical_or<'parser: 'a, 'a>(
       right.set_range(expr.span.real_lo(), expr.span.real_hi());
       Some(right)
     }
-    _ => {
-      let right_bool = scanner.evaluate_expression(&expr.right).as_bool();
-      if right_bool.is_some_and(|x| x) {
+    None => {
+      let right = scanner.evaluate_expression(&expr.right);
+      let right_bool = right.as_bool();
+      if right_bool == Some(true) {
         let mut res =
           BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         res.set_truthy();
         Some(res)
+      } else if left.is_dependency() {
+        if right_bool == Some(false) {
+          left.set_range(expr.span.real_lo(), expr.span.real_hi());
+          Some(left)
+        } else if right.is_dependency() {
+          let mut res =
+            BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
+          res.set_dependency(DependencyData::or(
+            left.into_dependency(),
+            right.into_dependency(),
+          ));
+          Some(res)
+        } else {
+          None
+        }
       } else {
         None
       }
@@ -208,7 +227,7 @@ fn handle_logical_or<'parser: 'a, 'a>(
 
 #[inline(always)]
 fn handle_logical_and<'parser: 'a, 'a>(
-  left: BasicEvaluatedExpression<'a>,
+  mut left: BasicEvaluatedExpression<'a>,
   expr: &'a BinExpr<'a>,
   scanner: &mut JavascriptParser<'parser>,
 ) -> Option<BasicEvaluatedExpression<'a>> {
@@ -228,12 +247,28 @@ fn handle_logical_and<'parser: 'a, 'a>(
       Some(res)
     }
     None => {
-      let right_bool = scanner.evaluate_expression(&expr.right).as_bool();
-      if right_bool.is_some_and(|x| !x) {
+      let right = scanner.evaluate_expression(&expr.right);
+      let right_bool = right.as_bool();
+      if right_bool == Some(false) {
         let mut res =
           BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
         res.set_falsy();
         Some(res)
+      } else if left.is_dependency() {
+        if right_bool == Some(true) {
+          left.set_range(expr.span.real_lo(), expr.span.real_hi());
+          Some(left)
+        } else if right.is_dependency() {
+          let mut res =
+            BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
+          res.set_dependency(DependencyData::and(
+            left.into_dependency(),
+            right.into_dependency(),
+          ));
+          Some(res)
+        } else {
+          None
+        }
       } else {
         None
       }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -210,10 +210,7 @@ fn handle_logical_or<'parser: 'a, 'a>(
         } else if right.is_dependency() {
           let mut res =
             BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
-          res.set_dependency(DependencyData::or(
-            left.into_dependency(),
-            right.into_dependency(),
-          ));
+          res.set_dependency(left.into_dependency().or(right.into_dependency()));
           Some(res)
         } else {
           None
@@ -261,10 +258,7 @@ fn handle_logical_and<'parser: 'a, 'a>(
         } else if right.is_dependency() {
           let mut res =
             BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
-          res.set_dependency(DependencyData::and(
-            left.into_dependency(),
-            right.into_dependency(),
-          ));
+          res.set_dependency(left.into_dependency().and(right.into_dependency()));
           Some(res)
         } else {
           None

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -30,6 +30,7 @@ pub fn eval_member_expression<'parser: 'a, 'a>(
       .evaluate_identifier(
         parser,
         &info.name,
+        Some(&info),
         member.span.real_lo(),
         member.span.real_hi(),
       )

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -118,6 +118,14 @@ pub fn eval_unary_expression<'parser: 'a, 'a>(
     UnaryOp::TypeOf => eval_typeof(scanner, expr),
     UnaryOp::Bang => {
       let arg = scanner.evaluate_expression(&expr.arg);
+      if arg.is_dependency() {
+        let side_effects = arg.could_have_side_effects();
+        let mut eval =
+          BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
+        eval.set_dependency(arg.into_dependency().not());
+        eval.set_side_effects(side_effects);
+        return Some(eval);
+      }
       let boolean = arg.as_bool()?;
       let mut eval = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.real_hi());
       eval.set_bool(!boolean);

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -12,7 +12,7 @@ mod eval_unary_expr;
 
 use bitflags::bitflags;
 use num_bigint::BigInt;
-use rspack_core::DependencyRange;
+use rspack_core::{DependencyId, DependencyRange};
 use swc_atoms::Atom;
 use swc_experimental_allocator::{Allocator, CloneIn};
 use swc_experimental_ecma_ast::{Expr, Span};
@@ -62,22 +62,54 @@ struct TemplateStringData<'a> {
   kind: TemplateStringKind,
 }
 
+#[rspack_cacheable::cacheable]
+#[derive(Debug, Clone)]
+pub enum DependencyData {
+  Dependency(DependencyId),
+  Or(
+    #[cacheable(omit_bounds)] Box<DependencyData>,
+    #[cacheable(omit_bounds)] Box<DependencyData>,
+  ),
+  And(
+    #[cacheable(omit_bounds)] Box<DependencyData>,
+    #[cacheable(omit_bounds)] Box<DependencyData>,
+  ),
+  Not(#[cacheable(omit_bounds)] Box<DependencyData>),
+}
+
+impl DependencyData {
+  pub fn or(self, other: DependencyData) -> Self {
+    DependencyData::Or(Box::new(self), Box::new(other))
+  }
+
+  pub fn and(self, other: DependencyData) -> Self {
+    DependencyData::And(Box::new(self), Box::new(other))
+  }
+
+  pub fn not(self) -> Self {
+    DependencyData::Not(Box::new(self))
+  }
+}
+
 #[derive(Debug)]
 enum Payload<'a> {
-  Unknown,
+  // Compile time value
   Undefined,
   Null,
   String(String),
   Number(Number),
   Boolean(Boolean),
   RegExp(Box<Regexp>),
+  ConstArray(Vec<String>),
+  BigInt(Bigint),
+  // Non-compile time value
   Conditional(Vec<BasicEvaluatedExpression<'a>>),
   Array(Vec<BasicEvaluatedExpression<'a>>),
   Wrapped(Box<WrappedData<'a>>),
-  ConstArray(Vec<String>),
-  BigInt(Bigint),
   Identifier(Box<IdentifierData>),
+  Dependency(DependencyData),
   TemplateString(Box<TemplateStringData<'a>>),
+  Unknown,
 }
 
 #[derive(Debug)]
@@ -178,6 +210,7 @@ impl<'alloc: 'a, 'a> CloneIn<'alloc> for Payload<'a> {
       Self::ConstArray(value) => Self::ConstArray(value.clone()),
       Self::BigInt(value) => Self::BigInt(value.clone()),
       Self::Identifier(value) => Self::Identifier(Box::new(value.clone_in(allocator))),
+      Self::Dependency(value) => Self::Dependency(value.clone()),
       Self::TemplateString(value) => Self::TemplateString(Box::new(value.clone_in(allocator))),
     }
   }
@@ -229,6 +262,10 @@ impl<'a> BasicEvaluatedExpression<'a> {
 
   pub fn is_identifier(&self) -> bool {
     matches!(self.payload, Payload::Identifier(_))
+  }
+
+  pub fn is_dependency(&self) -> bool {
+    matches!(self.payload, Payload::Dependency(_))
   }
 
   pub fn is_null(&self) -> bool {
@@ -520,6 +557,11 @@ impl<'a> BasicEvaluatedExpression<'a> {
     self.side_effects = true;
   }
 
+  pub fn set_dependency(&mut self, dep_data: DependencyData) {
+    self.payload = Payload::Dependency(dep_data);
+    self.side_effects = true;
+  }
+
   pub fn set_bool(&mut self, boolean: Boolean) {
     self.payload = Payload::Boolean(boolean);
     self.side_effects = false
@@ -618,6 +660,20 @@ impl<'a> BasicEvaluatedExpression<'a> {
     match &self.payload {
       Payload::Identifier(identifier) => identifier.member_ranges.as_ref(),
       _ => panic!("make sure identifier exist"),
+    }
+  }
+
+  pub fn dependency(&self) -> &DependencyData {
+    match &self.payload {
+      Payload::Dependency(dep_data) => dep_data,
+      _ => panic!("make sure dependency exist"),
+    }
+  }
+
+  pub fn into_dependency(self) -> DependencyData {
+    match self.payload {
+      Payload::Dependency(dep_data) => dep_data,
+      _ => panic!("make sure dependency exist"),
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -86,6 +86,7 @@ impl DependencyData {
     DependencyData::And(Box::new(self), Box::new(other))
   }
 
+  #[allow(clippy::should_implement_trait)]
   pub fn not(self) -> Self {
     DependencyData::Not(Box::new(self))
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -18,8 +18,9 @@ pub use self::{
   parser::{
     AllowedMemberTypes, AtomMembers, CallExpressionInfo, CallHooksName,
     DestructuringAssignmentProperties, DestructuringAssignmentProperty, ExportedVariableInfo,
-    JavascriptParser, MemberExpressionInfo, MemberRanges, OptionalMembers, PatRef, RootName,
-    ScopeTerminated, TagInfoData, TopLevelScope, ast::*, estree::*,
+    ExpressionExpressionInfo, JavascriptParser, MemberExpressionInfo, MemberRanges,
+    OptionalMembers, PatRef, RootName, ScopeTerminated, TagInfoData, TopLevelScope, ast::*,
+    estree::*,
   },
   util::*,
 };

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -692,23 +692,16 @@ impl<'parser> JavascriptParser<'parser> {
     &mut self,
     f: impl FnOnce(&mut JavascriptParser) -> T,
   ) -> T {
-    let old_deps = std::mem::replace(
-      &mut self.dependencies_in_branch_guard,
-      Some(Default::default()),
-    );
+    let old_deps = self
+      .dependencies_in_branch_guard
+      .replace(Default::default());
     let result = f(self);
     self.dependencies_in_branch_guard = old_deps;
     result
   }
 
   pub fn with_branch_guard(&mut self, guard: DependencyBranchGuard, f: impl FnOnce(&mut Self)) {
-    let guard = if let Some(old_guard) = self.current_branch_guard.clone() {
-      // handle for: if (A) { if (B) { import("./x") } }
-      old_guard.and(guard)
-    } else {
-      guard
-    };
-    let old_guard = std::mem::replace(&mut self.current_branch_guard, Some(guard));
+    let old_guard = self.current_branch_guard.replace(guard);
     f(self);
     self.current_branch_guard = old_guard;
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -22,7 +22,7 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
+  CompilerOptions, DependencyId, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
   JavascriptParserCommonjsExportsOption, JavascriptParserOptions, ModuleIdentifier, ModuleLayer,
   ModuleType, ParseMeta, ResourceData, SideEffectsBailoutItemWithSpan,
 };
@@ -40,7 +40,7 @@ use swc_experimental_ecma_ast::{
 
 use crate::{
   BoxJavascriptParserPlugin,
-  dependency::{DependencyBranchGuard, local_module::LocalModule, set_dependency_branch_guards},
+  dependency::{DependencyBranchGuard, local_module::LocalModule},
   parser_and_generator::ParserRuntimeRequirementsData,
   parser_plugin::{
     self, ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
@@ -424,7 +424,8 @@ pub struct JavascriptParser<'parser> {
   pub(crate) is_renaming: Option<Atom>,
   pub(crate) location_advancer: DependencyLocationAdvancer,
   pub(crate) collecting_dependencies_for_block: Option<usize>,
-  pub(crate) dependency_branch_guards: Vec<DependencyBranchGuard>,
+  pub(crate) dependencies_in_branch_guard: Option<FxHashMap<DependencyRange, DependencyId>>,
+  pub(crate) current_branch_guard: Option<DependencyBranchGuard>,
 }
 
 impl<'parser> JavascriptParser<'parser> {
@@ -617,7 +618,8 @@ impl<'parser> JavascriptParser<'parser> {
       is_renaming: None,
       location_advancer: DependencyLocationAdvancer::new(),
       collecting_dependencies_for_block: None,
-      dependency_branch_guards: Vec::new(),
+      dependencies_in_branch_guard: None,
+      current_branch_guard: None,
     }
   }
 
@@ -640,21 +642,20 @@ impl<'parser> JavascriptParser<'parser> {
   }
 
   pub fn add_dependency(&mut self, mut dep: BoxDependency) {
-    if !self.dependency_branch_guards.is_empty() {
-      set_dependency_branch_guards(dep.as_mut(), &self.dependency_branch_guards);
+    if let Some(guard) = &self.current_branch_guard {
+      guard.bind_dependency(dep.as_mut());
     }
     self.dependencies.push(dep);
   }
 
   pub fn add_dependencies(&mut self, deps: impl IntoIterator<Item = BoxDependency>) {
-    if self.dependency_branch_guards.is_empty() {
-      self.dependencies.extend(deps);
-    } else {
-      let branch_guards = self.dependency_branch_guards.clone();
+    if let Some(guard) = &self.current_branch_guard {
       self.dependencies.extend(deps.into_iter().map(|mut dep| {
-        set_dependency_branch_guards(dep.as_mut(), &branch_guards);
+        guard.bind_dependency(dep.as_mut());
         dep
       }));
+    } else {
+      self.dependencies.extend(deps);
     }
   }
 
@@ -687,6 +688,31 @@ impl<'parser> JavascriptParser<'parser> {
     std::mem::replace(&mut self.dependencies, old_deps)
   }
 
+  pub fn collect_dependencies_in_branch_guard<T>(
+    &mut self,
+    f: impl FnOnce(&mut JavascriptParser) -> T,
+  ) -> T {
+    let old_deps = std::mem::replace(
+      &mut self.dependencies_in_branch_guard,
+      Some(Default::default()),
+    );
+    let result = f(self);
+    self.dependencies_in_branch_guard = old_deps;
+    result
+  }
+
+  pub fn with_branch_guard(&mut self, guard: DependencyBranchGuard, f: impl FnOnce(&mut Self)) {
+    let guard = if let Some(old_guard) = self.current_branch_guard.clone() {
+      // handle for: if (A) { if (B) { import("./x") } }
+      old_guard.and(guard)
+    } else {
+      guard
+    };
+    let old_guard = std::mem::replace(&mut self.current_branch_guard, Some(guard));
+    f(self);
+    self.current_branch_guard = old_guard;
+  }
+
   pub fn add_presentational_dependency(&mut self, dep: BoxDependencyTemplate) {
     self.presentational_dependencies.push(dep);
   }
@@ -710,9 +736,9 @@ impl<'parser> JavascriptParser<'parser> {
   }
 
   pub fn add_block(&mut self, mut block: Box<AsyncDependenciesBlock>) {
-    if !self.dependency_branch_guards.is_empty() {
+    if let Some(guard) = &self.current_branch_guard {
       for dep in block.dependencies_mut() {
-        set_dependency_branch_guards(dep.as_mut(), &self.dependency_branch_guards);
+        guard.bind_dependency(dep.as_mut());
       }
     }
     self.blocks.push(block);
@@ -1519,7 +1545,13 @@ impl<'parser> JavascriptParser<'parser> {
         let drive = self.plugin_drive.clone();
         name
           .call_hooks_name(self, |parser, name| {
-            drive.evaluate_identifier(parser, name, ident.span.real_lo(), ident.span.real_hi())
+            drive.evaluate_identifier(
+              parser,
+              name,
+              None,
+              ident.span.real_lo(),
+              ident.span.real_hi(),
+            )
           })
           .or_else(|| {
             let info = self.get_variable_info(&name);
@@ -1571,7 +1603,7 @@ impl<'parser> JavascriptParser<'parser> {
         let Some(info) = self.get_variable_info(&"this".into()) else {
           // use `ident.sym` as fallback for global variable(or maybe just a undefined variable)
           return drive
-            .evaluate_identifier(self, "this", this.span.real_lo(), this.span.real_hi())
+            .evaluate_identifier(self, "this", None, this.span.real_lo(), this.span.real_hi())
             .or_else(default_eval);
         };
         if let Some(name) = &info.name
@@ -1579,7 +1611,7 @@ impl<'parser> JavascriptParser<'parser> {
         {
           let name = name.clone();
           return drive
-            .evaluate_identifier(self, &name, this.span.real_lo(), this.span.real_hi())
+            .evaluate_identifier(self, &name, None, this.span.real_lo(), this.span.real_hi())
             .or_else(default_eval);
         }
         None

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -701,6 +701,12 @@ impl<'parser> JavascriptParser<'parser> {
   }
 
   pub fn with_branch_guard(&mut self, guard: DependencyBranchGuard, f: impl FnOnce(&mut Self)) {
+    let guard = if let Some(old_guard) = self.current_branch_guard.clone() {
+      // handle for: if (A) { if (B) { import("./x") } }
+      DependencyBranchGuard::new(old_guard.into_inner().and(guard.into_inner()))
+    } else {
+      guard
+    };
     let old_guard = self.current_branch_guard.replace(guard);
     f(self);
     self.current_branch_guard = old_guard;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1,7 +1,5 @@
 use std::{borrow::Cow, cell::Cell};
 
-use rspack_core::{Dependency, DependencyId, DependencyRange};
-use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_allocator::{Allocator, CloneIn};
 use swc_experimental_ecma_ast::{
@@ -24,7 +22,7 @@ use super::{
   estree::{ClassDeclOrExpr, MaybeNamedClassDecl, MaybeNamedFunctionDecl, Statement},
 };
 use crate::{
-  dependency::{DependencyBranchGuard, ESMImportSpecifierDependency, ESMImportedBooleanGuardNode},
+  dependency::{DependencyBranchGuard, ESMImportSpecifierDependency},
   parser_plugin::{
     CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
     CreatedRequireTagData, JavascriptParserPlugin, is_create_require_namespace_member,
@@ -46,159 +44,7 @@ fn warp_ident_to_pat<'a>(ident: &Ident<'a>, allocator: &'a Allocator) -> Pat<'a>
   Pat::Ident(allocator.boxed(ident.clone_in(allocator).into_binding(allocator)))
 }
 
-#[derive(Debug)]
-enum ImportedBooleanConditionTemplate {
-  Constant(bool),
-  ESMImportedBoolean {
-    range: DependencyRange,
-    expected: bool,
-  },
-  All(
-    Box<ImportedBooleanConditionTemplate>,
-    Box<ImportedBooleanConditionTemplate>,
-  ),
-  Any(
-    Box<ImportedBooleanConditionTemplate>,
-    Box<ImportedBooleanConditionTemplate>,
-  ),
-}
-
-impl ImportedBooleanConditionTemplate {
-  fn into_branch_guard(
-    self,
-    dependencies: &[(DependencyRange, DependencyId)],
-  ) -> Option<DependencyBranchGuard> {
-    let mut nodes = Vec::new();
-    let root = self.push_branch_guard_node(dependencies, &mut nodes)?;
-    Some(DependencyBranchGuard::ESMImportedBooleanExpression { nodes, root })
-  }
-
-  fn push_branch_guard_node(
-    self,
-    dependencies: &[(DependencyRange, DependencyId)],
-    nodes: &mut Vec<ESMImportedBooleanGuardNode>,
-  ) -> Option<u32> {
-    let node = match self {
-      Self::Constant(value) => ESMImportedBooleanGuardNode::Constant(value),
-      Self::ESMImportedBoolean { range, expected } => {
-        let (_, dependency_id) = dependencies
-          .iter()
-          .find(|(dependency_range, _)| *dependency_range == range)?;
-        ESMImportedBooleanGuardNode::ESMImportedBoolean {
-          dependency_id: *dependency_id,
-          expected,
-        }
-      }
-      Self::All(left, right) => ESMImportedBooleanGuardNode::All {
-        left: left.push_branch_guard_node(dependencies, nodes)?,
-        right: right.push_branch_guard_node(dependencies, nodes)?,
-      },
-      Self::Any(left, right) => ESMImportedBooleanGuardNode::Any {
-        left: left.push_branch_guard_node(dependencies, nodes)?,
-        right: right.push_branch_guard_node(dependencies, nodes)?,
-      },
-    };
-    let index = u32::try_from(nodes.len()).ok()?;
-    nodes.push(node);
-    Some(index)
-  }
-}
-
 impl JavascriptParser<'_> {
-  fn with_dependency_branch_guards(
-    &mut self,
-    guards: impl IntoIterator<Item = DependencyBranchGuard>,
-    f: impl FnOnce(&mut Self),
-  ) {
-    let old_len = self.dependency_branch_guards.len();
-    self.dependency_branch_guards.extend(guards);
-    f(self);
-    self.dependency_branch_guards.truncate(old_len);
-  }
-
-  fn esm_import_condition_dependencies(
-    &self,
-    start: usize,
-  ) -> Vec<(DependencyRange, DependencyId)> {
-    self.dependencies[start..]
-      .iter()
-      .filter_map(|dependency| {
-        let dependency = dependency.downcast_ref::<ESMImportSpecifierDependency>()?;
-        Some((dependency.range()?, *dependency.id()))
-      })
-      .collect()
-  }
-
-  fn branch_condition_templates_for_imported_bool(
-    test: &Expr,
-  ) -> Option<(
-    ImportedBooleanConditionTemplate,
-    ImportedBooleanConditionTemplate,
-  )> {
-    match test {
-      Expr::Ident(ident) => {
-        let range = DependencyRange::new(ident.span.real_lo(), ident.span.real_hi());
-        Some((
-          ImportedBooleanConditionTemplate::ESMImportedBoolean {
-            range,
-            expected: true,
-          },
-          ImportedBooleanConditionTemplate::ESMImportedBoolean {
-            range,
-            expected: false,
-          },
-        ))
-      }
-      Expr::Lit(lit) if matches!(&**lit, Lit::Bool(_)) => {
-        let Lit::Bool(lit) = &**lit else {
-          unreachable!();
-        };
-        Some((
-          ImportedBooleanConditionTemplate::Constant(lit.value),
-          ImportedBooleanConditionTemplate::Constant(!lit.value),
-        ))
-      }
-      Expr::Paren(expr) => Self::branch_condition_templates_for_imported_bool(&expr.expr),
-      Expr::Unary(expr) if expr.op == UnaryOp::Bang => {
-        Self::branch_condition_templates_for_imported_bool(&expr.arg)
-          .map(|(consequent, alternate)| (alternate, consequent))
-      }
-      Expr::Bin(expr) if expr.op == BinaryOp::LogicalAnd => {
-        let (left_consequent, left_alternate) =
-          Self::branch_condition_templates_for_imported_bool(&expr.left)?;
-        let (right_consequent, right_alternate) =
-          Self::branch_condition_templates_for_imported_bool(&expr.right)?;
-        Some((
-          ImportedBooleanConditionTemplate::All(
-            Box::new(left_consequent),
-            Box::new(right_consequent),
-          ),
-          ImportedBooleanConditionTemplate::Any(
-            Box::new(left_alternate),
-            Box::new(right_alternate),
-          ),
-        ))
-      }
-      Expr::Bin(expr) if expr.op == BinaryOp::LogicalOr => {
-        let (left_consequent, left_alternate) =
-          Self::branch_condition_templates_for_imported_bool(&expr.left)?;
-        let (right_consequent, right_alternate) =
-          Self::branch_condition_templates_for_imported_bool(&expr.right)?;
-        Some((
-          ImportedBooleanConditionTemplate::Any(
-            Box::new(left_consequent),
-            Box::new(right_consequent),
-          ),
-          ImportedBooleanConditionTemplate::All(
-            Box::new(left_alternate),
-            Box::new(right_alternate),
-          ),
-        ))
-      }
-      _ => None,
-    }
-  }
-
   fn in_block_scope<F>(&mut self, in_executed_path: bool, f: F)
   where
     F: FnOnce(&mut Self),
@@ -508,26 +354,23 @@ impl JavascriptParser<'_> {
         self.walk_nested_statement(alt);
       }
     } else {
-      let mut test_walked = false;
-      let branch_condition = Self::branch_condition_templates_for_imported_bool(&stmt.test)
-        .and_then(|(consequent, alternate)| {
-          let dep_start = self.next_dependency_idx();
-          self.walk_expression(&stmt.test);
-          test_walked = true;
-          let dependencies = self.esm_import_condition_dependencies(dep_start);
-          Some((
-            consequent.into_branch_guard(&dependencies)?,
-            alternate.into_branch_guard(&dependencies)?,
-          ))
-        });
-
       // Unknown or non-constant condition – walk the test for side effects and
       // both branches, only keeping termination when *both* are terminated.
-      if !test_walked {
-        self.walk_expression(&stmt.test);
-      }
-      if let Some((consequent_condition, _)) = &branch_condition {
-        self.with_dependency_branch_guards(std::iter::once(consequent_condition.clone()), |this| {
+      let guard = self.collect_dependencies_in_branch_guard(|parser| {
+        parser.walk_expression(&stmt.test);
+        let deps_in_guard = parser.dependencies_in_branch_guard.as_ref()?;
+        if deps_in_guard.is_empty() {
+          return None;
+        }
+        let evaluated = parser.evaluate_expression(&stmt.test);
+        if evaluated.is_dependency() {
+          return Some(evaluated.into_dependency());
+        }
+        None
+      });
+
+      if let Some(guard) = &guard {
+        self.with_branch_guard(DependencyBranchGuard::new(guard.clone()), |this| {
           this.walk_nested_statement(&stmt.cons)
         });
       } else {
@@ -536,11 +379,10 @@ impl JavascriptParser<'_> {
       let consequent_terminated = self.terminated;
       self.terminated = None;
       if let Some(alt) = &stmt.alt {
-        if let Some((_, alternate_condition)) = &branch_condition {
-          self
-            .with_dependency_branch_guards(std::iter::once(alternate_condition.clone()), |this| {
-              this.walk_nested_statement(alt)
-            });
+        if let Some(guard) = guard {
+          self.with_branch_guard(DependencyBranchGuard::new(guard.not()), |this| {
+            this.walk_nested_statement(alt)
+          });
         } else {
           self.walk_nested_statement(alt);
         }
@@ -1267,9 +1109,33 @@ impl JavascriptParser<'_> {
         self.walk_expression(&expr.alt);
       }
     } else {
-      self.walk_expression(&expr.test);
-      self.walk_expression(&expr.cons);
-      self.walk_expression(&expr.alt);
+      let guard = self.collect_dependencies_in_branch_guard(|parser| {
+        parser.walk_expression(&expr.test);
+        let deps_in_guard = parser.dependencies_in_branch_guard.as_ref()?;
+        if deps_in_guard.is_empty() {
+          return None;
+        }
+        let evaluated = parser.evaluate_expression(&expr.test);
+        if evaluated.is_dependency() {
+          return Some(evaluated.into_dependency());
+        }
+        None
+      });
+
+      if let Some(guard) = &guard {
+        self.with_branch_guard(DependencyBranchGuard::new(guard.clone()), |this| {
+          this.walk_expression(&expr.cons)
+        });
+      } else {
+        self.walk_expression(&expr.cons);
+      }
+      if let Some(guard) = guard {
+        self.with_branch_guard(DependencyBranchGuard::new(guard.not()), |this| {
+          this.walk_expression(&expr.alt)
+        });
+      } else {
+        self.walk_expression(&expr.alt);
+      }
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -9,9 +9,9 @@ use swc_experimental_ecma_ast::{
   ExprOrSpread, ExprStmt, FnExpr, ForHead, ForInStmt, ForOfStmt, ForStmt, Function, GetSpan,
   GetterProp, Ident, IdentName, IfStmt, JSXAttr, JSXAttrOrSpread, JSXAttrValue, JSXElement,
   JSXElementChild, JSXElementName, JSXExpr, JSXExprContainer, JSXFragment, JSXMemberExpr,
-  JSXNamespacedName, JSXObject, KeyValueProp, LabeledStmt, Lit, MemberExpr, MemberProp,
-  MetaPropExpr, ModuleDecl, ModuleItem, NewExpr, ObjectLit, ObjectPat, ObjectPatProp, OptCall,
-  OptChainExpr, Param, Pat, Prop, PropName, PropOrSpread, RestPat, ReturnStmt, SeqExpr, SetterProp,
+  JSXNamespacedName, JSXObject, KeyValueProp, LabeledStmt, MemberExpr, MemberProp, MetaPropExpr,
+  ModuleDecl, ModuleItem, NewExpr, ObjectLit, ObjectPat, ObjectPatProp, OptCall, OptChainExpr,
+  Param, Pat, Prop, PropName, PropOrSpread, RestPat, ReturnStmt, SeqExpr, SetterProp,
   SimpleAssignTarget, Stmt, SwitchCase, SwitchStmt, TaggedTpl, ThisExpr, ThrowStmt, Tpl, TryStmt,
   UnaryExpr, UnaryOp, UpdateExpr, VarDeclOrExpr, WhileStmt, WithStmt, YieldExpr,
 };
@@ -22,7 +22,7 @@ use super::{
   estree::{ClassDeclOrExpr, MaybeNamedClassDecl, MaybeNamedFunctionDecl, Statement},
 };
 use crate::{
-  dependency::{DependencyBranchGuard, ESMImportSpecifierDependency},
+  dependency::DependencyBranchGuard,
   parser_plugin::{
     CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
     CreatedRequireTagData, JavascriptParserPlugin, is_create_require_namespace_member,

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -981,6 +981,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RstestParserPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     for_name: &str,
+    _member_expr_info: Option<&rspack_plugin_javascript::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<eval::BasicEvaluatedExpression<'p>> {

--- a/tests/rspack-test/configCases/inline-const/basic/branch-unused.js
+++ b/tests/rspack-test/configCases/inline-const/basic/branch-unused.js
@@ -1,2 +1,0 @@
-globalThis.__inlineConstBranchUnused = true;
-throw new Error("unreachable");

--- a/tests/rspack-test/configCases/inline-const/basic/index.js
+++ b/tests/rspack-test/configCases/inline-const/basic/index.js
@@ -7,7 +7,6 @@ import * as reexportedBarrelSideEffects from "./re-export.barrel-side-effects.js
 import * as reexportedDestructingBarrelSideEffects from "./re-export.destructing-barrel-side-effects.js";
 import * as constantsCjs from "./constants.cjs";
 import * as constantsNoInline from "./constants.no-inline.js";
-import { REMOVE_b as BRANCH_TRUE, REMOVE_FALSE as BRANCH_FALSE } from "./constants.js";
 
 const fs = __non_webpack_require__("fs");
 const path = __non_webpack_require__("path");
@@ -182,33 +181,4 @@ it("should keep the module if part of the exports is inlined and side effects fr
 
 it("should not inline no-inlinable constants", () => {
   expect(constantsNoInline.INLINE_1).toEqual({});
-})
-
-it("should drop inactive branch dependencies guarded by inlined imported booleans", () => {
-  const values = [];
-  if (BRANCH_TRUE) {
-    values.push("true-branch");
-  } else {
-    require("./branch-unused.js");
-  }
-  if (BRANCH_FALSE) {
-    require("./branch-unused.js");
-  } else {
-    values.push("false-branch-alt");
-  }
-  if (BRANCH_FALSE) {
-    import("./branch-unused.js");
-  } else {
-    values.push("dynamic-branch-alt");
-  }
-
-  expect(values).toEqual(["true-branch", "false-branch-alt", "dynamic-branch-alt"]);
-  const unusedMarker = "__inlineConst" + "BranchUnused";
-  const emittedSource = fs
-    .readdirSync(path.dirname(__filename))
-    .filter(file => file.endsWith(".js"))
-    .map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
-    .join("\n");
-  expect(globalThis[unusedMarker]).toBe(undefined);
-  expect(emittedSource.includes(unusedMarker)).toBe(false);
 })

--- a/tests/rspack-test/configCases/inline-const/branch-unused/branch-unused.js
+++ b/tests/rspack-test/configCases/inline-const/branch-unused/branch-unused.js
@@ -1,0 +1,1 @@
+throw new Error("unreachable: inline-const branch-unused");

--- a/tests/rspack-test/configCases/inline-const/branch-unused/constants.js
+++ b/tests/rspack-test/configCases/inline-const/branch-unused/constants.js
@@ -1,0 +1,4 @@
+export const BRANCH_TRUE = true;
+export const BRANCH_FALSE = false;
+export const OUTER = true;
+export const INNER = false;

--- a/tests/rspack-test/configCases/inline-const/branch-unused/index.js
+++ b/tests/rspack-test/configCases/inline-const/branch-unused/index.js
@@ -1,0 +1,57 @@
+import { BRANCH_FALSE, BRANCH_TRUE, INNER, OUTER } from "./constants";
+
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+function emittedSource() {
+  return fs
+    .readdirSync(path.dirname(__filename))
+    .filter(file => file.endsWith(".js"))
+    .map(file => fs.readFileSync(path.join(path.dirname(__filename), file), "utf-8"))
+    .join("\n");
+}
+
+it("should drop inactive branch dependencies guarded by inlined imported booleans", () => {
+  const values = [];
+  if (BRANCH_TRUE) {
+    values.push("true-branch");
+  } else {
+    require("./branch-unused.js");
+  }
+  if (BRANCH_FALSE) {
+    require("./branch-unused.js");
+  } else {
+    values.push("false-branch-alt");
+  }
+  if (BRANCH_FALSE) {
+    import("./branch-unused.js");
+  } else {
+    values.push("dynamic-branch-alt");
+  }
+
+  expect(values).toEqual(["true-branch", "false-branch-alt", "dynamic-branch-alt"]);
+  const unusedMarker = "unreachable: inline-const " + "branch-unused";
+  expect(emittedSource().includes(unusedMarker)).toBe(false);
+});
+
+it("should drop nested inactive require.ensure block dependencies", async () => {
+  if (OUTER) {
+    await new Promise((resolve, reject) => {
+      require.ensure([], require => {
+        try {
+          if (INNER) {
+            require("./nested-unused");
+          } else {
+            const unusedMarker = "unreachable: nested require.ensure " + "branch-unused";
+            expect(emittedSource().includes(unusedMarker)).toBe(false);
+          }
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  } else {
+    throw new Error("outer guard should be true");
+  }
+});

--- a/tests/rspack-test/configCases/inline-const/branch-unused/nested-unused.js
+++ b/tests/rspack-test/configCases/inline-const/branch-unused/nested-unused.js
@@ -1,0 +1,1 @@
+throw new Error("unreachable: nested require.ensure branch-unused");

--- a/tests/rspack-test/configCases/inline-const/branch-unused/rspack.config.js
+++ b/tests/rspack-test/configCases/inline-const/branch-unused/rspack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    inlineExports: true,
+    moduleIds: 'named',
+    usedExports: true,
+  },
+};

--- a/tests/rspack-test/esmOutputCases/basic/inline-const-branch-dependencies/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/inline-const-branch-dependencies/__snapshots__/esm.snap.txt
@@ -16,6 +16,7 @@ function foo() {
 
 
 
+
 const values = [];
 
 if ((/* inlined export .IS_DEV */true)) {
@@ -122,6 +123,25 @@ if (((/* inlined export .IS_DEV1 */false) || (/* inlined export .IS_DEV2 */true)
   values.push(bar());
 }
 
+values.push(((/* inlined export .IS_DEV */true) ? foo : bar)());
+values.push(((/* inlined export .IS_DEV1 */false) ? bar : alt)());
+
+if ((/* inlined export .IS_DEV */true)) {
+  console.log(foo);
+  values.push(foo());
+} else {
+  console.log(bar);
+  values.push(bar());
+}
+
+if ((/* inlined export .IS_DEV1 */false)) {
+  console.log(bar);
+  values.push(bar());
+} else {
+  console.log(alt);
+  values.push(alt());
+}
+
 if ((/* inlined export .IS_DEV */true)) {
   if ((/* inlined export .IS_DEV1 */false)) {
     console.log(bar);
@@ -182,6 +202,10 @@ it("should drop inactive ESM branch dependencies guarded by inlined booleans", (
     "foo",
     "alt",
     "foo",
+    "foo",
+    "alt",
+    "foo",
+    "alt",
     "foo",
     "foo",
     "alt",

--- a/tests/rspack-test/esmOutputCases/basic/inline-const-branch-dependencies/index.js
+++ b/tests/rspack-test/esmOutputCases/basic/inline-const-branch-dependencies/index.js
@@ -1,4 +1,5 @@
 import { IS_DEV, IS_DEV1, IS_DEV2 } from "./env";
+import * as envNs from "./env";
 import { alt } from "./alt";
 import { foo } from "./foo";
 import { bar } from "./bar";
@@ -109,6 +110,25 @@ if ((IS_DEV1 || IS_DEV2) && (IS_DEV && false || IS_DEV2)) {
   values.push(bar());
 }
 
+values.push((IS_DEV ? foo : bar)());
+values.push((IS_DEV1 ? bar : alt)());
+
+if (envNs.IS_DEV) {
+  console.log(foo);
+  values.push(foo());
+} else {
+  console.log(bar);
+  values.push(bar());
+}
+
+if (envNs.IS_DEV1) {
+  console.log(bar);
+  values.push(bar());
+} else {
+  console.log(alt);
+  values.push(alt());
+}
+
 if (IS_DEV) {
   if (IS_DEV1) {
     console.log(bar);
@@ -169,6 +189,10 @@ it("should drop inactive ESM branch dependencies guarded by inlined booleans", (
     "foo",
     "alt",
     "foo",
+    "foo",
+    "alt",
+    "foo",
+    "alt",
     "foo",
     "foo",
     "alt",

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 5494176960333ddb,
+			      hash: 07d47db741042d46,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 2574529075ccb8c5,
+			  hash: 8b0a53232015b9bd,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (7762259ba9d01658)
+Rspack compiled successfully (3d8679dfe3fc3efe)


### PR DESCRIPTION
## Summary

- Refactor code
- Support drop inactive branch dependencies for member expr
- Support drop inactive branch dependencies for `test ? cons : alt`

```js
import * as ns from "./x"

if (ns.IS_DEV) { // analyze member expr so require() can be dropped
  require("./unused")
}

ns.IS_DEV ? require("./unused") : xx; // support conditional expression
```
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
