### PR TITLE
fix(pure-functions): keep deferred pure import callees

### DIFF
--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -191,9 +191,9 @@ pub enum UsageState {
 #[cacheable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsedByExports {
-  pub condition: UsedByExportsCondition,
+  condition: UsedByExportsCondition,
   #[cacheable(with=AsVec)]
-  pub deferred_pure_checks: Vec<UsedByExportsDeferredPureCheck>,
+  deferred_pure_checks: Vec<UsedByExportsDeferredPureCheck>,
 }
 
 impl UsedByExports {
@@ -217,6 +217,23 @@ impl UsedByExports {
   ) -> Self {
     self.deferred_pure_checks = deferred_pure_checks;
     self
+  }
+
+  pub fn condition(&self) -> &UsedByExportsCondition {
+    &self.condition
+  }
+
+  pub fn deferred_pure_checks(&self) -> &[UsedByExportsDeferredPureCheck] {
+    &self.deferred_pure_checks
+  }
+
+  pub fn has_deferred_pure_checks(&self) -> bool {
+    !self.deferred_pure_checks.is_empty()
+  }
+
+  pub fn is_false_without_deferred_pure_checks(&self) -> bool {
+    matches!(&self.condition, UsedByExportsCondition::Bool(false))
+      && !self.has_deferred_pure_checks()
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -11,8 +11,8 @@ use rspack_core::{
   ImportAttributes, ImportPhase, JavascriptParserOptions, ModuleDependency, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport,
   ResourceIdentifier, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
-  TemplateReplaceSource, UsedByExports, UsedByExportsCondition, UsedName,
-  create_exports_object_referenced, property_access, to_normal_comment,
+  TemplateReplaceSource, UsedByExports, UsedName, create_exports_object_referenced,
+  property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
 use rspack_util::{ext::DynHash, json_stringify_str};
@@ -27,7 +27,7 @@ use crate::{
   dependency::{
     DependencyBranchGuard, compose_dependency_condition, is_dependency_export_presence_guarded,
   },
-  is_export_inlined,
+  has_impure_deferred_pure_checks, is_export_inlined,
   visitors::DestructuringAssignmentProperties,
 };
 
@@ -761,6 +761,44 @@ impl DependencyTemplate for ESMImportSpecifierDependencyTemplate {
 
 struct ESMImportSpecifierDependencyCondition;
 
+fn connection_active_for_esm_import_specifier(
+  dependency: &ESMImportSpecifierDependency,
+  connection: &ModuleGraphConnection,
+  runtime: Option<&RuntimeSpec>,
+  module_graph: &ModuleGraph,
+  exports_info_artifact: &ExportsInfoArtifact,
+) -> bool {
+  if let Some(used_by_exports) = dependency.used_by_exports.as_ref() {
+    if has_impure_deferred_pure_checks(module_graph, exports_info_artifact, used_by_exports) {
+      return true;
+    }
+
+    if used_by_exports.is_false_without_deferred_pure_checks() {
+      return false;
+    }
+  }
+
+  let active_by_used_exports = match dependency.used_by_exports.as_ref() {
+    Some(_) => connection_active_used_by_exports(
+      connection,
+      runtime,
+      module_graph,
+      exports_info_artifact,
+      dependency.used_by_exports.as_ref(),
+    ),
+    None => true,
+  };
+
+  active_by_used_exports
+    && connection_active_inline_value_for_esm_import_specifier(
+      dependency,
+      connection,
+      runtime,
+      module_graph,
+      exports_info_artifact,
+    )
+}
+
 impl DependencyConditionFn for ESMImportSpecifierDependencyCondition {
   fn is_connection_active(
     &self,
@@ -775,38 +813,13 @@ impl DependencyConditionFn for ESMImportSpecifierDependencyCondition {
     let dependency = dependency
       .downcast_ref::<ESMImportSpecifierDependency>()
       .expect("should be ESMImportSpecifierDependency");
-    match dependency.used_by_exports.as_ref() {
-      Some(used_by_exports)
-        if matches!(
-          used_by_exports.condition,
-          UsedByExportsCondition::Bool(false)
-        ) && used_by_exports.deferred_pure_checks.is_empty() =>
-      {
-        false
-      }
-      None => connection_active_inline_value_for_esm_import_specifier(
-        dependency,
-        connection,
-        runtime,
-        module_graph,
-        exports_info_artifact,
-      ),
-      Some(_) => {
-        connection_active_used_by_exports(
-          connection,
-          runtime,
-          module_graph,
-          exports_info_artifact,
-          dependency.used_by_exports.as_ref(),
-        ) && connection_active_inline_value_for_esm_import_specifier(
-          dependency,
-          connection,
-          runtime,
-          module_graph,
-          exports_info_artifact,
-        )
-      }
-    }
+    connection_active_for_esm_import_specifier(
+      dependency,
+      connection,
+      runtime,
+      module_graph,
+      exports_info_artifact,
+    )
   }
 
   fn get_connection_state(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/mod.rs
@@ -1,11 +1,74 @@
 use rspack_core::{
-  Compilation, ExportsInfoArtifact, GetTargetResult, ModuleGraph, ModuleGraphConnection,
-  ModuleIdentifier, ResolvedExportInfoTarget, RuntimeCondition, RuntimeSpec, UsageState,
-  UsedByExports, UsedByExportsCondition, filter_runtime, get_target,
+  Compilation, DependencyId, ExportsInfoArtifact, GetTargetResult, ModuleGraph,
+  ModuleGraphConnection, ModuleIdentifier, ResolvedExportInfoTarget, RuntimeCondition, RuntimeSpec,
+  UsageState, UsedByExports, UsedByExportsCondition, filter_runtime, get_target,
 };
+use swc_atoms::Atom;
 
 pub mod plugin;
 pub mod state;
+
+fn module_has_side_effects_free_export(
+  module_graph: &ModuleGraph,
+  module_identifier: &ModuleIdentifier,
+  atom: &Atom,
+) -> Option<bool> {
+  let module = module_graph.module_by_identifier(module_identifier)?;
+  let side_effects_free = module.build_info().side_effects_free.as_ref()?;
+  Some(side_effects_free.contains(atom))
+}
+
+pub(crate) fn deferred_pure_check_is_impure(
+  module_graph: &ModuleGraph,
+  exports_info_artifact: &ExportsInfoArtifact,
+  dep_id: &DependencyId,
+  atom: &Atom,
+) -> bool {
+  let Some(ref_module) = module_graph.module_identifier_by_dependency_id(dep_id) else {
+    return true;
+  };
+
+  let target_exports_info = exports_info_artifact.get_exports_info_data(ref_module);
+  let target_export_info = target_exports_info.get_export_info_without_mut_module_graph(atom);
+  let resolve_filter = |_: &ResolvedExportInfoTarget| true;
+
+  let (ref_module_id, resolved_atom) = if let Some(GetTargetResult::Target(target)) = get_target(
+    &target_export_info,
+    module_graph,
+    exports_info_artifact,
+    &resolve_filter,
+    &mut Default::default(),
+  ) {
+    let atom = if target.module == *ref_module {
+      Some(atom.clone())
+    } else {
+      target
+        .export
+        .as_ref()
+        .and_then(|export| export.first().cloned())
+    };
+    (target.module, atom)
+  } else {
+    (*ref_module, Some(atom.clone()))
+  };
+
+  if let Some(resolved_atom) = resolved_atom.as_ref()
+    && let Some(side_effects_free) =
+      module_has_side_effects_free_export(module_graph, &ref_module_id, resolved_atom)
+  {
+    return !side_effects_free;
+  }
+
+  if let Some(resolved_module) = module_graph.get_resolved_module(dep_id)
+    && resolved_module != &ref_module_id
+    && let Some(side_effects_free) =
+      module_has_side_effects_free_export(module_graph, resolved_module, atom)
+  {
+    return !side_effects_free;
+  }
+
+  true
+}
 
 pub(crate) fn has_impure_deferred_pure_checks(
   module_graph: &ModuleGraph,
@@ -13,49 +76,15 @@ pub(crate) fn has_impure_deferred_pure_checks(
   used_by_exports: &UsedByExports,
 ) -> bool {
   used_by_exports
-    .deferred_pure_checks
+    .deferred_pure_checks()
     .iter()
     .any(|deferred_check| {
-      let Some(ref_module) =
-        module_graph.module_identifier_by_dependency_id(&deferred_check.dep_id)
-      else {
-        return true;
-      };
-
-      let target_exports_info = exports_info_artifact.get_exports_info_data(ref_module);
-      let target_export_info =
-        target_exports_info.get_export_info_without_mut_module_graph(&deferred_check.atom);
-      let resolve_filter = |_: &ResolvedExportInfoTarget| true;
-
-      let (ref_module_id, atom) = if let Some(GetTargetResult::Target(target)) = get_target(
-        &target_export_info,
+      deferred_pure_check_is_impure(
         module_graph,
         exports_info_artifact,
-        &resolve_filter,
-        &mut Default::default(),
-      ) {
-        let atom = if target.module == *ref_module {
-          deferred_check.atom.clone()
-        } else {
-          target
-            .export
-            .as_ref()
-            .and_then(|export| export.first().cloned())
-            .unwrap_or_else(|| deferred_check.atom.clone())
-        };
-        (target.module, atom)
-      } else {
-        (*ref_module, deferred_check.atom.clone())
-      };
-
-      let Some(ref_module) = module_graph.module_by_identifier(&ref_module_id) else {
-        return true;
-      };
-      let Some(side_effects_free) = &ref_module.build_info().side_effects_free else {
-        return true;
-      };
-
-      !side_effects_free.contains(&atom)
+        &deferred_check.dep_id,
+        &deferred_check.atom,
+      )
     })
 }
 
@@ -77,7 +106,7 @@ pub(crate) fn runtime_condition_used_by_exports(
     return RuntimeCondition::Boolean(true);
   }
 
-  match &used_by_exports.condition {
+  match used_by_exports.condition() {
     UsedByExportsCondition::Bool(used) => RuntimeCondition::Boolean(*used),
     UsedByExportsCondition::Set(used_by_exports) => {
       let exports_info = compilation
@@ -109,7 +138,7 @@ pub fn connection_active_used_by_exports(
   if has_impure_deferred_pure_checks(mg, exports_info_artifact, used_by_exports) {
     return true;
   }
-  let used_by_exports = match &used_by_exports.condition {
+  let used_by_exports = match used_by_exports.condition() {
     UsedByExportsCondition::Set(used_by_exports) => used_by_exports,
     UsedByExportsCondition::Bool(used) => return *used,
   };

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -64,7 +64,10 @@ pub(crate) use self::{
   import_parser_plugin::{ImportParserPlugin, ImportsReferencesState},
   initialize_evaluating::InitializeEvaluating,
   inline_const::{ConstValue, ConstValuePlugin},
-  inner_graph::{connection_active_used_by_exports, plugin::*, runtime_condition_used_by_exports},
+  inner_graph::{
+    connection_active_used_by_exports, deferred_pure_check_is_impure,
+    has_impure_deferred_pure_checks, plugin::*, runtime_condition_used_by_exports,
+  },
   is_included_plugin::IsIncludedPlugin,
   javascript_meta_info_plugin::JavascriptMetaInfoPlugin,
   node_stuff_plugin::NodeStuffPlugin,

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -21,7 +21,7 @@ use sugar_path::SugarPath;
 use swc_experimental_ecma_ast::{ClassMember, Key, PropName};
 
 use crate::{
-  FLAG_DEPENDENCY_EXPORTS_STAGE,
+  FLAG_DEPENDENCY_EXPORTS_STAGE, deferred_pure_check_is_impure,
   dependency::{ESMExportImportedSpecifierDependency, ESMImportSpecifierDependency},
 };
 
@@ -199,47 +199,12 @@ async fn finish_modules(
         .deferred_pure_checks
         .iter()
         .any(|deferred_check| {
-          let Some(ref_module) =
-            module_graph.module_identifier_by_dependency_id(&deferred_check.dep_id)
-          else {
-            return true;
-          };
-
-          let target_exports_info = exports_info_artifact
-            .get_exports_info_data(ref_module);
-          let target_export_info =
-            target_exports_info.get_export_info_without_mut_module_graph(&deferred_check.atom);
-          let resolve_filter = |_: &ResolvedExportInfoTarget| true;
-
-          let (ref_module_id, atom) = if let Some(GetTargetResult::Target(target)) = get_target(
-            &target_export_info,
+          deferred_pure_check_is_impure(
             module_graph,
             exports_info_artifact,
-            &resolve_filter,
-            &mut Default::default(),
-          ) {
-            let atom = if target.module == *ref_module {
-              deferred_check.atom.clone()
-            } else {
-              target
-                .export
-                .as_ref()
-                .and_then(|export| export.first().cloned())
-                .unwrap_or_else(|| deferred_check.atom.clone())
-            };
-            (target.module, atom)
-          } else {
-            (*ref_module, deferred_check.atom.clone())
-          };
-
-          let ref_module = module_graph
-            .module_by_identifier(&ref_module_id)
-            .expect("should have module");
-
-          let Some(side_effects_free) = &ref_module.build_info().side_effects_free else {
-            return true;
-          };
-          !side_effects_free.contains(&atom)
+            &deferred_check.dep_id,
+            &deferred_check.atom,
+          )
         });
 
     deferred_side_effect_states.push((

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/factories.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/factories.js
@@ -1,0 +1,13 @@
+import { deepMerge } from "./merge";
+
+export function reducerFactory(prefix) {
+	return state => deepMerge(state, { type: prefix });
+}
+
+export function actionFactory(prefix) {
+	globalThis.__pureFunctionsSeveredExportActionFactoryCalls =
+		(globalThis.__pureFunctionsSeveredExportActionFactoryCalls || 0) + 1;
+	return bucket => ({ type: prefix, bucket });
+}
+
+export const pureDrop = () => "SHOULD_BE_DROPPED";

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/index.js
@@ -1,0 +1,29 @@
+import { reducerFactory } from "./factories";
+import { storeReducers } from "./store";
+const fs = require("fs");
+
+const pagePromise = import("./page").then(module => module.default());
+globalThis.__pureFunctionsSeveredExport = {
+	storeReducers,
+	reducerFactory
+};
+
+it("should keep imported pure callee while a retained initializer still calls it", async () => {
+	const page = await pagePromise;
+	const { storeReducers, reducerFactory } =
+		globalThis.__pureFunctionsSeveredExport;
+
+	expect(page).toBe("page");
+	expect(storeReducers.store({ value: 1 })).toEqual({
+		value: 1,
+		type: "Store/MERGE"
+	});
+	expect(globalThis.__pureFunctionsSeveredExportActionFactoryCalls).toBe(1);
+	expect(typeof reducerFactory).toBe("function");
+
+	const source = fs.readFileSync(__filename, "utf-8");
+	const severedCallee = ["undefined", '("Store/MERGE")'].join("");
+	const retainedPureDropImport = ["/* ", ".pureDrop", " */"].join("");
+	expect(source).not.toContain(severedCallee);
+	expect(source).not.toContain(retainedPureDropImport);
+});

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/merge.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/merge.js
@@ -1,0 +1,3 @@
+export function deepMerge(state, bucket) {
+	return { ...state, ...bucket };
+}

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/page.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/page.js
@@ -1,0 +1,9 @@
+import { mergeStore } from "./store";
+
+export function setup() {
+	return mergeStore({});
+}
+
+export default function render() {
+	return "page";
+}

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/rspack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  optimization: {
+    innerGraph: true,
+    minimize: false,
+    sideEffects: true,
+    usedExports: true,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/store.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-severed-export/store.js
@@ -1,0 +1,10 @@
+import { actionFactory, reducerFactory } from "./factories";
+import { pureDrop } from "./factories";
+
+export const mergeStore = actionFactory("Store/MERGE");
+
+export const droppedPure = pureDrop();
+
+export const storeReducers = {
+	store: reducerFactory("Store/MERGE")
+};


### PR DESCRIPTION
## Summary

Fixes a `experiments.pureFunctions` tree-shaking case where an imported callee could be rendered as `undefined` even though a retained top-level initializer still calls it.

Deferred pure checks now share one resolver for `usedExports` connection checks and side-effects analysis. The resolver keeps deferred pure callees active only when the referenced export resolves impure, and it falls back to the original resolved module when module concatenation redirects the dependency to a module without per-export side-effect metadata.

The regression also covers an unused pure helper imported from the same shared module, so pure deferred imports are not retained just because another export from that module is active.

## Related links

Closes #14387

## Validation

- `pnpm run build:js`
- `pnpm run build:binding:dev`
- `cargo fmt --all --check`
- `git diff --check`
- `pnpm --dir tests/rspack-test run test -t "configCases/tree-shaking/pure-functions-severed-export"`
- `pnpm --dir tests/rspack-test run test -t "configCases/tree-shaking"`
- External repro from #14387 compiled and ran with the local binding

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).