### PR TITLE
chore: speed up crate release pipeline

### DIFF
--- a/.github/workflows/reusable-release-crates.yml
+++ b/.github/workflows/reusable-release-crates.yml
@@ -61,7 +61,6 @@ jobs:
         id: auth
 
       - name: Publish Crates
-        # Pass the token via CARGO_REGISTRY_TOKEN env instead of `--token`, which cargo deprecated.
         run: |
           ./x crate-publish ${{ inputs.dry_run && '--dry-run' || '' }} ${{ inputs.push_tags && '--push-tags' || '' }}
         env:

--- a/.github/workflows/reusable-release-crates.yml
+++ b/.github/workflows/reusable-release-crates.yml
@@ -61,7 +61,8 @@ jobs:
         id: auth
 
       - name: Publish Crates
+        # Pass the token via CARGO_REGISTRY_TOKEN env instead of `--token`, which cargo deprecated.
         run: |
-          ./x crate-publish --token $CARGO_REGISTRY_TOKEN ${{ inputs.dry_run && '--dry-run' || '' }} ${{ inputs.push_tags && '--push-tags' || '' }}
+          ./x crate-publish ${{ inputs.dry_run && '--dry-run' || '' }} ${{ inputs.push_tags && '--push-tags' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run Cargo Check (separated strategy)
         if: ${{ inputs.cargo-check-strategy == 'separated' }}
-        run: cargo workspaces exec cargo check --all-targets --locked
+        run: cargo workspaces exec --ignore-private cargo check --lib --locked
 
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --tests -- -D warnings

--- a/crates/swc_plugin_ts_collector/Cargo.toml
+++ b/crates/swc_plugin_ts_collector/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 
 [dependencies]
 rustc-hash = { workspace = true }
-swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit", "ecma_parser"] }
+swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit", "ecma_parser", "ecma_utils"] }
 
 [dev-dependencies]
 glob                       = "0.3.3"

--- a/x.mjs
+++ b/x.mjs
@@ -279,8 +279,6 @@ program
       'workspaces',
       'publish',
       '--publish-as-is', // Publish crates from the current commit without versioning
-      '--publish-interval', // Number of seconds to wait between publish attempts
-      '5', // 5 seconds to wait between publish attempts to make sure the previous crate is published
       '--no-remove-dev-deps', // Do not remove dev-dependencies from `Cargo.lock`, otherwise the `Cargo.toml` will be updated and dirty check will fail
       '--no-verify', // Skip verification of the workspace. This was pre-checked by `release-crates.yml` with `cargo check` with `separated` strategy
       // Commented `--locked` flag


### PR DESCRIPTION
Speed up and clean up the crate release pipeline.

## 1. Drop redundant `--publish-interval 5` (publish job)

The publish step spends most of its time sleeping. Measured from a recent release run (91 crates, publish step = 969s / 87% of the job):

| phase | total | per crate |
|---|---|---|
| **artificial sleep (`--publish-interval 5`)** | **456s (~47%)** | 5.3s |
| real work (package + upload + cargo wait-for-index) | 414s | 4.8s |
| inter-crate overhead | 96s | 1.1s |

The interval was meant to "make sure the previous crate is published", but cargo already guarantees this — each crate logs `waiting for ... to be available at registry` before `Published`. That is cargo's built-in wait-for-publish (default since 1.66): it blocks until the just-published version is visible in the index. So the extra 5s sleep is redundant.

**Before:** publish step ~16min. **After:** ~8.5min expected.

> `--dry-run` does not exercise the crates.io rate limiter, so validate on a real nightly/canary publish. If a limit is ever hit, set the interval to `1`–`2` rather than reverting to `5`.

## 2. Drop deprecated `cargo publish --token` (publish job)

Every crate currently logs `warning: \`cargo publish --token\` is deprecated...`. The workflow already exports `CARGO_REGISTRY_TOKEN`, which cargo reads automatically, so we stop forwarding `--token`. Same auth, no warning.

## 3. Release "separated" check: only check publishable crate libs

The release gate runs `cargo workspaces exec cargo check --all-targets` per crate — the longest job in the whole release path (separated check = 961s / 16min).

For a *publish-readiness* gate this is wasteful: `--all-targets` compiles tests/benches/examples (only the **library** is published), and it also runs on the 7 `publish = false` packages (incl. `rspack_benchmark` with its heavy criterion graph, `rspack_node`, `xtask`).

Changed to `cargo workspaces exec --ignore-private cargo check --lib --locked` → checks exactly the published surface. Daily CI (`ci-rust.yaml`, `all` strategy) keeps `--all-targets`, so test/bench compilation is still covered on every PR.

Verified locally: all 86 publishable crates pass `cargo check --lib` after change 4 below.

## 4. `rspack_swc_plugin_ts_collector`: declare `ecma_utils` feature

The lib uses `swc_core::ecma::utils::number::ToJsString` but only declared `["common", "ecma_ast", "ecma_visit", "ecma_parser"]`. It compiled only because a dev-dependency (`rspack_javascript_compiler`) enabled `ecma_utils` on the shared `swc_core` under `--all-targets`. With lib-only (change 3) the feature is no longer pulled in transitively, exposing the latent missing declaration. Added `ecma_utils` — the correct, self-contained fix (Cargo.lock unchanged).
