### PR TITLE
docs: update Rollup comparison docs

### DIFF
--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -99,7 +99,7 @@ Turbopack is implemented in Rust like Rspack, but Turbopack started over with a 
 
 ### Compared with Rollup
 
-Rspack and Rollup are both bundling tools, but they focus on different areas. Rollup is more suitable for bundling libraries, while Rspack is more suitable for bundling applications. Therefore, Rspack has optimized many features for bundling applications, such as HMR and bundle splitting. Rollup produces ESM outputs that are more friendly to libraries than Rspack. Rspack also focuses on faster production builds for application workloads.
+Rollup is built around ES modules and supports multiple output formats. Rspack is designed for a broader set of build scenarios, including ESM and CJS library outputs as well as application bundles. It also prioritizes build performance and memory usage, making it suitable for large projects with complex production build requirements.
 
 ### Compared with Parcel
 

--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -99,7 +99,7 @@ Turbopack is implemented in Rust like Rspack, but Turbopack started over with a 
 
 ### Compared with Rollup
 
-Rollup is built around ES modules and supports multiple output formats. Rspack is designed for a broader set of build scenarios, including ESM and CJS library outputs as well as application bundles. It also prioritizes build performance and memory usage, making it suitable for large projects with complex production build requirements.
+Rollup is built around ES modules and supports multiple output formats. Rspack covers a broader range of build scenarios, including ESM and CJS library outputs as well as application bundles, while continuously improving build performance and memory usage.
 
 ### Compared with Parcel
 

--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -99,7 +99,7 @@ Turbopack is implemented in Rust like Rspack, but Turbopack started over with a 
 
 ### Compared with Rollup
 
-Rspack and Rollup are both bundling tools, but they focus on different areas. Rollup is more suitable for bundling libraries, while Rspack is more suitable for bundling applications. Therefore, Rspack has optimized many features for bundling applications, such as HMR and bundle splitting. Rollup produces ESM outputs that are more friendly to libraries than Rspack. There are also many tools in the community that encapsulate Rollup to some extent and provide more friendly support for bundling applications, such as Vite. Currently, Rspack has better production build performance than Rollup.
+Rspack and Rollup are both bundling tools, but they focus on different areas. Rollup is more suitable for bundling libraries, while Rspack is more suitable for bundling applications. Therefore, Rspack has optimized many features for bundling applications, such as HMR and bundle splitting. Rollup produces ESM outputs that are more friendly to libraries than Rspack. Rspack also focuses on faster production builds for application workloads.
 
 ### Compared with Parcel
 

--- a/website/docs/zh/guide/start/introduction.mdx
+++ b/website/docs/zh/guide/start/introduction.mdx
@@ -110,7 +110,7 @@ Rspack 和 Turbopack 都是基于 Rust 实现的 bundler，且都发挥了 Rust 
 
 ### 和 Rollup 的区别
 
-Rollup 以 ES Modules 为基础，同时支持多种输出格式。Rspack 则面向更广泛的构建场景，支持 ESM、CJS 等库产物以及应用打包产物，并持续优化构建性能和内存使用，适用于有复杂生产构建需求的大型项目。
+Rollup 以 ES Modules 为基础，同时支持多种输出格式。Rspack 则覆盖更广泛的构建场景，包括 ESM、CJS 等库产物以及应用打包产物，并持续优化构建性能和内存使用。
 
 ### 和 Parcel 的区别
 

--- a/website/docs/zh/guide/start/introduction.mdx
+++ b/website/docs/zh/guide/start/introduction.mdx
@@ -110,7 +110,7 @@ Rspack 和 Turbopack 都是基于 Rust 实现的 bundler，且都发挥了 Rust 
 
 ### 和 Rollup 的区别
 
-Rspack 和 Rollup 虽然都是打包工具，但是两者的侧重领域不同，Rollup 更适合用于打包库，而 Rspack 适合用于打包应用。因此 Rspack 对打包应用进行了很多优化，如 HMR、Bundle splitting 等功能，而 Rollup 则比 Rspack 的编译产物对库更为友好，如更好的 ESM 产物支持。Rspack 也专注于为应用场景提供更快的生产构建。
+Rollup 以 ES Modules 为基础，同时支持多种输出格式。Rspack 则面向更广泛的构建场景，支持 ESM、CJS 等库产物以及应用打包产物，并持续优化构建性能和内存使用，适用于有复杂生产构建需求的大型项目。
 
 ### 和 Parcel 的区别
 

--- a/website/docs/zh/guide/start/introduction.mdx
+++ b/website/docs/zh/guide/start/introduction.mdx
@@ -110,7 +110,7 @@ Rspack 和 Turbopack 都是基于 Rust 实现的 bundler，且都发挥了 Rust 
 
 ### 和 Rollup 的区别
 
-Rspack 和 Rollup 虽然都是打包工具，但是两者的侧重领域不同，Rollup 更适合用于打包库，而 Rspack 适合用于打包应用。因此 Rspack 对打包应用进行了很多优化，如 HMR、Bundle splitting 等功能，而 Rollup 则比 Rspack 的编译产物对库更为友好，如更好的 ESM 产物支持。 社区上也有很多的工具在 Rollup 基础上进行了一定的封装，提供了对应用打包更友好的支持，如 Vite, 目前 Rspack 比 Rollup 有更好的生产环境构建性能。
+Rspack 和 Rollup 虽然都是打包工具，但是两者的侧重领域不同，Rollup 更适合用于打包库，而 Rspack 适合用于打包应用。因此 Rspack 对打包应用进行了很多优化，如 HMR、Bundle splitting 等功能，而 Rollup 则比 Rspack 的编译产物对库更为友好，如更好的 ESM 产物支持。Rspack 也专注于为应用场景提供更快的生产构建。
 
 ### 和 Parcel 的区别
 


### PR DESCRIPTION
## Summary

This PR continues the cleanup of outdated Vite/Rollup wording in the introduction docs. The Rollup comparison no longer uses Vite as an example of a Rollup-based application tool, since Vite 8 is powered by Rolldown. The updated wording keeps the Rspack vs Rollup comparison focused on library and application bundling use cases.

## Related links

Related to #14410

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).