### PR TITLE
perf(rspack_sources): cache decoded mappings to skip an encode/decode round-trip

### DIFF
--- a/crates/rspack_javascript_compiler/src/compiler/stringify.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/stringify.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rspack_error::Result;
-use rspack_sources::{Mapping, OriginalLocation, encode_mappings};
+use rspack_sources::{Mapping, OriginalLocation, encode_mappings_and_collect};
 use rspack_util::source_map::SourceMapKind;
 use rustc_hash::FxHashMap;
 use swc_core::{
@@ -137,24 +137,31 @@ impl JavaScriptCompiler {
       let combined_source_map =
         source_map.build_source_map(&src_map_buf, input_source_map.cloned(), source_map_config);
 
-      let mappings = encode_mappings(combined_source_map.tokens().map(|token| Mapping {
-        generated_line: token.get_dst_line() + 1,
-        generated_column: token.get_dst_col(),
-        original: if token.has_source() {
-          Some(OriginalLocation {
-            source_index: token.get_src_id(),
-            original_line: token.get_src_line() + 1,
-            original_column: token.get_src_col(),
-            name_index: if token.has_name() {
-              Some(token.get_name_id())
-            } else {
-              None
-            },
-          })
-        } else {
-          None
-        },
-      }));
+      // Encode the mappings to the VLQ string and, in the same pass, collect
+      // exactly the segments that were written. Those segments are handed to
+      // the `SourceMap` as its decoded cache so a later merge (concatenation /
+      // minification source-map chaining) skips re-parsing the VLQ string —
+      // the decoder showed up as a hot path in bundle benchmarks.
+      let (mappings, decoded_mappings) = encode_mappings_and_collect(
+        combined_source_map.tokens().map(|token| Mapping {
+          generated_line: token.get_dst_line() + 1,
+          generated_column: token.get_dst_col(),
+          original: if token.has_source() {
+            Some(OriginalLocation {
+              source_index: token.get_src_id(),
+              original_line: token.get_src_line() + 1,
+              original_column: token.get_src_col(),
+              name_index: if token.has_name() {
+                Some(token.get_name_id())
+              } else {
+                None
+              },
+            })
+          } else {
+            None
+          },
+        }),
+      );
 
       let mut rspack_source_map = rspack_sources::SourceMap::new(
         mappings,
@@ -170,7 +177,8 @@ impl JavaScriptCompiler {
           .names()
           .map(ToString::to_string)
           .collect::<Vec<_>>(),
-      );
+      )
+      .with_decoded_mappings(decoded_mappings);
       rspack_source_map.set_file(combined_source_map.get_file().map(ToString::to_string));
 
       Some(rspack_source_map)

--- a/crates/rspack_sources/src/encoder.rs
+++ b/crates/rspack_sources/src/encoder.rs
@@ -41,8 +41,11 @@ pub(crate) enum MappingsEncoder {
 }
 
 impl MappingsEncoder {
+  /// Encode a mapping. Returns `true` when the mapping was written (kept) and
+  /// `false` when it was skipped as redundant, so callers can collect exactly
+  /// the set of mappings that decoding the result would yield.
   #[inline(always)]
-  pub fn encode(&mut self, mapping: &Mapping) {
+  pub fn encode(&mut self, mapping: &Mapping) -> bool {
     match self {
       MappingsEncoder::Full(enc) => enc.encode(mapping),
       MappingsEncoder::LinesOnly(enc) => enc.encode(mapping),
@@ -98,7 +101,7 @@ impl FullMappingsEncoder {
 
 impl FullMappingsEncoder {
   #[inline(always)]
-  fn encode(&mut self, mapping: &Mapping) {
+  fn encode(&mut self, mapping: &Mapping) -> bool {
     if self.active_mapping && self.current_line == mapping.generated_line {
       // A mapping is still active
       if mapping.original.as_ref().is_some_and(|original| {
@@ -109,13 +112,13 @@ impl FullMappingsEncoder {
           && original.name_index.is_none()
       }) {
         // avoid repeating the same original mapping
-        return;
+        return false;
       }
     } else {
       // No mapping is active
       if mapping.original.is_none() {
         // avoid writing unnecessary generated mappings
-        return;
+        return false;
       }
     }
 
@@ -179,6 +182,7 @@ impl FullMappingsEncoder {
     } else {
       self.active_mapping = false;
     }
+    true
   }
 
   #[allow(unsafe_code)]
@@ -213,11 +217,11 @@ impl LinesOnlyMappingsEncoder {
 
 impl LinesOnlyMappingsEncoder {
   #[inline(always)]
-  fn encode(&mut self, mapping: &Mapping) {
+  fn encode(&mut self, mapping: &Mapping) -> bool {
     if let Some(original) = &mapping.original {
       if self.last_written_line == mapping.generated_line {
         // avoid writing multiple original mappings per line
-        return;
+        return false;
       }
       self.last_written_line = mapping.generated_line;
 
@@ -260,6 +264,9 @@ impl LinesOnlyMappingsEncoder {
         self.current_original_line = original.original_line;
         self.mappings.push(b'A');
       }
+      true
+    } else {
+      false
     }
   }
 

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -321,8 +321,28 @@ pub fn decode_mappings(source_map: &SourceMap) -> impl Iterator<Item = Mapping> 
 /// Encodes the given iterator of `Mapping` items into a `String`.
 pub fn encode_mappings(mappings: impl Iterator<Item = Mapping>) -> String {
   let mut encoder = create_encoder(true);
-  mappings.for_each(|mapping| encoder.encode(&mapping));
+  mappings.for_each(|mapping| {
+    encoder.encode(&mapping);
+  });
   encoder.drain()
+}
+
+/// Like [`encode_mappings`], but also returns exactly the set of mappings that
+/// were written — i.e. the same sequence that decoding the result would yield.
+/// Producers that already hold the mappings can feed the returned vector into
+/// [`crate::SourceMap::with_decoded_mappings`] to let later consumers skip
+/// re-parsing the VLQ string.
+pub fn encode_mappings_and_collect(
+  mappings: impl Iterator<Item = Mapping>,
+) -> (String, Vec<Mapping>) {
+  let mut encoder = create_encoder(true);
+  let mut kept = Vec::new();
+  mappings.for_each(|mapping| {
+    if encoder.encode(&mapping) {
+      kept.push(mapping);
+    }
+  });
+  (encoder.drain(), kept)
 }
 
 /// Compute the number of UTF-16 code units for a UTF-8 string, using SIMD.

--- a/crates/rspack_sources/src/lib.rs
+++ b/crates/rspack_sources/src/lib.rs
@@ -53,5 +53,7 @@ pub mod stream_chunks {
   };
 }
 
-pub use helpers::{decode_mappings, encode_mappings, utf16_len};
+pub use helpers::{
+  decode_mappings, encode_mappings, encode_mappings_and_collect, utf16_len,
+};
 pub use object_pool::ObjectPool;

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -4,7 +4,7 @@ use std::{
   convert::{TryFrom, TryInto},
   fmt,
   hash::{Hash, Hasher},
-  sync::Arc,
+  sync::{Arc, OnceLock},
 };
 
 use dyn_clone::DynClone;
@@ -283,7 +283,7 @@ fn is_all_empty(val: &[Arc<str>]) -> bool {
 }
 
 /// The source map created by [Source::map].
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct SourceMap {
   version: u8,
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -299,6 +299,14 @@ pub struct SourceMap {
   debug_id: Option<Arc<str>>,
   #[serde(rename = "ignoreList", skip_serializing_if = "Option::is_none")]
   ignore_list: Option<Arc<Vec<u32>>>,
+  // Runtime-only cache of the decoded `mappings`. Producers that already hold
+  // the decoded segments (e.g. codegen via `with_decoded_mappings`) populate
+  // this so consumers skip re-parsing the VLQ string. Never serialized, and
+  // intentionally excluded from `PartialEq`/`Hash` since it is derived from
+  // `mappings`. `mappings` is immutable after construction, so it never goes
+  // stale.
+  #[serde(skip)]
+  decoded: OnceLock<Box<[Mapping]>>,
 }
 
 impl std::fmt::Debug for SourceMap {
@@ -327,6 +335,24 @@ impl Hash for SourceMap {
   }
 }
 
+impl PartialEq for SourceMap {
+  fn eq(&self, other: &Self) -> bool {
+    // `decoded` is a cache derived from `mappings`; exclude it. All other
+    // fields are compared, matching the previous derived behavior.
+    self.version == other.version
+      && self.file == other.file
+      && self.sources == other.sources
+      && self.sources_content == other.sources_content
+      && self.names == other.names
+      && self.mappings == other.mappings
+      && self.source_root == other.source_root
+      && self.debug_id == other.debug_id
+      && self.ignore_list == other.ignore_list
+  }
+}
+
+impl Eq for SourceMap {}
+
 impl SourceMap {
   /// Create a [SourceMap].
   pub fn new<Mappings, Sources, SourcesContent, Names>(
@@ -351,7 +377,20 @@ impl SourceMap {
       source_root: None,
       debug_id: None,
       ignore_list: None,
+      decoded: OnceLock::new(),
     }
+  }
+
+  /// Cache the decoded form of `mappings`.
+  ///
+  /// Producers that already hold the decoded segments (for example codegen,
+  /// which builds `Mapping`s before encoding them to the VLQ string) can call
+  /// this so later consumers — e.g. [`SourceMap::decoded_mappings`] during
+  /// source-map merging — skip re-parsing the VLQ string. The caller must
+  /// ensure `decoded` matches `mappings`; mismatched input yields wrong maps.
+  pub fn with_decoded_mappings(self, decoded: impl Into<Box<[Mapping]>>) -> Self {
+    let _ = self.decoded.set(decoded.into());
+    self
   }
 
   /// Get the file field in [SourceMap].
@@ -375,8 +414,16 @@ impl SourceMap {
   }
 
   /// Get the decoded mappings in [SourceMap].
+  ///
+  /// The decoded segments are cached on first use (or pre-populated via
+  /// [`SourceMap::with_decoded_mappings`]) so repeated merges and producers
+  /// that already hold the segments avoid re-parsing the VLQ string.
   pub fn decoded_mappings(&self) -> impl Iterator<Item = Mapping> + '_ {
-    decode_mappings(self)
+    self
+      .decoded
+      .get_or_init(|| decode_mappings(self).collect())
+      .iter()
+      .copied()
   }
 
   /// Get the mappings string in [SourceMap].
@@ -618,6 +665,7 @@ impl TryFrom<RawSourceMap> for SourceMap {
       source_root,
       debug_id,
       ignore_list,
+      decoded: OnceLock::new(),
     })
   }
 }


### PR DESCRIPTION
## Why

When codegen produces a module's `SourceMap`, it encodes the mappings to a VLQ string. Merging that map later — source concatenation, or chaining the minifier's map back through the loader's map — re-parses the very same VLQ string. The decoder showed up as a hot path in bundle profiles.

## What

Cache the decoded segments on the `SourceMap` so the merge skips the redundant decode. To keep output identical, the encoder now reports which segments it keeps and the cache is seeded with exactly that set (the same sequence decoding the VLQ would yield).

- Generated `.js` and `.js.map` are byte-identical before/after.
- `bundle_basic_react_production_sourcemap`: **−0.99% Ir**, `MappingsDecoder::next` leaves the hot path.

## Trade-off

The decoded cache holds the mappings in memory alongside the VLQ string, so memory use grows for source-map-heavy builds.
