### PR TITLE
fix(rstest): fallback to automock for missing manual mocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4947,6 +4947,7 @@ dependencies = [
  "rspack_error",
  "rspack_hook",
  "rspack_plugin_javascript",
+ "rspack_resolver",
  "rspack_util",
  "rustc-hash",
  "swc_experimental_ecma_ast",

--- a/crates/rspack_plugin_rstest/Cargo.toml
+++ b/crates/rspack_plugin_rstest/Cargo.toml
@@ -17,6 +17,7 @@ rspack_core               = { workspace = true }
 rspack_error              = { workspace = true }
 rspack_hook               = { workspace = true }
 rspack_plugin_javascript  = { workspace = true }
+rspack_resolver           = { workspace = true }
 rspack_util               = { workspace = true }
 rustc-hash                = { workspace = true }
 swc_experimental_ecma_ast = { workspace = true }

--- a/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
@@ -53,6 +53,10 @@ impl MockModuleIdDependency {
     self.missing_module_fallback = Some(fallback);
     self
   }
+
+  pub fn has_missing_module_fallback(&self) -> bool {
+    self.missing_module_fallback.is_some()
+  }
 }
 
 #[cacheable_dyn]

--- a/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
@@ -19,6 +19,7 @@ pub struct MockModuleIdDependency {
   factorize_info: FactorizeInfo,
   category: DependencyCategory,
   pub suffix: Option<String>,
+  missing_module_fallback: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -40,11 +41,17 @@ impl MockModuleIdDependency {
       factorize_info: Default::default(),
       category,
       suffix,
+      missing_module_fallback: None,
     }
   }
 
   pub fn set_request(&mut self, request: String) {
     self.request = request;
+  }
+
+  pub fn with_missing_module_fallback(mut self, fallback: String) -> Self {
+    self.missing_module_fallback = Some(fallback);
+    self
   }
 }
 
