### PR TITLE
docs: update rules use parallel type

### DIFF
--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -739,16 +739,9 @@ export default {
 
 ```ts
 type RuleSetUse =
-  | RuleSetUseItem[]
   | RuleSetUseItem
+  | RuleSetUseItem[]
   | ((ctx: RawFuncUseCtx) => RuleSetUseItem[]);
-type RuleSetUseItem = { loader: string; options: Record<string, any> } | string;
-interface RawFuncUseCtx {
-  resource?: string;
-  realResource?: string;
-  resourceQuery?: string;
-  issuer?: string;
-}
 ```
 
 An array to pass the Loader package name and its options. `string[]` e.g.: `use: ['svgr-loader']` is shorthand for `use: [ { loader: 'svgr-loader' } ]`.
@@ -805,7 +798,7 @@ export default {
 
 <ApiMeta addedVersion="1.3.1" />
 
-- **Type**: `boolean`
+- **Type**: `boolean | { maxWorkers?: number }`
 - **Default:** `false`
 
 Controls whether a given loader should run in worker threads for parallel execution. Loaders marked with `parallel` are scheduled across multiple threads, reducing pressure on the main thread and improving overall build performance.

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -738,18 +738,9 @@ export default {
 
 ```ts
 type RuleSetUse =
-  | RuleSetUseItem[]
   | RuleSetUseItem
+  | RuleSetUseItem[]
   | ((ctx: RawFuncUseCtx) => RuleSetUseItem[]);
-type RuleSetUseItem =
-  | { loader: string; options: Record<string, any>; parallel?: boolean }
-  | string;
-interface RawFuncUseCtx {
-  resource?: string;
-  realResource?: string;
-  resourceQuery?: string;
-  issuer?: string;
-}
 ```
 
 用于传递 Loader 包名与其选项的数组。`string[]` 如: `use: ['svgr-loader']` 是 `use: [ { loader: 'svgr-loader' } ]` 的简写。Loader 会按照从右到左的顺序执行。


### PR DESCRIPTION
## Summary

This PR updates the module rules docs to include the `{ maxWorkers }` object form in the `rules[].use.parallel` type so the documented API matches the loader parallelization option.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).