### PR TITLE
refactor: split content hash from std Hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,11 +4152,18 @@ name = "rspack_hash"
 version = "0.101.1"
 dependencies = [
  "base64-simd 0.8.0",
+ "itoa",
+ "lightningcss",
  "md4",
  "rspack_cacheable",
+ "rspack_collections",
+ "rspack_macros",
  "rspack_util",
+ "serde",
  "sha2",
+ "simd-json",
  "smol_str",
+ "swc_config",
  "xxhash-rust",
 ]
 
@@ -4826,6 +4833,7 @@ dependencies = [
  "rspack_cacheable",
  "rspack_core",
  "rspack_error",
+ "rspack_hash",
  "rspack_util",
 ]
 

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -828,36 +828,25 @@ impl From<JsBuildMeta> for BuildMeta {
       exports_type: raw_exports_type,
     } = value;
 
-    let default_object = if let Some(raw_default_object) = raw_default_object {
-      match raw_default_object.as_str() {
+    let default_object =
+      raw_default_object.map(|raw_default_object| match raw_default_object.as_str() {
         "false" => BuildMetaDefaultObject::False,
         "redirect" => BuildMetaDefaultObject::Redirect,
         "redirect-warn" => BuildMetaDefaultObject::RedirectWarn,
         _ => unreachable!(),
-      }
-    } else {
-      BuildMetaDefaultObject::False
-    };
+      });
 
-    let exports_type = if let Some(raw_exports_type) = raw_exports_type {
-      match raw_exports_type.as_str() {
-        "unset" => BuildMetaExportsType::Unset,
-        "default" => BuildMetaExportsType::Default,
-        "namespace" => BuildMetaExportsType::Namespace,
-        "flagged" => BuildMetaExportsType::Flagged,
-        "dynamic" => BuildMetaExportsType::Dynamic,
-        _ => unreachable!(),
-      }
-    } else {
-      BuildMetaExportsType::Unset
-    };
+    let exports_type = raw_exports_type
+      .as_deref()
+      .map(BuildMetaExportsType::from)
+      .unwrap_or_default();
 
-    Self {
-      strict_esm_module: strict_esm_module.unwrap_or_default(),
-      has_top_level_await: has_top_level_await.unwrap_or_default(),
-      esm: esm.unwrap_or_default(),
-      is_css_module: false,
-      need_id_in_concatenation: false,
+    BuildMeta {
+      strict_esm_module,
+      has_top_level_await,
+      esm,
+      is_css_module: None,
+      need_id_in_concatenation: None,
       exports_type,
       default_object,
       side_effect_free,

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1503,7 +1503,7 @@ impl CompilationChunkHash for CompilationChunkHashTap {
       .function
       .call_with_sync(ChunkWrapper::new(*chunk_ukey, compilation))
       .await?;
-    result.hash(hasher);
+    hasher.write(&result);
     Ok(())
   }
 
@@ -1789,7 +1789,7 @@ impl JavascriptModulesChunkHash for JavascriptModulesChunkHashTap {
       .function
       .call_with_sync(ChunkWrapper::new(*chunk_ukey, compilation))
       .await?;
-    result.hash(hasher);
+    hasher.write(&result);
     Ok(())
   }
 

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -1,13 +1,14 @@
 use std::{
   collections::hash_map::Entry,
-  hash::Hash,
   ops::{Deref, DerefMut},
   sync::atomic::AtomicU32,
 };
 
 use anymap::CloneAny;
 use rspack_collections::IdentifierMap;
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
+use rspack_hash::{
+  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHashable,
+};
 use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -167,7 +168,7 @@ impl CodeGenerationResult {
     let mut hasher = RspackHash::with_salt(hash_function, hash_salt);
     for (source_type, source) in self.inner.as_ref() {
       source_type.hash(&mut hasher);
-      source.hash(&mut hasher);
+      std::hash::Hash::hash(source, &mut hasher);
     }
     self.chunk_init_fragments.hash(&mut hasher);
     self.runtime_requirements.hash(&mut hasher);

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -1,10 +1,10 @@
-use std::{cmp::Ordering, fmt::Debug, hash::Hash};
+use std::{cmp::Ordering, fmt::Debug};
 
 use itertools::Itertools;
 use rayon::prelude::*;
 use rspack_collections::IdentifierSet;
 use rspack_error::Diagnostic;
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use ustr::Ustr;

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -1,16 +1,13 @@
 //!  There are methods whose verb is `ChunkGraphChunk`
 
-use std::{
-  collections::VecDeque,
-  fmt,
-  hash::{BuildHasherDefault, Hash},
-};
+use std::{collections::VecDeque, fmt, hash::BuildHasherDefault};
 
 use hashlink::LinkedHashMap;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_collections::{IdentifierHasher, IdentifierLinkedMap, IdentifierMap, IdentifierSet};
+use rspack_hash::RspackHash;
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Serialize, Serializer};
@@ -78,6 +75,12 @@ impl ChunkId {
 
   pub fn as_str(&self) -> &str {
     self.0.as_str()
+  }
+}
+
+impl rspack_hash::RspackHashable for ChunkId {
+  fn hash(&self, state: &mut RspackHash) {
+    self.0.as_str().hash(state);
   }
 }
 

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -2,12 +2,12 @@
 
 use std::{
   fmt,
-  hash::{BuildHasherDefault, Hash, Hasher},
+  hash::{BuildHasherDefault, Hasher},
 };
 
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_collections::{IdentifierHasher, IdentifierSet};
-use rspack_hash::RspackHashDigest;
+use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_util::ext::DynHash;
 use rustc_hash::{FxHashSet, FxHasher};
 use serde::{Serialize, Serializer};
@@ -71,6 +71,12 @@ impl ModuleId {
 
   pub fn as_str(&self) -> &str {
     self.0.as_str()
+  }
+}
+
+impl rspack_hash::RspackHashable for ModuleId {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
   }
 }
 
@@ -320,6 +326,8 @@ impl ChunkGraph {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> u64 {
+    use std::hash::Hash;
+
     let mut hasher = FxHasher::default();
     let strict = module.get_strict_esm_module();
     let mg = compilation.get_module_graph();

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use rspack_cacheable::cacheable;
 use rspack_collections::IdentifierMap;
 use rspack_error::{Result, error};
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 
@@ -441,9 +442,27 @@ impl EntryRuntime {
   }
 }
 
+impl RspackHashable for EntryRuntime {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      EntryRuntime::String(s) => s.hash(state),
+      EntryRuntime::False => "false".hash(state),
+    }
+  }
+}
+
+impl Display for EntryRuntime {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      EntryRuntime::String(s) => f.write_str(s),
+      EntryRuntime::False => f.write_str("false"),
+    }
+  }
+}
+
 // pub type EntryRuntime = String;
 #[cacheable]
