### PR TITLE
perf: reduce source map copying

### DIFF
--- a/crates/rspack_sources/src/encoder.rs
+++ b/crates/rspack_sources/src/encoder.rs
@@ -66,6 +66,16 @@ pub fn create_encoder(columns: bool) -> MappingsEncoder {
   }
 }
 
+pub fn create_encoder_with_capacity(columns: bool, capacity: usize) -> MappingsEncoder {
+  if columns {
+    MappingsEncoder::Full(FullMappingsEncoder::with_capacity(
+      capacity.max(INITIAL_MAPPINGS_CAPACITY),
+    ))
+  } else {
+    MappingsEncoder::LinesOnly(LinesOnlyMappingsEncoder::new())
+  }
+}
+
 pub(crate) struct FullMappingsEncoder {
   current_line: u32,
   current_column: u32,
@@ -81,6 +91,10 @@ pub(crate) struct FullMappingsEncoder {
 
 impl FullMappingsEncoder {
   pub fn new() -> Self {
+    Self::with_capacity(INITIAL_MAPPINGS_CAPACITY)
+  }
+
+  pub fn with_capacity(capacity: usize) -> Self {
     Self {
       current_line: 1,
       current_column: 0,
@@ -91,7 +105,7 @@ impl FullMappingsEncoder {
       active_mapping: false,
       active_name: false,
       initial: true,
-      mappings: Vec::with_capacity(INITIAL_MAPPINGS_CAPACITY),
+      mappings: Vec::with_capacity(capacity),
     }
   }
 }

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::{
   MapOptions, SourceMap,
   decoder::MappingsDecoder,
-  encoder::create_encoder,
+  encoder::{create_encoder, create_encoder_with_capacity},
   linear_map::LinearMap,
   object_pool::ObjectPool,
   source::{Mapping, OriginalLocation},
@@ -320,7 +320,7 @@ pub fn decode_mappings(source_map: &SourceMap) -> impl Iterator<Item = Mapping> 
 
 /// Encodes the given iterator of `Mapping` items into a `String`.
 pub fn encode_mappings(mappings: impl Iterator<Item = Mapping>) -> String {
-  let mut encoder = create_encoder(true);
+  let mut encoder = create_encoder_with_capacity(true, mappings.size_hint().0.saturating_mul(6));
   mappings.for_each(|mapping| encoder.encode(&mapping));
   encoder.drain()
 }

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -292,7 +292,7 @@ pub struct SourceMap {
   #[serde(rename = "sourcesContent", skip_serializing_if = "is_all_empty")]
   sources_content: Arc<[Arc<str>]>,
   names: Arc<[String]>,
-  mappings: Arc<str>,
+  mappings: String,
   #[serde(rename = "sourceRoot", skip_serializing_if = "Option::is_none")]
   source_root: Option<Arc<str>>,
   #[serde(rename = "debugId", skip_serializing_if = "Option::is_none")]
@@ -336,7 +336,7 @@ impl SourceMap {
     names: Names,
   ) -> Self
   where
-    Mappings: Into<Arc<str>>,
+    Mappings: Into<String>,
     Sources: Into<Arc<[String]>>,
     SourcesContent: Into<Vec<Arc<str>>>,
     Names: Into<Arc<[String]>>,


### PR DESCRIPTION
## What changed

- Store generated `SourceMap::mappings` as `String` instead of converting it into `Arc<str>`.
- Add a capacity-aware mappings encoder path and pre-size `encode_mappings` from the iterator size hint.

## Why

The `threejs-production-sourcemap` benchmark spends measurable time in libc copy routines while generating and storing large source map mappings. The mappings string is produced as owned data and is not shared independently from `SourceMap`, so converting it into `Arc<str>` adds an avoidable allocation and copy.

Pre-sizing the full mappings encoder also reduces Vec growth while encoding dense mapping tokens.

## Hot path and cardinality

This targets source map generation for production bundles, where mapping entries scale with emitted code/token count. The change keeps the optimization local to `rspack_sources` and avoids touching broader module graph or parser data structures.

## Expected benefit

Valgrind/Callgrind on the local `threejs-production-sourcemap` one-shot benchmark showed direct memcpy cost decreasing from `37,039,320` to `36,659,637` instructions, a `1.025%` reduction under the same harness.
