### PR TITLE
fix: include entry modules in chunk modules

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1248,8 +1248,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       .expect("chunk must in mask_by_chunk");
     chunk_mask.set_bit(module_ordinal, true);
 
-    self.add_and_enter_module(
-      &AddAndEnterModule {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .connect_chunk_and_module(item.chunk, item.module);
+
+    self.enter_module(
+      &EnterModule {
         module: item.module,
         chunk_group_info: item.chunk_group_info,
         chunk: item.chunk,

--- a/tests/rspack-test/configCases/chunk-graph/entry-module-in-chunk-modules/index.js
+++ b/tests/rspack-test/configCases/chunk-graph/entry-module-in-chunk-modules/index.js
@@ -1,0 +1,1 @@
+export const value = "entry";

--- a/tests/rspack-test/configCases/chunk-graph/entry-module-in-chunk-modules/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/entry-module-in-chunk-modules/rspack.config.js
@@ -1,0 +1,37 @@
+class Plugin {
+  /**
+   * @param {import("@rspack/core").Compiler} compiler
+   */
+  apply(compiler) {
+    compiler.hooks.compilation.tap('Test', (compilation) => {
+      compilation.hooks.processAssets.tap('Test', () => {
+        const chunk = Array.from(compilation.chunks).find(
+          (chunk) => chunk.name === 'main',
+        );
+        const entryModules = [
+          ...compilation.chunkGraph.getChunkEntryModulesIterable(chunk),
+        ];
+        const modules = new Set(compilation.chunkGraph.getChunkModules(chunk));
+
+        expect(entryModules).toHaveLength(1);
+        expect(modules.has(entryModules[0])).toBe(true);
+      });
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  node: false,
+  entry: {
+    main: './index.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    sideEffects: false,
+  },
+  plugins: [new Plugin()],
+};


### PR DESCRIPTION
## What changed

- Connect entry modules as normal chunk modules before entering them during build chunk graph traversal.
- Add a config test that asserts an entry module returned by `getChunkEntryModulesIterable` is also present in `getChunkModules`.

## Why

`connect_chunk_and_entry_module` only records the entry-module relation. Public chunk module APIs should still see the entry module as part of the chunk's normal module set.

## Validation

- `cargo fmt --all --check`
- `prettier --check tests/rspack-test/configCases/chunk-graph/entry-module-in-chunk-modules/{rspack.config.js,index.js}`
- `cargo clippy -p rspack_core --all-targets -- -D warnings`
- `cargo test -p rspack_core`
- `pnpm run build:js`
- `pnpm run build:binding:dev`
- `pnpm --dir tests/rspack-test run test:base -t "configCases/chunk-graph/entry-module-in-chunk-modules"`