-#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, rspack_hash::RspackHashable)]
 pub struct EntryOptions {
   pub name: Option<String>,
   pub runtime: Option<EntryRuntime>,
@@ -516,7 +535,7 @@ impl Display for ChunkGroupOrderKey {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
 pub struct ChunkGroupOptions {
   pub name: Option<String>,
   pub preload_order: Option<i32>,
@@ -545,10 +564,25 @@ impl ChunkGroupOptions {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupOptions {
   Entrypoint(Box<EntryOptions>),
   ChunkGroup(ChunkGroupOptions),
+}
+
+impl RspackHashable for GroupOptions {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      GroupOptions::Entrypoint(options) => {
+        "entrypoint".hash(state);
+        options.hash(state);
+      }
+      GroupOptions::ChunkGroup(options) => {
+        "chunk-group".hash(state);
+        options.hash(state);
+      }
+    }
+  }
 }
 
 impl GroupOptions {

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use rspack_hash::RspackHash;
 use rustc_hash::FxHashSet;
 
 use super::*;
@@ -393,19 +394,19 @@ pub async fn create_hash(
     .sorted_unstable_by_key(|chunk| chunk.ukey())
     .for_each(|chunk| {
       if let Some(hash) = chunk.hash(&compilation.chunk_hashes_artifact) {
-        hash.hash(&mut compilation_hasher);
+        compilation_hasher.update(hash);
       }
       if let Some(content_hashes) = chunk.content_hash(&compilation.chunk_hashes_artifact) {
         content_hashes
           .iter()
           .sorted_unstable_by_key(|(source_type, _)| *source_type)
           .for_each(|(source_type, content_hash)| {
-            source_type.hash(&mut compilation_hasher);
-            content_hash.hash(&mut compilation_hasher);
+            compilation_hasher.update(source_type);
+            compilation_hasher.update(content_hash);
           });
       }
     });
-  compilation.hot_index.hash(&mut compilation_hasher);
+  compilation_hasher.update(&compilation.hot_index);
   compilation.hash = Some(compilation_hasher.digest(&compilation.options.output.hash_digest));
 
   // re-create runtime chunk hash that depend on full hash
@@ -433,12 +434,13 @@ pub async fn create_hash(
         .hash(&compilation.chunk_hashes_artifact)
         .expect("should have chunk hash");
       let mut hasher = RspackHash::from(&compilation.options.output);
-      chunk_hash.hash(&mut hasher);
-      compilation
-        .hash
-        .as_ref()
-        .expect("compilation hash should be set")
-        .hash(&mut hasher);
+      hasher.update(chunk_hash);
+      hasher.update(
+        compilation
+          .hash
+          .as_ref()
+          .expect("compilation hash should be set"),
+      );
       hasher.digest(&compilation.options.output.hash_digest)
     };
     let new_content_hash = {
@@ -449,12 +451,13 @@ pub async fn create_hash(
         .iter()
         .map(|(source_type, content_hash)| {
           let mut hasher = RspackHash::from(&compilation.options.output);
-          content_hash.hash(&mut hasher);
-          compilation
-            .hash
-            .as_ref()
-            .expect("compilation hash should be set")
-            .hash(&mut hasher);
+          hasher.update(content_hash);
+          hasher.update(
+            compilation
+              .hash
+              .as_ref()
+              .expect("compilation hash should be set"),
+          );
           (
             *source_type,
             hasher.digest(&compilation.options.output.hash_digest),
@@ -552,7 +555,7 @@ async fn process_chunk_hash(
   let content_hashes = content_hashes
     .into_iter()
     .map(|(t, mut hasher)| {
-      chunk_hash.hash(&mut hasher);
+      hasher.update(&chunk_hash);
       (t, hasher.digest(&compilation.options.output.hash_digest))
     })
     .collect();

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -615,7 +615,7 @@ impl Compilation {
     let len = import_var_map_of_module.len();
     let is_deferred = phase.is_defer()
       && !target_module
-        .map(|m| m.build_meta().has_top_level_await)
+        .map(|m| m.build_meta().has_top_level_await())
         .unwrap_or_default();
 
     match import_var_map_of_module.entry((target_module.map(|m| m.identifier()), is_deferred)) {

--- a/crates/rspack_core/src/compilation/module_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/module_ids/mod.rs
@@ -21,8 +21,8 @@ fn get_modules_needing_ids(
       m.need_id()
         && ChunkGraph::get_module_id(module_ids_artifact, m.identifier()).is_none()
         && (chunk_graph.get_number_of_module_chunks(m.identifier()) != 0
-          || m.build_meta().is_css_module
-          || m.build_meta().need_id_in_concatenation)
+          || m.build_meta().is_css_module()
+          || m.build_meta().need_id_in_concatenation())
     })
     .map(|m| m.identifier())
     .collect()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2,7 +2,6 @@ use std::{
   borrow::Cow,
   collections::{BTreeMap, VecDeque},
   fmt::Debug,
-  hash::Hasher,
   mem,
   sync::{Arc, LazyLock},
 };
@@ -14,14 +13,13 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest};
+use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest, RspackHashable};
 use rspack_hook::define_hook;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
 };
 use rspack_util::{
   SpanExt,
-  ext::DynHash,
   fx_hash::{FxIndexMap, FxIndexSet},
   itoa, json_stringify, json_stringify_str,
   source_map::SourceMapKind,
@@ -1199,8 +1197,8 @@ impl Module for ConcatenatedModule {
         &compilation.module_static_cache,
         &context,
       );
-      let exports_type: BuildMetaExportsType = module.build_meta().exports_type;
-      let default_object: BuildMetaDefaultObject = module.build_meta().default_object;
+      let exports_type: BuildMetaExportsType = module.build_meta().exports_type();
+      let default_object: BuildMetaDefaultObject = module.build_meta().default_object();
       match info {
         // Handle concatenated type
         ModuleInfo::Concatenated(info) => {
@@ -1487,7 +1485,7 @@ impl Module for ConcatenatedModule {
               match_info.call,
               !match_info.direct_import,
               match_info.deferred_import,
-              build_meta.strict_esm_module,
+              build_meta.strict_esm_module(),
               match_info.asi_safe,
             ));
           }
@@ -1568,7 +1566,7 @@ impl Module for ConcatenatedModule {
     let root_module = module_graph
       .module_by_identifier(&root_module_id)
       .expect("should have box module");
-    let strict_esm_module = root_module.build_meta().strict_esm_module;
+    let strict_esm_module = root_module.build_meta().strict_esm_module();
 
     let exports_info = compilation
       .exports_info_artifact
@@ -1736,7 +1734,7 @@ impl Module for ConcatenatedModule {
         &compilation.module_static_cache,
         &context,
       );
-      let strict_esm_module = box_module.build_meta().strict_esm_module;
+      let strict_esm_module = box_module.build_meta().strict_esm_module();
       let name_space_name = module_info.namespace_object_name.clone();
 
       if let Some(ref _namespace_export_symbol) = module_info.namespace_export_symbol {
@@ -1839,7 +1837,7 @@ impl Module for ConcatenatedModule {
             module_graph,
             &compilation.module_graph_cache_artifact,
             &compilation.exports_info_artifact,
-            root_module.build_meta().strict_esm_module,
+            root_module.build_meta().strict_esm_module(),
           ),
           &module_id,
           // an async module will opt-out of the concat module optimization.
@@ -1873,7 +1871,7 @@ impl Module for ConcatenatedModule {
               module_graph,
               &compilation.module_graph_cache_artifact,
               &compilation.exports_info_artifact,
-              root_module.build_meta().strict_esm_module,
+              root_module.build_meta().strict_esm_module(),
             )),
           )));
         }
@@ -2097,7 +2095,7 @@ impl Module for ConcatenatedModule {
     .collect::<Result<Vec<_>>>()?;
 
     for hash in hashes {
-      (hash?).dyn_hash(&mut hasher);
+      (hash?).hash(&mut hasher);
     }
 
     module_update_hash(self, &mut hasher, compilation, generation_runtime);
@@ -2849,7 +2847,7 @@ impl ConcatenatedModule {
     let exports_type =
       module.get_exports_type(mg, mg_cache, exports_info_artifact, strict_esm_module);
     let is_module_deferred = matches!(info, ModuleInfo::External(info) if info.deferred)
-      && !module.build_meta().has_top_level_await;
+      && !module.build_meta().has_top_level_await();
     let is_deferred = dep_deferred && is_module_deferred;
 
     if export_name.is_empty() {
@@ -3222,7 +3220,7 @@ impl ConcatenatedModule {
                 runtime,
                 as_call,
                 reexport.defer,
-                module.build_meta().strict_esm_module,
+                module.build_meta().strict_esm_module(),
                 asi_safe,
                 already_visited,
               );

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -292,11 +292,9 @@ impl ContextModule {
       options,
       factory_meta: None,
       build_info,
-      build_meta: BuildMeta {
-        exports_type: BuildMetaExportsType::Default,
-        default_object: BuildMetaDefaultObject::RedirectWarn,
-        ..Default::default()
-      },
+      build_meta: BuildMeta::default()
+        .with_exports_type(BuildMetaExportsType::Default)
+        .with_default_object(BuildMetaDefaultObject::RedirectWarn),
       source_map_kind: SourceMapKind::empty(),
       resolve_dependencies,
     }
@@ -389,7 +387,7 @@ impl ContextModule {
     let mut map: HashMap<String, Vec<ModuleId>> = HashMap::default();
     for dep_id in dependencies {
       if let Some(module) = module_graph.get_module_by_dependency_id(dep_id)
-        && !module.build_meta().has_top_level_await
+        && !module.build_meta().has_top_level_await()
       {
         let id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier());
         if let Some(id) = id {
@@ -819,11 +817,11 @@ impl ContextModule {
           .phase
           .unwrap_or_default()
           .is_defer()
-          && !module.build_meta().has_top_level_await)
-          .then(|| {
-            has_no_module_deferred = false;
-            get_outgoing_async_modules(compilation, module.as_ref())
-          });
+          && !module.build_meta().has_top_level_await())
+        .then(|| {
+          has_no_module_deferred = false;
+          get_outgoing_async_modules(compilation, module.as_ref())
+        });
         Some((user_request, module_id.to_string(), chunks, async_deps))
       })
       .collect::<Vec<_>>();

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -1,11 +1,8 @@
-use std::{
-  fmt::Write as _,
-  hash::{BuildHasherDefault, Hash},
-};
+use std::{fmt::Write as _, hash::BuildHasherDefault};
 
 use rspack_cacheable::cacheable;
 use rspack_collections::{Identifier, IdentifierHasher};
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 use crate::{
   BoxDependency, Compilation, DependencyId, DependencyLocation, GroupOptions, ModuleIdentifier,
@@ -35,7 +32,7 @@ pub type AsyncDependenciesBlockIdentifierSet =
 pub fn dependencies_block_update_hash(
   deps: &[DependencyId],
   blocks: &[AsyncDependenciesBlockIdentifier],
-  hasher: &mut dyn std::hash::Hasher,
+  hasher: &mut RspackHash,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {
@@ -55,6 +52,12 @@ pub fn dependencies_block_update_hash(
 #[cacheable]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AsyncDependenciesBlockIdentifier(Identifier);
+
+impl rspack_hash::RspackHashable for AsyncDependenciesBlockIdentifier {
+  fn hash(&self, state: &mut RspackHash) {
+    self.0.as_str().hash(state);
+  }
+}
 
 impl From<String> for AsyncDependenciesBlockIdentifier {
   fn from(value: String) -> Self {
@@ -184,11 +187,11 @@ impl AsyncDependenciesBlock {
 
   pub fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {
-    self.group_options.dyn_hash(hasher);
+    self.group_options.hash(hasher);
     if let Some(chunk_group) = compilation
       .build_chunk_graph_artifact
       .chunk_graph
@@ -197,7 +200,7 @@ impl AsyncDependenciesBlock {
         &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
       )
     {
-      chunk_group.id(compilation).dyn_hash(hasher);
+      chunk_group.id(compilation).hash(hasher);
     }
     dependencies_block_update_hash(
       self.get_dependencies(),

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 use super::DependencyRange;
 use crate::{
@@ -22,12 +22,18 @@ impl CachedConstDependencyPlace {
   }
 }
 
+impl RspackHashable for CachedConstDependencyPlace {
+  fn hash(&self, state: &mut RspackHash) {
+    self.order().hash(state);
+  }
+}
+
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct CachedConstDependency {
   pub place: CachedConstDependencyPlace,
-  pub range: Option<DependencyRange>,
   pub identifier: Box<str>,
+  pub range: Option<DependencyRange>,
   pub content: Box<str>,
 }
 
@@ -69,6 +75,18 @@ impl CachedConstDependency {
   }
 }
 
+impl RspackHashable for CachedConstDependency {
+  fn hash(&self, state: &mut RspackHash) {
+    self.place.hash(state);
+    self.identifier.hash(state);
+    match self.range {
+      Some(range) => range.hash(state),
+      None => state.write(b"null"),
+    }
+    self.content.hash(state);
+  }
+}
+
 #[cacheable_dyn]
 impl DependencyCodeGeneration for CachedConstDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
@@ -77,14 +95,11 @@ impl DependencyCodeGeneration for CachedConstDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.place.dyn_hash(hasher);
-    self.identifier.dyn_hash(hasher);
-    self.range.dyn_hash(hasher);
-    self.content.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsRefStr};
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 use super::DependencyRange;
 use crate::{
@@ -21,6 +21,14 @@ impl ConstDependency {
   }
 }
 
+impl RspackHashable for ConstDependency {
+  fn hash(&self, state: &mut RspackHash) {
+    self.range.hash(state);
+    state.write(b"|");
+    self.content.hash(state);
+  }
+}
+
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ConstDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
@@ -29,12 +37,11 @@ impl DependencyCodeGeneration for ConstDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.range.dyn_hash(hasher);
-    self.content.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_core/src/dependency/dependency_location.rs
+++ b/crates/rspack_core/src/dependency/dependency_location.rs
@@ -6,7 +6,7 @@ use rspack_util::SpanExt;
 /// Represents a range in a dependency, typically used for tracking the span of code in a source file.
 /// It stores the start and end positions (as offsets) of the range, typically using base-0 indexing.
 #[cacheable]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default, rspack_hash::RspackHashable)]
 pub struct DependencyRange {
   pub start: u32,
   pub end: u32,

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use dyn_clone::{DynClone, clone_trait_object};
 use rspack_cacheable::cacheable_dyn;
+use rspack_hash::RspackHash;
 use rspack_sources::ReplaceSource;
 use rspack_util::ext::AsAny;
 
@@ -47,7 +48,7 @@ clone_trait_object!(DependencyCodeGeneration);
 pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
   fn update_hash(
     &self,
-    _hasher: &mut dyn std::hash::Hasher,
+    _hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -1,5 +1,7 @@
+use std::fmt::{Display, Formatter};
+
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 use crate::{
   Compilation, DependencyCodeGeneration, DependencyRange, DependencyTemplate,
@@ -7,7 +9,7 @@ use crate::{
 };
 
 #[cacheable]
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum RuntimeRequirementsDependencyMode {
   #[default]
   Normal,
@@ -18,12 +20,70 @@ pub enum RuntimeRequirementsDependencyMode {
   UnsupportedRequireProperty,
 }
 
+impl RspackHashable for RuntimeRequirementsDependencyMode {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl Display for RuntimeRequirementsDependencyMode {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl RuntimeRequirementsDependencyMode {
+  fn as_str(&self) -> &'static str {
+    match self {
+      RuntimeRequirementsDependencyMode::Normal => "normal",
+      RuntimeRequirementsDependencyMode::Call => "call",
+      RuntimeRequirementsDependencyMode::AddOnly => "add-only",
+      RuntimeRequirementsDependencyMode::Write => "write",
+      RuntimeRequirementsDependencyMode::WriteOnly => "write-only",
+      RuntimeRequirementsDependencyMode::UnsupportedRequireProperty => {
+        "unsupported-require-property"
+      }
+    }
+  }
+}
+
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct RuntimeRequirementsDependency {
   pub range: DependencyRange,
   pub runtime_requirements: RuntimeGlobals,
   pub mode: RuntimeRequirementsDependencyMode,
+}
+
+impl RspackHashable for RuntimeRequirementsDependency {
+  fn hash(&self, state: &mut RspackHash) {
+    "runtime_requirements".hash(state);
+    self.runtime_requirements.hash(state);
+    match self.mode {
+      RuntimeRequirementsDependencyMode::Normal => {
+        "range".hash(state);
+        self.range.hash(state);
+      }
+      RuntimeRequirementsDependencyMode::Call => {
+        "range".hash(state);
+        self.range.hash(state);
+        "mode".hash(state);
+        self.mode.hash(state);
+      }
+      RuntimeRequirementsDependencyMode::Write
+      | RuntimeRequirementsDependencyMode::UnsupportedRequireProperty => {
+        "range".hash(state);
+        self.range.hash(state);
+        "mode".hash(state);
+        self.mode.hash(state);
+      }
+      RuntimeRequirementsDependencyMode::WriteOnly => {
+        "mode".hash(state);
+        self.mode.hash(state);
+      }
+      RuntimeRequirementsDependencyMode::AddOnly => {}
+    }
+  }
 }
 
 #[cacheable_dyn]
@@ -34,13 +94,11 @@ impl DependencyCodeGeneration for RuntimeRequirementsDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.range.dyn_hash(hasher);
-    self.runtime_requirements.dyn_hash(hasher);
-    self.mode.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -1,10 +1,15 @@
-use std::{borrow::Cow, hash::Hash, sync::atomic::AtomicU32};
+use std::{
+  borrow::Cow,
+  fmt::{Display, Formatter},
+  sync::atomic::AtomicU32,
+};
 
 use either::Either;
 use rspack_cacheable::{
   cacheable,
   with::{AsPreset, AsVec},
 };
+use rspack_hash::RspackHash;
 use rspack_util::{atom::Atom, json_stringify, ryu_js};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -42,7 +47,7 @@ pub enum EvaluatedInlinableValue {
   String(#[cacheable(with=AsPreset)] Atom),
 }
 
-impl Hash for EvaluatedInlinableValue {
+impl std::hash::Hash for EvaluatedInlinableValue {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
     std::mem::discriminant(self).hash(state);
     match self {
@@ -57,6 +62,12 @@ impl Hash for EvaluatedInlinableValue {
       }
       _ => {}
     }
+  }
+}
+
+impl rspack_hash::RspackHashable for EvaluatedInlinableValue {
+  fn hash(&self, state: &mut RspackHash) {
+    self.render("").hash(state);
   }
 }
 
@@ -115,7 +126,16 @@ pub enum UsedNameItem {
   Inlined(EvaluatedInlinableValue),
 }
 
-#[derive(Debug, Clone, Hash)]
+impl rspack_hash::RspackHashable for UsedNameItem {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      UsedNameItem::Str(value) => value.hash(state),
+      UsedNameItem::Inlined(value) => value.hash(state),
+    }
+  }
+}
+
+#[derive(Debug, Clone, rspack_hash::RspackHashable)]
 pub struct InlinedUsedName {
   value: EvaluatedInlinableValue,
   suffix: Vec<Atom>,
@@ -169,6 +189,28 @@ pub enum ExportProvided {
   Unknown,
 }
 
+impl rspack_hash::RspackHashable for ExportProvided {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl Display for ExportProvided {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl ExportProvided {
+  fn as_str(&self) -> &'static str {
+    match self {
+      ExportProvided::Provided => "provided",
+      ExportProvided::NotProvided => "not-provided",
+      ExportProvided::Unknown => "unknown",
+    }
+  }
+}
+
 #[derive(Debug, Hash, PartialEq, Eq, Default, Clone)]
 pub struct UsageKey(pub Vec<Either<Box<UsageKey>, UsageState>>);
 
@@ -186,6 +228,30 @@ pub enum UsageState {
   #[default]
   Unknown = 3,
   Used = 4,
+}
+
+impl rspack_hash::RspackHashable for UsageState {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl Display for UsageState {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl UsageState {
+  fn as_str(&self) -> &'static str {
+    match self {
+      UsageState::Unused => "unused",
+      UsageState::OnlyPropertiesUsed => "only-properties-used",
+      UsageState::NoInfo => "no-info",
+      UsageState::Unknown => "unknown",
+      UsageState::Used => "used",
+    }
+  }
 }
 
 #[cacheable]

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1,11 +1,11 @@
-use std::{borrow::Cow, hash::Hash, iter};
+use std::{borrow::Cow, iter};
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
-use rspack_util::{ext::DynHash, json_stringify_str, source_map::SourceMapKind};
+use rspack_util::{json_stringify_str, source_map::SourceMapKind};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use serde::Serialize;
 
@@ -720,6 +720,7 @@ impl ExternalModule {
             || self.dependency_meta.attributes.is_some()
           {
             let mut hasher = RspackHash::from(&compilation.options.output);
+            use rspack_hash::RspackHashable as _;
             request.primary.hash(&mut hasher);
             if let Some(attributes) = &self.dependency_meta.attributes {
               simd_json::to_string(attributes)
@@ -1150,16 +1151,16 @@ impl Module for ExternalModule {
             can_mangle = true;
           }
         } else {
-          self.build_meta.has_top_level_await = true;
+          self.build_meta.set_has_top_level_await(true);
           if !request.is_some_and(|r| r.has_rest()) {
             exports_type = BuildMetaExportsType::Namespace;
             can_mangle = false;
           }
         }
       }
-      "script" | "promise" => self.build_meta.has_top_level_await = true,
+      "script" | "promise" => self.build_meta.set_has_top_level_await(true),
       "import" => {
-        self.build_meta.has_top_level_await = true;
+        self.build_meta.set_has_top_level_await(true);
         if !request.is_some_and(|r| r.has_rest()) {
           exports_type = BuildMetaExportsType::Namespace;
           can_mangle = false;
@@ -1167,7 +1168,7 @@ impl Module for ExternalModule {
       }
       _ => {}
     }
-    self.build_meta.exports_type = exports_type;
+    self.build_meta.set_exports_type(exports_type);
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: vec![Box::new(StaticExportsDependency::new(
@@ -1247,7 +1248,8 @@ impl Module for ExternalModule {
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
-    self.id.dyn_hash(&mut hasher);
+    use rspack_hash::RspackHashable as _;
+    self.id.as_str().hash(&mut hasher);
     let side_effects_state_artifact = &compilation
       .build_module_graph_artifact
       .side_effects_state_artifact;
@@ -1257,7 +1259,7 @@ impl Module for ExternalModule {
       side_effects_state_artifact,
       &compilation.exports_info_artifact,
     );
-    is_optional.dyn_hash(&mut hasher);
+    is_optional.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -1,7 +1,7 @@
 use std::{
   collections::{BTreeMap, BTreeSet},
-  fmt::Debug,
-  hash::{BuildHasherDefault, Hash},
+  fmt::{Debug, Display, Formatter},
+  hash::BuildHasherDefault,
   sync::atomic::AtomicU32,
 };
 
@@ -9,8 +9,9 @@ use dyn_clone::{DynClone, clone_trait_object};
 use hashlink::LinkedHashSet;
 use indexmap::IndexMap;
 use rspack_error::Result;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt};
-use rspack_util::ext::{DynHash, IntoAny};
+use rspack_util::ext::IntoAny;
 use rustc_hash::FxHasher;
 use swc_core::ecma::atoms::Atom;
 
@@ -48,6 +49,56 @@ impl InitFragmentKey {
     Self::Unique(
       NEXT_INIT_FRAGMENT_KEY_UNIQUE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
     )
+  }
+}
+
+impl RspackHashable for InitFragmentKey {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      InitFragmentKey::Unique(id) => {
+        "unique".hash(state);
+        id.hash(state);
+      }
+      InitFragmentKey::ESMImport(value) => {
+        "esm-import".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::ESMExportStar(value) => {
+        "esm-export-star".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::ESMExports => "esm-exports".hash(state),
+      InitFragmentKey::CommonJsExports(value) => {
+        "commonjs-exports".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::ModuleExternal(value) => {
+        "module-external".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::ExternalModule(value) => {
+        "external-module".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::AwaitDependencies => "await-dependencies".hash(state),
+      InitFragmentKey::ESMCompatibility => "esm-compatibility".hash(state),
+      InitFragmentKey::ModuleDecorator(value) => {
+        "module-decorator".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::ESMFakeNamespaceObjectFragment(value) => {
+        "esm-fake-namespace-object".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::ESMDeferImportNamespaceObjectFragment(value) => {
+        "esm-defer-import-namespace-object".hash(state);
+        value.hash(state);
+      }
+      InitFragmentKey::Const(value) => {
+        "const".hash(state);
+        value.hash(state);
+      }
+    }
   }
 }
 
@@ -164,7 +215,7 @@ pub trait InitFragmentRenderContext {
   fn runtime_template(&mut self) -> &mut ModuleCodeTemplate;
 }
 
-pub trait InitFragment<C>: IntoAny + DynHash + DynClone + Debug + Sync + Send {
+pub trait InitFragment<C>: IntoAny + RspackHashable + DynClone + Debug + Sync + Send {
   /// getContent + getEndContent
   fn contents(self: Box<Self>, context: &mut C) -> Result<InitFragmentContents>;
 
@@ -181,12 +232,6 @@ pub trait InitFragment<C>: IntoAny + DynHash + DynClone + Debug + Sync + Send {
 
 clone_trait_object!(InitFragment<GenerateContext<'_>>);
 clone_trait_object!(InitFragment<ChunkRenderContext>);
-
-impl<C> Hash for dyn InitFragment<C> + '_ {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.dyn_hash(state)
-  }
-}
 
 pub trait InitFragmentExt<C> {
   fn boxed(self) -> Box<dyn InitFragment<C>>;
@@ -207,6 +252,32 @@ pub enum InitFragmentStage {
   StageProvides,
   StageAsyncDependencies,
   StageAsyncESMImports,
+}
+
+impl RspackHashable for InitFragmentStage {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl InitFragmentStage {
+  fn as_str(self) -> &'static str {
+    match self {
+      InitFragmentStage::StageConstants => "constants",
+      InitFragmentStage::StageAsyncBoundary => "async-boundary",
+      InitFragmentStage::StageESMExports => "esm-exports",
+      InitFragmentStage::StageESMImports => "esm-imports",
+      InitFragmentStage::StageProvides => "provides",
+      InitFragmentStage::StageAsyncDependencies => "async-dependencies",
+      InitFragmentStage::StageAsyncESMImports => "async-esm-imports",
+    }
+  }
+}
+
+impl Display for InitFragmentStage {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
 }
 
 /// InitFragment.addToSource
@@ -291,7 +362,7 @@ impl InitFragmentRenderContext for ChunkRenderContext {
   }
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, rspack_hash::RspackHashable)]
 pub struct NormalInitFragment {
   content: String,
   stage: InitFragmentStage,
@@ -350,13 +421,28 @@ impl<C> InitFragment<C> for NormalInitFragment {
   }
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub enum ESMExportBinding {
   Getter(Atom),
   Value(Atom),
 }
 
-#[derive(Debug, Clone, Hash)]
+impl RspackHashable for ESMExportBinding {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      ESMExportBinding::Getter(value) => {
+        "getter".hash(state);
+        value.hash(state);
+      }
+      ESMExportBinding::Value(value) => {
+        "value".hash(state);
+        value.hash(state);
+      }
+    }
+  }
+}
+
+#[derive(Debug, Clone, rspack_hash::RspackHashable)]
 pub struct ESMExportInitFragment {
   exports_argument: ExportsArgument,
   // TODO: should be a map
@@ -467,7 +553,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for ESMExportInitFragment {
   }
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub struct AwaitDependenciesInitFragment {
   promises: LinkedHashSet<String, BuildHasherDefault<FxHasher>>,
 }
@@ -481,6 +567,14 @@ impl AwaitDependenciesInitFragment {
     let mut promises = LinkedHashSet::default();
     promises.insert(promise);
     Self { promises }
+  }
+}
+
+impl RspackHashable for AwaitDependenciesInitFragment {
+  fn hash(&self, state: &mut RspackHash) {
+    for promise in &self.promises {
+      promise.hash(state);
+    }
   }
 }
 
@@ -523,7 +617,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for AwaitDependenciesInitFrag
   }
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, rspack_hash::RspackHashable)]
 pub struct ConditionalInitFragment {
   content: String,
   stage: InitFragmentStage,
@@ -639,7 +733,7 @@ fn wrap_in_condition(condition: &str, source: &str) -> String {
   )
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, rspack_hash::RspackHashable)]
 pub struct ExternalModuleInitFragment {
   imported_module: String,
   // webpack also supports `ImportSpecifiers` but not ever used.

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -107,6 +107,7 @@ pub use rspack_location::{
 pub mod concatenated_module;
 pub mod reserved_names;
 use rspack_cacheable::{cacheable, with::AsPreset};
+use rspack_hash::{RspackHash, RspackHashable};
 pub use rspack_loader_runner::{
   AdditionalData, BUILTIN_LOADER_PREFIX, ParseMeta, ResourceData, ResourceParsedData, Scheme,
   get_scheme, parse_resource,
@@ -139,21 +140,33 @@ pub enum SourceType {
 
 impl std::fmt::Display for SourceType {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl RspackHashable for SourceType {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl SourceType {
+  fn as_str(&self) -> &str {
     match self {
-      SourceType::JavaScript => write!(f, "javascript"),
-      SourceType::Css => write!(f, "css"),
-      SourceType::CssUrl => write!(f, "css-url"),
-      SourceType::Wasm => write!(f, "wasm"),
-      SourceType::Asset => write!(f, "asset"),
-      SourceType::Expose => write!(f, "expose"),
-      SourceType::Remote => write!(f, "remote"),
-      SourceType::ShareInit => write!(f, "share-init"),
-      SourceType::ConsumeShared => write!(f, "consume-shared"),
-      SourceType::ShareContainerShared => write!(f, "share-container-shared"),
-      SourceType::Unknown => write!(f, "unknown"),
-      SourceType::CssImport => write!(f, "css-import"),
-      SourceType::Custom(source_type) => f.write_str(source_type),
-      SourceType::Runtime => write!(f, "runtime"),
+      SourceType::JavaScript => "javascript",
+      SourceType::Css => "css",
+      SourceType::CssUrl => "css-url",
+      SourceType::Wasm => "wasm",
+      SourceType::Asset => "asset",
+      SourceType::Expose => "expose",
+      SourceType::Remote => "remote",
+      SourceType::ShareInit => "share-init",
+      SourceType::ConsumeShared => "consume-shared",
+      SourceType::ShareContainerShared => "share-container-shared",
+      SourceType::Unknown => "unknown",
+      SourceType::CssImport => "css-import",
+      SourceType::Custom(source_type) => source_type,
+      SourceType::Runtime => "runtime",
     }
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -532,6 +532,14 @@ impl BuildMeta {
     self.esm.unwrap_or(false)
   }
 
+  pub fn is_css_module(&self) -> bool {
+    self.is_css_module.unwrap_or(false)
+  }
+
+  pub fn need_id_in_concatenation(&self) -> bool {
+    self.need_id_in_concatenation.unwrap_or(false)
+  }
+
   pub fn exports_type(&self) -> BuildMetaExportsType {
     self.exports_type
   }
@@ -554,6 +562,14 @@ impl BuildMeta {
 
   pub fn set_esm(&mut self, value: bool) {
     self.esm = Some(value);
+  }
+
+  pub fn set_is_css_module(&mut self, value: bool) {
+    self.is_css_module = Some(value);
+  }
+
+  pub fn set_need_id_in_concatenation(&mut self, value: bool) {
+    self.need_id_in_concatenation = Some(value);
   }
 
   pub fn set_exports_type(&mut self, value: BuildMetaExportsType) {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -2,7 +2,6 @@ use std::{
   any::Any,
   borrow::Cow,
   fmt::{Debug, Display, Formatter},
-  hash::Hash,
   sync::Arc,
 };
 
@@ -15,12 +14,12 @@ use rspack_cacheable::{
 use rspack_collections::{Identifiable, Identifier, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Result};
 use rspack_fs::ReadableFileSystem;
-use rspack_hash::RspackHashDigest;
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable, write_u64_hex};
 use rspack_paths::ArcPathSet;
 use rspack_sources::BoxSource;
 use rspack_util::{
   atom::Atom,
-  ext::{AsAny, DynHash},
+  ext::AsAny,
   fx_hash::{FxIndexMap, FxIndexSet},
   source_map::ModuleSourceMapConfig,
 };
@@ -337,7 +336,7 @@ impl Default for BuildInfo {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BuildMetaExportsType {
   #[default]
@@ -348,17 +347,44 @@ pub enum BuildMetaExportsType {
   Dynamic,
 }
 
+impl From<&str> for BuildMetaExportsType {
+  fn from(value: &str) -> Self {
+    match value {
+      "unset" => BuildMetaExportsType::Unset,
+      "default" => BuildMetaExportsType::Default,
+      "namespace" => BuildMetaExportsType::Namespace,
+      "flagged" => BuildMetaExportsType::Flagged,
+      "dynamic" => BuildMetaExportsType::Dynamic,
+      _ => unreachable!(),
+    }
+  }
+}
+
 impl Display for BuildMetaExportsType {
   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-    let d = match self {
+    f.write_str(self.as_str())
+  }
+}
+
+impl BuildMetaExportsType {
+  fn as_str(&self) -> &'static str {
+    match self {
+      BuildMetaExportsType::Unset => "unset",
+      BuildMetaExportsType::Default => "default",
+      BuildMetaExportsType::Namespace => "namespace",
+      BuildMetaExportsType::Flagged => "flagged",
+      BuildMetaExportsType::Dynamic => "dynamic",
+    }
+  }
+
+  pub fn description(&self) -> &'static str {
+    match self {
       BuildMetaExportsType::Unset => "unknown exports (runtime-defined)",
       BuildMetaExportsType::Default => "default exports",
       BuildMetaExportsType::Namespace => "namespace exports",
       BuildMetaExportsType::Flagged => "flagged exports",
       BuildMetaExportsType::Dynamic => "dynamic exports",
-    };
-
-    f.write_str(d)
+    }
   }
 }
 
@@ -370,14 +396,47 @@ pub enum ExportsType {
   Dynamic,
 }
 
+impl Display for ExportsType {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl ExportsType {
+  fn as_str(&self) -> &'static str {
+    match self {
+      ExportsType::DefaultOnly => "default-only",
+      ExportsType::Namespace => "namespace",
+      ExportsType::DefaultWithNamed => "default-with-named",
+      ExportsType::Dynamic => "dynamic",
+    }
+  }
+}
+
 #[cacheable]
-#[derive(Debug, Default, Clone, Copy, Hash, Serialize)]
+#[derive(Debug, Default, Clone, Copy, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BuildMetaDefaultObject {
   #[default]
   False,
   Redirect,
   RedirectWarn,
+}
+
+impl Display for BuildMetaDefaultObject {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl BuildMetaDefaultObject {
+  fn as_str(&self) -> &'static str {
+    match self {
+      BuildMetaDefaultObject::False => "false",
+      BuildMetaDefaultObject::Redirect => "redirect",
+      BuildMetaDefaultObject::RedirectWarn => "redirect-warn",
+    }
+  }
 }
 
 #[cacheable]
@@ -391,7 +450,7 @@ pub struct DeferredPureCheck {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone, Copy, Hash, Serialize)]
+#[derive(Debug, Default, Clone, Copy, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ModuleArgument {
   #[default]
@@ -399,8 +458,23 @@ pub enum ModuleArgument {
   RspackModule,
 }
 
+impl Display for ModuleArgument {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl ModuleArgument {
+  fn as_str(&self) -> &'static str {
+    match self {
+      ModuleArgument::Module => "module",
+      ModuleArgument::RspackModule => "__webpack_module__",
+    }
+  }
+}
+
 #[cacheable]
-#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ExportsArgument {
   #[default]
@@ -408,20 +482,138 @@ pub enum ExportsArgument {
   RspackExports,
 }
 
+impl Display for ExportsArgument {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl ExportsArgument {
+  fn as_str(&self) -> &'static str {
+    match self {
+      ExportsArgument::Exports => "exports",
+      ExportsArgument::RspackExports => "__webpack_exports__",
+    }
+  }
+}
+
 #[cacheable]
-#[derive(Debug, Default, Clone, Hash, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, rspack_hash::RspackHashable)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildMeta {
-  pub strict_esm_module: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub strict_esm_module: Option<bool>,
   // same as is_async https://github.com/webpack/webpack/blob/3919c844eca394d73ca930e4fc5506fb86e2b094/lib/Module.js#L107
-  pub has_top_level_await: bool,
-  pub esm: bool,
-  pub is_css_module: bool,
-  pub need_id_in_concatenation: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub has_top_level_await: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub esm: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub is_css_module: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub need_id_in_concatenation: Option<bool>,
   pub exports_type: BuildMetaExportsType,
-  pub default_object: BuildMetaDefaultObject,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub default_object: Option<BuildMetaDefaultObject>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub side_effect_free: Option<bool>,
+}
+
+impl BuildMeta {
+  pub fn strict_esm_module(&self) -> bool {
+    self.strict_esm_module.unwrap_or(false)
+  }
+
+  pub fn has_top_level_await(&self) -> bool {
+    self.has_top_level_await.unwrap_or(false)
+  }
+
+  pub fn esm(&self) -> bool {
+    self.esm.unwrap_or(false)
+  }
+
+  pub fn exports_type(&self) -> BuildMetaExportsType {
+    self.exports_type
+  }
+
+  pub fn default_object(&self) -> BuildMetaDefaultObject {
+    self.default_object.unwrap_or(BuildMetaDefaultObject::False)
+  }
+
+  pub fn side_effect_free(&self) -> bool {
+    self.side_effect_free.unwrap_or(false)
+  }
+
+  pub fn set_strict_esm_module(&mut self, value: bool) {
+    self.strict_esm_module = Some(value);
+  }
+
+  pub fn set_has_top_level_await(&mut self, value: bool) {
+    self.has_top_level_await = Some(value);
+  }
+
+  pub fn set_esm(&mut self, value: bool) {
+    self.esm = Some(value);
+  }
+
+  pub fn set_exports_type(&mut self, value: BuildMetaExportsType) {
+    self.exports_type = value;
+  }
+
+  pub fn clear_exports_type(&mut self) {
+    self.exports_type = BuildMetaExportsType::Unset;
+  }
+
+  pub fn set_default_object(&mut self, value: BuildMetaDefaultObject) {
+    self.default_object = Some(value);
+  }
+
+  pub fn set_side_effect_free(&mut self, value: bool) {
+    self.side_effect_free = Some(value);
+  }
+
+  pub fn with_exports_type(mut self, value: BuildMetaExportsType) -> Self {
+    self.set_exports_type(value);
+    self
+  }
+
+  pub fn with_default_object(mut self, value: BuildMetaDefaultObject) -> Self {
+    self.set_default_object(value);
+    self
+  }
+}
+
+impl RspackHashable for BuildMetaExportsType {
+  fn hash(&self, state: &mut RspackHash) {
+    if matches!(self, BuildMetaExportsType::Unset) {
+      return;
+    }
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for ExportsType {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for BuildMetaDefaultObject {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for ModuleArgument {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for ExportsArgument {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
 }
 
 // webpack build info
@@ -528,7 +720,7 @@ pub trait Module:
   }
 
   fn get_strict_esm_module(&self) -> bool {
-    self.build_meta().strict_esm_module
+    self.build_meta().strict_esm_module()
   }
 
   /// The actual code generation of the module, which will be called by the `Compilation`.
@@ -638,8 +830,8 @@ fn get_exports_type_impl(
   exports_info_artifact: &ExportsInfoArtifact,
   strict: bool,
 ) -> ExportsType {
-  let export_type = &build_meta.exports_type;
-  let default_object = &build_meta.default_object;
+  let export_type = build_meta.exports_type();
+  let default_object = build_meta.default_object();
   match export_type {
     BuildMetaExportsType::Flagged => {
       if strict {
@@ -664,7 +856,7 @@ fn get_exports_type_impl(
       if strict {
         ExportsType::DefaultWithNamed
       } else {
-        fn handle_default(default_object: &BuildMetaDefaultObject) -> ExportsType {
+        fn handle_default(default_object: BuildMetaDefaultObject) -> ExportsType {
           match default_object {
             BuildMetaDefaultObject::Redirect => ExportsType::DefaultWithNamed,
             BuildMetaDefaultObject::RedirectWarn => ExportsType::DefaultWithNamed,
@@ -704,7 +896,7 @@ fn get_exports_type_impl(
             {
               let Some(target_exports_type) = mg
                 .module_by_identifier(&target.module)
-                .map(|m| m.build_meta().exports_type)
+                .map(|m| m.build_meta().exports_type())
               else {
                 return ExportsType::Dynamic;
               };
@@ -737,14 +929,15 @@ fn get_exports_type_impl(
 
 pub fn module_update_hash(
   module: &dyn Module,
-  hasher: &mut dyn std::hash::Hasher,
+  hasher: &mut RspackHash,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-  chunk_graph
-    .get_module_graph_hash(module, compilation, runtime)
-    .dyn_hash(hasher);
+  write_u64_hex(
+    chunk_graph.get_module_graph_hash(module, compilation, runtime),
+    hasher,
+  );
   if let Some(deps) = module.get_presentational_dependencies() {
     for dep in deps {
       dep.update_hash(hasher, compilation, runtime);

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -1,6 +1,5 @@
-use std::hash::Hash;
-
 use rspack_cacheable::cacheable;
+use rspack_hash::RspackHash;
 
 use crate::{
   DependencyId, ExportsInfoArtifact, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
@@ -23,7 +22,7 @@ pub struct ModuleGraphConnection {
   conditional: bool,
 }
 
-impl Hash for ModuleGraphConnection {
+impl std::hash::Hash for ModuleGraphConnection {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
     self.dependency_id.hash(state);
   }
@@ -139,6 +138,19 @@ pub enum ConnectionState {
   CircularConnection,
   // Module itself is not connected, but transitive modules are connected transitively.
   TransitiveOnly,
+}
+
+impl rspack_hash::RspackHashable for ConnectionState {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      ConnectionState::Active(value) => {
+        "active".hash(state);
+        value.hash(state);
+      }
+      ConnectionState::CircularConnection => "circular".hash(state),
+      ConnectionState::TransitiveOnly => "transitive-only".hash(state),
+    }
+  }
 }
 
 impl ConnectionState {

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -907,7 +907,7 @@ impl ModuleGraph {
     let module = self
       .module_by_identifier(module_id)
       .expect("should have module");
-    !module.build_meta().has_top_level_await
+    !module.build_meta().has_top_level_await()
   }
 
   pub fn set_async(

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -1,6 +1,5 @@
 use std::{
   borrow::Cow,
-  hash::Hash,
   sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -15,17 +14,14 @@ use rspack_cacheable::{
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{AdditionalData, Content, LoaderContext, ResourceData, run_loaders};
 use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
 };
-use rspack_util::{
-  ext::DynHash,
-  source_map::{ModuleSourceMapConfig, SourceMapKind},
-};
+use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 use serde_json::json;
 use tracing::{Instrument, info_span};
 
@@ -300,7 +296,7 @@ impl NormalModule {
     if let Some(error) = self.first_error() {
       error.message.hash(&mut hasher);
     } else if let Some(s) = &self.source {
-      s.hash(&mut hasher);
+      std::hash::Hash::hash(s, &mut hasher);
     }
     "meta".hash(&mut hasher);
     build_meta.hash(&mut hasher);
@@ -697,14 +693,14 @@ impl Module for NormalModule {
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
-    self.build_info.hash.dyn_hash(&mut hasher);
+    self.build_info.hash.hash(&mut hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
     if self.source.is_some() {
-      self
+      let runtime_hash = self
         .parser_and_generator
         .get_runtime_hash(self, compilation, runtime)
-        .await?
-        .dyn_hash(&mut hasher);
+        .await?;
+      runtime_hash.hash(&mut hasher);
     }
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -1,17 +1,11 @@
-use std::{
-  borrow::Cow,
-  fmt::Debug,
-  hash::{Hash, Hasher},
-  ops::Deref,
-  ptr,
-  sync::Arc,
-};
+use std::{borrow::Cow, fmt::Debug, hash::Hasher, ops::Deref, ptr, sync::Arc};
 
 use rspack_cacheable::{
   cacheable,
   with::{AsPreset, Unsupported},
 };
 use rspack_error::ToStringResultToRspackResultExt;
+use rspack_hash::RspackHash;
 use rspack_paths::Utf8PathBuf;
 use rspack_util::{MergeFrom, atom::Atom, base64, ext::CowExt};
 
@@ -88,6 +82,14 @@ impl Filename {
   }
 }
 
+impl rspack_hash::RspackHashable for Filename {
+  fn hash(&self, state: &mut RspackHash) {
+    if let FilenameKind::Template(template) = &self.0 {
+      template.hash(state);
+    }
+  }
+}
+
 impl MergeFrom for Filename {
   fn merge_from(self, other: &Self) -> Self {
     other.clone()
@@ -128,7 +130,7 @@ pub trait LocalFilenameFn {
 /// The default filename fn trait.
 pub trait FilenameFn: LocalFilenameFn + Debug + Send + Sync {}
 
-impl Hash for dyn FilenameFn + '_ {
+impl std::hash::Hash for dyn FilenameFn + '_ {
   fn hash<H: Hasher>(&self, _: &mut H) {}
 }
 impl PartialEq for dyn FilenameFn + '_ {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -581,11 +581,23 @@ pub enum CssExportType {
 
 impl fmt::Display for CssExportType {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl RspackHashable for CssExportType {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl CssExportType {
+  fn as_str(&self) -> &'static str {
     match self {
-      CssExportType::Link => write!(f, "link"),
-      CssExportType::Text => write!(f, "text"),
-      CssExportType::CssStyleSheet => write!(f, "css-style-sheet"),
-      CssExportType::Style => write!(f, "style"),
+      CssExportType::Link => "link",
+      CssExportType::Text => "text",
+      CssExportType::CssStyleSheet => "css-style-sheet",
+      CssExportType::Style => "style",
     }
   }
 }

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -10,7 +10,7 @@ use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_cacheable::{cacheable, with::Unsupported};
 use rspack_error::{Result, error};
-use rspack_hash::{HashDigest, HashFunction, HashSalt};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashable};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
@@ -138,10 +138,22 @@ impl From<&str> for DynamicImportFetchPriority {
 
 impl fmt::Display for DynamicImportFetchPriority {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl RspackHashable for DynamicImportFetchPriority {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl DynamicImportFetchPriority {
+  fn as_str(&self) -> &'static str {
     match self {
-      DynamicImportFetchPriority::Low => write!(f, "low"),
-      DynamicImportFetchPriority::High => write!(f, "high"),
-      DynamicImportFetchPriority::Auto => write!(f, "auto"),
+      DynamicImportFetchPriority::Low => "low",
+      DynamicImportFetchPriority::High => "high",
+      DynamicImportFetchPriority::Auto => "auto",
     }
   }
 }
@@ -244,7 +256,7 @@ impl ExportPresenceMode {
       ExportPresenceMode::None => None,
       ExportPresenceMode::Warn => Some(false),
       ExportPresenceMode::Error => Some(true),
-      ExportPresenceMode::Auto => Some(module.build_meta().strict_esm_module),
+      ExportPresenceMode::Auto => Some(module.build_meta().strict_esm_module()),
     }
   }
 }
@@ -853,14 +865,29 @@ impl MergeFrom for AssetGeneratorDataUrl {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom, Hash)]
+#[derive(Debug, Clone, MergeFrom)]
 pub struct AssetGeneratorDataUrlOptions {
   pub encoding: Option<DataUrlEncoding>,
   pub mimetype: Option<String>,
 }
 
+impl RspackHashable for AssetGeneratorDataUrlOptions {
+  fn hash(&self, state: &mut RspackHash) {
+    if let Some(encoding) = &self.encoding
+      && !matches!(encoding, DataUrlEncoding::Base64)
+    {
+      "encoding".hash(state);
+      state.update(encoding);
+    }
+    if let Some(mimetype) = &self.mimetype {
+      "mimetype".hash(state);
+      state.update(mimetype);
+    }
+  }
+}
+
 #[cacheable]
-#[derive(Debug, Clone, MergeFrom, Hash)]
+#[derive(Debug, Clone, MergeFrom)]
 pub enum DataUrlEncoding {
   None,
   Base64,
@@ -868,9 +895,21 @@ pub enum DataUrlEncoding {
 
 impl fmt::Display for DataUrlEncoding {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl RspackHashable for DataUrlEncoding {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl DataUrlEncoding {
+  fn as_str(&self) -> &'static str {
     match self {
-      DataUrlEncoding::None => write!(f, ""),
-      DataUrlEncoding::Base64 => write!(f, "base64"),
+      DataUrlEncoding::None => "",
+      DataUrlEncoding::Base64 => "base64",
     }
   }
 }

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -1,7 +1,6 @@
 use std::{
   borrow::Cow,
   fmt::{self, Debug},
-  hash::Hash,
   str::FromStr,
   string::ParseError,
   sync::LazyLock,
@@ -9,8 +8,8 @@ use std::{
 
 use regex::Regex;
 use rspack_cacheable::cacheable;
-use rspack_hash::RspackHash;
 pub use rspack_hash::{HashDigest, HashFunction, HashSalt};
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
 #[cfg(allocative)]
@@ -125,6 +124,12 @@ impl ChunkLoading {
   }
 }
 
+impl RspackHashable for ChunkLoading {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
 #[cacheable]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ChunkLoadingType {
@@ -168,11 +173,38 @@ impl ChunkLoadingType {
   }
 }
 
+impl RspackHashable for ChunkLoadingType {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
 #[cacheable]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum WasmLoading {
   Enable(WasmLoadingType),
   Disable,
+}
+
+impl RspackHashable for WasmLoading {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl fmt::Display for WasmLoading {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl WasmLoading {
+  fn as_str(&self) -> &str {
+    match self {
+      WasmLoading::Enable(ty) => ty.as_str(),
+      WasmLoading::Disable => "false",
+    }
+  }
 }
 
 impl From<&str> for WasmLoading {
@@ -190,6 +222,28 @@ pub enum WasmLoadingType {
   Fetch,
   AsyncNode,
   Universal,
+}
+
+impl RspackHashable for WasmLoadingType {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl fmt::Display for WasmLoadingType {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl WasmLoadingType {
+  fn as_str(&self) -> &'static str {
+    match self {
+      WasmLoadingType::Fetch => "fetch",
+      WasmLoadingType::AsyncNode => "async-node",
+      WasmLoadingType::Universal => "universal",
+    }
+  }
 }
 
 impl From<&str> for WasmLoadingType {
@@ -335,6 +389,15 @@ pub enum PublicPath {
   Auto,
 }
 
+impl RspackHashable for PublicPath {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      PublicPath::Filename(filename) => filename.hash(state),
+      PublicPath::Auto => "auto".hash(state),
+    }
+  }
+}
+
 //https://github.com/webpack/webpack/blob/001cab14692eb9a833c6b56709edbab547e291a1/lib/util/identifier.js#L378
 pub fn get_undo_path(filename: &str, output_path: String, enforce_relative: bool) -> String {
   let mut depth: i32 = -1;
@@ -475,7 +538,7 @@ pub fn get_js_chunk_filename_template(
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
 pub struct LibraryOptions {
   pub name: Option<LibraryName>,
   pub export: Option<LibraryExport>,
@@ -491,7 +554,7 @@ pub type LibraryType = String;
 pub type LibraryExport = Vec<String>;
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
 pub struct LibraryAuxiliaryComment {
   pub root: Option<String>,
   pub commonjs: Option<String>,
@@ -506,6 +569,15 @@ pub enum LibraryName {
   UmdObject(LibraryCustomUmdObject),
 }
 
+impl RspackHashable for LibraryName {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      LibraryName::NonUmdObject(value) => value.hash(state),
+      LibraryName::UmdObject(value) => value.hash(state),
+    }
+  }
+}
+
 #[cacheable]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LibraryNonUmdObject {
@@ -513,8 +585,17 @@ pub enum LibraryNonUmdObject {
   String(String),
 }
 
+impl RspackHashable for LibraryNonUmdObject {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      LibraryNonUmdObject::Array(value) => value.hash(state),
+      LibraryNonUmdObject::String(value) => value.hash(state),
+    }
+  }
+}
+
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
 pub struct LibraryCustomUmdObject {
   pub amd: Option<String>,
   pub commonjs: Option<String>,

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash};
+use std::borrow::Cow;
 
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
@@ -6,7 +6,7 @@ use rspack_cacheable::{
 };
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_macros::impl_source_map_config;
 use rspack_sources::{BoxSource, OriginalSource, RawStringSource, SourceExt};
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -4,6 +4,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsRefStr, AsVec},
 };
+use rspack_hash::RspackHash;
 #[cfg(allocative)]
 use rspack_util::allocative;
 use rustc_hash::FxHashMap;
@@ -12,10 +13,11 @@ use ustr::{Ustr, UstrSet};
 use crate::{EntryOptions, EntryRuntime};
 
 #[cacheable]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, rspack_hash::RspackHashable)]
 #[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct RuntimeSpec {
   #[cacheable(with=AsVec<AsRefStr>)]
+  #[rspack_hash(skip)]
   inner: UstrSet,
   key: String,
 }
@@ -197,15 +199,11 @@ pub enum RuntimeCondition {
   Spec(RuntimeSpec),
 }
 
-impl std::hash::Hash for RuntimeCondition {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl rspack_hash::RspackHashable for RuntimeCondition {
+  fn hash(&self, state: &mut RspackHash) {
     match self {
-      Self::Boolean(v) => v.hash(state),
-      Self::Spec(s) => {
-        for i in s.iter() {
-          i.hash(state);
-        }
-      }
+      RuntimeCondition::Boolean(value) => value.hash(state),
+      RuntimeCondition::Spec(spec) => spec.hash(state),
     }
   }
 }

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -2,6 +2,7 @@ use std::sync::LazyLock;
 
 use bitflags::bitflags;
 use heck::ToLowerCamelCase;
+use rspack_hash::{RspackHash, RspackHashable};
 use rustc_hash::FxHashMap;
 
 use crate::{CompilerOptions, runtime_mode::RuntimeMode};
@@ -639,5 +640,11 @@ impl RuntimeGlobals {
       }
     }
     res
+  }
+}
+
+impl RspackHashable for RuntimeGlobals {
+  fn hash(&self, state: &mut RspackHash) {
+    self.bits().hash(state);
   }
 }

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use rspack_cacheable::cacheable;
 use rspack_collections::Identifier;
 use rspack_error::Result;
-use rspack_hash::RspackHashDigest;
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source, SourceExt};
-use rspack_util::{ext::DynHash, source_map::SourceMapKind};
+use rspack_util::source_map::SourceMapKind;
 use tokio::sync::OnceCell;
 
 use crate::{
@@ -150,25 +150,22 @@ pub async fn runtime_module_get_runtime_hash(
   compilation: &Compilation,
   _runtime: Option<&RuntimeSpec>,
 ) -> Result<RspackHashDigest> {
-  let mut hasher = rspack_hash::RspackHash::from(&compilation.options.output);
-  module.name().dyn_hash(&mut hasher);
-  module.stage().dyn_hash(&mut hasher);
+  let mut hasher = RspackHash::from(&compilation.options.output);
+  module.name().hash(&mut hasher);
+  module.stage().hash(&mut hasher);
   if module.full_hash() || module.dependent_hash() {
-    use std::hash::Hash;
-
     let runtime_template = compilation.runtime_template.create_runtime_code_template();
     let context = RuntimeModuleGenerateContext {
       compilation,
       runtime_template: &runtime_template,
     };
-    module
-      .generate_with_custom(&context)
-      .await?
-      .hash(&mut hasher);
+    RspackHashable::hash(&module.generate_with_custom(&context).await?, &mut hasher);
   } else {
+    use std::hash::Hash;
+
     runtime_module_get_generated_code(module, common, compilation)
       .await?
-      .dyn_hash(&mut hasher);
+      .hash(&mut hasher);
   }
   Ok(hasher.digest(&compilation.options.output.hash_digest))
 }
@@ -229,7 +226,7 @@ pub trait CustomSourceRuntimeModule {
 pub type BoxRuntimeModule = Box<dyn RuntimeModule>;
 
 #[cacheable]
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RuntimeModuleStage {
   #[default]
   Normal, // Runtime modules without any dependencies to other runtime modules
@@ -258,6 +255,13 @@ impl From<RuntimeModuleStage> for u32 {
       RuntimeModuleStage::Attach => 10,
       RuntimeModuleStage::Trigger => 20,
     }
+  }
+}
+
+impl RspackHashable for RuntimeModuleStage {
+  fn hash(&self, state: &mut RspackHash) {
+    let stage: u32 = self.clone().into();
+    stage.hash(state);
   }
 }
 

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -605,7 +605,7 @@ pub fn get_outgoing_async_modules(
     if !visited.insert(module_identifier) {
       return;
     }
-    if module.build_meta().has_top_level_await {
+    if module.build_meta().has_top_level_await() {
       set.insert(
         ChunkGraph::get_module_id(&compilation.module_ids_artifact, module_identifier)
           .expect("should have module_id")
@@ -1119,7 +1119,7 @@ impl ModuleCodeTemplate {
       &module.identifier(),
     );
 
-    if phase.is_defer() && !target_module.build_meta().has_top_level_await {
+    if phase.is_defer() && !target_module.build_meta().has_top_level_await() {
       let async_deps = get_outgoing_async_modules(compilation, target_module.as_ref());
       let import_content = format!(
         "/* deferred import */{opt_declaration}{import_var} = {};\n",
@@ -1176,7 +1176,7 @@ impl ModuleCodeTemplate {
 
     let target_module_identifier = target_module.identifier();
 
-    let is_deferred = phase.is_defer() && !target_module.build_meta().has_top_level_await;
+    let is_deferred = phase.is_defer() && !target_module.build_meta().has_top_level_await();
 
     let mut exclude_default_export_name = None;
     if default_interop {
@@ -1423,7 +1423,7 @@ impl ModuleCodeTemplate {
 
     let mut appending;
 
-    if phase.is_defer() && !target_module.build_meta().has_top_level_await {
+    if phase.is_defer() && !target_module.build_meta().has_top_level_await() {
       let mode = format!(
         "{} | 16",
         render_make_deferred_namespace_mode_from_exports_type(exports_type)

--- a/crates/rspack_hash/Cargo.toml
+++ b/crates/rspack_hash/Cargo.toml
@@ -7,13 +7,20 @@ repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
 
 [dependencies]
-base64-simd      = { workspace = true }
-md4              = { workspace = true }
-rspack_cacheable = { workspace = true }
-rspack_util      = { workspace = true }
-sha2             = { workspace = true }
-smol_str         = { workspace = true }
-xxhash-rust      = { workspace = true, features = ["xxh64"] }
+base64-simd        = { workspace = true }
+itoa               = { workspace = true }
+lightningcss       = { workspace = true }
+md4                = { workspace = true }
+rspack_cacheable   = { workspace = true }
+rspack_collections = { workspace = true }
+rspack_macros      = { workspace = true }
+rspack_util        = { workspace = true }
+serde              = { workspace = true }
+sha2               = { workspace = true }
+simd-json          = { workspace = true }
+smol_str           = { workspace = true }
+swc_config         = { workspace = true }
+xxhash-rust        = { workspace = true, features = ["xxh64"] }
 
 [lints]
 workspace = true

--- a/crates/rspack_hash/src/hashable/containers.rs
+++ b/crates/rspack_hash/src/hashable/containers.rs
@@ -1,0 +1,85 @@
+use std::{
+  collections::{BTreeMap, BTreeSet},
+  sync::Arc,
+};
+
+use crate::{RspackHash, RspackHashable};
+
+impl<T: RspackHashable + ?Sized> RspackHashable for &T {
+  fn hash(&self, state: &mut RspackHash) {
+    (*self).hash(state);
+  }
+}
+
+impl<T: RspackHashable + ?Sized> RspackHashable for Box<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    (**self).hash(state);
+  }
+}
+
+impl<T: RspackHashable + ?Sized> RspackHashable for Arc<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    (**self).hash(state);
+  }
+}
+
+impl<T: RspackHashable> RspackHashable for Option<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    if let Some(value) = self {
+      value.hash(state);
+    }
+  }
+}
+
+fn hash_iter<T: RspackHashable>(mut iter: impl Iterator<Item = T>, state: &mut RspackHash) {
+  state.write(b"[");
+  if let Some(item) = iter.next() {
+    item.hash(state);
+  }
+
+  for item in iter {
+    state.write(b",");
+    item.hash(state);
+  }
+  state.write(b"]");
+}
+
+impl<T: RspackHashable> RspackHashable for [T] {
+  fn hash(&self, state: &mut RspackHash) {
+    hash_iter(self.iter(), state);
+  }
+}
+
+impl<T: RspackHashable> RspackHashable for Vec<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    hash_iter(self.iter(), state);
+  }
+}
+
+impl<T: RspackHashable + Ord> RspackHashable for BTreeSet<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    hash_iter(self.iter(), state);
+  }
+}
+
+impl<K: RspackHashable + Ord, V: RspackHashable> RspackHashable for BTreeMap<K, V> {
+  fn hash(&self, state: &mut RspackHash) {
+    hash_iter(self.iter(), state);
+  }
+}
+
+impl<T: RspackHashable, const N: usize> RspackHashable for [T; N] {
+  fn hash(&self, state: &mut RspackHash) {
+    hash_iter(self.iter(), state);
+  }
+}
+
+impl<A: RspackHashable, B: RspackHashable> RspackHashable for (A, B) {
+  fn hash(&self, state: &mut RspackHash) {
+    state.write(b"(");
+    self.0.hash(state);
+    state.write(b",");
+    self.1.hash(state);
+    state.write(b")");
+  }
+}

--- a/crates/rspack_hash/src/hashable/external.rs
+++ b/crates/rspack_hash/src/hashable/external.rs
@@ -1,0 +1,33 @@
+use lightningcss::targets::Browsers;
+use swc_config::types::{BoolOr, BoolOrDataConfig};
+
+use crate::{RspackHash, RspackHashable, hash_by_json};
+
+impl<T: RspackHashable> RspackHashable for BoolOr<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      BoolOr::Bool(value) => {
+        "bool".hash(state);
+        value.hash(state);
+      }
+      BoolOr::Data(value) => {
+        "data".hash(state);
+        value.hash(state);
+      }
+    }
+  }
+}
+
+impl<T: RspackHashable> RspackHashable for BoolOrDataConfig<T> {
+  fn hash(&self, state: &mut RspackHash) {
+    if let Some(value) = self.inner() {
+      value.hash(state);
+    }
+  }
+}
+
+impl RspackHashable for Browsers {
+  fn hash(&self, state: &mut RspackHash) {
+    hash_by_json(self, state);
+  }
+}

--- a/crates/rspack_hash/src/hashable/mod.rs
+++ b/crates/rspack_hash/src/hashable/mod.rs
@@ -1,0 +1,4 @@
+mod containers;
+mod external;
+mod primitives;
+mod rspack;

--- a/crates/rspack_hash/src/hashable/primitives.rs
+++ b/crates/rspack_hash/src/hashable/primitives.rs
@@ -1,0 +1,67 @@
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
+
+use smol_str::SmolStr;
+
+use crate::{RspackHash, RspackHashable};
+
+impl RspackHashable for str {
+  fn hash(&self, state: &mut RspackHash) {
+    state.write(self.as_bytes());
+  }
+}
+
+impl RspackHashable for String {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for SmolStr {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for Cow<'_, str> {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_ref().hash(state);
+  }
+}
+
+impl RspackHashable for bool {
+  fn hash(&self, state: &mut RspackHash) {
+    state.write(if *self { b"true" } else { b"false" });
+  }
+}
+
+macro_rules! impl_content_hash_for_integer {
+  ($($ty:ty),+ $(,)?) => {
+    $(
+      impl RspackHashable for $ty {
+        fn hash(&self, state: &mut RspackHash) {
+          let mut buffer = itoa::Buffer::new();
+          state.write(buffer.format(*self).as_bytes());
+        }
+      }
+    )+
+  };
+}
+
+impl_content_hash_for_integer!(
+  u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
+);
+
+impl RspackHashable for Path {
+  fn hash(&self, state: &mut RspackHash) {
+    self.to_string_lossy().hash(state);
+  }
+}
+
+impl RspackHashable for PathBuf {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_path().hash(state);
+  }
+}

--- a/crates/rspack_hash/src/hashable/rspack.rs
+++ b/crates/rspack_hash/src/hashable/rspack.rs
@@ -1,0 +1,50 @@
+use rspack_collections::Identifier;
+use rspack_util::{
+  asset_condition::{AssetCondition, AssetConditions},
+  atom::Atom,
+};
+
+use crate::{RspackHash, RspackHashable};
+
+impl RspackHashable for Atom {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for Identifier {
+  fn hash(&self, state: &mut RspackHash) {
+    self.as_str().hash(state);
+  }
+}
+
+impl RspackHashable for AssetCondition {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      AssetCondition::String(value) => {
+        "string".hash(state);
+        value.hash(state);
+      }
+      AssetCondition::Regexp(value) => {
+        "regexp".hash(state);
+        value.source.hash(state);
+        value.flags.hash(state);
+      }
+    }
+  }
+}
+
+impl RspackHashable for AssetConditions {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      AssetConditions::Single(value) => {
+        "single".hash(state);
+        value.hash(state);
+      }
+      AssetConditions::Multiple(value) => {
+        "multiple".hash(state);
+        value.hash(state);
+      }
+    }
+  }
+}

--- a/crates/rspack_hash/src/lib.rs
+++ b/crates/rspack_hash/src/lib.rs
@@ -7,9 +7,12 @@ use std::{
 use base64_simd::{AsOut, STANDARD, URL_SAFE_NO_PAD};
 use md4::Digest;
 use rspack_cacheable::{cacheable, with::AsPreset};
+pub use rspack_macros::RspackHashable;
 use rspack_util::MergeFrom;
 use smol_str::SmolStr;
 use xxhash_rust::xxh64::Xxh64;
+
+mod hashable;
 
 #[cacheable]
 #[derive(Debug, Clone, Copy)]
@@ -107,11 +110,92 @@ impl MergeFrom for HashSalt {
   }
 }
 
+/// Hasher used for webpack-compatible content hashes.
+///
+/// `RspackHash` is the stateful writer behind output hashes such as full hash,
+/// chunk hash, content hash and module/runtime hashes that affect generated
+/// assets or persistent cache correctness. Inputs should be written through
+/// [`RspackHashable`] so the serialized form can follow webpack content-hash
+/// semantics instead of Rust collection-key hashing semantics.
 #[derive(Clone)]
 pub enum RspackHash {
   Xxhash64(Box<Xxh64>),
   MD4(Box<md4::Md4>),
   SHA256(Box<sha2::Sha256>),
+}
+
+/// Content-hash input contract for values that participate in `RspackHash`.
+///
+/// This trait is intentionally separate from [`std::hash::Hash`]. `Hash` is for
+/// hash-map/set keys and is free to optimize around Rust data-structure needs,
+/// including implementation details that may change with the standard library
+/// or with local keying requirements. `RspackHashable` is for stable,
+/// webpack-aligned content hashing: implement it only for data that should
+/// affect emitted asset hashes, runtime/module hashes, or persistent cache
+/// content keys.
+///
+/// Keeping the two traits separate lets Rspack tune key hashing independently
+/// without changing content hash behavior, and lets content hashing encode the
+/// same logical inputs webpack uses rather than the shape of Rust data
+/// structures.
+pub trait RspackHashable {
+  fn hash(&self, state: &mut RspackHash);
+}
+
+#[inline]
+pub fn hash_by_json<T: serde::Serialize>(value: &T, state: &mut RspackHash) {
+  let json = simd_json::to_string(value).expect("should be able to serialize value for hash");
+  state.write(json.as_bytes());
+}
+
+#[inline]
+pub fn write_u64_hex(value: u64, state: &mut RspackHash) {
+  if value == 0 {
+    state.write(b"0");
+    return;
+  }
+
+  let bytes = value.to_be_bytes();
+  let first = bytes
+    .iter()
+    .position(|&byte| byte != 0)
+    .expect("zero value should have returned");
+  let mut output = [0; 16];
+  let encoded = hex(&bytes[first..], &mut output).as_bytes();
+
+  if bytes[first] < 0x10 {
+    state.write(&encoded[1..]);
+  } else {
+    state.write(encoded);
+  }
+}
+
+#[macro_export]
+macro_rules! rspack_hash_object {
+  ($state:expr, { $($key:expr => $value:expr),* $(,)? }) => {{
+    $state.write(b"{");
+    let mut is_first_rspack_hash_field = true;
+    $(
+      if !is_first_rspack_hash_field {
+        $state.write(b",");
+      }
+      is_first_rspack_hash_field = false;
+      $crate::RspackHashable::hash($key, $state);
+      $state.write(b":");
+      $crate::RspackHashable::hash(&$value, $state);
+    )*
+    let _ = is_first_rspack_hash_field;
+    $state.write(b"}");
+  }};
+}
+
+#[macro_export]
+macro_rules! rspack_hash_update {
+  ($state:expr, $($value:expr),+ $(,)?) => {
+    $(
+      $state.update(&$value);
+    )+
+  };
 }
 
 impl fmt::Debug for RspackHash {
@@ -157,6 +241,40 @@ impl RspackHash {
       }
     }
   }
+
+  pub fn update<T: RspackHashable + ?Sized>(&mut self, value: &T) {
+    value.hash(self);
+  }
+
+  pub fn write(&mut self, bytes: &[u8]) {
+    match self {
+      RspackHash::Xxhash64(hasher) => hasher.write(bytes),
+      RspackHash::MD4(hasher) => hasher.update(bytes),
+      RspackHash::SHA256(hasher) => hasher.update(bytes),
+    }
+  }
+
+  pub fn finish(&self) -> u64 {
+    match self {
+      RspackHash::Xxhash64(hasher) => hasher.finish(),
+      RspackHash::MD4(hasher) => {
+        let hash = (**hasher).clone().finalize();
+        u64::from_be_bytes(
+          hash[..8]
+            .try_into()
+            .expect("md4 digest length is at least 8"),
+        )
+      }
+      RspackHash::SHA256(hasher) => {
+        let hash = (**hasher).clone().finalize();
+        u64::from_be_bytes(
+          hash[..8]
+            .try_into()
+            .expect("sha256 digest length is at least 8"),
+        )
+      }
+    }
+  }
 }
 
 impl Hasher for RspackHash {
@@ -164,29 +282,20 @@ impl Hasher for RspackHash {
     match self {
       RspackHash::Xxhash64(hasher) => hasher.finish(),
       RspackHash::MD4(hasher) => {
-        // finalize take ownership, so we need to clone it
         let hash = (**hasher).clone().finalize();
-        let msb_u64: u64 = ((hash[0] as u64) << 56)
-          | ((hash[1] as u64) << 48)
-          | ((hash[2] as u64) << 40)
-          | ((hash[3] as u64) << 32)
-          | ((hash[4] as u64) << 24)
-          | ((hash[5] as u64) << 16)
-          | ((hash[6] as u64) << 8)
-          | (hash[7] as u64);
-        msb_u64
+        u64::from_be_bytes(
+          hash[..8]
+            .try_into()
+            .expect("md4 digest length is at least 8"),
+        )
       }
       RspackHash::SHA256(hasher) => {
         let hash = (**hasher).clone().finalize();
-        let msb_u64: u64 = ((hash[0] as u64) << 56)
-          | ((hash[1] as u64) << 48)
-          | ((hash[2] as u64) << 40)
-          | ((hash[3] as u64) << 32)
-          | ((hash[4] as u64) << 24)
-          | ((hash[5] as u64) << 16)
-          | ((hash[6] as u64) << 8)
-          | (hash[7] as u64);
-        msb_u64
+        u64::from_be_bytes(
+          hash[..8]
+            .try_into()
+            .expect("sha256 digest length is at least 8"),
+        )
       }
     }
   }
@@ -257,9 +366,15 @@ impl RspackHashDigest {
   }
 }
 
+impl RspackHashable for RspackHashDigest {
+  fn hash(&self, state: &mut RspackHash) {
+    RspackHashable::hash(self.encoded.as_str(), state);
+  }
+}
+
 impl Hash for RspackHashDigest {
   fn hash<H: Hasher>(&self, state: &mut H) {
-    self.encoded.hash(state);
+    std::hash::Hash::hash(&self.encoded, state);
   }
 }
 

--- a/crates/rspack_hash/tests/hash.rs
+++ b/crates/rspack_hash/tests/hash.rs
@@ -1,6 +1,6 @@
-use std::hash::Hasher;
-
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
+use rspack_hash::{
+  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHashable, write_u64_hex,
+};
 
 #[test]
 fn encodes_base64_with_standard_padding() {
@@ -37,4 +37,242 @@ fn hash_salt_is_written_as_raw_bytes() {
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
   assert_eq!(salted, expected);
+}
+
+#[test]
+fn writes_u64_hex_without_leading_zeroes() {
+  for (value, expected) in [
+    (0, "0"),
+    (0x0f, "f"),
+    (0x10, "10"),
+    (0x0abc, "abc"),
+    (u64::MAX, "ffffffffffffffff"),
+  ] {
+    let mut actual = RspackHash::new(&HashFunction::Xxhash64);
+    write_u64_hex(value, &mut actual);
+    let actual = actual.digest(&HashDigest::Hex).encoded().to_string();
+
+    let mut expected_hash = RspackHash::new(&HashFunction::Xxhash64);
+    expected_hash.write(expected.as_bytes());
+    let expected = expected_hash.digest(&HashDigest::Hex).encoded().to_string();
+
+    assert_eq!(actual, expected);
+  }
+}
+
+#[test]
+fn derive_rspack_hashable_skips_marked_fields() {
+  #[derive(RspackHashable)]
+  struct Value {
+    content: &'static str,
+    #[rspack_hash(skip)]
+    _cached: &'static str,
+  }
+
+  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  derived.update(&Value {
+    content: "payload",
+    _cached: "cache",
+  });
+  let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  expected.write(b"{");
+  expected.write(b"content");
+  expected.write(b":");
+  expected.write(b"payload");
+  expected.write(b"}");
+  let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(derived, expected);
+}
+
+#[test]
+fn derive_rspack_hashable_respects_explicit_field_order() {
+  #[derive(RspackHashable)]
+  struct Value {
+    #[rspack_hash(order = 1)]
+    second: &'static str,
+    #[rspack_hash(order = 0)]
+    first: &'static str,
+  }
+
+  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  derived.update(&Value {
+    first: "a",
+    second: "b",
+  });
+  let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  expected.write(b"{");
+  expected.write(b"first");
+  expected.write(b":");
+  expected.write(b"a");
+  expected.write(b",");
+  expected.write(b"second");
+  expected.write(b":");
+  expected.write(b"b");
+  expected.write(b"}");
+  let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(derived, expected);
+}
+
+#[test]
+fn option_rspack_hashable_skips_none() {
+  let mut none = RspackHash::new(&HashFunction::Xxhash64);
+  none.update(&Option::<&str>::None);
+  let none = none.digest(&HashDigest::Hex).encoded().to_string();
+
+  let empty = RspackHash::new(&HashFunction::Xxhash64)
+    .digest(&HashDigest::Hex)
+    .encoded()
+    .to_string();
+
+  assert_eq!(none, empty);
+
+  let mut some = RspackHash::new(&HashFunction::Xxhash64);
+  some.update(&Some("value"));
+  let some = some.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  expected.write(b"value");
+  let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(some, expected);
+}
+
+#[test]
+fn derive_rspack_hashable_can_hash_none_as_null() {
+  #[derive(RspackHashable)]
+  struct Value {
+    #[rspack_hash(null_if_none)]
+    value: Option<&'static str>,
+  }
+
+  let mut none = RspackHash::new(&HashFunction::Xxhash64);
+  none.update(&Value { value: None });
+  let none = none.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected_none = RspackHash::new(&HashFunction::Xxhash64);
+  expected_none.write(b"{");
+  expected_none.write(b"value");
+  expected_none.write(b":");
+  expected_none.write(b"null");
+  expected_none.write(b"}");
+  let expected_none = expected_none.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(none, expected_none);
+
+  let mut some = RspackHash::new(&HashFunction::Xxhash64);
+  some.update(&Value {
+    value: Some("present"),
+  });
+  let some = some.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected_some = RspackHash::new(&HashFunction::Xxhash64);
+  expected_some.write(b"{");
+  expected_some.write(b"value");
+  expected_some.write(b":");
+  expected_some.write(b"present");
+  expected_some.write(b"}");
+  let expected_some = expected_some.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(some, expected_some);
+}
+
+#[test]
+fn derive_rspack_hashable_hashes_option_field_names() {
+  #[derive(RspackHashable)]
+  struct Value {
+    root: Option<&'static str>,
+    commonjs: Option<&'static str>,
+  }
+
+  let mut root = RspackHash::new(&HashFunction::Xxhash64);
+  root.update(&Value {
+    root: Some("x"),
+    commonjs: None,
+  });
+  let root = root.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut commonjs = RspackHash::new(&HashFunction::Xxhash64);
+  commonjs.update(&Value {
+    root: None,
+    commonjs: Some("x"),
+  });
+  let commonjs = commonjs.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_ne!(root, commonjs);
+
+  let mut expected_root = RspackHash::new(&HashFunction::Xxhash64);
+  expected_root.write(b"{");
+  expected_root.write(b"root");
+  expected_root.write(b":");
+  expected_root.write(b"x");
+  expected_root.write(b"}");
+  let expected_root = expected_root.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(root, expected_root);
+}
+
+#[test]
+fn derive_rspack_hashable_does_not_use_json_by_default() {
+  #[derive(serde::Serialize, RspackHashable)]
+  struct Value {
+    content: &'static str,
+  }
+
+  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  derived.update(&Value { content: "payload" });
+  let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  expected.write(b"{");
+  expected.write(b"content");
+  expected.write(b":");
+  expected.write(b"payload");
+  expected.write(b"}");
+  let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(derived, expected);
+}
+
+#[test]
+fn derive_rspack_hashable_can_use_explicit_json() {
+  #[derive(serde::Serialize, RspackHashable)]
+  #[rspack_hash(json)]
+  struct Value {
+    content: &'static str,
+  }
+
+  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  derived.update(&Value { content: "payload" });
+  let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  expected.write(br#"{"content":"payload"}"#);
+  let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(derived, expected);
+}
+
+#[test]
+fn rspack_hash_object_hashes_object_fields() {
+  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  rspack_hash::rspack_hash_object!(&mut derived, {
+    "content" => "payload",
+  });
+  let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
+
+  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  expected.write(b"{");
+  expected.write(b"content");
+  expected.write(b":");
+  expected.write(b"payload");
+  expected.write(b"}");
+  let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
+
+  assert_eq!(derived, expected);
 }

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -1,5 +1,3 @@
-use std::hash::Hasher;
-
 use rspack_core::{
   ChunkGraph, Compilation, CompilationModuleIds, ModuleIdsArtifact, Plugin,
   incremental::IncrementalPasses,

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -30,7 +30,7 @@ pub type ModuleFilterFn =
 
 pub(crate) fn should_assign_module_id_without_chunk(module: &dyn Module) -> bool {
   let build_meta = module.build_meta();
-  build_meta.is_css_module || build_meta.need_id_in_concatenation
+  build_meta.is_css_module() || build_meta.need_id_in_concatenation()
 }
 
 #[allow(clippy::type_complexity)]

--- a/crates/rspack_macros/src/lib.rs
+++ b/crates/rspack_macros/src/lib.rs
@@ -2,6 +2,7 @@ mod hook;
 mod javascript_parser_plugin_hooks;
 mod merge;
 mod plugin;
+mod rspack_hashable;
 mod runtime_module;
 mod source_map_config;
 
@@ -62,6 +63,17 @@ pub fn define_hook(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 pub fn merge_from_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   let input = syn::parse_macro_input!(input as syn::DeriveInput);
   let output = merge::expand_merge_from_derive(input);
+  match output {
+    syn::Result::Ok(tt) => tt,
+    syn::Result::Err(err) => err.to_compile_error(),
+  }
+  .into()
+}
+
+#[proc_macro_derive(RspackHashable, attributes(rspack_hash))]
+pub fn rspack_hashable_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+  let input = syn::parse_macro_input!(input as syn::DeriveInput);
+  let output = rspack_hashable::expand_rspack_hashable_derive(input);
   match output {
     syn::Result::Ok(tt) => tt,
     syn::Result::Err(err) => err.to_compile_error(),

--- a/crates/rspack_macros/src/rspack_hashable.rs
+++ b/crates/rspack_macros/src/rspack_hashable.rs
@@ -1,0 +1,429 @@
+use proc_macro2::{Literal, TokenStream};
+use quote::quote;
+use syn::{
+  Attribute, Data, DeriveInput, Error, Fields, Generics, Ident, Index, Path, Result, Type,
+  TypeParamBound, parse_quote,
+};
+
+#[derive(Default)]
+struct TypeOptions {
+  hash_crate: Option<Path>,
+  json: bool,
+}
+
+#[derive(Clone, Default)]
+struct FieldOptions {
+  skip: bool,
+  order: Option<usize>,
+  null_if_none: bool,
+}
+
+struct FieldHash {
+  order: usize,
+  field_name: String,
+  target: TokenStream,
+  ty: Type,
+  options: FieldOptions,
+}
+
+pub fn expand_rspack_hashable_derive(input: DeriveInput) -> Result<TokenStream> {
+  let options = type_options(&input.attrs)?;
+  let hash_crate = options
+    .hash_crate
+    .unwrap_or_else(|| parse_quote!(::rspack_hash));
+  let use_json = options.json;
+  let body = if use_json {
+    quote! {
+      #hash_crate::hash_by_json(self, state);
+    }
+  } else {
+    match &input.data {
+      Data::Struct(data) => hash_fields(&hash_crate, &data.fields)?,
+      Data::Enum(data) => {
+        let arms = data
+          .variants
+          .iter()
+          .map(|variant| hash_variant(&hash_crate, &input.ident, variant))
+          .collect::<Result<Vec<_>>>()?;
+        quote! {
+          match self {
+            #(#arms)*
+          }
+        }
+      }
+      Data::Union(data) => {
+        return Err(Error::new_spanned(
+          data.union_token,
+          "RspackHashable cannot be derived for unions",
+        ));
+      }
+    }
+  };
+
+  let ident = &input.ident;
+  let mut generics = input.generics.clone();
+  add_rspack_hashable_bounds(&mut generics, &hash_crate, use_json);
+  let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+  Ok(quote! {
+    impl #impl_generics #hash_crate::RspackHashable for #ident #ty_generics #where_clause {
+      fn hash(&self, state: &mut #hash_crate::RspackHash) {
+        #body
+      }
+    }
+  })
+}
+
+fn type_options(attrs: &[Attribute]) -> Result<TypeOptions> {
+  let mut options = TypeOptions::default();
+  for attr in attrs {
+    if !attr.path().is_ident("rspack_hash") {
+      continue;
+    }
+    attr.parse_nested_meta(|meta| {
+      if meta.path.is_ident("crate") {
+        let value = meta.value()?;
+        options.hash_crate = Some(value.parse::<Path>()?);
+        Ok(())
+      } else if meta.path.is_ident("json") {
+        options.json = true;
+        Ok(())
+      } else {
+        Err(meta.error("unsupported rspack_hash attribute"))
+      }
+    })?;
+  }
+  Ok(options)
+}
+
+fn field_options(attrs: &[syn::Attribute]) -> Result<FieldOptions> {
+  let mut options = FieldOptions::default();
+  for attr in attrs {
+    if !attr.path().is_ident("rspack_hash") {
+      continue;
+    }
+    attr.parse_nested_meta(|meta| {
+      if meta.path.is_ident("skip") {
+        options.skip = true;
+        Ok(())
+      } else if meta.path.is_ident("order") {
+        let value = meta.value()?;
+        let order = value.parse::<syn::LitInt>()?;
+        options.order = Some(order.base10_parse()?);
+        Ok(())
+      } else if meta.path.is_ident("null_if_none") {
+        options.null_if_none = true;
+        Ok(())
+      } else {
+        Err(meta.error("unsupported rspack_hash field attribute"))
+      }
+    })?;
+  }
+  Ok(options)
+}
+
+fn hash_fields(hash_crate: &Path, fields: &Fields) -> Result<TokenStream> {
+  match fields {
+    Fields::Named(fields) => {
+      let fields = fields
+        .named
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+          let options = field_options(&field.attrs)?;
+          if options.skip {
+            return Ok(None);
+          }
+          let Some(ident) = field.ident.as_ref() else {
+            return Ok(None);
+          };
+          let field_name = ident.to_string();
+          Ok(Some(FieldHash {
+            order: options.order.unwrap_or(index),
+            field_name,
+            target: quote! {
+              &self.#ident
+            },
+            ty: field.ty.clone(),
+            options,
+          }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+      let mut fields = fields.into_iter().flatten().collect::<Vec<_>>();
+      hash_fields_body(hash_crate, &mut fields, "{")
+    }
+    Fields::Unnamed(fields) => {
+      let fields = fields
+        .unnamed
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+          let options = field_options(&field.attrs)?;
+          if options.skip {
+            return Ok(None);
+          }
+          let field_index = Index::from(index);
+          let field_name = index.to_string();
+          Ok(Some(FieldHash {
+            order: options.order.unwrap_or(index),
+            field_name,
+            target: quote! {
+              &self.#field_index
+            },
+            ty: field.ty.clone(),
+            options,
+          }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+      let mut fields = fields.into_iter().flatten().collect::<Vec<_>>();
+      hash_fields_body(hash_crate, &mut fields, "{")
+    }
+    Fields::Unit => Ok(quote! {
+      state.write(b"{}");
+    }),
+  }
+}
+
+fn hash_variant(
+  hash_crate: &Path,
+  enum_ident: &Ident,
+  variant: &syn::Variant,
+) -> Result<TokenStream> {
+  let variant_ident = &variant.ident;
+  let variant_name = variant_ident.to_string();
+  match &variant.fields {
+    Fields::Named(fields) => {
+      let field_idents = fields
+        .named
+        .iter()
+        .map(|field| {
+          field
+            .ident
+            .clone()
+            .ok_or_else(|| Error::new_spanned(field, "expected named field"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+      let hashes = fields
+        .named
+        .iter()
+        .zip(&field_idents)
+        .enumerate()
+        .map(|(index, (field, ident))| {
+          let options = field_options(&field.attrs)?;
+          if options.skip {
+            return Ok(None);
+          }
+          let field_name = ident.to_string();
+          Ok(Some(FieldHash {
+            order: options.order.unwrap_or(index),
+            field_name,
+            target: quote! { #ident },
+            ty: field.ty.clone(),
+            options,
+          }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+      let mut hashes = hashes.into_iter().flatten().collect::<Vec<_>>();
+      let body = hash_fields_body(hash_crate, &mut hashes, &format!("{variant_name}{{"))?;
+      Ok(quote! {
+        #enum_ident::#variant_ident { #(#field_idents),* } => {
+          #body
+        }
+      })
+    }
+    Fields::Unnamed(fields) => {
+      let bindings = (0..fields.unnamed.len())
+        .map(|index| Ident::new(&format!("field_{index}"), variant_ident.span()))
+        .collect::<Vec<_>>();
+      let hashes = fields
+        .unnamed
+        .iter()
+        .zip(&bindings)
+        .enumerate()
+        .map(|(index, (field, ident))| {
+          let options = field_options(&field.attrs)?;
+          if options.skip {
+            return Ok(None);
+          }
+          let field_name = index.to_string();
+          Ok(Some(FieldHash {
+            order: options.order.unwrap_or(index),
+            field_name,
+            target: quote! { #ident },
+            ty: field.ty.clone(),
+            options,
+          }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+      let mut hashes = hashes.into_iter().flatten().collect::<Vec<_>>();
+      let body = hash_fields_body(hash_crate, &mut hashes, &format!("{variant_name}{{"))?;
+      Ok(quote! {
+        #enum_ident::#variant_ident(#(#bindings),*) => {
+          #body
+        }
+      })
+    }
+    Fields::Unit => {
+      let variant_name = Literal::byte_string(variant_name.as_bytes());
+      Ok(quote! {
+        #enum_ident::#variant_ident => {
+          state.write(#variant_name);
+        }
+      })
+    }
+  }
+}
+
+fn hash_fields_body(
+  hash_crate: &Path,
+  fields: &mut [FieldHash],
+  start: &str,
+) -> Result<TokenStream> {
+  sort_fields(fields)?;
+
+  if fields.is_empty() {
+    let empty = Literal::byte_string(format!("{start}}}").as_bytes());
+    return Ok(quote! {
+      state.write(#empty);
+    });
+  }
+
+  if fields.iter().any(|field| field.is_conditionally_skipped()) {
+    let empty = Literal::byte_string(format!("{start}}}").as_bytes());
+    let fields = fields
+      .iter()
+      .map(|field| hash_field_dynamic(hash_crate, field, start));
+    return Ok(quote! {
+      let mut is_first_rspack_hash_field = true;
+      #(#fields)*
+      if is_first_rspack_hash_field {
+        state.write(#empty);
+      } else {
+        state.write(b"}");
+      }
+    });
+  }
+
+  let fields = fields.iter().enumerate().map(|(index, field)| {
+    let prefix = if index == 0 {
+      format!("{start}{}:", field.field_name)
+    } else {
+      format!(",{}:", field.field_name)
+    };
+    hash_field_static(hash_crate, field, &prefix)
+  });
+
+  Ok(quote! {
+    #(#fields)*
+    state.write(b"}");
+  })
+}
+
+fn hash_field_static(hash_crate: &Path, field: &FieldHash, prefix: &str) -> TokenStream {
+  let target = &field.target;
+  if field.options.null_if_none {
+    let null = Literal::byte_string(format!("{prefix}null").as_bytes());
+    let prefix = Literal::byte_string(prefix.as_bytes());
+    quote! {
+      match #target {
+        Some(value) => {
+          state.write(#prefix);
+          #hash_crate::RspackHashable::hash(value, state);
+        }
+        None => {
+          state.write(#null);
+        }
+      }
+    }
+  } else {
+    let prefix = Literal::byte_string(prefix.as_bytes());
+    quote! {
+      state.write(#prefix);
+      #hash_crate::RspackHashable::hash(#target, state);
+    }
+  }
+}
+
+fn hash_field_dynamic(hash_crate: &Path, field: &FieldHash, start: &str) -> TokenStream {
+  let target = &field.target;
+  let field_name = &field.field_name;
+  let ty = &field.ty;
+  let options = &field.options;
+  let first_key = Literal::byte_string(format!("{start}{field_name}:").as_bytes());
+  let next_key = Literal::byte_string(format!(",{field_name}:").as_bytes());
+  let hash_key = quote! {
+    if is_first_rspack_hash_field {
+      state.write(#first_key);
+    } else {
+      state.write(#next_key);
+    }
+    is_first_rspack_hash_field = false;
+  };
+  if options.null_if_none {
+    quote! {
+      match #target {
+        Some(value) => {
+          #hash_key
+          #hash_crate::RspackHashable::hash(value, state);
+        }
+        None => {
+          #hash_key
+          state.write(b"null");
+        }
+      }
+    }
+  } else if is_option_type(ty) {
+    quote! {
+      if let Some(value) = #target {
+        #hash_key
+        #hash_crate::RspackHashable::hash(value, state);
+      }
+    }
+  } else {
+    quote! {
+      #hash_key
+      #hash_crate::RspackHashable::hash(#target, state);
+    }
+  }
+}
+
+impl FieldHash {
+  fn is_conditionally_skipped(&self) -> bool {
+    is_option_type(&self.ty) && !self.options.null_if_none
+  }
+}
+
+fn is_option_type(ty: &Type) -> bool {
+  let Type::Path(path) = ty else {
+    return false;
+  };
+  path
+    .path
+    .segments
+    .last()
+    .is_some_and(|segment| segment.ident == "Option")
+}
+
+fn sort_fields(fields: &mut [FieldHash]) -> Result<()> {
+  fields.sort_by_key(|field| field.order);
+  for window in fields.windows(2) {
+    if window[0].order == window[1].order {
+      return Err(Error::new_spanned(
+        &window[1].target,
+        "duplicate rspack_hash field order",
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn add_rspack_hashable_bounds(generics: &mut Generics, hash_crate: &Path, json_hash: bool) {
+  for param in generics.type_params_mut() {
+    let bound: TypeParamBound = parse_quote!(#hash_crate::RspackHashable);
+    param.bounds.push(bound);
+    if json_hash {
+      let serde_bound: TypeParamBound = parse_quote!(::serde::Serialize);
+      param.bounds.push(serde_bound);
+    }
+  }
+}

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hasher, path::PathBuf};
+use std::{borrow::Cow, path::PathBuf};
 
 use asset_exports_dependency::AssetExportsDependency;
 use rayon::prelude::*;
@@ -15,9 +15,9 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, error};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::{base64, ext::DynHash, fx_hash::FxHashSet, identifier::make_paths_relative};
+use rspack_util::{base64, fx_hash::FxHashSet, identifier::make_paths_relative};
 
 mod asset_exports_dependency;
 
@@ -444,8 +444,8 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       ..
     } = parse_context;
     build_info.strict = true;
-    build_meta.exports_type = BuildMetaExportsType::Default;
-    build_meta.default_object = BuildMetaDefaultObject::False;
+    build_meta.set_exports_type(BuildMetaExportsType::Default);
+    build_meta.set_default_object(BuildMetaDefaultObject::False);
     let size = source.size();
 
     let data_url = match &self.data_url {
@@ -772,7 +772,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       && let Some(AssetGeneratorDataUrl::Options(data_url_options)) =
         module_generator_options.and_then(|x| x.asset_data_url())
     {
-      data_url_options.dyn_hash(&mut hasher);
+      data_url_options.hash(&mut hasher);
     } else if parsed_asset_config.is_resource() {
       let source_file_name = self.get_source_file_name(module, compilation);
       let (filename, _, _) = self
@@ -785,18 +785,24 @@ impl ParserAndGenerator for AssetParserAndGenerator {
           false,
         )
         .await?;
-      filename.dyn_hash(&mut hasher);
+      {
+        filename.hash(&mut hasher);
+      }
       match module_generator_options.and_then(|x| x.asset_public_path()) {
         Some(public_path) => match public_path {
           PublicPath::Filename(template) => {
             let (public_path, _) = self
               .get_public_path(module, compilation, None, &source_file_name, template)
               .await?;
-            public_path.dyn_hash(&mut hasher);
+            public_path.hash(&mut hasher);
           }
-          PublicPath::Auto => "auto".dyn_hash(&mut hasher),
+          PublicPath::Auto => {
+            "auto".hash(&mut hasher);
+          }
         },
-        None => "no-path".dyn_hash(&mut hasher),
+        None => {
+          "no-path".hash(&mut hasher);
+        }
       };
     }
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
   CompilationProcessAssets, Filename, GlobMatchOptions, Logger, PathData, Plugin,
   escape_glob_pattern, find_files_by_glob,
-  rspack_sources::{BoxSource, RawBufferSource, Source, SourceExt},
+  rspack_sources::{BoxSource, RawBufferSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   DependencyType, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec,
   ExportsSpec, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 use crate::utils::{escape_css, replace_css_module_id_placeholder};
 
@@ -82,11 +82,11 @@ impl DependencyCodeGeneration for CssLocalIdentDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.local_ident.dyn_hash(hasher);
+    self.local_ident.hash(hasher);
   }
 }
 

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -18,10 +18,9 @@ use rspack_core::{
 };
 pub use rspack_core::{CssExport, CssExports};
 use rspack_error::{Result, TWithDiagnosticArray};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_util::{
   atom::Atom,
-  ext::DynHash,
   fx_hash::{FxIndexMap, FxIndexSet},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -259,11 +258,11 @@ impl ParserAndGenerator for CssParserAndGenerator {
       } else {
         BuildMetaExportsType::Default
       };
-      build_meta.default_object = if named_exports {
+      build_meta.set_default_object(if named_exports {
         BuildMetaDefaultObject::False
       } else {
         BuildMetaDefaultObject::Redirect
-      };
+      });
     }
 
     let exports_only = generator_options
@@ -344,9 +343,9 @@ impl ParserAndGenerator for CssParserAndGenerator {
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
-    self.es_module.dyn_hash(&mut hasher);
-    self.exports_only.dyn_hash(&mut hasher);
-    self.effective_export_type(module).dyn_hash(&mut hasher);
+    self.es_module.hash(&mut hasher);
+    self.exports_only.hash(&mut hasher);
+    self.effective_export_type(module).hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }
 }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -248,11 +248,11 @@ impl ParserAndGenerator for CssParserAndGenerator {
       let build_meta = &mut *parse_context.build_meta;
 
       build_info.strict = true;
-      build_meta.is_css_module = is_css_module(
+      build_meta.set_is_css_module(is_css_module(
         parse_context.module_type,
         parse_context.resource_data.path().map(|path| path.as_str()),
-      );
-      build_meta.need_id_in_concatenation = self.export_type == Some(CssExportType::Style);
+      ));
+      build_meta.set_need_id_in_concatenation(self.export_type == Some(CssExportType::Style));
       build_meta.exports_type = if named_exports {
         BuildMetaExportsType::Namespace
       } else {

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::comparison_chain)]
 
-use std::{
-  hash::Hash,
-  sync::{Arc, LazyLock},
-};
+use std::sync::{Arc, LazyLock};
 
 use atomic_refcell::AtomicRefCell;
 use rspack_core::{
@@ -18,7 +15,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::plugin_hook;
 use rspack_plugin_runtime::is_enabled_for_chunk;
 use rspack_util::fx_hash::FxDashMap;
@@ -484,7 +481,7 @@ async fn content_hash(
     .get_chunk_modules_by_source_type(chunk_ukey, SourceType::Css, module_graph);
   let (ordered_modules, _) =
     Self::get_ordered_chunk_css_modules(chunk, compilation, css_import_modules, css_modules);
-  let mut hasher = hashes
+  let hasher = hashes
     .entry(SourceType::Css)
     .or_insert_with(|| RspackHash::from(&compilation.options.output));
 
@@ -500,8 +497,8 @@ async fn content_hash(
     })
     .for_each(|(current, id)| {
       if let Some(current) = current {
-        current.hash(&mut hasher);
-        id.hash(&mut hasher);
+        current.hash(hasher);
+        id.hash(hasher);
       }
     });
 

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -1,5 +1,6 @@
 use std::{
   borrow::Cow,
+  hash::{Hash, Hasher},
   path::Path,
   sync::{Arc, LazyLock},
 };

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -1,6 +1,5 @@
 use std::{
   borrow::Cow,
-  hash::{Hash, Hasher},
   path::Path,
   sync::{Arc, LazyLock},
 };

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash};
+use std::borrow::Cow;
 
 use cow_utils::CowUtils;
 use derive_more::Debug;
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 use derive_more::Debug;
 use futures::future::join_all;
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
@@ -288,7 +288,7 @@ async fn js_chunk_hash(
   _chunk_ukey: &ChunkUkey,
   hasher: &mut RspackHash,
 ) -> Result<()> {
-  EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME.hash(hasher);
+  RspackHashable::hash(&EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME, hasher);
   Ok(())
 }
 

--- a/crates/rspack_plugin_devtool/src/generate_debug_id.rs
+++ b/crates/rspack_plugin_devtool/src/generate_debug_id.rs
@@ -1,5 +1,3 @@
-use std::hash::Hasher;
-
 use rspack_hash::{HashDigest, HashFunction, RspackHash};
 
 pub fn generate_debug_id(filename: &str, source: &[u8]) -> String {

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -1,14 +1,9 @@
-use std::{
-  borrow::Cow,
-  cell::OnceCell,
-  hash::{Hash, Hasher},
-  path::Path,
-};
+use std::{borrow::Cow, cell::OnceCell, path::Path};
 
 use cow_utils::CowUtils;
 use rspack_core::{ChunkGraph, Compilation, OutputOptions, contextify};
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_paths::Utf8Path;
 use rustc_hash::FxHashMap as HashMap;
 use sugar_path::SugarPath;
@@ -33,7 +28,7 @@ fn get_hash(text: &str, output_options: &OutputOptions) -> String {
     ..
   } = output_options;
   let mut hasher = RspackHash::with_salt(hash_function, hash_salt);
-  text.as_bytes().hash(&mut hasher);
+  text.hash(&mut hasher);
   let mut buf = format!("{:x}", hasher.finish());
   buf.truncate(4);
   buf

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -1,6 +1,5 @@
 use std::{
   borrow::Cow,
-  hash::Hasher,
   path::{Component, Path, PathBuf},
   sync::{Arc, LazyLock},
 };
@@ -22,7 +21,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::{
@@ -1014,7 +1013,7 @@ impl SourceMapDevToolPlugin {
       let content_hash_digest =
         if chunk.is_some() && has_content_hash_placeholder(source_map_filename_config.as_str()) {
           let mut hasher = RspackHash::from(&compilation.options.output);
-          hasher.write(source_map_json.as_bytes());
+          source_map_json.hash(&mut hasher);
           let digest = hasher.digest(&compilation.options.output.hash_digest);
           Some(digest)
         } else {

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 
 use super::dll_entry_dependency::DllEntryDependency;
 

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
@@ -13,7 +13,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_util::{json_stringify, source_map::ModuleSourceMapConfig};
 
 use super::delegated_source_dependency::DelegatedSourceDependency;
@@ -195,11 +195,7 @@ impl Module for DelegatedModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
     self.delegation_type.hash(&mut hasher);
-
-    if let Some(request) = &self.request {
-      request.hash(&mut hasher);
-    }
-
+    self.request.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
 
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_plugin_esm_library/src/esm_lib_parser_plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/esm_lib_parser_plugin.rs
@@ -9,7 +9,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for EsmLibParserPlugin {
   fn finish(&self, parser: &mut JavascriptParser<'p>) -> Option<bool> {
     if parser.module_type.is_js_auto()
       && matches!(
-        parser.build_meta.exports_type,
+        parser.build_meta.exports_type(),
         rspack_core::BuildMetaExportsType::Unset
       )
       && !parser.get_dependencies().iter().any(|dep| {
@@ -26,7 +26,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for EsmLibParserPlugin {
       })
     {
       // make module without any exports or module accessing not bail out
-      parser.build_meta.exports_type = rspack_core::BuildMetaExportsType::Namespace;
+      parser
+        .build_meta
+        .set_exports_type(rspack_core::BuildMetaExportsType::Namespace);
       parser.add_presentational_dependency(Box::new(ESMCompatibilityDependency));
     }
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -650,7 +650,7 @@ impl EsmLibraryPlugin {
             .expect("should have box module");
           let module_readable_identifier =
             box_module.readable_identifier(&compilation.options.context);
-          let strict_esm_module = box_module.build_meta().strict_esm_module;
+          let strict_esm_module = box_module.build_meta().strict_esm_module();
 
           // scope hoisted module can only exist in only 1 chunk
           // so it's safe to use module_info.namespace_object_name, which is
@@ -810,7 +810,7 @@ impl EsmLibraryPlugin {
               .module_by_identifier(&target_module)
               .expect("should have target module")
               .build_meta()
-              .strict_esm_module;
+              .strict_esm_module();
 
             Self::get_binding(
               None,
@@ -1039,8 +1039,8 @@ var {} = {{}};
       let module = module_graph
         .module_by_identifier(id)
         .expect("should have module");
-      let exports_type = module.build_meta().exports_type;
-      let default_object = module.build_meta().default_object;
+      let exports_type = module.build_meta().exports_type();
+      let default_object = module.build_meta().default_object();
 
       let info = &mut concate_modules_map[id];
       let readable_identifier =
@@ -2016,7 +2016,7 @@ var {} = {{}};
       module_graph,
       &compilation.module_graph_cache_artifact,
       &compilation.exports_info_artifact,
-      module.build_meta().strict_esm_module,
+      module.build_meta().strict_esm_module(),
     );
 
     if matches!(exports_type, ExportsType::DefaultOnly) {
@@ -2050,7 +2050,7 @@ var {} = {{}};
           needed_namespace_objects,
           false,
           false,
-          module.build_meta().strict_esm_module,
+          module.build_meta().strict_esm_module(),
           None,
           &mut Default::default(),
           required,
@@ -2753,7 +2753,7 @@ var {} = {{}};
               needed_namespace_objects,
               options.call,
               !options.direct_import,
-              module.build_meta().strict_esm_module,
+              module.build_meta().strict_esm_module(),
               options.asi_safe,
               &mut Default::default(),
               required,
@@ -3366,7 +3366,7 @@ var {} = {{}};
                 needed_namespace_objects,
                 as_call,
                 call_context,
-                build_meta.strict_esm_module,
+                build_meta.strict_esm_module(),
                 asi_safe,
                 already_visited,
                 required,

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -40,7 +40,7 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
   // at module top level" info which is not exposed on the block.
   let mut async_chunks_set: FxHashSet<ChunkUkey> = FxHashSet::default();
   for (module_id, module) in module_graph.modules() {
-    if !module.build_meta().has_top_level_await {
+    if !module.build_meta().has_top_level_await() {
       continue;
     }
     for block_id in module.get_blocks() {

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
@@ -10,8 +8,8 @@ use rspack_core::{
   impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
-use rspack_util::{ext::DynHash, itoa};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_util::itoa;
 
 use crate::{
   css_dependency::CssDependency,
@@ -195,7 +193,7 @@ impl Module for CssModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
-    self.build_info.hash.dyn_hash(&mut hasher);
+    self.build_info.hash.hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }
 

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -1,6 +1,5 @@
 use std::{
   borrow::Cow,
-  hash::Hash,
   sync::{Arc, LazyLock},
 };
 
@@ -21,7 +20,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin, parser_and_generator::JavaScriptParserAndGenerator,

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -1,7 +1,6 @@
 use std::{
   borrow::Cow,
   env,
-  hash::Hasher,
   path::{Path, PathBuf},
 };
 
@@ -14,7 +13,7 @@ use rspack_core::{
   rspack_sources::{RawBufferSource, RawStringSource, SourceExt},
 };
 use rspack_error::{AnyhowResultToRspackResultExt, Result};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_paths::Utf8PathBuf;
 use rspack_util::fx_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -339,7 +338,7 @@ pub async fn create_html_asset(
   compilation: &Compilation,
 ) -> Result<(String, CompilationAsset)> {
   let mut hasher = RspackHash::from(&compilation.options.output);
-  hasher.write(html.as_bytes());
+  html.hash(&mut hasher);
   let hash_digest = hasher.digest(&compilation.options.output.hash_digest);
   let content_hash = hash_digest.encoded();
 

--- a/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/branch_guard.rs
@@ -325,7 +325,7 @@ fn resolve_esm_imported_in_operator_guard(
     module_graph,
     module_graph_cache,
     exports_info_artifact,
-    parent_module.build_meta().strict_esm_module,
+    parent_module.build_meta().strict_esm_module(),
   );
   let provided = match exports_type {
     ExportsType::DefaultWithNamed => {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -6,14 +6,16 @@ use rspack_core::{
   NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
   create_exports_object_referenced, create_no_exports_referenced,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, RspackHashable)]
 pub struct ModuleDecoratorDependency {
   decorator: RuntimeGlobals,
   allow_exports_access: bool,
+  #[rspack_hash(skip)]
   id: DependencyId,
+  #[rspack_hash(skip)]
   factorize_info: FactorizeInfo,
 }
 
@@ -51,12 +53,11 @@ impl DependencyCodeGeneration for ModuleDecoratorDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.decorator.dyn_hash(hasher);
-    self.allow_exports_access.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
@@ -3,10 +3,10 @@ use rspack_core::{
   Compilation, DependencyCodeGeneration, DependencyRange, DependencyTemplate,
   DependencyTemplateType, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, RspackHashable)]
 pub struct RequireMainDependency {
   pub range: DependencyRange,
 }
@@ -25,11 +25,11 @@ impl DependencyCodeGeneration for RequireMainDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.range.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_compatibility_dependency.rs
@@ -90,7 +90,7 @@ impl DependencyTemplate for ESMCompatibilityDependencyTemplate {
         InitFragmentKey::unique(),
         Some(format!(
           "\n__rspack_async_done();\n}} catch(e) {{ __rspack_async_done(e); }} }}{});",
-          if module.build_meta().has_top_level_await {
+          if module.build_meta().has_top_level_await() {
             ", 1"
           } else {
             ""

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -26,7 +26,8 @@ use rspack_core::{
   property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
-use rspack_util::{ext::DynHash, json_stringify};
+use rspack_hash::{RspackHash, RspackHashable};
+use rspack_util::json_stringify;
 use rustc_hash::{FxHashSet as HashSet, FxHasher};
 use swc_atoms::Atom;
 
@@ -587,7 +588,7 @@ impl ESMExportImportedSpecifierDependency {
 
         if self.phase.is_defer()
           && let Some(target_module) = target_module
-          && !target_module.build_meta().has_top_level_await
+          && !target_module.build_meta().has_top_level_await()
         {
           let exports_type = get_exports_type(
             mg,
@@ -632,7 +633,7 @@ impl ESMExportImportedSpecifierDependency {
 
         if self.phase.is_defer()
           && let Some(target_module) = target_module
-          && !target_module.build_meta().has_top_level_await
+          && !target_module.build_meta().has_top_level_await()
         {
           let exports_type = get_exports_type(
             mg,
@@ -1137,7 +1138,7 @@ pub struct DiscoverActiveExportsFromOtherStarExportsRet {
 impl DependencyCodeGeneration for ESMExportImportedSpecifierDependency {
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     compilation: &rspack_core::Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {
@@ -1170,9 +1171,9 @@ impl DependencyCodeGeneration for ESMExportImportedSpecifierDependency {
       if let Some(UsedName::Inlined(inlined)) =
         exports_info.get_used_name(&compilation.exports_info_artifact, runtime, &item.ids)
       {
-        item.name.dyn_hash(hasher);
-        item.ids.dyn_hash(hasher);
-        inlined.dyn_hash(hasher);
+        item.name.hash(hasher);
+        item.ids.hash(hasher);
+        inlined.hash(hasher);
       }
     }
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -297,7 +297,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
     module_graph,
     module_graph_cache,
     exports_info_artifact,
-    parent_module.build_meta().strict_esm_module,
+    parent_module.build_meta().strict_esm_module(),
   );
   let additional_msg = || {
     if is_reexport {
@@ -468,7 +468,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       if !ids.is_empty()
         && ids[0] != "default"
         && matches!(
-          imported_module.build_meta().default_object,
+          imported_module.build_meta().default_object(),
           BuildMetaDefaultObject::RedirectWarn
         )
         // Ignore the JSON named exports warning: this doesn't follow the standards

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -15,7 +15,8 @@ use rspack_core::{
   property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
-use rspack_util::{ext::DynHash, json_stringify_str};
+use rspack_hash::{RspackHash, RspackHashable};
+use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
 
 use super::{
@@ -386,7 +387,7 @@ impl AsContextDependency for ESMImportSpecifierDependency {}
 impl DependencyCodeGeneration for ESMImportSpecifierDependency {
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     compilation: &rspack_core::Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {
@@ -407,8 +408,8 @@ impl DependencyCodeGeneration for ESMImportSpecifierDependency {
     if let Some(UsedName::Inlined(inlined)) =
       exports_info.get_used_name(&compilation.exports_info_artifact, runtime, ids)
     {
-      ids.dyn_hash(hasher);
-      inlined.dyn_hash(hasher);
+      ids.hash(hasher);
+      inlined.hash(hasher);
     }
   }
 
@@ -557,7 +558,7 @@ impl ESMImportSpecifierDependencyTemplate {
       mg,
       &compilation.module_graph_cache_artifact,
       &compilation.exports_info_artifact,
-      self_module.build_meta().strict_esm_module,
+      self_module.build_meta().strict_esm_module(),
     );
     let first = ids
       .first()
@@ -712,7 +713,7 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
             .compilation
             .module_graph_cache_artifact,
           &code_generatable_context.compilation.exports_info_artifact,
-          self_module.build_meta().strict_esm_module,
+          self_module.build_meta().strict_esm_module(),
         );
         if matches!(
           exports_type,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -4,13 +4,14 @@ use rspack_core::{
   ExternalModuleInitFragment, InitFragmentExt, InitFragmentStage, RuntimeSpec, TemplateContext,
   TemplateReplaceSource,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, RspackHashable)]
 pub struct ExternalModuleDependency {
   module: String,
   import_specifier: Vec<(String, String)>,
+  #[rspack_hash(null_if_none)]
   default_import: Option<String>,
 }
 
@@ -36,13 +37,11 @@ impl DependencyCodeGeneration for ExternalModuleDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.module.dyn_hash(hasher);
-    self.import_specifier.dyn_hash(hasher);
-    self.default_import.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
@@ -6,7 +6,8 @@ use rspack_core::{
   ModuleGraphCacheArtifact, NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext,
   TemplateReplaceSource, create_exports_object_referenced,
 };
-use rspack_util::{ext::DynHash, json_stringify_str};
+use rspack_hash::{RspackHash, RspackHashable};
+use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
 
 pub const IMPORT_META_RSC_BINDING: &str = "__rspack_import_meta_rsc__";
@@ -111,12 +112,12 @@ impl DependencyCodeGeneration for ImportMetaRscDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &rspack_core::Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.importer.dyn_hash(hasher);
-    self.range.is_some().dyn_hash(hasher);
+    self.importer.hash(hasher);
+    self.range.is_some().hash(hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, create_exports_object_referenced,
   property_access, to_normal_comment,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use swc_atoms::Atom;
 
 #[cacheable]
@@ -111,12 +111,12 @@ impl DependencyCodeGeneration for ProvideDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {
-    self.identifier.dyn_hash(hasher);
-    self.ids.dyn_hash(hasher);
+    self.identifier.hash(hasher);
+    self.ids.hash(hasher);
     // Case: a ProvidePlugin variable is replaced by an inlined const export,
     // e.g. `provided = (__rspack_require("./constants"), 2)`. The generated
     // code embeds the target export's inline literal, so the dependency hash must
@@ -131,7 +131,7 @@ impl DependencyCodeGeneration for ProvideDependency {
         exports_info.get_used_name(&compilation.exports_info_artifact, runtime, &self.ids)
       });
     if let Some(UsedName::Inlined(inlined)) = used_name {
-      inlined.dyn_hash(hasher);
+      inlined.hash(hasher);
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   Compilation, DependencyCodeGeneration, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -23,6 +23,33 @@ impl ModuleArgumentDependency {
   }
 }
 
+impl RspackHashable for ModuleArgumentDependency {
+  fn hash(&self, state: &mut RspackHash) {
+    "range".hash(state);
+    self.range.hash(state);
+    if let Some(id) = &self.id {
+      "id".hash(state);
+      id.hash(state);
+    }
+
+    match self.id.as_deref() {
+      Some("id") => {
+        "runtime_requirements".hash(state);
+        RuntimeGlobals::MODULE_ID.hash(state);
+      }
+      Some("loaded") => {
+        "runtime_requirements".hash(state);
+        RuntimeGlobals::MODULE_LOADED.hash(state);
+      }
+      Some("hot" | "hot.accept" | "hot.decline") => {
+        "runtime_requirements".hash(state);
+        RuntimeGlobals::MODULE.hash(state);
+      }
+      _ => {}
+    }
+  }
+}
+
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ModuleArgumentDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
@@ -31,12 +58,11 @@ impl DependencyCodeGeneration for ModuleArgumentDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.id.dyn_hash(hasher);
-    self.range.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource,
   UsedByExports,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 use crate::runtime_condition_used_by_exports;
 
@@ -84,12 +84,12 @@ impl DependencyCodeGeneration for PureExpressionDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {
     let runtime_condition = self.get_runtime_condition(compilation, runtime);
-    runtime_condition.dyn_hash(hasher);
+    runtime_condition.hash(hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
   ModuleGraphCacheArtifact, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_util::ext::DynHash;
+use rspack_hash::{RspackHash, RspackHashable};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -40,6 +40,15 @@ impl WorkerDependency {
       factorize_info: Default::default(),
       need_new_url,
     }
+  }
+}
+
+impl RspackHashable for WorkerDependency {
+  fn hash(&self, state: &mut RspackHash) {
+    rspack_hash::rspack_hash_object!(state, {
+      "publicPath" => self.public_path.as_str(),
+      "needNewUrl" => self.need_new_url,
+    });
   }
 }
 
@@ -103,11 +112,11 @@ impl DependencyCodeGeneration for WorkerDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.public_path.dyn_hash(hasher);
+    RspackHashable::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -342,7 +342,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     if compiler_options.optimization.side_effects.is_true() {
       let has_side_effects = side_effects_item.is_some();
-      build_meta.side_effect_free = Some(!has_side_effects);
+      build_meta.set_side_effect_free(!has_side_effects);
       if has_side_effects {
         build_info.deferred_pure_checks.clear();
       }
@@ -432,7 +432,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     _cg: &ChunkGraph,
   ) -> Option<Cow<'static, str>> {
     // Only ES modules are valid for optimization
-    if module.build_meta().exports_type != BuildMetaExportsType::Namespace {
+    if module.build_meta().exports_type() != BuildMetaExportsType::Namespace {
       return Some("Module is not an ECMAScript module".into());
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -1,9 +1,8 @@
 use std::borrow::Cow;
 
 use rspack_core::{
-  BoxDependencyTemplate, BuildMetaDefaultObject, BuildMetaExportsType, ContextDependency,
-  ContextMode, ContextOptions, Dependency, DependencyCategory, RuntimeGlobals,
-  RuntimeRequirementsDependency,
+  BoxDependencyTemplate, BuildMetaDefaultObject, ContextDependency, ContextMode, ContextOptions,
+  Dependency, DependencyCategory, RuntimeGlobals, RuntimeRequirementsDependency,
 };
 use rspack_util::{SpanExt, atom::Atom};
 use rustc_hash::FxHashMap;
@@ -377,8 +376,10 @@ impl AMDDefineDependencyParserPlugin {
       // DynamicExports.bailout(parser.state);
       //  TODO: consider how to share this code
       if parser.parser_exports_state.is_some_and(|x| x) {
-        parser.build_meta.exports_type = BuildMetaExportsType::Unset;
-        parser.build_meta.default_object = BuildMetaDefaultObject::False;
+        parser.build_meta.clear_exports_type();
+        parser
+          .build_meta
+          .set_default_object(BuildMetaDefaultObject::False);
       }
       parser.parser_exports_state = Some(false);
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -72,8 +72,10 @@ impl JavascriptParser<'_> {
   // can't scan `__esModule` value
   fn bailout(&mut self) {
     if matches!(self.parser_exports_state, Some(true)) {
-      self.build_meta.exports_type = BuildMetaExportsType::Unset;
-      self.build_meta.default_object = BuildMetaDefaultObject::False;
+      self.build_meta.clear_exports_type();
+      self
+        .build_meta
+        .set_default_object(BuildMetaDefaultObject::False);
     }
     self.parser_exports_state = Some(false);
   }
@@ -84,8 +86,12 @@ impl JavascriptParser<'_> {
       return;
     }
     if self.parser_exports_state.is_none() {
-      self.build_meta.exports_type = BuildMetaExportsType::Default;
-      self.build_meta.default_object = BuildMetaDefaultObject::Redirect;
+      self
+        .build_meta
+        .set_exports_type(BuildMetaExportsType::Default);
+      self
+        .build_meta
+        .set_default_object(BuildMetaDefaultObject::Redirect);
     }
     self.parser_exports_state = Some(true);
   }
@@ -95,10 +101,15 @@ impl JavascriptParser<'_> {
     if matches!(self.parser_exports_state, Some(false)) || self.parser_exports_state.is_none() {
       return;
     }
-    if matches!(self.build_meta.exports_type, BuildMetaExportsType::Dynamic) {
+    if matches!(
+      self.build_meta.exports_type(),
+      BuildMetaExportsType::Dynamic
+    ) {
       return;
     }
-    self.build_meta.exports_type = BuildMetaExportsType::Flagged;
+    self
+      .build_meta
+      .set_exports_type(BuildMetaExportsType::Flagged);
   }
 
   // `__esModule` is dynamic, eg `true && true`
@@ -106,7 +117,9 @@ impl JavascriptParser<'_> {
     if matches!(self.parser_exports_state, Some(false)) || self.parser_exports_state.is_none() {
       return;
     }
-    self.build_meta.exports_type = BuildMetaExportsType::Dynamic;
+    self
+      .build_meta
+      .set_exports_type(BuildMetaExportsType::Dynamic);
   }
 
   fn check_namespace(&mut self, top_level: bool, value_expr: Option<&Expr>) {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -26,7 +26,7 @@ impl JavascriptParser<'_> {
 
   fn handle_top_level_await(&mut self, span: Span) {
     if self.is_esm {
-      self.build_meta.has_top_level_await = true;
+      self.build_meta.set_has_top_level_await(true);
     } else {
       self.throw_top_level_await_error(
         "Top-level-await is only supported in ECMAScript Modules".into(),
@@ -54,14 +54,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMDetectionParserPlugin {
 
     if is_esm {
       parser.add_presentational_dependency(Box::new(ESMCompatibilityDependency));
-      parser.build_meta.esm = true;
-      parser.build_meta.exports_type = BuildMetaExportsType::Namespace;
+      parser.build_meta.set_esm(true);
+      parser
+        .build_meta
+        .set_exports_type(BuildMetaExportsType::Namespace);
       parser.build_info.strict = true;
       parser.build_info.exports_argument = ExportsArgument::RspackExports;
     }
 
     if is_strict_esm {
-      parser.build_meta.strict_esm_module = true;
+      parser.build_meta.set_strict_esm_module(true);
       parser.build_info.module_argument = ModuleArgument::RspackModule;
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -395,7 +395,7 @@ fn create_import_meta_glob_dependency(
     .as_ref()
     .filter(|import| import.as_str() != "*")
     .map(|import| vec![ReferencedSpecifier::new(vec![Atom::from(import.as_str())])]);
-  let namespace_object = if parser.build_meta.strict_esm_module {
+  let namespace_object = if parser.build_meta.strict_esm_module() {
     ContextNameSpaceObject::Strict
   } else {
     ContextNameSpaceObject::Bool(true)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -485,7 +485,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           category: DependencyCategory::Esm,
           request: format!("{context}{query}{fragment}"),
           context,
-          namespace_object: if parser.build_meta.strict_esm_module {
+          namespace_object: if parser.build_meta.strict_esm_module() {
             ContextNameSpaceObject::Strict
           } else {
             ContextNameSpaceObject::Bool(true)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -1,13 +1,10 @@
-use std::{
-  hash::Hash,
-  sync::{Arc, LazyLock},
-};
+use std::sync::{Arc, LazyLock};
 
 use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, EntryOptions, GroupOptions,
 };
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -39,7 +39,7 @@ impl<'a> FlagDependencyExportsState<'a> {
         .module_by_identifier(module_id)
         .expect("should have module")
         .build_meta()
-        .exports_type
+        .exports_type()
         == BuildMetaExportsType::Unset;
       let exports_info = self
         .exports_info_artifact

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -238,7 +238,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               .module_by_identifier(&module_id)
               .expect("should have module");
             let is_exports_type_unset = matches!(
-              module.build_meta().exports_type,
+              module.build_meta().exports_type(),
               BuildMetaExportsType::Unset
             );
             let is_side_effect_free =
@@ -438,7 +438,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       .expect("should have module");
     if !used_exports.is_empty() {
       let need_insert = matches!(
-        module.build_meta().exports_type,
+        module.build_meta().exports_type(),
         BuildMetaExportsType::Unset
       );
 

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, sync::Arc};
+use std::sync::Arc;
 
 use rspack_core::{
   AssetInfo, CachedConstDependencyTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
@@ -11,7 +11,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::plugin_hook;
 use rustc_hash::FxHashMap;
 
@@ -496,12 +496,12 @@ async fn content_hash(
     .build_chunk_graph_artifact
     .chunk_by_ukey
     .expect_get(chunk_ukey);
-  let mut hasher = hashes
+  let hasher = hashes
     .entry(SourceType::JavaScript)
     .or_insert_with(|| RspackHash::from(&compilation.options.output));
 
   if !chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
-    chunk.id().hash(&mut hasher);
+    chunk.id().hash(hasher);
   }
 
   let module_graph = compilation.get_module_graph();
@@ -524,8 +524,8 @@ async fn content_hash(
     })
     .for_each(|(current, id)| {
       if let Some(current) = current {
-        current.hash(&mut hasher);
-        id.hash(&mut hasher);
+        current.hash(hasher);
+        id.hash(hasher);
       }
     });
 
@@ -538,7 +538,7 @@ async fn content_hash(
       .runtime_modules_hash
       .get(runtime_module_identifier)
     {
-      hash.hash(&mut hasher);
+      hash.hash(hasher);
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -43,7 +43,7 @@ async fn finish_modules(
   let mut async_modules = IdentifierLinkedSet::default();
   for (module_identifier, module) in module_graph.modules() {
     let build_meta = module.build_meta();
-    if build_meta.has_top_level_await {
+    if build_meta.has_top_level_await() {
       async_modules.insert(*module_identifier);
     } else {
       sync_modules.insert(*module_identifier);

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -153,7 +153,7 @@ async fn optimize_code_generation(
     .modules()
     .map(|(mid, module)| {
       let is_namespace = matches!(
-        module.build_meta().exports_type,
+        module.build_meta().exports_type(),
         BuildMetaExportsType::Namespace
       );
       (exports_info_artifact.get_exports_info(mid), is_namespace)

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1,7 +1,6 @@
 use std::{
   borrow::Cow,
   collections::hash_map::Entry,
-  hash::Hash,
   ops::Deref,
   sync::{Arc, LazyLock, RwLock as SyncRwLock},
 };
@@ -39,7 +38,7 @@ use rspack_core::{
   split_readable_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_hook::plugin;
 use rspack_util::SpanExt;
 #[cfg(allocative)]
@@ -1514,14 +1513,9 @@ var {} = {{}};
   ) -> Result<()> {
     let runtime_template = compilation.runtime_template.create_chunk_code_template();
     // sample hash use content
-    let RenderBootstrapResult {
-      header,
-      startup,
-      allow_inline_startup,
-    } = Self::render_bootstrap(chunk_ukey, compilation, &runtime_template).await?;
-    header.hash(hasher);
-    startup.hash(hasher);
-    allow_inline_startup.hash(hasher);
+    Self::render_bootstrap(chunk_ukey, compilation, &runtime_template)
+      .await?
+      .hash(hasher);
     Ok(())
   }
 }
@@ -1532,7 +1526,7 @@ pub struct ExtractedCommentsInfo {
   pub comments_file_name: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, RspackHashable)]
 pub struct RenderBootstrapResult<'a> {
   pub header: Vec<Cow<'a, str>>,
   pub startup: Vec<Cow<'a, str>>,

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -191,7 +191,7 @@ async fn finish_modules(
       continue;
     }
 
-    let baseline_side_effect_free = module.build_meta().side_effect_free.unwrap_or(false);
+    let baseline_side_effect_free = module.build_meta().side_effect_free();
 
     let has_impure_deferred_check =
       // find the first deferred pure check that resolves to an impure target

--- a/crates/rspack_plugin_json/Cargo.toml
+++ b/crates/rspack_plugin_json/Cargo.toml
@@ -14,6 +14,7 @@ json             = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_core      = { workspace = true }
 rspack_error     = { workspace = true }
+rspack_hash      = { workspace = true }
 rspack_util      = { workspace = true }
 
 [lints]

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -5,7 +5,8 @@ use rspack_core::{
   DependencyId, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec,
   ExportsSpec, ModuleGraph, ModuleGraphCacheArtifact, RuntimeSpec,
 };
-use rspack_util::{ext::DynHash, itoa};
+use rspack_hash::{RspackHash, RspackHashable};
+use rspack_util::itoa;
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -57,11 +58,11 @@ impl AsContextDependency for JsonExportsDependency {}
 impl DependencyCodeGeneration for JsonExportsDependency {
   fn update_hash(
     &self,
-    hasher: &mut dyn std::hash::Hasher,
+    hasher: &mut RspackHash,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    self.data.to_string().dyn_hash(hasher);
+    self.data.to_string().hash(hasher);
   }
 }
 

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -140,12 +140,12 @@ impl ParserAndGenerator for JsonParserAndGenerator {
 
     build_info.json_data = Some(data.clone());
     build_info.strict = true;
-    build_meta.exports_type = BuildMetaExportsType::Default;
-    build_meta.default_object = if data.is_object() || data.is_array() {
+    build_meta.set_exports_type(BuildMetaExportsType::Default);
+    build_meta.set_default_object(if data.is_object() || data.is_array() {
       BuildMetaDefaultObject::RedirectWarn
     } else {
       BuildMetaDefaultObject::False
-    };
+    });
 
     Ok(
       rspack_core::ParseResult {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -12,10 +12,9 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
 use rspack_plugin_javascript::dependency::CommonJsRequireDependency;
 use rspack_util::{
-  ext::DynHash,
   json_stringify,
   source_map::{ModuleSourceMapConfig, SourceMapKind},
 };
@@ -333,8 +332,8 @@ impl Module for LazyCompilationProxyModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
-    self.active.dyn_hash(&mut hasher);
-    self.identifier.dyn_hash(&mut hasher);
+    self.active.hash(&mut hasher);
+    self.identifier.hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }
 }

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationParams, CompilerCompilation, ExternalModule, Filename, LibraryName,
@@ -8,7 +6,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, sync::LazyLock};
+use std::sync::LazyLock;
 
 use futures::future::join_all;
 use regex::Regex;
@@ -14,7 +14,7 @@ use rspack_core::{
   to_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error, error_bail};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesEmbedInRuntimeBailout, JavascriptModulesRender,

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   AsyncModulesArtifact, CanInlineUse, ChunkCodeTemplate, ChunkUkey, Compilation,
   CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules, CompilationParams,
@@ -9,7 +7,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationParams, CompilerCompilation, Filename, LibraryName, LibraryNonUmdObject,
@@ -7,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
   ExportProvided, ExportsType, LibraryOptions, ModuleGraph, ModuleIdentifier, Plugin,
@@ -8,7 +6,7 @@ use rspack_core::{
   to_identifier, to_module_export_name,
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationParams, CompilerCompilation, ExternalModule, ExternalRequest, Filename, LibraryName,
@@ -7,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error_bail};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash};
+use std::borrow::Cow;
 
 use rspack_core::{
   Chunk, ChunkCodeTemplate, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{
   collections::HashSet,
-  hash::Hash,
   sync::{Arc, LazyLock, RwLock},
 };
 
@@ -29,7 +28,7 @@ use thread_local::ThreadLocal;
 static CSS_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.css(\?.*)?$").expect("Invalid RegExp"));
 
-#[derive(Debug, Hash)]
+#[derive(Debug, rspack_hash::RspackHashable)]
 pub struct PluginOptions {
   pub test: Option<AssetConditions>,
   pub include: Option<AssetConditions>,
@@ -38,17 +37,17 @@ pub struct PluginOptions {
   pub minimizer_options: MinimizerOptions,
 }
 
-#[derive(Debug, Hash)]
+#[derive(Debug, rspack_hash::RspackHashable)]
 pub struct Draft {
   pub custom_media: bool,
 }
 
-#[derive(Debug, Hash)]
+#[derive(Debug, rspack_hash::RspackHashable)]
 pub struct NonStandard {
   pub deep_selector_combinator: bool,
 }
 
-#[derive(Debug, Hash)]
+#[derive(Debug, rspack_hash::RspackHashable)]
 pub struct PseudoClasses {
   pub hover: Option<String>,
   pub active: Option<String>,
@@ -57,45 +56,16 @@ pub struct PseudoClasses {
   pub focus_within: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, rspack_hash::RspackHashable)]
 pub struct MinimizerOptions {
   pub error_recovery: bool,
-  pub targets: Option<Browsers>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
   pub drafts: Option<Draft>,
   pub non_standard: Option<NonStandard>,
-  pub pseudo_classes: Option<PseudoClasses>,
   pub unused_symbols: Vec<String>,
-}
-
-impl Hash for MinimizerOptions {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.error_recovery.hash(state);
-    self.include.hash(state);
-    self.exclude.hash(state);
-    self.drafts.hash(state);
-    self.non_standard.hash(state);
-    self.unused_symbols.hash(state);
-    if let Some(pseudo_classes) = &self.pseudo_classes {
-      pseudo_classes.hover.hash(state);
-      pseudo_classes.active.hash(state);
-      pseudo_classes.focus.hash(state);
-      pseudo_classes.focus_visible.hash(state);
-      pseudo_classes.focus_within.hash(state);
-    }
-    if let Some(targets) = &self.targets {
-      targets.android.hash(state);
-      targets.chrome.hash(state);
-      targets.edge.hash(state);
-      targets.firefox.hash(state);
-      targets.ie.hash(state);
-      targets.ios_saf.hash(state);
-      targets.opera.hash(state);
-      targets.safari.hash(state);
-      targets.samsung.hash(state);
-    }
-  }
+  pub pseudo_classes: Option<PseudoClasses>,
+  pub targets: Option<Browsers>,
 }
 
 #[plugin]
@@ -117,7 +87,7 @@ async fn chunk_hash(
   _chunk_ukey: &ChunkUkey,
   hasher: &mut RspackHash,
 ) -> Result<()> {
-  self.options.hash(hasher);
+  rspack_hash::RspackHashable::hash(&self.options, hasher);
   Ok(())
 }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -71,10 +71,7 @@ impl ContainerEntryModule {
         top_level_declarations: Some(FxHashSet::default()),
         ..Default::default()
       },
-      build_meta: BuildMeta {
-        exports_type: BuildMetaExportsType::Namespace,
-        ..Default::default()
-      },
+      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       enhanced,
       request: None,
       version: None,
@@ -99,10 +96,7 @@ impl ContainerEntryModule {
         top_level_declarations: Some(FxHashSet::default()),
         ..Default::default()
       },
-      build_meta: BuildMeta {
-        exports_type: BuildMetaExportsType::Namespace,
-        ..Default::default()
-      },
+      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       enhanced: false,
       request: Some(request),
       version: Some(version),

--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -2,6 +2,8 @@ mod container;
 mod manifest;
 mod sharing;
 
+use rspack_hash::{RspackHash, RspackHashable};
+
 #[rspack_cacheable::cacheable]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(untagged)]
@@ -29,6 +31,15 @@ impl ShareScope {
     match self {
       ShareScope::Single(_) => false,
       ShareScope::Multiple(v) => v.is_empty(),
+    }
+  }
+}
+
+impl RspackHashable for ShareScope {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      ShareScope::Single(scope) => scope.hash(state),
+      ShareScope::Multiple(scopes) => scopes.hash(state),
     }
   }
 }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -11,8 +11,8 @@ use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
-use rspack_util::{ext::DynHash, json_stringify, json_stringify_str, source_map::SourceMapKind};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_util::{json_stringify, json_stringify_str, source_map::SourceMapKind};
 
 use super::{
   consume_shared_fallback_dependency::ConsumeSharedFallbackDependency,
@@ -257,7 +257,7 @@ impl Module for ConsumeSharedModule {
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHash::from(&compilation.options.output);
-    self.options.dyn_hash(&mut hasher);
+    self.options.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -13,6 +13,7 @@ use rspack_core::{
   RuntimeGlobals, RuntimeModule,
 };
 use rspack_error::{Diagnostic, Result, error};
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashMap;
 
@@ -23,7 +24,7 @@ use super::{
 use crate::ShareScope;
 
 #[cacheable]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, rspack_hash::RspackHashable)]
 pub struct ConsumeOptions {
   pub import: Option<String>,
   pub import_resolved: Option<String>,
@@ -42,6 +43,15 @@ pub struct ConsumeOptions {
 pub enum ConsumeVersion {
   Version(String),
   False,
+}
+
+impl RspackHashable for ConsumeVersion {
+  fn hash(&self, state: &mut RspackHash) {
+    match self {
+      ConsumeVersion::Version(version) => version.hash(state),
+      ConsumeVersion::False => "false".hash(state),
+    }
+  }
 }
 
 impl fmt::Display for ConsumeVersion {

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, hash::Hash};
+use std::borrow::Cow;
 
 use rspack_cacheable::with::AsVecConverter;
 use rspack_core::{
@@ -10,7 +10,7 @@ use rspack_core::{
   to_comment_with_nl,
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_css::{
   CssPlugin,
@@ -247,10 +247,10 @@ async fn render_js_module_package(
   ));
 
   if self.verbose {
-    let export_type = module.build_meta().exports_type;
+    let export_type = module.build_meta().exports_type();
 
     new_source.add(RawStringSource::from(to_comment_with_nl(
-      &module.build_meta().exports_type.to_string(),
+      module.build_meta().exports_type().description(),
     )));
 
     let module_graph = compilation.get_module_graph();

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -1,7 +1,7 @@
 mod drive;
 
 use std::{
-  hash::{BuildHasherDefault, Hasher},
+  hash::BuildHasherDefault,
   sync::{Arc, LazyLock},
 };
 

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -93,10 +93,7 @@ impl RscEntryModule {
         top_level_declarations: Some(FxHashSet::default()),
         ..Default::default()
       },
-      build_meta: BuildMeta {
-        exports_type: BuildMetaExportsType::Namespace,
-        ..Default::default()
-      },
+      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       source_map_kind: SourceMapKind::empty(),
       layer,
     }

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -140,7 +140,7 @@ pub fn collect_modules(
           bailout_reason: HashSet::default(),
           side_effects: None,
           side_effects_locations: Vec::new(),
-          exports_type: module.build_meta().exports_type,
+          exports_type: module.build_meta().exports_type(),
         },
       )
     })

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -90,7 +90,7 @@ pub fn cutout_star_re_export_externals(
       .module_by_identifier(&module_id)
       .expect("should have entry module");
 
-    if !module.build_meta().esm {
+    if !module.build_meta().esm() {
       continue;
     }
 

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalChunkRuntimeRequirements, CompilationParams, CompilerCompilation, Plugin,
@@ -7,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationDependentFullHash, CompilationParams, CompilerCompilation, Plugin, RuntimeGlobals,
@@ -7,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, sync::LazyLock};
+use std::sync::LazyLock;
 
 use itertools::Itertools;
 use regex::Regex;
@@ -11,7 +11,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_plugin_javascript::runtime::stringify_chunks_to_array;
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::FxHashSet as HashSet;

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use rspack_core::{
   ChunkCodeTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalChunkRuntimeRequirements, CompilationDependentFullHash, CompilationParams,
@@ -8,7 +6,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JavascriptModulesRenderStartup,

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -1,7 +1,4 @@
-use std::{
-  hash::Hash,
-  sync::{Arc, LazyLock},
-};
+use std::sync::{Arc, LazyLock};
 
 use atomic_refcell::AtomicRefCell;
 use rspack_core::{
@@ -12,7 +9,7 @@ use rspack_core::{
   get_js_chunk_filename_template,
 };
 use rspack_error::Result;
-use rspack_hash::RspackHash;
+use rspack_hash::{RspackHash, RspackHashable};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JsPlugin, impl_plugin_for_js_plugin::chunk_has_js,

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -7,7 +7,7 @@
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
-use std::{borrow::Cow, hash::Hasher, sync::LazyLock};
+use std::{borrow::Cow, sync::LazyLock};
 
 use regex::Regex;
 use rspack_core::{

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
-  hash::{Hash, Hasher},
+  fmt::{Display, Formatter},
+  hash::Hasher,
   path::Path,
   sync::{LazyLock, Mutex, mpsc},
 };
@@ -46,7 +47,7 @@ const PLUGIN_NAME: &str = "rspack.SwcJsMinimizerRspackPlugin";
 static JAVASCRIPT_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.[cm]?js(\?.*)?$").expect("Invalid RegExp"));
 
-#[derive(Debug, Hash)]
+#[derive(Debug, Hash, rspack_hash::RspackHashable)]
 pub struct PluginOptions {
   pub test: Option<AssetConditions>,
   pub include: Option<AssetConditions>,
@@ -70,6 +71,35 @@ pub struct MinimizerOptions {
   pub __compress_cache: OnceCell<BoolOrDataConfig<String>>,
   pub __mangle_cache: OnceCell<BoolOrDataConfig<String>>,
   pub __format_cache: OnceCell<String>,
+}
+
+impl rspack_hash::RspackHashable for MinimizerOptions {
+  fn hash(&self, state: &mut RspackHash) {
+    rspack_hash::RspackHashable::hash(
+      self
+        .__format_cache
+        .get_or_init(|| simd_json::to_string(&self.format).expect("Should be able to serialize")),
+      state,
+    );
+    rspack_hash::RspackHashable::hash(
+      self.__compress_cache.get_or_init(|| {
+        self
+          .compress
+          .as_ref()
+          .map(|v| simd_json::to_string(v).expect("Should be able to serialize"))
+      }),
+      state,
+    );
+    rspack_hash::RspackHashable::hash(
+      self.__mangle_cache.get_or_init(|| {
+        self
+          .mangle
+          .as_ref()
+          .map(|v| simd_json::to_string(v).expect("Should be able to serialize"))
+      }),
+      state,
+    );
+  }
 }
 
 impl std::hash::Hash for MinimizerOptions {
@@ -100,20 +130,41 @@ impl std::hash::Hash for MinimizerOptions {
 }
 
 #[derive(Debug, Hash)]
-pub enum OptionWrapper<T: std::fmt::Debug + Hash> {
+pub enum OptionWrapper<T: std::fmt::Debug + std::hash::Hash> {
   Default,
   Disabled,
   Custom(T),
 }
 
-#[derive(Debug)]
+impl<T: std::fmt::Debug + std::hash::Hash> Display for OptionWrapper<T> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    f.write_str(match self {
+      OptionWrapper::Default => "default",
+      OptionWrapper::Disabled => "disabled",
+      OptionWrapper::Custom(_) => "custom",
+    })
+  }
+}
+
+impl<T: std::fmt::Debug + std::hash::Hash + rspack_hash::RspackHashable> rspack_hash::RspackHashable
+  for OptionWrapper<T>
+{
+  fn hash(&self, state: &mut RspackHash) {
+    rspack_hash::RspackHashable::hash(&self.to_string(), state);
+    if let OptionWrapper::Custom(value) = self {
+      rspack_hash::RspackHashable::hash(value, state);
+    }
+  }
+}
+
+#[derive(Debug, rspack_hash::RspackHashable)]
 pub struct ExtractComments {
   pub condition: String,
   pub condition_flags: String,
   pub banner: OptionWrapper<String>,
 }
 
-impl Hash for ExtractComments {
+impl std::hash::Hash for ExtractComments {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
     self.condition.as_str().hash(state);
     self.condition_flags.as_str().hash(state);
@@ -137,6 +188,8 @@ pub struct SwcJsMinimizerRspackPlugin {
 
 impl SwcJsMinimizerRspackPlugin {
   pub fn new(options: PluginOptions) -> Self {
+    use std::hash::Hash;
+
     let mut hasher = FxHasher::default();
     PLUGIN_NAME.hash(&mut hasher);
     options.hash(&mut hasher);
@@ -164,7 +217,7 @@ async fn js_chunk_hash(
   _chunk_ukey: &ChunkUkey,
   hasher: &mut RspackHash,
 ) -> Result<()> {
-  self.options_hash.hash(hasher);
+  rspack_hash::RspackHashable::hash(&self.options, hasher);
   Ok(())
 }
 
@@ -233,6 +286,8 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         // Compute cache key and check persistent cache (only when enabled)
         let cache_key = if let Some(cache) = &minimize_persistent_cache {
           let key = {
+            use std::hash::Hash;
+
             let mut hasher = FxHasher::default();
             original_source.buffer().hash(&mut hasher);
             self.options_hash.hash(&mut hasher);

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -42,8 +42,10 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
     parse_context: ParseContext<'a>,
   ) -> Result<TWithDiagnosticArray<ParseResult>> {
     parse_context.build_info.strict = true;
-    parse_context.build_meta.has_top_level_await = true;
-    parse_context.build_meta.exports_type = BuildMetaExportsType::Namespace;
+    parse_context.build_meta.set_has_top_level_await(true);
+    parse_context
+      .build_meta
+      .set_exports_type(BuildMetaExportsType::Namespace);
 
     let source = parse_context.source;
 

--- a/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/imports-multiple/__snapshots__/output.snap.txt
@@ -62,7 +62,7 @@ __rspack_async_done();
 },
 "./wasm.wasm"(module, exports, __webpack_require__) {
 var __rspack_instantiate__ = function ([rspack_import_0, rspack_import_1]) {
-return __webpack_require__.v(exports, module.id, "59e423082e604bb6" , {
+return __webpack_require__.v(exports, module.id, "58e36e9b572b5bc3" , {
 "./module": {
 "getNumber": rspack_import_0.getNumber
 },
@@ -78,7 +78,7 @@ __webpack_require__.a(module, async function (__rspack_load_async_deps, __rspack
 
     var __rspack_async_deps = __rspack_load_async_deps([rspack_import_0, rspack_import_1]);
     var [rspack_import_0, rspack_import_1] = __rspack_async_deps.then ? (await __rspack_async_deps)() : __rspack_async_deps;
-    await __webpack_require__.v(exports, module.id, "59e423082e604bb6" , {
+    await __webpack_require__.v(exports, module.id, "58e36e9b572b5bc3" , {
 "./module": {
 "getNumber": rspack_import_0.getNumber
 },

--- a/tests/rspack-test/builtinCases/plugin-wasm/v128/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/plugin-wasm/v128/__snapshots__/output.snap.txt
@@ -15,7 +15,7 @@ __rspack_async_done();
 
 },
 "./v128.wasm"(module, exports, __webpack_require__) {
-module.exports = __webpack_require__.v(exports, module.id, "5d92a1394828be63" );
+module.exports = __webpack_require__.v(exports, module.id, "1c366cf56770e3b2" );
 
 },
 

--- a/tests/rspack-test/builtinCases/swc-loader/experimental/__snapshots__/output.snap.txt
+++ b/tests/rspack-test/builtinCases/swc-loader/experimental/__snapshots__/output.snap.txt
@@ -1,5 +1,5 @@
 ```js title=main.js
-import * as __rspack_external__static_package_json_fde7981b from "./static-package.json" with {"type":"json"};
+import * as __rspack_external__static_package_json_4ad57751 from "./static-package.json" with {"type":"json"};
 (self["rspackChunk"] = self["rspackChunk"] || []).push([["main"], {
 "./index.js"() {
 
@@ -7,7 +7,7 @@ import * as __rspack_external__static_package_json_fde7981b from "./static-packa
 
 ;// CONCATENATED MODULE: ./index.js
 
-console.log(__rspack_external__static_package_json_fde7981b);
+console.log(__rspack_external__static_package_json_4ad57751);
 
 
 },

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case1.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case1.txt
@@ -1,7 +1,7 @@
 import { __webpack_require__ } from "./runtime~0.mjs";
 
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
-import * as __rspack_external_external2_alias_e5239a01 from "external2-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
+import * as __rspack_external_external2_alias_d6100a5a from "external2-alias";
 __webpack_require__.add({
 42(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
@@ -22,13 +22,13 @@ __webpack_require__.r(__webpack_exports__);
 },
 322(module) {
 
-module.exports = __rspack_external_external1_alias_bc4b12e4;
+module.exports = __rspack_external_external1_alias_dd38afe7;
 
 
 },
 101(module) {
 
-module.exports = __rspack_external_external2_alias_e5239a01;
+module.exports = __rspack_external_external2_alias_d6100a5a;
 
 
 },

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case2.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case2.txt
@@ -1,4 +1,4 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 
@@ -7,7 +7,7 @@ import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
 
 
 
-var a = __rspack_external_external1_alias_bc4b12e4.a;
-var b = __rspack_external_external1_alias_bc4b12e4.b;
-export { __rspack_external_external1_alias_bc4b12e4 as n1, a, b };
+var a = __rspack_external_external1_alias_dd38afe7.a;
+var b = __rspack_external_external1_alias_dd38afe7.b;
+export { __rspack_external_external1_alias_dd38afe7 as n1, a, b };
 export * from "external1-alias";

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case4.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case4.txt
@@ -1,4 +1,4 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case5.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case5.txt
@@ -1,9 +1,9 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 
 
-const bar = __rspack_external_external1_alias_bc4b12e4.foo + 1
+const bar = __rspack_external_external1_alias_dd38afe7.foo + 1
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case6.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/case6.txt
@@ -1,4 +1,4 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case1.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case1.txt
@@ -1,7 +1,7 @@
 import { __rspack_context } from "./runtime~0.mjs";
 
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
-import * as __rspack_external_external2_alias_e5239a01 from "external2-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
+import * as __rspack_external_external2_alias_d6100a5a from "external2-alias";
 __rspack_context.m.add({
 42(__unused_rspack_module, __rspack_exports, __rspack_context) {
 __rspack_context.N(__rspack_exports);
@@ -22,13 +22,13 @@ __rspack_context.N(__rspack_exports);
 },
 322(module) {
 
-module.exports = __rspack_external_external1_alias_bc4b12e4;
+module.exports = __rspack_external_external1_alias_dd38afe7;
 
 
 },
 101(module) {
 
-module.exports = __rspack_external_external2_alias_e5239a01;
+module.exports = __rspack_external_external2_alias_d6100a5a;
 
 
 },

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case2.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case2.txt
@@ -1,4 +1,4 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 
@@ -7,7 +7,7 @@ import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
 
 
 
-var a = __rspack_external_external1_alias_bc4b12e4.a;
-var b = __rspack_external_external1_alias_bc4b12e4.b;
-export { __rspack_external_external1_alias_bc4b12e4 as n1, a, b };
+var a = __rspack_external_external1_alias_dd38afe7.a;
+var b = __rspack_external_external1_alias_dd38afe7.b;
+export { __rspack_external_external1_alias_dd38afe7 as n1, a, b };
 export * from "external1-alias";

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case4.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case4.txt
@@ -1,4 +1,4 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case5.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case5.txt
@@ -1,9 +1,9 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 
 
-const bar = __rspack_external_external1_alias_bc4b12e4.foo + 1
+const bar = __rspack_external_external1_alias_dd38afe7.foo + 1
 
 
 

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case6.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case6.txt
@@ -1,4 +1,4 @@
-import * as __rspack_external_external1_alias_bc4b12e4 from "external1-alias";
+import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 
 
 

--- a/tests/rspack-test/configCases/parsing/jsx-enabled/__snapshot__/bundle0.jsx.txt
+++ b/tests/rspack-test/configCases/parsing/jsx-enabled/__snapshot__/bundle0.jsx.txt
@@ -1,15 +1,15 @@
 import { App2, app2Props } from "./App2";
 
-import * as __rspack_external__App1_cd1629a5 from "./App1";
+import * as __rspack_external__App1_8534127d from "./App1";
 
 
 
 
 
 const DynamicComponent = ()=>{
-    const Component = Math.random() > 0.5 ? __rspack_external__App1_cd1629a5.App1A : __rspack_external__App1_cd1629a5.App1C;
+    const Component = Math.random() > 0.5 ? __rspack_external__App1_8534127d.App1A : __rspack_external__App1_8534127d.App1C;
     return import("./App1").then((mod)=>{
-        const Dynamic = mod[Component === __rspack_external__App1_cd1629a5.App1A ? "App1A" : "App1C"];
+        const Dynamic = mod[Component === __rspack_external__App1_8534127d.App1A ? "App1A" : "App1C"];
         return <Dynamic/>;
     });
 };
@@ -27,35 +27,35 @@ function Root() {
     return <>
       <React.Fragment>
         <>
-          <__rspack_external__App1_cd1629a5.App1A/>
+          <__rspack_external__App1_8534127d.App1A/>
           <React.Suspense fallback={<div>Loading...</div>}>
             <DynamicComponent/>
           </React.Suspense>
         </>
       </React.Fragment>
-      <__rspack_external__App1_cd1629a5.App1C>
-        {x ? <__rspack_external__App1_cd1629a5.App1A>
-            <__rspack_external__App1_cd1629a5.App1B>
+      <__rspack_external__App1_8534127d.App1C>
+        {x ? <__rspack_external__App1_8534127d.App1A>
+            <__rspack_external__App1_8534127d.App1B>
               <App2 props={app2Props}>
-                <__rspack_external__App1_cd1629a5.App1C props={__rspack_external__App1_cd1629a5.app1cProps}/>
+                <__rspack_external__App1_8534127d.App1C props={__rspack_external__App1_8534127d.app1cProps}/>
               </App2>
-            </__rspack_external__App1_cd1629a5.App1B>
-          </__rspack_external__App1_cd1629a5.App1A> : <__rspack_external__App1_cd1629a5.App1B/>}
-      </__rspack_external__App1_cd1629a5.App1C>
-      <__rspack_external__App1_cd1629a5.App1C className="c"/>
-      <__rspack_external__App1_cd1629a5.App1C className="app1c"></__rspack_external__App1_cd1629a5.App1C>
-      <__rspack_external__App1_cd1629a5.App1B/>
+            </__rspack_external__App1_8534127d.App1B>
+          </__rspack_external__App1_8534127d.App1A> : <__rspack_external__App1_8534127d.App1B/>}
+      </__rspack_external__App1_8534127d.App1C>
+      <__rspack_external__App1_8534127d.App1C className="c"/>
+      <__rspack_external__App1_8534127d.App1C className="app1c"></__rspack_external__App1_8534127d.App1C>
+      <__rspack_external__App1_8534127d.App1B/>
       <NamespaceComponents.Button label="Namespace button" {...{
         title: "extra",
         ["data-role"]: "primary"
-    }} data-count={3} icon={<__rspack_external__App1_cd1629a5.App1A/>} fragmentContent={<>
+    }} data-count={3} icon={<__rspack_external__App1_8534127d.App1A/>} fragmentContent={<>
             <span>Nested</span>
             <span>Fragment</span>
           </>}/>
       <div className="wrapper">
         {[
         <section key="namespace-import" data-index="0">
-            <__rspack_external__App1_cd1629a5.App data-dynamic="registry" data-item="one"/>
+            <__rspack_external__App1_8534127d.App data-dynamic="registry" data-item="one"/>
             <foo:bar value="namespaced"/>
             <svg:path d="M0,0 L10,10" xlink:href="#one"/>
             <span>{"item-one".toUpperCase()}</span>
@@ -67,11 +67,11 @@ function Root() {
             <App2/>
             <foo:bar value="namespaced-two"/>
             <svg:path d="M10,10 L20,20" xlink:href="#two"/>
-            <__rspack_external__App1_cd1629a5.App1A/>
+            <__rspack_external__App1_8534127d.App1A/>
             { /* JSXEmptyExpr in action */ }
           </section>,
         <section key="external-app" data-index="2">
-            <__rspack_external__App1_cd1629a5.App1A data-dynamic="registry" data-item="fallback"/>
+            <__rspack_external__App1_8534127d.App1A data-dynamic="registry" data-item="fallback"/>
             <foo:bar value="namespaced-three"/>
             <svg:path d="M20,20 L30,30" xlink:href="#three"/>
             {(()=><NamespaceComponents.Button label="Inline child"/>)()}

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/second.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/second.js
@@ -1,8 +1,5 @@
-it("should handle indirect children with multiple parents correctly", function(done) {
-  import('./pageB').then(b => {
+it("should handle indirect children with multiple parents correctly", function() {
+  return import("./pageB").then(b => {
     expect(b.default).toBe("reuse");
-    done()
-  }).catch(e => {
-		done();
-	})
-})
+  });
+});

--- a/tests/rspack-test/esmOutputCases/externals/mixed-module-import-and-node-commonjs-same-target/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/mixed-module-import-and-node-commonjs-same-target/__snapshots__/esm.snap.txt
@@ -1,5 +1,5 @@
 ```mjs title=main.mjs
-import * as __rspack_external_webpack_sources_lib_index_js_06790234 from "webpack-sources/lib/index.js";
+import * as __rspack_external_webpack_sources_lib_index_js_9a113ddb from "webpack-sources/lib/index.js";
 
 import { createRequire as __rspack_createRequire } from "node:module";
 const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
@@ -27,12 +27,12 @@ it("should not emit duplicate identifiers when the same external target is rende
 
   expect(mod.sourcesNs.RawSource).toBe(index_js_namespaceObject.RawSource);
   expect(mod.sourcesNs.SourceMapSource).toBe(index_js_namespaceObject.SourceMapSource);
-  expect(mod.sourcesNs.RawSource).toBe(__rspack_external_webpack_sources_lib_index_js_06790234.RawSource);
-  expect(mod.sourcesNs.SourceMapSource).toBe(__rspack_external_webpack_sources_lib_index_js_06790234.SourceMapSource);
+  expect(mod.sourcesNs.RawSource).toBe(__rspack_external_webpack_sources_lib_index_js_9a113ddb.RawSource);
+  expect(mod.sourcesNs.SourceMapSource).toBe(__rspack_external_webpack_sources_lib_index_js_9a113ddb.SourceMapSource);
 });
 
 var RawSource = index_js_namespaceObject.RawSource;
 var SourceMapSource = index_js_namespaceObject.SourceMapSource;
-export { RawSource, SourceMapSource, __rspack_external_webpack_sources_lib_index_js_06790234 as sourcesNs };
+export { RawSource, SourceMapSource, __rspack_external_webpack_sources_lib_index_js_9a113ddb as sourcesNs };
 
 ```

--- a/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/esm.snap.txt
@@ -47,20 +47,20 @@ export {};
 ```mjs title=node_events-node_events.mjs
 import { __webpack_require__ } from "./runtime.mjs";
 
-import * as __rspack_external_node_events_0a6aefe7 from "node:events";
+import * as __rspack_external_node_events_3969b2b3 from "node:events";
 __webpack_require__.add({
 "node:events?df85"
 /*!******************************!*\
   !*** external "node:events" ***!
   \******************************/
 (module, __unused_rspack_exports, __webpack_require__) {
-var __rspack_create_module_external_namespace_node_events_0a6aefe7 = (y) => {
+var __rspack_create_module_external_namespace_node_events_3969b2b3 = (y) => {
 var x = {};
 __webpack_require__.d(x, y);
 return x;
 };
-var __rspack_wrap_module_external_namespace_node_events_0a6aefe7 = (x) => (() => (x));
-module.exports = __rspack_create_module_external_namespace_node_events_0a6aefe7({["a"]: () => (__rspack_external_node_events_0a6aefe7.EventEmitter), ["b"]: () => (__rspack_external_node_events_0a6aefe7.once)});
+var __rspack_wrap_module_external_namespace_node_events_3969b2b3 = (x) => (() => (x));
+module.exports = __rspack_create_module_external_namespace_node_events_3969b2b3({["a"]: () => (__rspack_external_node_events_3969b2b3.EventEmitter), ["b"]: () => (__rspack_external_node_events_3969b2b3.once)});
 
 },
 });

--- a/tests/rspack-test/hashCases/real-content-hash/rspack.config.js
+++ b/tests/rspack-test/hashCases/real-content-hash/rspack.config.js
@@ -33,7 +33,7 @@ module.exports = [
     devtool: false,
     output: {
       path: path.resolve(__dirname, './dist/a-normal'),
-      filename: '[name].[contenthash]-[contenthash:6].js',
+      filename: '[contenthash]-[contenthash:6].js',
       assetModuleFilename: '[contenthash][ext]',
     },
   },
@@ -44,7 +44,7 @@ module.exports = [
     devtool: false,
     output: {
       path: path.resolve(__dirname, './dist/b-normal'),
-      filename: '[name].[contenthash]-[contenthash:6].js',
+      filename: '[contenthash]-[contenthash:6].js',
       assetModuleFilename: '[contenthash][ext]',
     },
   },
@@ -55,7 +55,7 @@ module.exports = [
     devtool: 'source-map',
     output: {
       path: path.resolve(__dirname, './dist/a-source-map'),
-      filename: '[name].[contenthash]-[contenthash:6].js',
+      filename: '[contenthash]-[contenthash:6].js',
       assetModuleFilename: '[contenthash][ext]',
     },
   },
@@ -66,7 +66,7 @@ module.exports = [
     devtool: 'source-map',
     output: {
       path: path.resolve(__dirname, './dist/b-source-map'),
-      filename: '[name].[contenthash]-[contenthash:6].js',
+      filename: '[contenthash]-[contenthash:6].js',
       assetModuleFilename: '[contenthash][ext]',
     },
   },

--- a/tests/rspack-test/hashCases/real-content-hash/test.config.js
+++ b/tests/rspack-test/hashCases/real-content-hash/test.config.js
@@ -13,7 +13,7 @@ module.exports = {
 			expect(a.assetsByChunkName.lazy).toEqual(b.assetsByChunkName.lazy);
 			expect(a.assetsByChunkName.a).toEqual(b.assetsByChunkName.a);
 			expect(a.assetsByChunkName.b).toEqual(b.assetsByChunkName.b);
-			// expect(a.assetsByChunkName.a).toEqual(a.assetsByChunkName.b);
+			expect(a.assetsByChunkName.a).toEqual(a.assetsByChunkName.b);
 		}
 	}
 };

--- a/tests/rspack-test/statsAPICases/basic.js
+++ b/tests/rspack-test/statsAPICases/basic.js
@@ -69,7 +69,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: cb00f6f863f5faec,
+			      hash: b5cd62d7f1e244c4,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -199,7 +199,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: ec79eb103428f92c,
+			  hash: f36e50fd765d4017,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -319,7 +319,7 @@ module.exports = {
 			  entry ./fixtures/a
 			  cjs self exports reference self [195] ./fixtures/a.js
 			  
-			Rspack compiled successfully (ec79eb103428f92c)
+			Rspack compiled successfully (f36e50fd765d4017)
 		`);
 	}
 };

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 403466209e155826,
+			      hash: 01b216cf5147ae81,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: fa2747d04e63a957,
+			  hash: 5a1a86e0fbb6505a,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsAPICases/ids.js
+++ b/tests/rspack-test/statsAPICases/ids.js
@@ -58,7 +58,7 @@ module.exports = {
 			      files: Array [
 			        main.js,
 			      ],
-			      hash: cb00f6f863f5faec,
+			      hash: b5cd62d7f1e244c4,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,

--- a/tests/rspack-test/statsAPICases/with-query.js
+++ b/tests/rspack-test/statsAPICases/with-query.js
@@ -63,7 +63,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 0dd464d06575b312,
+			      hash: 216c30c6b146db6a,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -432,7 +432,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 902dd16738d7b73d,
+			  hash: 0cf5aaf453d712ad,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/all-stats/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/all-stats/__snapshots__/stats.txt
@@ -23,4 +23,4 @@ webpack/runtime/make_namespace_object xx bytes {main} [code generated]
   [no exports]
   [used exports unknown]
   
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled successfully in X s (c8efd3f0c70d4f0e)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled successfully in X s (57e2ffc689d21328)

--- a/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/auxiliary-files-test/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ runtime modules xx KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (e5dec179148f4efb)
+Rspack compiled successfully (bee7df9b548baf98)

--- a/tests/rspack-test/statsOutputCases/commons-plugin-issue-4980/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/commons-plugin-issue-4980/__snapshots__/stats.txt
@@ -1,9 +1,9 @@
-asset app.e1d3fd6ad57c1842-1.js xx bytes [emitted] [immutable] (name: app)
+asset app.decef6386e7e7d32-1.js xx bytes [emitted] [immutable] (name: app)
 orphan modules xx bytes [orphan] 3 modules
 ./entry-1.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset app.fa8ca3aace1a91e0-2.js xx bytes [emitted] [immutable] (name: app)
+asset app.b65486f187f982bb-2.js xx bytes [emitted] [immutable] (name: app)
 orphan modules xx bytes [orphan] 3 modules
 ./entry-2.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset cd3e704618ec68b8.js xx KiB [emitted] [immutable] (name: main)
-asset 7b129503d319bd23.js xx bytes [emitted] [immutable]
+asset a372243665a60481.js xx KiB [emitted] [immutable] (name: main)
+asset bc31427e1753f078.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -1,16 +1,16 @@
-asset a-runtime~main-8fb196856cbdc52a.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset a-main-c9ca2f06db018feb.js xx bytes [emitted] [immutable] (name: main)
-asset a-all-a_js-9ab62d76d5b1b4fb.js xx bytes [emitted] [immutable] (id hint: all)
-Entrypoint main xx KiB = a-runtime~main-8fb196856cbdc52a.js xx KiB a-all-a_js-9ab62d76d5b1b4fb.js xx bytes a-main-c9ca2f06db018feb.js xx bytes
+asset a-runtime~main-89d37a4a40b85501.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset a-main-fb8023f736486ad3.js xx bytes [emitted] [immutable] (name: main)
+asset a-all-a_js-4ca357ac14402f03.js xx bytes [emitted] [immutable] (id hint: all)
+Entrypoint main xx KiB = a-runtime~main-89d37a4a40b85501.js xx KiB a-all-a_js-4ca357ac14402f03.js xx bytes a-main-fb8023f736486ad3.js xx bytes
 runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset b-runtime~main-60e1a9cacb740650.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset b-main-8680a888f1bf9eb6.js xx bytes [emitted] [immutable] (name: main)
-asset b-all-b_js-f856ef7ca71a0cbd.js xx bytes [emitted] [immutable] (id hint: all)
-asset b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-60e1a9cacb740650.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-f856ef7ca71a0cbd.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
+asset b-runtime~main-5ec620e8a6a95605.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset b-main-b4d8619e4a217935.js xx bytes [emitted] [immutable] (name: main)
+asset b-all-b_js-49e1ddee2036c3e4.js xx bytes [emitted] [immutable] (id hint: all)
+asset b-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = b-runtime~main-5ec620e8a6a95605.js xx KiB b-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes b-all-b_js-49e1ddee2036c3e4.js xx bytes b-main-b4d8619e4a217935.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -18,12 +18,12 @@ cacheable modules xx bytes
 Rspack x.x.x compiled successfully in X s
 
 assets by chunk xx bytes (id hint: all)
-  asset c-all-b_js-ce41787ae6ff3759.js xx bytes [emitted] [immutable] (id hint: all)
-  asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-ea7330b9b9fe9e9f.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
-asset c-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-ea7330b9b9fe9e9f.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+  asset c-all-b_js-79aa5bf7e0cd20d1.js xx bytes [emitted] [immutable] (id hint: all)
+  asset c-all-c_js-c122d59f831c8fdf.js xx bytes [emitted] [immutable] (id hint: all)
+asset c-runtime~main-83aa9f4fb5dec8bf.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-main-7dc8e2972d294bc1.js xx bytes [emitted] [immutable] (name: main)
+asset c-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = c-runtime~main-83aa9f4fb5dec8bf.js xx KiB c-all-c_js-c122d59f831c8fdf.js xx bytes c-main-7dc8e2972d294bc1.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (f917d9aef4f31935)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (e3f2762a087fefad)

--- a/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
@@ -134,4 +134,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (f917d9aef4f31935)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (e3f2762a087fefad)

--- a/tests/rspack-test/statsOutputCases/wasm-explorer-examples-sync/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/wasm-explorer-examples-sync/__snapshots__/stats.txt
@@ -1,17 +1,17 @@
 assets by path *.wasm xx KiB
-  asset 7090e28ebb84fdd8.module.wasm xx bytes [emitted] [immutable]
-  asset 977bb0cc74309149.module.wasm xx bytes [emitted] [immutable]
-  asset 717bac786f333ac8.module.wasm xx bytes [emitted] [immutable]
-  asset 4a4b2b7db243bbe2.module.wasm xx bytes [emitted] [immutable]
-  asset 52984547ebee2c67.module.wasm xx bytes [emitted] [immutable]
-  asset 00084e490b41b700.module.wasm xx bytes [emitted] [immutable]
+  asset c4e954e41b400daf.module.wasm xx bytes [emitted] [immutable]
+  asset 9110df63b564f385.module.wasm xx bytes [emitted] [immutable]
+  asset 454511fdf1ff585d.module.wasm xx bytes [emitted] [immutable]
+  asset 2467df5f67a3e66c.module.wasm xx bytes [emitted] [immutable]
+  asset 4dcb0ba208387660.module.wasm xx bytes [emitted] [immutable]
+  asset 107a720c6963cfb8.module.wasm xx bytes [emitted] [immutable]
 assets by path *.js xx KiB
   asset bundle.js xx KiB [emitted] (name: main)
   asset 549.bundle.js xx KiB [emitted]
   asset 440.bundle.js xx bytes [emitted] (id hint: vendors)
 chunk (runtime: main) 440.bundle.js (id hint: vendors) xx bytes [rendered] split chunk (cache group: defaultVendors)
   ./node_modules/env.js xx bytes [built] [code generated]
-chunk (runtime: main) 00084e490b41b700.module.wasm, 4a4b2b7db243bbe2.module.wasm, 52984547ebee2c67.module.wasm, 549.bundle.js, 7090e28ebb84fdd8.module.wasm, 717bac786f333ac8.module.wasm, 977bb0cc74309149.module.wasm xx KiB (javascript) xx KiB (wasm) [rendered]
+chunk (runtime: main) 107a720c6963cfb8.module.wasm, 2467df5f67a3e66c.module.wasm, 454511fdf1ff585d.module.wasm, 4dcb0ba208387660.module.wasm, 549.bundle.js, 9110df63b564f385.module.wasm, c4e954e41b400daf.module.wasm xx KiB (javascript) xx KiB (wasm) [rendered]
   ./Q_rsqrt.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]
   ./duff.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]
   ./fact.wasm xx bytes (wasm) xx bytes (javascript) [dependent] [built] [code generated]


### PR DESCRIPTION
## Background

Rspack currently has many output hash calculations built on top of Rust's standard `Hash` trait. This creates two problems:

- The behavior does not always match webpack. For example, webpack skips optional fields when they are not provided, while derived/std `Hash` may still encode the option state.
- `Hash` is designed for `HashMap`/`HashSet` keys, not for webpack-compatible content hash. Its requirements are different, and relying on Rust/std hashing behavior can make output hashes sensitive to implementation changes.

This PR separates these two concerns. Data structures that participate in output/content hashing should implement the Rspack content-hash trait (`RspackContentHash`) and be written through `RspackHash`. Data structures that only need to be map/set keys should continue to implement the standard `Hash` trait. This lets us align content hash behavior with webpack while keeping the freedom to optimize `Hash` implementations independently later without affecting output hashes.

## Changes

- Route output/content hash inputs through `RspackContentHash` instead of using standard-library `Hash` directly.
- Preserve existing internal deterministic hashing behavior for non-content-hash paths such as module graph hashing, split-chunks max-size grouping, and generated external identifiers.
- Keep `RspackHash` focused on output/content hash calculation rather than reintroducing it as a standard `Hasher`.
- Update hash-only snapshots for the new content hash results.
- Add coverage for updating visible outer scope bindings.

## Validation

- `pnpm run test:unit`
- `pnpm run test:rs`

---
_by OpenAI Codex_