### PR TITLE
fix(browser): point wasi-worker-browser export to dist file

### DIFF
--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -15,7 +15,7 @@
       "types": "./dist/browser/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./wasi-worker-browser.mjs": "./wasi-worker-browser.mjs",
+    "./wasi-worker-browser.mjs": "./dist/wasi-worker-browser.mjs",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
## Why

The `./wasi-worker-browser.mjs` subpath export pointed to `./wasi-worker-browser.mjs` (package root), but:

- The build emits the worker into **`dist/`** (`filename: 'wasi-worker-browser.mjs'`, `distPath.root = ../rspack-browser/dist` in `rslib.browser.config.ts`).
- `files` only ships `dist`, so a root-level file would never be published anyway.

So the export resolved to a non-existent path.

### Before / After

```diff
- "./wasi-worker-browser.mjs": "./wasi-worker-browser.mjs",
+ "./wasi-worker-browser.mjs": "./dist/wasi-worker-browser.mjs",
```

## Question for reviewer

@CPunisher — this subpath export looks **unused**: the worker is loaded via a relative URL next to `rspack.wasi-browser.js` (`new URL('./wasi-worker-browser.mjs', import.meta.url)`), both sitting in `dist/`, not via the `@rspack/browser/wasi-worker-browser.mjs` package specifier (no such import anywhere in the repo).

This PR just fixes the path to be correct. But if you confirm nothing consumes this subpath, we could **drop the export entirely** instead. WDYT?
