### PR TITLE
perf: use chunk masks for module checks

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -400,6 +400,28 @@ impl CodeSplitter {
     })
   }
 
+  #[inline]
+  fn get_module_ordinal_and_chunk_mask_state(
+    &self,
+    module_identifier: &ModuleIdentifier,
+    chunk: ChunkUkey,
+  ) -> (u64, bool) {
+    let module_ordinal = *self
+      .ordinal_by_module
+      .get(module_identifier)
+      .unwrap_or_else(|| {
+        panic!(
+          "expected a module ordinal for identifier '{module_identifier}', but none was found."
+        )
+      });
+    let is_in_chunk = self
+      .mask_by_chunk
+      .get(&chunk)
+      .expect("chunk must in mask_by_chunk")
+      .bit(module_ordinal);
+    (module_ordinal, is_in_chunk)
+  }
+
   pub fn prepare_entry_input(
     &mut self,
     name: &str,
@@ -1260,21 +1282,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   fn add_and_enter_module(&mut self, item: &AddAndEnterModule, compilation: &mut Compilation) {
     tracing::trace!("add_and_enter_module {:?}", item);
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .is_module_in_chunk(&item.module, item.chunk)
-    {
+    let (module_ordinal, is_in_chunk) =
+      self.get_module_ordinal_and_chunk_mask_state(&item.module, item.chunk);
+    if is_in_chunk {
       return;
     }
 
-    // if this module in parent chunks
-    let module_ordinal = *self.ordinal_by_module.get(&item.module).unwrap_or_else(|| {
-      panic!(
-        "expected a module ordinal for identifier '{}', but none was found.",
-        &item.module
-      )
-    });
     let cgi = self.chunk_group_info_mut(&item.chunk_group_info);
 
     if cgi.min_available_modules.bit(module_ordinal) {
@@ -1467,18 +1480,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     );
 
     for (module, active_state, connections) in block_modules.iter().rev() {
-      if compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .is_module_in_chunk(module, item.chunk)
-      {
+      let (ordinal, is_in_chunk) = self.get_module_ordinal_and_chunk_mask_state(module, item.chunk);
+      if is_in_chunk {
         // skip early if already connected
         continue;
       }
 
-      let ordinal = *self.ordinal_by_module.get(module).unwrap_or_else(|| {
-        panic!("expected a module ordinal for identifier '{module}', but none was found.")
-      });
       let chunk_group_info = self.chunk_group_info_mut(&item.chunk_group_info);
       if !active_state.is_true() {
         chunk_group_info


### PR DESCRIPTION
## What changed

- Add a helper that reads a module's ordinal and current chunk mask state together.
- Reuse `CodeSplitter::mask_by_chunk` for hot module-in-chunk checks in `add_and_enter_module` and `process_block`.
- Keep the existing chunk graph writes unchanged.

## Why

`mask_by_chunk` is already maintained by the build chunk graph traversal. Reading it avoids repeated `ChunkGraph::is_module_in_chunk` hash lookups in this hot path.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p rspack_core --all-targets -- -D warnings`
- `cargo test -p rspack_core`