### PR TITLE
chore(deps): group emnapi renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,11 @@
       groupName: 'napi',
       matchPackagePrefixes: ['napi', '@napi-rs/'],
     },
+    {
+      groupName: 'emnapi',
+      matchManagers: ['npm'],
+      matchPackageNames: ['emnapi', '/^@emnapi\\//'],
+    },
     // Rspack npm packages
     {
       groupName: 'Rspack',


### PR DESCRIPTION
## Summary

This PR groups emnapi package updates in Renovate so related npm packages such as `emnapi`, `@emnapi/core`, and `@emnapi/runtime` are proposed together instead of separate dependency PRs. This should keep future emnapi updates aligned across the WASM-related packages without changing runtime behavior.

## Related links

- Refs https://github.com/web-infra-dev/rspack/pull/14388
- Refs https://github.com/web-infra-dev/rspack/pull/14389

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).