@@ -139,13 +146,23 @@ impl DependencyTemplate for MockModuleIdDependencyTemplate {
       .downcast_ref::<MockModuleIdDependency>()
       .expect("MockModuleIdDependencyTemplate should only be used for MockModuleIdDependency");
 
-    let module_id = module_id_rstest(
-      code_generatable_context.compilation,
-      code_generatable_context.runtime_template,
-      &dep.id,
-      &dep.request,
-      dep.weak,
-    );
+    let module_id = if code_generatable_context
+      .compilation
+      .get_module_graph()
+      .module_identifier_by_dependency_id(&dep.id)
+      .is_none()
+      && let Some(fallback) = &dep.missing_module_fallback
+    {
+      fallback.clone()
+    } else {
+      module_id_rstest(
+        code_generatable_context.compilation,
+        code_generatable_context.runtime_template,
+        &dep.id,
+        &dep.request,
+        dep.weak,
+      )
+    };
 
     source.replace(
       dep.range.start,

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -378,20 +378,27 @@ impl RstestParserPlugin {
 
           if has_b {
             let second_arg = Span::new(first_arg.span().end, first_arg.span().end);
-            parser.add_dependency(Box::new(MockModuleIdDependency::new(
-              format!("{MOCK_TARGET_REQUEST_PREFIX}{lit_str}"),
-              second_arg.into(),
-              false,
-              true,
-              if is_esm {
-                rspack_core::DependencyCategory::Esm
-              } else {
-                rspack_core::DependencyCategory::CommonJS
-              },
-              // Render the synthetic target id followed by the clean request
-              // literal, yielding `rstest_mock(<id>, <targetId>, "X")`.
-              Some(format!(", {}", json_stringify_str(&lit_str))),
-            )));
+            parser.add_dependency(Box::new(
+              MockModuleIdDependency::new(
+                format!("{MOCK_TARGET_REQUEST_PREFIX}{lit_str}"),
+                second_arg.into(),
+                false,
+                true,
+                if is_esm {
+                  rspack_core::DependencyCategory::Esm
+                } else {
+                  rspack_core::DependencyCategory::CommonJS
+                },
+                // Render the synthetic target id followed by the clean request
+                // literal, yielding `rstest_mock(<id>, <targetId>, "X")`.
+                Some(format!(", {}", json_stringify_str(&lit_str))),
+              )
+              // `rs.mock('X')` first tries to resolve a manual mock target. If no
+              // `__mocks__` file exists, fall back to Vitest-style automocking by
+              // passing `{ mock: true }` to the runtime, equivalent to
+              // `rs.mock('X', { mock: true })`.
+              .with_missing_module_fallback("{ mock: true }".to_string()),
+            ));
           }
         }
       }

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -194,11 +194,14 @@ impl RstestPlugin {
       .map(|main_file| request.join("__mocks__").join(main_file))
   }
 
-  async fn resolve_mock_request(&self, data: &mut ModuleFactoryCreateData) {
+  async fn resolve_mock_request(&self, data: &mut ModuleFactoryCreateData) -> Option<bool> {
     let Some(dep) = data.dependencies.first() else {
-      return;
+      return None;
     };
     let dependency_category = *dep.category();
+    let has_missing_module_fallback = dep
+      .downcast_ref::<MockModuleIdDependency>()
+      .is_some_and(|dep| dep.has_missing_module_fallback());
     let request = data
       .request
       .strip_prefix(MOCK_TARGET_REQUEST_PREFIX)
@@ -206,19 +209,6 @@ impl RstestPlugin {
       .to_string();
     let stripped = request.strip_prefix("node:").unwrap_or(&request);
     let default_target = self.calc_default_mocked_target(&request);
-
-    if !stripped.starts_with('.') {
-      let resolved_request = default_target.to_string();
-      if let Some(dep) = data
-        .dependencies
-        .first_mut()
-        .and_then(|dep| dep.downcast_mut::<MockModuleIdDependency>())
-      {
-        dep.set_request(resolved_request.clone());
-      }
-      data.request = resolved_request;
-      return;
-    }
 
     let dep = ResolveOptionsWithDependencyType {
       resolve_options: data
@@ -230,24 +220,41 @@ impl RstestPlugin {
     };
     let resolver = data.resolver_factory.get(dep);
 
-    let (resolve_result, resolve_dependencies) = resolver
-      .resolve_with_context(data.context.as_ref(), stripped)
-      .await;
-    let resolved_directory_target = match resolve_result {
-      Ok(ResolveResult::Resource(resource)) => self.resolve_directory_mock_target(
-        Utf8Path::new(stripped),
-        data.context.as_ref(),
-        &resource.path,
-        resolver.options().main_files().cloned(),
-      ),
-      _ => None,
+    let resolved_directory_target = if stripped.starts_with('.') {
+      let (resolve_result, resolve_dependencies) = resolver
+        .resolve_with_context(data.context.as_ref(), stripped)
+        .await;
+
+      data.add_file_dependencies(resolve_dependencies.file_dependencies);
+      data.add_missing_dependencies(resolve_dependencies.missing_dependencies);
+
+      match resolve_result {
+        Ok(ResolveResult::Resource(resource)) => self.resolve_directory_mock_target(
+          Utf8Path::new(stripped),
+          data.context.as_ref(),
+          &resource.path,
+          resolver.options().main_files().cloned(),
+        ),
+        _ => None,
+      }
+    } else {
+      None
     };
 
-    data.add_file_dependencies(resolve_dependencies.file_dependencies);
-    data.add_missing_dependencies(resolve_dependencies.missing_dependencies);
     let resolved_request = resolved_directory_target
       .unwrap_or(default_target)
       .to_string();
+
+    let (manual_mock_result, manual_mock_dependencies) = resolver
+      .resolve_with_context(data.context.as_ref(), &resolved_request)
+      .await;
+    data.add_file_dependencies(manual_mock_dependencies.file_dependencies);
+    data.add_missing_dependencies(manual_mock_dependencies.missing_dependencies);
+
+    if manual_mock_result.is_err() && has_missing_module_fallback {
+      return Some(false);
+    }
+
     if let Some(dep) = data
       .dependencies
       .first_mut()
@@ -256,6 +263,8 @@ impl RstestPlugin {
       dep.set_request(resolved_request.clone());
     }
     data.request = resolved_request;
+
+    None
   }
 
   fn generate_define_property_getters_runtime_source(compilation: &Compilation) -> String {
@@ -349,7 +358,9 @@ impl RstestPlugin {
 #[plugin_hook(NormalModuleFactoryBeforeResolve for RstestPlugin)]
 async fn nmf_before_resolve(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<bool>> {
   if Self::synthetic_mock_dep(data) {
-    self.resolve_mock_request(data).await;
+    if let Some(result) = self.resolve_mock_request(data).await {
+      return Ok(Some(result));
+    }
   }
 
   Ok(None)

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -16,6 +16,7 @@ use rspack_core::{
   RuntimeModule, SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   module_declared_side_effect_free,
+  resolver::ResolveInnerError,
   rspack_sources::{BoxSource, ReplaceSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -249,8 +250,12 @@ impl RstestPlugin {
     data.add_file_dependencies(manual_mock_dependencies.file_dependencies);
     data.add_missing_dependencies(manual_mock_dependencies.missing_dependencies);
 
-    if manual_mock_result.is_err() && has_missing_module_fallback {
-      return Some(false);
+    match manual_mock_result {
+      Err(ResolveInnerError::RspackResolver(
+        rspack_resolver::ResolveError::NotFound(_)
+        | rspack_resolver::ResolveError::MatchedAliasNotFound(_, _),
+      )) if has_missing_module_fallback => return Some(false),
+      _ => {}
     }
 
     if let Some(dep) = data

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -195,9 +195,7 @@ impl RstestPlugin {
   }
 
   async fn resolve_mock_request(&self, data: &mut ModuleFactoryCreateData) -> Option<bool> {
-    let Some(dep) = data.dependencies.first() else {
-      return None;
-    };
+    let dep = data.dependencies.first()?;
     let dependency_category = *dep.category();
     let has_missing_module_fallback = dep
       .downcast_ref::<MockModuleIdDependency>()
@@ -357,10 +355,10 @@ impl RstestPlugin {
 
 #[plugin_hook(NormalModuleFactoryBeforeResolve for RstestPlugin)]
 async fn nmf_before_resolve(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<bool>> {
-  if Self::synthetic_mock_dep(data) {
-    if let Some(result) = self.resolve_mock_request(data).await {
-      return Ok(Some(result));
-    }
+  if Self::synthetic_mock_dep(data)
+    && let Some(result) = self.resolve_mock_request(data).await
+  {
+    return Ok(Some(result));
   }
 
   Ok(None)

--- a/tests/rspack-test/configCases/rstest/mock/autoMockFallback.js
+++ b/tests/rspack-test/configCases/rstest/mock/autoMockFallback.js
@@ -1,0 +1,7 @@
+import { value } from './src/auto-mock';
+
+rs.mock('./src/auto-mock');
+
+it('should fall back to automock when no manual mock exists', () => {
+	expect(value).toBe('auto_mock');
+});

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -77,7 +77,9 @@ __webpack_require__.rstest_mock = (id, modFactory) => {
   } finally {
     __webpack_require__.rstest_original_modules[id] = requiredModule;
   }
-  if (typeof modFactory === 'string' || typeof modFactory === 'number') {
+  if (modFactory && modFactory.mock === true) {
+    return;
+  } else if (typeof modFactory === 'string' || typeof modFactory === 'number') {
     __webpack_module_cache__[id] = { exports: __webpack_require__(modFactory) };
   } else if (typeof modFactory === 'function') {
     const finalModFactory = function (
@@ -189,6 +191,7 @@ module.exports = [
   rstestEntry('./doMock.js'),
   rstestEntry('./mockFactory.js'),
   rstestEntry('./manualMock.js'),
+  rstestEntry('./autoMockFallback.js'),
   rstestEntry('./builtinManualMock.js'),
   rstestEntry('./nodeModulesManualMock.js'),
   rstestEntry('./directoryManualMock.js'),

--- a/tests/rspack-test/configCases/rstest/mock/src/auto-mock.js
+++ b/tests/rspack-test/configCases/rstest/mock/src/auto-mock.js
@@ -1,0 +1,1 @@
+export const value = 'auto_mock';


### PR DESCRIPTION
## Summary

This PR makes one-argument `rs.mock('X')` behave like Vitest automocking when no manual mock file exists. RstestPlugin still prefers `__mocks__` targets first, but now falls back to emitting `{ mock: true }` instead of leaving the missing manual mock request to fail resolution.

## Related links

https://rstest.rs/guide/migration/vitest#auto-mocking-modules

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).