### PR TITLE
feat(watcher): populate native watcher file/context time info entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,6 +5317,7 @@ dependencies = [
  "cow-utils",
  "dashmap",
  "fast-glob",
+ "memchr",
  "notify",
  "regex",
  "rspack_error",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -477,11 +477,6 @@ export declare class NativeWatcher {
   pause(): void
 }
 
-export declare class NativeWatchResult {
-  changedFiles: Array<string>
-  removedFiles: Array<string>
-}
-
 
 export declare class RawExternalItemFnCtx {
   data(): RawExternalItemFnCtxData
@@ -1785,6 +1780,14 @@ export interface NapiResolveOptions {
   enablePnp?: boolean
 }
 
+export interface NativeTimeInfoEntry {
+  path: string
+  /** `None` => JS `null` (registered path absent on disk). */
+  safeTime?: number
+  /** `None` for directory/context entries. */
+  timestamp?: number
+}
+
 export interface NativeWatcherOptions {
   followSymlinks?: boolean
   pollInterval?: number
@@ -1794,6 +1797,13 @@ export interface NativeWatcherOptions {
    * It can be a single path, an array of paths, or a regular expression.
    */
   ignored?: string | string[] | RegExp
+}
+
+export interface NativeWatchResult {
+  changedFiles: Array<string>
+  removedFiles: Array<string>
+  fileTimeInfoEntries: Array<NativeTimeInfoEntry>
+  contextTimeInfoEntries: Array<NativeTimeInfoEntry>
 }
 
 export interface NodeFsStats {

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -8,7 +8,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::*;
 use rspack_paths::ArcPath;
 use rspack_regex::RspackRegex;
-use rspack_watcher::{FsEventKind, FsWatcher, FsWatcherIgnored, FsWatcherOptions};
+use rspack_watcher::{FsEventKind, FsWatcher, FsWatcherIgnored, FsWatcherOptions, TimeInfoEntry};
 
 type JsWatcherIgnored = Either3<String, Vec<String>, RspackRegex>;
 
@@ -38,10 +38,21 @@ pub struct NativeWatcherOptions {
   pub ignored: Option<JsWatcherIgnored>,
 }
 
-#[napi]
+#[napi(object)]
+pub struct NativeTimeInfoEntry {
+  pub path: String,
+  /// `None` => JS `null` (registered path absent on disk).
+  pub safe_time: Option<f64>,
+  /// `None` for directory/context entries.
+  pub timestamp: Option<f64>,
+}
+
+#[napi(object)]
 pub struct NativeWatchResult {
   pub changed_files: Vec<String>,
   pub removed_files: Vec<String>,
+  pub file_time_info_entries: Vec<NativeTimeInfoEntry>,
+  pub context_time_info_entries: Vec<NativeTimeInfoEntry>,
 }
 
 #[napi]
@@ -200,12 +211,24 @@ impl rspack_watcher::EventAggregateHandler for JsEventHandler {
     &self,
     changed_files: rspack_util::fx_hash::FxHashSet<String>,
     deleted_files: rspack_util::fx_hash::FxHashSet<String>,
+    file_time_info_entries: Vec<TimeInfoEntry>,
+    context_time_info_entries: Vec<TimeInfoEntry>,
   ) {
-    let changed_files_vec: Vec<String> = changed_files.into_iter().collect();
-    let deleted_files_vec: Vec<String> = deleted_files.into_iter().collect();
+    let to_native = |entries: Vec<TimeInfoEntry>| {
+      entries
+        .into_iter()
+        .map(|e| NativeTimeInfoEntry {
+          path: e.path,
+          safe_time: e.safe_time.map(|v| v as f64),
+          timestamp: e.timestamp.map(|v| v as f64),
+        })
+        .collect::<Vec<_>>()
+    };
     let result = NativeWatchResult {
-      changed_files: changed_files_vec,
-      removed_files: deleted_files_vec,
+      changed_files: changed_files.into_iter().collect(),
+      removed_files: deleted_files.into_iter().collect(),
+      file_time_info_entries: to_native(file_time_info_entries),
+      context_time_info_entries: to_native(context_time_info_entries),
     };
     self.inner.call(
       Ok(result),

--- a/crates/rspack_watcher/Cargo.toml
+++ b/crates/rspack_watcher/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 cow-utils    = { workspace = true }
 dashmap      = { workspace = true }
 fast-glob    = { workspace = true }
+memchr       = { workspace = true }
 notify       = { workspace = true, features = ["macos_fsevent"] }
 regex        = { workspace = true }
 rspack_error = { workspace = true }

--- a/crates/rspack_watcher/src/executor.rs
+++ b/crates/rspack_watcher/src/executor.rs
@@ -10,7 +10,7 @@ use tokio::sync::{
 };
 
 use super::{EventAggregateHandler, EventHandler, FsEventKind};
-use crate::EventBatch;
+use crate::{EventBatch, paths::PathManager};
 
 type ThreadSafetyReceiver<T> = ThreadSafety<UnboundedReceiver<T>>;
 type ThreadSafety<T> = Arc<Mutex<T>>;
@@ -124,6 +124,7 @@ impl Executor {
     &mut self,
     event_aggregate_handler: Box<dyn EventAggregateHandler + Send>,
     event_handler: Box<dyn EventHandler + Send>,
+    path_manager: Arc<PathManager>,
   ) {
     if !self.start_waiting {
       let files_data = Arc::clone(&self.files_data);
@@ -170,7 +171,7 @@ impl Executor {
     // abort the previous handlers if they exist
     self.abort().await;
 
-    self.run_execute_handler(event_aggregate_handler, event_handler);
+    self.run_execute_handler(event_aggregate_handler, event_handler, path_manager);
 
     // Flush events accumulated during the pause period.
     // Without this, events that arrived while paused would sit in files_data
@@ -186,6 +187,7 @@ impl Executor {
     &mut self,
     event_aggregate_handler: Box<dyn EventAggregateHandler + Send>,
     event_handler: Box<dyn EventHandler + Send>,
+    path_manager: Arc<PathManager>,
   ) {
     self.execute_aggregate_handle = Some(create_execute_aggregate_task(
       event_aggregate_handler,
@@ -193,6 +195,7 @@ impl Executor {
       Arc::clone(&self.files_data),
       self.aggregate_timeout as u64,
       Arc::clone(&self.aggregate_running),
+      path_manager,
     ));
 
     self.execute_handle = Some(create_execute_task(
@@ -242,6 +245,7 @@ fn create_execute_aggregate_task(
   files: ThreadSafety<FilesData>,
   aggregate_timeout: u64,
   running: Arc<AtomicBool>,
+  path_manager: Arc<PathManager>,
 ) -> tokio::task::JoinHandle<()> {
   let future = async move {
     loop {
@@ -270,8 +274,17 @@ fn create_execute_aggregate_task(
           std::mem::take(&mut *files)
         };
 
-        // Call the event handler with the changed and deleted files
-        event_handler.on_event_handle(files.changed, files.deleted);
+        // Snapshot the time-info maps AFTER the aggregate window, so they
+        // reflect post-change disk state. Borrow `&files.deleted` before the
+        // sets are moved into the handler.
+        let (file_time_info_entries, context_time_info_entries) =
+          path_manager.collect_time_info(&files.deleted);
+        event_handler.on_event_handle(
+          files.changed,
+          files.deleted,
+          file_time_info_entries,
+          context_time_info_entries,
+        );
         running.store(false, Ordering::Relaxed);
       }
     }

--- a/crates/rspack_watcher/src/lib.rs
+++ b/crates/rspack_watcher/src/lib.rs
@@ -40,6 +40,18 @@ pub(crate) struct FsEvent {
   pub kind: FsEventKind,
 }
 
+/// A single time-info entry for one watched path, mirroring watchpack's
+/// per-path `{ safeTime, timestamp }`. `safe_time == None` means the path is
+/// absent on disk (the JS side maps it to `null`); `timestamp == None` marks a
+/// directory/context entry, which carries only a safe time (watchpack's
+/// `OnlySafeTimeEntry`).
+#[derive(Debug, Clone)]
+pub struct TimeInfoEntry {
+  pub path: String,
+  pub safe_time: Option<u64>,
+  pub timestamp: Option<u64>,
+}
+
 pub(crate) type EventBatch = Vec<FsEvent>;
 
 /// `EventAggregateHandler` is a trait for handling aggregated file system events.
@@ -49,8 +61,15 @@ pub(crate) type EventBatch = Vec<FsEvent>;
 /// This trait is intended to be used with the file system watcher to aggregate events
 /// and handle them in a single place.
 pub trait EventAggregateHandler {
-  /// Handle a batch of file system events.
-  fn on_event_handle(&self, _changed_files: HashSet<String>, _deleted_files: HashSet<String>);
+  /// Handle a batch of aggregated file system events together with the current
+  /// file/context time-info snapshots.
+  fn on_event_handle(
+    &self,
+    _changed_files: HashSet<String>,
+    _deleted_files: HashSet<String>,
+    _file_time_info_entries: Vec<TimeInfoEntry>,
+    _context_time_info_entries: Vec<TimeInfoEntry>,
+  );
 
   /// Handle an error that occurs during file system watching.
   fn on_error(&self, _error: rspack_error::Error) {
@@ -145,7 +164,11 @@ impl FsWatcher {
 
     self
       .executor
-      .wait_for_execute(event_aggregate_handler, event_handler)
+      .wait_for_execute(
+        event_aggregate_handler,
+        event_handler,
+        Arc::clone(&self.path_manager),
+      )
       .await;
   }
 

--- a/crates/rspack_watcher/src/paths.rs
+++ b/crates/rspack_watcher/src/paths.rs
@@ -9,7 +9,8 @@ use dashmap::setref::multiple::RefMulti;
 use rspack_error::Result;
 use rspack_paths::{ArcPath, ArcPathDashMap, ArcPathDashSet};
 
-use super::{FsWatcherIgnored, ignored::IgnoredMatcher};
+use super::{FsWatcherIgnored, TimeInfoEntry, ignored::IgnoredMatcher};
+use crate::time_info;
 
 /// An iterator that chains together references to all files, directories, and missing paths
 /// stored in the [`PathTracker`]. This allows iteration over all registered paths as a single sequence.
@@ -319,6 +320,118 @@ impl PathManager {
   }
 }
 
+impl PathManager {
+  /// Resolve a file's mtime in epoch-millis, preferring the cached
+  /// `file_mtimes` baseline (no syscall) and falling back to a fresh stat for
+  /// files with no baseline yet (e.g. registered-but-missing deps).
+  fn file_mtime_ms(&self, path: &ArcPath) -> Option<u64> {
+    if let Some(mtime) = self.file_mtimes.get(path) {
+      return Some(time_info::system_time_to_millis(*mtime));
+    }
+    Self::stat_mtime_ms(path)
+  }
+
+  /// Read a path's mtime in epoch-millis with a fresh stat (used for
+  /// directories, which have no baseline cache).
+  fn stat_mtime_ms(path: &ArcPath) -> Option<u64> {
+    path
+      .metadata()
+      .and_then(|m| m.modified().or_else(|_| m.created()))
+      .ok()
+      .map(time_info::system_time_to_millis)
+  }
+
+  /// Build the file and context time-info maps for all registered paths,
+  /// mirroring watchpack's `fileTimeInfoEntries` / `contextTimeInfoEntries`.
+  ///
+  /// Files reuse the `file_mtimes` baseline. A directory's safe time is the max
+  /// of its own mtime and the safe times of every registered file beneath it,
+  /// so an in-directory content change — which does NOT bump the directory
+  /// mtime — still advances it. Paths in `deleted` are forced to null, guarding
+  /// the stale-baseline case where a just-removed file is still registered with
+  /// an old cached mtime.
+  pub(crate) fn collect_time_info(
+    &self,
+    deleted: &rspack_util::fx_hash::FxHashSet<String>,
+  ) -> (Vec<TimeInfoEntry>, Vec<TimeInfoEntry>) {
+    let accessor = self.access();
+
+    // ---- files ----
+    let file_paths: Vec<ArcPath> = accessor.files().0.iter().map(|p| p.clone()).collect();
+    let mut file_entries = Vec::with_capacity(file_paths.len());
+    let mut file_safe_times: Vec<(ArcPath, u64)> = Vec::new();
+    for path in &file_paths {
+      let key = path.to_string_lossy().to_string();
+      let mtime_ms = if deleted.contains(&key) {
+        None
+      } else {
+        self.file_mtime_ms(path)
+      };
+      match mtime_ms {
+        Some(ms) => {
+          let st = time_info::safe_time(ms);
+          file_safe_times.push((path.clone(), st));
+          file_entries.push(TimeInfoEntry {
+            path: key,
+            safe_time: Some(st),
+            timestamp: Some(ms),
+          });
+        }
+        None => file_entries.push(TimeInfoEntry {
+          path: key,
+          safe_time: None,
+          timestamp: None,
+        }),
+      }
+    }
+    // Registered-missing dependencies read as null in the file map. webpack
+    // registers `files` and `missing` as disjoint sets, so a null missing entry
+    // never clobbers a real file entry sharing the same key in the final map.
+    for path in accessor.missing().0.iter() {
+      file_entries.push(TimeInfoEntry {
+        path: path.to_string_lossy().to_string(),
+        safe_time: None,
+        timestamp: None,
+      });
+    }
+
+    // ---- contexts ----
+    let dir_paths: Vec<ArcPath> = accessor.directories().0.iter().map(|p| p.clone()).collect();
+    let mut dir_safe: rspack_util::fx_hash::FxHashMap<ArcPath, Option<u64>> =
+      rspack_util::fx_hash::FxHashMap::with_capacity_and_hasher(
+        dir_paths.len(),
+        Default::default(),
+      );
+    for dir in &dir_paths {
+      dir_safe.insert(
+        dir.clone(),
+        Self::stat_mtime_ms(dir).map(time_info::safe_time),
+      );
+    }
+    // Raise each registered ancestor directory by its descendant files' safe
+    // times (mirrors `Trigger::recurse_parent_directories`).
+    for (file, st) in &file_safe_times {
+      let mut cursor = file.parent().map(ArcPath::from);
+      while let Some(dir) = cursor {
+        if let Some(slot) = dir_safe.get_mut(&dir) {
+          *slot = Some(slot.map_or(*st, |cur| cur.max(*st)));
+        }
+        cursor = dir.parent().map(ArcPath::from);
+      }
+    }
+    let context_entries = dir_paths
+      .iter()
+      .map(|dir| TimeInfoEntry {
+        path: dir.to_string_lossy().to_string(),
+        safe_time: dir_safe.get(dir).and_then(|v| *v),
+        timestamp: None,
+      })
+      .collect();
+
+    (file_entries, context_entries)
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use rspack_paths::Utf8Path;
@@ -435,6 +548,69 @@ mod tests {
     for path in should_exist_paths {
       assert!(all_paths.iter().any(|p| p.ends_with(path)));
     }
+  }
+
+  /// `collect_time_info` reports an existing file with both safe_time and
+  /// timestamp, a registered-but-absent file as null (safe_time None), and a
+  /// directory whose safe_time is at least the max of its contained files
+  /// (watchpack's "max safeTime of children").
+  #[test]
+  fn collect_time_info_files_dirs_and_nulls() {
+    use rspack_util::fx_hash::FxHashSet;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ctx = ArcPath::from(dir.path());
+    let present = ArcPath::from(dir.path().join("present.js").as_path());
+    let gone = ArcPath::from(dir.path().join("gone.js").as_path());
+    std::fs::write(present.as_ref(), b"x").expect("write present");
+
+    let pm = PathManager::default();
+    pm.update(
+      (
+        vec![present.clone(), gone.clone()].into_iter(),
+        std::iter::empty(),
+      ),
+      (vec![ctx.clone()].into_iter(), std::iter::empty()),
+      (std::iter::empty(), std::iter::empty()),
+    )
+    .expect("register paths");
+    // Seed the baseline the way a real `watch()` cycle does.
+    if let Ok(mtime) = present.as_ref().metadata().and_then(|m| m.modified()) {
+      pm.set_file_mtime_if_absent(present.clone(), mtime);
+    }
+
+    let deleted: FxHashSet<String> = FxHashSet::default();
+    let (files, contexts) = pm.collect_time_info(&deleted);
+
+    let find = |v: &[crate::TimeInfoEntry], p: &ArcPath| {
+      v.iter().find(|e| e.path == p.to_string_lossy()).cloned()
+    };
+
+    let present_entry = find(&files, &present).expect("present file entry");
+    assert!(
+      present_entry.safe_time.is_some(),
+      "present file has safe_time"
+    );
+    assert!(
+      present_entry.timestamp.is_some(),
+      "present file has timestamp"
+    );
+
+    let gone_entry = find(&files, &gone).expect("gone file entry");
+    assert!(
+      gone_entry.safe_time.is_none(),
+      "absent file -> null safe_time"
+    );
+
+    let ctx_entry = find(&contexts, &ctx).expect("context entry");
+    assert_eq!(
+      ctx_entry.timestamp, None,
+      "context entry carries no timestamp"
+    );
+    assert!(
+      ctx_entry.safe_time.unwrap() >= present_entry.safe_time.unwrap(),
+      "context safe_time >= contained file safe_time",
+    );
   }
 
   /// Regression for the FSEvents stale-event race: simulate two consecutive

--- a/crates/rspack_watcher/src/paths.rs
+++ b/crates/rspack_watcher/src/paths.rs
@@ -416,15 +416,49 @@ impl PathManager {
       dir_index.insert(dir.as_os_str(), i);
     }
     // Raise each registered ancestor directory by its descendant files' safe
-    // times (mirrors `Trigger::recurse_parent_directories`), walking borrowed
-    // `&Path`s so no per-step allocation happens.
+    // times (mirrors `Trigger::recurse_parent_directories`). On unix the
+    // ancestors are byte prefixes of the path truncated at `/`, found with a
+    // vectorized reverse scan — no per-step `Path::parent` component re-parse and
+    // no allocation. Matching stays byte-identical to the `dir_index` keys.
     for (file, st) in &file_safe_times {
-      let mut cursor = file.parent();
-      while let Some(dir) = cursor {
-        if let Some(&i) = dir_index.get(dir.as_os_str()) {
-          dir_safe[i] = Some(dir_safe[i].map_or(*st, |cur| cur.max(*st)));
+      let mut raise = |i: usize| {
+        dir_safe[i] = Some(dir_safe[i].map_or(*st, |cur| cur.max(*st)));
+      };
+
+      #[cfg(unix)]
+      {
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+        let bytes = file.as_os_str().as_bytes();
+        let mut end = bytes.len();
+        while let Some(pos) = memchr::memrchr(b'/', &bytes[..end]) {
+          if pos == 0 {
+            // Reached the root; the parent is "/" unless the file IS "/".
+            if end > 1
+              && let Some(&i) = dir_index.get(OsStr::from_bytes(b"/"))
+            {
+              raise(i);
+            }
+            break;
+          }
+          if let Some(&i) = dir_index.get(OsStr::from_bytes(&bytes[..pos])) {
+            raise(i);
+          }
+          end = pos;
         }
-        cursor = dir.parent();
+      }
+
+      // Non-unix path semantics (drive prefixes, UNC, verbatim paths) are
+      // intricate; keep the exact `Path::parent` walk there — correctness over
+      // speed on a platform that is not the watcher's performance hot path.
+      #[cfg(not(unix))]
+      {
+        let mut cursor = file.parent();
+        while let Some(dir) = cursor {
+          if let Some(&i) = dir_index.get(dir.as_os_str()) {
+            raise(i);
+          }
+          cursor = dir.parent();
+        }
       }
     }
     let context_entries = dir_paths

--- a/crates/rspack_watcher/src/paths.rs
+++ b/crates/rspack_watcher/src/paths.rs
@@ -397,33 +397,42 @@ impl PathManager {
 
     // ---- contexts ----
     let dir_paths: Vec<ArcPath> = accessor.directories().0.iter().map(|p| p.clone()).collect();
-    let mut dir_safe: rspack_util::fx_hash::FxHashMap<ArcPath, Option<u64>> =
+    // `dir_safe[i]` is the running safe time for `dir_paths[i]`, seeded from the
+    // directory's own mtime.
+    let mut dir_safe: Vec<Option<u64>> = dir_paths
+      .iter()
+      .map(|dir| Self::stat_mtime_ms(dir).map(time_info::safe_time))
+      .collect();
+    // Index registered directories by their raw path bytes so the ancestor walk
+    // can probe them without allocating an `ArcPath` per step. Byte matching is
+    // identical to the previous `ArcPath` keying, whose hash is `hash_path` over
+    // exactly these bytes.
+    let mut dir_index: rspack_util::fx_hash::FxHashMap<&std::ffi::OsStr, usize> =
       rspack_util::fx_hash::FxHashMap::with_capacity_and_hasher(
         dir_paths.len(),
         Default::default(),
       );
-    for dir in &dir_paths {
-      dir_safe.insert(
-        dir.clone(),
-        Self::stat_mtime_ms(dir).map(time_info::safe_time),
-      );
+    for (i, dir) in dir_paths.iter().enumerate() {
+      dir_index.insert(dir.as_os_str(), i);
     }
     // Raise each registered ancestor directory by its descendant files' safe
-    // times (mirrors `Trigger::recurse_parent_directories`).
+    // times (mirrors `Trigger::recurse_parent_directories`), walking borrowed
+    // `&Path`s so no per-step allocation happens.
     for (file, st) in &file_safe_times {
-      let mut cursor = file.parent().map(ArcPath::from);
+      let mut cursor = file.parent();
       while let Some(dir) = cursor {
-        if let Some(slot) = dir_safe.get_mut(&dir) {
-          *slot = Some(slot.map_or(*st, |cur| cur.max(*st)));
+        if let Some(&i) = dir_index.get(dir.as_os_str()) {
+          dir_safe[i] = Some(dir_safe[i].map_or(*st, |cur| cur.max(*st)));
         }
-        cursor = dir.parent().map(ArcPath::from);
+        cursor = dir.parent();
       }
     }
     let context_entries = dir_paths
       .iter()
-      .map(|dir| TimeInfoEntry {
+      .zip(&dir_safe)
+      .map(|(dir, &safe_time)| TimeInfoEntry {
         path: dir.to_string_lossy().to_string(),
-        safe_time: dir_safe.get(dir).and_then(|v| *v),
+        safe_time,
         timestamp: None,
       })
       .collect();

--- a/crates/rspack_watcher/tests/helpers/mod.rs
+++ b/crates/rspack_watcher/tests/helpers/mod.rs
@@ -269,6 +269,8 @@ impl TestHelper {
         &self,
         changed_files: FxHashSet<String>,
         deleted_files: FxHashSet<String>,
+        _file_time_info_entries: Vec<rspack_watcher::TimeInfoEntry>,
+        _context_time_info_entries: Vec<rspack_watcher::TimeInfoEntry>,
       ) {
         let _ = self.0.send(Event::Aggregated(AggregatedEvent {
           changed_files,

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -62,8 +62,11 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
     options: Watchpack.WatchOptions,
     callback: (
       error: Error | null,
-      fileTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore'>,
-      contextTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore'>,
+      fileTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore' | null>,
+      contextTimeInfoEntries: Map<
+        string,
+        FileSystemInfoEntry | 'ignore' | null
+      >,
       changedFiles: Set<string>,
       removedFiles: Set<string>,
     ) => void,
@@ -120,11 +123,35 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
             fs.purge?.(item);
           }
         }
-        // TODO: add fileTimeInfoEntries and contextTimeInfoEntries
+
+        const toMap = (
+          entries: binding.NativeTimeInfoEntry[],
+        ): Map<string, FileSystemInfoEntry | 'ignore' | null> => {
+          const map = new Map<string, FileSystemInfoEntry | 'ignore' | null>();
+          for (const entry of entries) {
+            map.set(
+              entry.path,
+              entry.safeTime == null
+                ? null
+                : {
+                    safeTime: entry.safeTime,
+                    timestamp: entry.timestamp ?? undefined,
+                  },
+            );
+          }
+          return map;
+        };
+        const fileTimeInfoEntries = toMap(result.fileTimeInfoEntries);
+        const contextTimeInfoEntries = toMap(result.contextTimeInfoEntries);
+        // watchpack convention: a removed path reads as null.
+        for (const removed of removedFiles) {
+          fileTimeInfoEntries.set(removed, null);
+        }
+
         callback(
           err,
-          new Map(),
-          new Map(),
+          fileTimeInfoEntries,
+          contextTimeInfoEntries,
           new Set(changedFiles),
           new Set(removedFiles),
         );

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -246,8 +246,8 @@ export class Watching {
   }
 
   #invalidate(
-    fileTimeInfoEntries?: Map<string, FileSystemInfoEntry | 'ignore'>,
-    contextTimeInfoEntries?: Map<string, FileSystemInfoEntry | 'ignore'>,
+    fileTimeInfoEntries?: Map<string, FileSystemInfoEntry | 'ignore' | null>,
+    contextTimeInfoEntries?: Map<string, FileSystemInfoEntry | 'ignore' | null>,
     changedFiles?: Set<string>,
     removedFiles?: Set<string>,
   ) {
@@ -270,10 +270,13 @@ export class Watching {
   }
 
   #go(
-    fileTimeInfoEntries?: ReadonlyMap<string, FileSystemInfoEntry | 'ignore'>,
+    fileTimeInfoEntries?: ReadonlyMap<
+      string,
+      FileSystemInfoEntry | 'ignore' | null
+    >,
     contextTimeInfoEntries?: ReadonlyMap<
       string,
-      FileSystemInfoEntry | 'ignore'
+      FileSystemInfoEntry | 'ignore' | null
     >,
     changedFiles?: ReadonlySet<string>,
     removedFiles?: ReadonlySet<string>,

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -41,8 +41,11 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
     options: Watchpack.WatchOptions,
     callback: (
       error: Error | null,
-      fileTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore'>,
-      contextTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore'>,
+      fileTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore' | null>,
+      contextTimeInfoEntries: Map<
+        string,
+        FileSystemInfoEntry | 'ignore' | null
+      >,
       changedFiles: Set<string>,
       removedFiles: Set<string>,
     ) => void,

--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -747,8 +747,11 @@ export interface WatchFileSystem {
     options: WatchOptions,
     callback: (
       error: Error | null,
-      fileTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore'>,
-      contextTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore'>,
+      fileTimeInfoEntries: Map<string, FileSystemInfoEntry | 'ignore' | null>,
+      contextTimeInfoEntries: Map<
+        string,
+        FileSystemInfoEntry | 'ignore' | null
+      >,
       changedFiles: Set<string>,
       removedFiles: Set<string>,
     ) => void,

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/ctx/__ignored__/seed.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/ctx/__ignored__/seed.js
@@ -1,0 +1,1 @@
+module.exports = "seed";

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/ctx/keep.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/ctx/keep.js
@@ -1,0 +1,2 @@
+// a stable, non-ignored member so the context always has content
+module.exports = 1;

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/ctx/trigger.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/ctx/trigger.js
@@ -1,0 +1,1 @@
+module.exports = "initial";

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/index.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/0/index.js
@@ -1,0 +1,37 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+// `ctx` is watched as a context dependency; its `__ignored__` subtree is
+// excluded by `watchOptions.ignored`. Import two of its files directly so each
+// is an individually-tracked file dependency: editing the non-ignored
+// `trigger.js` drives a rebuild, while editing the ignored
+// `__ignored__/seed.js` must be filtered out of the change set.
+require.context("./ctx");
+const trigger = require("./ctx/trigger.js");
+require("./ctx/__ignored__/seed.js");
+
+it("an edit inside an ignored subtree of a watched context is filtered from the rebuild", () => {
+	if (WATCH_STEP === "0") {
+		expect(trigger).toBe("initial");
+		return;
+	}
+
+	if (WATCH_STEP === "1") {
+		const probe = JSON.parse(
+			fs.readFileSync(path.resolve(__dirname, "probe.json"), "utf-8")
+		);
+		const modified = probe.modifiedFiles;
+		// Step 1 edited `ctx/trigger.js` and `ctx/__ignored__/seed.js` together.
+		// A rebuild driven by the non-ignored edit happened (non-empty changes)...
+		expect(modified.length).toBeGreaterThan(0);
+		// ...while the ignored-subtree edit must be filtered from the change set.
+		// (The native watcher reports the individual `ctx/__ignored__/seed.js`
+		// path when unfiltered; watchpack collapses context-member changes to the
+		// `ctx` directory, so this is the discriminating assertion on the native
+		// path — exactly where the ignored-subtree filter lives.)
+		expect(modified.some((p) => p.includes("__ignored__"))).toBe(false);
+		return;
+	}
+
+	throw new Error(`unexpected watch step: ${WATCH_STEP}`);
+});

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/1/ctx/__ignored__/seed.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/1/ctx/__ignored__/seed.js
@@ -1,0 +1,1 @@
+module.exports = "noise";

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/1/ctx/trigger.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/1/ctx/trigger.js
@@ -1,0 +1,1 @@
+module.exports = "changed";

--- a/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/rspack.config.js
+++ b/tests/rspack-test/watchCases/change-event/ignored-context-subtree-no-rebuild/rspack.config.js
@@ -1,0 +1,32 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// `ctx/__ignored__/seed.js` is a bundled member of the watched `require.context`
+// (see 0/index.js), so a normal edit would show up in `compiler.modifiedFiles`
+// and drive a rebuild — unless the watcher filters its `__ignored__` subtree via
+// `watchOptions.ignored`. Step 1 edits both `ctx/trigger.js` (not ignored) and
+// `ctx/__ignored__/seed.js` (ignored) at once; the rebuild's `modifiedFiles`
+// must contain the former and exclude the latter.
+class IgnoredContextProbe {
+  apply(compiler) {
+    const probeFile = path.join(compiler.options.output.path, 'probe.json');
+    compiler.hooks.done.tap('IgnoredContextProbe', () => {
+      fs.mkdirSync(path.dirname(probeFile), { recursive: true });
+      fs.writeFileSync(
+        probeFile,
+        JSON.stringify({
+          modifiedFiles: Array.from(compiler.modifiedFiles || []),
+        }),
+      );
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  watchOptions: {
+    aggregateTimeout: 200,
+    ignored: ['**/__ignored__'],
+  },
+  plugins: [new IgnoredContextProbe()],
+};

--- a/tests/rspack-test/watchCases/change-event/time-info-entries/0/ctx/keep.js
+++ b/tests/rspack-test/watchCases/change-event/time-info-entries/0/ctx/keep.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/rspack-test/watchCases/change-event/time-info-entries/0/index.js
+++ b/tests/rspack-test/watchCases/change-event/time-info-entries/0/index.js
@@ -1,0 +1,34 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+// Register a context dependency so contextTimestamps is non-empty on rebuild.
+require.context("./ctx").keys();
+
+it("native watcher populates file/context time info entries", () => {
+	if (WATCH_STEP === "0") {
+		// The initial build does not populate timestamps; they are set on the
+		// first watcher callback, which fires before the step-1 bundle runs.
+		return;
+	}
+
+	const probe = JSON.parse(
+		fs.readFileSync(path.resolve(__dirname, "probe.json"), "utf-8")
+	);
+
+	// fileTimestamps populated; the entry file has numeric safeTime + timestamp.
+	expect(Array.isArray(probe.file)).toBe(true);
+	expect(probe.file.length).toBeGreaterThan(0);
+	const entry = probe.file.find(([p]) => p.endsWith("index.js"));
+	expect(entry).toBeTruthy();
+	expect(typeof entry[1].safeTime).toBe("number");
+	expect(entry[1].safeTime).toBeGreaterThan(0);
+	expect(typeof entry[1].timestamp).toBe("number");
+
+	// contextTimestamps populated; the ctx directory has a numeric safeTime.
+	expect(Array.isArray(probe.context)).toBe(true);
+	expect(probe.context.length).toBeGreaterThan(0);
+	const ctx = probe.context.find(([p]) => p.endsWith("ctx"));
+	expect(ctx).toBeTruthy();
+	expect(typeof ctx[1].safeTime).toBe("number");
+	expect(ctx[1].safeTime).toBeGreaterThan(0);
+});

--- a/tests/rspack-test/watchCases/change-event/time-info-entries/rspack.config.js
+++ b/tests/rspack-test/watchCases/change-event/time-info-entries/rspack.config.js
@@ -1,0 +1,45 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// `aggregateTimeout` is far smaller than `SETTLE_MS`: any rebuild wrongly
+// triggered before the file write would complete before the watch step-1
+// listener is ready, so that spurious event is not what we test.
+const SETTLE_MS = 1500;
+
+class TimeInfoProbe {
+  constructor() {
+    this.builds = 0;
+  }
+
+  apply(compiler) {
+    const triggerFile = path.join(compiler.context, 'ctx', 'keep.js');
+    const probeFile = path.join(compiler.options.output.path, 'probe.json');
+    const dump = (map) => (map ? Array.from(map.entries()) : null);
+
+    compiler.hooks.done.tap('TimeInfoProbe', () => {
+      this.builds += 1;
+      fs.mkdirSync(path.dirname(probeFile), { recursive: true });
+      fs.writeFileSync(
+        probeFile,
+        JSON.stringify({
+          file: dump(compiler.fileTimestamps),
+          context: dump(compiler.contextTimestamps),
+        }),
+      );
+      // After the initial build, schedule a file change to trigger a rebuild.
+      // The delay ensures the step-1 listener is already registered when the
+      // watcher fires, avoiding a race against watchpack's own initial scan.
+      if (this.builds === 1) {
+        setTimeout(() => {
+          fs.writeFileSync(triggerFile, `module.exports = ${Date.now()};\n`);
+        }, SETTLE_MS);
+      }
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  watchOptions: { aggregateTimeout: 200 },
+  plugins: [new TimeInfoProbe()],
+};


### PR DESCRIPTION
## Why

The native watcher returned empty `fileTimeInfoEntries` / `contextTimeInfoEntries` maps (left as a `// TODO`), unlike the watchpack path. These maps feed `compiler.fileTimestamps` / `compiler.contextTimestamps`, so under the native watcher snapshot/cache validation had no timing data — not at parity with watchpack.

**Before:** native watcher → `callback(err, new Map(), new Map(), changed, removed)`
**After:** native watcher → populated maps with `{ safeTime, timestamp }` per path, matching watchpack semantics.

## What

- **Rust:** `PathManager::collect_time_info` builds both maps, reusing the `file_mtimes` baseline and `time_info::safe_time`. A context directory's `safeTime` is `max(own mtime, descendant files' safeTimes)` so an in-directory content change (which does not bump the dir mtime) still advances it. Absent / just-removed paths read as `null`.
- Threaded through `EventAggregateHandler::on_event_handle` → napi (`NativeWatchResult` gains `fileTimeInfoEntries` / `contextTimeInfoEntries`).
- **JS:** `NativeWatchFileSystem` assembles the two `Map`s; the `WatchFileSystem` callback / `Watching` map types are widened to `| null` to match the already-`| null` `compiler.fileTimestamps`.
- **Test:** a `time-info-entries` watchCase that runs under both the watchpack and native paths (parity), asserting both maps are populated.

Out of scope (separate TODOs): `Watcher.getInfo()` real impl, `callbackUndelayed` real change time.