### PR TITLE
test(wasm): skip file-dependencies-huge to fix flaky afterAll timeout

### DIFF
--- a/tests/rspack-test/configCases/dependencies/file-dependencies-huge/test.filter.js
+++ b/tests/rspack-test/configCases/dependencies/file-dependencies-huge/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () =>{return !process.env.WASM}


### PR DESCRIPTION
## Why

`Test WASM / Test Node 24` is flaky and randomly fails with `afterAll hook timed out in 10000ms` in `Config.part*` (e.g. [run 27419342276](https://github.com/web-infra-dev/rspack/actions/runs/27419342276/job/81041881382)). The signature has been tracked since #13515.

Root cause is **not** the failing suite. The `configCases/dependencies/file-dependencies-huge` case processes **1,000,000** file dependencies **synchronously** inside a `done` hook — generating 1M paths, `addAll`-ing them, reading them all back, and a 1M-element `toEqual`. On native targets this is fast; under the wasm target (32-bit, per-string JS↔wasm marshalling, GC pressure on a fixed 2 GB shared memory) it freezes the test worker's event loop:

- ~3.5 s locally on Apple Silicon
- **12–15 s on the 4-vCPU CI runner**

While the loop is frozen, whichever `Config` suite happens to be awaiting in its `afterAll`/test window trips the 10 s hook timeout — so the victim case looks random across runs, but always sits a few suites ahead of `file-dependencies-huge` (the concurrent runner chain runs ahead of the reporter cursor).

This was introduced by #13517, which raised the count from 100k → 1M and added the full read-back + `toEqual`; #13515 was filed 4 days later.

## What

Skip `file-dependencies-huge` under the wasm target via `test.filter.js` (the existing convention — 22 other cases already do this). The guarded regression (huge dependency iterable spread, #13305) is pure JS-layer logic and remains fully covered on native targets.

### Before / After (full `Config.part1` on wasm, local)

| | Duration |
|---|---|
| Before | 12–15 s stall → `afterAll hook timed out` |
| After | 10.5 s, no stall, 517 passed |
