### PR TITLE
perf: reduce build chunk graph preparation work

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1,7 +1,7 @@
 use std::{
   collections::hash_map,
   hash::BuildHasherDefault,
-  sync::{Arc, atomic::AtomicU32},
+  sync::{Arc, LazyLock, atomic::AtomicU32},
 };
 
 use itertools::Itertools;
@@ -36,8 +36,10 @@ pub(crate) type DependenciesBlockIdentifierSet =
 
 type ConnectionIdList = Arc<Vec<DependencyId>>;
 type PreparedBlockConnectionMap = Vec<PreparedBlockConnection>;
-type BlockConnectionMap =
-  DependenciesBlockIdentifierMap<Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>>>;
+type BlockModules = Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>;
+type BlockConnectionMap = DependenciesBlockIdentifierMap<Arc<BlockModules>>;
+
+static EMPTY_BLOCK_MODULES: LazyLock<Arc<BlockModules>> = LazyLock::new(|| Arc::new(Vec::new()));
 
 #[derive(Debug, Clone)]
 struct PreparedBlockConnection {
@@ -1861,7 +1863,18 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     module: DependenciesBlockIdentifier,
     runtime: Option<Arc<RuntimeSpec>>,
     compilation: &Compilation,
-  ) -> Arc<Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>> {
+  ) -> Arc<BlockModules> {
+    if let DependenciesBlockIdentifier::Module(module_identifier) = module {
+      let block = module_identifier.into();
+      if !self.prepared_blocks_map.contains_key(&block)
+        && !self
+          .prepared_connection_map
+          .contains_key(&module_identifier)
+      {
+        return EMPTY_BLOCK_MODULES.clone();
+      }
+    }
+
     let runtime_map = self
       .block_modules_runtime_map
       .entry(runtime.clone())
@@ -2348,15 +2361,20 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let mg = compilation.get_module_graph();
     self.prepared_connection_map = all_modules
       .par_iter()
-      .map(|module| {
+      .filter_map(|module| {
         let all_dependencies = mg
           .module_graph_module_by_identifier(module)
           .map(|mgm| mgm.all_dependencies())
           .unwrap_or_default();
         let dependency_count = all_dependencies.len();
+        if dependency_count == 0 {
+          return None;
+        }
 
         let mut ordered_deps = Vec::new();
         let mut unordered_deps = Vec::with_capacity(dependency_count);
+        let mut ordered_deps_sorted = true;
+        let mut last_source_order = None;
         for dep_id in all_dependencies {
           let dep = mg.dependency_by_id(dep_id);
           let module_dep = dep.as_module_dependency();
@@ -2377,14 +2395,25 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             (*module).into()
           };
           if let Some(source_order) = dep.source_order() {
+            if let Some(last_source_order) = last_source_order
+              && source_order < last_source_order
+            {
+              ordered_deps_sorted = false;
+            }
+            last_source_order = Some(source_order);
             ordered_deps.push((source_order, block_id, *dep_id, module_identifier));
           } else {
             unordered_deps.push((block_id, *dep_id, module_identifier));
           }
         }
-        ordered_deps.sort_by_key(|(source_order, _, _, _)| *source_order);
+        if !ordered_deps_sorted {
+          ordered_deps.sort_by_key(|(source_order, _, _, _)| *source_order);
+        }
 
         let connection_count = ordered_deps.len() + unordered_deps.len();
+        if connection_count == 0 {
+          return None;
+        }
         let ordered_deps = ordered_deps
           .into_iter()
           .map(
@@ -2404,10 +2433,10 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             },
           );
 
-        (
+        Some((
           *module,
           finalize_prepared_connection_map(ordered_deps.chain(unordered_deps), connection_count),
-        )
+        ))
       })
       .collect::<IdentifierMap<_>>();
 
@@ -2547,39 +2576,41 @@ fn extract_block_modules(
     .get(&block)
     .map(|blocks| blocks.as_slice())
     .unwrap_or_default();
-  let mut module_map: DependenciesBlockIdentifierMap<
-    Vec<(ModuleIdentifier, ConnectionState, ConnectionIdList)>,
-  > =
+  let connection_map = prepared_connection_map.get(&module);
+
+  if blocks.is_empty() && connection_map.is_none() {
+    return;
+  }
+
+  let mut module_map: DependenciesBlockIdentifierMap<BlockModules> =
     DependenciesBlockIdentifierMap::with_capacity_and_hasher(blocks.len() + 1, Default::default());
   module_map.insert(block, Vec::new());
   module_map.extend(blocks.iter().map(|block| ((*block).into(), Vec::new())));
 
-  let connection_map = prepared_connection_map
-    .get(&module)
-    .expect("should have outgoing deps");
-
-  for connection in connection_map {
-    if map.contains_key(&connection.block) {
-      continue;
+  if let Some(connection_map) = connection_map {
+    for connection in connection_map {
+      if map.contains_key(&connection.block) {
+        continue;
+      }
+      let modules = module_map
+        .get_mut(&connection.block)
+        .expect("should have modules in block_modules_runtime_map");
+      let active_state = get_active_state_of_connections(
+        &connection.connections,
+        runtime.as_deref(),
+        compilation.get_module_graph(),
+        &compilation.module_graph_cache_artifact,
+        &compilation
+          .build_module_graph_artifact
+          .side_effects_state_artifact,
+        &compilation.exports_info_artifact,
+      );
+      modules.push((
+        connection.module,
+        active_state,
+        connection.connections.clone(),
+      ));
     }
-    let modules = module_map
-      .get_mut(&connection.block)
-      .expect("should have modules in block_modules_runtime_map");
-    let active_state = get_active_state_of_connections(
-      &connection.connections,
-      runtime.as_deref(),
-      compilation.get_module_graph(),
-      &compilation.module_graph_cache_artifact,
-      &compilation
-        .build_module_graph_artifact
-        .side_effects_state_artifact,
-      &compilation.exports_info_artifact,
-    );
-    modules.push((
-      connection.module,
-      active_state,
-      connection.connections.clone(),
-    ));
   }
   for (block, modules) in module_map {
     map.insert(block, Arc::new(modules));


### PR DESCRIPTION
## What changed

- Skip prepared connection-map entries for modules with no effective outgoing build-chunk-graph connections.
- Avoid sorting prepared ordered dependencies when their `source_order` values are already monotonic.
- Use a shared empty block-module result for leaf modules and avoid populating runtime cache entries for them.
- Let block extraction handle modules with blocks but no prepared connection map.

## Why

Leaf modules and already ordered dependency lists are common in build chunk graph preparation. Avoiding empty allocations, cache writes, and unnecessary sorts reduces work in the preparation and traversal paths.

