### PR TITLE
perf(codegen): use ast source plan for concatenation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,6 +4620,7 @@ dependencies = [
  "smallvec",
  "sugar_path",
  "swc_atoms",
+ "swc_core",
  "swc_experimental_allocator",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,7 +4620,6 @@ dependencies = [
  "smallvec",
  "sugar_path",
  "swc_atoms",
- "swc_core",
  "swc_experimental_allocator",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -118,7 +118,7 @@ pub enum Binding {
   Symbol(SymbolBinding),
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct ConcatenatedModuleReplacement {
   start: u32,
   end: u32,
@@ -141,17 +141,6 @@ impl PartialOrd for ConcatenatedModuleReplacement {
     Some(self.cmp(other))
   }
 }
-
-impl PartialEq for ConcatenatedModuleReplacement {
-  fn eq(&self, other: &Self) -> bool {
-    self.start == other.start
-      && self.end == other.end
-      && self.content == other.content
-      && self.insertion_order == other.insertion_order
-  }
-}
-
-impl Eq for ConcatenatedModuleReplacement {}
 
 #[derive(Debug, Clone)]
 pub struct ConcatenatedModuleSource {
@@ -636,8 +625,9 @@ impl stream_chunks::Chunks for ConcatenatedModuleSourceChunks<'_> {
 
           let next_replacement_start = replacements
             .get(replacement_idx)
-            .map(|replacement| (replacement.start as usize).min(source_len))
-            .unwrap_or(source_len);
+            .map_or(source_len, |replacement| {
+              (replacement.start as usize).min(source_len)
+            });
           let emit_end = next_replacement_start.min(chunk_end);
           if emit_end <= current_pos {
             continue;
@@ -2649,7 +2639,7 @@ impl Module for ConcatenatedModule {
 
             if condition != "true" {
               is_conditional = true;
-              write!(result, "if ({condition}) {{\n").expect("write to string");
+              writeln!(result, "if ({condition}) {{").expect("write to string");
             }
 
             write!(

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1,8 +1,9 @@
 use std::{
   borrow::Cow,
+  cell::RefCell,
   collections::{BTreeMap, VecDeque},
-  fmt::Debug,
-  hash::Hasher,
+  fmt::{Debug, Write},
+  hash::{Hash, Hasher},
   mem,
   sync::{Arc, LazyLock},
 };
@@ -16,9 +17,6 @@ use rspack_collections::{
 use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
 use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
-use rspack_sources::{
-  BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
-};
 use rspack_util::{
   SpanExt,
   ext::DynHash,
@@ -42,23 +40,25 @@ use swc_experimental_ecma_semantic::resolver::{Semantic, resolver};
 
 use crate::{
   AsyncDependenciesBlockIdentifier, BoxDependency, BoxDependencyTemplate, BoxModule,
-  BoxModuleDependency, BuildContext, BuildInfo, BuildMeta, BuildMetaDefaultObject,
+  BoxModuleDependency, BoxSource, BuildContext, BuildInfo, BuildMeta, BuildMetaDefaultObject,
   BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
   CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
   CodeGenerationPublicPathAutoReplace, CodeGenerationResult, Compilation, ConcatenatedModuleIdent,
   ConcatenationScope, ConditionalInitFragment, ConnectionState, Context, DEFAULT_EXPORT,
   DEFAULT_EXPORT_ATOM, DependenciesBlock, DependencyId, DependencyType, ExportInfo, ExportProvided,
   ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta, ImportedByDeferModulesArtifact,
-  InitFragment, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
+  InitFragment, InitFragmentStage, LibIdentOptions, MapOptions, Mapping, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
   ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT,
-  ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
-  SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set,
+  ObjectPool, OriginalLocation, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals,
+  RuntimeSpec, SideEffectsStateArtifact, Source, SourceExt, SourceMap, SourceType, SourceValue,
+  URLStaticMode, UsageState, UsedName, UsedNameItem, encode_mappings, escape_identifier, fast_set,
   filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
   merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
-  subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
+  stream_chunks::{self, StreamChunks},
+  subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment, utf16_len,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -116,6 +116,751 @@ pub struct SymbolBinding {
 pub enum Binding {
   Raw(RawBinding),
   Symbol(SymbolBinding),
+}
+
+#[derive(Debug, Clone, Hash)]
+struct ConcatenatedModuleReplacement {
+  start: u32,
+  end: u32,
+  content: String,
+  insertion_order: u32,
+}
+
+impl Ord for ConcatenatedModuleReplacement {
+  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    (self.start, self.end, self.insertion_order).cmp(&(
+      other.start,
+      other.end,
+      other.insertion_order,
+    ))
+  }
+}
+
+impl PartialOrd for ConcatenatedModuleReplacement {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl PartialEq for ConcatenatedModuleReplacement {
+  fn eq(&self, other: &Self) -> bool {
+    self.start == other.start
+      && self.end == other.end
+      && self.content == other.content
+      && self.insertion_order == other.insertion_order
+  }
+}
+
+impl Eq for ConcatenatedModuleReplacement {}
+
+#[derive(Debug, Clone)]
+pub struct ConcatenatedModuleSource {
+  source: BoxSource,
+  source_code: String,
+  replacements: Vec<ConcatenatedModuleReplacement>,
+}
+
+impl ConcatenatedModuleSource {
+  pub fn new(source: BoxSource, source_code: String) -> Self {
+    Self {
+      source,
+      source_code,
+      replacements: Vec::new(),
+    }
+  }
+
+  pub fn insert(&mut self, start: u32, content: String) {
+    self.replace(start, start, content);
+  }
+
+  pub fn replace(&mut self, start: u32, end: u32, content: String) {
+    let replacement = ConcatenatedModuleReplacement {
+      start,
+      end,
+      content,
+      insertion_order: self.replacements.len() as u32,
+    };
+
+    if let Some(last) = self.replacements.last() {
+      if replacement >= *last {
+        self.replacements.push(replacement);
+      } else {
+        let insert_at = self
+          .replacements
+          .binary_search(&replacement)
+          .unwrap_or_else(|index| index);
+        self.replacements.insert(insert_at, replacement);
+      }
+    } else {
+      self.replacements.push(replacement);
+    }
+  }
+
+  fn rendered_size(&self) -> usize {
+    let source_len = self.source_code.len();
+    if self.replacements.is_empty() {
+      return source_len;
+    }
+
+    let mut size = source_len;
+    let mut cursor = 0usize;
+    for replacement in &self.replacements {
+      let start = (replacement.start as usize).min(source_len);
+      let end = (replacement.end as usize).min(source_len).max(start);
+
+      if start >= source_len {
+        size += replacement.content.len();
+        continue;
+      }
+
+      let removed_len = end.saturating_sub(start.max(cursor));
+      size = size
+        .saturating_sub(removed_len)
+        .saturating_add(replacement.content.len());
+      cursor = cursor.max(end);
+    }
+    size
+  }
+
+  pub fn render_into(&self, output: &mut String) {
+    if self.replacements.is_empty() {
+      output.push_str(&self.source_code);
+      return;
+    }
+
+    let source_len = self.source_code.len();
+    let mut cursor = 0usize;
+    for replacement in &self.replacements {
+      let start = (replacement.start as usize).min(source_len);
+      let end = (replacement.end as usize).min(source_len).max(start);
+
+      if start > cursor {
+        output.push_str(&self.source_code[cursor..start]);
+        cursor = start;
+      }
+
+      output.push_str(&replacement.content);
+      if end > cursor {
+        cursor = end;
+      }
+    }
+
+    if cursor < source_len {
+      output.push_str(&self.source_code[cursor..]);
+    }
+  }
+}
+
+impl PartialEq for ConcatenatedModuleSource {
+  fn eq(&self, other: &Self) -> bool {
+    Arc::ptr_eq(&self.source, &other.source)
+      && self.source_code == other.source_code
+      && self.replacements == other.replacements
+  }
+}
+
+impl Eq for ConcatenatedModuleSource {}
+
+impl Source for ConcatenatedModuleSource {
+  fn source(&self) -> SourceValue<'_> {
+    if self.replacements.is_empty() {
+      return SourceValue::String(Cow::Borrowed(&self.source_code));
+    }
+
+    let mut string = String::with_capacity(self.rendered_size());
+    self.render_into(&mut string);
+    SourceValue::String(Cow::Owned(string))
+  }
+
+  fn rope<'a>(&'a self, on_chunk: &mut dyn FnMut(&'a str)) {
+    if self.replacements.is_empty() {
+      on_chunk(&self.source_code);
+      return;
+    }
+
+    let source_len = self.source_code.len();
+    let mut cursor = 0usize;
+    for replacement in &self.replacements {
+      let start = (replacement.start as usize).min(source_len);
+      let end = (replacement.end as usize).min(source_len).max(start);
+
+      if start > cursor {
+        on_chunk(&self.source_code[cursor..start]);
+        cursor = start;
+      }
+
+      on_chunk(&replacement.content);
+      if end > cursor {
+        cursor = end;
+      }
+    }
+
+    if cursor < source_len {
+      on_chunk(&self.source_code[cursor..]);
+    }
+  }
+
+  fn buffer(&self) -> Cow<'_, [u8]> {
+    self.source().into_bytes()
+  }
+
+  fn size(&self) -> usize {
+    self.rendered_size()
+  }
+
+  fn map(&self, object_pool: &ObjectPool, options: &MapOptions) -> Option<SourceMap> {
+    if self.replacements.is_empty() {
+      return self.source.map(object_pool, options);
+    }
+    let chunks = self.stream_chunks();
+    source_map_from_chunks(object_pool, chunks.as_ref(), options)
+  }
+
+  fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    let mut result = Ok(());
+    self.rope(&mut |chunk| {
+      if result.is_ok() {
+        result = std::io::Write::write_all(writer, chunk.as_bytes());
+      }
+    });
+    result
+  }
+}
+
+impl Hash for ConcatenatedModuleSource {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    "ConcatenatedModuleSource".hash(state);
+    self.source.hash(state);
+    self.source_code.hash(state);
+    self.replacements.hash(state);
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ConcatenatedModuleOutputPart {
+  Raw(String),
+  Source(ConcatenatedModuleSource),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ConcatenatedModuleOutputSource {
+  parts: Vec<ConcatenatedModuleOutputPart>,
+  size: usize,
+}
+
+impl ConcatenatedModuleOutputSource {
+  fn with_capacity(capacity: usize) -> Self {
+    Self {
+      parts: vec![ConcatenatedModuleOutputPart::Raw(String::with_capacity(
+        capacity,
+      ))],
+      size: 0,
+    }
+  }
+
+  fn push_str(&mut self, content: &str) {
+    if content.is_empty() {
+      return;
+    }
+
+    self.size += content.len();
+    if let Some(ConcatenatedModuleOutputPart::Raw(raw)) = self.parts.last_mut() {
+      raw.push_str(content);
+    } else {
+      self
+        .parts
+        .push(ConcatenatedModuleOutputPart::Raw(content.to_string()));
+    }
+  }
+
+  fn push_source(&mut self, source: ConcatenatedModuleSource) {
+    self.size += source.rendered_size();
+    self
+      .parts
+      .push(ConcatenatedModuleOutputPart::Source(source));
+  }
+}
+
+impl Write for ConcatenatedModuleOutputSource {
+  fn write_str(&mut self, s: &str) -> std::fmt::Result {
+    self.push_str(s);
+    Ok(())
+  }
+}
+
+impl Source for ConcatenatedModuleOutputSource {
+  fn source(&self) -> SourceValue<'_> {
+    let mut string = String::with_capacity(self.size);
+    self.rope(&mut |chunk| {
+      string.push_str(chunk);
+    });
+    SourceValue::String(Cow::Owned(string))
+  }
+
+  fn rope<'a>(&'a self, on_chunk: &mut dyn FnMut(&'a str)) {
+    for part in &self.parts {
+      match part {
+        ConcatenatedModuleOutputPart::Raw(raw) => on_chunk(raw),
+        ConcatenatedModuleOutputPart::Source(source) => source.rope(on_chunk),
+      }
+    }
+  }
+
+  fn buffer(&self) -> Cow<'_, [u8]> {
+    let mut buffer = Vec::with_capacity(self.size);
+    self.to_writer(&mut buffer).expect("write to vec");
+    Cow::Owned(buffer)
+  }
+
+  fn size(&self) -> usize {
+    self.size
+  }
+
+  fn map(&self, object_pool: &ObjectPool, options: &MapOptions) -> Option<SourceMap> {
+    let chunks = self.stream_chunks();
+    source_map_from_chunks(object_pool, chunks.as_ref(), options)
+  }
+
+  fn to_writer(&self, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    for part in &self.parts {
+      match part {
+        ConcatenatedModuleOutputPart::Raw(raw) => {
+          std::io::Write::write_all(writer, raw.as_bytes())?
+        }
+        ConcatenatedModuleOutputPart::Source(source) => source.to_writer(writer)?,
+      }
+    }
+    Ok(())
+  }
+}
+
+impl Hash for ConcatenatedModuleOutputSource {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    "ConcatenatedModuleOutputSource".hash(state);
+    self.parts.hash(state);
+  }
+}
+
+fn source_map_from_chunks(
+  object_pool: &ObjectPool,
+  chunks: &dyn stream_chunks::Chunks,
+  options: &MapOptions,
+) -> Option<SourceMap> {
+  let mut mappings = Vec::new();
+  let mut sources: Vec<String> = Vec::new();
+  let mut sources_content: Vec<Arc<str>> = Vec::new();
+  let mut names: Vec<String> = Vec::new();
+  let mut has_original_mapping = false;
+  let map_options = MapOptions::new(options.columns);
+
+  chunks.stream(
+    object_pool,
+    &map_options,
+    &mut |_, mapping| {
+      has_original_mapping |= mapping.original.is_some();
+      mappings.push(mapping);
+    },
+    &mut |source_index, source, source_content| {
+      let source_index = source_index as usize;
+      if sources.len() <= source_index {
+        sources.resize(source_index + 1, String::new());
+      }
+      sources[source_index] = source.to_string();
+      if let Some(source_content) = source_content {
+        if sources_content.len() <= source_index {
+          sources_content.resize(source_index + 1, "".into());
+        }
+        sources_content[source_index] = source_content.clone();
+      }
+    },
+    &mut |name_index, name| {
+      let name_index = name_index as usize;
+      if names.len() <= name_index {
+        names.resize(name_index + 1, String::new());
+      }
+      names[name_index] = name.to_string();
+    },
+  );
+
+  if !has_original_mapping {
+    return None;
+  }
+
+  let mappings = encode_mappings(mappings.into_iter());
+  (!mappings.is_empty()).then(|| SourceMap::new(mappings, sources, sources_content, names))
+}
+
+#[inline]
+fn advance_generated_position(line: &mut u32, column: &mut u32, content: &str) {
+  if content.is_empty() {
+    return;
+  }
+
+  for segment in content.split_inclusive('\n') {
+    if segment.ends_with('\n') {
+      *line += 1;
+      *column = 0;
+    } else {
+      *column += utf16_len(segment) as u32;
+    }
+  }
+}
+
+#[inline]
+fn advance_original_location(mut original: OriginalLocation, prefix: &str) -> OriginalLocation {
+  if prefix.is_empty() {
+    return original;
+  }
+
+  original.name_index = None;
+  for segment in prefix.split_inclusive('\n') {
+    if segment.ends_with('\n') {
+      original.original_line += 1;
+      original.original_column = 0;
+    } else {
+      original.original_column += utf16_len(segment) as u32;
+    }
+  }
+  original
+}
+
+struct ConcatenatedModuleSourceChunks<'a> {
+  source: &'a ConcatenatedModuleSource,
+  chunks: Box<dyn stream_chunks::Chunks + 'a>,
+}
+
+impl<'a> ConcatenatedModuleSourceChunks<'a> {
+  fn new(source: &'a ConcatenatedModuleSource) -> Self {
+    Self {
+      source,
+      chunks: source.source.stream_chunks(),
+    }
+  }
+
+  fn emit_chunk<'b>(
+    generated_line: &mut u32,
+    generated_column: &mut u32,
+    content: stream_chunks::TextSpan<'b>,
+    original: Option<OriginalLocation>,
+    on_chunk: stream_chunks::OnChunk<'_, 'b>,
+  ) {
+    if content.is_empty() {
+      return;
+    }
+
+    on_chunk(
+      Some(content),
+      Mapping {
+        generated_line: *generated_line,
+        generated_column: *generated_column,
+        original,
+      },
+    );
+    advance_generated_position(generated_line, generated_column, content.as_str());
+  }
+}
+
+impl stream_chunks::Chunks for ConcatenatedModuleSourceChunks<'_> {
+  fn stream<'a>(
+    &'a self,
+    object_pool: &'a ObjectPool,
+    options: &MapOptions,
+    mut on_chunk: stream_chunks::OnChunk<'_, 'a>,
+    on_source: stream_chunks::OnSource<'_, 'a>,
+    on_name: stream_chunks::OnName<'_, 'a>,
+  ) -> stream_chunks::GeneratedInfo {
+    let source_code = self.source.source_code.as_str();
+    let source_len = source_code.len();
+    let replacements = &self.source.replacements;
+    let mut replacement_idx = 0usize;
+    let mut replacement_end = 0usize;
+    let mut source_pos = 0usize;
+    let mut generated_line = 1u32;
+    let mut generated_column = 0u32;
+    let inner_options = MapOptions::new(options.columns);
+
+    let emit_pending_replacements =
+      |current_pos: usize,
+       replacement_idx: &mut usize,
+       replacement_end: &mut usize,
+       generated_line: &mut u32,
+       generated_column: &mut u32,
+       on_chunk: &mut stream_chunks::OnChunk<'_, 'a>| {
+        while let Some(replacement) = replacements.get(*replacement_idx) {
+          let start = (replacement.start as usize).min(source_len);
+          if start > current_pos {
+            break;
+          }
+
+          let end = (replacement.end as usize).min(source_len).max(start);
+          Self::emit_chunk(
+            generated_line,
+            generated_column,
+            stream_chunks::TextSpan::new(&replacement.content),
+            None,
+            on_chunk,
+          );
+          *replacement_end = (*replacement_end).max(end);
+          *replacement_idx += 1;
+        }
+      };
+
+    self.chunks.stream(
+      object_pool,
+      &inner_options,
+      &mut |chunk, mapping| {
+        let Some(chunk) = chunk else {
+          return;
+        };
+
+        let chunk_start = source_pos;
+        let chunk_end = chunk_start + chunk.len();
+        let mut chunk_pos = 0usize;
+
+        while chunk_pos < chunk.len() {
+          let current_pos = chunk_start + chunk_pos;
+          emit_pending_replacements(
+            current_pos,
+            &mut replacement_idx,
+            &mut replacement_end,
+            &mut generated_line,
+            &mut generated_column,
+            &mut on_chunk,
+          );
+
+          if current_pos < replacement_end {
+            chunk_pos +=
+              (replacement_end.min(chunk_end) - current_pos).min(chunk.len() - chunk_pos);
+            continue;
+          }
+
+          let next_replacement_start = replacements
+            .get(replacement_idx)
+            .map(|replacement| (replacement.start as usize).min(source_len))
+            .unwrap_or(source_len);
+          let emit_end = next_replacement_start.min(chunk_end);
+          if emit_end <= current_pos {
+            continue;
+          }
+
+          let local_end = emit_end - chunk_start;
+          let prefix = chunk.slice_to(chunk_pos);
+          let original = mapping
+            .original
+            .map(|original| advance_original_location(original, prefix.as_str()));
+          Self::emit_chunk(
+            &mut generated_line,
+            &mut generated_column,
+            chunk.slice(chunk_pos, local_end),
+            original,
+            &mut on_chunk,
+          );
+          chunk_pos = local_end;
+        }
+
+        source_pos = chunk_end;
+      },
+      on_source,
+      on_name,
+    );
+
+    emit_pending_replacements(
+      source_len,
+      &mut replacement_idx,
+      &mut replacement_end,
+      &mut generated_line,
+      &mut generated_column,
+      &mut on_chunk,
+    );
+
+    stream_chunks::GeneratedInfo {
+      generated_line,
+      generated_column,
+    }
+  }
+}
+
+impl stream_chunks::StreamChunks for ConcatenatedModuleSource {
+  fn stream_chunks<'a>(&'a self) -> Box<dyn stream_chunks::Chunks + 'a> {
+    Box::new(ConcatenatedModuleSourceChunks::new(self))
+  }
+}
+
+struct RawOutputChunks<'a>(&'a str);
+
+impl stream_chunks::Chunks for RawOutputChunks<'_> {
+  fn stream<'a>(
+    &'a self,
+    object_pool: &'a ObjectPool,
+    options: &MapOptions,
+    on_chunk: stream_chunks::OnChunk<'_, 'a>,
+    on_source: stream_chunks::OnSource<'_, 'a>,
+    on_name: stream_chunks::OnName<'_, 'a>,
+  ) -> stream_chunks::GeneratedInfo {
+    stream_chunks::stream_chunks_default(
+      options,
+      object_pool,
+      self.0,
+      None,
+      on_chunk,
+      on_source,
+      on_name,
+    )
+  }
+}
+
+enum ConcatenatedModuleOutputPartChunk<'a> {
+  Raw(RawOutputChunks<'a>),
+  Source(Box<dyn stream_chunks::Chunks + 'a>),
+}
+
+struct ConcatenatedModuleOutputSourceChunks<'a> {
+  part_chunks: Vec<ConcatenatedModuleOutputPartChunk<'a>>,
+}
+
+impl<'a> ConcatenatedModuleOutputSourceChunks<'a> {
+  fn new(source: &'a ConcatenatedModuleOutputSource) -> Self {
+    let part_chunks = source
+      .parts
+      .iter()
+      .map(|part| match part {
+        ConcatenatedModuleOutputPart::Raw(raw) => {
+          ConcatenatedModuleOutputPartChunk::Raw(RawOutputChunks(raw))
+        }
+        ConcatenatedModuleOutputPart::Source(source) => {
+          ConcatenatedModuleOutputPartChunk::Source(source.stream_chunks())
+        }
+      })
+      .collect();
+    Self { part_chunks }
+  }
+}
+
+impl stream_chunks::Chunks for ConcatenatedModuleOutputSourceChunks<'_> {
+  fn stream<'a>(
+    &'a self,
+    object_pool: &'a ObjectPool,
+    options: &MapOptions,
+    on_chunk: stream_chunks::OnChunk<'_, 'a>,
+    mut on_source: stream_chunks::OnSource<'_, 'a>,
+    mut on_name: stream_chunks::OnName<'_, 'a>,
+  ) -> stream_chunks::GeneratedInfo {
+    let mut current_line_offset = 0;
+    let mut current_column_offset = 0;
+    let mut source_mapping: HashMap<String, u32> = HashMap::default();
+    let mut name_mapping: HashMap<String, u32> = HashMap::default();
+
+    for part in &self.part_chunks {
+      let source_index_mapping: RefCell<HashMap<u32, u32>> = RefCell::new(HashMap::default());
+      let name_index_mapping: RefCell<HashMap<u32, u32>> = RefCell::new(HashMap::default());
+
+      let stream_chunks::GeneratedInfo {
+        generated_line,
+        generated_column,
+      } = match part {
+        ConcatenatedModuleOutputPartChunk::Raw(raw) => raw.stream(
+          object_pool,
+          options,
+          &mut |chunk, mapping| {
+            let line = mapping.generated_line + current_line_offset;
+            let column = if mapping.generated_line == 1 {
+              mapping.generated_column + current_column_offset
+            } else {
+              mapping.generated_column
+            };
+            on_chunk(
+              chunk,
+              Mapping {
+                generated_line: line,
+                generated_column: column,
+                original: None,
+              },
+            );
+          },
+          &mut on_source,
+          &mut on_name,
+        ),
+        ConcatenatedModuleOutputPartChunk::Source(chunks) => chunks.stream(
+          object_pool,
+          options,
+          &mut |chunk, mapping| {
+            let line = mapping.generated_line + current_line_offset;
+            let column = if mapping.generated_line == 1 {
+              mapping.generated_column + current_column_offset
+            } else {
+              mapping.generated_column
+            };
+            let original = mapping.original.as_ref().and_then(|original| {
+              let source_index = source_index_mapping
+                .borrow()
+                .get(&original.source_index)
+                .copied()?;
+              Some(OriginalLocation {
+                source_index,
+                original_line: original.original_line,
+                original_column: original.original_column,
+                name_index: original
+                  .name_index
+                  .and_then(|name_index| name_index_mapping.borrow().get(&name_index).copied()),
+              })
+            });
+            on_chunk(
+              chunk,
+              Mapping {
+                generated_line: line,
+                generated_column: column,
+                original,
+              },
+            );
+          },
+          &mut |index, source, source_content| {
+            let source_key = source.to_string();
+            let global_index = if let Some(index) = source_mapping.get(&source_key) {
+              *index
+            } else {
+              let index = source_mapping.len() as u32;
+              source_mapping.insert(source_key, index);
+              on_source(index, source, source_content);
+              index
+            };
+            source_index_mapping
+              .borrow_mut()
+              .insert(index, global_index);
+          },
+          &mut |index, name| {
+            let name_key = name.to_string();
+            let global_index = if let Some(index) = name_mapping.get(&name_key) {
+              *index
+            } else {
+              let index = name_mapping.len() as u32;
+              name_mapping.insert(name_key, index);
+              on_name(index, name);
+              index
+            };
+            name_index_mapping.borrow_mut().insert(index, global_index);
+          },
+        ),
+      };
+
+      if generated_line > 1 {
+        current_column_offset = generated_column;
+      } else {
+        current_column_offset += generated_column;
+      }
+      current_line_offset += generated_line - 1;
+    }
+
+    stream_chunks::GeneratedInfo {
+      generated_line: current_line_offset + 1,
+      generated_column: current_column_offset,
+    }
+  }
+}
+
+impl stream_chunks::StreamChunks for ConcatenatedModuleOutputSource {
+  fn stream_chunks<'a>(&'a self) -> Box<dyn stream_chunks::Chunks + 'a> {
+    Box::new(ConcatenatedModuleOutputSourceChunks::new(self))
+  }
 }
 
 #[derive(Debug)]
@@ -298,8 +1043,7 @@ pub struct ConcatenatedModuleInfo {
   pub global_ctxt: SyntaxContext,
   pub runtime_requirements: RuntimeGlobals,
   pub has_ast: bool,
-  pub source: Option<ReplaceSource>,
-  pub internal_source: Option<Arc<dyn Source>>,
+  pub source: Option<ConcatenatedModuleSource>,
   pub internal_names: HashMap<Atom, Atom>,
   pub export_map: Option<HashMap<Atom, String>>,
   pub raw_export_map: Option<HashMap<Atom, String>>,
@@ -995,9 +1739,7 @@ impl Module for ConcatenatedModule {
     let mut needed_namespace_objects = IdentifierIndexSet::default();
     let mut needed_namespace_objects_queue = VecDeque::new();
 
-    // Generate source code and analyze scopes
-    // Prepare a ReplaceSource for the final source
-    //
+    // Generate source code and analyze scopes.
     let mut all_used_names: HashSet<Atom> = RESERVED_NAMES_ATOM_SET.clone();
 
     let arc_map = Arc::new(module_to_info_map);
@@ -1201,11 +1943,11 @@ impl Module for ConcatenatedModule {
                 let low = span.real_lo();
                 let high = span.real_hi();
                 if identifier.shorthand {
-                  source.insert(high, format!(": {new_name}"), None);
+                  source.insert(high, format!(": {new_name}"));
                   continue;
                 }
 
-                source.replace(low, high, new_name.to_string(), None);
+                source.replace(low, high, new_name.to_string());
               }
             } else {
               // Handle the case when the name is not already used
@@ -1514,7 +2256,7 @@ impl Module for ConcatenatedModule {
           .and_then(|info| info.try_as_concatenated_mut())
           .expect("should have concatenate module info");
         let source = info.source.as_mut().expect("should have source");
-        source.replace(low, high, name_result.name, None);
+        source.replace(low, high, name_result.name);
       }
     }
 
@@ -1592,7 +2334,8 @@ impl Module for ConcatenatedModule {
       });
     }
 
-    let mut result: ConcatSource = ConcatSource::default();
+    let estimated_size = self.modules.iter().map(|m| m.size as usize).sum::<usize>() + 1024;
+    let mut result = ConcatenatedModuleOutputSource::with_capacity(estimated_size);
     let mut should_add_esm_flag = false;
     let mut chunk_init_fragments: Vec<Box<dyn InitFragment<ChunkRenderContext>>> = Vec::new();
 
@@ -1654,35 +2397,40 @@ impl Module for ConcatenatedModule {
 
       if !matches!(should_skip_render_definitions, Some(true)) {
         if should_add_esm_flag {
-          result.add(RawStringSource::from_static("// ESM COMPAT FLAG\n"));
-          result.add(RawStringSource::from(
-            runtime_template.define_es_module_flag_statement(self.get_exports_argument()),
-          ));
+          result.push_str("// ESM COMPAT FLAG\n");
+          result.push_str(
+            &runtime_template.define_es_module_flag_statement(self.get_exports_argument()),
+          );
         }
 
-        result.add(RawStringSource::from_static("\n// EXPORTS\n"));
-        result.add(RawStringSource::from(format!(
-          "{}({}, {{{}\n}});\n",
+        write!(
+          result,
+          "\n// EXPORTS\n{}({}, {{{}\n}});\n",
           runtime_template.render_runtime_globals(&RuntimeGlobals::DEFINE_PROPERTY_GETTERS),
           runtime_template.render_exports_argument(exports_argument),
           definitions.join(",")
-        )));
+        )
+        .expect("write to string");
       }
     }
 
     // List unused exports
     if !unused_exports.is_empty() {
-      result.add(RawStringSource::from(format!(
+      write!(
+        result,
         "\n// UNUSED EXPORTS: {}\n",
         join_atom(unused_exports.iter(), ", ")
-      )));
+      )
+      .expect("write to string");
     }
     // List inlined exports
     if !inlined_exports.is_empty() {
-      result.add(RawStringSource::from(format!(
+      write!(
+        result,
         "\n// INLINED EXPORTS: {}\n",
         join_atom(inlined_exports.iter(), ", ")
-      )));
+      )
+      .expect("write to string");
     }
 
     let mut namespace_object_sources: IdentifierMap<String> = IdentifierMap::default();
@@ -1781,7 +2529,7 @@ impl Module for ConcatenatedModule {
       if let Some(info) = info.try_as_concatenated()
         && let Some(source) = namespace_object_sources.get(&info.module)
       {
-        result.add(RawStringSource::from(source.as_str()));
+        result.push_str(source);
       }
 
       // Define deferred modules namespace objects
@@ -1812,13 +2560,15 @@ impl Module for ConcatenatedModule {
           // an async module will opt-out of the concat module optimization.
           Default::default(),
         );
-        result.add(RawStringSource::from(format!(
+        write!(
+          result,
           "\n// DEFERRED EXTERNAL MODULE: {module_readable_identifier}\nvar {} = {loader};",
           info
             .deferred_name
             .as_ref()
             .expect("should have deferred_name"),
-        )));
+        )
+        .expect("write to string");
         if info.deferred_namespace_object_used {
           let module_id = json_stringify(
             ChunkGraph::get_module_id(&compilation.module_ids_artifact, info.module)
@@ -1827,7 +2577,8 @@ impl Module for ConcatenatedModule {
           let module = module_graph
             .module_by_identifier(&info.module)
             .expect("should have module");
-          result.add(RawStringSource::from(format!(
+          write!(
+            result,
             "\nvar {} = /*#__PURE__*/{}({}, {});",
             info
               .deferred_namespace_object_name
@@ -1842,7 +2593,8 @@ impl Module for ConcatenatedModule {
               &compilation.exports_info_artifact,
               root_module.build_meta().strict_esm_module,
             )),
-          )));
+          )
+          .expect("write to string");
         }
       }
     }
@@ -1864,12 +2616,15 @@ impl Module for ConcatenatedModule {
 
       match info {
         ModuleInfo::Concatenated(info) => {
-          result.add(RawStringSource::from(
-            format!("\n;// CONCATENATED MODULE: {module_readable_identifier}\n").as_str(),
-          ));
+          write!(
+            result,
+            "\n;// CONCATENATED MODULE: {module_readable_identifier}\n"
+          )
+          .expect("write to string");
 
           // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L1582
-          result.add(info.source.take().expect("should have source"));
+          let source = info.source.take().expect("should have source");
+          result.push_source(source);
           chunk_init_fragments.extend(mem::take(&mut info.chunk_init_fragments));
 
           runtime_template
@@ -1880,9 +2635,11 @@ impl Module for ConcatenatedModule {
         ModuleInfo::External(info) => {
           // Deferred modules namespace objects is hoisted up at above loop
           if !info.deferred {
-            result.add(RawStringSource::from(format!(
+            write!(
+              result,
               "\n// EXTERNAL MODULE: {module_readable_identifier}\n"
-            )));
+            )
+            .expect("write to string");
 
             let condition = runtime_template.runtime_condition_expression(
               &compilation.build_chunk_graph_artifact.chunk_graph,
@@ -1892,10 +2649,11 @@ impl Module for ConcatenatedModule {
 
             if condition != "true" {
               is_conditional = true;
-              result.add(RawStringSource::from(format!("if ({condition}) {{\n")));
+              write!(result, "if ({condition}) {{\n").expect("write to string");
             }
 
-            result.add(RawStringSource::from(format!(
+            write!(
+              result,
               "var {} = {}({});",
               info.name.as_ref().expect("should have name"),
               runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
@@ -1903,7 +2661,8 @@ impl Module for ConcatenatedModule {
                 ChunkGraph::get_module_id(&compilation.module_ids_artifact, info.module)
                   .expect("should have module id")
               )
-            )));
+            )
+            .expect("write to string");
 
             name.clone_from(&info.name);
           }
@@ -1911,7 +2670,8 @@ impl Module for ConcatenatedModule {
           // the module itself will be emitted as mod_deferred (in the case "external"),
           // we need to emit an extra import declaration to evaluate it in order.
           if info.deferred && reference_info.non_defer_access == NonDeferAccess(true) {
-            result.add(RawStringSource::from(format!(
+            write!(
+              result,
               "\n// non-deferred import to a deferred module ({})\nvar {} = {}.a;",
               get_cached_readable_identifier(
                 &info.module,
@@ -1924,46 +2684,53 @@ impl Module for ConcatenatedModule {
                 .deferred_name
                 .as_ref()
                 .expect("should have deferred_name"),
-            )));
+            )
+            .expect("write to string");
           }
         }
       }
 
       if info.get_interop_namespace_object_used() {
-        result.add(RawStringSource::from(format!(
+        write!(
+          result,
           "\nvar {} = /*#__PURE__*/{}({}, 2);",
           info
             .get_interop_namespace_object_name()
             .expect("should have interop_namespace_object_name"),
           runtime_template.render_runtime_globals(&RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT),
           name.as_ref().expect("should have name")
-        )));
+        )
+        .expect("write to string");
       }
 
       if info.get_interop_namespace_object2_used() {
-        result.add(RawStringSource::from(format!(
+        write!(
+          result,
           "\nvar {} = /*#__PURE__*/{}({});",
           info
             .get_interop_namespace_object2_name()
             .expect("should have interop_namespace_object2_name"),
           runtime_template.render_runtime_globals(&RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT),
           name.as_ref().expect("should have name")
-        )));
+        )
+        .expect("write to string");
       }
 
       if info.get_interop_default_access_used() {
-        result.add(RawStringSource::from(format!(
+        write!(
+          result,
           "\nvar {} = /*#__PURE__*/{}({});",
           info
             .get_interop_default_access_name()
             .expect("should have interop_default_access_name"),
           runtime_template.render_runtime_globals(&RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT),
           name.expect("should have name")
-        )));
+        )
+        .expect("write to string");
       }
 
       if is_conditional {
-        result.add(RawStringSource::from_static("\n}"));
+        result.push_str("\n}");
       }
     }
 
@@ -1971,7 +2738,7 @@ impl Module for ConcatenatedModule {
     fast_set(&mut module_to_info_map, IdentifierIndexMap::default());
 
     let mut code_generation_result = CodeGenerationResult::default();
-    code_generation_result.add(SourceType::JavaScript, CachedSource::new(result).boxed());
+    code_generation_result.add(SourceType::JavaScript, result.boxed());
     code_generation_result.chunk_init_fragments = chunk_init_fragments;
 
     if public_path_auto_replace {
@@ -2554,7 +3321,7 @@ impl ConcatenatedModule {
       let source = inner
         .remove(&SourceType::JavaScript)
         .expect("should have javascript source");
-      let source_code = source.source().into_string_lossy();
+      let source_code = source.source().into_string_lossy().into_owned();
       let mut module_info = concatenation_scope.current_module;
 
       let jsx = module
@@ -2576,7 +3343,7 @@ impl ConcatenatedModule {
           ..Default::default()
         }),
         EsVersion::EsNext,
-        StringSource::new(source_code.as_ref()),
+        StringSource::new(source_code.as_str()),
         None,
       );
       let mut p = Parser::new_from(&allocator, lexer);
@@ -2587,7 +3354,7 @@ impl ConcatenatedModule {
         Err(err) => {
           // return empty error as we already push error to compilation.diagnostics
           return Err(Error::from_string(
-            Some(source_code.into_owned()),
+            Some(source_code.clone()),
             err.span().start.saturating_sub(1) as usize,
             err.span().end.saturating_sub(1) as usize,
             "JavaScript parse error:\n".to_string(),
@@ -2641,11 +3408,9 @@ impl ConcatenatedModule {
       }
       module_info.all_used_names = all_used_names;
       module_info.binding_to_ref = binding_to_ref;
-      let result_source = ReplaceSource::new(source.clone());
       module_info.has_ast = true;
       module_info.runtime_requirements = runtime_requirements;
-      module_info.internal_source = Some(source);
-      module_info.source = Some(result_source);
+      module_info.source = Some(ConcatenatedModuleSource::new(source, source_code));
       module_info.chunk_init_fragments = chunk_init_fragments;
       if let Some(CodeGenerationPublicPathAutoReplace(true)) = codegen_res
         .data

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -32,6 +32,10 @@ impl DependencyCodeGeneration for CachedConstDependency {
     Some(CachedConstDependencyTemplate::template_type())
   }
 
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -31,6 +31,13 @@ impl DependencyCodeGeneration for ConstDependency {
     Some(self.range)
   }
 
+  fn ast_dependency_replacements(
+    &self,
+    _context: &mut TemplateContext<'_, '_, '_>,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    Some(vec![(self.range, self.content.to_string())])
+  }
+
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -27,6 +27,10 @@ impl DependencyCodeGeneration for ConstDependency {
     Some(ConstDependencyTemplate::template_type())
   }
 
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -57,8 +57,7 @@ pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
     None
   }
 
-  /// Returns the source range that should be matched against a parsed AST node
-  /// before this dependency is rendered.
+  /// Returns the source range this dependency rewrites in the AST codegen plan.
   fn ast_dependency_range(&self) -> Option<DependencyRange> {
     None
   }

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -6,8 +6,8 @@ use rspack_sources::ReplaceSource;
 use rspack_util::ext::AsAny;
 
 use crate::{
-  ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope, DependencyType, Module,
-  ModuleCodeTemplate, ModuleInitFragments, RuntimeSpec,
+  ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope, DependencyRange,
+  DependencyType, Module, ModuleCodeTemplate, ModuleInitFragments, RuntimeSpec,
 };
 
 pub struct TemplateContext<'a, 'b, 'c> {
@@ -56,6 +56,12 @@ pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     None
   }
+
+  /// Returns the source range that should be matched against a parsed AST node
+  /// before this dependency is rendered.
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    None
+  }
 }
 
 pub type BoxDependencyTemplate = Box<dyn DependencyCodeGeneration>;
@@ -85,4 +91,13 @@ pub trait DependencyTemplate: Debug + Sync + Send {
     source: &mut ReplaceSource,
     code_generatable_context: &mut TemplateContext,
   );
+
+  fn render_ast(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    source: &mut ReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    self.render(dep, source, code_generatable_context);
+  }
 }

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -91,13 +91,4 @@ pub trait DependencyTemplate: Debug + Sync + Send {
     source: &mut ReplaceSource,
     code_generatable_context: &mut TemplateContext,
   );
-
-  fn render_ast(
-    &self,
-    dep: &dyn DependencyCodeGeneration,
-    source: &mut ReplaceSource,
-    code_generatable_context: &mut TemplateContext,
-  ) {
-    self.render(dep, source, code_generatable_context);
-  }
 }

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -62,6 +62,13 @@ pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
   fn ast_dependency_range(&self) -> Option<DependencyRange> {
     None
   }
+
+  fn ast_dependency_replacements(
+    &self,
+    _context: &mut TemplateContext<'_, '_, '_>,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    None
+  }
 }
 
 pub type BoxDependencyTemplate = Box<dyn DependencyCodeGeneration>;
@@ -85,6 +92,22 @@ pub enum DependencyTemplateType {
 }
 
 pub trait DependencyTemplate: Debug + Sync + Send {
+  fn render_ast(
+    &self,
+    _dep: &dyn DependencyCodeGeneration,
+    _code_generatable_context: &mut TemplateContext,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    None
+  }
+
+  fn after_ast_render(
+    &self,
+    _dep: &dyn DependencyCodeGeneration,
+    _code_generatable_context: &mut TemplateContext,
+    _init_fragments_start: usize,
+  ) {
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -36,7 +36,8 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 pub use runtime_requirements_dependency::{
-  RuntimeRequirementsDependency, RuntimeRequirementsDependencyTemplate,
+  RuntimeRequirementsDependency, RuntimeRequirementsDependencyMode,
+  RuntimeRequirementsDependencyTemplate,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -29,6 +29,14 @@ impl DependencyCodeGeneration for RuntimeRequirementsDependency {
     Some(RuntimeRequirementsDependencyTemplate::template_type())
   }
 
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    if matches!(self.mode, RuntimeRequirementsDependencyMode::AddOnly) {
+      None
+    } else {
+      Some(self.range)
+    }
+  }
+
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -108,7 +108,10 @@ pub use rspack_loader_runner::{
   get_scheme, parse_resource,
 };
 pub use rspack_macros::{impl_runtime_module, impl_source_map_config};
-pub use rspack_sources;
+pub use rspack_sources::{
+  self, BoxSource, MapOptions, Mapping, ObjectPool, OriginalLocation, Source, SourceExt, SourceMap,
+  SourceValue, encode_mappings, stream_chunks, utf16_len,
+};
 
 #[cfg(debug_assertions)]
 pub mod debug_info;

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -497,7 +497,7 @@ pub fn get_outgoing_async_modules(
   set
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ModuleCodeTemplate {
   compiler_options: Arc<CompilerOptions>,
   runtime_requirements: RuntimeGlobals,

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -278,6 +278,11 @@ pub struct ChunkLinkContext {
   pub raw_star_exports: FxIndexMap<String, FxIndexSet<Atom>>,
 
   /**
+   * raw star exports that should be rendered before module source.
+   */
+  pub raw_star_exports_before_source: FxIndexMap<String, FxIndexSet<Atom>>,
+
+  /**
   import order matters, it affects execution order
   */
   pub imports: IdentifierIndexMap<FxHashMap<Atom, Atom>>,
@@ -362,6 +367,7 @@ impl ChunkLinkContext {
       raw_import_stmts: Default::default(),
       module_external_namespace_imports: Default::default(),
       raw_star_exports: Default::default(),
+      raw_star_exports_before_source: Default::default(),
       exports_require_via_runtime_module: false,
     }
   }

--- a/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
+++ b/crates/rspack_plugin_esm_library/src/dependency/dyn_import.rs
@@ -3,12 +3,12 @@ use std::{borrow::Cow, sync::Arc};
 use atomic_refcell::AtomicRefCell;
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  Dependency, DependencyId, DependencyTemplate, ExportsType, ExternalModule,
+  Dependency, DependencyId, DependencyRange, DependencyTemplate, ExportsType, ExternalModule,
   FakeNamespaceObjectMode, ModuleGraph, ModuleReferenceOptions, RuntimeGlobals, TemplateContext,
   get_exports_type, property_access,
 };
 use rspack_plugin_javascript::dependency::ImportDependency;
-use rspack_plugin_rslib::dyn_import_external::render_dyn_import_external_module;
+use rspack_plugin_rslib::dyn_import_external::render_dyn_import_external_module_content;
 use rspack_util::atom::Atom;
 
 use crate::EsmLibraryPlugin;
@@ -203,17 +203,12 @@ pub struct DynamicImportDependencyTemplate {
   pub dyn_import_ns_map: Arc<AtomicRefCell<IdentifierMap<Atom>>>,
 }
 
-impl DependencyTemplate for DynamicImportDependencyTemplate {
-  fn render(
+impl DynamicImportDependencyTemplate {
+  fn render_content(
     &self,
-    dep: &dyn rspack_core::DependencyCodeGeneration,
-    source: &mut rspack_core::TemplateReplaceSource,
+    import_dep: &ImportDependency,
     code_generatable_context: &mut rspack_core::TemplateContext,
-  ) {
-    let import_dep = dep
-      .as_any()
-      .downcast_ref::<ImportDependency>()
-      .expect("ImportDependencyTemplate can only be applied to ImportDependency");
+  ) -> String {
     let dep = import_dep as &dyn Dependency;
     let dep_id = dep.id();
     let module_graph = code_generatable_context.compilation.get_module_graph();
@@ -226,33 +221,20 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
       let missing_promise = code_generatable_context
         .runtime_template
         .missing_module_promise(request);
-      source.replace(
-        import_dep.range.start,
-        import_dep.range.end,
-        missing_promise,
-        None,
-      );
-      return;
+      return missing_promise;
     };
 
     if let Some(external_module) = ref_module.as_external_module()
       && matches!(external_module.resolve_external_type(), "import" | "module")
     {
-      render_dyn_import_external_module(import_dep, external_module, source);
-      return;
+      return render_dyn_import_external_module_content(import_dep, external_module);
     }
     if let Some(external_module) = ref_module.as_external_module() {
       let fake_type = get_fake_namespace_object_mode(code_generatable_context, dep_id);
       if let Some(external_import) =
         render_lazy_commonjs_external_import(code_generatable_context, external_module, fake_type)
       {
-        source.replace(
-          import_dep.range.start,
-          import_dep.range.end,
-          external_import,
-          None,
-        );
-        return;
+        return external_import;
       }
     }
 
@@ -266,13 +248,7 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
         let missing_promise = code_generatable_context
           .runtime_template
           .missing_module_promise(request);
-        source.replace(
-          import_dep.range.start,
-          import_dep.range.end,
-          missing_promise,
-          None,
-        );
-        return;
+        return missing_promise;
       }
     };
 
@@ -288,13 +264,7 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
         let missing_promise = code_generatable_context
           .runtime_template
           .missing_module_promise(request);
-        source.replace(
-          import_dep.range.start,
-          import_dep.range.end,
-          missing_promise,
-          None,
-        );
-        return;
+        return missing_promise;
       }
     };
 
@@ -335,16 +305,10 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
     let Some(concatenation_scope) = &mut code_generatable_context.concatenation_scope else {
       // if we are not in a concatenation scope, then all its children are not scope hoisted as well
       // we can safely use __webpack_require__ to fetch module
-      source.replace(
-        import_dep.range.start,
-        import_dep.range.end,
-        format!(
-          "{import_promise}{}",
-          then_expr(code_generatable_context, dep_id, request)
-        ),
-        None,
+      return format!(
+        "{import_promise}{}",
+        then_expr(code_generatable_context, dep_id, request)
       );
-      return;
     };
 
     let is_ref_module_concatenated =
@@ -353,17 +317,10 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
     if !is_ref_module_concatenated {
       // if target is not in a concatenation scope, then all its children are not scope hoisted as well
       // we can safely use __webpack_require__ to fetch module
-      source.replace(
-        import_dep.range.start,
-        import_dep.range.end,
-        format!(
-          "{import_promise}{}",
-          then_expr(code_generatable_context, dep_id, request)
-        ),
-        None,
+      return format!(
+        "{import_promise}{}",
+        then_expr(code_generatable_context, dep_id, request)
       );
-
-      return;
     }
 
     if already_in_chunk {
@@ -381,13 +338,7 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
           ..Default::default()
         },
       );
-      source.replace(
-        import_dep.range.start,
-        import_dep.range.end,
-        format!("Promise.resolve({ns_ref})"),
-        None,
-      );
-      return;
+      return format!("Promise.resolve({ns_ref})");
     }
 
     // Cross-chunk: check if the module needs namespace remapping (exports were renamed or namespace access)
@@ -399,20 +350,45 @@ impl DependencyTemplate for DynamicImportDependencyTemplate {
     if let Some(ns_name) = ns_name {
       // Module's exports were renamed in the chunk or accessed as namespace.
       // Use .then(m => m.<ns_name>) to get the correct module namespace.
-      source.replace(
-        import_dep.range.start,
-        import_dep.range.end,
-        format!("{import_promise}.then(m => m.{ns_name})"),
-        None,
-      );
+      format!("{import_promise}.then(m => m.{ns_name})")
     } else {
       // Module's exports are not renamed in the chunk — direct import works.
-      source.replace(
-        import_dep.range.start,
-        import_dep.range.end,
-        import_promise.into_owned(),
-        None,
-      );
+      import_promise.into_owned()
     }
+  }
+}
+
+impl DependencyTemplate for DynamicImportDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn rspack_core::DependencyCodeGeneration,
+    code_generatable_context: &mut rspack_core::TemplateContext,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    let import_dep = dep
+      .as_any()
+      .downcast_ref::<ImportDependency>()
+      .expect("ImportDependencyTemplate can only be applied to ImportDependency");
+    Some(vec![(
+      import_dep.range,
+      self.render_content(import_dep, code_generatable_context),
+    )])
+  }
+
+  fn render(
+    &self,
+    dep: &dyn rspack_core::DependencyCodeGeneration,
+    source: &mut rspack_core::TemplateReplaceSource,
+    code_generatable_context: &mut rspack_core::TemplateContext,
+  ) {
+    let import_dep = dep
+      .as_any()
+      .downcast_ref::<ImportDependency>()
+      .expect("ImportDependencyTemplate can only be applied to ImportDependency");
+    source.replace(
+      import_dep.range.start,
+      import_dep.range.end,
+      self.render_content(import_dep, code_generatable_context),
+      None,
+    );
   }
 }

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -9,14 +9,14 @@ use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
   ChunkUkey, CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent,
-  ConditionalInitFragment, DependencyType, ExportInfo, ExportMode, ExportProvided,
-  ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, PathData,
-  RuntimeGlobals, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName,
-  UsedNameItem, collect_ident, escape_name_atom_ref, find_new_name, find_target,
+  ConcatenatedModuleSource, ConditionalInitFragment, DependencyType, ExportInfo, ExportMode,
+  ExportProvided, ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT,
+  PathData, RuntimeGlobals, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState,
+  UsedName, UsedNameItem, collect_ident, escape_name_atom_ref, find_new_name, find_target,
   get_cached_readable_identifier, get_js_chunk_filename_template, get_module_directives,
   get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
-  rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
+  split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_plugin_javascript::{
@@ -1613,8 +1613,9 @@ var {} = {{}};
                 concate_info.all_used_names = all_used_names;
                 concate_info.binding_to_ref = binding_to_ref;
                 concate_info.has_ast = true;
-                concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
-                concate_info.internal_source = Some(render_source.source.clone());
+                let source = render_source.source.clone();
+                let source_code = source.source().into_string_lossy().into_owned();
+                concate_info.source = Some(ConcatenatedModuleSource::new(source, source_code));
                 concate_info.runtime_requirements = codegen_res.runtime_requirements;
                 concate_info.chunk_init_fragments = codegen_res
                   .data

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -4,7 +4,7 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use rayon::{iter::Either, prelude::*};
+use rayon::prelude::*;
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
@@ -65,6 +65,13 @@ pub(crate) struct ExportsContext {
   exports: FxHashMap<Atom, FxIndexSet<Atom>>,
   exported_symbols: FxHashSet<Atom>,
   re_exports: FxIndexMap<ReExportFrom, FxHashMap<Atom, FxHashSet<Atom>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum StarReExport {
+  Export(Atom),
+  Module(ModuleIdentifier),
+  BeforeSourceModuleExternal(ModuleIdentifier),
 }
 
 enum ExternalImportBinding {
@@ -1703,8 +1710,8 @@ var {} = {{}};
     side_effects_state_artifact: &SideEffectsStateArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     collect_own_exports: bool,
-    cache: &mut IdentifierMap<FxIndexSet<Either<Atom, ModuleIdentifier>>>,
-  ) -> FxIndexSet<Either<Atom, ModuleIdentifier>> {
+    cache: &mut IdentifierMap<FxIndexSet<StarReExport>>,
+  ) -> FxIndexSet<StarReExport> {
     // Memoize recursive calls to avoid redundant traversals of the same
     // module's export * chains (hot path: conn.is_active + dep.get_mode).
     if collect_own_exports && let Some(cached) = cache.get(&module_id) {
@@ -1716,7 +1723,7 @@ var {} = {{}};
       .expect("should have module");
 
     if module.as_external_module().is_some() {
-      let result: FxIndexSet<_> = std::iter::once(Either::Right(module_id)).collect();
+      let result: FxIndexSet<_> = std::iter::once(StarReExport::Module(module_id)).collect();
       if collect_own_exports {
         cache.insert(module_id, result.clone());
       }
@@ -1729,7 +1736,7 @@ var {} = {{}};
         .exports()
         .iter()
         .filter(|(_, export_info)| matches!(export_info.provided(), Some(ExportProvided::Provided)))
-        .map(|(name, _)| Either::Left(name.clone()))
+        .map(|(name, _)| StarReExport::Export(name.clone()))
         .collect()
     } else {
       FxIndexSet::default()
@@ -1740,17 +1747,37 @@ var {} = {{}};
         continue;
       };
 
-      if !conn.is_active(
+      let dep = module_graph.dependency_by_id(dep);
+      let mut force_resolve_module_external_star = false;
+      if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
+        && dep.name.is_none()
+      {
+        let mode = dep.get_mode(
+          module_graph,
+          None,
+          module_graph_cache,
+          exports_info_artifact,
+        );
+        force_resolve_module_external_star = matches!(
+          mode,
+          ExportMode::DynamicReexport(_) | ExportMode::EmptyStar(_)
+        ) && module_graph
+          .module_by_identifier(conn.module_identifier())
+          .and_then(|module| module.as_external_module())
+          .is_some_and(|external| external.resolve_external_type() == "module");
+      }
+
+      let connection_active = conn.is_active(
         module_graph,
         None,
         module_graph_cache,
         side_effects_state_artifact,
         exports_info_artifact,
-      ) {
+      );
+      if !connection_active && !force_resolve_module_external_star {
         continue;
       }
 
-      let dep = module_graph.dependency_by_id(dep);
       if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
         && dep.name.is_none()
       {
@@ -1761,10 +1788,14 @@ var {} = {{}};
           exports_info_artifact,
         );
 
-        if matches!(mode, ExportMode::DynamicReexport(_)) {
-          let ref_module = conn.module_identifier();
+        if !connection_active && force_resolve_module_external_star {
+          exports.insert(StarReExport::BeforeSourceModuleExternal(
+            *conn.module_identifier(),
+          ));
+        } else if matches!(mode, ExportMode::DynamicReexport(_)) {
+          let ref_module = *conn.module_identifier();
           exports.extend(Self::resolve_re_export_star_from_unknown(
-            *ref_module,
+            ref_module,
             module_graph,
             module_graph_cache,
             side_effects_state_artifact,
@@ -1789,7 +1820,7 @@ var {} = {{}};
     module_graph_cache: &ModuleGraphCacheArtifact,
     side_effects_state_artifact: &SideEffectsStateArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
-    cache: &mut IdentifierMap<FxIndexSet<Either<Atom, ModuleIdentifier>>>,
+    cache: &mut IdentifierMap<FxIndexSet<StarReExport>>,
   ) -> Option<ModuleIdentifier> {
     let mut star_target = None;
     for export in Self::resolve_re_export_star_from_unknown(
@@ -1801,8 +1832,11 @@ var {} = {{}};
       false,
       cache,
     ) {
-      let Either::Right(module_id) = export else {
-        continue;
+      let module_id = match export {
+        StarReExport::Module(module_id) | StarReExport::BeforeSourceModuleExternal(module_id) => {
+          module_id
+        }
+        StarReExport::Export(_) => continue,
       };
 
       match star_target {
@@ -1961,7 +1995,7 @@ var {} = {{}};
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
     allow_rename: bool,
     filter_unused: bool,
-    re_export_star_cache: &mut IdentifierMap<FxIndexSet<Either<Atom, ModuleIdentifier>>>,
+    re_export_star_cache: &mut IdentifierMap<FxIndexSet<StarReExport>>,
   ) -> Vec<Diagnostic> {
     let mut errors = vec![];
     let context = &compilation.options.context;
@@ -1972,7 +2006,7 @@ var {} = {{}};
       .get_exports_info_data(&entry_module);
 
     // detect reexport star
-    let mut star_re_exports_modules = IdentifierIndexSet::default();
+    let mut star_re_exports_modules = IdentifierIndexMap::<bool>::default();
     let keep_export_name =
       !allow_rename && (current_chunk == entry_chunk || self.strict_export_chunk(current_chunk));
 
@@ -2003,8 +2037,15 @@ var {} = {{}};
     .iter()
     .for_each(|either| {
       match either {
-        Either::Left(atom) => entry_exports.insert(atom.clone()),
-        Either::Right(module_id) => star_re_exports_modules.insert(*module_id),
+        StarReExport::Export(atom) => {
+          entry_exports.insert(atom.clone());
+        }
+        StarReExport::Module(module_id) => {
+          star_re_exports_modules.entry(*module_id).or_insert(false);
+        }
+        StarReExport::BeforeSourceModuleExternal(module_id) => {
+          star_re_exports_modules.insert(*module_id, true);
+        }
       };
     });
 
@@ -2250,7 +2291,7 @@ var {} = {{}};
 
     let entry_chunk_link = link.get_mut_unwrap(&entry_chunk);
 
-    for id in star_re_exports_modules {
+    for (id, render_before_source) in star_re_exports_modules {
       let external_module = module_graph
         .module_by_identifier(&id)
         .expect("should have module")
@@ -2259,11 +2300,19 @@ var {} = {{}};
       if external_module.resolve_external_type() != "module" {
         continue;
       }
+      let source = external_module.get_request().primary().to_string();
       entry_chunk_link
         .raw_star_exports
-        .entry(external_module.get_request().primary().into())
+        .entry(source.clone())
         .or_default()
         .insert(START_EXPORTS.clone());
+      if render_before_source {
+        entry_chunk_link
+          .raw_star_exports_before_source
+          .entry(source)
+          .or_default()
+          .insert(START_EXPORTS.clone());
+      }
     }
 
     if concate_modules_map[&entry_module].is_external() {
@@ -2295,7 +2344,7 @@ var {} = {{}};
 
     // Cache for resolve_re_export_star_from_unknown to avoid redundant
     // traversals of the same module's export * chains across entry modules.
-    let mut re_export_star_cache: IdentifierMap<FxIndexSet<Either<Atom, ModuleIdentifier>>> =
+    let mut re_export_star_cache: IdentifierMap<FxIndexSet<StarReExport>> =
       IdentifierMap::default();
 
     // we don't modify exports and imports in chunk_link directly unless,

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -616,23 +616,37 @@ var {} = {{}};
       final_source.add(RawStringSource::from(format!("{directive}\n")));
     }
     final_source.add(import_source.boxed());
-    final_source.add(render_init_fragments(
-      ConcatSource::new([
-        runtime_source.boxed(),
-        decl_source.boxed(),
-        render_source.boxed(),
-      ])
-      .boxed(),
-      chunk_init_fragments,
-      &mut ChunkRenderContext {},
-    )?);
+
+    let mut raw_star_content_before_source = String::new();
+    let mut raw_star_content_after_source = String::new();
+    for (source, export_names) in &chunk_link.raw_star_exports {
+      for name in export_names {
+        let content = if name == "*" {
+          format!(
+            "export * from {};\n",
+            rspack_util::json_stringify_str(source)
+          )
+        } else {
+          let name_str = export_name(name).expect("should have export_name");
+          format!(
+            "export * as {name_str} from {};\n",
+            rspack_util::json_stringify_str(source)
+          )
+        };
+        if chunk_link
+          .raw_star_exports_before_source
+          .get(source)
+          .is_some_and(|export_names| export_names.contains(name))
+        {
+          raw_star_content_before_source.push_str(&content);
+        } else {
+          raw_star_content_after_source.push_str(&content);
+        }
+      }
+    }
 
     let mut exports = chunk_link.exports().iter().collect::<Vec<_>>();
     exports.sort_by(|a, b| a.0.cmp(b.0));
-    for decl_before_export in chunk_link.decl_before_exports.iter() {
-      final_source.add(RawStringSource::from(decl_before_export.clone()));
-    }
-
     for (raw_symbol, exports) in exports {
       let mut exports = exports.iter().collect::<Vec<_>>();
       exports.sort_unstable();
@@ -666,11 +680,27 @@ var {} = {{}};
       }
     }
 
-    // Keep side-effect-only Node chunks explicitly in ESM form.
-    // We only emit `export {};` when the chunk would otherwise render no export syntax at all.
+    final_source.add(render_init_fragments(
+      ConcatSource::new([
+        RawStringSource::from(raw_star_content_before_source).boxed(),
+        runtime_source.boxed(),
+        decl_source.boxed(),
+        render_source.boxed(),
+      ])
+      .boxed(),
+      chunk_init_fragments,
+      &mut ChunkRenderContext {},
+    )?);
+
+    for decl_before_export in chunk_link.decl_before_exports.iter() {
+      final_source.add(RawStringSource::from(decl_before_export.clone()));
+    }
+
+    // Keep Node chunks without local export specifiers explicitly in ESM form.
+    // Raw star reexports are rendered above and do not replace this marker.
     let should_render_empty_export = compilation.platform.is_node()
       && export_specifiers.is_empty()
-      && chunk_link.raw_star_exports.is_empty()
+      && raw_star_content_after_source.is_empty()
       && chunk_link.re_exports().is_empty()
       && export_default.is_none();
 
@@ -687,22 +717,8 @@ var {} = {{}};
       final_source.add(RawStringSource::from(export_str));
     }
 
-    // render star exports
-    for (source, export_names) in &chunk_link.raw_star_exports {
-      for name in export_names {
-        if name == "*" {
-          final_source.add(RawStringSource::from(format!(
-            "export * from {};\n",
-            rspack_util::json_stringify_str(source)
-          )));
-        } else {
-          let name_str = export_name(name).expect("should have export_name");
-          final_source.add(RawStringSource::from(format!(
-            "export * as {name_str} from {};\n",
-            rspack_util::json_stringify_str(source)
-          )));
-        }
-      }
+    if !raw_star_content_after_source.is_empty() {
+      final_source.add(RawStringSource::from(raw_star_content_after_source));
     }
 
     // render re-exports

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -372,7 +372,7 @@ var {} = {{}};
         &mut already_required,
         runtime_template,
       ));
-      render_source.add(source);
+      render_source.add(RawStringSource::from(source));
       render_source.add(RawStringSource::from_static("\n"));
 
       chunk_init_fragments.extend(info.chunk_init_fragments.clone());
@@ -929,7 +929,7 @@ var {} = {{}};
   pub fn render_module(
     info: &ConcatenatedModuleInfo,
     chunk_link: &ChunkLinkContext,
-  ) -> Result<ReplaceSource> {
+  ) -> Result<String> {
     let Some(mut source) = info.source.clone() else {
       return Err(rspack_error::Error::error(format!(
         "module: {} has no source",
@@ -956,7 +956,6 @@ var {} = {{}};
             ident.id.span.real_lo(),
             ident.id.span.real_hi() + 2,
             name.into_owned(),
-            None,
           );
         }
       }
@@ -973,11 +972,13 @@ var {} = {{}};
         } else {
           internal_name.to_string()
         };
-        source.replace(ident.id.span.real_lo(), ident.id.span.real_hi(), name, None);
+        source.replace(ident.id.span.real_lo(), ident.id.span.real_hi(), name);
       }
     }
 
-    Ok(source)
+    let mut rendered = String::new();
+    source.render_into(&mut rendered);
+    Ok(rendered)
   }
 
   pub fn render_external_required(

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -41,7 +41,6 @@ slotmap                               = { workspace = true }
 smallvec                              = { workspace = true }
 sugar_path                            = { workspace = true }
 swc_atoms                             = { workspace = true }
-swc_core                              = { workspace = true, features = ["__ecma", "__parser", "__visit", "ecma_ast", "ecma_codegen", "ecma_parser", "swc_ecma_ast", "swc_ecma_codegen", "swc_ecma_visit"] }
 swc_experimental_allocator            = { workspace = true }
 swc_experimental_ecma_ast             = { workspace = true }
 swc_experimental_ecma_parser          = { workspace = true, features = ["unstable"] }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -41,6 +41,7 @@ slotmap                               = { workspace = true }
 smallvec                              = { workspace = true }
 sugar_path                            = { workspace = true }
 swc_atoms                             = { workspace = true }
+swc_core                              = { workspace = true, features = ["__ecma", "__parser", "__visit", "ecma_ast", "ecma_codegen", "ecma_parser", "swc_ecma_ast", "swc_ecma_codegen", "swc_ecma_visit"] }
 swc_experimental_allocator            = { workspace = true }
 swc_experimental_ecma_ast             = { workspace = true }
 swc_experimental_ecma_parser          = { workspace = true, features = ["unstable"] }

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
@@ -13,6 +13,9 @@ use rspack_util::{atom::Atom, json_stringify_str};
 
 use super::local_module::LocalModule;
 
+type AstDefineReplacement = (String, u32, u32);
+type AstDefineReplacements = (Option<String>, Vec<AstDefineReplacement>);
+
 bitflags! {
   #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
   struct Branch: u8 {
@@ -190,7 +193,7 @@ impl AMDDefineDependency {
   pub fn ast_define_replacements(
     &self,
     runtime_template: &mut ModuleCodeTemplate,
-  ) -> Option<(Option<String>, Vec<(String, u32, u32)>)> {
+  ) -> Option<AstDefineReplacements> {
     let branch = self.branch();
     if branch.is_empty() {
       return None;

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_define_dependency.rs
@@ -182,6 +182,65 @@ impl AMDDefineDependency {
   pub fn set_local_module(&mut self, local_module: LocalModule) {
     self.local_module = Some(local_module);
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn ast_define_replacements(
+    &self,
+    runtime_template: &mut ModuleCodeTemplate,
+  ) -> Option<(Option<String>, Vec<(String, u32, u32)>)> {
+    let branch = self.branch();
+    if branch.is_empty() {
+      return None;
+    }
+
+    let local_module_var = self.local_module_var();
+    let text = branch.get_content(&local_module_var, &self.named_module, runtime_template);
+    let definition = branch.get_definition(&local_module_var);
+    let mut texts = text.split('#');
+    let mut replacements = Vec::new();
+    let mut current = self.range.start;
+
+    if let Some(array_range) = self.array_range {
+      replacements.push((
+        texts.next().unwrap_or("").to_string(),
+        current,
+        array_range.start,
+      ));
+      current = array_range.end;
+    }
+
+    if let Some(object_range) = self.object_range {
+      replacements.push((
+        texts.next().unwrap_or("").to_string(),
+        current,
+        object_range.start,
+      ));
+      current = object_range.end;
+    } else if let Some(function_range) = self.function_range {
+      replacements.push((
+        texts.next().unwrap_or("").to_string(),
+        current,
+        function_range.start,
+      ));
+      current = function_range.end;
+    } else {
+      return None;
+    }
+
+    replacements.push((
+      texts.next().unwrap_or("").to_string(),
+      current,
+      self.range.end,
+    ));
+    if texts.next().is_some() {
+      return None;
+    }
+
+    Some(((!definition.is_empty()).then_some(definition), replacements))
+  }
 }
 
 #[cacheable_dyn]
@@ -244,6 +303,10 @@ impl AsContextDependency for AMDDefineDependency {}
 impl DependencyCodeGeneration for AMDDefineDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDDefineDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_array_dependency.rs
@@ -62,7 +62,7 @@ impl Dependency for AMDRequireArrayDependency {
 }
 
 impl AMDRequireArrayDependency {
-  fn get_content(&self, code_generatable_context: &mut TemplateContext) -> String {
+  pub fn content(&self, code_generatable_context: &mut TemplateContext) -> String {
     format!(
       "[{}]",
       self
@@ -108,6 +108,10 @@ impl AMDRequireArrayDependency {
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for AMDRequireArrayDependency {
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireArrayDependencyTemplate::template_type())
   }
@@ -141,7 +145,7 @@ impl DependencyTemplate for AMDRequireArrayDependencyTemplate {
         "AMDRequireArrayDependencyTemplate should only be used for AMDRequireArrayDependency",
       );
 
-    let content = dep.get_content(code_generatable_context);
+    let content = dep.content(code_generatable_context);
     source.replace(dep.range.start, dep.range.end, content, None);
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_dependency.rs
@@ -37,6 +37,22 @@ impl AMDRequireDependency {
       error_callback_bind_this: false,
     }
   }
+
+  pub fn outer_range(&self) -> DependencyRange {
+    self.outer_range
+  }
+
+  pub fn array_range(&self) -> Option<DependencyRange> {
+    self.array_range
+  }
+
+  pub fn function_range(&self) -> Option<DependencyRange> {
+    self.function_range
+  }
+
+  pub fn error_callback_range(&self) -> Option<DependencyRange> {
+    self.error_callback_range
+  }
 }
 
 #[cacheable_dyn]
@@ -70,6 +86,10 @@ impl AsContextDependency for AMDRequireDependency {}
 impl DependencyCodeGeneration for AMDRequireDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.outer_range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/amd_require_item_dependency.rs
@@ -31,6 +31,14 @@ impl AMDRequireItemDependency {
   pub fn set_optional(&mut self, optional: bool) {
     self.optional = optional;
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
 }
 
 #[cacheable_dyn]
@@ -81,6 +89,10 @@ impl AsContextDependency for AMDRequireItemDependency {}
 impl DependencyCodeGeneration for AMDRequireItemDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(AMDRequireItemDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    self.range
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
@@ -25,6 +25,17 @@ impl LocalModuleDependency {
       call_new,
     }
   }
+
+  pub fn module_instance(&self) -> String {
+    if self.call_new {
+      format!(
+        "new (function () {{ return {}; }})()",
+        self.local_module.variable_name()
+      )
+    } else {
+      self.local_module.variable_name().to_string()
+    }
+  }
 }
 
 #[cacheable_dyn]
@@ -46,6 +57,10 @@ impl Dependency for LocalModuleDependency {
 impl DependencyCodeGeneration for LocalModuleDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(LocalModuleDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    self.range
   }
 }
 
@@ -76,15 +91,7 @@ impl DependencyTemplate for LocalModuleDependencyTemplate {
       .expect("LocalModuleDependencyTemplate should only be used for LocalModuleDependency");
 
     if let Some(range) = &dep.range {
-      let module_instance = if dep.call_new {
-        format!(
-          "new (function () {{ return {}; }})()",
-          dep.local_module.variable_name()
-        )
-      } else {
-        dep.local_module.variable_name()
-      };
-      source.replace(range.start, range.end, module_instance, None);
+      source.replace(range.start, range.end, dep.module_instance(), None);
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/local_module_dependency.rs
@@ -33,7 +33,7 @@ impl LocalModuleDependency {
         self.local_module.variable_name()
       )
     } else {
-      self.local_module.variable_name().to_string()
+      self.local_module.variable_name()
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/amd/unsupported_dependency.rs
@@ -23,6 +23,13 @@ impl UnsupportedDependency {
       range,
     }
   }
+
+  pub fn content(&self) -> String {
+    format!(
+      "Object(function webpackMissingModule() {{var e = new Error(\"Cannot find module '{}'\"); e.code = 'MODULE_NOT_FOUND'; throw e;}}())",
+      self.request
+    )
+  }
 }
 
 #[cacheable_dyn]
@@ -53,6 +60,10 @@ impl DependencyCodeGeneration for UnsupportedDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(UnsupportedDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 impl AsModuleDependency for UnsupportedDependency {}
@@ -81,10 +92,6 @@ impl DependencyTemplate for UnsupportedDependencyTemplate {
       .downcast_ref::<UnsupportedDependency>()
       .expect("UnsupportedDependencyTemplate should only be used for UnsupportedDependency");
 
-    let content = format!(
-      "Object(function webpackMissingModule() {{var e = new Error(\"Cannot find module '{}'\"); e.code = 'MODULE_NOT_FOUND'; throw e;}}())",
-      dep.request
-    );
-    source.replace(dep.range.start, dep.range.end, content, None);
+    source.replace(dep.range.start, dep.range.end, dep.content(), None);
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -58,6 +58,22 @@ impl CommonJsExportRequireDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn base(&self) -> ExportsBase {
+    self.base
+  }
+
+  pub fn names(&self) -> &[Atom] {
+    &self.names
+  }
 }
 
 impl CommonJsExportRequireDependency {
@@ -418,6 +434,10 @@ impl AsContextDependency for CommonJsExportRequireDependency {}
 impl DependencyCodeGeneration for CommonJsExportRequireDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsExportRequireDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -80,6 +80,18 @@ impl CommonJsExportsDependency {
       names,
     }
   }
+
+  pub fn base(&self) -> ExportsBase {
+    self.base
+  }
+
+  pub fn names(&self) -> &[Atom] {
+    &self.names
+  }
+
+  pub fn value_range(&self) -> Option<DependencyRange> {
+    self.value_range
+  }
 }
 
 #[cacheable_dyn]
@@ -132,6 +144,10 @@ impl AsModuleDependency for CommonJsExportsDependency {}
 impl DependencyCodeGeneration for CommonJsExportsDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsExportsDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -54,6 +54,26 @@ impl CommonJsFullRequireDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn names(&self) -> &[Atom] {
+    &self.names
+  }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn asi_safe(&self) -> bool {
+    self.asi_safe
+  }
 }
 
 #[cacheable_dyn]
@@ -150,6 +170,10 @@ impl ModuleDependency for CommonJsFullRequireDependency {
 impl DependencyCodeGeneration for CommonJsFullRequireDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsFullRequireDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -94,6 +94,14 @@ impl CommonJsRequireDependency {
   pub fn add_branch_guards(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
     self.branch_guards.get_or_insert_default().extend(guards);
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
 }
 
 #[cacheable_dyn]
@@ -192,6 +200,10 @@ impl ModuleDependency for CommonJsRequireDependency {
 impl DependencyCodeGeneration for CommonJsRequireDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsRequireDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -43,6 +43,22 @@ impl CommonJsSelfReferenceDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn base(&self) -> ExportsBase {
+    self.base
+  }
+
+  pub fn names(&self) -> &[Atom] {
+    &self.names
+  }
+
+  pub fn names_optionals(&self) -> &[bool] {
+    &self.names_optionals
+  }
 }
 
 #[cacheable_dyn]
@@ -113,6 +129,10 @@ impl AsContextDependency for CommonJsSelfReferenceDependency {}
 impl DependencyCodeGeneration for CommonJsSelfReferenceDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CommonJsSelfReferenceDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -26,6 +26,10 @@ impl ModuleDecoratorDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn decorator(&self) -> RuntimeGlobals {
+    self.decorator
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_ensure_dependency.rs
@@ -27,6 +27,18 @@ impl RequireEnsureDependency {
       error_handler_range,
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn content_range(&self) -> DependencyRange {
+    self.content_range
+  }
+
+  pub fn error_handler_range(&self) -> Option<DependencyRange> {
+    self.error_handler_range
+  }
 }
 
 #[cacheable_dyn]
@@ -58,6 +70,10 @@ impl AsModuleDependency for RequireEnsureDependency {}
 impl DependencyCodeGeneration for RequireEnsureDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireEnsureDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -46,6 +46,10 @@ impl DependencyCodeGeneration for RequireHeaderDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireHeaderDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
@@ -23,6 +23,10 @@ impl DependencyCodeGeneration for RequireMainDependency {
     Some(RequireMainDependencyTemplate::template_type())
   }
 
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn update_hash(
     &self,
     hasher: &mut dyn std::hash::Hasher,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -133,6 +133,10 @@ impl DependencyCodeGeneration for RequireResolveDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireResolveDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 impl AsContextDependency for RequireResolveDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_header_dependency.rs
@@ -46,6 +46,10 @@ impl DependencyCodeGeneration for RequireResolveHeaderDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireResolveHeaderDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/amd_require_context_dependency.rs
@@ -36,6 +36,10 @@ impl AMDRequireContextDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -61,6 +61,14 @@ impl CommonJsRequireContextDependency {
       &self.options,
     );
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn value_range(&self) -> Option<DependencyRange> {
+    self.value_range
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -59,6 +59,14 @@ impl ImportContextDependency {
     self.options.referenced_specifiers = Some(referenced_specifiers);
     self.resource_identifier = create_resource_identifier(&self.options);
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn value_range(&self) -> DependencyRange {
+    self.value_range
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -73,6 +73,18 @@ impl ImportMetaContextDependency {
       ImportMetaContextDependencyKind::Glob => DependencyType::ImportMetaGlob,
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.options.request
+  }
+
+  pub fn optional(&self) -> bool {
+    self.optional
+  }
 }
 
 #[cacheable_dyn]
@@ -158,6 +170,10 @@ impl DependencyCodeGeneration for ImportMetaContextDependency {
     Some(DependencyTemplateType::Dependency(
       self.dependency_type_value(),
     ))
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_resolve_context_dependency.rs
@@ -34,6 +34,10 @@ impl ImportMetaResolveContextDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -34,6 +34,18 @@ impl RequireContextDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.options.request
+  }
+
+  pub fn optional(&self) -> bool {
+    self.optional
+  }
 }
 
 #[cacheable_dyn]
@@ -117,6 +129,10 @@ impl ContextDependency for RequireContextDependency {
 impl DependencyCodeGeneration for RequireContextDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(RequireContextDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_resolve_context_dependency.rs
@@ -45,6 +45,10 @@ impl RequireResolveContextDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/context/url_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/url_context_dependency.rs
@@ -43,6 +43,14 @@ impl URLContextDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn value_range(&self) -> DependencyRange {
+    self.value_range
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -36,6 +36,18 @@ impl DeclarationInfo {
       suffix,
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn prefix(&self) -> &str {
+    &self.prefix
+  }
+
+  pub fn suffix(&self) -> &str {
+    &self.suffix
+  }
 }
 
 #[cacheable]
@@ -68,6 +80,22 @@ impl ESMExportExpressionDependency {
       prefix,
       loc,
     }
+  }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn range_stmt(&self) -> DependencyRange {
+    self.range_stmt
+  }
+
+  pub fn prefix(&self) -> &str {
+    &self.prefix
+  }
+
+  pub fn declaration(&self) -> Option<&DeclarationId> {
+    self.declaration.as_ref()
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_header_dependency.rs
@@ -30,6 +30,14 @@ impl ESMExportHeaderDependency {
       id: DependencyId::default(),
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn range_decl(&self) -> Option<DependencyRange> {
+    self.range_decl
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -132,6 +132,10 @@ impl ESMExportImportedSpecifierDependency {
     self.phase
   }
 
+  pub fn source_order(&self) -> i32 {
+    self.source_order
+  }
+
   pub fn get_mode(
     &self,
     module_graph: &ModuleGraph,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -128,6 +128,10 @@ impl ESMExportImportedSpecifierDependency {
       .map_or_else(|| self.ids.as_slice(), |meta| meta.ids.as_slice())
   }
 
+  pub fn phase(&self) -> ImportPhase {
+    self.phase
+  }
+
   pub fn get_mode(
     &self,
     module_graph: &ModuleGraph,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -46,6 +46,22 @@ impl ESMExportSpecifierDependency {
       id: DependencyId::new(),
     }
   }
+
+  pub fn name(&self) -> &Atom {
+    &self.name
+  }
+
+  pub fn value(&self) -> &Atom {
+    &self.value
+  }
+
+  pub fn const_value(&self) -> Option<&ConstValue> {
+    self.const_value.as_ref()
+  }
+
+  pub fn enum_value(&self) -> Option<&TSEnumValue> {
+    self.enum_value.as_ref()
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -146,9 +146,7 @@ pub fn esm_import_dependency_prime_import_var<T: ModuleDependency>(
 
   let target_module = module_graph.get_module_by_dependency_id(module_dependency.id());
   if module_dependency.weak() {
-    if target_module.is_none() {
-      return None;
-    }
+    target_module?;
     if let Some(target_module) = target_module
       && ChunkGraph::get_module_id(&compilation.module_ids_artifact, target_module.identifier())
         .is_none()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -103,9 +103,67 @@ impl ESMImportSideEffectDependency {
     }
   }
 
-  fn missing_module_active(&self) -> bool {
+  pub fn missing_module_active(&self) -> bool {
     !self.lazy_make
   }
+
+  pub fn phase(&self) -> ImportPhase {
+    self.phase
+  }
+
+  pub fn source_order(&self) -> i32 {
+    self.source_order
+  }
+}
+
+pub fn esm_import_dependency_prime_import_var<T: ModuleDependency>(
+  module_dependency: &T,
+  phase: ImportPhase,
+  code_generatable_context: &TemplateContext,
+) -> Option<String> {
+  let compilation = code_generatable_context.compilation;
+  let module = code_generatable_context.module;
+  let runtime = code_generatable_context.runtime;
+  let module_graph = compilation.get_module_graph();
+  let module_graph_cache = &compilation.module_graph_cache_artifact;
+  let connection = module_graph.connection_by_dependency_id(module_dependency.id());
+  let is_target_active = if let Some(con) = connection {
+    con.is_target_active(
+      module_graph,
+      runtime,
+      module_graph_cache,
+      &compilation
+        .build_module_graph_artifact
+        .side_effects_state_artifact,
+      &compilation.exports_info_artifact,
+    )
+  } else {
+    true
+  };
+  if !is_target_active {
+    return None;
+  }
+
+  let target_module = module_graph.get_module_by_dependency_id(module_dependency.id());
+  if module_dependency.weak() {
+    if target_module.is_none() {
+      return None;
+    }
+    if let Some(target_module) = target_module
+      && ChunkGraph::get_module_id(&compilation.module_ids_artifact, target_module.identifier())
+        .is_none()
+    {
+      return None;
+    }
+  }
+
+  Some(compilation.get_import_var(
+    module.identifier(),
+    target_module,
+    module_dependency.user_request(),
+    phase,
+    runtime,
+  ))
 }
 
 pub fn esm_import_dependency_apply<T: ModuleDependency>(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -176,6 +176,28 @@ impl ESMImportSpecifierDependency {
   pub fn add_branch_guards(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
     self.branch_guards.get_or_insert_default().extend(guards);
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
+  pub fn shorthand(&self) -> bool {
+    self.shorthand
+  }
+
+  pub fn has_referenced_properties_in_destructuring(&self) -> bool {
+    self.referenced_properties_in_destructuring.is_some()
+  }
+
+  pub fn referenced_properties_in_destructuring(
+    &self,
+  ) -> Option<&DestructuringAssignmentProperties> {
+    self.referenced_properties_in_destructuring.as_ref()
+  }
 }
 
 #[cacheable_dyn]
@@ -411,7 +433,7 @@ impl ESMImportSpecifierDependencyTemplate {
     DependencyTemplateType::Dependency(DependencyType::EsmImportSpecifier)
   }
 
-  fn get_code_for_ids(
+  pub(crate) fn get_code_for_ids(
     &self,
     ids: &[Atom],
     dep: &ESMImportSpecifierDependency,
@@ -514,17 +536,14 @@ impl ESMImportSpecifierDependencyTemplate {
     }
   }
 
-  fn render_evaluated_in_operator(
+  pub(crate) fn get_evaluated_in_operator_code(
     &self,
     ids: &[Atom],
     dep: &ESMImportSpecifierDependency,
     connection: Option<&ModuleGraphConnection>,
-    source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
-  ) {
-    let Some(con) = connection else {
-      return;
-    };
+  ) -> Option<String> {
+    let con = connection?;
     let TemplateContext {
       runtime,
       module: self_module,
@@ -532,9 +551,7 @@ impl ESMImportSpecifierDependencyTemplate {
     } = code_generatable_context;
     let compilation = code_generatable_context.compilation;
     let mg = compilation.get_module_graph();
-    let Some(module) = mg.get_module_by_dependency_id(&dep.id) else {
-      return;
-    };
+    let module = mg.get_module_by_dependency_id(&dep.id)?;
     let exports_info = compilation
       .exports_info_artifact
       .get_exports_info_data(con.module_identifier());
@@ -580,12 +597,8 @@ impl ESMImportSpecifierDependencyTemplate {
       ExportsType::DefaultOnly => None,
     };
     match value {
-      Some(ExportProvided::Provided) => {
-        source.replace_static(dep.range.start, dep.range.end, " true", None);
-      }
-      Some(ExportProvided::NotProvided) => {
-        source.replace_static(dep.range.start, dep.range.end, " false", None)
-      }
+      Some(ExportProvided::Provided) => Some(" true".to_string()),
+      Some(ExportProvided::NotProvided) => Some(" false".to_string()),
       _ => {
         let used_name_ids = if matches!(exports_type, ExportsType::DefaultWithNamed)
           && first == "default"
@@ -595,28 +608,38 @@ impl ESMImportSpecifierDependencyTemplate {
         } else {
           ids
         };
-        let Some(used_name) = exports_info
+        let used_name = exports_info
           .get_used_name(&compilation.exports_info_artifact, *runtime, used_name_ids)
           .and_then(|used_name| match used_name {
             UsedName::Normal(names) => names.last().cloned(),
             UsedName::Inlined(_) => unreachable!("Inlined must be provided"),
-          })
-        else {
-          return;
-        };
+          })?;
         let code = self.get_code_for_ids(
           &ids[..(ids.len() - 1)],
           dep,
           connection,
           code_generatable_context,
         );
-        source.replace(
-          dep.range.start,
-          dep.range.end,
-          format!("{} in {code}", json_stringify_str(used_name.as_str())),
-          None,
-        )
+        Some(format!(
+          "{} in {code}",
+          json_stringify_str(used_name.as_str())
+        ))
       }
+    }
+  }
+
+  fn render_evaluated_in_operator(
+    &self,
+    ids: &[Atom],
+    dep: &ESMImportSpecifierDependency,
+    connection: Option<&ModuleGraphConnection>,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    if let Some(code) =
+      self.get_evaluated_in_operator_code(ids, dep, connection, code_generatable_context)
+    {
+      source.replace(dep.range.start, dep.range.end, code, None);
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -26,6 +26,18 @@ impl ExternalModuleDependency {
       default_import,
     }
   }
+
+  pub fn module(&self) -> &str {
+    &self.module
+  }
+
+  pub fn import_specifier(&self) -> &[(String, String)] {
+    &self.import_specifier
+  }
+
+  pub fn default_import(&self) -> Option<&String> {
+    self.default_import.as_ref()
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -70,6 +70,18 @@ impl ImportDependency {
   pub fn add_branch_guards(&mut self, guards: impl IntoIterator<Item = DependencyBranchGuard>) {
     self.branch_guards.get_or_insert_default().extend(guards);
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn phase(&self) -> ImportPhase {
+    self.phase
+  }
 }
 
 #[cacheable_dyn]
@@ -172,6 +184,10 @@ impl ModuleDependency for ImportDependency {
 impl DependencyCodeGeneration for ImportDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -53,6 +53,18 @@ impl ImportEagerDependency {
   pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
     self.referenced_specifiers = Some(referenced_specifiers);
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn phase(&self) -> ImportPhase {
+    self.phase
+  }
 }
 
 #[cacheable_dyn]
@@ -147,6 +159,10 @@ impl ModuleDependency for ImportEagerDependency {
 impl DependencyCodeGeneration for ImportEagerDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportEagerDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_resolve_dependency.rs
@@ -89,6 +89,10 @@ impl DependencyCodeGeneration for ImportMetaResolveDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaResolveDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 impl AsContextDependency for ImportMetaResolveDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_resolve_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_resolve_header_dependency.rs
@@ -46,6 +46,10 @@ impl DependencyCodeGeneration for ImportMetaResolveHeaderDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaResolveHeaderDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
@@ -105,6 +105,10 @@ impl ModuleDependency for ImportMetaRscDependency {
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ImportMetaRscDependency {
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    self.range
+  }
+
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaRscDependencyTemplate::template_type())
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
@@ -45,6 +45,10 @@ impl ImportMetaRscDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn importer(&self) -> &str {
+    &self.importer
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
@@ -58,6 +58,18 @@ impl ImportWeakDependency {
   pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
     self.referenced_specifiers = Some(referenced_specifiers);
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn phase(&self) -> ImportPhase {
+    self.phase
+  }
 }
 
 #[cacheable_dyn]
@@ -160,6 +172,10 @@ impl ModuleDependency for ImportWeakDependency {
 impl DependencyCodeGeneration for ImportWeakDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportWeakDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
   },
   esm_import_dependency::{
     ESMImportSideEffectDependency, ESMImportSideEffectDependencyTemplate,
-    esm_import_dependency_apply, import_emitted_runtime,
+    esm_import_dependency_apply, esm_import_dependency_prime_import_var, import_emitted_runtime,
   },
   esm_import_specifier_dependency::{
     ESMImportSpecifierDependency, ESMImportSpecifierDependencyTemplate,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -45,6 +45,10 @@ impl ProvideDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn identifier(&self) -> &str {
+    &self.identifier
+  }
 }
 
 #[cacheable_dyn]
@@ -107,6 +111,10 @@ impl ModuleDependency for ProvideDependency {
 impl DependencyCodeGeneration for ProvideDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ProvideDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn update_hash(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -49,6 +49,10 @@ impl ProvideDependency {
   pub fn identifier(&self) -> &str {
     &self.identifier
   }
+
+  pub fn ids(&self) -> &[Atom] {
+    &self.ids
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_dependency.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, ExportProvided,
-  TemplateContext, TemplateReplaceSource, UsageState, UsedExports, UsedName,
+  DependencyCodeGeneration, DependencyRange, DependencyTemplate, DependencyTemplateType,
+  ExportProvided, TemplateContext, TemplateReplaceSource, UsageState, UsedExports, UsedName,
 };
 use swc_atoms::Atom;
 
@@ -29,6 +29,10 @@ impl ExportInfoDependency {
       property,
     }
   }
+
+  pub fn range(&self) -> DependencyRange {
+    DependencyRange::new(self.start, self.end)
+  }
 }
 
 #[cacheable_dyn]
@@ -36,10 +40,14 @@ impl DependencyCodeGeneration for ExportInfoDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ExportInfoDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range())
+  }
 }
 
 impl ExportInfoDependency {
-  fn get_property(&self, context: &TemplateContext) -> Option<String> {
+  pub fn get_property(&self, context: &TemplateContext) -> Option<String> {
     let TemplateContext {
       compilation,
       module,

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/esm_accept_dependency.rs
@@ -10,6 +10,7 @@ use crate::dependency::import_emitted_runtime;
 #[derive(Debug, Clone)]
 pub struct ESMAcceptDependency {
   range: DependencyRange,
+  call_range: DependencyRange,
   has_callback: bool,
   dependency_ids: Vec<DependencyId>,
   loc: Option<DependencyLocation>,
@@ -18,12 +19,14 @@ pub struct ESMAcceptDependency {
 impl ESMAcceptDependency {
   pub fn new(
     range: DependencyRange,
+    call_range: DependencyRange,
     has_callback: bool,
     dependency_ids: Vec<DependencyId>,
     loc: Option<DependencyLocation>,
   ) -> Self {
     Self {
       range,
+      call_range,
       has_callback,
       dependency_ids,
       loc,
@@ -33,12 +36,36 @@ impl ESMAcceptDependency {
   pub fn loc(&self) -> Option<DependencyLocation> {
     self.loc.clone()
   }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn call_range(&self) -> DependencyRange {
+    self.call_range
+  }
+
+  pub fn has_callback(&self) -> bool {
+    self.has_callback
+  }
+
+  pub fn dependency_ids(&self) -> &[DependencyId] {
+    &self.dependency_ids
+  }
 }
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ESMAcceptDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ESMAcceptDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(if self.has_callback {
+      self.range
+    } else {
+      self.call_range
+    })
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -25,6 +25,18 @@ impl ImportMetaHotAcceptDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn weak(&self) -> bool {
+    true
+  }
 }
 
 #[cacheable_dyn]
@@ -75,6 +87,10 @@ impl ModuleDependency for ImportMetaHotAcceptDependency {
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ImportMetaHotAcceptDependency {
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaHotAcceptDependencyTemplate::template_type())
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -25,6 +25,18 @@ impl ImportMetaHotDeclineDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn weak(&self) -> bool {
+    true
+  }
 }
 
 #[cacheable_dyn]
@@ -75,6 +87,10 @@ impl ModuleDependency for ImportMetaHotDeclineDependency {
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ImportMetaHotDeclineDependency {
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ImportMetaHotDeclineDependencyTemplate::template_type())
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -25,6 +25,18 @@ impl ModuleHotAcceptDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn weak(&self) -> bool {
+    true
+  }
 }
 
 #[cacheable_dyn]
@@ -75,6 +87,10 @@ impl ModuleDependency for ModuleHotAcceptDependency {
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ModuleHotAcceptDependency {
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleHotAcceptDependencyTemplate::template_type())
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -25,6 +25,18 @@ impl ModuleHotDeclineDependency {
       factorize_info: Default::default(),
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn weak(&self) -> bool {
+    true
+  }
 }
 
 #[cacheable_dyn]
@@ -75,6 +87,10 @@ impl ModuleDependency for ModuleHotDeclineDependency {
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ModuleHotDeclineDependency {
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleHotDeclineDependencyTemplate::template_type())
   }

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -81,6 +81,10 @@ impl DependencyCodeGeneration for IsIncludeDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(IsIncludedDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -21,12 +21,24 @@ impl ModuleArgumentDependency {
   pub fn loc(&self) -> Option<DependencyLocation> {
     self.loc.clone()
   }
+
+  pub fn id(&self) -> Option<&str> {
+    self.id.as_deref()
+  }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
 }
 
 #[cacheable_dyn]
 impl DependencyCodeGeneration for ModuleArgumentDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(ModuleArgumentDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn update_hash(

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -30,7 +30,7 @@ impl PureExpressionDependency {
     }
   }
 
-  fn get_runtime_condition(
+  pub fn get_runtime_condition(
     &self,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
@@ -80,6 +80,10 @@ impl AsModuleDependency for PureExpressionDependency {}
 impl DependencyCodeGeneration for PureExpressionDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(PureExpressionDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
   }
 
   fn update_hash(

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -48,6 +48,26 @@ impl URLDependency {
   pub fn set_used_by_exports(&mut self, used_by_exports: Option<UsedByExports>) {
     self.used_by_exports = used_by_exports;
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn range(&self) -> DependencyRange {
+    self.range
+  }
+
+  pub fn range_url(&self) -> DependencyRange {
+    self.range_url
+  }
+
+  pub fn mode(&self) -> Option<JavascriptParserUrl> {
+    self.mode
+  }
 }
 
 #[cacheable_dyn]
@@ -100,6 +120,13 @@ impl ModuleDependency for URLDependency {
 impl DependencyCodeGeneration for URLDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(URLDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    match self.mode {
+      Some(JavascriptParserUrl::Relative | JavascriptParserUrl::NewUrlRelative) => Some(self.range),
+      _ => None,
+    }
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/create_script_url_dependency.rs
@@ -21,6 +21,10 @@ impl CreateScriptUrlDependency {
       range_path,
     }
   }
+
+  pub fn range_path(&self) -> DependencyRange {
+    self.range_path
+  }
 }
 
 #[cacheable_dyn]
@@ -50,6 +54,10 @@ impl Dependency for CreateScriptUrlDependency {
 impl DependencyCodeGeneration for CreateScriptUrlDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(CreateScriptUrlDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range_path)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -41,6 +41,26 @@ impl WorkerDependency {
       need_new_url,
     }
   }
+
+  pub fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  pub fn request(&self) -> &str {
+    &self.request
+  }
+
+  pub fn public_path(&self) -> &str {
+    &self.public_path
+  }
+
+  pub fn range_path(&self) -> DependencyRange {
+    self.range_path
+  }
+
+  pub fn need_new_url(&self) -> bool {
+    self.need_new_url
+  }
 }
 
 #[cacheable_dyn]
@@ -99,6 +119,10 @@ impl ModuleDependency for WorkerDependency {
 impl DependencyCodeGeneration for WorkerDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(WorkerDependencyTemplate::template_type())
+  }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range_path)
   }
 
   fn update_hash(

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -5,6 +5,7 @@ use rspack_core::{
   NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 use rustc_hash::FxHashSet;
+use swc_atoms::Atom;
 use swc_experimental_allocator::{Allocator, boxed::Box as AstBox, vec::Vec as AstVec};
 use swc_experimental_ecma_ast::{
   EsVersion, Expr, GetSpan, Ident, Lit, MemberExpr, ModuleItem, Program, PropName, Stmt, VisitMut,
@@ -18,6 +19,11 @@ pub enum AstDependencySideEffect {
   CachedConst {
     identifier: Box<str>,
     content: Box<str>,
+  },
+  CommonJsExportsVar(Box<str>),
+  ProvidedDependency {
+    identifier: Box<str>,
+    expression: Box<str>,
   },
 }
 
@@ -41,6 +47,34 @@ impl AstDependencySideEffect {
           InitFragmentKey::Const(identifier.to_string()),
           None,
         )
+        .boxed(),
+      ),
+      Self::CommonJsExportsVar(identifier) => context.init_fragments.push(
+        NormalInitFragment::new(
+          format!("var {};\n", identifier.as_ref()),
+          InitFragmentStage::StageConstants,
+          0,
+          InitFragmentKey::CommonJsExports(identifier.to_string()),
+          None,
+        )
+        .boxed(),
+      ),
+      Self::ProvidedDependency {
+        identifier,
+        expression,
+      } => context.init_fragments.push(
+        NormalInitFragment::new(
+          format!(
+            "/* provided dependency */ var {} = {};\n",
+            identifier.as_ref(),
+            expression.as_ref()
+          ),
+          InitFragmentStage::StageProvides,
+          1,
+          InitFragmentKey::ModuleExternal(format!("provided {}", identifier.as_ref())),
+          None,
+        )
+        .with_top_level_decl_symbols(vec![Atom::from(identifier.as_ref())])
         .boxed(),
       ),
     }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -1,11 +1,9 @@
 use std::{borrow::Cow, sync::Arc};
 
 use rspack_core::{
-  DependencyCodeGeneration, DependencyId, DependencyRange, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, ModuleType, NormalInitFragment, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  DependencyRange, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleType,
+  NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
-use rspack_util::SpanExt;
 use rustc_hash::FxHashSet;
 use swc_core::{
   common::{
@@ -25,46 +23,6 @@ use swc_core::{
     visit::{VisitMut, VisitMutWith},
   },
 };
-use swc_experimental_allocator::Allocator;
-use swc_experimental_ecma_ast::{
-  Expr as ExperimentalExpr, GetSpan, Ident, Lit, MemberExpr, ModuleDecl, ModuleItem, Program, Stmt,
-  Str, Visit, VisitWith,
-};
-use swc_experimental_ecma_parser::{EsSyntax, Lexer, Parser, StringSource, Syntax};
-
-#[derive(Debug, Clone, Copy)]
-pub enum AstDependencyRenderKey {
-  Dependency(DependencyId),
-  Presentational(usize),
-}
-
-pub struct AstDependencyRenderEntry {
-  pub key: AstDependencyRenderKey,
-  range: DependencyRange,
-  applied: bool,
-}
-
-impl AstDependencyRenderEntry {
-  pub fn new(
-    key: AstDependencyRenderKey,
-    dependency: &dyn DependencyCodeGeneration,
-  ) -> Option<Self> {
-    let range = dependency.ast_dependency_range()?;
-    if range.start >= range.end {
-      return None;
-    }
-
-    Some(Self {
-      key,
-      range,
-      applied: false,
-    })
-  }
-
-  pub fn applied(&self) -> bool {
-    self.applied
-  }
-}
 
 #[derive(Debug, Clone)]
 pub enum AstDependencySideEffect {
@@ -73,7 +31,6 @@ pub enum AstDependencySideEffect {
     identifier: Box<str>,
     content: Box<str>,
   },
-  RenderTemplate(AstDependencyRenderKey),
 }
 
 impl AstDependencySideEffect {
@@ -98,7 +55,6 @@ impl AstDependencySideEffect {
         )
         .boxed(),
       ),
-      Self::RenderTemplate(_) => {}
     }
   }
 }
@@ -787,7 +743,7 @@ pub fn render_ast_dependencies(
   plan: &AstDependencyRenderPlan,
 ) -> Option<String> {
   if !plan.has_actions() {
-    return None;
+    return Some(source_text.to_string());
   }
 
   validate_ast_dependency_actions(source_text, module_type, &plan.actions)?;
@@ -958,114 +914,6 @@ fn push_source_replacement(
   replacements.push((range, content));
 }
 
-struct AstDependencyMarker<'a> {
-  entries: &'a mut [AstDependencyRenderEntry],
-}
-
-impl AstDependencyMarker<'_> {
-  fn mark_span(&mut self, span: swc_experimental_ecma_ast::Span) {
-    let range = DependencyRange::new(span.real_lo(), span.real_hi());
-    if range.start >= range.end {
-      return;
-    }
-
-    for entry in self.entries.iter_mut() {
-      if !entry.applied && entry.range == range {
-        entry.applied = true;
-      }
-    }
-  }
-}
-
-impl<'ast> Visit<'ast> for AstDependencyMarker<'_> {
-  fn visit_module_item(&mut self, node: &ModuleItem<'ast>) {
-    self.mark_span(node.span());
-    node.visit_children_with(self);
-  }
-
-  fn visit_module_decl(&mut self, node: &ModuleDecl<'ast>) {
-    self.mark_span(node.span());
-    node.visit_children_with(self);
-  }
-
-  fn visit_stmt(&mut self, node: &Stmt<'ast>) {
-    self.mark_span(node.span());
-    node.visit_children_with(self);
-  }
-
-  fn visit_expr(&mut self, node: &ExperimentalExpr<'ast>) {
-    self.mark_span(node.span());
-    node.visit_children_with(self);
-  }
-
-  fn visit_member_expr(&mut self, node: &MemberExpr<'ast>) {
-    self.mark_span(node.span());
-    node.visit_children_with(self);
-  }
-
-  fn visit_ident(&mut self, node: &Ident<'ast>) {
-    self.mark_span(node.span);
-    node.visit_children_with(self);
-  }
-
-  fn visit_lit(&mut self, node: &Lit<'ast>) {
-    self.mark_span(node.span());
-    node.visit_children_with(self);
-  }
-
-  fn visit_str(&mut self, node: &Str<'ast>) {
-    self.mark_span(node.span);
-    node.visit_children_with(self);
-  }
-}
-
-pub fn mark_ast_dependencies(
-  source_text: &str,
-  module_type: &ModuleType,
-  entries: &mut [AstDependencyRenderEntry],
-) -> bool {
-  let allocator = Allocator::new();
-  let mut comments = Default::default();
-  let lexer = Lexer::new(
-    &allocator,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      allow_return_outside_function: matches!(
-        module_type,
-        ModuleType::JsDynamic | ModuleType::JsAuto
-      ),
-      explicit_resource_management: true,
-      import_attributes: true,
-      ..Default::default()
-    }),
-    swc_experimental_ecma_ast::EsVersion::EsNext,
-    StringSource::new(source_text),
-    Some(&mut comments),
-  );
-  let mut parser = Parser::new_from(&allocator, lexer);
-
-  let program = match match module_type {
-    ModuleType::JsEsm => parser
-      .parse_module()
-      .map(|module| Program::Module(allocator.boxed(module))),
-    ModuleType::JsDynamic => parser
-      .parse_commonjs()
-      .map(|script| Program::Script(allocator.boxed(script))),
-    _ => parser.parse_program(),
-  } {
-    Ok(program) => program,
-    Err(_) => return false,
-  };
-
-  if !parser.take_errors().is_empty() {
-    return false;
-  }
-  drop(parser);
-
-  program.visit_with(&mut AstDependencyMarker { entries });
-  true
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -1095,6 +943,16 @@ mod tests {
       };
       DependencyRange::from(if_stmt.cons.span())
     })
+  }
+
+  #[test]
+  fn renders_original_source_for_empty_plan() {
+    let source = "console.log(1);\n";
+    let plan = AstDependencyRenderPlan::default();
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, source);
   }
 
   #[test]

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -1,0 +1,1417 @@
+use std::{borrow::Cow, sync::Arc};
+
+use rspack_core::{
+  DependencyCodeGeneration, DependencyId, DependencyRange, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, ModuleType, NormalInitFragment, RuntimeGlobals, TemplateContext,
+  TemplateReplaceSource,
+};
+use rspack_util::SpanExt;
+use rustc_hash::FxHashSet;
+use swc_core::{
+  common::{
+    FileName, GLOBALS, Globals, SourceMap, Spanned, comments::SingleThreadedComments,
+    input::SourceFileInput,
+  },
+  ecma::{
+    ast::{
+      EsVersion as StableEsVersion, Expr, Ident as StableIdent, Lit as StableLit,
+      ModuleItem as StableModuleItem, Program as StableProgram, PropName as StablePropName,
+      Stmt as StableStmt,
+    },
+    parser::{
+      EsSyntax as StableEsSyntax, Parser as StableParser, Syntax as StableSyntax,
+      lexer::Lexer as StableLexer,
+    },
+    visit::{VisitMut, VisitMutWith},
+  },
+};
+use swc_experimental_allocator::Allocator;
+use swc_experimental_ecma_ast::{
+  Expr as ExperimentalExpr, GetSpan, Ident, Lit, MemberExpr, ModuleDecl, ModuleItem, Program, Stmt,
+  Str, Visit, VisitWith,
+};
+use swc_experimental_ecma_parser::{EsSyntax, Lexer, Parser, StringSource, Syntax};
+
+#[derive(Debug, Clone, Copy)]
+pub enum AstDependencyRenderKey {
+  Dependency(DependencyId),
+  Presentational(usize),
+}
+
+pub struct AstDependencyRenderEntry {
+  pub key: AstDependencyRenderKey,
+  range: DependencyRange,
+  applied: bool,
+}
+
+impl AstDependencyRenderEntry {
+  pub fn new(
+    key: AstDependencyRenderKey,
+    dependency: &dyn DependencyCodeGeneration,
+  ) -> Option<Self> {
+    let range = dependency.ast_dependency_range()?;
+    if range.start >= range.end {
+      return None;
+    }
+
+    Some(Self {
+      key,
+      range,
+      applied: false,
+    })
+  }
+
+  pub fn applied(&self) -> bool {
+    self.applied
+  }
+}
+
+#[derive(Debug, Clone)]
+pub enum AstDependencySideEffect {
+  RuntimeRequirements(RuntimeGlobals),
+  CachedConst {
+    identifier: Box<str>,
+    content: Box<str>,
+  },
+  RenderTemplate(AstDependencyRenderKey),
+}
+
+impl AstDependencySideEffect {
+  pub fn apply(&self, context: &mut TemplateContext<'_, '_, '_>) {
+    match self {
+      Self::RuntimeRequirements(runtime_requirements) => {
+        context
+          .runtime_template
+          .runtime_requirements_mut()
+          .insert(*runtime_requirements);
+      }
+      Self::CachedConst {
+        identifier,
+        content,
+      } => context.init_fragments.push(
+        NormalInitFragment::new(
+          format!("var {identifier} = {content};\n"),
+          InitFragmentStage::StageConstants,
+          0,
+          InitFragmentKey::Const(identifier.to_string()),
+          None,
+        )
+        .boxed(),
+      ),
+      Self::RenderTemplate(_) => {}
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct AstDependencyAction {
+  range: DependencyRange,
+  replacement: AstDependencyReplacement,
+}
+
+#[derive(Debug, Clone)]
+enum AstDependencyReplacement {
+  Generated(Box<str>),
+  RawExpr(Box<str>),
+  RawIdent(Box<str>),
+  RawIdentWithSuffix(Box<str>),
+  Insert {
+    position: u32,
+    content: Box<str>,
+  },
+  WrappedSource {
+    replacement: DependencyRange,
+    prefix: Box<str>,
+    suffix: Box<str>,
+  },
+  WrappedSourceWithReplacements {
+    replacement: DependencyRange,
+    prefix: Box<str>,
+    suffix: Box<str>,
+    replacements: Vec<(Box<str>, u32, u32)>,
+  },
+  ValidatedReplacements {
+    replacements: Vec<(Box<str>, u32, u32)>,
+  },
+  SourceWithReplacements {
+    replacement: DependencyRange,
+    replacements: Vec<(Box<str>, u32, u32)>,
+  },
+}
+
+impl AstDependencyAction {
+  pub fn expr(range: DependencyRange, content: impl Into<Box<str>>) -> Option<Self> {
+    if range.start >= range.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::Generated(content.into()),
+    })
+  }
+
+  pub fn raw_expr(range: DependencyRange, content: impl Into<Box<str>>) -> Option<Self> {
+    if range.start >= range.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::RawExpr(content.into()),
+    })
+  }
+
+  pub fn raw_ident(range: DependencyRange, content: impl Into<Box<str>>) -> Option<Self> {
+    if range.start >= range.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::RawIdent(content.into()),
+    })
+  }
+
+  pub fn raw_ident_with_suffix(
+    range: DependencyRange,
+    suffix: impl Into<Box<str>>,
+  ) -> Option<Self> {
+    if range.start >= range.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::RawIdentWithSuffix(suffix.into()),
+    })
+  }
+
+  pub fn insert(
+    validate_range: DependencyRange,
+    position: u32,
+    content: impl Into<Box<str>>,
+  ) -> Option<Self> {
+    if validate_range.start >= validate_range.end {
+      return None;
+    }
+
+    Some(Self {
+      range: validate_range,
+      replacement: AstDependencyReplacement::Insert {
+        position,
+        content: content.into(),
+      },
+    })
+  }
+
+  pub fn wrapped_source(
+    range: DependencyRange,
+    replacement: DependencyRange,
+    prefix: impl Into<Box<str>>,
+    suffix: impl Into<Box<str>>,
+  ) -> Option<Self> {
+    if range.start >= range.end || replacement.start > replacement.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::WrappedSource {
+        replacement,
+        prefix: prefix.into(),
+        suffix: suffix.into(),
+      },
+    })
+  }
+
+  pub fn wrapped_source_with_replacements(
+    range: DependencyRange,
+    replacement: DependencyRange,
+    prefix: impl Into<Box<str>>,
+    suffix: impl Into<Box<str>>,
+    replacements: Vec<(String, u32, u32)>,
+  ) -> Option<Self> {
+    if range.start >= range.end || replacement.start > replacement.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::WrappedSourceWithReplacements {
+        replacement,
+        prefix: prefix.into(),
+        suffix: suffix.into(),
+        replacements: replacements
+          .into_iter()
+          .map(|(content, start, end)| (content.into_boxed_str(), start, end))
+          .collect(),
+      },
+    })
+  }
+
+  pub fn source_with_replacements(
+    range: DependencyRange,
+    replacement: DependencyRange,
+    replacements: Vec<(String, u32, u32)>,
+  ) -> Option<Self> {
+    if range.start >= range.end
+      || replacement.start > replacement.end
+      || replacement.start < range.start
+      || replacement.end > range.end
+    {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::SourceWithReplacements {
+        replacement,
+        replacements: replacements
+          .into_iter()
+          .map(|(content, start, end)| (content.into_boxed_str(), start, end))
+          .collect(),
+      },
+    })
+  }
+
+  pub fn validated_replacements(
+    validate_range: DependencyRange,
+    replacements: Vec<(String, u32, u32)>,
+  ) -> Option<Self> {
+    if validate_range.start >= validate_range.end {
+      return None;
+    }
+
+    Some(Self {
+      range: validate_range,
+      replacement: AstDependencyReplacement::ValidatedReplacements {
+        replacements: replacements
+          .into_iter()
+          .map(|(content, start, end)| (content.into_boxed_str(), start, end))
+          .collect(),
+      },
+    })
+  }
+
+  fn replacement_content<'a>(&'a self, source_text: &'a str) -> Option<Cow<'a, str>> {
+    match &self.replacement {
+      AstDependencyReplacement::Generated(content) => Some(Cow::Borrowed(content.as_ref())),
+      AstDependencyReplacement::RawExpr(content) => Some(Cow::Borrowed(content.as_ref())),
+      AstDependencyReplacement::RawIdent(content) => Some(Cow::Borrowed(content.as_ref())),
+      AstDependencyReplacement::RawIdentWithSuffix(suffix) => source_text
+        .get(self.range.start as usize..self.range.end as usize)
+        .map(|source| Cow::Owned(format!("{source}{suffix}"))),
+      AstDependencyReplacement::Insert { content, .. } => Some(Cow::Borrowed(content.as_ref())),
+      AstDependencyReplacement::WrappedSource {
+        replacement,
+        prefix,
+        suffix,
+      } => source_text
+        .get(replacement.start as usize..replacement.end as usize)
+        .map(|source| Cow::Owned(format!("{prefix}{source}{suffix}"))),
+      AstDependencyReplacement::WrappedSourceWithReplacements {
+        replacement,
+        prefix,
+        suffix,
+        replacements,
+      } => apply_inner_replacements(source_text, *replacement, replacements)
+        .map(|source| Cow::Owned(format!("{prefix}{source}{suffix}"))),
+      AstDependencyReplacement::ValidatedReplacements { .. } => None,
+      AstDependencyReplacement::SourceWithReplacements {
+        replacement,
+        replacements,
+      } => {
+        let prefix = source_text.get(self.range.start as usize..replacement.start as usize)?;
+        let suffix = source_text.get(replacement.end as usize..self.range.end as usize)?;
+        apply_inner_replacements(source_text, *replacement, replacements)
+          .map(|source| Cow::Owned(format!("{prefix}{source}{suffix}")))
+      }
+    }
+  }
+
+  fn edit_range(&self) -> DependencyRange {
+    match &self.replacement {
+      AstDependencyReplacement::Insert { position, .. } => {
+        DependencyRange::new(*position, *position)
+      }
+      AstDependencyReplacement::ValidatedReplacements { .. } => self.range,
+      _ => self.range,
+    }
+  }
+
+  fn edit_ranges(&self) -> Vec<DependencyRange> {
+    match &self.replacement {
+      AstDependencyReplacement::ValidatedReplacements { replacements } => replacements
+        .iter()
+        .map(|(_, start, end)| DependencyRange::new(*start, *end))
+        .collect(),
+      _ => vec![self.edit_range()],
+    }
+  }
+}
+
+fn apply_inner_replacements(
+  source_text: &str,
+  range: DependencyRange,
+  replacements: &[(Box<str>, u32, u32)],
+) -> Option<String> {
+  if range.start > range.end
+    || range.end as usize > source_text.len()
+    || !source_text.is_char_boundary(range.start as usize)
+    || !source_text.is_char_boundary(range.end as usize)
+  {
+    return None;
+  }
+
+  let mut replacements = replacements.to_vec();
+  replacements.sort_by_key(|(_, start, _)| *start);
+
+  let mut last_end = range.start;
+  for (_, start, end) in &replacements {
+    if *start < last_end
+      || start > end
+      || *start < range.start
+      || *end > range.end
+      || !source_text.is_char_boundary(*start as usize)
+      || !source_text.is_char_boundary(*end as usize)
+    {
+      return None;
+    }
+    last_end = *end;
+  }
+
+  let mut output = String::new();
+  let mut cursor = range.start as usize;
+  for (content, start, end) in replacements {
+    let start = start as usize;
+    let end = end as usize;
+    output.push_str(&source_text[cursor..start]);
+    output.push_str(&content);
+    cursor = end;
+  }
+  output.push_str(&source_text[cursor..range.end as usize]);
+  Some(output)
+}
+
+#[derive(Debug, Default)]
+pub struct AstDependencyRenderPlan {
+  actions: Vec<AstDependencyAction>,
+  side_effects: Vec<AstDependencySideEffect>,
+}
+
+impl AstDependencyRenderPlan {
+  pub fn push_action(&mut self, action: AstDependencyAction) {
+    self.actions.push(action);
+  }
+
+  pub fn push_side_effect(&mut self, side_effect: AstDependencySideEffect) {
+    self.side_effects.push(side_effect);
+  }
+
+  pub fn has_actions(&self) -> bool {
+    !self.actions.is_empty()
+  }
+
+  pub fn side_effects(&self) -> &[AstDependencySideEffect] {
+    &self.side_effects
+  }
+}
+
+struct ParsedAstDependencyAction {
+  range: DependencyRange,
+  expr_replacement: Option<Box<Expr>>,
+  ident_replacement: bool,
+  validate_only: bool,
+  stmt_replacement: Option<Option<StableStmt>>,
+  module_item_replacement: Option<Option<StableModuleItem>>,
+  applied: bool,
+}
+
+impl ParsedAstDependencyAction {
+  fn new(action: &AstDependencyAction, source_text: &str) -> Option<Self> {
+    if matches!(action.replacement, AstDependencyReplacement::RawExpr(_)) {
+      return Some(Self {
+        range: action.range,
+        expr_replacement: parse_replacement_expr("__rspack_ast_dependency_raw_replacement__"),
+        ident_replacement: false,
+        validate_only: false,
+        stmt_replacement: None,
+        module_item_replacement: None,
+        applied: false,
+      });
+    }
+
+    if matches!(
+      action.replacement,
+      AstDependencyReplacement::RawIdent(_) | AstDependencyReplacement::RawIdentWithSuffix(_)
+    ) {
+      return Some(Self {
+        range: action.range,
+        expr_replacement: None,
+        ident_replacement: true,
+        validate_only: false,
+        stmt_replacement: None,
+        module_item_replacement: None,
+        applied: false,
+      });
+    }
+
+    if matches!(
+      action.replacement,
+      AstDependencyReplacement::Insert { .. }
+        | AstDependencyReplacement::ValidatedReplacements { .. }
+    ) {
+      return Some(Self {
+        range: action.range,
+        expr_replacement: None,
+        ident_replacement: false,
+        validate_only: true,
+        stmt_replacement: None,
+        module_item_replacement: None,
+        applied: false,
+      });
+    }
+
+    let content = action.replacement_content(source_text)?;
+    let delete = content.trim().is_empty();
+    let expr_replacement = if delete {
+      None
+    } else {
+      parse_replacement_expr(&content)
+    };
+    let stmt_replacement = if delete {
+      Some(None)
+    } else {
+      parse_replacement_stmt(&content).map(Some)
+    };
+    let module_item_replacement = if delete {
+      Some(None)
+    } else {
+      parse_replacement_module_item(&content).map(Some)
+    };
+
+    if !delete
+      && expr_replacement.is_none()
+      && stmt_replacement.is_none()
+      && module_item_replacement.is_none()
+    {
+      return None;
+    }
+
+    Some(Self {
+      range: action.range,
+      expr_replacement,
+      ident_replacement: false,
+      validate_only: false,
+      stmt_replacement,
+      module_item_replacement,
+      applied: false,
+    })
+  }
+}
+
+struct StableAstDependencyApplier {
+  actions: Vec<ParsedAstDependencyAction>,
+}
+
+impl StableAstDependencyApplier {
+  fn new(actions: Vec<ParsedAstDependencyAction>) -> Self {
+    Self { actions }
+  }
+
+  fn is_fully_applied(&self) -> bool {
+    self.actions.iter().all(|action| action.applied)
+  }
+
+  fn replacement_for_expr(&mut self, range: DependencyRange) -> Option<Box<Expr>> {
+    let action = self.actions.iter_mut().find(|action| {
+      !action.applied && action.range == range && action.expr_replacement.is_some()
+    })?;
+    action.applied = true;
+    action.expr_replacement.take()
+  }
+
+  fn replacement_for_ident(&mut self, range: DependencyRange) -> bool {
+    let Some(action) = self
+      .actions
+      .iter_mut()
+      .find(|action| !action.applied && action.range == range && action.ident_replacement)
+    else {
+      return false;
+    };
+    action.applied = true;
+    true
+  }
+
+  fn validate_node(&mut self, range: DependencyRange) {
+    for action in self
+      .actions
+      .iter_mut()
+      .filter(|action| !action.applied && action.range == range && action.validate_only)
+    {
+      action.applied = true;
+    }
+  }
+
+  fn replacement_for_stmt_list(&mut self, range: DependencyRange) -> Option<Option<StableStmt>> {
+    let action = self.actions.iter_mut().find(|action| {
+      !action.applied && action.range == range && action.stmt_replacement.is_some()
+    })?;
+    action.applied = true;
+    action.stmt_replacement.take()
+  }
+
+  fn replacement_for_stmt_node(&mut self, range: DependencyRange) -> Option<StableStmt> {
+    let action = self.actions.iter_mut().find(|action| {
+      !action.applied
+        && action.range == range
+        && action
+          .stmt_replacement
+          .as_ref()
+          .is_some_and(|replacement| replacement.is_some())
+    })?;
+    action.applied = true;
+    action.stmt_replacement.take().flatten()
+  }
+
+  fn replacement_for_module_item(
+    &mut self,
+    range: DependencyRange,
+  ) -> Option<Option<StableModuleItem>> {
+    let action = self.actions.iter_mut().find(|action| {
+      !action.applied && action.range == range && action.module_item_replacement.is_some()
+    })?;
+    action.applied = true;
+    action.module_item_replacement.take()
+  }
+}
+
+impl VisitMut for StableAstDependencyApplier {
+  fn visit_mut_module_items(&mut self, node: &mut Vec<StableModuleItem>) {
+    let mut next = Vec::with_capacity(node.len());
+
+    for mut item in std::mem::take(node) {
+      let range = DependencyRange::from(item.span());
+      self.validate_node(range);
+      if let Some(replacement) = self.replacement_for_module_item(range) {
+        if let Some(replacement) = replacement {
+          next.push(replacement);
+        }
+        continue;
+      }
+
+      item.visit_mut_children_with(self);
+      next.push(item);
+    }
+
+    *node = next;
+  }
+
+  fn visit_mut_stmts(&mut self, node: &mut Vec<StableStmt>) {
+    let mut next = Vec::with_capacity(node.len());
+
+    for mut stmt in std::mem::take(node) {
+      let range = DependencyRange::from(stmt.span());
+      self.validate_node(range);
+      if let Some(replacement) = self.replacement_for_stmt_list(range) {
+        if let Some(replacement) = replacement {
+          next.push(replacement);
+        }
+        continue;
+      }
+
+      stmt.visit_mut_children_with(self);
+      next.push(stmt);
+    }
+
+    *node = next;
+  }
+
+  fn visit_mut_stmt(&mut self, node: &mut StableStmt) {
+    let range = DependencyRange::from(node.span());
+    self.validate_node(range);
+    if let Some(replacement) = self.replacement_for_stmt_node(range) {
+      *node = replacement;
+      return;
+    }
+
+    node.visit_mut_children_with(self);
+  }
+
+  fn visit_mut_expr(&mut self, node: &mut Expr) {
+    let range = DependencyRange::from(node.span());
+    self.validate_node(range);
+    if let Some(replacement) = self.replacement_for_expr(range) {
+      *node = *replacement;
+      return;
+    }
+
+    node.visit_mut_children_with(self);
+  }
+
+  fn visit_mut_ident(&mut self, node: &mut StableIdent) {
+    let range = DependencyRange::from(node.span());
+    self.validate_node(range);
+    if self.replacement_for_ident(range) {
+      return;
+    }
+
+    node.visit_mut_children_with(self);
+  }
+
+  fn visit_mut_lit(&mut self, node: &mut StableLit) {
+    let range = DependencyRange::from(node.span());
+    self.validate_node(range);
+    if self.replacement_for_ident(range) {
+      return;
+    }
+
+    node.visit_mut_children_with(self);
+  }
+
+  fn visit_mut_prop_name(&mut self, node: &mut StablePropName) {
+    let range = DependencyRange::from(node.span());
+    self.validate_node(range);
+    if self.replacement_for_ident(range) {
+      return;
+    }
+
+    node.visit_mut_children_with(self);
+  }
+}
+
+fn stable_syntax(module_type: &ModuleType) -> StableSyntax {
+  StableSyntax::Es(StableEsSyntax {
+    jsx: true,
+    allow_return_outside_function: matches!(
+      module_type,
+      ModuleType::JsDynamic | ModuleType::JsAuto
+    ),
+    explicit_resource_management: true,
+    import_attributes: true,
+    ..Default::default()
+  })
+}
+
+fn parse_stable_program(
+  cm: Arc<SourceMap>,
+  source_text: &str,
+  module_type: &ModuleType,
+  comments: &SingleThreadedComments,
+) -> Option<StableProgram> {
+  let fm = cm.new_source_file(
+    Arc::new(FileName::Custom("<rspack ast dependency>".to_string())),
+    source_text.to_string(),
+  );
+  let lexer = StableLexer::new(
+    stable_syntax(module_type),
+    StableEsVersion::EsNext,
+    SourceFileInput::from(&*fm),
+    Some(comments),
+  );
+  let mut parser = StableParser::new_from(lexer);
+  let program = match module_type {
+    ModuleType::JsEsm => parser.parse_module().map(StableProgram::Module),
+    ModuleType::JsDynamic => parser.parse_commonjs().map(StableProgram::Script),
+    _ => parser.parse_program(),
+  }
+  .ok()?;
+
+  parser.take_errors().is_empty().then_some(program)
+}
+
+fn parse_replacement_expr(content: &str) -> Option<Box<Expr>> {
+  let cm = Arc::<SourceMap>::default();
+  let fm = cm.new_source_file(
+    Arc::new(FileName::Custom(
+      "<rspack ast dependency replacement>".to_string(),
+    )),
+    content.to_string(),
+  );
+  let lexer = StableLexer::new(
+    stable_syntax(&ModuleType::JsAuto),
+    StableEsVersion::EsNext,
+    SourceFileInput::from(&*fm),
+    None,
+  );
+  let mut parser = StableParser::new_from(lexer);
+  let expr = parser.parse_expr().ok()?;
+
+  parser.take_errors().is_empty().then_some(expr)
+}
+
+fn parse_replacement_stmt(content: &str) -> Option<StableStmt> {
+  let cm = Arc::<SourceMap>::default();
+  let fm = cm.new_source_file(
+    Arc::new(FileName::Custom(
+      "<rspack ast dependency replacement>".to_string(),
+    )),
+    content.to_string(),
+  );
+  let lexer = StableLexer::new(
+    stable_syntax(&ModuleType::JsAuto),
+    StableEsVersion::EsNext,
+    SourceFileInput::from(&*fm),
+    None,
+  );
+  let mut parser = StableParser::new_from(lexer);
+  let stmt = parser.parse_stmt().ok()?;
+
+  parser.take_errors().is_empty().then_some(stmt)
+}
+
+fn parse_replacement_module_item(content: &str) -> Option<StableModuleItem> {
+  let cm = Arc::<SourceMap>::default();
+  let fm = cm.new_source_file(
+    Arc::new(FileName::Custom(
+      "<rspack ast dependency replacement>".to_string(),
+    )),
+    content.to_string(),
+  );
+  let lexer = StableLexer::new(
+    stable_syntax(&ModuleType::JsAuto),
+    StableEsVersion::EsNext,
+    SourceFileInput::from(&*fm),
+    None,
+  );
+  let mut parser = StableParser::new_from(lexer);
+  let module_item = parser.parse_module_item().ok()?;
+
+  parser.take_errors().is_empty().then_some(module_item)
+}
+
+pub fn render_ast_dependencies(
+  source_text: &str,
+  module_type: &ModuleType,
+  plan: &AstDependencyRenderPlan,
+) -> Option<String> {
+  if !plan.has_actions() {
+    return None;
+  }
+
+  validate_ast_dependency_actions(source_text, module_type, &plan.actions)?;
+  render_source_replacements(source_text, &plan.actions)
+}
+
+pub fn apply_ast_dependency_replacements(
+  source_text: &str,
+  module_type: &ModuleType,
+  plan: &AstDependencyRenderPlan,
+  source: &mut TemplateReplaceSource,
+) -> bool {
+  if validate_ast_dependency_actions(source_text, module_type, &plan.actions).is_none() {
+    return false;
+  }
+
+  let Some(replacements) = source_replacements(source_text, &plan.actions) else {
+    return false;
+  };
+
+  for (range, replacement) in replacements {
+    source.replace(range.start, range.end, replacement, None);
+  }
+
+  true
+}
+
+fn validate_ast_dependency_actions(
+  source_text: &str,
+  module_type: &ModuleType,
+  actions: &[AstDependencyAction],
+) -> Option<()> {
+  let mut seen_ranges = FxHashSet::default();
+  let actions = actions
+    .iter()
+    .map(|action| {
+      for range in action.edit_ranges() {
+        if !seen_ranges.insert(range) {
+          return None;
+        }
+      }
+      ParsedAstDependencyAction::new(action, source_text)
+    })
+    .collect::<Option<Vec<_>>>()?;
+
+  let globals = Globals::new();
+  GLOBALS.set(&globals, || {
+    let cm = Arc::<SourceMap>::default();
+    let comments = SingleThreadedComments::default();
+    let mut program = parse_stable_program(cm.clone(), source_text, module_type, &comments)?;
+    let mut applier = StableAstDependencyApplier::new(actions);
+    program.visit_mut_with(&mut applier);
+    applier.is_fully_applied().then_some(())
+  })
+}
+
+fn render_source_replacements(
+  source_text: &str,
+  actions: &[AstDependencyAction],
+) -> Option<String> {
+  let replacements = source_replacements(source_text, actions)?;
+
+  let mut output = String::with_capacity(source_text.len());
+  let mut cursor = 0usize;
+  for (range, replacement) in replacements {
+    let start = range.start as usize;
+    let end = range.end as usize;
+    output.push_str(&source_text[cursor..start]);
+    output.push_str(&replacement);
+    cursor = end;
+  }
+  output.push_str(&source_text[cursor..]);
+  Some(output)
+}
+
+fn source_replacements(
+  source_text: &str,
+  actions: &[AstDependencyAction],
+) -> Option<Vec<(DependencyRange, String)>> {
+  let mut replacements = Vec::new();
+  for action in actions {
+    match &action.replacement {
+      AstDependencyReplacement::WrappedSource {
+        replacement,
+        prefix,
+        suffix,
+      } => {
+        push_source_replacement(
+          &mut replacements,
+          DependencyRange::new(action.range.start, replacement.start),
+          prefix.to_string(),
+        );
+        push_source_replacement(
+          &mut replacements,
+          DependencyRange::new(replacement.end, action.range.end),
+          suffix.to_string(),
+        );
+        continue;
+      }
+      AstDependencyReplacement::WrappedSourceWithReplacements {
+        replacement,
+        prefix,
+        suffix,
+        replacements: inner_replacements,
+      } => {
+        push_source_replacement(
+          &mut replacements,
+          DependencyRange::new(action.range.start, replacement.start),
+          prefix.to_string(),
+        );
+        replacements.extend(
+          inner_replacements
+            .iter()
+            .map(|(content, start, end)| (DependencyRange::new(*start, *end), content.to_string())),
+        );
+        push_source_replacement(
+          &mut replacements,
+          DependencyRange::new(replacement.end, action.range.end),
+          suffix.to_string(),
+        );
+        continue;
+      }
+      AstDependencyReplacement::ValidatedReplacements { replacements: r }
+      | AstDependencyReplacement::SourceWithReplacements {
+        replacements: r, ..
+      } => {
+        replacements
+          .extend(r.iter().map(|(content, start, end)| {
+            (DependencyRange::new(*start, *end), content.to_string())
+          }));
+        continue;
+      }
+      _ => {}
+    }
+
+    replacements.push((
+      action.edit_range(),
+      action.replacement_content(source_text)?.into_owned(),
+    ));
+  }
+
+  replacements.sort_by_key(|(range, _)| (range.start, range.end));
+  let mut last_end = 0;
+  for (range, _) in &replacements {
+    if range.start < last_end
+      || range.start > range.end
+      || range.end as usize > source_text.len()
+      || !source_text.is_char_boundary(range.start as usize)
+      || !source_text.is_char_boundary(range.end as usize)
+    {
+      return None;
+    }
+    last_end = range.end;
+  }
+
+  Some(replacements)
+}
+
+fn push_source_replacement(
+  replacements: &mut Vec<(DependencyRange, String)>,
+  range: DependencyRange,
+  content: String,
+) {
+  if range.start == range.end && content.is_empty() {
+    return;
+  }
+
+  replacements.push((range, content));
+}
+
+struct AstDependencyMarker<'a> {
+  entries: &'a mut [AstDependencyRenderEntry],
+}
+
+impl AstDependencyMarker<'_> {
+  fn mark_span(&mut self, span: swc_experimental_ecma_ast::Span) {
+    let range = DependencyRange::new(span.real_lo(), span.real_hi());
+    if range.start >= range.end {
+      return;
+    }
+
+    for entry in self.entries.iter_mut() {
+      if !entry.applied && entry.range == range {
+        entry.applied = true;
+      }
+    }
+  }
+}
+
+impl<'ast> Visit<'ast> for AstDependencyMarker<'_> {
+  fn visit_module_item(&mut self, node: &ModuleItem<'ast>) {
+    self.mark_span(node.span());
+    node.visit_children_with(self);
+  }
+
+  fn visit_module_decl(&mut self, node: &ModuleDecl<'ast>) {
+    self.mark_span(node.span());
+    node.visit_children_with(self);
+  }
+
+  fn visit_stmt(&mut self, node: &Stmt<'ast>) {
+    self.mark_span(node.span());
+    node.visit_children_with(self);
+  }
+
+  fn visit_expr(&mut self, node: &ExperimentalExpr<'ast>) {
+    self.mark_span(node.span());
+    node.visit_children_with(self);
+  }
+
+  fn visit_member_expr(&mut self, node: &MemberExpr<'ast>) {
+    self.mark_span(node.span());
+    node.visit_children_with(self);
+  }
+
+  fn visit_ident(&mut self, node: &Ident<'ast>) {
+    self.mark_span(node.span);
+    node.visit_children_with(self);
+  }
+
+  fn visit_lit(&mut self, node: &Lit<'ast>) {
+    self.mark_span(node.span());
+    node.visit_children_with(self);
+  }
+
+  fn visit_str(&mut self, node: &Str<'ast>) {
+    self.mark_span(node.span);
+    node.visit_children_with(self);
+  }
+}
+
+pub fn mark_ast_dependencies(
+  source_text: &str,
+  module_type: &ModuleType,
+  entries: &mut [AstDependencyRenderEntry],
+) -> bool {
+  let allocator = Allocator::new();
+  let mut comments = Default::default();
+  let lexer = Lexer::new(
+    &allocator,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      allow_return_outside_function: matches!(
+        module_type,
+        ModuleType::JsDynamic | ModuleType::JsAuto
+      ),
+      explicit_resource_management: true,
+      import_attributes: true,
+      ..Default::default()
+    }),
+    swc_experimental_ecma_ast::EsVersion::EsNext,
+    StringSource::new(source_text),
+    Some(&mut comments),
+  );
+  let mut parser = Parser::new_from(&allocator, lexer);
+
+  let program = match match module_type {
+    ModuleType::JsEsm => parser
+      .parse_module()
+      .map(|module| Program::Module(allocator.boxed(module))),
+    ModuleType::JsDynamic => parser
+      .parse_commonjs()
+      .map(|script| Program::Script(allocator.boxed(script))),
+    _ => parser.parse_program(),
+  } {
+    Ok(program) => program,
+    Err(_) => return false,
+  };
+
+  if !parser.take_errors().is_empty() {
+    return false;
+  }
+  drop(parser);
+
+  program.visit_with(&mut AstDependencyMarker { entries });
+  true
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn first_top_level_range(source: &str, module_type: ModuleType) -> DependencyRange {
+    GLOBALS.set(&Globals::new(), || {
+      let cm = Arc::<SourceMap>::default();
+      let comments = SingleThreadedComments::default();
+      let program = parse_stable_program(cm, source, &module_type, &comments).unwrap();
+      match program {
+        StableProgram::Module(module) => DependencyRange::from(module.body[0].span()),
+        StableProgram::Script(script) => DependencyRange::from(script.body[0].span()),
+      }
+    })
+  }
+
+  fn if_consequent_range(source: &str) -> DependencyRange {
+    GLOBALS.set(&Globals::new(), || {
+      let cm = Arc::<SourceMap>::default();
+      let comments = SingleThreadedComments::default();
+      let program = parse_stable_program(cm, source, &ModuleType::JsAuto, &comments).unwrap();
+      let StableProgram::Script(script) = program else {
+        unreachable!()
+      };
+      let StableStmt::If(if_stmt) = &script.body[0] else {
+        unreachable!()
+      };
+      DependencyRange::from(if_stmt.cons.span())
+    })
+  }
+
+  #[test]
+  fn replaces_expression_by_ast_range() {
+    let source = "if (process.env.NODE_ENV) console.log(1);\n";
+    let start = source.find("process.env.NODE_ENV").unwrap() as u32;
+    let end = start + "process.env.NODE_ENV".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(AstDependencyAction::expr((start, end).into(), "\"production\"").unwrap());
+
+    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+
+    assert!(output.contains("if (\"production\")"));
+  }
+
+  #[test]
+  fn deletes_top_level_statement_by_ast_range() {
+    let source = "\"use strict\";\nconsole.log(1);\n";
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::expr(first_top_level_range(source, ModuleType::JsAuto), "").unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert!(!output.contains("use strict"));
+    assert!(output.contains("console.log(1)"));
+  }
+
+  #[test]
+  fn replaces_nested_statement_by_ast_range() {
+    let source = "if (true) console.log('x');\n";
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(AstDependencyAction::expr(if_consequent_range(source), "{}").unwrap());
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert!(output.contains("if (true) {}"));
+  }
+
+  #[test]
+  fn deletes_module_item_by_ast_range() {
+    let source = "import './a';\nconsole.log(1);\n";
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::expr(first_top_level_range(source, ModuleType::JsEsm), "").unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+
+    assert!(!output.contains("import"));
+    assert!(output.contains("console.log(1)"));
+  }
+
+  #[test]
+  fn deletes_module_item_prefix_after_validating_whole_item() {
+    let source = "export const answer = 42;\n";
+    let range = first_top_level_range(source, ModuleType::JsEsm);
+    let replacement_start = source.find("const").unwrap() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::validated_replacements(
+        range,
+        vec![("".to_string(), range.start, replacement_start)],
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+
+    assert!(!output.contains("export"));
+    assert!(output.contains("const answer = 42"));
+  }
+
+  #[test]
+  fn wraps_expression_source_slice() {
+    let source = "new Worker(workerUrl);\n";
+    let start = source.find("workerUrl").unwrap() as u32;
+    let end = start + "workerUrl".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::wrapped_source(
+        DependencyRange::new(start, end),
+        DependencyRange::new(start, end),
+        "__webpack_require__.tu(",
+        ")",
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert!(output.contains("new Worker(__webpack_require__.tu(workerUrl))"));
+  }
+
+  #[test]
+  fn emits_wrapped_source_as_insert_replacements() {
+    let source = "const b = { a: 123 };\n";
+    let start = source.find("{ a: 123 }").unwrap() as u32;
+    let end = start + "{ a: 123 }".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::wrapped_source(
+        DependencyRange::new(start, end),
+        DependencyRange::new(start, end),
+        "(/* unused pure expression or super */ null && (",
+        "))",
+      )
+      .unwrap(),
+    );
+
+    let replacements = source_replacements(source, &plan.actions).unwrap();
+
+    assert_eq!(
+      replacements,
+      vec![
+        (
+          DependencyRange::new(start, start),
+          "(/* unused pure expression or super */ null && (".to_string()
+        ),
+        (DependencyRange::new(end, end), "))".to_string()),
+      ]
+    );
+  }
+
+  #[test]
+  fn wraps_expression_source_slice_with_inner_replacements() {
+    let source = "const value = import(\"./dir/\" + name);\n";
+    let range_start = source.find("import(").unwrap() as u32;
+    let range_end = source.find(");").unwrap() as u32 + 1;
+    let replacement_start = source.find("\"./dir/\"").unwrap() as u32;
+    let replacement_end = range_end - 1;
+    let replace_start = source.find("name").unwrap() as u32;
+    let replace_end = replace_start + "name".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::wrapped_source_with_replacements(
+        DependencyRange::new(range_start, range_end),
+        DependencyRange::new(replacement_start, replacement_end),
+        "__webpack_require__(42)(",
+        ")",
+        vec![("\"tmpl\"".to_string(), replace_start, replace_end)],
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(
+      output,
+      "const value = __webpack_require__(42)(\"./dir/\" + \"tmpl\");\n"
+    );
+  }
+
+  #[test]
+  fn preserves_outer_source_while_replacing_inner_range() {
+    let source = "const url = new MyURL(\"./asset.png\", import.meta.url);\n";
+    let range_start = source.find("new MyURL").unwrap() as u32;
+    let range_end = source.find(");").unwrap() as u32 + 1;
+    let replacement_start = source.find("\"./asset.png\"").unwrap() as u32;
+    let replacement_end = range_end - 1;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::source_with_replacements(
+        DependencyRange::new(range_start, range_end),
+        DependencyRange::new(replacement_start, replacement_end),
+        vec![(
+          "/* asset import */__webpack_require__(1), __webpack_require__.b".to_string(),
+          replacement_start,
+          replacement_end,
+        )],
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(
+      output,
+      "const url = new MyURL(/* asset import */__webpack_require__(1), __webpack_require__.b);\n"
+    );
+  }
+
+  #[test]
+  fn replaces_expression_with_raw_content() {
+    let source = "const id = require.resolve(\"./a\");\n";
+    let start = source.find("require.resolve").unwrap() as u32;
+    let end = start + "require.resolve".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::raw_expr((start, end).into(), "/*require.resolve*/").unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, "const id = /*require.resolve*/(\"./a\");\n");
+  }
+
+  #[test]
+  fn inserts_content_after_validating_outer_expression() {
+    let source = "module.hot.accept(\"./a\");\n";
+    let call_start = source.find("module.hot.accept").unwrap() as u32;
+    let call_end = source.find(");").unwrap() as u32 + 1;
+    let callee_end = call_start + "module.hot.accept".len() as u32;
+    let insert_position = call_end - 1;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::expr(
+        DependencyRange::new(call_start, callee_end),
+        "__webpack_module__.hot.accept",
+      )
+      .unwrap(),
+    );
+    plan.push_action(
+      AstDependencyAction::insert(
+        DependencyRange::new(call_start, call_end),
+        insert_position,
+        ", function(){}",
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(
+      output,
+      "__webpack_module__.hot.accept(\"./a\", function(){});\n"
+    );
+  }
+
+  #[test]
+  fn inserts_prefix_while_replacing_the_same_validated_expression() {
+    let source = "foo(bar);\n";
+    let call_start = source.find("foo").unwrap() as u32;
+    let call_end = source.find(");").unwrap() as u32 + 1;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::insert(DependencyRange::new(call_start, call_end), 0, "var x;").unwrap(),
+    );
+    plan.push_action(
+      AstDependencyAction::expr(DependencyRange::new(call_start, call_end), "baz(bar)").unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, "var x;baz(bar);\n");
+  }
+
+  #[test]
+  fn applies_validated_disjoint_replacements_around_nested_action() {
+    let source = "define([\"a\"], function(a) {});\n";
+    let call_start = source.find("define").unwrap() as u32;
+    let call_end = source.find(");").unwrap() as u32 + 1;
+    let array_start = source.find("[\"a\"]").unwrap() as u32;
+    let array_end = array_start + "[\"a\"]".len() as u32;
+    let function_start = source.find("function").unwrap() as u32;
+    let function_end = source.find(");").unwrap() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::validated_replacements(
+        DependencyRange::new(call_start, call_end),
+        vec![
+          ("wrap(".to_string(), call_start, array_start),
+          (", ".to_string(), array_end, function_start),
+          (")".to_string(), function_end, call_end),
+        ],
+      )
+      .unwrap(),
+    );
+    plan.push_action(
+      AstDependencyAction::expr(DependencyRange::new(array_start, array_end), "deps").unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, "wrap(deps, function(a) {});\n");
+  }
+
+  #[test]
+  fn inserts_suffix_after_raw_identifier() {
+    let source = "const obj = { value };\n";
+    let start = source.find("value").unwrap() as u32;
+    let end = start + "value".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::raw_ident_with_suffix((start, end).into(), ": replacement").unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, "const obj = { value: replacement };\n");
+  }
+
+  #[test]
+  fn replaces_raw_identifier_with_property_fragment() {
+    let source = "const { value } = source;\n";
+    let start = source.find("value").unwrap() as u32;
+    let end = start + "value".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan
+      .push_action(AstDependencyAction::raw_ident((start, end).into(), "renamed: value").unwrap());
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, "const { renamed: value } = source;\n");
+  }
+
+  #[test]
+  fn replaces_raw_literal_with_property_fragment() {
+    let source = "const { \"value\": local } = source;\n";
+    let start = source.find("\"value\"").unwrap() as u32;
+    let end = start + "\"value\"".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(AstDependencyAction::raw_ident((start, end).into(), "renamed").unwrap());
+
+    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+
+    assert_eq!(output, "const { renamed: local } = source;\n");
+  }
+}

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -1,28 +1,16 @@
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 use rspack_core::{
   DependencyRange, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleType,
   NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 use rustc_hash::FxHashSet;
-use swc_core::{
-  common::{
-    FileName, GLOBALS, Globals, SourceMap, Spanned, comments::SingleThreadedComments,
-    input::SourceFileInput,
-  },
-  ecma::{
-    ast::{
-      EsVersion as StableEsVersion, Expr, Ident as StableIdent, Lit as StableLit,
-      MemberExpr as StableMemberExpr, ModuleItem as StableModuleItem, Program as StableProgram,
-      PropName as StablePropName, Stmt as StableStmt,
-    },
-    parser::{
-      EsSyntax as StableEsSyntax, Parser as StableParser, Syntax as StableSyntax,
-      lexer::Lexer as StableLexer,
-    },
-    visit::{VisitMut, VisitMutWith},
-  },
+use swc_experimental_allocator::{Allocator, boxed::Box as AstBox, vec::Vec as AstVec};
+use swc_experimental_ecma_ast::{
+  EsVersion, Expr, GetSpan, Ident, Lit, MemberExpr, ModuleItem, Program, PropName, Stmt, VisitMut,
+  VisitMutWith,
 };
+use swc_experimental_ecma_parser::{EsSyntax, Lexer, Parser, StringSource, Syntax};
 
 #[derive(Debug, Clone)]
 pub enum AstDependencySideEffect {
@@ -430,22 +418,29 @@ impl AstDependencyRenderPlan {
   }
 }
 
-struct ParsedAstDependencyAction {
+struct ParsedAstDependencyAction<'ast> {
   range: DependencyRange,
-  expr_replacement: Option<Box<Expr>>,
+  expr_replacement: Option<Expr<'ast>>,
   ident_replacement: bool,
   validate_only: bool,
-  stmt_replacement: Option<Option<StableStmt>>,
-  module_item_replacement: Option<Option<StableModuleItem>>,
+  stmt_replacement: Option<Option<Stmt<'ast>>>,
+  module_item_replacement: Option<Option<ModuleItem<'ast>>>,
   applied: bool,
 }
 
-impl ParsedAstDependencyAction {
-  fn new(action: &AstDependencyAction, source_text: &str) -> Option<Self> {
+impl<'ast> ParsedAstDependencyAction<'ast> {
+  fn new(
+    action: &AstDependencyAction,
+    source_text: &str,
+    allocator: &'ast Allocator,
+  ) -> Option<Self> {
     if matches!(action.replacement, AstDependencyReplacement::RawExpr(_)) {
       return Some(Self {
         range: action.range,
-        expr_replacement: parse_replacement_expr("__rspack_ast_dependency_raw_replacement__"),
+        expr_replacement: parse_replacement_expr(
+          "__rspack_ast_dependency_raw_replacement__",
+          allocator,
+        ),
         ident_replacement: false,
         validate_only: false,
         stmt_replacement: None,
@@ -490,17 +485,17 @@ impl ParsedAstDependencyAction {
     let expr_replacement = if delete {
       None
     } else {
-      parse_replacement_expr(&content)
+      parse_replacement_expr(&content, allocator)
     };
     let stmt_replacement = if delete {
       Some(None)
     } else {
-      parse_replacement_stmt(&content).map(Some)
+      parse_replacement_stmt(&content, allocator).map(Some)
     };
     let module_item_replacement = if delete {
       Some(None)
     } else {
-      parse_replacement_module_item(&content).map(Some)
+      parse_replacement_module_item(&content, allocator).map(Some)
     };
 
     if !delete
@@ -523,20 +518,21 @@ impl ParsedAstDependencyAction {
   }
 }
 
-struct StableAstDependencyApplier {
-  actions: Vec<ParsedAstDependencyAction>,
+struct ExperimentalAstDependencyApplier<'ast> {
+  allocator: &'ast Allocator,
+  actions: Vec<ParsedAstDependencyAction<'ast>>,
 }
 
-impl StableAstDependencyApplier {
-  fn new(actions: Vec<ParsedAstDependencyAction>) -> Self {
-    Self { actions }
+impl<'ast> ExperimentalAstDependencyApplier<'ast> {
+  fn new(actions: Vec<ParsedAstDependencyAction<'ast>>, allocator: &'ast Allocator) -> Self {
+    Self { allocator, actions }
   }
 
   fn is_fully_applied(&self) -> bool {
     self.actions.iter().all(|action| action.applied)
   }
 
-  fn replacement_for_expr(&mut self, range: DependencyRange) -> Option<Box<Expr>> {
+  fn replacement_for_expr(&mut self, range: DependencyRange) -> Option<Expr<'ast>> {
     let action = self.actions.iter_mut().find(|action| {
       !action.applied && action.range == range && action.expr_replacement.is_some()
     })?;
@@ -544,17 +540,17 @@ impl StableAstDependencyApplier {
     action.expr_replacement.take()
   }
 
-  fn replacement_for_member_expr(&mut self, range: DependencyRange) -> Option<StableMemberExpr> {
+  fn replacement_for_member_expr(&mut self, range: DependencyRange) -> Option<MemberExpr<'ast>> {
     let action = self.actions.iter_mut().find(|action| {
       !action.applied
         && action.range == range
-        && matches!(action.expr_replacement.as_deref(), Some(Expr::Member(_)))
+        && matches!(action.expr_replacement.as_ref(), Some(Expr::Member(_)))
     })?;
     action.applied = true;
-    let Some(Expr::Member(member)) = action.expr_replacement.take().map(|expr| *expr) else {
+    let Some(Expr::Member(member)) = action.expr_replacement.take() else {
       unreachable!()
     };
-    Some(member)
+    Some(AstBox::into_inner(member))
   }
 
   fn replacement_for_ident(&mut self, range: DependencyRange) -> bool {
@@ -579,7 +575,7 @@ impl StableAstDependencyApplier {
     }
   }
 
-  fn replacement_for_stmt_list(&mut self, range: DependencyRange) -> Option<Option<StableStmt>> {
+  fn replacement_for_stmt_list(&mut self, range: DependencyRange) -> Option<Option<Stmt<'ast>>> {
     let action = self.actions.iter_mut().find(|action| {
       !action.applied && action.range == range && action.stmt_replacement.is_some()
     })?;
@@ -587,7 +583,7 @@ impl StableAstDependencyApplier {
     action.stmt_replacement.take()
   }
 
-  fn replacement_for_stmt_node(&mut self, range: DependencyRange) -> Option<StableStmt> {
+  fn replacement_for_stmt_node(&mut self, range: DependencyRange) -> Option<Stmt<'ast>> {
     let action = self.actions.iter_mut().find(|action| {
       !action.applied
         && action.range == range
@@ -603,7 +599,7 @@ impl StableAstDependencyApplier {
   fn replacement_for_module_item(
     &mut self,
     range: DependencyRange,
-  ) -> Option<Option<StableModuleItem>> {
+  ) -> Option<Option<ModuleItem<'ast>>> {
     let action = self.actions.iter_mut().find(|action| {
       !action.applied && action.range == range && action.module_item_replacement.is_some()
     })?;
@@ -612,11 +608,11 @@ impl StableAstDependencyApplier {
   }
 }
 
-impl VisitMut for StableAstDependencyApplier {
-  fn visit_mut_module_items(&mut self, node: &mut Vec<StableModuleItem>) {
-    let mut next = Vec::with_capacity(node.len());
+impl<'ast> VisitMut<'ast> for ExperimentalAstDependencyApplier<'ast> {
+  fn visit_mut_module_items(&mut self, node: &mut AstVec<'ast, ModuleItem<'ast>>) {
+    let mut next = AstVec::with_capacity_in(node.len(), self.allocator);
 
-    for mut item in std::mem::take(node) {
+    for mut item in std::mem::replace(node, AstVec::new_in(self.allocator)) {
       let range = DependencyRange::from(item.span());
       self.validate_node(range);
       if let Some(replacement) = self.replacement_for_module_item(range) {
@@ -633,10 +629,10 @@ impl VisitMut for StableAstDependencyApplier {
     *node = next;
   }
 
-  fn visit_mut_stmts(&mut self, node: &mut Vec<StableStmt>) {
-    let mut next = Vec::with_capacity(node.len());
+  fn visit_mut_stmts(&mut self, node: &mut AstVec<'ast, Stmt<'ast>>) {
+    let mut next = AstVec::with_capacity_in(node.len(), self.allocator);
 
-    for mut stmt in std::mem::take(node) {
+    for mut stmt in std::mem::replace(node, AstVec::new_in(self.allocator)) {
       let range = DependencyRange::from(stmt.span());
       self.validate_node(range);
       if let Some(replacement) = self.replacement_for_stmt_list(range) {
@@ -653,7 +649,7 @@ impl VisitMut for StableAstDependencyApplier {
     *node = next;
   }
 
-  fn visit_mut_stmt(&mut self, node: &mut StableStmt) {
+  fn visit_mut_stmt(&mut self, node: &mut Stmt<'ast>) {
     let range = DependencyRange::from(node.span());
     self.validate_node(range);
     if let Some(replacement) = self.replacement_for_stmt_node(range) {
@@ -664,18 +660,18 @@ impl VisitMut for StableAstDependencyApplier {
     node.visit_mut_children_with(self);
   }
 
-  fn visit_mut_expr(&mut self, node: &mut Expr) {
+  fn visit_mut_expr(&mut self, node: &mut Expr<'ast>) {
     let range = DependencyRange::from(node.span());
     self.validate_node(range);
     if let Some(replacement) = self.replacement_for_expr(range) {
-      *node = *replacement;
+      *node = replacement;
       return;
     }
 
     node.visit_mut_children_with(self);
   }
 
-  fn visit_mut_member_expr(&mut self, node: &mut StableMemberExpr) {
+  fn visit_mut_member_expr(&mut self, node: &mut MemberExpr<'ast>) {
     let range = DependencyRange::from(node.span());
     self.validate_node(range);
     if let Some(replacement) = self.replacement_for_member_expr(range) {
@@ -686,7 +682,7 @@ impl VisitMut for StableAstDependencyApplier {
     node.visit_mut_children_with(self);
   }
 
-  fn visit_mut_ident(&mut self, node: &mut StableIdent) {
+  fn visit_mut_ident(&mut self, node: &mut Ident<'ast>) {
     let range = DependencyRange::from(node.span());
     self.validate_node(range);
     if self.replacement_for_ident(range) {
@@ -696,7 +692,7 @@ impl VisitMut for StableAstDependencyApplier {
     node.visit_mut_children_with(self);
   }
 
-  fn visit_mut_lit(&mut self, node: &mut StableLit) {
+  fn visit_mut_lit(&mut self, node: &mut Lit<'ast>) {
     let range = DependencyRange::from(node.span());
     self.validate_node(range);
     if self.replacement_for_ident(range) {
@@ -706,7 +702,7 @@ impl VisitMut for StableAstDependencyApplier {
     node.visit_mut_children_with(self);
   }
 
-  fn visit_mut_prop_name(&mut self, node: &mut StablePropName) {
+  fn visit_mut_prop_name(&mut self, node: &mut PropName<'ast>) {
     let range = DependencyRange::from(node.span());
     self.validate_node(range);
     if self.replacement_for_ident(range) {
@@ -717,8 +713,8 @@ impl VisitMut for StableAstDependencyApplier {
   }
 }
 
-fn stable_syntax(module_type: &ModuleType) -> StableSyntax {
-  StableSyntax::Es(StableEsSyntax {
+fn ast_syntax(module_type: &ModuleType) -> Syntax {
+  Syntax::Es(EsSyntax {
     jsx: true,
     allow_return_outside_function: matches!(
       module_type,
@@ -730,26 +726,26 @@ fn stable_syntax(module_type: &ModuleType) -> StableSyntax {
   })
 }
 
-fn parse_stable_program(
-  cm: Arc<SourceMap>,
-  source_text: &str,
+fn parse_experimental_program<'ast>(
+  allocator: &'ast Allocator,
+  source_text: &'ast str,
   module_type: &ModuleType,
-  comments: &SingleThreadedComments,
-) -> Option<StableProgram> {
-  let fm = cm.new_source_file(
-    Arc::new(FileName::Custom("<rspack ast dependency>".to_string())),
-    source_text.to_string(),
+) -> Option<Program<'ast>> {
+  let lexer = Lexer::new(
+    allocator,
+    ast_syntax(module_type),
+    EsVersion::EsNext,
+    StringSource::new(source_text),
+    None,
   );
-  let lexer = StableLexer::new(
-    stable_syntax(module_type),
-    StableEsVersion::EsNext,
-    SourceFileInput::from(&*fm),
-    Some(comments),
-  );
-  let mut parser = StableParser::new_from(lexer);
+  let mut parser = Parser::new_from(allocator, lexer);
   let program = match module_type {
-    ModuleType::JsEsm => parser.parse_module().map(StableProgram::Module),
-    ModuleType::JsDynamic => parser.parse_commonjs().map(StableProgram::Script),
+    ModuleType::JsEsm => parser
+      .parse_module()
+      .map(|module| Program::Module(allocator.boxed(module))),
+    ModuleType::JsDynamic => parser
+      .parse_commonjs()
+      .map(|script| Program::Script(allocator.boxed(script))),
     _ => parser.parse_program(),
   }
   .ok()?;
@@ -757,61 +753,49 @@ fn parse_stable_program(
   parser.take_errors().is_empty().then_some(program)
 }
 
-fn parse_replacement_expr(content: &str) -> Option<Box<Expr>> {
-  let cm = Arc::<SourceMap>::default();
-  let fm = cm.new_source_file(
-    Arc::new(FileName::Custom(
-      "<rspack ast dependency replacement>".to_string(),
-    )),
-    content.to_string(),
-  );
-  let lexer = StableLexer::new(
-    stable_syntax(&ModuleType::JsAuto),
-    StableEsVersion::EsNext,
-    SourceFileInput::from(&*fm),
+fn parse_replacement_expr<'ast>(content: &str, allocator: &'ast Allocator) -> Option<Expr<'ast>> {
+  let content = allocator.alloc_str(content);
+  let lexer = Lexer::new(
+    allocator,
+    ast_syntax(&ModuleType::JsAuto),
+    EsVersion::EsNext,
+    StringSource::new(content),
     None,
   );
-  let mut parser = StableParser::new_from(lexer);
+  let mut parser = Parser::new_from(allocator, lexer);
   let expr = parser.parse_expr().ok()?;
 
   parser.take_errors().is_empty().then_some(expr)
 }
 
-fn parse_replacement_stmt(content: &str) -> Option<StableStmt> {
-  let cm = Arc::<SourceMap>::default();
-  let fm = cm.new_source_file(
-    Arc::new(FileName::Custom(
-      "<rspack ast dependency replacement>".to_string(),
-    )),
-    content.to_string(),
-  );
-  let lexer = StableLexer::new(
-    stable_syntax(&ModuleType::JsAuto),
-    StableEsVersion::EsNext,
-    SourceFileInput::from(&*fm),
+fn parse_replacement_stmt<'ast>(content: &str, allocator: &'ast Allocator) -> Option<Stmt<'ast>> {
+  let content = allocator.alloc_str(content);
+  let lexer = Lexer::new(
+    allocator,
+    ast_syntax(&ModuleType::JsAuto),
+    EsVersion::EsNext,
+    StringSource::new(content),
     None,
   );
-  let mut parser = StableParser::new_from(lexer);
+  let mut parser = Parser::new_from(allocator, lexer);
   let stmt = parser.parse_stmt().ok()?;
 
   parser.take_errors().is_empty().then_some(stmt)
 }
 
-fn parse_replacement_module_item(content: &str) -> Option<StableModuleItem> {
-  let cm = Arc::<SourceMap>::default();
-  let fm = cm.new_source_file(
-    Arc::new(FileName::Custom(
-      "<rspack ast dependency replacement>".to_string(),
-    )),
-    content.to_string(),
-  );
-  let lexer = StableLexer::new(
-    stable_syntax(&ModuleType::JsAuto),
-    StableEsVersion::EsNext,
-    SourceFileInput::from(&*fm),
+fn parse_replacement_module_item<'ast>(
+  content: &str,
+  allocator: &'ast Allocator,
+) -> Option<ModuleItem<'ast>> {
+  let content = allocator.alloc_str(content);
+  let lexer = Lexer::new(
+    allocator,
+    ast_syntax(&ModuleType::JsAuto),
+    EsVersion::EsNext,
+    StringSource::new(content),
     None,
   );
-  let mut parser = StableParser::new_from(lexer);
+  let mut parser = Parser::new_from(allocator, lexer);
   let module_item = parser.parse_module_item().ok()?;
 
   parser.take_errors().is_empty().then_some(module_item)
@@ -856,6 +840,7 @@ fn validate_ast_dependency_actions(
   module_type: &ModuleType,
   actions: &[AstDependencyAction],
 ) -> Option<()> {
+  let allocator = Allocator::new();
   let mut seen_ranges = FxHashSet::default();
   let actions = actions
     .iter()
@@ -865,19 +850,15 @@ fn validate_ast_dependency_actions(
           return None;
         }
       }
-      ParsedAstDependencyAction::new(action, source_text)
+      ParsedAstDependencyAction::new(action, source_text, &allocator)
     })
     .collect::<Option<Vec<_>>>()?;
 
-  let globals = Globals::new();
-  GLOBALS.set(&globals, || {
-    let cm = Arc::<SourceMap>::default();
-    let comments = SingleThreadedComments::default();
-    let mut program = parse_stable_program(cm, source_text, module_type, &comments)?;
-    let mut applier = StableAstDependencyApplier::new(actions);
-    program.visit_mut_with(&mut applier);
-    applier.is_fully_applied().then_some(())
-  })
+  let source_text = allocator.alloc_str(source_text);
+  let mut program = parse_experimental_program(&allocator, source_text, module_type)?;
+  let mut applier = ExperimentalAstDependencyApplier::new(actions, &allocator);
+  program.visit_mut_with(&mut applier);
+  applier.is_fully_applied().then_some(())
 }
 
 fn render_source_replacements(
@@ -999,30 +980,26 @@ mod tests {
   use super::*;
 
   fn first_top_level_range(source: &str, module_type: ModuleType) -> DependencyRange {
-    GLOBALS.set(&Globals::new(), || {
-      let cm = Arc::<SourceMap>::default();
-      let comments = SingleThreadedComments::default();
-      let program = parse_stable_program(cm, source, &module_type, &comments).unwrap();
-      match program {
-        StableProgram::Module(module) => DependencyRange::from(module.body[0].span()),
-        StableProgram::Script(script) => DependencyRange::from(script.body[0].span()),
-      }
-    })
+    let allocator = Allocator::new();
+    let source = allocator.alloc_str(source);
+    let program = parse_experimental_program(&allocator, source, &module_type).unwrap();
+    match program {
+      Program::Module(module) => DependencyRange::from(module.body[0].span()),
+      Program::Script(script) => DependencyRange::from(script.body[0].span()),
+    }
   }
 
   fn if_consequent_range(source: &str) -> DependencyRange {
-    GLOBALS.set(&Globals::new(), || {
-      let cm = Arc::<SourceMap>::default();
-      let comments = SingleThreadedComments::default();
-      let program = parse_stable_program(cm, source, &ModuleType::JsAuto, &comments).unwrap();
-      let StableProgram::Script(script) = program else {
-        unreachable!()
-      };
-      let StableStmt::If(if_stmt) = &script.body[0] else {
-        unreachable!()
-      };
-      DependencyRange::from(if_stmt.cons.span())
-    })
+    let allocator = Allocator::new();
+    let source = allocator.alloc_str(source);
+    let program = parse_experimental_program(&allocator, source, &ModuleType::JsAuto).unwrap();
+    let Program::Script(script) = program else {
+      unreachable!()
+    };
+    let Stmt::If(if_stmt) = &script.body[0] else {
+      unreachable!()
+    };
+    DependencyRange::from(if_stmt.cons.span())
   }
 
   #[test]

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -13,8 +13,8 @@ use swc_core::{
   ecma::{
     ast::{
       EsVersion as StableEsVersion, Expr, Ident as StableIdent, Lit as StableLit,
-      ModuleItem as StableModuleItem, Program as StableProgram, PropName as StablePropName,
-      Stmt as StableStmt,
+      MemberExpr as StableMemberExpr, ModuleItem as StableModuleItem, Program as StableProgram,
+      PropName as StablePropName, Stmt as StableStmt,
     },
     parser::{
       EsSyntax as StableEsSyntax, Parser as StableParser, Syntax as StableSyntax,
@@ -305,6 +305,53 @@ impl AstDependencyAction {
       _ => vec![self.edit_range()],
     }
   }
+
+  fn source_replacement_ranges(&self) -> Vec<DependencyRange> {
+    match &self.replacement {
+      AstDependencyReplacement::WrappedSource { replacement, .. } => vec![
+        DependencyRange::new(self.range.start, replacement.start),
+        DependencyRange::new(replacement.end, self.range.end),
+      ],
+      AstDependencyReplacement::WrappedSourceWithReplacements {
+        replacement,
+        replacements,
+        ..
+      } => {
+        let mut ranges = vec![
+          DependencyRange::new(self.range.start, replacement.start),
+          DependencyRange::new(replacement.end, self.range.end),
+        ];
+        ranges.extend(
+          replacements
+            .iter()
+            .map(|(_, start, end)| DependencyRange::new(*start, *end)),
+        );
+        ranges
+      }
+      AstDependencyReplacement::ValidatedReplacements { replacements }
+      | AstDependencyReplacement::SourceWithReplacements { replacements, .. } => replacements
+        .iter()
+        .map(|(_, start, end)| DependencyRange::new(*start, *end))
+        .collect(),
+      _ => vec![self.edit_range()],
+    }
+  }
+
+  fn is_redundant_validated_replacement(
+    &self,
+    existing_ranges: &FxHashSet<DependencyRange>,
+  ) -> bool {
+    let AstDependencyReplacement::ValidatedReplacements { replacements } = &self.replacement else {
+      return false;
+    };
+    if replacements.is_empty() {
+      return false;
+    }
+
+    replacements
+      .iter()
+      .all(|(_, start, end)| existing_ranges.contains(&DependencyRange::new(*start, *end)))
+  }
 }
 
 fn apply_inner_replacements(
@@ -358,6 +405,15 @@ pub struct AstDependencyRenderPlan {
 
 impl AstDependencyRenderPlan {
   pub fn push_action(&mut self, action: AstDependencyAction) {
+    let existing_ranges = self
+      .actions
+      .iter()
+      .flat_map(AstDependencyAction::source_replacement_ranges)
+      .collect::<FxHashSet<_>>();
+    if action.is_redundant_validated_replacement(&existing_ranges) {
+      return;
+    }
+
     self.actions.push(action);
   }
 
@@ -488,6 +544,19 @@ impl StableAstDependencyApplier {
     action.expr_replacement.take()
   }
 
+  fn replacement_for_member_expr(&mut self, range: DependencyRange) -> Option<StableMemberExpr> {
+    let action = self.actions.iter_mut().find(|action| {
+      !action.applied
+        && action.range == range
+        && matches!(action.expr_replacement.as_deref(), Some(Expr::Member(_)))
+    })?;
+    action.applied = true;
+    let Some(Expr::Member(member)) = action.expr_replacement.take().map(|expr| *expr) else {
+      unreachable!()
+    };
+    Some(member)
+  }
+
   fn replacement_for_ident(&mut self, range: DependencyRange) -> bool {
     let Some(action) = self
       .actions
@@ -600,6 +669,17 @@ impl VisitMut for StableAstDependencyApplier {
     self.validate_node(range);
     if let Some(replacement) = self.replacement_for_expr(range) {
       *node = *replacement;
+      return;
+    }
+
+    node.visit_mut_children_with(self);
+  }
+
+  fn visit_mut_member_expr(&mut self, node: &mut StableMemberExpr) {
+    let range = DependencyRange::from(node.span());
+    self.validate_node(range);
+    if let Some(replacement) = self.replacement_for_member_expr(range) {
+      *node = replacement;
       return;
     }
 
@@ -969,6 +1049,28 @@ mod tests {
   }
 
   #[test]
+  fn replaces_member_expression_assignment_target_by_ast_range() {
+    let source = "Curve.create = function () {};\n";
+    let start = source.find("Curve.create").unwrap() as u32;
+    let end = start + "Curve.create".len() as u32;
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::expr(
+        DependencyRange::new(start, end),
+        "_extras_core_Curve_js__rspack_import_10.Curve.create",
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+
+    assert_eq!(
+      output,
+      "_extras_core_Curve_js__rspack_import_10.Curve.create = function () {};\n"
+    );
+  }
+
+  #[test]
   fn deletes_top_level_statement_by_ast_range() {
     let source = "\"use strict\";\nconsole.log(1);\n";
     let mut plan = AstDependencyRenderPlan::default();
@@ -1025,6 +1127,46 @@ mod tests {
 
     assert!(!output.contains("export"));
     assert!(output.contains("const answer = 42"));
+  }
+
+  #[test]
+  fn replaces_export_default_template_with_leading_comment() {
+    let source = "export default /* glsl */`\nvoid main() {}\n`;\n";
+    let range_stmt = DependencyRange::new(0, source.find(';').unwrap() as u32 + 1);
+    let range = DependencyRange::new(
+      source.find('`').unwrap() as u32,
+      source.rfind('`').unwrap() as u32 + 1,
+    );
+    let mut plan = AstDependencyRenderPlan::default();
+    plan.push_action(
+      AstDependencyAction::source_with_replacements(
+        range_stmt,
+        range_stmt,
+        vec![
+          (
+            "/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (/* glsl */".to_string(),
+            range_stmt.start,
+            range.start,
+          ),
+          (");".to_string(), range.end, range_stmt.end),
+        ],
+      )
+      .unwrap(),
+    );
+    plan.push_action(
+      AstDependencyAction::validated_replacements(
+        range_stmt,
+        vec![(String::new(), range_stmt.start, range.start)],
+      )
+      .unwrap(),
+    );
+
+    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+
+    assert_eq!(
+      output,
+      "/* export default */ const __WEBPACK_DEFAULT_EXPORT__ = (/* glsl */`\nvoid main() {}\n`);\n"
+    );
   }
 
   #[test]

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -793,7 +793,7 @@ fn validate_ast_dependency_actions(
   GLOBALS.set(&globals, || {
     let cm = Arc::<SourceMap>::default();
     let comments = SingleThreadedComments::default();
-    let mut program = parse_stable_program(cm.clone(), source_text, module_type, &comments)?;
+    let mut program = parse_stable_program(cm, source_text, module_type, &comments)?;
     let mut applier = StableAstDependencyApplier::new(actions);
     program.visit_mut_with(&mut applier);
     applier.is_fully_applied().then_some(())
@@ -1016,7 +1016,7 @@ mod tests {
     plan.push_action(
       AstDependencyAction::validated_replacements(
         range,
-        vec![("".to_string(), range.start, replacement_start)],
+        vec![(String::new(), range.start, replacement_start)],
       )
       .unwrap(),
     );

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/ast_dependency.rs
@@ -1,17 +1,11 @@
 use std::borrow::Cow;
 
 use rspack_core::{
-  DependencyRange, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleType,
-  NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  DependencyRange, InitFragmentExt, InitFragmentKey, InitFragmentStage, NormalInitFragment,
+  RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 use rustc_hash::FxHashSet;
 use swc_atoms::Atom;
-use swc_experimental_allocator::{Allocator, boxed::Box as AstBox, vec::Vec as AstVec};
-use swc_experimental_ecma_ast::{
-  EsVersion, Expr, GetSpan, Ident, Lit, MemberExpr, ModuleItem, Program, PropName, Stmt, VisitMut,
-  VisitMutWith,
-};
-use swc_experimental_ecma_parser::{EsSyntax, Lexer, Parser, StringSource, Syntax};
 
 #[derive(Debug, Clone)]
 pub enum AstDependencySideEffect {
@@ -108,7 +102,11 @@ enum AstDependencyReplacement {
     suffix: Box<str>,
     replacements: Vec<(Box<str>, u32, u32)>,
   },
-  ValidatedReplacements {
+  WrappedSourceTrimTrailingSemicolon {
+    prefix: Box<str>,
+    suffix: Box<str>,
+  },
+  RangeReplacements {
     replacements: Vec<(Box<str>, u32, u32)>,
   },
   SourceWithReplacements {
@@ -119,7 +117,7 @@ enum AstDependencyReplacement {
 
 impl AstDependencyAction {
   pub fn expr(range: DependencyRange, content: impl Into<Box<str>>) -> Option<Self> {
-    if range.start >= range.end {
+    if range.start > range.end {
       return None;
     }
 
@@ -130,7 +128,7 @@ impl AstDependencyAction {
   }
 
   pub fn raw_expr(range: DependencyRange, content: impl Into<Box<str>>) -> Option<Self> {
-    if range.start >= range.end {
+    if range.start > range.end {
       return None;
     }
 
@@ -141,7 +139,7 @@ impl AstDependencyAction {
   }
 
   pub fn raw_ident(range: DependencyRange, content: impl Into<Box<str>>) -> Option<Self> {
-    if range.start >= range.end {
+    if range.start > range.end {
       return None;
     }
 
@@ -155,7 +153,7 @@ impl AstDependencyAction {
     range: DependencyRange,
     suffix: impl Into<Box<str>>,
   ) -> Option<Self> {
-    if range.start >= range.end {
+    if range.start > range.end {
       return None;
     }
 
@@ -166,16 +164,16 @@ impl AstDependencyAction {
   }
 
   pub fn insert(
-    validate_range: DependencyRange,
+    range: DependencyRange,
     position: u32,
     content: impl Into<Box<str>>,
   ) -> Option<Self> {
-    if validate_range.start >= validate_range.end {
+    if range.start > range.end {
       return None;
     }
 
     Some(Self {
-      range: validate_range,
+      range,
       replacement: AstDependencyReplacement::Insert {
         position,
         content: content.into(),
@@ -189,7 +187,7 @@ impl AstDependencyAction {
     prefix: impl Into<Box<str>>,
     suffix: impl Into<Box<str>>,
   ) -> Option<Self> {
-    if range.start >= range.end || replacement.start > replacement.end {
+    if range.start > range.end || replacement.start > replacement.end {
       return None;
     }
 
@@ -210,7 +208,7 @@ impl AstDependencyAction {
     suffix: impl Into<Box<str>>,
     replacements: Vec<(String, u32, u32)>,
   ) -> Option<Self> {
-    if range.start >= range.end || replacement.start > replacement.end {
+    if range.start > range.end || replacement.start > replacement.end {
       return None;
     }
 
@@ -228,12 +226,30 @@ impl AstDependencyAction {
     })
   }
 
+  pub fn wrapped_source_trim_trailing_semicolon(
+    range: DependencyRange,
+    prefix: impl Into<Box<str>>,
+    suffix: impl Into<Box<str>>,
+  ) -> Option<Self> {
+    if range.start > range.end {
+      return None;
+    }
+
+    Some(Self {
+      range,
+      replacement: AstDependencyReplacement::WrappedSourceTrimTrailingSemicolon {
+        prefix: prefix.into(),
+        suffix: suffix.into(),
+      },
+    })
+  }
+
   pub fn source_with_replacements(
     range: DependencyRange,
     replacement: DependencyRange,
     replacements: Vec<(String, u32, u32)>,
   ) -> Option<Self> {
-    if range.start >= range.end
+    if range.start > range.end
       || replacement.start > replacement.end
       || replacement.start < range.start
       || replacement.end > range.end
@@ -253,17 +269,17 @@ impl AstDependencyAction {
     })
   }
 
-  pub fn validated_replacements(
-    validate_range: DependencyRange,
+  pub fn range_replacements(
+    range: DependencyRange,
     replacements: Vec<(String, u32, u32)>,
   ) -> Option<Self> {
-    if validate_range.start >= validate_range.end {
+    if range.start > range.end {
       return None;
     }
 
     Some(Self {
-      range: validate_range,
-      replacement: AstDependencyReplacement::ValidatedReplacements {
+      range,
+      replacement: AstDependencyReplacement::RangeReplacements {
         replacements: replacements
           .into_iter()
           .map(|(content, start, end)| (content.into_boxed_str(), start, end))
@@ -272,38 +288,47 @@ impl AstDependencyAction {
     })
   }
 
-  fn replacement_content<'a>(&'a self, source_text: &'a str) -> Option<Cow<'a, str>> {
+  fn replacement_content<'a>(&'a self, source_text: &'a str) -> Cow<'a, str> {
     match &self.replacement {
-      AstDependencyReplacement::Generated(content) => Some(Cow::Borrowed(content.as_ref())),
-      AstDependencyReplacement::RawExpr(content) => Some(Cow::Borrowed(content.as_ref())),
-      AstDependencyReplacement::RawIdent(content) => Some(Cow::Borrowed(content.as_ref())),
-      AstDependencyReplacement::RawIdentWithSuffix(suffix) => source_text
-        .get(self.range.start as usize..self.range.end as usize)
-        .map(|source| Cow::Owned(format!("{source}{suffix}"))),
-      AstDependencyReplacement::Insert { content, .. } => Some(Cow::Borrowed(content.as_ref())),
+      AstDependencyReplacement::Generated(content) => Cow::Borrowed(content.as_ref()),
+      AstDependencyReplacement::RawExpr(content) => Cow::Borrowed(content.as_ref()),
+      AstDependencyReplacement::RawIdent(content) => Cow::Borrowed(content.as_ref()),
+      AstDependencyReplacement::RawIdentWithSuffix(suffix) => {
+        let source = &source_text[self.range.start as usize..self.range.end as usize];
+        Cow::Owned(format!("{source}{suffix}"))
+      }
+      AstDependencyReplacement::Insert { content, .. } => Cow::Borrowed(content.as_ref()),
       AstDependencyReplacement::WrappedSource {
         replacement,
         prefix,
         suffix,
-      } => source_text
-        .get(replacement.start as usize..replacement.end as usize)
-        .map(|source| Cow::Owned(format!("{prefix}{source}{suffix}"))),
+      } => {
+        let source = &source_text[replacement.start as usize..replacement.end as usize];
+        Cow::Owned(format!("{prefix}{source}{suffix}"))
+      }
       AstDependencyReplacement::WrappedSourceWithReplacements {
         replacement,
         prefix,
         suffix,
         replacements,
-      } => apply_inner_replacements(source_text, *replacement, replacements)
-        .map(|source| Cow::Owned(format!("{prefix}{source}{suffix}"))),
-      AstDependencyReplacement::ValidatedReplacements { .. } => None,
+      } => {
+        let source = apply_inner_replacements(source_text, *replacement, replacements);
+        Cow::Owned(format!("{prefix}{source}{suffix}"))
+      }
+      AstDependencyReplacement::WrappedSourceTrimTrailingSemicolon { .. } => {
+        unreachable!("trimmed wrapped source is expanded by source_replacements")
+      }
+      AstDependencyReplacement::RangeReplacements { .. } => {
+        unreachable!("range replacements are expanded by source_replacements")
+      }
       AstDependencyReplacement::SourceWithReplacements {
         replacement,
         replacements,
       } => {
-        let prefix = source_text.get(self.range.start as usize..replacement.start as usize)?;
-        let suffix = source_text.get(replacement.end as usize..self.range.end as usize)?;
-        apply_inner_replacements(source_text, *replacement, replacements)
-          .map(|source| Cow::Owned(format!("{prefix}{source}{suffix}")))
+        let prefix = &source_text[self.range.start as usize..replacement.start as usize];
+        let suffix = &source_text[replacement.end as usize..self.range.end as usize];
+        let source = apply_inner_replacements(source_text, *replacement, replacements);
+        Cow::Owned(format!("{prefix}{source}{suffix}"))
       }
     }
   }
@@ -313,18 +338,9 @@ impl AstDependencyAction {
       AstDependencyReplacement::Insert { position, .. } => {
         DependencyRange::new(*position, *position)
       }
-      AstDependencyReplacement::ValidatedReplacements { .. } => self.range,
+      AstDependencyReplacement::RangeReplacements { .. } => self.range,
+      AstDependencyReplacement::WrappedSourceTrimTrailingSemicolon { .. } => self.range,
       _ => self.range,
-    }
-  }
-
-  fn edit_ranges(&self) -> Vec<DependencyRange> {
-    match &self.replacement {
-      AstDependencyReplacement::ValidatedReplacements { replacements } => replacements
-        .iter()
-        .map(|(_, start, end)| DependencyRange::new(*start, *end))
-        .collect(),
-      _ => vec![self.edit_range()],
     }
   }
 
@@ -350,20 +366,21 @@ impl AstDependencyAction {
         );
         ranges
       }
-      AstDependencyReplacement::ValidatedReplacements { replacements }
+      AstDependencyReplacement::RangeReplacements { replacements }
       | AstDependencyReplacement::SourceWithReplacements { replacements, .. } => replacements
         .iter()
         .map(|(_, start, end)| DependencyRange::new(*start, *end))
         .collect(),
+      AstDependencyReplacement::WrappedSourceTrimTrailingSemicolon { .. } => vec![
+        DependencyRange::new(self.range.start, self.range.start),
+        DependencyRange::new(self.range.end, self.range.end),
+      ],
       _ => vec![self.edit_range()],
     }
   }
 
-  fn is_redundant_validated_replacement(
-    &self,
-    existing_ranges: &FxHashSet<DependencyRange>,
-  ) -> bool {
-    let AstDependencyReplacement::ValidatedReplacements { replacements } = &self.replacement else {
+  fn is_redundant_range_replacement(&self, existing_ranges: &FxHashSet<DependencyRange>) -> bool {
+    let AstDependencyReplacement::RangeReplacements { replacements } = &self.replacement else {
       return false;
     };
     if replacements.is_empty() {
@@ -380,62 +397,39 @@ fn apply_inner_replacements(
   source_text: &str,
   range: DependencyRange,
   replacements: &[(Box<str>, u32, u32)],
-) -> Option<String> {
-  if range.start > range.end
-    || range.end as usize > source_text.len()
-    || !source_text.is_char_boundary(range.start as usize)
-    || !source_text.is_char_boundary(range.end as usize)
-  {
-    return None;
-  }
-
-  let mut replacements = replacements.to_vec();
+) -> String {
+  let mut replacements = replacements.iter().collect::<Vec<_>>();
   replacements.sort_by_key(|(_, start, _)| *start);
-
-  let mut last_end = range.start;
-  for (_, start, end) in &replacements {
-    if *start < last_end
-      || start > end
-      || *start < range.start
-      || *end > range.end
-      || !source_text.is_char_boundary(*start as usize)
-      || !source_text.is_char_boundary(*end as usize)
-    {
-      return None;
-    }
-    last_end = *end;
-  }
 
   let mut output = String::new();
   let mut cursor = range.start as usize;
   for (content, start, end) in replacements {
-    let start = start as usize;
-    let end = end as usize;
+    let start = *start as usize;
+    let end = *end as usize;
     output.push_str(&source_text[cursor..start]);
-    output.push_str(&content);
+    output.push_str(content.as_ref());
     cursor = end;
   }
   output.push_str(&source_text[cursor..range.end as usize]);
-  Some(output)
+  output
 }
 
 #[derive(Debug, Default)]
 pub struct AstDependencyRenderPlan {
   actions: Vec<AstDependencyAction>,
   side_effects: Vec<AstDependencySideEffect>,
+  source_replacement_ranges: FxHashSet<DependencyRange>,
 }
 
 impl AstDependencyRenderPlan {
   pub fn push_action(&mut self, action: AstDependencyAction) {
-    let existing_ranges = self
-      .actions
-      .iter()
-      .flat_map(AstDependencyAction::source_replacement_ranges)
-      .collect::<FxHashSet<_>>();
-    if action.is_redundant_validated_replacement(&existing_ranges) {
+    if action.is_redundant_range_replacement(&self.source_replacement_ranges) {
       return;
     }
 
+    for range in action.source_replacement_ranges() {
+      self.source_replacement_ranges.insert(range);
+    }
     self.actions.push(action);
   }
 
@@ -452,472 +446,51 @@ impl AstDependencyRenderPlan {
   }
 }
 
-struct ParsedAstDependencyAction<'ast> {
-  range: DependencyRange,
-  expr_replacement: Option<Expr<'ast>>,
-  ident_replacement: bool,
-  validate_only: bool,
-  stmt_replacement: Option<Option<Stmt<'ast>>>,
-  module_item_replacement: Option<Option<ModuleItem<'ast>>>,
-  applied: bool,
-}
-
-impl<'ast> ParsedAstDependencyAction<'ast> {
-  fn new(
-    action: &AstDependencyAction,
-    source_text: &str,
-    allocator: &'ast Allocator,
-  ) -> Option<Self> {
-    if matches!(action.replacement, AstDependencyReplacement::RawExpr(_)) {
-      return Some(Self {
-        range: action.range,
-        expr_replacement: parse_replacement_expr(
-          "__rspack_ast_dependency_raw_replacement__",
-          allocator,
-        ),
-        ident_replacement: false,
-        validate_only: false,
-        stmt_replacement: None,
-        module_item_replacement: None,
-        applied: false,
-      });
-    }
-
-    if matches!(
-      action.replacement,
-      AstDependencyReplacement::RawIdent(_) | AstDependencyReplacement::RawIdentWithSuffix(_)
-    ) {
-      return Some(Self {
-        range: action.range,
-        expr_replacement: None,
-        ident_replacement: true,
-        validate_only: false,
-        stmt_replacement: None,
-        module_item_replacement: None,
-        applied: false,
-      });
-    }
-
-    if matches!(
-      action.replacement,
-      AstDependencyReplacement::Insert { .. }
-        | AstDependencyReplacement::ValidatedReplacements { .. }
-    ) {
-      return Some(Self {
-        range: action.range,
-        expr_replacement: None,
-        ident_replacement: false,
-        validate_only: true,
-        stmt_replacement: None,
-        module_item_replacement: None,
-        applied: false,
-      });
-    }
-
-    let content = action.replacement_content(source_text)?;
-    let delete = content.trim().is_empty();
-    let expr_replacement = if delete {
-      None
-    } else {
-      parse_replacement_expr(&content, allocator)
-    };
-    let stmt_replacement = if delete {
-      Some(None)
-    } else {
-      parse_replacement_stmt(&content, allocator).map(Some)
-    };
-    let module_item_replacement = if delete {
-      Some(None)
-    } else {
-      parse_replacement_module_item(&content, allocator).map(Some)
-    };
-
-    if !delete
-      && expr_replacement.is_none()
-      && stmt_replacement.is_none()
-      && module_item_replacement.is_none()
-    {
-      return None;
-    }
-
-    Some(Self {
-      range: action.range,
-      expr_replacement,
-      ident_replacement: false,
-      validate_only: false,
-      stmt_replacement,
-      module_item_replacement,
-      applied: false,
-    })
-  }
-}
-
-struct ExperimentalAstDependencyApplier<'ast> {
-  allocator: &'ast Allocator,
-  actions: Vec<ParsedAstDependencyAction<'ast>>,
-}
-
-impl<'ast> ExperimentalAstDependencyApplier<'ast> {
-  fn new(actions: Vec<ParsedAstDependencyAction<'ast>>, allocator: &'ast Allocator) -> Self {
-    Self { allocator, actions }
-  }
-
-  fn is_fully_applied(&self) -> bool {
-    self.actions.iter().all(|action| action.applied)
-  }
-
-  fn replacement_for_expr(&mut self, range: DependencyRange) -> Option<Expr<'ast>> {
-    let action = self.actions.iter_mut().find(|action| {
-      !action.applied && action.range == range && action.expr_replacement.is_some()
-    })?;
-    action.applied = true;
-    action.expr_replacement.take()
-  }
-
-  fn replacement_for_member_expr(&mut self, range: DependencyRange) -> Option<MemberExpr<'ast>> {
-    let action = self.actions.iter_mut().find(|action| {
-      !action.applied
-        && action.range == range
-        && matches!(action.expr_replacement.as_ref(), Some(Expr::Member(_)))
-    })?;
-    action.applied = true;
-    let Some(Expr::Member(member)) = action.expr_replacement.take() else {
-      unreachable!()
-    };
-    Some(AstBox::into_inner(member))
-  }
-
-  fn replacement_for_ident(&mut self, range: DependencyRange) -> bool {
-    let Some(action) = self
-      .actions
-      .iter_mut()
-      .find(|action| !action.applied && action.range == range && action.ident_replacement)
-    else {
-      return false;
-    };
-    action.applied = true;
-    true
-  }
-
-  fn validate_node(&mut self, range: DependencyRange) {
-    for action in self
-      .actions
-      .iter_mut()
-      .filter(|action| !action.applied && action.range == range && action.validate_only)
-    {
-      action.applied = true;
-    }
-  }
-
-  fn replacement_for_stmt_list(&mut self, range: DependencyRange) -> Option<Option<Stmt<'ast>>> {
-    let action = self.actions.iter_mut().find(|action| {
-      !action.applied && action.range == range && action.stmt_replacement.is_some()
-    })?;
-    action.applied = true;
-    action.stmt_replacement.take()
-  }
-
-  fn replacement_for_stmt_node(&mut self, range: DependencyRange) -> Option<Stmt<'ast>> {
-    let action = self.actions.iter_mut().find(|action| {
-      !action.applied
-        && action.range == range
-        && action
-          .stmt_replacement
-          .as_ref()
-          .is_some_and(|replacement| replacement.is_some())
-    })?;
-    action.applied = true;
-    action.stmt_replacement.take().flatten()
-  }
-
-  fn replacement_for_module_item(
-    &mut self,
-    range: DependencyRange,
-  ) -> Option<Option<ModuleItem<'ast>>> {
-    let action = self.actions.iter_mut().find(|action| {
-      !action.applied && action.range == range && action.module_item_replacement.is_some()
-    })?;
-    action.applied = true;
-    action.module_item_replacement.take()
-  }
-}
-
-impl<'ast> VisitMut<'ast> for ExperimentalAstDependencyApplier<'ast> {
-  fn visit_mut_module_items(&mut self, node: &mut AstVec<'ast, ModuleItem<'ast>>) {
-    let mut next = AstVec::with_capacity_in(node.len(), self.allocator);
-
-    for mut item in std::mem::replace(node, AstVec::new_in(self.allocator)) {
-      let range = DependencyRange::from(item.span());
-      self.validate_node(range);
-      if let Some(replacement) = self.replacement_for_module_item(range) {
-        if let Some(replacement) = replacement {
-          next.push(replacement);
-        }
-        continue;
-      }
-
-      item.visit_mut_children_with(self);
-      next.push(item);
-    }
-
-    *node = next;
-  }
-
-  fn visit_mut_stmts(&mut self, node: &mut AstVec<'ast, Stmt<'ast>>) {
-    let mut next = AstVec::with_capacity_in(node.len(), self.allocator);
-
-    for mut stmt in std::mem::replace(node, AstVec::new_in(self.allocator)) {
-      let range = DependencyRange::from(stmt.span());
-      self.validate_node(range);
-      if let Some(replacement) = self.replacement_for_stmt_list(range) {
-        if let Some(replacement) = replacement {
-          next.push(replacement);
-        }
-        continue;
-      }
-
-      stmt.visit_mut_children_with(self);
-      next.push(stmt);
-    }
-
-    *node = next;
-  }
-
-  fn visit_mut_stmt(&mut self, node: &mut Stmt<'ast>) {
-    let range = DependencyRange::from(node.span());
-    self.validate_node(range);
-    if let Some(replacement) = self.replacement_for_stmt_node(range) {
-      *node = replacement;
-      return;
-    }
-
-    node.visit_mut_children_with(self);
-  }
-
-  fn visit_mut_expr(&mut self, node: &mut Expr<'ast>) {
-    let range = DependencyRange::from(node.span());
-    self.validate_node(range);
-    if let Some(replacement) = self.replacement_for_expr(range) {
-      *node = replacement;
-      return;
-    }
-
-    node.visit_mut_children_with(self);
-  }
-
-  fn visit_mut_member_expr(&mut self, node: &mut MemberExpr<'ast>) {
-    let range = DependencyRange::from(node.span());
-    self.validate_node(range);
-    if let Some(replacement) = self.replacement_for_member_expr(range) {
-      *node = replacement;
-      return;
-    }
-
-    node.visit_mut_children_with(self);
-  }
-
-  fn visit_mut_ident(&mut self, node: &mut Ident<'ast>) {
-    let range = DependencyRange::from(node.span());
-    self.validate_node(range);
-    if self.replacement_for_ident(range) {
-      return;
-    }
-
-    node.visit_mut_children_with(self);
-  }
-
-  fn visit_mut_lit(&mut self, node: &mut Lit<'ast>) {
-    let range = DependencyRange::from(node.span());
-    self.validate_node(range);
-    if self.replacement_for_ident(range) {
-      return;
-    }
-
-    node.visit_mut_children_with(self);
-  }
-
-  fn visit_mut_prop_name(&mut self, node: &mut PropName<'ast>) {
-    let range = DependencyRange::from(node.span());
-    self.validate_node(range);
-    if self.replacement_for_ident(range) {
-      return;
-    }
-
-    node.visit_mut_children_with(self);
-  }
-}
-
-fn ast_syntax(module_type: &ModuleType) -> Syntax {
-  Syntax::Es(EsSyntax {
-    jsx: true,
-    allow_return_outside_function: matches!(
-      module_type,
-      ModuleType::JsDynamic | ModuleType::JsAuto
-    ),
-    explicit_resource_management: true,
-    import_attributes: true,
-    ..Default::default()
-  })
-}
-
-fn parse_experimental_program<'ast>(
-  allocator: &'ast Allocator,
-  source_text: &'ast str,
-  module_type: &ModuleType,
-) -> Option<Program<'ast>> {
-  let lexer = Lexer::new(
-    allocator,
-    ast_syntax(module_type),
-    EsVersion::EsNext,
-    StringSource::new(source_text),
-    None,
-  );
-  let mut parser = Parser::new_from(allocator, lexer);
-  let program = match module_type {
-    ModuleType::JsEsm => parser
-      .parse_module()
-      .map(|module| Program::Module(allocator.boxed(module))),
-    ModuleType::JsDynamic => parser
-      .parse_commonjs()
-      .map(|script| Program::Script(allocator.boxed(script))),
-    _ => parser.parse_program(),
-  }
-  .ok()?;
-
-  parser.take_errors().is_empty().then_some(program)
-}
-
-fn parse_replacement_expr<'ast>(content: &str, allocator: &'ast Allocator) -> Option<Expr<'ast>> {
-  let content = allocator.alloc_str(content);
-  let lexer = Lexer::new(
-    allocator,
-    ast_syntax(&ModuleType::JsAuto),
-    EsVersion::EsNext,
-    StringSource::new(content),
-    None,
-  );
-  let mut parser = Parser::new_from(allocator, lexer);
-  let expr = parser.parse_expr().ok()?;
-
-  parser.take_errors().is_empty().then_some(expr)
-}
-
-fn parse_replacement_stmt<'ast>(content: &str, allocator: &'ast Allocator) -> Option<Stmt<'ast>> {
-  let content = allocator.alloc_str(content);
-  let lexer = Lexer::new(
-    allocator,
-    ast_syntax(&ModuleType::JsAuto),
-    EsVersion::EsNext,
-    StringSource::new(content),
-    None,
-  );
-  let mut parser = Parser::new_from(allocator, lexer);
-  let stmt = parser.parse_stmt().ok()?;
-
-  parser.take_errors().is_empty().then_some(stmt)
-}
-
-fn parse_replacement_module_item<'ast>(
-  content: &str,
-  allocator: &'ast Allocator,
-) -> Option<ModuleItem<'ast>> {
-  let content = allocator.alloc_str(content);
-  let lexer = Lexer::new(
-    allocator,
-    ast_syntax(&ModuleType::JsAuto),
-    EsVersion::EsNext,
-    StringSource::new(content),
-    None,
-  );
-  let mut parser = Parser::new_from(allocator, lexer);
-  let module_item = parser.parse_module_item().ok()?;
-
-  parser.take_errors().is_empty().then_some(module_item)
-}
-
-pub fn render_ast_dependencies(
-  source_text: &str,
-  module_type: &ModuleType,
-  plan: &AstDependencyRenderPlan,
-) -> Option<String> {
+pub fn render_ast_dependencies(source_text: &str, plan: &AstDependencyRenderPlan) -> String {
   if !plan.has_actions() {
-    return Some(source_text.to_string());
+    return source_text.to_string();
   }
 
-  validate_ast_dependency_actions(source_text, module_type, &plan.actions)?;
   render_source_replacements(source_text, &plan.actions)
 }
 
 pub fn apply_ast_dependency_replacements(
   source_text: &str,
-  module_type: &ModuleType,
   plan: &AstDependencyRenderPlan,
   source: &mut TemplateReplaceSource,
-) -> bool {
-  if validate_ast_dependency_actions(source_text, module_type, &plan.actions).is_none() {
-    return false;
-  }
-
-  let Some(replacements) = source_replacements(source_text, &plan.actions) else {
-    return false;
-  };
-
-  for (range, replacement) in replacements {
+) {
+  for (range, replacement, _) in source_replacements(source_text, &plan.actions) {
     source.replace(range.start, range.end, replacement, None);
   }
-
-  true
 }
 
-fn validate_ast_dependency_actions(
-  source_text: &str,
-  module_type: &ModuleType,
-  actions: &[AstDependencyAction],
-) -> Option<()> {
-  let allocator = Allocator::new();
-  let mut seen_ranges = FxHashSet::default();
-  let actions = actions
-    .iter()
-    .map(|action| {
-      for range in action.edit_ranges() {
-        if !seen_ranges.insert(range) {
-          return None;
-        }
-      }
-      ParsedAstDependencyAction::new(action, source_text, &allocator)
-    })
-    .collect::<Option<Vec<_>>>()?;
-
-  let source_text = allocator.alloc_str(source_text);
-  let mut program = parse_experimental_program(&allocator, source_text, module_type)?;
-  let mut applier = ExperimentalAstDependencyApplier::new(actions, &allocator);
-  program.visit_mut_with(&mut applier);
-  applier.is_fully_applied().then_some(())
-}
-
-fn render_source_replacements(
-  source_text: &str,
-  actions: &[AstDependencyAction],
-) -> Option<String> {
-  let replacements = source_replacements(source_text, actions)?;
+fn render_source_replacements(source_text: &str, actions: &[AstDependencyAction]) -> String {
+  let replacements = source_replacements(source_text, actions);
 
   let mut output = String::with_capacity(source_text.len());
   let mut cursor = 0usize;
-  for (range, replacement) in replacements {
+  let source_len = source_text.len();
+  for (range, replacement, _) in replacements {
     let start = range.start as usize;
     let end = range.end as usize;
-    output.push_str(&source_text[cursor..start]);
+    if start > cursor {
+      let prefix_end = start.min(source_len);
+      output.push_str(&source_text[cursor..prefix_end]);
+      cursor = prefix_end;
+    }
     output.push_str(&replacement);
-    cursor = end;
+    cursor = cursor.max(end.min(source_len));
   }
-  output.push_str(&source_text[cursor..]);
-  Some(output)
+  if cursor < source_len {
+    output.push_str(&source_text[cursor..]);
+  }
+  output
 }
 
 fn source_replacements(
   source_text: &str,
   actions: &[AstDependencyAction],
-) -> Option<Vec<(DependencyRange, String)>> {
+) -> Vec<(DependencyRange, String, i8)> {
   let mut replacements = Vec::new();
   for action in actions {
     match &action.replacement {
@@ -930,11 +503,13 @@ fn source_replacements(
           &mut replacements,
           DependencyRange::new(action.range.start, replacement.start),
           prefix.to_string(),
+          0,
         );
         push_source_replacement(
           &mut replacements,
           DependencyRange::new(replacement.end, action.range.end),
           suffix.to_string(),
+          0,
         );
         continue;
       }
@@ -948,27 +523,42 @@ fn source_replacements(
           &mut replacements,
           DependencyRange::new(action.range.start, replacement.start),
           prefix.to_string(),
+          0,
         );
-        replacements.extend(
-          inner_replacements
-            .iter()
-            .map(|(content, start, end)| (DependencyRange::new(*start, *end), content.to_string())),
-        );
+        replacements.extend(inner_replacements.iter().map(|(content, start, end)| {
+          (DependencyRange::new(*start, *end), content.to_string(), 0)
+        }));
         push_source_replacement(
           &mut replacements,
           DependencyRange::new(replacement.end, action.range.end),
           suffix.to_string(),
+          0,
         );
         continue;
       }
-      AstDependencyReplacement::ValidatedReplacements { replacements: r }
+      AstDependencyReplacement::WrappedSourceTrimTrailingSemicolon { prefix, suffix } => {
+        let suffix_position = trim_trailing_semicolon(source_text, action.range);
+        push_source_replacement(
+          &mut replacements,
+          DependencyRange::new(action.range.start, action.range.start),
+          prefix.to_string(),
+          0,
+        );
+        push_source_replacement(
+          &mut replacements,
+          DependencyRange::new(suffix_position, suffix_position),
+          suffix.to_string(),
+          -1,
+        );
+        continue;
+      }
+      AstDependencyReplacement::RangeReplacements { replacements: r }
       | AstDependencyReplacement::SourceWithReplacements {
         replacements: r, ..
       } => {
-        replacements
-          .extend(r.iter().map(|(content, start, end)| {
-            (DependencyRange::new(*start, *end), content.to_string())
-          }));
+        replacements.extend(r.iter().map(|(content, start, end)| {
+          (DependencyRange::new(*start, *end), content.to_string(), 0)
+        }));
         continue;
       }
       _ => {}
@@ -976,47 +566,96 @@ fn source_replacements(
 
     replacements.push((
       action.edit_range(),
-      action.replacement_content(source_text)?.into_owned(),
+      action.replacement_content(source_text).into_owned(),
+      0,
     ));
   }
 
-  replacements.sort_by_key(|(range, _)| (range.start, range.end));
-  let mut last_end = 0;
-  for (range, _) in &replacements {
-    if range.start < last_end
-      || range.start > range.end
-      || range.end as usize > source_text.len()
-      || !source_text.is_char_boundary(range.start as usize)
-      || !source_text.is_char_boundary(range.end as usize)
-    {
-      return None;
-    }
-    last_end = range.end;
-  }
+  replacements.sort_by_key(|(range, _, enforce)| (range.start, range.end, *enforce));
+  replacements
+}
 
-  Some(replacements)
+fn trim_trailing_semicolon(source_text: &str, range: DependencyRange) -> u32 {
+  let bytes = source_text.as_bytes();
+  let start = range.start as usize;
+  let mut end = range.end as usize;
+  while end > start && matches!(bytes[end - 1], b' ' | b'\t' | b'\n' | b'\r') {
+    end -= 1;
+  }
+  if end > start && bytes[end - 1] == b';' {
+    (end - 1) as u32
+  } else {
+    range.end
+  }
 }
 
 fn push_source_replacement(
-  replacements: &mut Vec<(DependencyRange, String)>,
+  replacements: &mut Vec<(DependencyRange, String, i8)>,
   range: DependencyRange,
   content: String,
+  enforce: i8,
 ) {
   if range.start == range.end && content.is_empty() {
     return;
   }
 
-  replacements.push((range, content));
+  replacements.push((range, content, enforce));
 }
 
 #[cfg(test)]
 mod tests {
+  use rspack_core::ModuleType;
+  use swc_experimental_allocator::Allocator;
+  use swc_experimental_ecma_ast::{EsVersion, GetSpan, Program, Stmt};
+  use swc_experimental_ecma_parser::{EsSyntax, Lexer, Parser, StringSource, Syntax};
+
   use super::*;
+
+  fn ast_syntax(module_type: &ModuleType) -> Syntax {
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      allow_return_outside_function: matches!(
+        module_type,
+        ModuleType::JsDynamic | ModuleType::JsAuto
+      ),
+      explicit_resource_management: true,
+      import_attributes: true,
+      ..Default::default()
+    })
+  }
+
+  fn parse_program_for_test<'ast>(
+    allocator: &'ast Allocator,
+    source_text: &'ast str,
+    module_type: &ModuleType,
+  ) -> Program<'ast> {
+    let lexer = Lexer::new(
+      allocator,
+      ast_syntax(module_type),
+      EsVersion::EsNext,
+      StringSource::new(source_text),
+      None,
+    );
+    let mut parser = Parser::new_from(allocator, lexer);
+    let program = match module_type {
+      ModuleType::JsEsm => parser
+        .parse_module()
+        .map(|module| Program::Module(allocator.boxed(module))),
+      ModuleType::JsDynamic => parser
+        .parse_commonjs()
+        .map(|script| Program::Script(allocator.boxed(script))),
+      _ => parser.parse_program(),
+    }
+    .unwrap();
+
+    assert!(parser.take_errors().is_empty());
+    program
+  }
 
   fn first_top_level_range(source: &str, module_type: ModuleType) -> DependencyRange {
     let allocator = Allocator::new();
     let source = allocator.alloc_str(source);
-    let program = parse_experimental_program(&allocator, source, &module_type).unwrap();
+    let program = parse_program_for_test(&allocator, source, &module_type);
     match program {
       Program::Module(module) => DependencyRange::from(module.body[0].span()),
       Program::Script(script) => DependencyRange::from(script.body[0].span()),
@@ -1026,7 +665,7 @@ mod tests {
   fn if_consequent_range(source: &str) -> DependencyRange {
     let allocator = Allocator::new();
     let source = allocator.alloc_str(source);
-    let program = parse_experimental_program(&allocator, source, &ModuleType::JsAuto).unwrap();
+    let program = parse_program_for_test(&allocator, source, &ModuleType::JsAuto);
     let Program::Script(script) = program else {
       unreachable!()
     };
@@ -1041,7 +680,7 @@ mod tests {
     let source = "console.log(1);\n";
     let plan = AstDependencyRenderPlan::default();
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, source);
   }
@@ -1054,7 +693,7 @@ mod tests {
     let mut plan = AstDependencyRenderPlan::default();
     plan.push_action(AstDependencyAction::expr((start, end).into(), "\"production\"").unwrap());
 
-    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert!(output.contains("if (\"production\")"));
   }
@@ -1073,7 +712,7 @@ mod tests {
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(
       output,
@@ -1089,7 +728,7 @@ mod tests {
       AstDependencyAction::expr(first_top_level_range(source, ModuleType::JsAuto), "").unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert!(!output.contains("use strict"));
     assert!(output.contains("console.log(1)"));
@@ -1101,7 +740,7 @@ mod tests {
     let mut plan = AstDependencyRenderPlan::default();
     plan.push_action(AstDependencyAction::expr(if_consequent_range(source), "{}").unwrap());
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert!(output.contains("if (true) {}"));
   }
@@ -1114,27 +753,27 @@ mod tests {
       AstDependencyAction::expr(first_top_level_range(source, ModuleType::JsEsm), "").unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert!(!output.contains("import"));
     assert!(output.contains("console.log(1)"));
   }
 
   #[test]
-  fn deletes_module_item_prefix_after_validating_whole_item() {
+  fn deletes_module_item_prefix_with_replacements() {
     let source = "export const answer = 42;\n";
     let range = first_top_level_range(source, ModuleType::JsEsm);
     let replacement_start = source.find("const").unwrap() as u32;
     let mut plan = AstDependencyRenderPlan::default();
     plan.push_action(
-      AstDependencyAction::validated_replacements(
+      AstDependencyAction::range_replacements(
         range,
         vec![(String::new(), range.start, replacement_start)],
       )
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert!(!output.contains("export"));
     assert!(output.contains("const answer = 42"));
@@ -1165,14 +804,14 @@ mod tests {
       .unwrap(),
     );
     plan.push_action(
-      AstDependencyAction::validated_replacements(
+      AstDependencyAction::range_replacements(
         range_stmt,
         vec![(String::new(), range_stmt.start, range.start)],
       )
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsEsm, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(
       output,
@@ -1196,7 +835,7 @@ mod tests {
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert!(output.contains("new Worker(__webpack_require__.tu(workerUrl))"));
   }
@@ -1217,16 +856,17 @@ mod tests {
       .unwrap(),
     );
 
-    let replacements = source_replacements(source, &plan.actions).unwrap();
+    let replacements = source_replacements(source, &plan.actions);
 
     assert_eq!(
       replacements,
       vec![
         (
           DependencyRange::new(start, start),
-          "(/* unused pure expression or super */ null && (".to_string()
+          "(/* unused pure expression or super */ null && (".to_string(),
+          0
         ),
-        (DependencyRange::new(end, end), "))".to_string()),
+        (DependencyRange::new(end, end), "))".to_string(), 0),
       ]
     );
   }
@@ -1252,7 +892,7 @@ mod tests {
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(
       output,
@@ -1281,7 +921,7 @@ mod tests {
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(
       output,
@@ -1299,13 +939,13 @@ mod tests {
       AstDependencyAction::raw_expr((start, end).into(), "/*require.resolve*/").unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, "const id = /*require.resolve*/(\"./a\");\n");
   }
 
   #[test]
-  fn inserts_content_after_validating_outer_expression() {
+  fn inserts_content_around_outer_expression() {
     let source = "module.hot.accept(\"./a\");\n";
     let call_start = source.find("module.hot.accept").unwrap() as u32;
     let call_end = source.find(");").unwrap() as u32 + 1;
@@ -1328,7 +968,7 @@ mod tests {
       .unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(
       output,
@@ -1337,7 +977,7 @@ mod tests {
   }
 
   #[test]
-  fn inserts_prefix_while_replacing_the_same_validated_expression() {
+  fn inserts_prefix_while_replacing_the_same_expression() {
     let source = "foo(bar);\n";
     let call_start = source.find("foo").unwrap() as u32;
     let call_end = source.find(");").unwrap() as u32 + 1;
@@ -1349,13 +989,13 @@ mod tests {
       AstDependencyAction::expr(DependencyRange::new(call_start, call_end), "baz(bar)").unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, "var x;baz(bar);\n");
   }
 
   #[test]
-  fn applies_validated_disjoint_replacements_around_nested_action() {
+  fn applies_disjoint_replacements_around_nested_action() {
     let source = "define([\"a\"], function(a) {});\n";
     let call_start = source.find("define").unwrap() as u32;
     let call_end = source.find(");").unwrap() as u32 + 1;
@@ -1365,7 +1005,7 @@ mod tests {
     let function_end = source.find(");").unwrap() as u32;
     let mut plan = AstDependencyRenderPlan::default();
     plan.push_action(
-      AstDependencyAction::validated_replacements(
+      AstDependencyAction::range_replacements(
         DependencyRange::new(call_start, call_end),
         vec![
           ("wrap(".to_string(), call_start, array_start),
@@ -1379,7 +1019,7 @@ mod tests {
       AstDependencyAction::expr(DependencyRange::new(array_start, array_end), "deps").unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, "wrap(deps, function(a) {});\n");
   }
@@ -1394,7 +1034,7 @@ mod tests {
       AstDependencyAction::raw_ident_with_suffix((start, end).into(), ": replacement").unwrap(),
     );
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, "const obj = { value: replacement };\n");
   }
@@ -1408,7 +1048,7 @@ mod tests {
     plan
       .push_action(AstDependencyAction::raw_ident((start, end).into(), "renamed: value").unwrap());
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, "const { renamed: value } = source;\n");
   }
@@ -1421,7 +1061,7 @@ mod tests {
     let mut plan = AstDependencyRenderPlan::default();
     plan.push_action(AstDependencyAction::raw_ident((start, end).into(), "renamed").unwrap());
 
-    let output = render_ast_dependencies(source, &ModuleType::JsAuto, &plan).unwrap();
+    let output = render_ast_dependencies(source, &plan);
 
     assert_eq!(output, "const { renamed: local } = source;\n");
   }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -1053,10 +1053,7 @@ impl JavaScriptParserAndGenerator {
     let block = module_graph.get_parent_block(dep.id());
     let mut runtime_template = context.runtime_template.clone();
     let promise = runtime_template.block_promise(block, context.compilation, "AMD require");
-    context
-      .runtime_template
-      .runtime_requirements_mut()
-      .insert(*runtime_template.runtime_requirements());
+    let mut runtime_requirements = *runtime_template.runtime_requirements();
     let uncaught_error_handler = context
       .runtime_template
       .render_runtime_globals_without_adding(&RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
@@ -1072,10 +1069,7 @@ impl JavaScriptParserAndGenerator {
       dep.error_callback_range(),
     ) {
       (Some(array_range), None, _) => {
-        context
-          .runtime_template
-          .runtime_requirements_mut()
-          .insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
+        runtime_requirements.insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
         replacements.push((
           format!("{promise}.then(function() {{"),
           outer_range.start,
@@ -1088,12 +1082,8 @@ impl JavaScriptParserAndGenerator {
         ));
       }
       (None, Some(function_range), _) => {
-        let mut runtime_requirements = RuntimeGlobals::REQUIRE;
+        runtime_requirements.insert(RuntimeGlobals::REQUIRE);
         runtime_requirements.insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
-        context
-          .runtime_template
-          .runtime_requirements_mut()
-          .insert(runtime_requirements);
         replacements.push((
           format!("{promise}.then(("),
           outer_range.start,
@@ -1144,10 +1134,7 @@ impl JavaScriptParserAndGenerator {
         ));
       }
       (Some(array_range), Some(function_range), None) => {
-        context
-          .runtime_template
-          .runtime_requirements_mut()
-          .insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
+        runtime_requirements.insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
         replacements.push((
           format!("{promise}.then(function() {{ "),
           outer_range.start,
@@ -1186,6 +1173,11 @@ impl JavaScriptParserAndGenerator {
       return false;
     };
     plan.push_action(action);
+    if !runtime_requirements.is_empty() {
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        runtime_requirements,
+      ));
+    }
     true
   }
 
@@ -1502,6 +1494,7 @@ impl JavaScriptParserAndGenerator {
       else {
         return false;
       };
+      let runtime_requirements = *runtime_template.runtime_requirements();
       if let Some(definition) = definition {
         let Some(action) = AstDependencyAction::insert(dep.range(), 0, definition) else {
           return false;
@@ -1513,6 +1506,11 @@ impl JavaScriptParserAndGenerator {
         return false;
       };
       plan.push_action(action);
+      if !runtime_requirements.is_empty() {
+        plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+          runtime_requirements,
+        ));
+      }
       return true;
     }
 
@@ -1700,12 +1698,52 @@ impl JavaScriptParserAndGenerator {
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<ProvideDependency>() {
+      let module_graph = context.compilation.get_module_graph();
+      let Some(connection) = module_graph.connection_by_dependency_id(dep.id()) else {
+        return true;
+      };
+      let exports_info = context
+        .compilation
+        .exports_info_artifact
+        .get_exports_info_data(connection.module_identifier());
+      let used_name = exports_info.get_used_name(
+        &context.compilation.exports_info_artifact,
+        context.runtime,
+        dep.ids(),
+      );
+      let mut runtime_template = context.runtime_template.clone();
+      let module_raw =
+        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), dep.weak());
+      let runtime_requirements = *runtime_template.runtime_requirements();
+      let provided_expr = match used_name {
+        Some(UsedName::Normal(used_name)) => {
+          format!("{module_raw}{}", property_access(used_name, 0))
+        }
+        Some(UsedName::Inlined(inlined)) => format!(
+          "({}, {})",
+          module_raw,
+          inlined.render(&to_normal_comment(&format!(
+            "inlined export {}",
+            property_access(dep.ids(), 0)
+          )))
+        ),
+        None => module_raw,
+      };
       let Some(action) =
         AstDependencyAction::expr(range, dep.identifier().to_string().into_boxed_str())
       else {
         return false;
       };
       plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::ProvidedDependency {
+        identifier: dep.identifier().into(),
+        expression: provided_expr.into_boxed_str(),
+      });
+      if !runtime_requirements.is_empty() {
+        plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+          runtime_requirements,
+        ));
+      }
       return true;
     }
 
@@ -2140,15 +2178,18 @@ impl JavaScriptParserAndGenerator {
         unreachable!();
       };
 
+      let mut common_js_exports_var = None;
       let action = if dep.base().is_expression() {
         let content = match used {
           Some(UsedName::Normal(used)) => format!("{}{}", base, property_access(used, 0)),
           used => {
             let is_inlined = matches!(used, Some(UsedName::Inlined(_)));
-            format!(
+            let placeholder_var = format!(
               "__webpack_{}_export__",
               if is_inlined { "inlined" } else { "unused" }
-            )
+            );
+            common_js_exports_var = Some(placeholder_var.clone().into_boxed_str());
+            placeholder_var
           }
         };
         AstDependencyAction::expr(range, content.into_boxed_str())
@@ -2179,6 +2220,7 @@ impl JavaScriptParserAndGenerator {
             ("))".to_string(), value_range.end, range.end),
           ]
         } else {
+          common_js_exports_var = Some("__webpack_unused_export__".into());
           vec![
             (
               "__webpack_unused_export__ = (".to_string(),
@@ -2196,6 +2238,9 @@ impl JavaScriptParserAndGenerator {
         return false;
       };
       plan.push_action(action);
+      if let Some(identifier) = common_js_exports_var {
+        plan.push_side_effect(AstDependencySideEffect::CommonJsExportsVar(identifier));
+      }
       if !base_runtime_requirements.is_empty() {
         plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
           base_runtime_requirements,

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -8,15 +8,16 @@ use regex::Regex;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
-  CachedConstDependency, ChunkGraph, CodeGenerationData, CollectedTypeScriptInfo, Compilation,
-  ConstDependency, ContextDependency, ContextMode, DEFAULT_EXPORT, DependenciesBlock, Dependency,
+  CachedConstDependency, ChunkGraph, CollectedTypeScriptInfo, Compilation, ConstDependency,
+  ContextDependency, ContextMode, DEFAULT_EXPORT, DependenciesBlock, Dependency,
   DependencyCodeGeneration, DependencyId, DependencyRange, ESMExportBinding, ESMExportInitFragment,
   ExportMode, ExportsArgument, ExportsType, ExternalModuleInitFragment, GenerateContext,
   ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, JavascriptParserUrl, Module,
   ModuleArgument, ModuleCodeTemplate, ModuleDependency, ModuleGraph, ModuleType,
   NormalInitFragment, ParseContext, ParseResult, ParserAndGenerator, RuntimeCondition,
   RuntimeGlobals, RuntimeRequirementsDependency, RuntimeRequirementsDependencyMode,
-  RuntimeVariable, SideEffectsBailoutItem, SourceType, TemplateContext, UsageState, UsedName,
+  RuntimeVariable, SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
+  UsageState, UsedName,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   property_access, property_access_with_optional, remove_bom, render_init_fragments,
   rspack_sources::{
@@ -112,14 +113,6 @@ fn append_experimental_parse_errors(
   }));
 }
 
-fn ast_dependency_codegen_error(module: &dyn Module, reason: &str) -> Error {
-  rspack_error::error!(
-    "AST dependency code generation failed for module {}: {}",
-    module.identifier(),
-    reason
-  )
-}
-
 impl ParserRuntimeRequirementsData {
   pub fn new(runtime_template: &ModuleCodeTemplate) -> Self {
     let require_name =
@@ -170,6 +163,89 @@ impl std::fmt::Debug for JavaScriptParserAndGenerator {
 impl JavaScriptParserAndGenerator {
   pub fn add_parser_plugin(&mut self, parser_plugin: BoxJavascriptParserPlugin) {
     self.parser_plugins.push(parser_plugin);
+  }
+
+  fn source_block(
+    &self,
+    compilation: &Compilation,
+    block_id: &AsyncDependenciesBlockIdentifier,
+    source: &mut TemplateReplaceSource,
+    context: &mut TemplateContext,
+  ) {
+    let module_graph = compilation.get_module_graph();
+    let block = module_graph
+      .block_by_id(block_id)
+      .expect("should have block");
+    block.get_dependencies().iter().for_each(|dependency_id| {
+      self.source_dependency(compilation, dependency_id, source, context)
+    });
+    block
+      .get_blocks()
+      .iter()
+      .for_each(|block_id| self.source_block(compilation, block_id, source, context));
+  }
+
+  fn source_dependency(
+    &self,
+    compilation: &Compilation,
+    dependency_id: &DependencyId,
+    source: &mut TemplateReplaceSource,
+    context: &mut TemplateContext,
+  ) {
+    if let Some(dependency) = compilation
+      .get_module_graph()
+      .dependency_by_id(dependency_id)
+      .as_dependency_code_generation()
+    {
+      if let Some(template) = dependency
+        .dependency_template()
+        .and_then(|template_type| compilation.get_dependency_template(template_type))
+      {
+        template.render(dependency, source, context)
+      } else {
+        panic!(
+          "Can not find dependency template of {:?}",
+          dependency.dependency_template()
+        );
+      }
+    }
+  }
+
+  fn render_dependency_templates(
+    &self,
+    source: &BoxSource,
+    compilation: &Compilation,
+    module: &dyn Module,
+    context: &mut TemplateContext,
+  ) -> BoxSource {
+    let mut source = ReplaceSource::new(source.clone());
+
+    module.get_dependencies().iter().for_each(|dependency_id| {
+      self.source_dependency(compilation, dependency_id, &mut source, context)
+    });
+
+    if let Some(dependencies) = module.get_presentational_dependencies() {
+      dependencies.iter().for_each(|dependency| {
+        if let Some(template) = dependency
+          .dependency_template()
+          .and_then(|template_type| compilation.get_dependency_template(template_type))
+        {
+          template.render(dependency.as_ref(), &mut source, context)
+        } else {
+          panic!(
+            "Can not find dependency template of {:?}",
+            dependency.dependency_template()
+          );
+        }
+      });
+    };
+
+    module
+      .get_blocks()
+      .iter()
+      .for_each(|block_id| self.source_block(compilation, block_id, &mut source, context));
+
+    source.boxed()
   }
 
   fn collect_ast_render_dependency(
@@ -327,7 +403,7 @@ impl JavaScriptParserAndGenerator {
 
   fn render_ast_esm_import_specifier(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     dep: &ESMImportSpecifierDependency,
   ) -> Option<Option<String>> {
     let module_graph = context.compilation.get_module_graph();
@@ -354,34 +430,15 @@ impl JavaScriptParserAndGenerator {
       return Some(None);
     }
 
-    let mut init_fragments = Vec::new();
-    let mut data = CodeGenerationData::default();
-    let mut runtime_template = context.runtime_template.clone();
-    let mut concatenation_scope = context
-      .concatenation_scope
-      .as_ref()
-      .map(|scope| (**scope).clone());
-    let mut temp_context = TemplateContext {
-      compilation: context.compilation,
-      module: context.module,
-      init_fragments: &mut init_fragments,
-      runtime: context.runtime,
-      concatenation_scope: concatenation_scope.as_mut(),
-      data: &mut data,
-      runtime_template: &mut runtime_template,
-    };
     let template = ESMImportSpecifierDependencyTemplate::default();
     if dep.evaluated_in_operator {
       template
-        .get_evaluated_in_operator_code(ids, dep, connection, &mut temp_context)
+        .get_evaluated_in_operator_code(ids, dep, connection, context)
         .map(Some)
     } else {
-      Some(Some(template.get_code_for_ids(
-        ids,
-        dep,
-        connection,
-        &mut temp_context,
-      )))
+      Some(Some(
+        template.get_code_for_ids(ids, dep, connection, context),
+      ))
     }
   }
 
@@ -2406,18 +2463,11 @@ impl JavaScriptParserAndGenerator {
     source_text: &str,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Result<BoxSource> {
-    let plan = self
-      .collect_ast_render_plan(module, context)
-      .ok_or_else(|| {
-        ast_dependency_codegen_error(module, "unsupported dependency in AST render plan")
-      })?;
-    let source =
-      render_ast_dependencies(source_text, module.module_type(), &plan).ok_or_else(|| {
-        ast_dependency_codegen_error(module, "failed to apply AST dependency replacements")
-      })?;
+  ) -> Option<BoxSource> {
+    let plan = self.collect_ast_render_plan(module, context)?;
+    let source = render_ast_dependencies(source_text, module.module_type(), &plan)?;
     self.apply_ast_dependency_side_effects(context, &plan);
-    Ok(RawStringSource::from(source).boxed())
+    Some(RawStringSource::from(source).boxed())
   }
 
   fn try_render_ast_dependencies_with_source_map(
@@ -2426,21 +2476,14 @@ impl JavaScriptParserAndGenerator {
     source: &BoxSource,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Result<BoxSource> {
-    let plan = self
-      .collect_ast_render_plan(module, context)
-      .ok_or_else(|| {
-        ast_dependency_codegen_error(module, "unsupported dependency in AST render plan")
-      })?;
+  ) -> Option<BoxSource> {
+    let plan = self.collect_ast_render_plan(module, context)?;
     let mut source = ReplaceSource::new(source.clone());
     if !apply_ast_dependency_replacements(source_text, module.module_type(), &plan, &mut source) {
-      return Err(ast_dependency_codegen_error(
-        module,
-        "failed to apply AST dependency replacements with source map",
-      ));
+      return None;
     }
     self.apply_ast_dependency_side_effects(context, &plan);
-    Ok(source.boxed())
+    Some(source.boxed())
   }
 
   fn apply_ast_dependency_side_effects(
@@ -2660,6 +2703,61 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     ) {
       let source_text = source.source().into_string_lossy();
       let compilation = generate_context.compilation;
+      let has_source_map = source
+        .map(&ObjectPool::default(), &MapOptions::default())
+        .is_some();
+
+      let ast_result = {
+        let mut init_fragments = vec![];
+        let mut data = generate_context.data.clone();
+        let mut runtime_template = generate_context.runtime_template.clone();
+        let mut concatenation_scope = generate_context
+          .concatenation_scope
+          .as_ref()
+          .map(|scope| (**scope).clone());
+        let mut context = TemplateContext {
+          compilation,
+          module,
+          init_fragments: &mut init_fragments,
+          runtime: generate_context.runtime,
+          concatenation_scope: concatenation_scope.as_mut(),
+          data: &mut data,
+          runtime_template: &mut runtime_template,
+        };
+        let source = if has_source_map {
+          self.try_render_ast_dependencies_with_source_map(
+            &source_text,
+            source,
+            module,
+            &mut context,
+          )
+        } else {
+          self.try_render_ast_dependencies(&source_text, module, &mut context)
+        };
+        source.map(|source| {
+          (
+            source,
+            init_fragments,
+            data,
+            runtime_template,
+            concatenation_scope,
+          )
+        })
+      };
+
+      if let Some((source, init_fragments, data, runtime_template, concatenation_scope)) =
+        ast_result
+      {
+        *generate_context.data = data;
+        *generate_context.runtime_template = runtime_template;
+        if let Some(scope) = generate_context.concatenation_scope.as_deref_mut()
+          && let Some(concatenation_scope) = concatenation_scope
+        {
+          *scope = concatenation_scope;
+        }
+        return render_init_fragments(source, init_fragments, generate_context);
+      }
+
       let mut init_fragments = vec![];
       let mut context = TemplateContext {
         compilation,
@@ -2670,20 +2768,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         data: generate_context.data,
         runtime_template: generate_context.runtime_template,
       };
-
-      let has_source_map = source
-        .map(&ObjectPool::default(), &MapOptions::default())
-        .is_some();
-      let source = if has_source_map {
-        self.try_render_ast_dependencies_with_source_map(
-          &source_text,
-          source,
-          module,
-          &mut context,
-        )?
-      } else {
-        self.try_render_ast_dependencies(&source_text, module, &mut context)?
-      };
+      let source = self.render_dependency_templates(source, compilation, module, &mut context);
       generate_context.concatenation_scope = context.concatenation_scope.take();
       render_init_fragments(source, init_fragments, generate_context)
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -10,12 +10,13 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
   CachedConstDependency, ChunkGraph, CodeGenerationData, CollectedTypeScriptInfo, Compilation,
   ConstDependency, ContextDependency, ContextMode, DEFAULT_EXPORT, DependenciesBlock, Dependency,
-  DependencyCodeGeneration, DependencyId, DependencyRange, ExportMode, ExportsArgument,
-  ExportsType, GenerateContext, ImportPhase, JavascriptParserUrl, Module, ModuleArgument,
-  ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult, ParserAndGenerator,
-  RuntimeCondition, RuntimeGlobals, RuntimeRequirementsDependency,
-  RuntimeRequirementsDependencyMode, RuntimeVariable, SideEffectsBailoutItem, SourceType,
-  TemplateContext, TemplateReplaceSource, UsedName,
+  DependencyCodeGeneration, DependencyId, DependencyRange, ESMExportBinding, ESMExportInitFragment,
+  ExportMode, ExportsArgument, ExportsType, ExternalModuleInitFragment, GenerateContext,
+  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, JavascriptParserUrl, Module,
+  ModuleArgument, ModuleCodeTemplate, ModuleDependency, ModuleGraph, ModuleType,
+  NormalInitFragment, ParseContext, ParseResult, ParserAndGenerator, RuntimeCondition,
+  RuntimeGlobals, RuntimeRequirementsDependency, RuntimeRequirementsDependencyMode,
+  RuntimeVariable, SideEffectsBailoutItem, SourceType, TemplateContext, UsageState, UsedName,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   property_access, property_access_with_optional, remove_bom, render_init_fragments,
   rspack_sources::{
@@ -24,6 +25,7 @@ use rspack_core::{
   to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use swc_atoms::Atom;
 use swc_experimental_allocator::Allocator;
 use swc_experimental_ecma_ast::{Comments, EsVersion, Program, VisitWith};
 use swc_experimental_ecma_parser::{
@@ -55,8 +57,8 @@ use crate::{
     amd_require_array_dependency::AMDRequireArrayDependency,
     amd_require_dependency::AMDRequireDependency,
     amd_require_item_dependency::AMDRequireItemDependency, esm_import_dependency_apply,
-    esm_import_dependency_prime_import_var, import_emitted_runtime,
-    local_module_dependency::LocalModuleDependency, unsupported_dependency::UnsupportedDependency,
+    import_emitted_runtime, local_module_dependency::LocalModuleDependency,
+    unsupported_dependency::UnsupportedDependency,
   },
   is_export_inlined,
   parser_plugin::JS_DEFAULT_KEYWORD,
@@ -66,9 +68,8 @@ use crate::{
 mod ast_dependency;
 
 use ast_dependency::{
-  AstDependencyAction, AstDependencyRenderEntry, AstDependencyRenderKey, AstDependencyRenderPlan,
-  AstDependencySideEffect, apply_ast_dependency_replacements, mark_ast_dependencies,
-  render_ast_dependencies,
+  AstDependencyAction, AstDependencyRenderPlan, AstDependencySideEffect,
+  apply_ast_dependency_replacements, render_ast_dependencies,
 };
 
 #[derive(Debug)]
@@ -109,6 +110,14 @@ fn append_experimental_parse_errors(
       .into(),
     )
   }));
+}
+
+fn ast_dependency_codegen_error(module: &dyn Module, reason: &str) -> Error {
+  rspack_error::error!(
+    "AST dependency code generation failed for module {}: {}",
+    module.identifier(),
+    reason
+  )
 }
 
 impl ParserRuntimeRequirementsData {
@@ -163,76 +172,6 @@ impl JavaScriptParserAndGenerator {
     self.parser_plugins.push(parser_plugin);
   }
 
-  fn source_block(
-    &self,
-    compilation: &Compilation,
-    block_id: &AsyncDependenciesBlockIdentifier,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-    applied_ast_dependency_ids: &HashSet<DependencyId>,
-  ) {
-    let module_graph = compilation.get_module_graph();
-    let block = module_graph
-      .block_by_id(block_id)
-      .expect("should have block");
-    //    let block = block_id.expect_get(compilation);
-    block.get_dependencies().iter().for_each(|dependency_id| {
-      if applied_ast_dependency_ids.contains(dependency_id) {
-        self.source_ast_dependency(compilation, dependency_id, source, context)
-      } else {
-        self.source_dependency(compilation, dependency_id, source, context)
-      }
-    });
-    block.get_blocks().iter().for_each(|block_id| {
-      self.source_block(
-        compilation,
-        block_id,
-        source,
-        context,
-        applied_ast_dependency_ids,
-      )
-    });
-  }
-
-  fn collect_ast_dependency<'a>(
-    &self,
-    compilation: &'a Compilation,
-    dependency_id: &DependencyId,
-    entries: &mut Vec<AstDependencyRenderEntry>,
-  ) {
-    if let Some(dependency) = compilation
-      .get_module_graph()
-      .dependency_by_id(dependency_id)
-      .as_dependency_code_generation()
-      && let Some(entry) = AstDependencyRenderEntry::new(
-        AstDependencyRenderKey::Dependency(*dependency_id),
-        dependency,
-      )
-    {
-      entries.push(entry);
-    }
-  }
-
-  fn collect_ast_block<'a>(
-    &self,
-    compilation: &'a Compilation,
-    block_id: &AsyncDependenciesBlockIdentifier,
-    entries: &mut Vec<AstDependencyRenderEntry>,
-  ) {
-    let module_graph = compilation.get_module_graph();
-    let block = module_graph
-      .block_by_id(block_id)
-      .expect("should have block");
-    block
-      .get_dependencies()
-      .iter()
-      .for_each(|dependency_id| self.collect_ast_dependency(compilation, dependency_id, entries));
-    block
-      .get_blocks()
-      .iter()
-      .for_each(|block_id| self.collect_ast_block(compilation, block_id, entries));
-  }
-
   fn collect_ast_render_dependency(
     &self,
     compilation: &Compilation,
@@ -248,12 +187,7 @@ impl JavaScriptParserAndGenerator {
       return true;
     };
 
-    self.collect_ast_render_action(
-      dependency,
-      context,
-      plan,
-      Some(AstDependencyRenderKey::Dependency(*dependency_id)),
-    )
+    self.collect_ast_render_action(dependency, context, plan)
   }
 
   fn collect_ast_render_block(
@@ -288,14 +222,9 @@ impl JavaScriptParserAndGenerator {
     }) && module
       .get_presentational_dependencies()
       .map(|dependencies| {
-        dependencies.iter().enumerate().all(|(idx, dependency)| {
-          self.collect_ast_render_action(
-            dependency.as_ref(),
-            context,
-            &mut plan,
-            Some(AstDependencyRenderKey::Presentational(idx)),
-          )
-        })
+        dependencies
+          .iter()
+          .all(|dependency| self.collect_ast_render_action(dependency.as_ref(), context, &mut plan))
       })
       .unwrap_or(true)
       && module
@@ -308,108 +237,27 @@ impl JavaScriptParserAndGenerator {
 
   fn render_ast_amd_require_array(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     dep: &AMDRequireArrayDependency,
   ) -> String {
-    let mut init_fragments = Vec::new();
-    let mut data = CodeGenerationData::default();
-    let mut runtime_template = context.runtime_template.clone();
-    let mut temp_context = TemplateContext {
-      compilation: context.compilation,
-      module: context.module,
-      init_fragments: &mut init_fragments,
-      runtime: context.runtime,
-      concatenation_scope: None,
-      data: &mut data,
-      runtime_template: &mut runtime_template,
-    };
-
-    dep.content(&mut temp_context)
+    dep.content(context)
   }
 
   fn render_ast_context_module_raw(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     dep: &dyn ContextDependency,
     weak: bool,
   ) -> String {
-    let mut runtime_template = context.runtime_template.clone();
-    runtime_template.module_raw(context.compilation, dep.id(), dep.request(), weak)
-  }
-
-  fn render_ast_template_replacements(
-    &self,
-    context: &mut TemplateContext,
-    dependency: &dyn DependencyCodeGeneration,
-    validate_range: DependencyRange,
-  ) -> Option<Vec<(String, u32, u32)>> {
-    let template = dependency
-      .dependency_template()
-      .and_then(|template_type| context.compilation.get_dependency_template(template_type))?;
-    let mut init_fragments = Vec::new();
-    let mut data = CodeGenerationData::default();
-    let mut runtime_template = context.runtime_template.clone();
-    let mut temp_context = TemplateContext {
-      compilation: context.compilation,
-      module: context.module,
-      init_fragments: &mut init_fragments,
-      runtime: context.runtime,
-      concatenation_scope: context
-        .concatenation_scope
-        .as_mut()
-        .map(|scope| &mut **scope),
-      data: &mut data,
-      runtime_template: &mut runtime_template,
-    };
-    let mut source =
-      ReplaceSource::new(RawStringSource::from(" ".repeat(validate_range.end as usize)).boxed());
-    template.render(dependency, &mut source, &mut temp_context);
-    Some(
-      source
-        .replacements()
-        .iter()
-        .map(|replacement| {
-          (
-            replacement.content().to_string(),
-            replacement.start(),
-            replacement.end(),
-          )
-        })
-        .collect(),
-    )
-  }
-
-  fn push_template_replacement_actions(
-    &self,
-    plan: &mut AstDependencyRenderPlan,
-    validate_range: DependencyRange,
-    replacements: Vec<(String, u32, u32)>,
-  ) -> bool {
-    if replacements.is_empty() {
-      return true;
-    }
-
-    let action = if replacements.len() == 1
-      && replacements[0].1 == validate_range.start
-      && replacements[0].2 == validate_range.end
-    {
-      let (content, _, _) = replacements.into_iter().next().expect("checked len");
-      AstDependencyAction::expr(validate_range, content)
-    } else {
-      AstDependencyAction::validated_replacements(validate_range, replacements)
-    };
-    let Some(action) = action else {
-      return false;
-    };
-    plan.push_action(action);
-    true
+    context
+      .runtime_template
+      .module_raw(context.compilation, dep.id(), dep.request(), weak)
   }
 
   fn collect_ast_context_require_call_action(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
     dep: &dyn ContextDependency,
     range: DependencyRange,
     value_range: Option<DependencyRange>,
@@ -440,19 +288,14 @@ impl JavaScriptParserAndGenerator {
     let Some(action) = action else {
       return false;
     };
-    let Some(key) = key else {
-      return false;
-    };
     plan.push_action(action);
-    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
     true
   }
 
   fn collect_ast_context_id_action(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
     dep: &dyn ContextDependency,
     range: DependencyRange,
   ) -> bool {
@@ -479,11 +322,7 @@ impl JavaScriptParserAndGenerator {
     let Some(action) = action else {
       return false;
     };
-    let Some(key) = key else {
-      return false;
-    };
     plan.push_action(action);
-    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
     true
   }
 
@@ -635,9 +474,9 @@ impl JavaScriptParserAndGenerator {
     true
   }
 
-  fn prime_ast_esm_import_side_effect(
+  fn apply_ast_esm_import_side_effect(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     dep: &ESMImportSideEffectDependency,
   ) {
     let module_graph = context.compilation.get_module_graph();
@@ -663,30 +502,149 @@ impl JavaScriptParserAndGenerator {
       return;
     }
 
-    let mut init_fragments = Vec::new();
-    let mut data = CodeGenerationData::default();
-    let mut runtime_template = context.runtime_template.clone();
-    let mut temp_context = TemplateContext {
-      compilation: context.compilation,
-      module: context.module,
-      init_fragments: &mut init_fragments,
-      runtime: context.runtime,
-      concatenation_scope: None,
-      data: &mut data,
-      runtime_template: &mut runtime_template,
-    };
-    esm_import_dependency_apply(dep, dep.source_order(), dep.phase(), &mut temp_context);
+    esm_import_dependency_apply(dep, dep.source_order(), dep.phase(), context);
   }
 
-  fn prime_ast_esm_export_imported_specifier(
-    &self,
-    context: &TemplateContext,
-    dep: &ESMExportImportedSpecifierDependency,
-  ) {
+  fn apply_ast_esm_compatibility(&self, context: &mut TemplateContext) {
     if context.concatenation_scope.is_some() {
       return;
     }
 
+    let module_graph = context.compilation.get_module_graph();
+    let module = module_graph
+      .module_by_identifier(&context.module.identifier())
+      .expect("should have mgm");
+    let name = Atom::from("__esModule");
+    let exports_info = context
+      .compilation
+      .exports_info_artifact
+      .get_exports_info_data(&module.identifier());
+    let used = exports_info
+      .get_read_only_export_info(&name)
+      .get_used(context.runtime);
+    if !matches!(used, UsageState::Unused) {
+      context
+        .init_fragments
+        .push(Box::new(NormalInitFragment::new(
+          format!(
+            "{}({});\n",
+            context
+              .runtime_template
+              .render_runtime_globals(&RuntimeGlobals::MAKE_NAMESPACE_OBJECT),
+            context
+              .runtime_template
+              .render_exports_argument(module.get_exports_argument()),
+          ),
+          InitFragmentStage::StageESMExports,
+          0,
+          InitFragmentKey::ESMCompatibility,
+          None,
+        )));
+    }
+
+    if ModuleGraph::is_async(
+      &context.compilation.async_modules_artifact,
+      &module.identifier(),
+    ) {
+      context
+        .init_fragments
+        .push(Box::new(NormalInitFragment::new(
+          format!(
+            "{}({}, async function (__rspack_load_async_deps, __rspack_async_done) {{ try {{\n",
+            context
+              .runtime_template
+              .render_runtime_globals(&RuntimeGlobals::ASYNC_MODULE),
+            context
+              .runtime_template
+              .render_module_argument(module.get_module_argument())
+          ),
+          InitFragmentStage::StageAsyncBoundary,
+          0,
+          InitFragmentKey::unique(),
+          Some(format!(
+            "\n__rspack_async_done();\n}} catch(e) {{ __rspack_async_done(e); }} }}{});",
+            if module.build_meta().has_top_level_await {
+              ", 1"
+            } else {
+              ""
+            }
+          )),
+        )));
+    }
+  }
+
+  fn apply_ast_esm_export_specifier(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ESMExportSpecifierDependency,
+  ) {
+    if let Some(scope) = &mut context.concatenation_scope {
+      scope.register_export(dep.name().clone(), dep.value().to_string());
+      return;
+    }
+
+    let module_graph = context.compilation.get_module_graph();
+    let module = module_graph
+      .module_by_identifier(&context.module.identifier())
+      .expect("should have module graph module");
+
+    if let Some(enum_value) = dep.enum_value() {
+      let all_enum_member_inlined = enum_value.iter().all(|(enum_key, enum_member)| {
+        if enum_member.is_none() {
+          return false;
+        }
+        let export_name = &[dep.name().clone(), enum_key.clone()];
+        is_export_inlined(
+          &context.compilation.exports_info_artifact,
+          &module.identifier(),
+          export_name,
+          context.runtime,
+        )
+      });
+      if all_enum_member_inlined {
+        return;
+      }
+    }
+
+    let exports_info = context
+      .compilation
+      .exports_info_artifact
+      .get_exports_info_data(&module.identifier());
+    let Some(used_name) = exports_info.get_used_name(
+      &context.compilation.exports_info_artifact,
+      context.runtime,
+      std::slice::from_ref(dep.name()),
+    ) else {
+      return;
+    };
+    let used_name = match used_name {
+      UsedName::Normal(vec) => vec[0].clone(),
+      UsedName::Inlined(_) => return,
+    };
+    let is_circular_module = context
+      .compilation
+      .circular_modules
+      .is_circular_module(&module.identifier());
+    let binding = if matches!(is_circular_module, Some(false)) && dep.const_value().is_some() {
+      ESMExportBinding::Value(dep.value().clone())
+    } else {
+      ESMExportBinding::Getter(dep.value().clone())
+    };
+    context.init_fragments.push(
+      ESMExportInitFragment::new(
+        module.get_exports_argument(),
+        vec![(used_name, binding)],
+        is_circular_module,
+      )
+      .boxed(),
+    );
+  }
+
+  fn apply_ast_esm_export_imported_specifier(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ESMExportImportedSpecifierDependency,
+  ) {
     let module_graph = context.compilation.get_module_graph();
     let mode = dep.get_mode(
       module_graph,
@@ -695,25 +653,137 @@ impl JavaScriptParserAndGenerator {
       &context.compilation.exports_info_artifact,
     );
 
-    if matches!(
-      mode,
-      ExportMode::LazyMake | ExportMode::Unused(_) | ExportMode::EmptyStar(_)
-    ) {
+    if let Some(scope) = &mut context.concatenation_scope {
+      if let ExportMode::ReexportUndefined(mode) = mode {
+        scope.register_raw_export(
+          mode.name,
+          String::from("/* reexport non-default export from non-ESM */ undefined"),
+        );
+      }
       return;
     }
 
-    let _ = esm_import_dependency_prime_import_var(dep, dep.phase(), context);
+    if !matches!(
+      mode,
+      ExportMode::LazyMake | ExportMode::Unused(_) | ExportMode::EmptyStar(_)
+    ) {
+      esm_import_dependency_apply(dep, dep.source_order(), dep.phase(), context);
+      dep.add_export_fragments(context, mode);
+    }
   }
 
-  fn render_ast_esm_export_expression_head(&self, context: &TemplateContext) -> String {
+  fn apply_ast_external_module(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ExternalModuleDependency,
+  ) {
+    let need_prefix = context
+      .compilation
+      .options
+      .output
+      .environment
+      .supports_node_prefix_for_core_modules();
+    let chunk_init_fragments = context.chunk_init_fragments();
+    let fragment = ExternalModuleInitFragment::new(
+      format!("{}{}", if need_prefix { "node:" } else { "" }, dep.module()),
+      dep.import_specifier().to_vec(),
+      dep.default_import().cloned(),
+      InitFragmentStage::StageConstants,
+      0,
+    );
+    chunk_init_fragments.push(fragment.boxed());
+  }
+
+  fn apply_ast_module_decorator(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ModuleDecoratorDependency,
+  ) {
+    let module_graph = context.compilation.get_module_graph();
+    let module = module_graph
+      .module_by_identifier(&context.module.identifier())
+      .expect("should have mgm");
+
+    let module_id = ChunkGraph::get_module_id(
+      &context.compilation.module_ids_artifact,
+      module.identifier(),
+    )
+    .map(|s| s.to_string())
+    .unwrap_or_default();
+
+    context
+      .init_fragments
+      .push(Box::new(NormalInitFragment::new(
+        format!(
+          "/* module decorator */ {module} = {decorator}({module});\n",
+          module = context
+            .runtime_template
+            .render_module_argument(module.get_module_argument()),
+          decorator = context
+            .runtime_template
+            .render_runtime_globals(&dep.decorator()),
+        ),
+        InitFragmentStage::StageProvides,
+        0,
+        InitFragmentKey::ModuleDecorator(module_id),
+        None,
+      )));
+  }
+
+  fn apply_ast_import_meta_rsc(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ImportMetaRscDependency,
+  ) {
+    let rsc_manifest = context
+      .runtime_template
+      .render_runtime_globals(&RuntimeGlobals::RSC_MANIFEST);
+    let react =
+      context
+        .runtime_template
+        .module_raw(context.compilation, dep.id(), dep.request(), false);
+    let importer = rspack_util::json_stringify_str(dep.importer());
+
+    context.init_fragments.push(Box::new(
+      NormalInitFragment::new(
+        format!(
+          r#"var {IMPORT_META_RSC_BINDING} = {{
+  loadCss: function() {{
+    return (({rsc_manifest}.entryCssFiles[{importer}] || []).map(function(href) {{
+      return {react}.createElement("link", Object.assign({{}}, {rsc_manifest}.cssLinkProps, {{
+        key: href,
+        rel: "stylesheet",
+        href: href
+      }}));
+    }}));
+  }}
+}};
+"#
+        ),
+        InitFragmentStage::StageProvides,
+        0,
+        InitFragmentKey::ModuleExternal(format!("import.meta.rspackRsc {}", dep.importer())),
+        None,
+      )
+      .with_top_level_decl_symbols(vec![Atom::from(IMPORT_META_RSC_BINDING)]),
+    ));
+  }
+
+  fn render_ast_esm_export_expression_head(&self, context: &mut TemplateContext) -> String {
     let supports_const = context
       .compilation
       .options
       .output
       .environment
       .supports_const();
+    let module_identifier = context.module.identifier();
+    let is_circular_module = context
+      .compilation
+      .circular_modules
+      .is_circular_module(&module_identifier);
 
-    if context.concatenation_scope.is_some() {
+    if let Some(scope) = &mut context.concatenation_scope {
+      scope.register_export(JS_DEFAULT_KEYWORD.clone(), DEFAULT_EXPORT.to_string());
       return format!(
         "/* export default */ {} {DEFAULT_EXPORT} = ",
         if supports_const { "const" } else { "var" }
@@ -723,7 +793,7 @@ impl JavaScriptParserAndGenerator {
     if let Some(used) = context
       .compilation
       .exports_info_artifact
-      .get_exports_info_data(&context.module.identifier())
+      .get_exports_info_data(&module_identifier)
       .get_used_name(
         &context.compilation.exports_info_artifact,
         context.runtime,
@@ -732,17 +802,34 @@ impl JavaScriptParserAndGenerator {
     {
       if let UsedName::Normal(used) = used {
         if supports_const {
+          let binding = if matches!(is_circular_module, Some(false)) {
+            ESMExportBinding::Value(DEFAULT_EXPORT.into())
+          } else {
+            ESMExportBinding::Getter(DEFAULT_EXPORT.into())
+          };
+          context.init_fragments.push(
+            ESMExportInitFragment::new(
+              context.module.get_exports_argument(),
+              vec![(
+                used
+                  .iter()
+                  .map(|i| i.to_string())
+                  .collect::<Vec<_>>()
+                  .join("")
+                  .into(),
+                binding,
+              )],
+              is_circular_module,
+            )
+            .boxed(),
+          );
           format!("/* export default */ const {DEFAULT_EXPORT} = ")
         } else {
-          let exports_argument = match context.module.get_exports_argument() {
-            ExportsArgument::Exports => "exports".to_string(),
-            ExportsArgument::RspackExports => context
-              .runtime_template
-              .render_runtime_variable(&RuntimeVariable::Exports),
-          };
           format!(
             "/* export default */ {}{} = ",
-            exports_argument,
+            context
+              .runtime_template
+              .render_exports_argument(context.module.get_exports_argument()),
             property_access(used, 0)
           )
         }
@@ -756,9 +843,8 @@ impl JavaScriptParserAndGenerator {
 
   fn collect_ast_esm_export_expression_action(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
     dep: &ESMExportExpressionDependency,
   ) -> bool {
     let range = dep.range();
@@ -766,6 +852,43 @@ impl JavaScriptParserAndGenerator {
     let mut replacements = Vec::new();
 
     if let Some(declaration) = dep.declaration() {
+      let name = match declaration {
+        DeclarationId::Id(id) => id,
+        DeclarationId::Func(_) => DEFAULT_EXPORT,
+      };
+      if let Some(scope) = &mut context.concatenation_scope {
+        scope.register_export(JS_DEFAULT_KEYWORD.clone(), name.to_string());
+      } else if let Some(UsedName::Normal(used)) = context
+        .compilation
+        .exports_info_artifact
+        .get_exports_info_data(&context.module.identifier())
+        .get_used_name(
+          &context.compilation.exports_info_artifact,
+          context.runtime,
+          std::slice::from_ref(&JS_DEFAULT_KEYWORD),
+        )
+      {
+        context.init_fragments.push(
+          ESMExportInitFragment::new(
+            context.module.get_exports_argument(),
+            vec![(
+              used
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join("")
+                .into(),
+              ESMExportBinding::Getter(Atom::from(format!("/* export default binding */ {name}"))),
+            )],
+            context
+              .compilation
+              .circular_modules
+              .is_circular_module(&context.module.identifier()),
+          )
+          .boxed(),
+        );
+      }
+
       replacements.push((
         format!("/* export default */ {}", dep.prefix()),
         range_stmt.start,
@@ -798,19 +921,14 @@ impl JavaScriptParserAndGenerator {
     else {
       return false;
     };
-    let Some(key) = key else {
-      return false;
-    };
     plan.push_action(action);
-    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
     true
   }
 
   fn collect_ast_require_ensure_action(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
     dep: &RequireEnsureDependency,
   ) -> bool {
     let module_graph = context.compilation.get_module_graph();
@@ -818,6 +936,10 @@ impl JavaScriptParserAndGenerator {
     let mut runtime_template = context.runtime_template.clone();
     let promise =
       runtime_template.block_promise(block, context.compilation, dep.dependency_type().as_str());
+    context
+      .runtime_template
+      .runtime_requirements_mut()
+      .insert(*runtime_template.runtime_requirements());
     let require = context
       .runtime_template
       .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE);
@@ -830,6 +952,10 @@ impl JavaScriptParserAndGenerator {
     )];
 
     if let Some(error_handler_range) = dep.error_handler_range() {
+      context
+        .runtime_template
+        .runtime_requirements_mut()
+        .insert(RuntimeGlobals::REQUIRE);
       replacements.push((
         format!(").bind(null, {require}))['catch']("),
         content_range.end,
@@ -837,6 +963,12 @@ impl JavaScriptParserAndGenerator {
       ));
       replacements.push((")".to_string(), error_handler_range.end, range.end));
     } else {
+      let mut runtime_requirements = RuntimeGlobals::REQUIRE;
+      runtime_requirements.insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
+      context
+        .runtime_template
+        .runtime_requirements_mut()
+        .insert(runtime_requirements);
       replacements.push((
         format!(
           ").bind(null, {require}))['catch']({})",
@@ -853,25 +985,24 @@ impl JavaScriptParserAndGenerator {
     else {
       return false;
     };
-    let Some(key) = key else {
-      return false;
-    };
     plan.push_action(action);
-    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
     true
   }
 
   fn collect_ast_amd_require_action(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
     dep: &AMDRequireDependency,
   ) -> bool {
     let module_graph = context.compilation.get_module_graph();
     let block = module_graph.get_parent_block(dep.id());
     let mut runtime_template = context.runtime_template.clone();
     let promise = runtime_template.block_promise(block, context.compilation, "AMD require");
+    context
+      .runtime_template
+      .runtime_requirements_mut()
+      .insert(*runtime_template.runtime_requirements());
     let uncaught_error_handler = context
       .runtime_template
       .render_runtime_globals_without_adding(&RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
@@ -887,6 +1018,10 @@ impl JavaScriptParserAndGenerator {
       dep.error_callback_range(),
     ) {
       (Some(array_range), None, _) => {
+        context
+          .runtime_template
+          .runtime_requirements_mut()
+          .insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
         replacements.push((
           format!("{promise}.then(function() {{"),
           outer_range.start,
@@ -899,6 +1034,12 @@ impl JavaScriptParserAndGenerator {
         ));
       }
       (None, Some(function_range), _) => {
+        let mut runtime_requirements = RuntimeGlobals::REQUIRE;
+        runtime_requirements.insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
+        context
+          .runtime_template
+          .runtime_requirements_mut()
+          .insert(runtime_requirements);
         replacements.push((
           format!("{promise}.then(("),
           outer_range.start,
@@ -949,6 +1090,10 @@ impl JavaScriptParserAndGenerator {
         ));
       }
       (Some(array_range), Some(function_range), None) => {
+        context
+          .runtime_template
+          .runtime_requirements_mut()
+          .insert(RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
         replacements.push((
           format!("{promise}.then(function() {{ "),
           outer_range.start,
@@ -986,11 +1131,7 @@ impl JavaScriptParserAndGenerator {
     else {
       return false;
     };
-    let Some(key) = key else {
-      return false;
-    };
     plan.push_action(action);
-    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
     true
   }
 
@@ -1062,7 +1203,6 @@ impl JavaScriptParserAndGenerator {
     &self,
     context: &TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
     dep: &ESMAcceptDependency,
   ) -> bool {
     let content = self.render_ast_esm_accept_content(context, dep);
@@ -1084,17 +1224,13 @@ impl JavaScriptParserAndGenerator {
     let Some(action) = action else {
       return false;
     };
-    let Some(key) = key else {
-      return false;
-    };
     plan.push_action(action);
-    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
     true
   }
 
   fn render_ast_worker_import(
     &self,
-    context: &TemplateContext,
+    context: &mut TemplateContext,
     dep: &WorkerDependency,
   ) -> Option<String> {
     let chunk_id = context
@@ -1129,8 +1265,18 @@ impl JavaScriptParserAndGenerator {
     } else {
       context
         .runtime_template
+        .runtime_requirements_mut()
+        .insert(RuntimeGlobals::PUBLIC_PATH);
+      context
+        .runtime_template
         .render_runtime_globals_without_adding(&RuntimeGlobals::PUBLIC_PATH)
     };
+    let mut runtime_requirements = RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME;
+    runtime_requirements.insert(RuntimeGlobals::BASE_URI);
+    context
+      .runtime_template
+      .runtime_requirements_mut()
+      .insert(runtime_requirements);
 
     let worker_import_str = format!(
       "/* worker import */{} + {}({}), {}",
@@ -1156,7 +1302,6 @@ impl JavaScriptParserAndGenerator {
     dependency: &dyn DependencyCodeGeneration,
     context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-    key: Option<AstDependencyRenderKey>,
   ) -> bool {
     if dependency.dependency_template().is_none() {
       return true;
@@ -1166,11 +1311,7 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ESMImportSideEffectDependency>()
     {
-      self.prime_ast_esm_import_side_effect(context, dep);
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      self.apply_ast_esm_import_side_effect(context, dep);
       return true;
     }
 
@@ -1178,15 +1319,16 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ESMCompatibilityDependency>()
       .is_some()
-      || dependency
-        .as_any()
-        .downcast_ref::<ESMExportSpecifierDependency>()
-        .is_some()
     {
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      self.apply_ast_esm_compatibility(context);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ESMExportSpecifierDependency>()
+    {
+      self.apply_ast_esm_export_specifier(context, dep);
       return true;
     }
 
@@ -1194,27 +1336,23 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ESMExportImportedSpecifierDependency>()
     {
-      self.prime_ast_esm_export_imported_specifier(context, dep);
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      self.apply_ast_esm_export_imported_specifier(context, dep);
       return true;
     }
 
-    if dependency
+    if let Some(dep) = dependency
       .as_any()
       .downcast_ref::<ExternalModuleDependency>()
-      .is_some()
-      || dependency
-        .as_any()
-        .downcast_ref::<ModuleDecoratorDependency>()
-        .is_some()
     {
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      self.apply_ast_external_module(context, dep);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ModuleDecoratorDependency>()
+    {
+      self.apply_ast_module_decorator(context, dep);
       return true;
     }
 
@@ -1222,16 +1360,13 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ImportMetaRscDependency>()
     {
+      self.apply_ast_import_meta_rsc(context, dep);
       if let Some(range) = dep.ast_dependency_range() {
         let Some(action) = AstDependencyAction::expr(range, IMPORT_META_RSC_BINDING) else {
           return false;
         };
         plan.push_action(action);
       }
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1242,7 +1377,6 @@ impl JavaScriptParserAndGenerator {
       return self.collect_ast_context_require_call_action(
         context,
         plan,
-        key,
         dep,
         dep.range(),
         dep.value_range(),
@@ -1256,7 +1390,6 @@ impl JavaScriptParserAndGenerator {
       return self.collect_ast_context_require_call_action(
         context,
         plan,
-        key,
         dep,
         dep.range(),
         Some(dep.value_range()),
@@ -1267,7 +1400,6 @@ impl JavaScriptParserAndGenerator {
       return self.collect_ast_context_require_call_action(
         context,
         plan,
-        key,
         dep,
         dep.range(),
         Some(dep.value_range()),
@@ -1281,7 +1413,6 @@ impl JavaScriptParserAndGenerator {
       return self.collect_ast_context_require_call_action(
         context,
         plan,
-        key,
         dep,
         dep.range(),
         Some(dep.range()),
@@ -1292,14 +1423,14 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<RequireResolveContextDependency>()
     {
-      return self.collect_ast_context_id_action(context, plan, key, dep, dep.range());
+      return self.collect_ast_context_id_action(context, plan, dep, dep.range());
     }
 
     if let Some(dep) = dependency
       .as_any()
       .downcast_ref::<ImportMetaResolveContextDependency>()
     {
-      return self.collect_ast_context_id_action(context, plan, key, dep, dep.range());
+      return self.collect_ast_context_id_action(context, plan, dep, dep.range());
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<URLDependency>()
@@ -1308,19 +1439,7 @@ impl JavaScriptParserAndGenerator {
         Some(JavascriptParserUrl::Relative | JavascriptParserUrl::NewUrlRelative)
       )
     {
-      let Some(replacements) =
-        self.render_ast_template_replacements(context, dependency, dep.range())
-      else {
-        return false;
-      };
-      if !self.push_template_replacement_actions(plan, dep.range(), replacements) {
-        return false;
-      }
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
-      return true;
+      return false;
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<AMDDefineDependency>() {
@@ -1339,11 +1458,7 @@ impl JavaScriptParserAndGenerator {
       else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1368,14 +1483,10 @@ impl JavaScriptParserAndGenerator {
       let Some(action) = action else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
       if !self.collect_ast_esm_import_specifier_destructuring_actions(context, dep, plan) {
         return false;
       }
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1383,7 +1494,7 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ESMExportExpressionDependency>()
     {
-      return self.collect_ast_esm_export_expression_action(context, plan, key, dep);
+      return self.collect_ast_esm_export_expression_action(context, plan, dep);
     }
 
     if let Some(dep) = dependency
@@ -1425,11 +1536,11 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<RequireEnsureDependency>()
     {
-      return self.collect_ast_require_ensure_action(context, plan, key, dep);
+      return self.collect_ast_require_ensure_action(context, plan, dep);
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<ESMAcceptDependency>() {
-      return self.collect_ast_esm_accept_action(context, plan, key, dep);
+      return self.collect_ast_esm_accept_action(context, plan, dep);
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<ConstDependency>() {
@@ -1465,17 +1576,14 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<AMDRequireItemDependency>()
     {
-      let mut runtime_template = context.runtime_template.clone();
       let content =
-        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), false);
+        context
+          .runtime_template
+          .module_raw(context.compilation, dep.id(), dep.request(), false);
       let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1487,16 +1595,12 @@ impl JavaScriptParserAndGenerator {
       let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<AMDRequireDependency>() {
-      return self.collect_ast_amd_require_action(context, plan, key, dep);
+      return self.collect_ast_amd_require_action(context, plan, dep);
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<UnsupportedDependency>() {
@@ -1511,17 +1615,16 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<RequireContextDependency>()
     {
-      let mut runtime_template = context.runtime_template.clone();
-      let content =
-        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), dep.optional());
+      let content = context.runtime_template.module_raw(
+        context.compilation,
+        dep.id(),
+        dep.request(),
+        dep.optional(),
+      );
       let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1529,17 +1632,16 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ImportMetaContextDependency>()
     {
-      let mut runtime_template = context.runtime_template.clone();
-      let content =
-        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), dep.optional());
+      let content = context.runtime_template.module_raw(
+        context.compilation,
+        dep.id(),
+        dep.request(),
+        dep.optional(),
+      );
       let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1549,11 +1651,7 @@ impl JavaScriptParserAndGenerator {
       else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1608,12 +1706,7 @@ impl JavaScriptParserAndGenerator {
         return false;
       };
       plan.push_action(action);
-      if needs_side_effect {
-        let Some(key) = key else {
-          return false;
-        };
-        plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
-      }
+      if needs_side_effect {}
       return true;
     }
 
@@ -1739,26 +1832,22 @@ impl JavaScriptParserAndGenerator {
       return true;
     }
 
-    if let Some(dep) = dependency.as_any().downcast_ref::<URLDependency>() {
-      let Some(replacements) =
-        self.render_ast_template_replacements(context, dependency, dep.range())
-      else {
-        return false;
-      };
-      if !self.push_template_replacement_actions(plan, dep.range(), replacements) {
-        return false;
-      }
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
-      return true;
+    if dependency
+      .as_any()
+      .downcast_ref::<URLDependency>()
+      .is_some()
+    {
+      return false;
     }
 
     if let Some(dep) = dependency
       .as_any()
       .downcast_ref::<CreateScriptUrlDependency>()
     {
+      context
+        .runtime_template
+        .runtime_requirements_mut()
+        .insert(RuntimeGlobals::CREATE_SCRIPT_URL);
       let Some(action) = AstDependencyAction::wrapped_source(
         range,
         dep.range_path(),
@@ -1772,11 +1861,7 @@ impl JavaScriptParserAndGenerator {
       ) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1787,11 +1872,7 @@ impl JavaScriptParserAndGenerator {
       let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
       return true;
     }
 
@@ -1833,6 +1914,7 @@ impl JavaScriptParserAndGenerator {
       .downcast_ref::<CommonJsFullRequireDependency>()
     {
       let module_graph = context.compilation.get_module_graph();
+      let mut uses_require = false;
       let require_expr = if let Some(imported_module) =
         module_graph.module_graph_module_by_dependency_id(dep.id())
         && let Some(used) = {
@@ -1847,17 +1929,23 @@ impl JavaScriptParserAndGenerator {
           )
         } {
         let mut require_expr = match used {
-          UsedName::Normal(used) => format!(
-            "{}({}){}{}",
-            context
-              .runtime_template
-              .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
-            context
-              .runtime_template
-              .module_id(context.compilation, dep.id(), dep.request(), false),
-            to_normal_comment(&property_access(dep.names(), 0)),
-            property_access(used, 0)
-          ),
+          UsedName::Normal(used) => {
+            uses_require = true;
+            format!(
+              "{}({}){}{}",
+              context
+                .runtime_template
+                .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
+              context.runtime_template.module_id(
+                context.compilation,
+                dep.id(),
+                dep.request(),
+                false
+              ),
+              to_normal_comment(&property_access(dep.names(), 0)),
+              property_access(used, 0)
+            )
+          }
           UsedName::Inlined(inlined) => inlined.render(&to_normal_comment(&format!(
             "inlined export {}",
             property_access(dep.names(), 0)
@@ -1868,6 +1956,7 @@ impl JavaScriptParserAndGenerator {
         }
         require_expr
       } else {
+        uses_require = true;
         format!(
           "{}({})",
           context
@@ -1881,11 +1970,12 @@ impl JavaScriptParserAndGenerator {
       let Some(action) = AstDependencyAction::expr(range, require_expr.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      if uses_require {
+        plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+          RuntimeGlobals::REQUIRE,
+        ));
+      }
       return true;
     }
 
@@ -1975,7 +2065,9 @@ impl JavaScriptParserAndGenerator {
         dep.names(),
       );
 
+      let mut base_runtime_requirements = RuntimeGlobals::default();
       let base = if dep.base().is_exports() {
+        base_runtime_requirements.insert(RuntimeGlobals::EXPORTS);
         match module.get_exports_argument() {
           ExportsArgument::Exports => "exports".to_string(),
           ExportsArgument::RspackExports => context
@@ -1983,6 +2075,7 @@ impl JavaScriptParserAndGenerator {
             .render_runtime_variable(&RuntimeVariable::Exports),
         }
       } else if dep.base().is_module_exports() {
+        base_runtime_requirements.insert(RuntimeGlobals::MODULE);
         let module_argument = match module.get_module_argument() {
           ModuleArgument::Module => "module".to_string(),
           ModuleArgument::RspackModule => context
@@ -1991,6 +2084,7 @@ impl JavaScriptParserAndGenerator {
         };
         format!("{module_argument}.exports")
       } else if dep.base().is_this() {
+        base_runtime_requirements.insert(RuntimeGlobals::THIS_AS_EXPORTS);
         "this".to_string()
       } else {
         unreachable!();
@@ -2051,11 +2145,12 @@ impl JavaScriptParserAndGenerator {
       let Some(action) = action else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      if !base_runtime_requirements.is_empty() {
+        plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+          base_runtime_requirements,
+        ));
+      }
       return true;
     }
 
@@ -2082,7 +2177,9 @@ impl JavaScriptParserAndGenerator {
         dep.names(),
       );
 
+      let mut base_runtime_requirements = RuntimeGlobals::default();
       let base = if dep.base().is_exports() {
+        base_runtime_requirements.insert(RuntimeGlobals::EXPORTS);
         match module.get_exports_argument() {
           ExportsArgument::Exports => "exports".to_string(),
           ExportsArgument::RspackExports => context
@@ -2090,6 +2187,7 @@ impl JavaScriptParserAndGenerator {
             .render_runtime_variable(&RuntimeVariable::Exports),
         }
       } else if dep.base().is_module_exports() {
+        base_runtime_requirements.insert(RuntimeGlobals::MODULE);
         let module_argument = match module.get_module_argument() {
           ModuleArgument::Module => "module".to_string(),
           ModuleArgument::RspackModule => context
@@ -2098,31 +2196,38 @@ impl JavaScriptParserAndGenerator {
         };
         format!("{module_argument}.exports")
       } else if dep.base().is_this() {
+        base_runtime_requirements.insert(RuntimeGlobals::THIS_AS_EXPORTS);
         "this".to_string()
       } else {
         unreachable!();
       };
 
-      let module_raw = if let Some(module_identifier) =
+      let (module_raw, module_raw_uses_require) = if let Some(module_identifier) =
         module_graph.module_identifier_by_dependency_id(dep.id())
         && let Some(module_id) =
           ChunkGraph::get_module_id(&context.compilation.module_ids_artifact, *module_identifier)
       {
-        format!(
-          "{}({})",
-          context
-            .runtime_template
-            .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
-          context
-            .runtime_template
-            .module_id_expr(dep.request(), module_id)
+        (
+          format!(
+            "{}({})",
+            context
+              .runtime_template
+              .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
+            context
+              .runtime_template
+              .module_id_expr(dep.request(), module_id)
+          ),
+          true,
         )
       } else {
-        context.runtime_template.missing_module(dep.request())
+        (
+          context.runtime_template.missing_module(dep.request()),
+          false,
+        )
       };
 
       let ids = dep.get_ids(&module_graph);
-      let require_expr = if let Some(imported_module) =
+      let (require_expr, uses_require) = if let Some(imported_module) =
         module_graph.get_module_by_dependency_id(dep.id())
         && let Some(used_imported) = context
           .compilation
@@ -2134,19 +2239,25 @@ impl JavaScriptParserAndGenerator {
             ids,
           ) {
         match used_imported {
-          UsedName::Normal(used_imported) => format!(
-            "{}{}{}",
-            module_raw,
-            to_normal_comment(&property_access(ids, 0)),
-            property_access(used_imported, 0)
+          UsedName::Normal(used_imported) => (
+            format!(
+              "{}{}{}",
+              module_raw,
+              to_normal_comment(&property_access(ids, 0)),
+              property_access(used_imported, 0)
+            ),
+            module_raw_uses_require,
           ),
-          UsedName::Inlined(inlined) => inlined.render(&to_normal_comment(&format!(
-            "inlined export {}",
-            property_access(ids, 0)
-          ))),
+          UsedName::Inlined(inlined) => (
+            inlined.render(&to_normal_comment(&format!(
+              "inlined export {}",
+              property_access(ids, 0)
+            ))),
+            false,
+          ),
         }
       } else {
-        module_raw
+        (module_raw, module_raw_uses_require)
       };
 
       let expr = match used {
@@ -2160,11 +2271,17 @@ impl JavaScriptParserAndGenerator {
       let Some(action) = AstDependencyAction::expr(range, expr.into_boxed_str()) else {
         return false;
       };
-      let Some(key) = key else {
-        return false;
-      };
       plan.push_action(action);
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      if !base_runtime_requirements.is_empty() {
+        plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+          base_runtime_requirements,
+        ));
+      }
+      if uses_require {
+        plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+          RuntimeGlobals::REQUIRE,
+        ));
+      }
       return true;
     }
 
@@ -2173,18 +2290,7 @@ impl JavaScriptParserAndGenerator {
       .downcast_ref::<ImportDependency>()
       .is_some()
     {
-      let Some(replacements) = self.render_ast_template_replacements(context, dependency, range)
-      else {
-        return false;
-      };
-      if !self.push_template_replacement_actions(plan, range, replacements) {
-        return false;
-      }
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
-      return true;
+      return false;
     }
 
     if dependency
@@ -2192,18 +2298,7 @@ impl JavaScriptParserAndGenerator {
       .downcast_ref::<ImportEagerDependency>()
       .is_some()
     {
-      let Some(replacements) = self.render_ast_template_replacements(context, dependency, range)
-      else {
-        return false;
-      };
-      if !self.push_template_replacement_actions(plan, range, replacements) {
-        return false;
-      }
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
-      return true;
+      return false;
     }
 
     if dependency
@@ -2211,18 +2306,7 @@ impl JavaScriptParserAndGenerator {
       .downcast_ref::<ImportWeakDependency>()
       .is_some()
     {
-      let Some(replacements) = self.render_ast_template_replacements(context, dependency, range)
-      else {
-        return false;
-      };
-      if !self.push_template_replacement_actions(plan, range, replacements) {
-        return false;
-      }
-      let Some(key) = key else {
-        return false;
-      };
-      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
-      return true;
+      return false;
     }
 
     if dependency
@@ -2329,11 +2413,18 @@ impl JavaScriptParserAndGenerator {
     source_text: &str,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Option<BoxSource> {
-    let plan = self.collect_ast_render_plan(module, context)?;
-    let source = render_ast_dependencies(source_text, module.module_type(), &plan)?;
-    self.apply_ast_dependency_side_effects(module, context, &plan, source_text.len());
-    Some(RawStringSource::from(source).boxed())
+  ) -> Result<BoxSource> {
+    let plan = self
+      .collect_ast_render_plan(module, context)
+      .ok_or_else(|| {
+        ast_dependency_codegen_error(module, "unsupported dependency in AST render plan")
+      })?;
+    let source =
+      render_ast_dependencies(source_text, module.module_type(), &plan).ok_or_else(|| {
+        ast_dependency_codegen_error(module, "failed to apply AST dependency replacements")
+      })?;
+    self.apply_ast_dependency_side_effects(context, &plan);
+    Ok(RawStringSource::from(source).boxed())
   }
 
   fn try_render_ast_dependencies_with_source_map(
@@ -2342,144 +2433,30 @@ impl JavaScriptParserAndGenerator {
     source: &BoxSource,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Option<BoxSource> {
-    let plan = self.collect_ast_render_plan(module, context)?;
+  ) -> Result<BoxSource> {
+    let plan = self
+      .collect_ast_render_plan(module, context)
+      .ok_or_else(|| {
+        ast_dependency_codegen_error(module, "unsupported dependency in AST render plan")
+      })?;
     let mut source = ReplaceSource::new(source.clone());
     if !apply_ast_dependency_replacements(source_text, module.module_type(), &plan, &mut source) {
-      return None;
+      return Err(ast_dependency_codegen_error(
+        module,
+        "failed to apply AST dependency replacements with source map",
+      ));
     }
-    self.apply_ast_dependency_side_effects(module, context, &plan, source_text.len());
-    Some(source.boxed())
+    self.apply_ast_dependency_side_effects(context, &plan);
+    Ok(source.boxed())
   }
 
   fn apply_ast_dependency_side_effects(
     &self,
-    module: &dyn Module,
     context: &mut TemplateContext,
     plan: &AstDependencyRenderPlan,
-    source_len: usize,
   ) {
-    let mut side_effect_source =
-      ReplaceSource::new(RawStringSource::from(" ".repeat(source_len)).boxed());
     for side_effect in plan.side_effects() {
-      match side_effect {
-        AstDependencySideEffect::RenderTemplate(AstDependencyRenderKey::Dependency(
-          dependency_id,
-        )) => {
-          self.source_dependency(
-            context.compilation,
-            dependency_id,
-            &mut side_effect_source,
-            context,
-          );
-        }
-        AstDependencySideEffect::RenderTemplate(AstDependencyRenderKey::Presentational(idx)) => {
-          if let Some(dependency) = module
-            .get_presentational_dependencies()
-            .and_then(|dependencies| dependencies.get(*idx))
-          {
-            self.render_presentational_dependency(
-              context.compilation,
-              dependency.as_ref(),
-              &mut side_effect_source,
-              context,
-            );
-          }
-        }
-        _ => side_effect.apply(context),
-      }
-    }
-  }
-
-  fn source_dependency(
-    &self,
-    compilation: &Compilation,
-    dependency_id: &DependencyId,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-  ) {
-    if let Some(dependency) = compilation
-      .get_module_graph()
-      .dependency_by_id(dependency_id)
-      .as_dependency_code_generation()
-    {
-      if let Some(template) = dependency
-        .dependency_template()
-        .and_then(|template_type| compilation.get_dependency_template(template_type))
-      {
-        template.render(dependency, source, context)
-      } else {
-        panic!(
-          "Can not find dependency template of {:?}",
-          dependency.dependency_template()
-        );
-      }
-    }
-  }
-
-  fn source_ast_dependency(
-    &self,
-    compilation: &Compilation,
-    dependency_id: &DependencyId,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-  ) {
-    if let Some(dependency) = compilation
-      .get_module_graph()
-      .dependency_by_id(dependency_id)
-      .as_dependency_code_generation()
-    {
-      if let Some(template) = dependency
-        .dependency_template()
-        .and_then(|template_type| compilation.get_dependency_template(template_type))
-      {
-        template.render_ast(dependency, source, context)
-      } else {
-        panic!(
-          "Can not find dependency template of {:?}",
-          dependency.dependency_template()
-        );
-      }
-    }
-  }
-
-  fn render_presentational_dependency(
-    &self,
-    compilation: &Compilation,
-    dependency: &dyn DependencyCodeGeneration,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-  ) {
-    if let Some(template) = dependency
-      .dependency_template()
-      .and_then(|template_type| compilation.get_dependency_template(template_type))
-    {
-      template.render(dependency, source, context)
-    } else {
-      panic!(
-        "Can not find dependency template of {:?}",
-        dependency.dependency_template()
-      );
-    }
-  }
-
-  fn render_ast_presentational_dependency(
-    &self,
-    compilation: &Compilation,
-    dependency: &dyn DependencyCodeGeneration,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-  ) {
-    if let Some(template) = dependency
-      .dependency_template()
-      .and_then(|template_type| compilation.get_dependency_template(template_type))
-    {
-      template.render_ast(dependency, source, context)
-    } else {
-      panic!(
-        "Can not find dependency template of {:?}",
-        dependency.dependency_template()
-      );
+      side_effect.apply(context);
     }
   }
 }
@@ -2704,108 +2681,18 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       let has_source_map = source
         .map(&ObjectPool::default(), &MapOptions::default())
         .is_some();
-      if !has_source_map
-        && let Some(source) = self.try_render_ast_dependencies(&source_text, module, &mut context)
-      {
-        generate_context.concatenation_scope = context.concatenation_scope.take();
-        return render_init_fragments(source, init_fragments, generate_context);
-      }
-      if has_source_map
-        && let Some(source) = self.try_render_ast_dependencies_with_source_map(
+      let source = if has_source_map {
+        self.try_render_ast_dependencies_with_source_map(
           &source_text,
           source,
           module,
           &mut context,
-        )
-      {
-        generate_context.concatenation_scope = context.concatenation_scope.take();
-        return render_init_fragments(source, init_fragments, generate_context);
-      }
-
-      let mut source = ReplaceSource::new(source.clone());
-      let mut ast_dependencies = Vec::new();
-      module.get_dependencies().iter().for_each(|dependency_id| {
-        self.collect_ast_dependency(compilation, dependency_id, &mut ast_dependencies)
-      });
-
-      if let Some(dependencies) = module.get_presentational_dependencies() {
-        dependencies
-          .iter()
-          .enumerate()
-          .for_each(|(idx, dependency)| {
-            if let Some(entry) = AstDependencyRenderEntry::new(
-              AstDependencyRenderKey::Presentational(idx),
-              dependency.as_ref(),
-            ) {
-              ast_dependencies.push(entry);
-            }
-          });
+        )?
+      } else {
+        self.try_render_ast_dependencies(&source_text, module, &mut context)?
       };
-
-      module
-        .get_blocks()
-        .iter()
-        .for_each(|block_id| self.collect_ast_block(compilation, block_id, &mut ast_dependencies));
-
-      let mut applied_ast_dependency_ids = HashSet::new();
-      let mut applied_ast_presentational_dependencies = HashSet::new();
-      if !ast_dependencies.is_empty()
-        && mark_ast_dependencies(&source_text, module.module_type(), &mut ast_dependencies)
-      {
-        for entry in ast_dependencies.iter().filter(|entry| entry.applied()) {
-          match entry.key {
-            AstDependencyRenderKey::Dependency(dependency_id) => {
-              applied_ast_dependency_ids.insert(dependency_id);
-            }
-            AstDependencyRenderKey::Presentational(idx) => {
-              applied_ast_presentational_dependencies.insert(idx);
-            }
-          }
-        }
-      }
-
-      module.get_dependencies().iter().for_each(|dependency_id| {
-        if applied_ast_dependency_ids.contains(dependency_id) {
-          self.source_ast_dependency(compilation, dependency_id, &mut source, &mut context)
-        } else {
-          self.source_dependency(compilation, dependency_id, &mut source, &mut context)
-        }
-      });
-
-      if let Some(dependencies) = module.get_presentational_dependencies() {
-        dependencies
-          .iter()
-          .enumerate()
-          .for_each(|(idx, dependency)| {
-            if applied_ast_presentational_dependencies.contains(&idx) {
-              self.render_ast_presentational_dependency(
-                compilation,
-                dependency.as_ref(),
-                &mut source,
-                &mut context,
-              )
-            } else {
-              self.render_presentational_dependency(
-                compilation,
-                dependency.as_ref(),
-                &mut source,
-                &mut context,
-              );
-            }
-          });
-      };
-
-      module.get_blocks().iter().for_each(|block_id| {
-        self.source_block(
-          compilation,
-          block_id,
-          &mut source,
-          &mut context,
-          &applied_ast_dependency_ids,
-        )
-      });
       generate_context.concatenation_scope = context.concatenation_scope.take();
-      render_init_fragments(source.boxed(), init_fragments, generate_context)
+      render_init_fragments(source, init_fragments, generate_context)
     } else {
       panic!(
         "Unsupported source type: {:?}",

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -8,13 +8,20 @@ use regex::Regex;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
-  ChunkGraph, CollectedTypeScriptInfo, Compilation, DependenciesBlock, DependencyId,
-  GenerateContext, Module, ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  ParseContext, ParseResult, ParserAndGenerator, RuntimeGlobals, RuntimeVariable,
-  SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
+  CachedConstDependency, ChunkGraph, CodeGenerationData, CollectedTypeScriptInfo, Compilation,
+  ConstDependency, ContextDependency, ContextMode, DEFAULT_EXPORT, DependenciesBlock, Dependency,
+  DependencyCodeGeneration, DependencyId, DependencyRange, ExportMode, ExportsArgument,
+  ExportsType, GenerateContext, ImportPhase, JavascriptParserUrl, Module, ModuleArgument,
+  ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult, ParserAndGenerator,
+  RuntimeCondition, RuntimeGlobals, RuntimeRequirementsDependency,
+  RuntimeRequirementsDependencyMode, RuntimeVariable, SideEffectsBailoutItem, SourceType,
+  TemplateContext, TemplateReplaceSource, UsedName,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
-  remove_bom, render_init_fragments,
-  rspack_sources::{BoxSource, ReplaceSource, Source, SourceExt},
+  property_access, property_access_with_optional, remove_bom, render_init_fragments,
+  rspack_sources::{
+    BoxSource, MapOptions, ObjectPool, RawStringSource, ReplaceSource, Source, SourceExt,
+  },
+  to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use swc_experimental_allocator::Allocator;
@@ -27,8 +34,41 @@ use swc_experimental_ecma_transforms_base::remove_paren::remove_paren;
 
 use crate::{
   BoxJavascriptParserPlugin,
-  dependency::ESMCompatibilityDependency,
+  dependency::{
+    AMDRequireContextDependency, CommonJsExportRequireDependency, CommonJsExportsDependency,
+    CommonJsFullRequireDependency, CommonJsRequireContextDependency, CommonJsRequireDependency,
+    CommonJsSelfReferenceDependency, CreateScriptUrlDependency, DeclarationId, ESMAcceptDependency,
+    ESMCompatibilityDependency, ESMExportExpressionDependency, ESMExportHeaderDependency,
+    ESMExportImportedSpecifierDependency, ESMExportSpecifierDependency,
+    ESMImportSideEffectDependency, ESMImportSpecifierDependency,
+    ESMImportSpecifierDependencyTemplate, ExportInfoDependency, ExternalModuleDependency,
+    IMPORT_META_RSC_BINDING, ImportContextDependency, ImportDependency, ImportEagerDependency,
+    ImportMetaContextDependency, ImportMetaHotAcceptDependency, ImportMetaHotDeclineDependency,
+    ImportMetaResolveContextDependency, ImportMetaResolveDependency,
+    ImportMetaResolveHeaderDependency, ImportMetaRscDependency, ImportWeakDependency,
+    IsIncludeDependency, ModuleArgumentDependency, ModuleDecoratorDependency,
+    ModuleHotAcceptDependency, ModuleHotDeclineDependency, ProvideDependency,
+    PureExpressionDependency, RequireContextDependency, RequireEnsureDependency,
+    RequireHeaderDependency, RequireMainDependency, RequireResolveContextDependency,
+    RequireResolveDependency, RequireResolveHeaderDependency, URLContextDependency, URLDependency,
+    WorkerDependency, amd_define_dependency::AMDDefineDependency,
+    amd_require_array_dependency::AMDRequireArrayDependency,
+    amd_require_dependency::AMDRequireDependency,
+    amd_require_item_dependency::AMDRequireItemDependency, esm_import_dependency_apply,
+    esm_import_dependency_prime_import_var, import_emitted_runtime,
+    local_module_dependency::LocalModuleDependency, unsupported_dependency::UnsupportedDependency,
+  },
+  is_export_inlined,
+  parser_plugin::JS_DEFAULT_KEYWORD,
   visitors::{ParsedJavaScriptAst, ScanDependenciesResult, scan_dependencies, semicolon},
+};
+
+mod ast_dependency;
+
+use ast_dependency::{
+  AstDependencyAction, AstDependencyRenderEntry, AstDependencyRenderKey, AstDependencyRenderPlan,
+  AstDependencySideEffect, apply_ast_dependency_replacements, mark_ast_dependencies,
+  render_ast_dependencies,
 };
 
 #[derive(Debug)]
@@ -129,6 +169,7 @@ impl JavaScriptParserAndGenerator {
     block_id: &AsyncDependenciesBlockIdentifier,
     source: &mut TemplateReplaceSource,
     context: &mut TemplateContext,
+    applied_ast_dependency_ids: &HashSet<DependencyId>,
   ) {
     let module_graph = compilation.get_module_graph();
     let block = module_graph
@@ -136,12 +177,2218 @@ impl JavaScriptParserAndGenerator {
       .expect("should have block");
     //    let block = block_id.expect_get(compilation);
     block.get_dependencies().iter().for_each(|dependency_id| {
-      self.source_dependency(compilation, dependency_id, source, context)
+      if applied_ast_dependency_ids.contains(dependency_id) {
+        self.source_ast_dependency(compilation, dependency_id, source, context)
+      } else {
+        self.source_dependency(compilation, dependency_id, source, context)
+      }
     });
+    block.get_blocks().iter().for_each(|block_id| {
+      self.source_block(
+        compilation,
+        block_id,
+        source,
+        context,
+        applied_ast_dependency_ids,
+      )
+    });
+  }
+
+  fn collect_ast_dependency<'a>(
+    &self,
+    compilation: &'a Compilation,
+    dependency_id: &DependencyId,
+    entries: &mut Vec<AstDependencyRenderEntry>,
+  ) {
+    if let Some(dependency) = compilation
+      .get_module_graph()
+      .dependency_by_id(dependency_id)
+      .as_dependency_code_generation()
+      && let Some(entry) = AstDependencyRenderEntry::new(
+        AstDependencyRenderKey::Dependency(*dependency_id),
+        dependency,
+      )
+    {
+      entries.push(entry);
+    }
+  }
+
+  fn collect_ast_block<'a>(
+    &self,
+    compilation: &'a Compilation,
+    block_id: &AsyncDependenciesBlockIdentifier,
+    entries: &mut Vec<AstDependencyRenderEntry>,
+  ) {
+    let module_graph = compilation.get_module_graph();
+    let block = module_graph
+      .block_by_id(block_id)
+      .expect("should have block");
+    block
+      .get_dependencies()
+      .iter()
+      .for_each(|dependency_id| self.collect_ast_dependency(compilation, dependency_id, entries));
     block
       .get_blocks()
       .iter()
-      .for_each(|block_id| self.source_block(compilation, block_id, source, context));
+      .for_each(|block_id| self.collect_ast_block(compilation, block_id, entries));
+  }
+
+  fn collect_ast_render_dependency(
+    &self,
+    compilation: &Compilation,
+    dependency_id: &DependencyId,
+    context: &mut TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+  ) -> bool {
+    let Some(dependency) = compilation
+      .get_module_graph()
+      .dependency_by_id(dependency_id)
+      .as_dependency_code_generation()
+    else {
+      return true;
+    };
+
+    self.collect_ast_render_action(
+      dependency,
+      context,
+      plan,
+      Some(AstDependencyRenderKey::Dependency(*dependency_id)),
+    )
+  }
+
+  fn collect_ast_render_block(
+    &self,
+    compilation: &Compilation,
+    block_id: &AsyncDependenciesBlockIdentifier,
+    context: &mut TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+  ) -> bool {
+    let module_graph = compilation.get_module_graph();
+    let block = module_graph
+      .block_by_id(block_id)
+      .expect("should have block");
+    block.get_dependencies().iter().all(|dependency_id| {
+      self.collect_ast_render_dependency(compilation, dependency_id, context, plan)
+    }) && block
+      .get_blocks()
+      .iter()
+      .all(|block_id| self.collect_ast_render_block(compilation, block_id, context, plan))
+  }
+
+  fn collect_ast_render_plan(
+    &self,
+    module: &dyn Module,
+    context: &mut TemplateContext,
+  ) -> Option<AstDependencyRenderPlan> {
+    let mut plan = AstDependencyRenderPlan::default();
+    let compilation = context.compilation;
+
+    let supported = module.get_dependencies().iter().all(|dependency_id| {
+      self.collect_ast_render_dependency(compilation, dependency_id, context, &mut plan)
+    }) && module
+      .get_presentational_dependencies()
+      .map(|dependencies| {
+        dependencies.iter().enumerate().all(|(idx, dependency)| {
+          self.collect_ast_render_action(
+            dependency.as_ref(),
+            context,
+            &mut plan,
+            Some(AstDependencyRenderKey::Presentational(idx)),
+          )
+        })
+      })
+      .unwrap_or(true)
+      && module
+        .get_blocks()
+        .iter()
+        .all(|block_id| self.collect_ast_render_block(compilation, block_id, context, &mut plan));
+
+    supported.then_some(plan)
+  }
+
+  fn render_ast_amd_require_array(
+    &self,
+    context: &TemplateContext,
+    dep: &AMDRequireArrayDependency,
+  ) -> String {
+    let mut init_fragments = Vec::new();
+    let mut data = CodeGenerationData::default();
+    let mut runtime_template = context.runtime_template.clone();
+    let mut temp_context = TemplateContext {
+      compilation: context.compilation,
+      module: context.module,
+      init_fragments: &mut init_fragments,
+      runtime: context.runtime,
+      concatenation_scope: None,
+      data: &mut data,
+      runtime_template: &mut runtime_template,
+    };
+
+    dep.content(&mut temp_context)
+  }
+
+  fn render_ast_context_module_raw(
+    &self,
+    context: &TemplateContext,
+    dep: &dyn ContextDependency,
+    weak: bool,
+  ) -> String {
+    let mut runtime_template = context.runtime_template.clone();
+    runtime_template.module_raw(context.compilation, dep.id(), dep.request(), weak)
+  }
+
+  fn render_ast_template_replacements(
+    &self,
+    context: &mut TemplateContext,
+    dependency: &dyn DependencyCodeGeneration,
+    validate_range: DependencyRange,
+  ) -> Option<Vec<(String, u32, u32)>> {
+    let template = dependency
+      .dependency_template()
+      .and_then(|template_type| context.compilation.get_dependency_template(template_type))?;
+    let mut init_fragments = Vec::new();
+    let mut data = CodeGenerationData::default();
+    let mut runtime_template = context.runtime_template.clone();
+    let mut temp_context = TemplateContext {
+      compilation: context.compilation,
+      module: context.module,
+      init_fragments: &mut init_fragments,
+      runtime: context.runtime,
+      concatenation_scope: context
+        .concatenation_scope
+        .as_mut()
+        .map(|scope| &mut **scope),
+      data: &mut data,
+      runtime_template: &mut runtime_template,
+    };
+    let mut source =
+      ReplaceSource::new(RawStringSource::from(" ".repeat(validate_range.end as usize)).boxed());
+    template.render(dependency, &mut source, &mut temp_context);
+    Some(
+      source
+        .replacements()
+        .iter()
+        .map(|replacement| {
+          (
+            replacement.content().to_string(),
+            replacement.start(),
+            replacement.end(),
+          )
+        })
+        .collect(),
+    )
+  }
+
+  fn push_template_replacement_actions(
+    &self,
+    plan: &mut AstDependencyRenderPlan,
+    validate_range: DependencyRange,
+    replacements: Vec<(String, u32, u32)>,
+  ) -> bool {
+    if replacements.is_empty() {
+      return true;
+    }
+
+    let action = if replacements.len() == 1
+      && replacements[0].1 == validate_range.start
+      && replacements[0].2 == validate_range.end
+    {
+      let (content, _, _) = replacements.into_iter().next().expect("checked len");
+      AstDependencyAction::expr(validate_range, content)
+    } else {
+      AstDependencyAction::validated_replacements(validate_range, replacements)
+    };
+    let Some(action) = action else {
+      return false;
+    };
+    plan.push_action(action);
+    true
+  }
+
+  fn collect_ast_context_require_call_action(
+    &self,
+    context: &TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+    dep: &dyn ContextDependency,
+    range: DependencyRange,
+    value_range: Option<DependencyRange>,
+  ) -> bool {
+    let expr = self.render_ast_context_module_raw(context, dep, false);
+    let module_exists = context
+      .compilation
+      .get_module_graph()
+      .module_graph_module_by_dependency_id(dep.id())
+      .is_some();
+
+    let action = if module_exists {
+      if let Some(value_range) = value_range {
+        AstDependencyAction::wrapped_source_with_replacements(
+          range,
+          value_range,
+          format!("{expr}("),
+          ")",
+          dep.options().replaces.clone(),
+        )
+      } else {
+        AstDependencyAction::expr(range, expr)
+      }
+    } else {
+      AstDependencyAction::expr(range, expr)
+    };
+
+    let Some(action) = action else {
+      return false;
+    };
+    let Some(key) = key else {
+      return false;
+    };
+    plan.push_action(action);
+    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+    true
+  }
+
+  fn collect_ast_context_id_action(
+    &self,
+    context: &TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+    dep: &dyn ContextDependency,
+    range: DependencyRange,
+  ) -> bool {
+    let expr =
+      self.render_ast_context_module_raw(context, dep, dep.options().mode == ContextMode::Weak);
+    let module_exists = context
+      .compilation
+      .get_module_graph()
+      .module_graph_module_by_dependency_id(dep.id())
+      .is_some();
+
+    let action = if module_exists {
+      AstDependencyAction::wrapped_source_with_replacements(
+        range,
+        range,
+        format!("{expr}.resolve("),
+        ")",
+        dep.options().replaces.clone(),
+      )
+    } else {
+      AstDependencyAction::expr(range, expr)
+    };
+
+    let Some(action) = action else {
+      return false;
+    };
+    let Some(key) = key else {
+      return false;
+    };
+    plan.push_action(action);
+    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+    true
+  }
+
+  fn render_ast_esm_import_specifier(
+    &self,
+    context: &TemplateContext,
+    dep: &ESMImportSpecifierDependency,
+  ) -> Option<Option<String>> {
+    let module_graph = context.compilation.get_module_graph();
+    let ids = dep.get_ids(module_graph);
+    let connection = module_graph.connection_by_dependency_id(dep.id());
+    if let Some(con) = connection
+      && !con.is_target_active(
+        module_graph,
+        context.runtime,
+        &context.compilation.module_graph_cache_artifact,
+        &context
+          .compilation
+          .build_module_graph_artifact
+          .side_effects_state_artifact,
+        &context.compilation.exports_info_artifact,
+      )
+      && !is_export_inlined(
+        &context.compilation.exports_info_artifact,
+        con.module_identifier(),
+        ids,
+        context.runtime,
+      )
+    {
+      return Some(None);
+    }
+
+    let mut init_fragments = Vec::new();
+    let mut data = CodeGenerationData::default();
+    let mut runtime_template = context.runtime_template.clone();
+    let mut concatenation_scope = context
+      .concatenation_scope
+      .as_ref()
+      .map(|scope| (**scope).clone());
+    let mut temp_context = TemplateContext {
+      compilation: context.compilation,
+      module: context.module,
+      init_fragments: &mut init_fragments,
+      runtime: context.runtime,
+      concatenation_scope: concatenation_scope.as_mut(),
+      data: &mut data,
+      runtime_template: &mut runtime_template,
+    };
+    let template = ESMImportSpecifierDependencyTemplate::default();
+    if dep.evaluated_in_operator {
+      template
+        .get_evaluated_in_operator_code(ids, dep, connection, &mut temp_context)
+        .map(Some)
+    } else {
+      Some(Some(template.get_code_for_ids(
+        ids,
+        dep,
+        connection,
+        &mut temp_context,
+      )))
+    }
+  }
+
+  fn collect_ast_esm_import_specifier_destructuring_actions(
+    &self,
+    context: &TemplateContext,
+    dep: &ESMImportSpecifierDependency,
+    plan: &mut AstDependencyRenderPlan,
+  ) -> bool {
+    let Some(referenced_properties) = dep.referenced_properties_in_destructuring() else {
+      return true;
+    };
+
+    let module_graph = context.compilation.get_module_graph();
+    let ids = dep.get_ids(module_graph);
+    let mut prefixed_ids = ids.to_vec();
+
+    let Some(module) = module_graph.get_module_by_dependency_id(dep.id()) else {
+      return true;
+    };
+
+    if ids.first().is_some_and(|id| id == "default") {
+      let Some(self_module) = module_graph
+        .get_parent_module(dep.id())
+        .and_then(|id| module_graph.module_by_identifier(id))
+      else {
+        return false;
+      };
+      let exports_type = module.get_exports_type(
+        module_graph,
+        &context.compilation.module_graph_cache_artifact,
+        &context.compilation.exports_info_artifact,
+        self_module.build_meta().strict_esm_module,
+      );
+      if matches!(
+        exports_type,
+        ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
+      ) && !ids.is_empty()
+      {
+        prefixed_ids = ids[1..].to_vec();
+      }
+    }
+
+    let mut actions = Vec::new();
+    referenced_properties.traverse_on_enter(&mut |stack| {
+      let prop = stack.last().expect("should have last");
+      let mut concated_ids = prefixed_ids.clone();
+      concated_ids.extend(stack.iter().map(|p| p.id.clone()));
+      let Some(new_name) = context
+        .compilation
+        .exports_info_artifact
+        .get_exports_info_data(&module.identifier())
+        .get_used_name(
+          &context.compilation.exports_info_artifact,
+          context.runtime,
+          &concated_ids,
+        )
+        .and_then(|used| match used {
+          UsedName::Normal(names) => names.last().cloned(),
+          UsedName::Inlined(inlined) => {
+            unreachable!("should not inline for destructuring {:#?}", inlined)
+          }
+        })
+      else {
+        return;
+      };
+
+      if new_name == prop.id {
+        return;
+      }
+
+      let comment = to_normal_comment(prop.id.as_str());
+      let key = format!("{comment}{new_name}");
+      let content = if prop.shorthand {
+        format!("{key}: {}", prop.id)
+      } else {
+        key
+      };
+      actions.push((prop.range, content));
+    });
+
+    for (range, content) in actions {
+      let Some(action) = AstDependencyAction::raw_ident(range, content) else {
+        return false;
+      };
+      plan.push_action(action);
+    }
+
+    true
+  }
+
+  fn prime_ast_esm_import_side_effect(
+    &self,
+    context: &TemplateContext,
+    dep: &ESMImportSideEffectDependency,
+  ) {
+    let module_graph = context.compilation.get_module_graph();
+    let module = module_graph.get_module_by_dependency_id(dep.id());
+
+    if module.is_none() && !dep.missing_module_active() {
+      return;
+    }
+
+    if let Some(module) = module {
+      let source_types = module.source_types(module_graph);
+      if source_types
+        .iter()
+        .all(|source_type| matches!(source_type, SourceType::Css))
+      {
+        return;
+      }
+    }
+
+    if let Some(scope) = context.concatenation_scope.as_ref()
+      && module.is_some_and(|m| scope.is_module_in_scope(&m.identifier()))
+    {
+      return;
+    }
+
+    let mut init_fragments = Vec::new();
+    let mut data = CodeGenerationData::default();
+    let mut runtime_template = context.runtime_template.clone();
+    let mut temp_context = TemplateContext {
+      compilation: context.compilation,
+      module: context.module,
+      init_fragments: &mut init_fragments,
+      runtime: context.runtime,
+      concatenation_scope: None,
+      data: &mut data,
+      runtime_template: &mut runtime_template,
+    };
+    esm_import_dependency_apply(dep, dep.source_order(), dep.phase(), &mut temp_context);
+  }
+
+  fn prime_ast_esm_export_imported_specifier(
+    &self,
+    context: &TemplateContext,
+    dep: &ESMExportImportedSpecifierDependency,
+  ) {
+    if context.concatenation_scope.is_some() {
+      return;
+    }
+
+    let module_graph = context.compilation.get_module_graph();
+    let mode = dep.get_mode(
+      module_graph,
+      context.runtime,
+      &context.compilation.module_graph_cache_artifact,
+      &context.compilation.exports_info_artifact,
+    );
+
+    if matches!(
+      mode,
+      ExportMode::LazyMake | ExportMode::Unused(_) | ExportMode::EmptyStar(_)
+    ) {
+      return;
+    }
+
+    let _ = esm_import_dependency_prime_import_var(dep, dep.phase(), context);
+  }
+
+  fn render_ast_esm_export_expression_head(&self, context: &TemplateContext) -> String {
+    let supports_const = context
+      .compilation
+      .options
+      .output
+      .environment
+      .supports_const();
+
+    if context.concatenation_scope.is_some() {
+      return format!(
+        "/* export default */ {} {DEFAULT_EXPORT} = ",
+        if supports_const { "const" } else { "var" }
+      );
+    }
+
+    if let Some(used) = context
+      .compilation
+      .exports_info_artifact
+      .get_exports_info_data(&context.module.identifier())
+      .get_used_name(
+        &context.compilation.exports_info_artifact,
+        context.runtime,
+        std::slice::from_ref(&JS_DEFAULT_KEYWORD),
+      )
+    {
+      if let UsedName::Normal(used) = used {
+        if supports_const {
+          format!("/* export default */ const {DEFAULT_EXPORT} = ")
+        } else {
+          let exports_argument = match context.module.get_exports_argument() {
+            ExportsArgument::Exports => "exports".to_string(),
+            ExportsArgument::RspackExports => context
+              .runtime_template
+              .render_runtime_variable(&RuntimeVariable::Exports),
+          };
+          format!(
+            "/* export default */ {}{} = ",
+            exports_argument,
+            property_access(used, 0)
+          )
+        }
+      } else {
+        format!("/* inlined export default */ var {DEFAULT_EXPORT} = ")
+      }
+    } else {
+      format!("/* unused export default */ var {DEFAULT_EXPORT} = ")
+    }
+  }
+
+  fn collect_ast_esm_export_expression_action(
+    &self,
+    context: &TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+    dep: &ESMExportExpressionDependency,
+  ) -> bool {
+    let range = dep.range();
+    let range_stmt = dep.range_stmt();
+    let mut replacements = Vec::new();
+
+    if let Some(declaration) = dep.declaration() {
+      replacements.push((
+        format!("/* export default */ {}", dep.prefix()),
+        range_stmt.start,
+        range.start,
+      ));
+
+      if let DeclarationId::Func(func) = declaration {
+        let func_range = func.range();
+        replacements.push((
+          format!("{}{}{}", func.prefix(), DEFAULT_EXPORT, func.suffix()),
+          func_range.start,
+          func_range.end,
+        ));
+      }
+    } else {
+      replacements.push((
+        format!(
+          "{}({}",
+          self.render_ast_esm_export_expression_head(context),
+          dep.prefix()
+        ),
+        range_stmt.start,
+        range.start,
+      ));
+      replacements.push((");".to_string(), range.end, range_stmt.end));
+    }
+
+    let Some(action) =
+      AstDependencyAction::source_with_replacements(range_stmt, range_stmt, replacements)
+    else {
+      return false;
+    };
+    let Some(key) = key else {
+      return false;
+    };
+    plan.push_action(action);
+    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+    true
+  }
+
+  fn collect_ast_require_ensure_action(
+    &self,
+    context: &TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+    dep: &RequireEnsureDependency,
+  ) -> bool {
+    let module_graph = context.compilation.get_module_graph();
+    let block = module_graph.get_parent_block(dep.id());
+    let mut runtime_template = context.runtime_template.clone();
+    let promise =
+      runtime_template.block_promise(block, context.compilation, dep.dependency_type().as_str());
+    let require = context
+      .runtime_template
+      .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE);
+    let range = dep.range();
+    let content_range = dep.content_range();
+    let mut replacements = vec![(
+      format!("{promise}.then(("),
+      range.start,
+      content_range.start,
+    )];
+
+    if let Some(error_handler_range) = dep.error_handler_range() {
+      replacements.push((
+        format!(").bind(null, {require}))['catch']("),
+        content_range.end,
+        error_handler_range.start,
+      ));
+      replacements.push((")".to_string(), error_handler_range.end, range.end));
+    } else {
+      replacements.push((
+        format!(
+          ").bind(null, {require}))['catch']({})",
+          context
+            .runtime_template
+            .render_runtime_globals_without_adding(&RuntimeGlobals::UNCAUGHT_ERROR_HANDLER)
+        ),
+        content_range.end,
+        range.end,
+      ));
+    }
+
+    let Some(action) = AstDependencyAction::source_with_replacements(range, range, replacements)
+    else {
+      return false;
+    };
+    let Some(key) = key else {
+      return false;
+    };
+    plan.push_action(action);
+    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+    true
+  }
+
+  fn collect_ast_amd_require_action(
+    &self,
+    context: &TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+    dep: &AMDRequireDependency,
+  ) -> bool {
+    let module_graph = context.compilation.get_module_graph();
+    let block = module_graph.get_parent_block(dep.id());
+    let mut runtime_template = context.runtime_template.clone();
+    let promise = runtime_template.block_promise(block, context.compilation, "AMD require");
+    let uncaught_error_handler = context
+      .runtime_template
+      .render_runtime_globals_without_adding(&RuntimeGlobals::UNCAUGHT_ERROR_HANDLER);
+    let require = context
+      .runtime_template
+      .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE);
+    let outer_range = dep.outer_range();
+    let mut replacements = Vec::new();
+
+    match (
+      dep.array_range(),
+      dep.function_range(),
+      dep.error_callback_range(),
+    ) {
+      (Some(array_range), None, _) => {
+        replacements.push((
+          format!("{promise}.then(function() {{"),
+          outer_range.start,
+          array_range.start,
+        ));
+        replacements.push((
+          format!(";}})['catch']({uncaught_error_handler})"),
+          array_range.end,
+          outer_range.end,
+        ));
+      }
+      (None, Some(function_range), _) => {
+        replacements.push((
+          format!("{promise}.then(("),
+          outer_range.start,
+          function_range.start,
+        ));
+        replacements.push((
+          format!(
+            ").bind(exports, {require}, exports, module))['catch']({uncaught_error_handler})"
+          ),
+          function_range.end,
+          outer_range.end,
+        ));
+      }
+      (Some(array_range), Some(function_range), Some(error_callback_range)) => {
+        replacements.push((
+          format!("{promise}.then(function() {{ "),
+          outer_range.start,
+          array_range.start,
+        ));
+        replacements.push((
+          "var __rspack_amd_require_deps = ".to_string(),
+          array_range.start,
+          array_range.start,
+        ));
+        replacements.push(("; (".to_string(), array_range.end, function_range.start));
+        replacements.push((
+          ").apply(null, __rspack_amd_require_deps);".to_string(),
+          function_range.end,
+          function_range.end,
+        ));
+        replacements.push((
+          if dep.function_bind_this {
+            "}.bind(this))['catch'](".to_string()
+          } else {
+            "})['catch'](".to_string()
+          },
+          function_range.end,
+          error_callback_range.start,
+        ));
+        replacements.push((
+          if dep.error_callback_bind_this {
+            ".bind(this))".to_string()
+          } else {
+            ")".to_string()
+          },
+          error_callback_range.end,
+          outer_range.end,
+        ));
+      }
+      (Some(array_range), Some(function_range), None) => {
+        replacements.push((
+          format!("{promise}.then(function() {{ "),
+          outer_range.start,
+          array_range.start,
+        ));
+        replacements.push((
+          "var __rspack_amd_require_deps = ".to_string(),
+          array_range.start,
+          array_range.start,
+        ));
+        replacements.push(("; (".to_string(), array_range.end, function_range.start));
+        replacements.push((
+          ").apply(null, __rspack_amd_require_deps);".to_string(),
+          function_range.end,
+          function_range.end,
+        ));
+        replacements.push((
+          format!(
+            "}}{})['catch']({uncaught_error_handler})",
+            if dep.function_bind_this {
+              ".bind(this)"
+            } else {
+              ""
+            }
+          ),
+          function_range.end,
+          outer_range.end,
+        ));
+      }
+      (None, None, _) => return false,
+    }
+
+    let Some(action) =
+      AstDependencyAction::source_with_replacements(outer_range, outer_range, replacements)
+    else {
+      return false;
+    };
+    let Some(key) = key else {
+      return false;
+    };
+    plan.push_action(action);
+    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+    true
+  }
+
+  fn render_ast_esm_accept_content(
+    &self,
+    context: &TemplateContext,
+    dep: &ESMAcceptDependency,
+  ) -> String {
+    let mut content = String::new();
+    let module_graph = context.compilation.get_module_graph();
+    let module_identifier = context.module.identifier();
+    let mut runtime_template = context.runtime_template.clone();
+
+    for id in dep.dependency_ids() {
+      let dependency = module_graph.dependency_by_id(id);
+      let target_module = module_graph.get_module_by_dependency_id(dependency.id());
+      let runtime_condition = match target_module {
+        Some(target_module) => {
+          import_emitted_runtime::get_runtime(&module_identifier, &target_module.identifier())
+        }
+        None => RuntimeCondition::Boolean(false),
+      };
+
+      if matches!(runtime_condition, RuntimeCondition::Boolean(false)) {
+        continue;
+      }
+
+      let condition = runtime_template.runtime_condition_expression(
+        &context.compilation.build_chunk_graph_artifact.chunk_graph,
+        Some(&runtime_condition),
+        context.runtime,
+      );
+
+      let module_dependency = dependency
+        .as_module_dependency()
+        .expect("should be module dependency");
+      let phase = ImportPhase::Evaluation;
+      let import_var = context.compilation.get_import_var(
+        module_identifier,
+        target_module,
+        module_dependency.user_request(),
+        phase,
+        context.runtime,
+      );
+      let stmts = runtime_template.import_statement(
+        context.module,
+        context.compilation,
+        id,
+        &import_var,
+        module_dependency.request(),
+        phase,
+        true,
+      );
+      if condition == "true" {
+        content.push_str(&stmts.0);
+        content.push_str(&stmts.1);
+      } else {
+        content.push_str(&format!("if ({condition}) {{\n"));
+        content.push_str(&stmts.0);
+        content.push_str(&stmts.1);
+        content.push_str("\n}\n");
+      }
+    }
+
+    content
+  }
+
+  fn collect_ast_esm_accept_action(
+    &self,
+    context: &TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+    dep: &ESMAcceptDependency,
+  ) -> bool {
+    let content = self.render_ast_esm_accept_content(context, dep);
+    let action = if dep.has_callback() {
+      let range = dep.range();
+      AstDependencyAction::wrapped_source(
+        range,
+        range,
+        format!("function(__rspack_hmr_outdated) {{\n{content}("),
+        ")(__rspack_hmr_outdated); }.bind(this)",
+      )
+    } else {
+      AstDependencyAction::insert(
+        dep.call_range(),
+        dep.range().start,
+        format!(", function(){{\n{content}\n}}"),
+      )
+    };
+    let Some(action) = action else {
+      return false;
+    };
+    let Some(key) = key else {
+      return false;
+    };
+    plan.push_action(action);
+    plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+    true
+  }
+
+  fn render_ast_worker_import(
+    &self,
+    context: &TemplateContext,
+    dep: &WorkerDependency,
+  ) -> Option<String> {
+    let chunk_id = context
+      .compilation
+      .get_module_graph()
+      .get_parent_block(dep.id())
+      .and_then(|block| {
+        context
+          .compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .get_block_chunk_group(
+            block,
+            &context
+              .compilation
+              .build_chunk_graph_artifact
+              .chunk_group_by_ukey,
+          )
+      })
+      .map(|entrypoint| entrypoint.get_entrypoint_chunk())
+      .and_then(|ukey| {
+        context
+          .compilation
+          .build_chunk_graph_artifact
+          .chunk_by_ukey
+          .get(&ukey)
+      })
+      .and_then(|chunk| chunk.id())
+      .map(rspack_util::json_stringify)?;
+    let worker_import_base_url = if !dep.public_path().is_empty() {
+      format!("\"{}\"", dep.public_path())
+    } else {
+      context
+        .runtime_template
+        .render_runtime_globals_without_adding(&RuntimeGlobals::PUBLIC_PATH)
+    };
+
+    let worker_import_str = format!(
+      "/* worker import */{} + {}({}), {}",
+      worker_import_base_url,
+      context
+        .runtime_template
+        .render_runtime_globals_without_adding(&RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME),
+      chunk_id,
+      context
+        .runtime_template
+        .render_runtime_globals_without_adding(&RuntimeGlobals::BASE_URI)
+    );
+
+    if dep.need_new_url() {
+      Some(format!("new URL({worker_import_str})"))
+    } else {
+      Some(worker_import_str)
+    }
+  }
+
+  fn collect_ast_render_action(
+    &self,
+    dependency: &dyn DependencyCodeGeneration,
+    context: &mut TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    key: Option<AstDependencyRenderKey>,
+  ) -> bool {
+    if dependency.dependency_template().is_none() {
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ESMImportSideEffectDependency>()
+    {
+      self.prime_ast_esm_import_side_effect(context, dep);
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<ESMCompatibilityDependency>()
+      .is_some()
+      || dependency
+        .as_any()
+        .downcast_ref::<ESMExportSpecifierDependency>()
+        .is_some()
+    {
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ESMExportImportedSpecifierDependency>()
+    {
+      self.prime_ast_esm_export_imported_specifier(context, dep);
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<ExternalModuleDependency>()
+      .is_some()
+      || dependency
+        .as_any()
+        .downcast_ref::<ModuleDecoratorDependency>()
+        .is_some()
+    {
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportMetaRscDependency>()
+    {
+      if let Some(range) = dep.ast_dependency_range() {
+        let Some(action) = AstDependencyAction::expr(range, IMPORT_META_RSC_BINDING) else {
+          return false;
+        };
+        plan.push_action(action);
+      }
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CommonJsRequireContextDependency>()
+    {
+      return self.collect_ast_context_require_call_action(
+        context,
+        plan,
+        key,
+        dep,
+        dep.range(),
+        dep.value_range(),
+      );
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportContextDependency>()
+    {
+      return self.collect_ast_context_require_call_action(
+        context,
+        plan,
+        key,
+        dep,
+        dep.range(),
+        Some(dep.value_range()),
+      );
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<URLContextDependency>() {
+      return self.collect_ast_context_require_call_action(
+        context,
+        plan,
+        key,
+        dep,
+        dep.range(),
+        Some(dep.value_range()),
+      );
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<AMDRequireContextDependency>()
+    {
+      return self.collect_ast_context_require_call_action(
+        context,
+        plan,
+        key,
+        dep,
+        dep.range(),
+        Some(dep.range()),
+      );
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<RequireResolveContextDependency>()
+    {
+      return self.collect_ast_context_id_action(context, plan, key, dep, dep.range());
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportMetaResolveContextDependency>()
+    {
+      return self.collect_ast_context_id_action(context, plan, key, dep, dep.range());
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<URLDependency>()
+      && !matches!(
+        dep.mode(),
+        Some(JavascriptParserUrl::Relative | JavascriptParserUrl::NewUrlRelative)
+      )
+    {
+      let Some(replacements) =
+        self.render_ast_template_replacements(context, dependency, dep.range())
+      else {
+        return false;
+      };
+      if !self.push_template_replacement_actions(plan, dep.range(), replacements) {
+        return false;
+      }
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<AMDDefineDependency>() {
+      let mut runtime_template = context.runtime_template.clone();
+      let Some((definition, replacements)) = dep.ast_define_replacements(&mut runtime_template)
+      else {
+        return false;
+      };
+      if let Some(definition) = definition {
+        let Some(action) = AstDependencyAction::insert(dep.range(), 0, definition) else {
+          return false;
+        };
+        plan.push_action(action);
+      }
+      let Some(action) = AstDependencyAction::validated_replacements(dep.range(), replacements)
+      else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ESMImportSpecifierDependency>()
+    {
+      let Some(content) = self.render_ast_esm_import_specifier(context, dep) else {
+        return false;
+      };
+      let Some(content) = content else {
+        return true;
+      };
+      let Some(range) = dep.range() else {
+        return false;
+      };
+      let action = if dep.shorthand() {
+        AstDependencyAction::raw_ident_with_suffix(range, format!(": {content}"))
+      } else {
+        AstDependencyAction::expr(range, content.into_boxed_str())
+      };
+      let Some(action) = action else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      if !self.collect_ast_esm_import_specifier_destructuring_actions(context, dep, plan) {
+        return false;
+      }
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ESMExportExpressionDependency>()
+    {
+      return self.collect_ast_esm_export_expression_action(context, plan, key, dep);
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ESMExportHeaderDependency>()
+    {
+      let range = dep.range();
+      let action = if let Some(range_decl) = dep.range_decl() {
+        AstDependencyAction::validated_replacements(
+          range,
+          vec![("".to_string(), range.start, range_decl.start)],
+        )
+      } else {
+        AstDependencyAction::expr(range, "")
+      };
+      let Some(action) = action else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<RuntimeRequirementsDependency>()
+      && matches!(dep.mode, RuntimeRequirementsDependencyMode::AddOnly)
+    {
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        dep.runtime_requirements,
+      ));
+      return true;
+    }
+
+    let Some(range) = dependency.ast_dependency_range() else {
+      return false;
+    };
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<RequireEnsureDependency>()
+    {
+      return self.collect_ast_require_ensure_action(context, plan, key, dep);
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<ESMAcceptDependency>() {
+      return self.collect_ast_esm_accept_action(context, plan, key, dep);
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<ConstDependency>() {
+      let Some(action) = AstDependencyAction::expr(range, dep.content.clone()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<CachedConstDependency>() {
+      let Some(action) = AstDependencyAction::expr(range, dep.identifier.clone()) else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::CachedConst {
+        identifier: dep.identifier.clone(),
+        content: dep.content.clone(),
+      });
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<LocalModuleDependency>() {
+      let Some(action) = AstDependencyAction::expr(range, dep.module_instance().into_boxed_str())
+      else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<AMDRequireItemDependency>()
+    {
+      let mut runtime_template = context.runtime_template.clone();
+      let content =
+        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), false);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<AMDRequireArrayDependency>()
+    {
+      let content = self.render_ast_amd_require_array(context, dep);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<AMDRequireDependency>() {
+      return self.collect_ast_amd_require_action(context, plan, key, dep);
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<UnsupportedDependency>() {
+      let Some(action) = AstDependencyAction::expr(range, dep.content().into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<RequireContextDependency>()
+    {
+      let mut runtime_template = context.runtime_template.clone();
+      let content =
+        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), dep.optional());
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportMetaContextDependency>()
+    {
+      let mut runtime_template = context.runtime_template.clone();
+      let content =
+        runtime_template.module_raw(context.compilation, dep.id(), dep.request(), dep.optional());
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<ProvideDependency>() {
+      let Some(action) =
+        AstDependencyAction::expr(range, dep.identifier().to_string().into_boxed_str())
+      else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<RuntimeRequirementsDependency>()
+    {
+      let mut content = context
+        .runtime_template
+        .render_runtime_globals_without_adding(&dep.runtime_requirements);
+      if matches!(dep.mode, RuntimeRequirementsDependencyMode::Call) {
+        content = format!("{content}()");
+      }
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        dep.runtime_requirements,
+      ));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<PureExpressionDependency>()
+    {
+      let (prefix, suffix, needs_side_effect) =
+        match dep.get_runtime_condition(context.compilation, context.runtime) {
+          RuntimeCondition::Boolean(true) => return true,
+          RuntimeCondition::Boolean(false) => (
+            "(/* unused pure expression or super */ null && (".to_string(),
+            "))",
+            false,
+          ),
+          RuntimeCondition::Spec(runtime_condition) => {
+            let mut runtime_template = context.runtime_template.clone();
+            let condition = runtime_template.runtime_condition_expression(
+              &context.compilation.build_chunk_graph_artifact.chunk_graph,
+              Some(&RuntimeCondition::Spec(runtime_condition)),
+              context.runtime,
+            );
+            (
+              format!("(/* runtime-dependent pure expression or super */ {condition} ? ("),
+              ") : null)",
+              true,
+            )
+          }
+        };
+
+      let Some(action) = AstDependencyAction::wrapped_source(range, range, prefix, suffix) else {
+        return false;
+      };
+      plan.push_action(action);
+      if needs_side_effect {
+        let Some(key) = key else {
+          return false;
+        };
+        plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      }
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ModuleHotAcceptDependency>()
+    {
+      let content = context.runtime_template.module_id(
+        context.compilation,
+        dep.id(),
+        dep.request(),
+        dep.weak(),
+      );
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ModuleHotDeclineDependency>()
+    {
+      let content = context.runtime_template.module_id(
+        context.compilation,
+        dep.id(),
+        dep.request(),
+        dep.weak(),
+      );
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportMetaHotAcceptDependency>()
+    {
+      let content = context.runtime_template.module_id(
+        context.compilation,
+        dep.id(),
+        dep.request(),
+        dep.weak(),
+      );
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportMetaHotDeclineDependency>()
+    {
+      let content = context.runtime_template.module_id(
+        context.compilation,
+        dep.id(),
+        dep.request(),
+        dep.weak(),
+      );
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<RequireResolveHeaderDependency>()
+      .is_some()
+    {
+      let Some(action) = AstDependencyAction::raw_expr(range, "/*require.resolve*/") else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<ImportMetaResolveHeaderDependency>()
+      .is_some()
+    {
+      let Some(action) = AstDependencyAction::raw_expr(range, "/*import.meta.resolve*/") else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<RequireResolveDependency>()
+    {
+      let content =
+        context
+          .runtime_template
+          .module_id(context.compilation, &dep.id, &dep.request, dep.weak);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ImportMetaResolveDependency>()
+    {
+      let content =
+        context
+          .runtime_template
+          .module_id(context.compilation, &dep.id, &dep.request, false);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<URLDependency>() {
+      let Some(replacements) =
+        self.render_ast_template_replacements(context, dependency, dep.range())
+      else {
+        return false;
+      };
+      if !self.push_template_replacement_actions(plan, dep.range(), replacements) {
+        return false;
+      }
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CreateScriptUrlDependency>()
+    {
+      let Some(action) = AstDependencyAction::wrapped_source(
+        range,
+        dep.range_path(),
+        format!(
+          "{}(",
+          context
+            .runtime_template
+            .render_runtime_globals_without_adding(&RuntimeGlobals::CREATE_SCRIPT_URL)
+        ),
+        ")",
+      ) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<WorkerDependency>() {
+      let Some(content) = self.render_ast_worker_import(context, dep) else {
+        return false;
+      };
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<RequireHeaderDependency>()
+      .is_some()
+    {
+      let content = context
+        .runtime_template
+        .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        RuntimeGlobals::REQUIRE,
+      ));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CommonJsRequireDependency>()
+    {
+      let content =
+        context
+          .runtime_template
+          .module_id(context.compilation, dep.id(), dep.request(), false);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CommonJsFullRequireDependency>()
+    {
+      let module_graph = context.compilation.get_module_graph();
+      let require_expr = if let Some(imported_module) =
+        module_graph.module_graph_module_by_dependency_id(dep.id())
+        && let Some(used) = {
+          let exports_info = context
+            .compilation
+            .exports_info_artifact
+            .get_exports_info_data(&imported_module.module_identifier);
+          exports_info.get_used_name(
+            &context.compilation.exports_info_artifact,
+            context.runtime,
+            dep.names(),
+          )
+        } {
+        let mut require_expr = match used {
+          UsedName::Normal(used) => format!(
+            "{}({}){}{}",
+            context
+              .runtime_template
+              .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
+            context
+              .runtime_template
+              .module_id(context.compilation, dep.id(), dep.request(), false),
+            to_normal_comment(&property_access(dep.names(), 0)),
+            property_access(used, 0)
+          ),
+          UsedName::Inlined(inlined) => inlined.render(&to_normal_comment(&format!(
+            "inlined export {}",
+            property_access(dep.names(), 0)
+          ))),
+        };
+        if dep.asi_safe() {
+          require_expr = format!("({require_expr})");
+        }
+        require_expr
+      } else {
+        format!(
+          "{}({})",
+          context
+            .runtime_template
+            .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
+          context
+            .runtime_template
+            .module_id(context.compilation, dep.id(), dep.request(), false)
+        )
+      };
+      let Some(action) = AstDependencyAction::expr(range, require_expr.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CommonJsSelfReferenceDependency>()
+    {
+      let module_graph = context.compilation.get_module_graph();
+      let module = module_graph
+        .module_by_identifier(&context.module.identifier())
+        .expect("should have mgm");
+
+      let used = if !dep.names().is_empty() {
+        let exports_info = context
+          .compilation
+          .exports_info_artifact
+          .get_exports_info_data(&module.identifier());
+        exports_info
+          .get_used_name(
+            &context.compilation.exports_info_artifact,
+            context.runtime,
+            dep.names(),
+          )
+          .unwrap_or_else(|| UsedName::Normal(dep.names().to_vec()))
+      } else {
+        UsedName::Normal(dep.names().to_vec())
+      };
+
+      let (base, runtime_requirements) = if dep.base().is_exports() {
+        let base = match module.get_exports_argument() {
+          ExportsArgument::Exports => "exports".to_string(),
+          ExportsArgument::RspackExports => context
+            .runtime_template
+            .render_runtime_variable(&RuntimeVariable::Exports),
+        };
+        (base, RuntimeGlobals::EXPORTS)
+      } else if dep.base().is_module_exports() {
+        let module_argument = match module.get_module_argument() {
+          ModuleArgument::Module => "module".to_string(),
+          ModuleArgument::RspackModule => context
+            .runtime_template
+            .render_runtime_variable(&RuntimeVariable::Module),
+        };
+        (format!("{module_argument}.exports"), RuntimeGlobals::MODULE)
+      } else if dep.base().is_this() {
+        ("this".to_string(), RuntimeGlobals::THIS_AS_EXPORTS)
+      } else {
+        unreachable!();
+      };
+
+      let content = match used {
+        UsedName::Normal(used) => {
+          format!(
+            "{}{}",
+            base,
+            property_access_with_optional(used, dep.names_optionals(), 0)
+          )
+        }
+        UsedName::Inlined(inlined) => inlined.render(""),
+      };
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        runtime_requirements,
+      ));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CommonJsExportsDependency>()
+    {
+      let module_graph = context.compilation.get_module_graph();
+      let module = module_graph
+        .module_by_identifier(&context.module.identifier())
+        .expect("should have mgm");
+
+      let exports_info = context
+        .compilation
+        .exports_info_artifact
+        .get_exports_info_data(&module.identifier());
+      let used = exports_info.get_used_name(
+        &context.compilation.exports_info_artifact,
+        context.runtime,
+        dep.names(),
+      );
+
+      let base = if dep.base().is_exports() {
+        match module.get_exports_argument() {
+          ExportsArgument::Exports => "exports".to_string(),
+          ExportsArgument::RspackExports => context
+            .runtime_template
+            .render_runtime_variable(&RuntimeVariable::Exports),
+        }
+      } else if dep.base().is_module_exports() {
+        let module_argument = match module.get_module_argument() {
+          ModuleArgument::Module => "module".to_string(),
+          ModuleArgument::RspackModule => context
+            .runtime_template
+            .render_runtime_variable(&RuntimeVariable::Module),
+        };
+        format!("{module_argument}.exports")
+      } else if dep.base().is_this() {
+        "this".to_string()
+      } else {
+        unreachable!();
+      };
+
+      let action = if dep.base().is_expression() {
+        let content = match used {
+          Some(UsedName::Normal(used)) => format!("{}{}", base, property_access(used, 0)),
+          used => {
+            let is_inlined = matches!(used, Some(UsedName::Inlined(_)));
+            format!(
+              "__webpack_{}_export__",
+              if is_inlined { "inlined" } else { "unused" }
+            )
+          }
+        };
+        AstDependencyAction::expr(range, content.into_boxed_str())
+      } else if dep.base().is_define_property() {
+        let Some(value_range) = dep.value_range() else {
+          return false;
+        };
+        let replacements = if let Some(UsedName::Normal(used)) = used {
+          if used.is_empty() {
+            return false;
+          }
+          vec![
+            (
+              format!(
+                "Object.defineProperty({}{}, {}, (",
+                base,
+                property_access(used[0..used.len() - 1].iter(), 0),
+                rspack_util::json_stringify_str(
+                  used
+                    .last()
+                    .expect("Unexpected render define property base")
+                    .as_str()
+                )
+              ),
+              range.start,
+              value_range.start,
+            ),
+            ("))".to_string(), value_range.end, range.end),
+          ]
+        } else {
+          vec![
+            (
+              "__webpack_unused_export__ = (".to_string(),
+              range.start,
+              value_range.start,
+            ),
+            (")".to_string(), value_range.end, range.end),
+          ]
+        };
+        AstDependencyAction::source_with_replacements(range, range, replacements)
+      } else {
+        return false;
+      };
+      let Some(action) = action else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<CommonJsExportRequireDependency>()
+    {
+      if !dep.base().is_expression() {
+        return false;
+      }
+
+      let module_graph = context.compilation.get_module_graph();
+      let module = module_graph
+        .module_by_identifier(&context.module.identifier())
+        .expect("should have mgm");
+
+      let exports_info = context
+        .compilation
+        .exports_info_artifact
+        .get_exports_info_data(&module.identifier());
+      let used = exports_info.get_used_name(
+        &context.compilation.exports_info_artifact,
+        context.runtime,
+        dep.names(),
+      );
+
+      let base = if dep.base().is_exports() {
+        match module.get_exports_argument() {
+          ExportsArgument::Exports => "exports".to_string(),
+          ExportsArgument::RspackExports => context
+            .runtime_template
+            .render_runtime_variable(&RuntimeVariable::Exports),
+        }
+      } else if dep.base().is_module_exports() {
+        let module_argument = match module.get_module_argument() {
+          ModuleArgument::Module => "module".to_string(),
+          ModuleArgument::RspackModule => context
+            .runtime_template
+            .render_runtime_variable(&RuntimeVariable::Module),
+        };
+        format!("{module_argument}.exports")
+      } else if dep.base().is_this() {
+        "this".to_string()
+      } else {
+        unreachable!();
+      };
+
+      let module_raw = if let Some(module_identifier) =
+        module_graph.module_identifier_by_dependency_id(dep.id())
+        && let Some(module_id) =
+          ChunkGraph::get_module_id(&context.compilation.module_ids_artifact, *module_identifier)
+      {
+        format!(
+          "{}({})",
+          context
+            .runtime_template
+            .render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE),
+          context
+            .runtime_template
+            .module_id_expr(dep.request(), module_id)
+        )
+      } else {
+        context.runtime_template.missing_module(dep.request())
+      };
+
+      let ids = dep.get_ids(&module_graph);
+      let require_expr = if let Some(imported_module) =
+        module_graph.get_module_by_dependency_id(dep.id())
+        && let Some(used_imported) = context
+          .compilation
+          .exports_info_artifact
+          .get_exports_info_data(&imported_module.identifier())
+          .get_used_name(
+            &context.compilation.exports_info_artifact,
+            context.runtime,
+            ids,
+          ) {
+        match used_imported {
+          UsedName::Normal(used_imported) => format!(
+            "{}{}{}",
+            module_raw,
+            to_normal_comment(&property_access(ids, 0)),
+            property_access(used_imported, 0)
+          ),
+          UsedName::Inlined(inlined) => inlined.render(&to_normal_comment(&format!(
+            "inlined export {}",
+            property_access(ids, 0)
+          ))),
+        }
+      } else {
+        module_raw
+      };
+
+      let expr = match used {
+        Some(UsedName::Normal(used)) => {
+          format!("{base}{} = {require_expr}", property_access(used, 0))
+        }
+        Some(UsedName::Inlined(_)) => format!("/* inlined reexport */ {require_expr}"),
+        None => format!("/* unused reexport */ {require_expr}"),
+      };
+
+      let Some(action) = AstDependencyAction::expr(range, expr.into_boxed_str()) else {
+        return false;
+      };
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<ImportDependency>()
+      .is_some()
+    {
+      let Some(replacements) = self.render_ast_template_replacements(context, dependency, range)
+      else {
+        return false;
+      };
+      if !self.push_template_replacement_actions(plan, range, replacements) {
+        return false;
+      }
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<ImportEagerDependency>()
+      .is_some()
+    {
+      let Some(replacements) = self.render_ast_template_replacements(context, dependency, range)
+      else {
+        return false;
+      };
+      if !self.push_template_replacement_actions(plan, range, replacements) {
+        return false;
+      }
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<ImportWeakDependency>()
+      .is_some()
+    {
+      let Some(replacements) = self.render_ast_template_replacements(context, dependency, range)
+      else {
+        return false;
+      };
+      if !self.push_template_replacement_actions(plan, range, replacements) {
+        return false;
+      }
+      let Some(key) = key else {
+        return false;
+      };
+      plan.push_side_effect(AstDependencySideEffect::RenderTemplate(key));
+      return true;
+    }
+
+    if dependency
+      .as_any()
+      .downcast_ref::<RequireMainDependency>()
+      .is_some()
+    {
+      let content = format!(
+        "{}[{}]",
+        context
+          .runtime_template
+          .render_runtime_globals_without_adding(&RuntimeGlobals::MODULE_CACHE),
+        context
+          .runtime_template
+          .render_runtime_globals_without_adding(&RuntimeGlobals::ENTRY_MODULE_ID)
+      );
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      let mut runtime_requirements = RuntimeGlobals::MODULE_CACHE;
+      runtime_requirements.insert(RuntimeGlobals::ENTRY_MODULE_ID);
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        runtime_requirements,
+      ));
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<IsIncludeDependency>() {
+      let included = context
+        .compilation
+        .get_module_graph()
+        .connection_by_dependency_id(&dep.id)
+        .is_some_and(|connection| {
+          context
+            .compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .get_number_of_module_chunks(*connection.module_identifier())
+            > 0
+        });
+      let Some(action) = AstDependencyAction::expr(range, included.to_string().into_boxed_str())
+      else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency.as_any().downcast_ref::<ExportInfoDependency>() {
+      let value = dep
+        .get_property(context)
+        .unwrap_or_else(|| "undefined".to_string());
+      let Some(action) = AstDependencyAction::expr(range, value.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<ModuleArgumentDependency>()
+    {
+      let module_argument = context
+        .compilation
+        .get_module_graph()
+        .module_by_identifier(&context.module.identifier())
+        .expect("should have mgm")
+        .get_module_argument();
+      let mut content = match module_argument {
+        ModuleArgument::Module => "module".to_string(),
+        ModuleArgument::RspackModule => context
+          .runtime_template
+          .render_runtime_variable(&RuntimeVariable::Module),
+      };
+      let mut runtime_requirements = RuntimeGlobals::MODULE;
+
+      if let Some(id) = dep.id() {
+        match id {
+          "id" => runtime_requirements.insert(RuntimeGlobals::MODULE_ID),
+          "loaded" => runtime_requirements.insert(RuntimeGlobals::MODULE_LOADED),
+          _ => {}
+        };
+        content.push('.');
+        content.push_str(id);
+      }
+
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
+      plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
+        runtime_requirements,
+      ));
+      return true;
+    }
+
+    false
+  }
+
+  fn try_render_ast_dependencies(
+    &self,
+    source_text: &str,
+    module: &dyn Module,
+    context: &mut TemplateContext,
+  ) -> Option<BoxSource> {
+    let plan = self.collect_ast_render_plan(module, context)?;
+    let source = render_ast_dependencies(source_text, module.module_type(), &plan)?;
+    self.apply_ast_dependency_side_effects(module, context, &plan, source_text.len());
+    Some(RawStringSource::from(source).boxed())
+  }
+
+  fn try_render_ast_dependencies_with_source_map(
+    &self,
+    source_text: &str,
+    source: &BoxSource,
+    module: &dyn Module,
+    context: &mut TemplateContext,
+  ) -> Option<BoxSource> {
+    let plan = self.collect_ast_render_plan(module, context)?;
+    let mut source = ReplaceSource::new(source.clone());
+    if !apply_ast_dependency_replacements(source_text, module.module_type(), &plan, &mut source) {
+      return None;
+    }
+    self.apply_ast_dependency_side_effects(module, context, &plan, source_text.len());
+    Some(source.boxed())
+  }
+
+  fn apply_ast_dependency_side_effects(
+    &self,
+    module: &dyn Module,
+    context: &mut TemplateContext,
+    plan: &AstDependencyRenderPlan,
+    source_len: usize,
+  ) {
+    let mut side_effect_source =
+      ReplaceSource::new(RawStringSource::from(" ".repeat(source_len)).boxed());
+    for side_effect in plan.side_effects() {
+      match side_effect {
+        AstDependencySideEffect::RenderTemplate(AstDependencyRenderKey::Dependency(
+          dependency_id,
+        )) => {
+          self.source_dependency(
+            context.compilation,
+            dependency_id,
+            &mut side_effect_source,
+            context,
+          );
+        }
+        AstDependencySideEffect::RenderTemplate(AstDependencyRenderKey::Presentational(idx)) => {
+          if let Some(dependency) = module
+            .get_presentational_dependencies()
+            .and_then(|dependencies| dependencies.get(*idx))
+          {
+            self.render_presentational_dependency(
+              context.compilation,
+              dependency.as_ref(),
+              &mut side_effect_source,
+              context,
+            );
+          }
+        }
+        _ => side_effect.apply(context),
+      }
+    }
   }
 
   fn source_dependency(
@@ -167,6 +2414,72 @@ impl JavaScriptParserAndGenerator {
           dependency.dependency_template()
         );
       }
+    }
+  }
+
+  fn source_ast_dependency(
+    &self,
+    compilation: &Compilation,
+    dependency_id: &DependencyId,
+    source: &mut TemplateReplaceSource,
+    context: &mut TemplateContext,
+  ) {
+    if let Some(dependency) = compilation
+      .get_module_graph()
+      .dependency_by_id(dependency_id)
+      .as_dependency_code_generation()
+    {
+      if let Some(template) = dependency
+        .dependency_template()
+        .and_then(|template_type| compilation.get_dependency_template(template_type))
+      {
+        template.render_ast(dependency, source, context)
+      } else {
+        panic!(
+          "Can not find dependency template of {:?}",
+          dependency.dependency_template()
+        );
+      }
+    }
+  }
+
+  fn render_presentational_dependency(
+    &self,
+    compilation: &Compilation,
+    dependency: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    context: &mut TemplateContext,
+  ) {
+    if let Some(template) = dependency
+      .dependency_template()
+      .and_then(|template_type| compilation.get_dependency_template(template_type))
+    {
+      template.render(dependency, source, context)
+    } else {
+      panic!(
+        "Can not find dependency template of {:?}",
+        dependency.dependency_template()
+      );
+    }
+  }
+
+  fn render_ast_presentational_dependency(
+    &self,
+    compilation: &Compilation,
+    dependency: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    context: &mut TemplateContext,
+  ) {
+    if let Some(template) = dependency
+      .dependency_template()
+      .and_then(|template_type| compilation.get_dependency_template(template_type))
+    {
+      template.render_ast(dependency, source, context)
+    } else {
+      panic!(
+        "Can not find dependency template of {:?}",
+        dependency.dependency_template()
+      );
     }
   }
 }
@@ -375,7 +2688,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       generate_context.requested_source_type,
       SourceType::JavaScript
     ) {
-      let mut source = ReplaceSource::new(source.clone());
+      let source_text = source.source().into_string_lossy();
       let compilation = generate_context.compilation;
       let mut init_fragments = vec![];
       let mut context = TemplateContext {
@@ -388,30 +2701,109 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         runtime_template: generate_context.runtime_template,
       };
 
+      let has_source_map = source
+        .map(&ObjectPool::default(), &MapOptions::default())
+        .is_some();
+      if !has_source_map
+        && let Some(source) = self.try_render_ast_dependencies(&source_text, module, &mut context)
+      {
+        generate_context.concatenation_scope = context.concatenation_scope.take();
+        return render_init_fragments(source, init_fragments, generate_context);
+      }
+      if has_source_map
+        && let Some(source) = self.try_render_ast_dependencies_with_source_map(
+          &source_text,
+          source,
+          module,
+          &mut context,
+        )
+      {
+        generate_context.concatenation_scope = context.concatenation_scope.take();
+        return render_init_fragments(source, init_fragments, generate_context);
+      }
+
+      let mut source = ReplaceSource::new(source.clone());
+      let mut ast_dependencies = Vec::new();
       module.get_dependencies().iter().for_each(|dependency_id| {
-        self.source_dependency(compilation, dependency_id, &mut source, &mut context)
+        self.collect_ast_dependency(compilation, dependency_id, &mut ast_dependencies)
       });
 
       if let Some(dependencies) = module.get_presentational_dependencies() {
-        dependencies.iter().for_each(|dependency| {
-          if let Some(template) = dependency
-            .dependency_template()
-            .and_then(|template_type| compilation.get_dependency_template(template_type))
-          {
-            template.render(dependency.as_ref(), &mut source, &mut context)
-          } else {
-            panic!(
-              "Can not find dependency template of {:?}",
-              dependency.dependency_template()
-            );
-          }
-        });
+        dependencies
+          .iter()
+          .enumerate()
+          .for_each(|(idx, dependency)| {
+            if let Some(entry) = AstDependencyRenderEntry::new(
+              AstDependencyRenderKey::Presentational(idx),
+              dependency.as_ref(),
+            ) {
+              ast_dependencies.push(entry);
+            }
+          });
       };
 
       module
         .get_blocks()
         .iter()
-        .for_each(|block_id| self.source_block(compilation, block_id, &mut source, &mut context));
+        .for_each(|block_id| self.collect_ast_block(compilation, block_id, &mut ast_dependencies));
+
+      let mut applied_ast_dependency_ids = HashSet::new();
+      let mut applied_ast_presentational_dependencies = HashSet::new();
+      if !ast_dependencies.is_empty()
+        && mark_ast_dependencies(&source_text, module.module_type(), &mut ast_dependencies)
+      {
+        for entry in ast_dependencies.iter().filter(|entry| entry.applied()) {
+          match entry.key {
+            AstDependencyRenderKey::Dependency(dependency_id) => {
+              applied_ast_dependency_ids.insert(dependency_id);
+            }
+            AstDependencyRenderKey::Presentational(idx) => {
+              applied_ast_presentational_dependencies.insert(idx);
+            }
+          }
+        }
+      }
+
+      module.get_dependencies().iter().for_each(|dependency_id| {
+        if applied_ast_dependency_ids.contains(dependency_id) {
+          self.source_ast_dependency(compilation, dependency_id, &mut source, &mut context)
+        } else {
+          self.source_dependency(compilation, dependency_id, &mut source, &mut context)
+        }
+      });
+
+      if let Some(dependencies) = module.get_presentational_dependencies() {
+        dependencies
+          .iter()
+          .enumerate()
+          .for_each(|(idx, dependency)| {
+            if applied_ast_presentational_dependencies.contains(&idx) {
+              self.render_ast_presentational_dependency(
+                compilation,
+                dependency.as_ref(),
+                &mut source,
+                &mut context,
+              )
+            } else {
+              self.render_presentational_dependency(
+                compilation,
+                dependency.as_ref(),
+                &mut source,
+                &mut context,
+              );
+            }
+          });
+      };
+
+      module.get_blocks().iter().for_each(|block_id| {
+        self.source_block(
+          compilation,
+          block_id,
+          &mut source,
+          &mut context,
+          &applied_ast_dependency_ids,
+        )
+      });
       generate_context.concatenation_scope = context.concatenation_scope.take();
       render_init_fragments(source.boxed(), init_fragments, generate_context)
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -8,16 +8,16 @@ use regex::Regex;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
-  CachedConstDependency, ChunkGraph, CollectedTypeScriptInfo, Compilation, ConstDependency,
-  ContextDependency, ContextMode, DEFAULT_EXPORT, DependenciesBlock, Dependency,
-  DependencyCodeGeneration, DependencyId, DependencyRange, ESMExportBinding, ESMExportInitFragment,
-  ExportMode, ExportsArgument, ExportsType, ExternalModuleInitFragment, GenerateContext,
-  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, JavascriptParserUrl, Module,
-  ModuleArgument, ModuleCodeTemplate, ModuleDependency, ModuleGraph, ModuleType,
-  NormalInitFragment, ParseContext, ParseResult, ParserAndGenerator, RuntimeCondition,
+  CachedConstDependency, ChunkGraph, CodeGenerationPublicPathAutoReplace, CollectedTypeScriptInfo,
+  Compilation, ConstDependency, ContextDependency, ContextMode, DEFAULT_EXPORT, DependenciesBlock,
+  Dependency, DependencyCodeGeneration, DependencyId, DependencyRange, ESMExportBinding,
+  ESMExportInitFragment, ExportMode, ExportsArgument, ExportsType, ExternalModuleInitFragment,
+  GenerateContext, ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  JavascriptParserUrl, Module, ModuleArgument, ModuleCodeTemplate, ModuleDependency, ModuleGraph,
+  ModuleType, NormalInitFragment, ParseContext, ParseResult, ParserAndGenerator, RuntimeCondition,
   RuntimeGlobals, RuntimeRequirementsDependency, RuntimeRequirementsDependencyMode,
-  RuntimeVariable, SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
-  UsageState, UsedName,
+  RuntimeVariable, SideEffectsBailoutItem, SourceType, TemplateContext, URLStaticMode, UsageState,
+  UsedName,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   property_access, property_access_with_optional, remove_bom, render_init_fragments,
   rspack_sources::{
@@ -53,8 +53,9 @@ use crate::{
     ModuleHotAcceptDependency, ModuleHotDeclineDependency, ProvideDependency,
     PureExpressionDependency, RequireContextDependency, RequireEnsureDependency,
     RequireHeaderDependency, RequireMainDependency, RequireResolveContextDependency,
-    RequireResolveDependency, RequireResolveHeaderDependency, URLContextDependency, URLDependency,
-    WorkerDependency, amd_define_dependency::AMDDefineDependency,
+    RequireResolveDependency, RequireResolveHeaderDependency, URL_STATIC_PLACEHOLDER,
+    URLContextDependency, URLDependency, WorkerDependency,
+    amd_define_dependency::AMDDefineDependency,
     amd_require_array_dependency::AMDRequireArrayDependency,
     amd_require_dependency::AMDRequireDependency,
     amd_require_item_dependency::AMDRequireItemDependency, esm_import_dependency_apply,
@@ -63,6 +64,7 @@ use crate::{
   },
   is_export_inlined,
   parser_plugin::JS_DEFAULT_KEYWORD,
+  runtime::AUTO_PUBLIC_PATH_PLACEHOLDER,
   visitors::{ParsedJavaScriptAst, ScanDependenciesResult, scan_dependencies, semicolon},
 };
 
@@ -165,105 +167,27 @@ impl JavaScriptParserAndGenerator {
     self.parser_plugins.push(parser_plugin);
   }
 
-  fn source_block(
-    &self,
-    compilation: &Compilation,
-    block_id: &AsyncDependenciesBlockIdentifier,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-  ) {
-    let module_graph = compilation.get_module_graph();
-    let block = module_graph
-      .block_by_id(block_id)
-      .expect("should have block");
-    block.get_dependencies().iter().for_each(|dependency_id| {
-      self.source_dependency(compilation, dependency_id, source, context)
-    });
-    block
-      .get_blocks()
-      .iter()
-      .for_each(|block_id| self.source_block(compilation, block_id, source, context));
-  }
-
-  fn source_dependency(
-    &self,
-    compilation: &Compilation,
-    dependency_id: &DependencyId,
-    source: &mut TemplateReplaceSource,
-    context: &mut TemplateContext,
-  ) {
-    if let Some(dependency) = compilation
-      .get_module_graph()
-      .dependency_by_id(dependency_id)
-      .as_dependency_code_generation()
-    {
-      if let Some(template) = dependency
-        .dependency_template()
-        .and_then(|template_type| compilation.get_dependency_template(template_type))
-      {
-        template.render(dependency, source, context)
-      } else {
-        panic!(
-          "Can not find dependency template of {:?}",
-          dependency.dependency_template()
-        );
-      }
-    }
-  }
-
-  fn render_dependency_templates(
-    &self,
-    source: &BoxSource,
-    compilation: &Compilation,
-    module: &dyn Module,
-    context: &mut TemplateContext,
-  ) -> BoxSource {
-    let mut source = ReplaceSource::new(source.clone());
-
-    module.get_dependencies().iter().for_each(|dependency_id| {
-      self.source_dependency(compilation, dependency_id, &mut source, context)
-    });
-
-    if let Some(dependencies) = module.get_presentational_dependencies() {
-      dependencies.iter().for_each(|dependency| {
-        if let Some(template) = dependency
-          .dependency_template()
-          .and_then(|template_type| compilation.get_dependency_template(template_type))
-        {
-          template.render(dependency.as_ref(), &mut source, context)
-        } else {
-          panic!(
-            "Can not find dependency template of {:?}",
-            dependency.dependency_template()
-          );
-        }
-      });
-    };
-
-    module
-      .get_blocks()
-      .iter()
-      .for_each(|block_id| self.source_block(compilation, block_id, &mut source, context));
-
-    source.boxed()
-  }
-
   fn collect_ast_render_dependency(
     &self,
     compilation: &Compilation,
     dependency_id: &DependencyId,
     context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-  ) -> bool {
+  ) {
     let Some(dependency) = compilation
       .get_module_graph()
       .dependency_by_id(dependency_id)
       .as_dependency_code_generation()
     else {
-      return true;
+      return;
     };
 
-    self.collect_ast_render_action(dependency, context, plan)
+    if !self.collect_ast_render_action(dependency, context, plan) {
+      panic!(
+        "Unsupported dependency in AST codegen: {:?}",
+        dependency.dependency_template()
+      );
+    }
   }
 
   fn collect_ast_render_block(
@@ -272,42 +196,45 @@ impl JavaScriptParserAndGenerator {
     block_id: &AsyncDependenciesBlockIdentifier,
     context: &mut TemplateContext,
     plan: &mut AstDependencyRenderPlan,
-  ) -> bool {
+  ) {
     let module_graph = compilation.get_module_graph();
     let block = module_graph
       .block_by_id(block_id)
       .expect("should have block");
-    block.get_dependencies().iter().all(|dependency_id| {
-      self.collect_ast_render_dependency(compilation, dependency_id, context, plan)
-    }) && block
-      .get_blocks()
-      .iter()
-      .all(|block_id| self.collect_ast_render_block(compilation, block_id, context, plan))
+    for dependency_id in block.get_dependencies() {
+      self.collect_ast_render_dependency(compilation, dependency_id, context, plan);
+    }
+    for block_id in block.get_blocks() {
+      self.collect_ast_render_block(compilation, block_id, context, plan);
+    }
   }
 
   fn collect_ast_render_plan(
     &self,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Option<AstDependencyRenderPlan> {
+  ) -> AstDependencyRenderPlan {
     let mut plan = AstDependencyRenderPlan::default();
     let compilation = context.compilation;
 
-    let supported = module.get_dependencies().iter().all(|dependency_id| {
-      self.collect_ast_render_dependency(compilation, dependency_id, context, &mut plan)
-    }) && module
-      .get_presentational_dependencies()
-      .is_none_or(|dependencies| {
-        dependencies
-          .iter()
-          .all(|dependency| self.collect_ast_render_action(dependency.as_ref(), context, &mut plan))
-      })
-      && module
-        .get_blocks()
-        .iter()
-        .all(|block_id| self.collect_ast_render_block(compilation, block_id, context, &mut plan));
+    for dependency_id in module.get_dependencies() {
+      self.collect_ast_render_dependency(compilation, dependency_id, context, &mut plan);
+    }
+    if let Some(dependencies) = module.get_presentational_dependencies() {
+      for dependency in dependencies {
+        if !self.collect_ast_render_action(dependency.as_ref(), context, &mut plan) {
+          panic!(
+            "Unsupported dependency in AST codegen: {:?}",
+            dependency.dependency_template()
+          );
+        }
+      }
+    }
+    for block_id in module.get_blocks() {
+      self.collect_ast_render_block(compilation, block_id, context, &mut plan);
+    }
 
-    supported.then_some(plan)
+    plan
   }
 
   fn render_ast_amd_require_array(
@@ -327,6 +254,83 @@ impl JavaScriptParserAndGenerator {
     context
       .runtime_template
       .module_raw(context.compilation, dep.id(), dep.request(), weak)
+  }
+
+  fn render_ast_module_namespace_promise(
+    &self,
+    context: &mut TemplateContext,
+    dependency_id: &DependencyId,
+    request: &str,
+    dependency_type: &str,
+    weak: bool,
+    phase: ImportPhase,
+  ) -> String {
+    let module_graph = context.compilation.get_module_graph();
+    let block = module_graph.get_parent_block(dependency_id);
+    context.runtime_template.module_namespace_promise(
+      context.compilation,
+      context.module.identifier(),
+      dependency_id,
+      block,
+      request,
+      dependency_type,
+      weak,
+      phase,
+    )
+  }
+
+  fn render_ast_import_dependency(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ImportDependency,
+  ) -> String {
+    let mut content = self.render_ast_module_namespace_promise(
+      context,
+      dep.id(),
+      dep.request(),
+      dep.dependency_type().as_str(),
+      false,
+      dep.phase(),
+    );
+    if dep.phase().is_source() {
+      content = format!(
+        "{content}.then({})",
+        context
+          .runtime_template
+          .returning_function("m[\"default\"]", "m")
+      );
+    }
+    content
+  }
+
+  fn render_ast_import_eager_dependency(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ImportEagerDependency,
+  ) -> String {
+    self.render_ast_module_namespace_promise(
+      context,
+      dep.id(),
+      dep.request(),
+      dep.dependency_type().as_str(),
+      false,
+      dep.phase(),
+    )
+  }
+
+  fn render_ast_import_weak_dependency(
+    &self,
+    context: &mut TemplateContext,
+    dep: &ImportWeakDependency,
+  ) -> String {
+    self.render_ast_module_namespace_promise(
+      context,
+      dep.id(),
+      dep.request(),
+      dep.dependency_type().as_str(),
+      true,
+      dep.phase(),
+    )
   }
 
   fn collect_ast_context_require_call_action(
@@ -401,6 +405,68 @@ impl JavaScriptParserAndGenerator {
     true
   }
 
+  fn collect_ast_url_action(
+    &self,
+    context: &mut TemplateContext,
+    plan: &mut AstDependencyRenderPlan,
+    dep: &URLDependency,
+  ) -> bool {
+    let (range, content) = match dep.mode() {
+      Some(JavascriptParserUrl::Relative) => (
+        dep.range(),
+        format!(
+          "/* asset import */ new {}({}({}))",
+          context
+            .runtime_template
+            .render_runtime_globals(&RuntimeGlobals::RELATIVE_URL),
+          context
+            .runtime_template
+            .render_runtime_globals(&RuntimeGlobals::REQUIRE),
+          context
+            .runtime_template
+            .module_id(context.compilation, dep.id(), dep.request(), false),
+        ),
+      ),
+      Some(JavascriptParserUrl::NewUrlRelative) => {
+        context.data.insert(URLStaticMode);
+        context
+          .data
+          .insert(CodeGenerationPublicPathAutoReplace(true));
+        (
+          dep.range(),
+          format!(
+            "new URL({}, import.meta.url)",
+            rspack_util::json_stringify_str(&format!(
+              "{AUTO_PUBLIC_PATH_PLACEHOLDER}{URL_STATIC_PLACEHOLDER}{}",
+              dep.id().as_u32()
+            )),
+          ),
+        )
+      }
+      _ => (
+        dep.range_url(),
+        format!(
+          "/* asset import */{}({}), {}",
+          context
+            .runtime_template
+            .render_runtime_globals(&RuntimeGlobals::REQUIRE),
+          context
+            .runtime_template
+            .module_id(context.compilation, dep.id(), dep.request(), false),
+          context
+            .runtime_template
+            .render_runtime_globals(&RuntimeGlobals::BASE_URI)
+        ),
+      ),
+    };
+
+    let Some(action) = AstDependencyAction::expr(range, content) else {
+      return false;
+    };
+    plan.push_action(action);
+    true
+  }
+
   fn render_ast_esm_import_specifier(
     &self,
     context: &mut TemplateContext,
@@ -432,9 +498,7 @@ impl JavaScriptParserAndGenerator {
 
     let template = ESMImportSpecifierDependencyTemplate::default();
     if dep.evaluated_in_operator {
-      template
-        .get_evaluated_in_operator_code(ids, dep, connection, context)
-        .map(Some)
+      Some(template.get_evaluated_in_operator_code(ids, dep, connection, context))
     } else {
       Some(Some(
         template.get_code_for_ids(ids, dep, connection, context),
@@ -1343,6 +1407,61 @@ impl JavaScriptParserAndGenerator {
     }
   }
 
+  fn push_ast_dependency_replacements(
+    &self,
+    plan: &mut AstDependencyRenderPlan,
+    replacements: Vec<(DependencyRange, String)>,
+  ) -> bool {
+    if replacements.is_empty() {
+      return true;
+    }
+
+    let range = replacements
+      .iter()
+      .fold(None, |range: Option<DependencyRange>, (replacement, _)| {
+        Some(if let Some(range) = range {
+          DependencyRange::new(
+            range.start.min(replacement.start),
+            range.end.max(replacement.end),
+          )
+        } else {
+          *replacement
+        })
+      })
+      .expect("replacements is not empty");
+
+    let action = if replacements.len() == 1 {
+      let (range, content) = replacements.into_iter().next().expect("replacement exists");
+      AstDependencyAction::expr(range, content)
+    } else {
+      AstDependencyAction::range_replacements(
+        range,
+        replacements
+          .into_iter()
+          .map(|(range, content)| (content, range.start, range.end))
+          .collect(),
+      )
+    };
+    let Some(action) = action else {
+      return false;
+    };
+    plan.push_action(action);
+    true
+  }
+
+  fn apply_ast_template_side_effects(
+    &self,
+    dependency: &dyn DependencyCodeGeneration,
+    context: &mut TemplateContext,
+    init_fragments_start: usize,
+  ) {
+    if let Some(template_type) = dependency.dependency_template()
+      && let Some(template) = context.compilation.get_dependency_template(template_type)
+    {
+      template.after_ast_render(dependency, context, init_fragments_start);
+    }
+  }
+
   fn collect_ast_render_action(
     &self,
     dependency: &dyn DependencyCodeGeneration,
@@ -1353,11 +1472,24 @@ impl JavaScriptParserAndGenerator {
       return true;
     }
 
+    if let Some(replacements) = dependency.ast_dependency_replacements(context) {
+      return self.push_ast_dependency_replacements(plan, replacements);
+    }
+
+    if let Some(template_type) = dependency.dependency_template()
+      && let Some(template) = context.compilation.get_dependency_template(template_type)
+      && let Some(replacements) = template.render_ast(dependency, context)
+    {
+      return self.push_ast_dependency_replacements(plan, replacements);
+    }
+
     if let Some(dep) = dependency
       .as_any()
       .downcast_ref::<ESMImportSideEffectDependency>()
     {
+      let init_fragments_start = context.init_fragments.len();
       self.apply_ast_esm_import_side_effect(context, dep);
+      self.apply_ast_template_side_effects(dependency, context, init_fragments_start);
       return true;
     }
 
@@ -1479,13 +1611,8 @@ impl JavaScriptParserAndGenerator {
       return self.collect_ast_context_id_action(context, plan, dep, dep.range());
     }
 
-    if let Some(dep) = dependency.as_any().downcast_ref::<URLDependency>()
-      && !matches!(
-        dep.mode(),
-        Some(JavascriptParserUrl::Relative | JavascriptParserUrl::NewUrlRelative)
-      )
-    {
-      return false;
+    if let Some(dep) = dependency.as_any().downcast_ref::<URLDependency>() {
+      return self.collect_ast_url_action(context, plan, dep);
     }
 
     if let Some(dep) = dependency.as_any().downcast_ref::<AMDDefineDependency>() {
@@ -1501,8 +1628,7 @@ impl JavaScriptParserAndGenerator {
         };
         plan.push_action(action);
       }
-      let Some(action) = AstDependencyAction::validated_replacements(dep.range(), replacements)
-      else {
+      let Some(action) = AstDependencyAction::range_replacements(dep.range(), replacements) else {
         return false;
       };
       plan.push_action(action);
@@ -1518,10 +1644,12 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<ESMImportSpecifierDependency>()
     {
+      let init_fragments_start = context.init_fragments.len();
       let Some(content) = self.render_ast_esm_import_specifier(context, dep) else {
         return false;
       };
       let Some(content) = content else {
+        self.apply_ast_template_side_effects(dependency, context, init_fragments_start);
         return true;
       };
       let Some(range) = dep.range() else {
@@ -1539,6 +1667,7 @@ impl JavaScriptParserAndGenerator {
       if !self.collect_ast_esm_import_specifier_destructuring_actions(context, dep, plan) {
         return false;
       }
+      self.apply_ast_template_side_effects(dependency, context, init_fragments_start);
       return true;
     }
 
@@ -1555,7 +1684,7 @@ impl JavaScriptParserAndGenerator {
     {
       let range = dep.range();
       let action = if let Some(range_decl) = dep.range_decl() {
-        AstDependencyAction::validated_replacements(
+        AstDependencyAction::range_replacements(
           range,
           vec![(String::new(), range.start, range_decl.start)],
         )
@@ -1577,6 +1706,24 @@ impl JavaScriptParserAndGenerator {
       plan.push_side_effect(AstDependencySideEffect::RuntimeRequirements(
         dep.runtime_requirements,
       ));
+      return true;
+    }
+
+    if let Some(dep) = dependency
+      .as_any()
+      .downcast_ref::<AMDRequireItemDependency>()
+    {
+      let Some(range) = dep.ast_dependency_range() else {
+        return true;
+      };
+      let content =
+        context
+          .runtime_template
+          .module_raw(context.compilation, dep.id(), dep.request(), false);
+      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
+        return false;
+      };
+      plan.push_action(action);
       return true;
     }
 
@@ -1618,21 +1765,6 @@ impl JavaScriptParserAndGenerator {
     if let Some(dep) = dependency.as_any().downcast_ref::<LocalModuleDependency>() {
       let Some(action) = AstDependencyAction::expr(range, dep.module_instance().into_boxed_str())
       else {
-        return false;
-      };
-      plan.push_action(action);
-      return true;
-    }
-
-    if let Some(dep) = dependency
-      .as_any()
-      .downcast_ref::<AMDRequireItemDependency>()
-    {
-      let content =
-        context
-          .runtime_template
-          .module_raw(context.compilation, dep.id(), dep.request(), false);
-      let Some(action) = AstDependencyAction::expr(range, content.into_boxed_str()) else {
         return false;
       };
       plan.push_action(action);
@@ -1791,7 +1923,9 @@ impl JavaScriptParserAndGenerator {
         }
       };
 
-      let Some(action) = AstDependencyAction::wrapped_source(range, range, prefix, suffix) else {
+      let Some(action) =
+        AstDependencyAction::wrapped_source_trim_trailing_semicolon(range, prefix, suffix)
+      else {
         return false;
       };
       plan.push_action(action);
@@ -2380,28 +2514,34 @@ impl JavaScriptParserAndGenerator {
       return true;
     }
 
-    if dependency
-      .as_any()
-      .downcast_ref::<ImportDependency>()
-      .is_some()
-    {
-      return false;
+    if let Some(dep) = dependency.as_any().downcast_ref::<ImportDependency>() {
+      let Some(action) =
+        AstDependencyAction::expr(range, self.render_ast_import_dependency(context, dep))
+      else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
     }
 
-    if dependency
-      .as_any()
-      .downcast_ref::<ImportEagerDependency>()
-      .is_some()
-    {
-      return false;
+    if let Some(dep) = dependency.as_any().downcast_ref::<ImportEagerDependency>() {
+      let Some(action) =
+        AstDependencyAction::expr(range, self.render_ast_import_eager_dependency(context, dep))
+      else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
     }
 
-    if dependency
-      .as_any()
-      .downcast_ref::<ImportWeakDependency>()
-      .is_some()
-    {
-      return false;
+    if let Some(dep) = dependency.as_any().downcast_ref::<ImportWeakDependency>() {
+      let Some(action) =
+        AstDependencyAction::expr(range, self.render_ast_import_weak_dependency(context, dep))
+      else {
+        return false;
+      };
+      plan.push_action(action);
+      return true;
     }
 
     if dependency
@@ -2503,32 +2643,30 @@ impl JavaScriptParserAndGenerator {
     false
   }
 
-  fn try_render_ast_dependencies(
+  fn render_ast_dependencies(
     &self,
     source_text: &str,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Option<BoxSource> {
-    let plan = self.collect_ast_render_plan(module, context)?;
-    let source = render_ast_dependencies(source_text, module.module_type(), &plan)?;
+  ) -> BoxSource {
+    let plan = self.collect_ast_render_plan(module, context);
+    let source = render_ast_dependencies(source_text, &plan);
     self.apply_ast_dependency_side_effects(context, &plan);
-    Some(RawStringSource::from(source).boxed())
+    RawStringSource::from(source).boxed()
   }
 
-  fn try_render_ast_dependencies_with_source_map(
+  fn render_ast_dependencies_with_source_map(
     &self,
     source_text: &str,
     source: &BoxSource,
     module: &dyn Module,
     context: &mut TemplateContext,
-  ) -> Option<BoxSource> {
-    let plan = self.collect_ast_render_plan(module, context)?;
+  ) -> BoxSource {
+    let plan = self.collect_ast_render_plan(module, context);
     let mut source = ReplaceSource::new(source.clone());
-    if !apply_ast_dependency_replacements(source_text, module.module_type(), &plan, &mut source) {
-      return None;
-    }
+    apply_ast_dependency_replacements(source_text, &plan, &mut source);
     self.apply_ast_dependency_side_effects(context, &plan);
-    Some(source.boxed())
+    source.boxed()
   }
 
   fn apply_ast_dependency_side_effects(
@@ -2752,57 +2890,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         .map(&ObjectPool::default(), &MapOptions::default())
         .is_some();
 
-      let ast_result = {
-        let mut init_fragments = vec![];
-        let mut data = generate_context.data.clone();
-        let mut runtime_template = generate_context.runtime_template.clone();
-        let mut concatenation_scope = generate_context
-          .concatenation_scope
-          .as_ref()
-          .map(|scope| (**scope).clone());
-        let mut context = TemplateContext {
-          compilation,
-          module,
-          init_fragments: &mut init_fragments,
-          runtime: generate_context.runtime,
-          concatenation_scope: concatenation_scope.as_mut(),
-          data: &mut data,
-          runtime_template: &mut runtime_template,
-        };
-        let source = if has_source_map {
-          self.try_render_ast_dependencies_with_source_map(
-            &source_text,
-            source,
-            module,
-            &mut context,
-          )
-        } else {
-          self.try_render_ast_dependencies(&source_text, module, &mut context)
-        };
-        source.map(|source| {
-          (
-            source,
-            init_fragments,
-            data,
-            runtime_template,
-            concatenation_scope,
-          )
-        })
-      };
-
-      if let Some((source, init_fragments, data, runtime_template, concatenation_scope)) =
-        ast_result
-      {
-        *generate_context.data = data;
-        *generate_context.runtime_template = runtime_template;
-        if let Some(scope) = generate_context.concatenation_scope.as_deref_mut()
-          && let Some(concatenation_scope) = concatenation_scope
-        {
-          *scope = concatenation_scope;
-        }
-        return render_init_fragments(source, init_fragments, generate_context);
-      }
-
       let mut init_fragments = vec![];
       let mut context = TemplateContext {
         compilation,
@@ -2813,7 +2900,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         data: generate_context.data,
         runtime_template: generate_context.runtime_template,
       };
-      let source = self.render_dependency_templates(source, compilation, module, &mut context);
+      let source = if has_source_map {
+        self.render_ast_dependencies_with_source_map(&source_text, source, module, &mut context)
+      } else {
+        self.render_ast_dependencies(&source_text, module, &mut context)
+      };
       generate_context.concatenation_scope = context.concatenation_scope.take();
       render_init_fragments(source, init_fragments, generate_context)
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -221,12 +221,11 @@ impl JavaScriptParserAndGenerator {
       self.collect_ast_render_dependency(compilation, dependency_id, context, &mut plan)
     }) && module
       .get_presentational_dependencies()
-      .map(|dependencies| {
+      .is_none_or(|dependencies| {
         dependencies
           .iter()
           .all(|dependency| self.collect_ast_render_action(dependency.as_ref(), context, &mut plan))
       })
-      .unwrap_or(true)
       && module
         .get_blocks()
         .iter()
@@ -814,8 +813,7 @@ impl JavaScriptParserAndGenerator {
                 used
                   .iter()
                   .map(|i| i.to_string())
-                  .collect::<Vec<_>>()
-                  .join("")
+                  .collect::<String>()
                   .into(),
                 binding,
               )],
@@ -875,8 +873,7 @@ impl JavaScriptParserAndGenerator {
               used
                 .iter()
                 .map(|i| i.to_string())
-                .collect::<Vec<_>>()
-                .join("")
+                .collect::<String>()
                 .into(),
               ESMExportBinding::Getter(Atom::from(format!("/* export default binding */ {name}"))),
             )],
@@ -1505,7 +1502,7 @@ impl JavaScriptParserAndGenerator {
       let action = if let Some(range_decl) = dep.range_decl() {
         AstDependencyAction::validated_replacements(
           range,
-          vec![("".to_string(), range.start, range_decl.start)],
+          vec![(String::new(), range.start, range_decl.start)],
         )
       } else {
         AstDependencyAction::expr(range, "")
@@ -1679,34 +1676,30 @@ impl JavaScriptParserAndGenerator {
       .as_any()
       .downcast_ref::<PureExpressionDependency>()
     {
-      let (prefix, suffix, needs_side_effect) =
-        match dep.get_runtime_condition(context.compilation, context.runtime) {
-          RuntimeCondition::Boolean(true) => return true,
-          RuntimeCondition::Boolean(false) => (
-            "(/* unused pure expression or super */ null && (".to_string(),
-            "))",
-            false,
-          ),
-          RuntimeCondition::Spec(runtime_condition) => {
-            let mut runtime_template = context.runtime_template.clone();
-            let condition = runtime_template.runtime_condition_expression(
-              &context.compilation.build_chunk_graph_artifact.chunk_graph,
-              Some(&RuntimeCondition::Spec(runtime_condition)),
-              context.runtime,
-            );
-            (
-              format!("(/* runtime-dependent pure expression or super */ {condition} ? ("),
-              ") : null)",
-              true,
-            )
-          }
-        };
+      let (prefix, suffix) = match dep.get_runtime_condition(context.compilation, context.runtime) {
+        RuntimeCondition::Boolean(true) => return true,
+        RuntimeCondition::Boolean(false) => (
+          "(/* unused pure expression or super */ null && (".to_string(),
+          "))",
+        ),
+        RuntimeCondition::Spec(runtime_condition) => {
+          let mut runtime_template = context.runtime_template.clone();
+          let condition = runtime_template.runtime_condition_expression(
+            &context.compilation.build_chunk_graph_artifact.chunk_graph,
+            Some(&RuntimeCondition::Spec(runtime_condition)),
+            context.runtime,
+          );
+          (
+            format!("(/* runtime-dependent pure expression or super */ {condition} ? ("),
+            ") : null)",
+          )
+        }
+      };
 
       let Some(action) = AstDependencyAction::wrapped_source(range, range, prefix, suffix) else {
         return false;
       };
       plan.push_action(action);
-      if needs_side_effect {}
       return true;
     }
 
@@ -2226,7 +2219,7 @@ impl JavaScriptParserAndGenerator {
         )
       };
 
-      let ids = dep.get_ids(&module_graph);
+      let ids = dep.get_ids(module_graph);
       let (require_expr, uses_require) = if let Some(imported_module) =
         module_graph.get_module_by_dependency_id(dep.id())
         && let Some(used_imported) = context

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use rspack_core::{
   BoxDependencyTemplate, BuildMetaDefaultObject, BuildMetaExportsType, ContextDependency,
-  ContextMode, ContextOptions, Dependency, DependencyCategory, RuntimeGlobals,
-  RuntimeRequirementsDependency,
+  ContextMode, ContextOptions, DependencyCategory, RuntimeGlobals, RuntimeRequirementsDependency,
 };
 use rspack_util::{SpanExt, atom::Atom};
 use rustc_hash::FxHashMap;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -4,7 +4,7 @@ use either::Either;
 use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, ContextDependency, ContextMode, ContextOptions,
-  Dependency, DependencyCategory, DependencyRange, RuntimeGlobals, RuntimeRequirementsDependency,
+  DependencyCategory, DependencyRange, RuntimeGlobals, RuntimeRequirementsDependency,
 };
 use rspack_error::{Error, Severity};
 use rspack_util::{SpanExt, atom::Atom};

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -86,6 +86,7 @@ impl JavascriptParser<'_> {
       let loc = self.to_dependency_location(call_range);
       self.add_presentational_dependency(Box::new(ESMAcceptDependency::new(
         range,
+        call_range,
         callback_arg.is_some(),
         dependency_ids,
         loc,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -1,6 +1,5 @@
 use rspack_core::{
-  BoxDependency, Dependency, DependencyId, DependencyRange, UsedByExports,
-  UsedByExportsDeferredPureCheck,
+  BoxDependency, DependencyId, DependencyRange, UsedByExports, UsedByExportsDeferredPureCheck,
 };
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, cell::Cell};
 
-use rspack_core::{Dependency, DependencyId, DependencyRange};
+use rspack_core::{DependencyId, DependencyRange};
 use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_allocator::{Allocator, CloneIn};

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -199,11 +199,6 @@ impl ScopeInfoDB {
   }
 
   pub fn set(&mut self, id: ScopeInfoId, key: Atom, variable_info_id: VariableInfoId) {
-    debug_assert_eq!(
-      self.current,
-      Some(id),
-      "bindings can only be set in the innermost active scope"
-    );
     let stack = self.bindings.entry(key.clone()).or_default();
     if let Some(top) = stack.last_mut()
       && top.scope == id
@@ -211,6 +206,11 @@ impl ScopeInfoDB {
       top.value = variable_info_id;
       return;
     }
+    debug_assert_eq!(
+      self.current,
+      Some(id),
+      "new bindings can only be set in the innermost active scope"
+    );
     stack.push(Binding {
       scope: id,
       value: variable_info_id,

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   BuildModuleGraphArtifact, Compilation, DependenciesBlock, Dependency, DependencyId,
-  DependencyTemplate, ExportsInfoArtifact, ExternalModule, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, NormalInitFragment,
+  DependencyRange, DependencyTemplate, ExportsInfoArtifact, ExternalModule, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, NormalInitFragment,
 };
 use rspack_plugin_javascript::dependency::{
   ESMExportImportedSpecifierDependency, ESMImportSideEffectDependency, ImportDependency,
@@ -197,6 +197,18 @@ pub fn render_dyn_import_external_module(
   external_module: &ExternalModule,
   source: &mut rspack_core::TemplateReplaceSource,
 ) {
+  source.replace(
+    import_dep.range.start,
+    import_dep.range.end,
+    render_dyn_import_external_module_content(import_dep, external_module),
+    None,
+  );
+}
+
+pub fn render_dyn_import_external_module_content(
+  import_dep: &ImportDependency,
+  external_module: &ExternalModule,
+) -> String {
   let request = external_module.get_request();
   let attributes_str = if let Some(attributes) = import_dep.get_attributes() {
     format!(
@@ -220,17 +232,12 @@ pub fn render_dyn_import_external_module(
     comments_string
   };
 
-  source.replace(
-    import_dep.range.start,
-    import_dep.range.end,
-    format!(
-      "import({}{}{})",
-      comments_str,
-      rspack_util::json_stringify_str(&request.primary),
-      attributes_str
-    ),
-    None,
-  );
+  format!(
+    "import({}{}{})",
+    comments_str,
+    rspack_util::json_stringify_str(&request.primary),
+    attributes_str
+  )
 }
 
 #[derive(Debug)]
@@ -239,6 +246,32 @@ pub(crate) struct ImportDependencyTemplate {
 }
 
 impl DependencyTemplate for ImportDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn rspack_core::DependencyCodeGeneration,
+    code_generatable_context: &mut rspack_core::TemplateContext,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ImportDependency>()
+      .expect("should be import dependency");
+    let mg = code_generatable_context.compilation.get_module_graph();
+    let ref_module = mg
+      .module_identifier_by_dependency_id(&dep.id)
+      .and_then(|module_id| mg.module_by_identifier(module_id));
+    if let Some(external) = ref_module.and_then(|m| m.as_external_module()) {
+      return Some(vec![(
+        dep.range,
+        render_dyn_import_external_module_content(dep, external),
+      )]);
+    }
+
+    self
+      .template
+      .as_ref()
+      .and_then(|template| template.render_ast(dep, code_generatable_context))
+  }
+
   fn render(
     &self,
     dep: &dyn rspack_core::DependencyCodeGeneration,

--- a/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/dynamic_import_origin_dependency.rs
@@ -67,6 +67,31 @@ impl RstestDynamicImportOriginDependencyTemplate {
 }
 
 impl DependencyTemplate for RstestDynamicImportOriginDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    _code_generatable_context: &mut TemplateContext,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<RstestDynamicImportOriginDependency>()
+      .expect(
+        "RstestDynamicImportOriginDependencyTemplate can only be applied to \
+         RstestDynamicImportOriginDependency",
+      );
+
+    let tail = if dep.has_attributes {
+      format!(", {}", json_stringify_str(&dep.origin_path))
+    } else {
+      format!(", void 0, {}", json_stringify_str(&dep.origin_path))
+    };
+
+    Some(vec![
+      (dep.callee_range, self.function_name.clone()),
+      (DependencyRange::new(dep.args_end, dep.args_end), tail),
+    ])
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,

--- a/crates/rspack_plugin_rstest/src/esm_import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/esm_import_dependency.rs
@@ -20,6 +20,26 @@ impl RstestESMImportSideEffectDependencyTemplate {
 }
 
 impl DependencyTemplate for RstestESMImportSideEffectDependencyTemplate {
+  fn after_ast_render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    code_generatable_context: &mut TemplateContext,
+    init_fragments_start: usize,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ESMImportSideEffectDependency>()
+      .expect("RstestESMImportSideEffectDependencyTemplate should only be used for ESMImportSideEffectDependency");
+    if has_import_actual_attr(dep.get_attributes()) {
+      hoist_new_esm_import_fragments(
+        code_generatable_context,
+        init_fragments_start,
+        Some(dep.request()),
+        false,
+      );
+    }
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,
@@ -54,6 +74,29 @@ impl RstestESMImportSpecifierDependencyTemplate {
 }
 
 impl DependencyTemplate for RstestESMImportSpecifierDependencyTemplate {
+  fn after_ast_render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    code_generatable_context: &mut TemplateContext,
+    init_fragments_start: usize,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ESMImportSpecifierDependency>()
+      .expect("RstestESMImportSpecifierDependencyTemplate should only be used for ESMImportSpecifierDependency");
+
+    if !has_import_actual_attr(dep.get_attributes()) {
+      return;
+    }
+
+    hoist_new_esm_import_fragments(
+      code_generatable_context,
+      init_fragments_start,
+      Some(dep.request()),
+      true,
+    );
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -19,6 +19,43 @@ impl ImportDependencyTemplate {
 }
 
 impl DependencyTemplate for ImportDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    code_generatable_context: &mut TemplateContext,
+  ) -> Option<Vec<(rspack_core::DependencyRange, String)>> {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<ImportDependency>()
+      .expect("ImportDependencyTemplate can only be applied to ImportDependency");
+    let range = dep.range().expect("ImportDependency should have range");
+    let module_graph = code_generatable_context.compilation.get_module_graph();
+    let block = module_graph.get_parent_block(dep.id());
+    let attributes = &dep.get_attributes();
+    let is_import_actual = if let Some(attrs) = attributes {
+      if let Some(actual) = attrs.get("rstest") {
+        actual == "importActual"
+      } else {
+        false
+      }
+    } else {
+      false
+    };
+
+    Some(vec![(
+      range,
+      module_namespace_promise_rstest(
+        code_generatable_context,
+        dep.id(),
+        block,
+        dep.request(),
+        dep.dependency_type().as_str(),
+        false,
+        is_import_actual,
+      ),
+    )])
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -2,8 +2,8 @@ use rspack_cacheable::cacheable;
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, ChunkGraph, Compilation, Dependency, DependencyCodeGeneration,
   DependencyId, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsType,
-  FakeNamespaceObjectMode, ModuleCodeTemplate, ModuleDependency, ModuleGraph, RuntimeGlobals,
-  TemplateContext, TemplateReplaceSource, get_exports_type,
+  FakeNamespaceObjectMode, ModuleCodeTemplate, ModuleGraph, RuntimeGlobals, TemplateContext,
+  TemplateReplaceSource, get_exports_type,
 };
 use rspack_plugin_javascript::dependency::ImportDependency;
 use rspack_util::json_stringify_str;

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -121,13 +121,10 @@ impl DependencyCodeGeneration for MockMethodDependency {
     let hoist_marker = hoist_flag.map(|flag| format!("{flag}:{hoist_id}:{request}"));
     let mut replacements = Vec::new();
 
-    if should_hoist && self.statement_range.is_some() {
-      let stmt_range = self
-        .statement_range
-        .expect("statement_range should exist for statement hoist");
-      let hoist_marker = hoist_marker
-        .as_deref()
-        .expect("hoist marker should exist when should_hoist is true");
+    if should_hoist
+      && let Some(stmt_range) = self.statement_range
+      && let Some(hoist_marker) = hoist_marker.as_deref()
+    {
       replacements.push((
         DependencyRange::new(stmt_range.start, stmt_range.start),
         format!("/* RSTEST:{hoist_marker}:HOIST_START */"),

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -91,6 +91,95 @@ impl DependencyCodeGeneration for MockMethodDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(MockMethodDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_replacements(
+    &self,
+    code_generatable_context: &mut TemplateContext<'_, '_, '_>,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    let TemplateContext {
+      init_fragments,
+      runtime_template,
+      ..
+    } = code_generatable_context;
+    let request = &self.request;
+    let require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE);
+    let hoist_id = self.hoist_id();
+    let hoist_flag = MockMethodDependencyTemplate::get_hoist_flag(&self.method);
+    let mock_method = MockMethodDependencyTemplate::get_mock_method(&self.method);
+
+    if let Some(flag) = hoist_flag {
+      MockMethodDependencyTemplate::add_placeholder_fragment(
+        init_fragments,
+        flag,
+        &hoist_id,
+        request,
+      );
+    }
+    MockMethodDependencyTemplate::hoist_rstest_core_import(init_fragments);
+
+    let should_hoist = hoist_flag.is_some() && self.hoist;
+    let hoist_marker = hoist_flag.map(|flag| format!("{flag}:{hoist_id}:{request}"));
+    let mut replacements = Vec::new();
+
+    if should_hoist && self.statement_range.is_some() {
+      let stmt_range = self
+        .statement_range
+        .expect("statement_range should exist for statement hoist");
+      let hoist_marker = hoist_marker
+        .as_deref()
+        .expect("hoist marker should exist when should_hoist is true");
+      replacements.push((
+        DependencyRange::new(stmt_range.start, stmt_range.start),
+        format!("/* RSTEST:{hoist_marker}:HOIST_START */"),
+      ));
+      replacements.push((
+        DependencyRange::new(stmt_range.end, stmt_range.end),
+        format!("\n/* RSTEST:{hoist_marker}:HOIST_END */"),
+      ));
+      replacements.push((
+        DependencyRange::new(self.callee_range.start, self.callee_range.start),
+        "/* ".to_string(),
+      ));
+      replacements.push((
+        DependencyRange::new(self.callee_range.end, self.callee_range.end),
+        format!(" */ {require_name}.{mock_method}"),
+      ));
+    } else if should_hoist {
+      let hoist_marker = hoist_marker
+        .as_deref()
+        .expect("hoist marker should exist when should_hoist is true");
+      replacements.push((
+        DependencyRange::new(self.callee_range.start, self.callee_range.start),
+        "/* ".to_string(),
+      ));
+      replacements.push((
+        DependencyRange::new(self.callee_range.end, self.callee_range.end),
+        format!(" */ /* RSTEST:{hoist_marker}:HOIST_START */{require_name}.{mock_method}"),
+      ));
+      replacements.push((
+        DependencyRange::new(self.call_expr_range.end, self.call_expr_range.end),
+        format!("\n/* RSTEST:{hoist_marker}:HOIST_END */"),
+      ));
+    } else {
+      replacements.push((
+        DependencyRange::new(self.callee_range.start, self.callee_range.start),
+        "/* ".to_string(),
+      ));
+      replacements.push((
+        DependencyRange::new(self.callee_range.end, self.callee_range.end),
+        format!(" */ {require_name}.{mock_method}"),
+      ));
+    }
+
+    if let Some(end) = self.args_request_end {
+      replacements.push((
+        DependencyRange::new(end, end),
+        format!(", {}", json_stringify_str(request)),
+      ));
+    }
+
+    Some(replacements)
+  }
 }
 
 impl AsModuleDependency for MockMethodDependency {}

--- a/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
@@ -113,6 +113,28 @@ impl DependencyCodeGeneration for MockModuleIdDependency {
   fn dependency_template(&self) -> Option<DependencyTemplateType> {
     Some(MockModuleIdDependencyTemplate::template_type())
   }
+
+  fn ast_dependency_range(&self) -> Option<DependencyRange> {
+    Some(self.range)
+  }
+
+  fn ast_dependency_replacements(
+    &self,
+    code_generatable_context: &mut TemplateContext<'_, '_, '_>,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    let module_id = module_id_rstest(
+      code_generatable_context.compilation,
+      code_generatable_context.runtime_template,
+      &self.id,
+      &self.request,
+      self.weak,
+    );
+
+    Some(vec![(
+      self.range,
+      format!("{}{}", module_id, self.suffix.as_deref().unwrap_or("")),
+    )])
+  }
 }
 
 impl AsContextDependency for MockModuleIdDependency {}

--- a/crates/rspack_plugin_rstest/src/module_path_name_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/module_path_name_dependency.rs
@@ -43,13 +43,10 @@ impl ModulePathNameDependencyTemplate {
   pub fn template_type() -> DependencyTemplateType {
     DependencyTemplateType::Dependency(DependencyType::RstestModulePath)
   }
-}
 
-impl DependencyTemplate for ModulePathNameDependencyTemplate {
-  fn render(
+  fn apply(
     &self,
     dep: &dyn DependencyCodeGeneration,
-    _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {
     let TemplateContext {
@@ -102,5 +99,25 @@ impl DependencyTemplate for ModulePathNameDependencyTemplate {
         init_fragments.push(init.boxed());
       }
     }
+  }
+}
+
+impl DependencyTemplate for ModulePathNameDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    code_generatable_context: &mut TemplateContext,
+  ) -> Option<Vec<(rspack_core::DependencyRange, String)>> {
+    self.apply(dep, code_generatable_context);
+    Some(Vec::new())
+  }
+
+  fn render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    _source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    self.apply(dep, code_generatable_context);
   }
 }

--- a/crates/rspack_plugin_rstest/src/require_resolve_origin_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/require_resolve_origin_dependency.rs
@@ -51,6 +51,28 @@ impl RstestRequireResolveOriginDependencyTemplate {
 }
 
 impl DependencyTemplate for RstestRequireResolveOriginDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    _code_generatable_context: &mut TemplateContext,
+  ) -> Option<Vec<(DependencyRange, String)>> {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<RstestRequireResolveOriginDependency>()
+      .expect(
+        "RstestRequireResolveOriginDependencyTemplate can only be applied to \
+         RstestRequireResolveOriginDependency",
+      );
+
+    Some(vec![
+      (dep.callee_range, self.function_name.clone()),
+      (
+        DependencyRange::new(dep.args_end, dep.args_end),
+        format!(", {}", json_stringify_str(&dep.origin_path)),
+      ),
+    ])
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,

--- a/crates/rspack_plugin_rstest/src/url_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/url_dependency.rs
@@ -25,6 +25,23 @@ impl RstestUrlDependencyTemplate {
 }
 
 impl DependencyTemplate for RstestUrlDependencyTemplate {
+  fn render_ast(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    _code_generatable_context: &mut TemplateContext,
+  ) -> Option<Vec<(rspack_core::DependencyRange, String)>> {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<URLDependency>()
+      .expect("RstestUrlDependencyTemplate should be used for URLDependency");
+
+    if self.should_preserve(dep.request()) {
+      Some(Vec::new())
+    } else {
+      None
+    }
+  }
+
   fn render(
     &self,
     dep: &dyn DependencyCodeGeneration,
@@ -36,22 +53,25 @@ impl DependencyTemplate for RstestUrlDependencyTemplate {
       .downcast_ref::<URLDependency>()
       .expect("RstestUrlDependencyTemplate should be used for URLDependency");
 
+    if self.should_preserve(dep.request()) {
+      return;
+    }
+
+    URLDependencyTemplate::default().render(dep, source, code_generatable_context);
+  }
+}
+
+impl RstestUrlDependencyTemplate {
+  fn should_preserve(&self, request: &str) -> bool {
     // Strip query string and fragment from request path before checking extension
-    let request = dep.request();
     let request_path = request.split(&['?', '#'][..]).next().unwrap_or(request);
 
-    let should_preserve = request_path.rsplit('.').next().is_some_and(|ext| {
+    request_path.rsplit('.').next().is_some_and(|ext| {
       self.preserve_extensions.iter().any(|preserve_ext| {
         // Support both ".ext" and "ext" formats
         let preserve_ext = preserve_ext.trim_start_matches('.');
         ext.eq_ignore_ascii_case(preserve_ext)
       })
-    });
-
-    if should_preserve {
-      return;
-    }
-
-    URLDependencyTemplate::default().render(dep, source, code_generatable_context);
+    })
   }
 }

--- a/crates/rspack_plugin_rstest/src/url_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/url_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_cacheable::cacheable;
 use rspack_core::{
   DependencyCodeGeneration, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ModuleDependency, TemplateContext, TemplateReplaceSource,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_plugin_javascript::dependency::{URLDependency, URLDependencyTemplate};
 

--- a/tests/rspack-test/statsAPICases/basic.js
+++ b/tests/rspack-test/statsAPICases/basic.js
@@ -69,7 +69,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: cb00f6f863f5faec,
+			      hash: 3f49c4e8aa1889da,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -199,7 +199,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: ec79eb103428f92c,
+			  hash: 20b50c3144a22c56,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -319,7 +319,7 @@ module.exports = {
 			  entry ./fixtures/a
 			  cjs self exports reference self [195] ./fixtures/a.js
 			  
-			Rspack compiled successfully (ec79eb103428f92c)
+			Rspack compiled successfully (20b50c3144a22c56)
 		`);
 	}
 };

--- a/tests/rspack-test/statsAPICases/ids.js
+++ b/tests/rspack-test/statsAPICases/ids.js
@@ -58,7 +58,7 @@ module.exports = {
 			      files: Array [
 			        main.js,
 			      ],
-			      hash: cb00f6f863f5faec,
+			      hash: 3f49c4e8aa1889da,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,

--- a/tests/rspack-test/statsAPICases/with-query.js
+++ b/tests/rspack-test/statsAPICases/with-query.js
@@ -63,7 +63,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 0dd464d06575b312,
+			      hash: 160116da4427c8ba,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -432,7 +432,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 902dd16738d7b73d,
+			  hash: a8cc170caacfd628,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsAPICases/with-query.js
+++ b/tests/rspack-test/statsAPICases/with-query.js
@@ -63,7 +63,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 160116da4427c8ba,
+			      hash: 4b341e3019272f74,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -432,7 +432,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: a8cc170caacfd628,
+			  hash: b9a5abe5ec0f0f43,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsOutputCases/all-stats/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/all-stats/__snapshots__/stats.txt
@@ -23,4 +23,4 @@ webpack/runtime/make_namespace_object xx bytes {main} [code generated]
   [no exports]
   [used exports unknown]
   
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled successfully in X s (c8efd3f0c70d4f0e)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled successfully in X s (e2ea6929566a64e9)

--- a/tests/rspack-test/statsOutputCases/commons-plugin-issue-4980/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/commons-plugin-issue-4980/__snapshots__/stats.txt
@@ -1,9 +1,9 @@
-asset app.e1d3fd6ad57c1842-1.js xx bytes [emitted] [immutable] (name: app)
+asset app.5a632e2f77459a40-1.js xx bytes [emitted] [immutable] (name: app)
 orphan modules xx bytes [orphan] 3 modules
 ./entry-1.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset app.fa8ca3aace1a91e0-2.js xx bytes [emitted] [immutable] (name: app)
+asset app.9dcd94afa47f2f6b-2.js xx bytes [emitted] [immutable] (name: app)
 orphan modules xx bytes [orphan] 3 modules
 ./entry-2.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 6632dd142c468559.js xx KiB [emitted] [immutable] (name: main)
+asset 4d138d147aa2fe77.js xx KiB [emitted] [immutable] (name: main)
 asset 7b129503d319bd23.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 8d81ee1b3ec6af34.js xx KiB [emitted] [immutable] (name: main)
+asset 154a197e259132cd.js xx KiB [emitted] [immutable] (name: main)
 asset a1e4f06ae018828b.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 4d138d147aa2fe77.js xx KiB [emitted] [immutable] (name: main)
-asset 7b129503d319bd23.js xx bytes [emitted] [immutable]
+asset 8d81ee1b3ec6af34.js xx KiB [emitted] [immutable] (name: main)
+asset a1e4f06ae018828b.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -19,11 +19,11 @@ Rspack x.x.x compiled successfully in X s
 
 assets by chunk xx bytes (id hint: all)
   asset c-all-b_js-24857901ee44690e.js xx bytes [emitted] [immutable] (id hint: all)
-  asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
+  asset c-all-c_js-bf7ea2a1c513ca9a.js xx bytes [emitted] [immutable] (id hint: all)
 asset c-runtime~main-212607be4ae2f0c7.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-6fcede52465c6f8d.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-212607be4ae2f0c7.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+Entrypoint main xx KiB = c-runtime~main-212607be4ae2f0c7.js xx KiB c-all-c_js-bf7ea2a1c513ca9a.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -8,9 +8,9 @@ Rspack x.x.x compiled successfully in X s
 
 asset b-runtime~main-60e1a9cacb740650.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset b-main-8680a888f1bf9eb6.js xx bytes [emitted] [immutable] (name: main)
-asset b-all-b_js-f856ef7ca71a0cbd.js xx bytes [emitted] [immutable] (id hint: all)
+asset b-all-b_js-b850fa6748efbccd.js xx bytes [emitted] [immutable] (id hint: all)
 asset b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-60e1a9cacb740650.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-f856ef7ca71a0cbd.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
+Entrypoint main xx KiB = b-runtime~main-60e1a9cacb740650.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-b850fa6748efbccd.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -18,12 +18,12 @@ cacheable modules xx bytes
 Rspack x.x.x compiled successfully in X s
 
 assets by chunk xx bytes (id hint: all)
-  asset c-all-b_js-ce41787ae6ff3759.js xx bytes [emitted] [immutable] (id hint: all)
-  asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-f15de686b780a99d.js xx KiB [emitted] [immutable] (name: runtime~main)
+  asset c-all-b_js-24857901ee44690e.js xx bytes [emitted] [immutable] (id hint: all)
+  asset c-all-c_js-bf7ea2a1c513ca9a.js xx bytes [emitted] [immutable] (id hint: all)
+asset c-runtime~main-a747f07e4934bcce.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-f15de686b780a99d.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+Entrypoint main xx KiB = c-runtime~main-a747f07e4934bcce.js xx KiB c-all-c_js-bf7ea2a1c513ca9a.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -1,7 +1,7 @@
 asset a-runtime~main-8fb196856cbdc52a.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset a-main-c9ca2f06db018feb.js xx bytes [emitted] [immutable] (name: main)
-asset a-all-a_js-9ab62d76d5b1b4fb.js xx bytes [emitted] [immutable] (id hint: all)
-Entrypoint main xx KiB = a-runtime~main-8fb196856cbdc52a.js xx KiB a-all-a_js-9ab62d76d5b1b4fb.js xx bytes a-main-c9ca2f06db018feb.js xx bytes
+asset a-all-a_js-bede7ab375dbf72c.js xx bytes [emitted] [immutable] (id hint: all)
+Entrypoint main xx KiB = a-runtime~main-8fb196856cbdc52a.js xx KiB a-all-a_js-bede7ab375dbf72c.js xx bytes a-main-c9ca2f06db018feb.js xx bytes
 runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
@@ -9,8 +9,8 @@ Rspack x.x.x compiled successfully in X s
 asset b-runtime~main-60e1a9cacb740650.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset b-main-8680a888f1bf9eb6.js xx bytes [emitted] [immutable] (name: main)
 asset b-all-b_js-b850fa6748efbccd.js xx bytes [emitted] [immutable] (id hint: all)
-asset b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-60e1a9cacb740650.js xx KiB b-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes b-all-b_js-b850fa6748efbccd.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
+asset b-vendors-node_modules_vendor_js-6fcede52465c6f8d.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = b-runtime~main-60e1a9cacb740650.js xx KiB b-vendors-node_modules_vendor_js-6fcede52465c6f8d.js xx bytes b-all-b_js-b850fa6748efbccd.js xx bytes b-main-8680a888f1bf9eb6.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -19,11 +19,11 @@ Rspack x.x.x compiled successfully in X s
 
 assets by chunk xx bytes (id hint: all)
   asset c-all-b_js-24857901ee44690e.js xx bytes [emitted] [immutable] (id hint: all)
-  asset c-all-c_js-bf7ea2a1c513ca9a.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-a747f07e4934bcce.js xx KiB [emitted] [immutable] (name: runtime~main)
+  asset c-all-c_js-305d7d7dfb13d2f8.js xx bytes [emitted] [immutable] (id hint: all)
+asset c-runtime~main-212607be4ae2f0c7.js xx KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-cb74163fc8cc359b.js xx bytes [emitted] [immutable] (name: main)
-asset c-vendors-node_modules_vendor_js-e936af1c5d692780.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-a747f07e4934bcce.js xx KiB c-all-c_js-bf7ea2a1c513ca9a.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
+asset c-vendors-node_modules_vendor_js-6fcede52465c6f8d.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = c-runtime~main-212607be4ae2f0c7.js xx KiB c-all-c_js-305d7d7dfb13d2f8.js xx bytes c-main-cb74163fc8cc359b.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (f917d9aef4f31935)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (15c8fd06d493d1f7)

--- a/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (15c8fd06d493d1f7)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (e0a7826e5a580567)

--- a/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
@@ -134,4 +134,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (f917d9aef4f31935)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (15c8fd06d493d1f7)

--- a/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
@@ -134,4 +134,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (15c8fd06d493d1f7)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (e0a7826e5a580567)


### PR DESCRIPTION
## Summary

Optimize JavaScript AST dependency code generation and scope-hoisted module concatenation by keeping the hot path on direct AST replacement plans.

- render supported dependencies directly through AST replacement plans
- fail fast for unsupported AST dependencies instead of falling back to string templates
- preserve template side effects through explicit AST hooks
- replace `ModuleConcatenationPlugin` `ReplaceSource`/`ConcatSource` editing with a lightweight AST-range source plan
- preserve source maps for concatenated modules through custom `Source`/`stream_chunks` implementations
- align dynamic import, URL, rstest, rslib, and ESM library rendering with the fast path

## Why

The previous AST codegen path paid extra cost for validation and kept a legacy string fallback. This PR keeps the optimized path strict and direct, closer to Turbopack's approach: dependencies and concatenated modules that participate in AST codegen provide the required AST rendering behavior up front.

## Testing

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p rspack_core -p rspack_plugin_esm_library`
- `cargo clippy -p rspack_core --all-targets --tests -- -D warnings`
- `pnpm run build:binding:dev`
- `cd tests/rspack-test && pnpm exec rstest Config.part3.test.js --project base`
- `cd tests/rspack-test && pnpm exec rstest`

Full rstest result: 39 test files passed, 6275 tests passed, 4 skipped.