### PR TITLE
fix: update active outer scope bindings

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -198,19 +198,32 @@ impl ScopeInfoDB {
     }
   }
 
+  fn is_active_scope(&self, id: ScopeInfoId) -> bool {
+    let mut current = self.current;
+    while let Some(scope_id) = current {
+      if scope_id == id {
+        return true;
+      }
+      current = self.expect_get_scope(scope_id).parent;
+    }
+    false
+  }
+
   pub fn set(&mut self, id: ScopeInfoId, key: Atom, variable_info_id: VariableInfoId) {
+    debug_assert!(
+      self.is_active_scope(id),
+      "bindings can only be set in an active scope"
+    );
+    let stack = self.bindings.entry(key.clone()).or_default();
+    if let Some(binding) = stack.iter_mut().rev().find(|binding| binding.scope == id) {
+      binding.value = variable_info_id;
+      return;
+    }
     debug_assert_eq!(
       self.current,
       Some(id),
-      "bindings can only be set in the innermost active scope"
+      "new bindings can only be set in the innermost active scope"
     );
-    let stack = self.bindings.entry(key.clone()).or_default();
-    if let Some(top) = stack.last_mut()
-      && top.scope == id
-    {
-      top.value = variable_info_id;
-      return;
-    }
     stack.push(Binding {
       scope: id,
       value: variable_info_id,
@@ -416,6 +429,24 @@ mod tests {
 
     db.exit_scope(child);
     assert_eq!(db.get(root, &a), Some(outer));
+  }
+
+  #[test]
+  fn active_outer_binding_can_be_updated_from_inner_scope() {
+    let mut db = ScopeInfoDB::new();
+    let root = db.create();
+    let a = "a".into();
+
+    let outer = new_variable(&mut db, root);
+    db.set(root, "a".into(), outer);
+
+    let child = db.create_child(root);
+    let updated_outer = new_variable(&mut db, root);
+    db.set(root, "a".into(), updated_outer);
+    assert_eq!(db.get(child, &a), Some(updated_outer));
+
+    db.exit_scope(child);
+    assert_eq!(db.get(root, &a), Some(updated_outer));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

This fixes a debug assertion panic in the JavaScript parser scope table that surfaced during `pnpm run test:unit` in the `configCases/require/module-require` tests.

The parser can legitimately update metadata for a binding declared in an outer active scope while it is currently walking a nested child scope. One concrete path is `createRequire` tag clearing: an imported `createRequire` binding is declared in the module/root scope, then later used inside a nested expression or function scope. When the parser decides the tag should be cleared, it writes the replacement `VariableInfo` back to the binding's declared scope.

Before this change, `ScopeInfoDB::set` assumed every write must target the innermost active scope. That invariant is valid for creating new bindings, but it is too strict for replacing an existing binding in an outer scope that is still active. In debug builds this caused:

```text
assertion `left == right` failed: bindings can only be set in the innermost active scope
```

## Changes

- Allow `ScopeInfoDB::set` to update an existing binding in any currently active scope.
- Keep the stricter invariant for new bindings: new binding entries can still only be introduced in the innermost active scope.
- Add `is_active_scope` so debug assertions continue to reject writes to inactive scopes.
- Add a focused unit test covering an outer binding update while a child scope is active, including lookup before and after unwinding the child scope.

## Rationale

`ScopeInfoDB` stores bindings as a per-name stack of active bindings. Updating an existing entry in that stack does not violate stack discipline because it does not introduce or remove scopes, and it preserves the current shadowing order. The stack discipline still matters when adding a new binding, so this PR keeps that path restricted to the current innermost scope.

This matches the parser behavior needed by tag replacement/clearing without weakening the checks that protect scope entry, exit, and shadowing behavior.

## Testing

- `cargo test -p rspack_plugin_javascript scope_info`
- `pnpm run build:binding:dev`
- `cd tests/rspack-test && pnpm exec rstest -t "configCases/require/module-require"`
- `pnpm run test:unit`