### PR TITLE
chore(ci): use forked CodSpeed runner

### DIFF
--- a/.github/workflows/bench-binding.yml
+++ b/.github/workflows/bench-binding.yml
@@ -51,7 +51,7 @@ jobs:
         run: pnpm run build:js
 
       - name: Run benchmark binding
-        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
+        uses: hardfist/action@750625725fb8def914579fc789c6249580c84a95
         timeout-minutes: 30
         env:
           RAYON_NUM_THREADS: 1
@@ -60,4 +60,5 @@ jobs:
           mode: 'simulation'
           run: pnpm --filter bench run bench
           token: ${{ secrets.CODSPEED_TOKEN }}
-          runner-version: 4.13.0
+          runner-version: rev:ddb6dbed2445bd209e7ca83f218c2176967bb1d8
+          skip-hash-check-warning: true

--- a/.github/workflows/bench-binding.yml
+++ b/.github/workflows/bench-binding.yml
@@ -60,5 +60,5 @@ jobs:
           mode: 'simulation'
           run: pnpm --filter bench run bench
           token: ${{ secrets.CODSPEED_TOKEN }}
-          runner-version: rev:ddb6dbed2445bd209e7ca83f218c2176967bb1d8
+          runner-version: rev:2ca934f5a71e0299e0a3941a84ac3b242b3b63b6
           skip-hash-check-warning: true

--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -107,7 +107,7 @@ jobs:
               pnpm run bench:rust
             fi
           token: ${{ secrets.CODSPEED_TOKEN }}
-          runner-version: rev:ddb6dbed2445bd209e7ca83f218c2176967bb1d8
+          runner-version: rev:2ca934f5a71e0299e0a3941a84ac3b242b3b63b6
           skip-hash-check-warning: true
 
       - name: Run benchmark (walltime)
@@ -130,7 +130,7 @@ jobs:
               taskset -c 176-191 pnpm run bench:rust
             fi
           token: ${{ secrets.CODSPEED_TOKEN }}
-          runner-version: rev:ddb6dbed2445bd209e7ca83f218c2176967bb1d8
+          runner-version: rev:2ca934f5a71e0299e0a3941a84ac3b242b3b63b6
           skip-hash-check-warning: true
 
       - name: Prepare Valgrind temporary files artifact

--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run benchmark (simulation)
         if: ${{ inputs.measurement == 'simulation' }}
-        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
+        uses: hardfist/action@750625725fb8def914579fc789c6249580c84a95
         timeout-minutes: 30
         env:
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
@@ -107,11 +107,12 @@ jobs:
               pnpm run bench:rust
             fi
           token: ${{ secrets.CODSPEED_TOKEN }}
-          runner-version: 4.13.0
+          runner-version: rev:ddb6dbed2445bd209e7ca83f218c2176967bb1d8
+          skip-hash-check-warning: true
 
       - name: Run benchmark (walltime)
         if: ${{ inputs.measurement == 'walltime' }}
-        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
+        uses: hardfist/action@750625725fb8def914579fc789c6249580c84a95
         timeout-minutes: 30
         env:
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
@@ -129,7 +130,8 @@ jobs:
               taskset -c 176-191 pnpm run bench:rust
             fi
           token: ${{ secrets.CODSPEED_TOKEN }}
-          runner-version: 4.13.0
+          runner-version: rev:ddb6dbed2445bd209e7ca83f218c2176967bb1d8
+          skip-hash-check-warning: true
 
       - name: Prepare Valgrind temporary files artifact
         if: ${{ always() && inputs.measurement == 'simulation' }}


### PR DESCRIPTION
## Summary

Use a forked CodSpeed action and runner for benchmark workflows so Valgrind collects instruction-only callgrind data.

- `hardfist/codspeed@2ca934f5a71e0299e0a3941a84ac3b242b3b63b6` keeps `--cache-sim=no` and removes the explicit `--I1`, `--D1`, `--LL`, and `--collect-systime=nsec` arguments.
- `hardfist/action@750625725fb8def914579fc789c6249580c84a95` is based on the previously pinned CodSpeed action commit and installs branch/rev runners from `hardfist/codspeed`.
- Rspack Rust and binding benchmark workflows now pin those fork commits.

## Related forks

- CodSpeed runner fork: https://github.com/hardfist/codspeed/tree/rspack-disable-cache-sim
- Runner commit: https://github.com/hardfist/codspeed/commit/2ca934f5a71e0299e0a3941a84ac3b242b3b63b6
- CodSpeed action fork: https://github.com/hardfist/action/tree/rspack-use-forked-codspeed-v4.13.0
- Action commit: https://github.com/hardfist/action/commit/750625725fb8def914579fc789c6249580c84a95

## Why

The persistent cache benchmark investigation showed the reported fluctuation was dominated by Cachegrind cache-miss simulation noise around identical memcpy/string-copy workloads, not by increased instruction count or filesystem syscall time. Removing the cache model arguments avoids collecting cache simulation data for these runs.

## rustc-perf reference

rustc-perf uses Valgrind for profiling in an instruction-only mode:

- `rustc-fake` runs Cachegrind with `--cache-sim=no --branch-sim=no`, and Callgrind with the same flags. Its source comment says that with these flags Cachegrind/Callgrind just collect instruction counts: https://github.com/rust-lang/rustc-perf/blob/master/collector/src/bin/rustc-fake.rs
- Cachegrind output is post-processed as profile artifacts through `cg_annotate` / `cg_diff`; rustc-perf does not persist Cachegrind cache fields like D1/LL miss counts as benchmark metrics: https://github.com/rust-lang/rustc-perf/blob/master/collector/src/utils/cachegrind.rs
- rustc-perf does have a `cache-misses` benchmark metric, but it is collected from Linux `perf stat` hardware counters, not Valgrind cache simulation: https://github.com/rust-lang/rustc-perf/blob/master/collector/src/compile/execute/mod.rs and https://github.com/rust-lang/rustc-perf/blob/master/database/src/metric.rs

## Validation

- Verified both modified workflow YAML files parse successfully.
- Verified the forked runner commit contains `--cache-sim=no` and no longer contains `--I1`, `--D1`, `--LL`, or `--collect-systime=nsec`.
- Verified the forked action commit installs the runner from `https://github.com/hardfist/codspeed` for `branch:` and `rev:` runner versions.
- Ran `cargo fmt --check` in the forked CodSpeed runner checkout.
