### PR TITLE
chore(deps): bump swc_ecma_minifier to 55.0.2 for template-literal minify fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5878,9 +5878,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebd5f732c45e88fa1c69cf2ac65bf24e2578bfd428b74348d3346ee137b8c50"
+checksum = "353daaf5e6c2ad90efd4ff52270173074ded88fdba5a40f302c7c3a9b1c037fb"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -6020,9 +6020,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "28.0.0"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b560623690970aeae3446dda6a7074d07df48a60c3eaf159d087d8f5bd8f437c"
+checksum = "974430a6e2668306f87bb83d8603447d7616da1c84270409e9b463ea613cb38a"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6276,9 +6276,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "55.0.0"
+version = "55.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b40292b19844721cc4087351cb984947902160ec04455a51719925a71778f9"
+checksum = "bdf85a4040114f7f2397d57e1d6993fe013f3ad6ba42d4e8af4f2c834c8a9ab9"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -6312,9 +6312,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "41.0.0"
+version = "41.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303c2e32df97d5d4f2f3fc35dab367ff676668786a0d3ad496cefb0357b0bbb1"
+checksum = "dbde2c4c9378d2c0a3f6d041c4071072b5bb791d02d7f8c89b1e900459bfb7bb"
 dependencies = [
  "bitflags 2.11.1",
  "either",
@@ -6475,9 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "44.0.1"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa49dce90ef0c68177e3515f7ecf93db32a96182c9f9264f1ee4193c17aef3b"
+checksum = "6943187aa25fa8639cee16ff2746c4ec6b768c4d3db0be7f6989c042f9d25593"
 dependencies = [
  "better_scoped_tls",
  "indexmap",


### PR DESCRIPTION
## Summary

Bumps **`swc_ecma_minifier` 55.0.0 → 55.0.2** in `Cargo.lock`, which pulls the template-literal minification fix from swc-project/swc#11939. rspack's minify path (`rspack_javascript_compiler`) depends on `swc_ecma_minifier` directly, so this is sufficient — no `swc_core` facade bump needed (that would also drag in 68.1.x's react-compiler crates).

Also bumps the shared swc crates required by 55.0.2 to their compatible patch versions: `swc_common` 23.0.1, `swc_ecma_codegen` 28.0.1, `swc_ecma_parser` 41.1.0, `swc_ecma_transforms_base` 44.0.2. **Lock-only** — no `Cargo.toml` changes (all within existing `^` ranges).

## The bug it fixes

The SWC minifier drops a character when constant-folding the `+`-concatenation of two template literals that each contain an interpolation. `concat_tpl` merged the boundary quasis' `raw` but left `cooked` stale, and downstream passes evaluate the template to a string via `cooked`.

Repro on current rspack (`swc_ecma_minifier` 55.0.0) — a production build minifying:

```js
const html = `<b>${1}</b>` + `<i>${2}</i>`;
```

emits:

```js
const html = "<b>1<i>2</i>";   // wrong — the `</b>` is dropped (expected "<b>1</b><i>2</i>")
```

Fixed in `swc_ecma_minifier` 55.0.2.

Upstream fix: https://github.com/swc-project/swc/pull/11939
