### PR TITLE
refactor: remove unused unresolved context from pure checks

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -7,7 +7,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
   AssignExpr, AssignOp, ClassMember, DefaultDecl, Expr, GetSpan, Ident, MemberExpr, ModuleDecl,
-  Pat, Program, ScopeId, Span, ThisExpr, VarDeclarator,
+  Pat, Program, Span, ThisExpr, VarDeclarator,
 };
 
 use super::state::{
@@ -41,22 +41,16 @@ fn class_member_is_static(member: &ClassMember<'_>) -> bool {
 
 #[derive(Debug)]
 pub struct InnerGraphParserPlugin {
-  unresolved_scope_id: ScopeId,
   analyze_pure_annotation: bool,
 }
 
 pub static TOP_LEVEL_SYMBOL: &str = "inner graph top level symbol";
 
 impl InnerGraphParserPlugin {
-  pub fn new(unresolved_scope_id: ScopeId, analyze_pure_annotation: bool) -> Self {
+  pub fn new(analyze_pure_annotation: bool) -> Self {
     Self {
-      unresolved_scope_id,
       analyze_pure_annotation,
     }
-  }
-
-  fn unresolved_context(&self) -> ScopeId {
-    self.unresolved_scope_id
   }
 
   pub fn for_each_expression(parser: &mut JavascriptParser, for_name: &str) {
@@ -444,7 +438,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
         parser,
         self.analyze_pure_annotation,
         class_decl.class(),
-        self.unresolved_context(),
         parser.ast.comments,
         None,
       )
@@ -481,7 +474,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           parser,
           self.analyze_pure_annotation,
           &class_expr.class,
-          self.unresolved_context(),
           parser.ast.comments,
           None,
         )
@@ -496,7 +488,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           parser,
           self.analyze_pure_annotation,
           &fn_expr.function,
-          self.unresolved_context(),
           parser.ast.comments,
           None,
         )
@@ -518,7 +509,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
         parser,
         self.analyze_pure_annotation,
         &default_expr.expr,
-        self.unresolved_context(),
         parser.ast.comments,
         Some(&mut callees),
       )
@@ -568,7 +558,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           parser,
           self.analyze_pure_annotation,
           &init.as_class().expect("should be class").class,
-          self.unresolved_context(),
           parser.ast.comments,
           None,
         )
@@ -583,7 +572,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
         parser,
         self.analyze_pure_annotation,
         init,
-        self.unresolved_context(),
         parser.ast.comments,
         Some(&mut callees),
       ) {
@@ -683,7 +671,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
       parser,
       self.analyze_pure_annotation,
       super_class,
-      self.unresolved_context(),
       parser.ast.comments,
       None,
     );
@@ -772,7 +759,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
       parser,
       self.analyze_pure_annotation,
       element,
-      self.unresolved_context(),
       parser.ast.comments,
       None,
     );

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -11,7 +11,7 @@ use swc_experimental_ecma_ast::{
   ArrayLit, ArrowExpr, BlockStmt, BlockStmtOrExpr, CallExpr, Class, ClassMember, CommentKind,
   Comments, Decl, DefaultDecl, ExportSpecifier, Expr, ExprOrSpread, Function, GetSpan,
   ImportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, ObjectPatProp, Pat, Program, PropName,
-  ScopeId, Span, Span as AstSpan, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
+  Span, Span as AstSpan, Stmt, VarDecl, VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
 };
 use swc_experimental_ecma_utils::{ExprCtx, ExprExt};
 
@@ -26,14 +26,12 @@ static PURE_COMMENTS: LazyLock<regex::Regex> = LazyLock::new(|| {
   regex::Regex::new("(?s)^\\s*(#|@)__PURE__(?:\\s|$)").expect("Should create the regex")
 });
 pub struct SideEffectsParserPlugin {
-  unresolved_scope_id: ScopeId,
   analyze_side_effects_free: bool,
 }
 
 impl SideEffectsParserPlugin {
-  pub fn new(unresolved_scope_id: ScopeId, analyze_side_effects_free: bool) -> Self {
+  pub fn new(analyze_side_effects_free: bool) -> Self {
     Self {
-      unresolved_scope_id,
       analyze_side_effects_free,
     }
   }
@@ -381,7 +379,6 @@ fn try_mark_auto_side_effects_free_var_decl(
   analyze_side_effects_free: bool,
   var_decl: &VarDecl,
   export_name: Option<&Atom>,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   duplicate_names: &FxHashSet<Atom>,
 ) {
@@ -413,16 +410,11 @@ fn try_mark_auto_side_effects_free_var_decl(
         parser,
         analyze_side_effects_free,
         &fn_expr.function,
-        unresolved_ctxt,
         comments,
       ),
-      Some(Expr::Arrow(arrow_expr)) => is_side_effects_free_arrow_body(
-        parser,
-        analyze_side_effects_free,
-        arrow_expr,
-        unresolved_ctxt,
-        comments,
-      ),
+      Some(Expr::Arrow(arrow_expr)) => {
+        is_side_effects_free_arrow_body(parser, analyze_side_effects_free, arrow_expr, comments)
+      }
       _ => false,
     };
 
@@ -436,7 +428,6 @@ fn try_mark_auto_side_effects_free_stmt(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   stmt: &Stmt,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   duplicate_names: &FxHashSet<Atom>,
 ) {
@@ -458,7 +449,6 @@ fn try_mark_auto_side_effects_free_stmt(
           parser,
           analyze_side_effects_free,
           &fn_decl.function,
-          unresolved_ctxt,
           comments,
         ) {
           mark_side_effects_free(parser, &ident, None);
@@ -469,7 +459,6 @@ fn try_mark_auto_side_effects_free_stmt(
         analyze_side_effects_free,
         var_decl,
         None,
-        unresolved_ctxt,
         comments,
         duplicate_names,
       ),
@@ -482,7 +471,6 @@ fn try_mark_auto_side_effects_free_module_decl(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   decl: &ModuleDecl,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   duplicate_names: &FxHashSet<Atom>,
 ) {
@@ -509,7 +497,6 @@ fn try_mark_auto_side_effects_free_module_decl(
         parser,
         analyze_side_effects_free,
         &fn_expr.function,
-        unresolved_ctxt,
         comments,
       ) {
         mark_side_effects_free(parser, &ident, Some(&export_name));
@@ -537,7 +524,6 @@ fn try_mark_auto_side_effects_free_module_decl(
         parser,
         analyze_side_effects_free,
         &fn_expr.function,
-        unresolved_ctxt,
         comments,
       ) {
         mark_side_effects_free(parser, &ident, Some(&export_name));
@@ -561,7 +547,6 @@ fn try_mark_auto_side_effects_free_module_decl(
           parser,
           analyze_side_effects_free,
           &fn_decl.function,
-          unresolved_ctxt,
           comments,
         ) {
           mark_side_effects_free(parser, &compat_atom(&fn_decl.ident.sym), None);
@@ -572,7 +557,6 @@ fn try_mark_auto_side_effects_free_module_decl(
         analyze_side_effects_free,
         var_decl,
         None,
-        unresolved_ctxt,
         comments,
         duplicate_names,
       ),
@@ -586,7 +570,6 @@ fn mark_auto_side_effects_free_program(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   program: &Program,
-  unresolved_scope_id: ScopeId,
   comments: &Comments<'_>,
   duplicate_names: &FxHashSet<Atom>,
 ) {
@@ -598,7 +581,6 @@ fn mark_auto_side_effects_free_program(
             parser,
             analyze_side_effects_free,
             stmt,
-            unresolved_scope_id,
             comments,
             duplicate_names,
           ),
@@ -606,7 +588,6 @@ fn mark_auto_side_effects_free_program(
             parser,
             analyze_side_effects_free,
             decl,
-            unresolved_scope_id,
             comments,
             duplicate_names,
           ),
@@ -619,7 +600,6 @@ fn mark_auto_side_effects_free_program(
           parser,
           analyze_side_effects_free,
           stmt,
-          unresolved_scope_id,
           comments,
           duplicate_names,
         );
@@ -674,7 +654,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           ast,
-          self.unresolved_scope_id,
           parser.ast.comments,
           &duplicate_names,
         );
@@ -704,7 +683,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &expr.expr,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -742,7 +720,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &decl.decl,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -824,7 +801,6 @@ fn is_pure_call_expr(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   expr: &Expr,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -840,7 +816,6 @@ fn is_pure_call_expr(
       parser,
       analyze_side_effects_free,
       call_expr,
-      unresolved_ctxt,
       comments,
       callees,
     );
@@ -856,7 +831,6 @@ fn is_pure_call_expr(
           parser,
           analyze_side_effects_free,
           call_expr,
-          unresolved_ctxt,
           comments,
           callees,
         );
@@ -870,7 +844,6 @@ fn is_pure_call_expr(
           parser,
           analyze_side_effects_free,
           call_expr,
-          unresolved_ctxt,
           comments,
           Some(callees),
         );
@@ -885,7 +858,6 @@ fn is_pure_call_expr(
         parser,
         analyze_side_effects_free,
         call_expr,
-        unresolved_ctxt,
         comments,
         Some(callees),
       );
@@ -900,7 +872,6 @@ fn is_pure_call_args(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   call_expr: &CallExpr,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -912,7 +883,6 @@ fn is_pure_call_args(
       parser,
       analyze_side_effects_free,
       &arg.expr,
-      unresolved_ctxt,
       comments,
       callees.as_deref_mut(),
     ) {
@@ -926,7 +896,6 @@ fn is_pure_array_lit<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   array_lit: &'a ArrayLit,
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -936,7 +905,6 @@ fn is_pure_array_lit<'a>(
         parser,
         analyze_side_effects_free,
         &elem.expr,
-        unresolved_ctxt,
         comments,
         callees.as_deref_mut(),
       )
@@ -1049,7 +1017,6 @@ fn is_pure_new_expr(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   expr: &Expr,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
 ) -> bool {
   let Expr::New(new_expr) = expr else {
@@ -1063,7 +1030,6 @@ fn is_pure_new_expr(
       parser,
       analyze_side_effects_free,
       new_expr.args.as_deref().unwrap_or(&[]),
-      unresolved_ctxt,
       comments,
     )
   }
@@ -1081,21 +1047,13 @@ fn are_pure_args<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   args: &'a [ExprOrSpread],
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
 ) -> bool {
   args.iter().all(|arg| {
     if arg.spread.is_some() {
       false
     } else {
-      is_pure_expression(
-        parser,
-        analyze_side_effects_free,
-        &arg.expr,
-        unresolved_ctxt,
-        comments,
-        None,
-      )
+      is_pure_expression(parser, analyze_side_effects_free, &arg.expr, comments, None)
     }
   })
 }
@@ -1112,7 +1070,6 @@ impl SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &if_stmt.test,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -1130,7 +1087,6 @@ impl SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &while_stmt.test,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -1148,7 +1104,6 @@ impl SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &do_while_stmt.test,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -1168,7 +1123,6 @@ impl SideEffectsParserPlugin {
               parser,
               self.analyze_side_effects_free,
               decl,
-              self.unresolved_scope_id,
               parser.ast.comments,
               Some(&mut callees),
             ),
@@ -1176,7 +1130,6 @@ impl SideEffectsParserPlugin {
               parser,
               self.analyze_side_effects_free,
               expr,
-              self.unresolved_scope_id,
               parser.ast.comments,
               Some(&mut callees),
             ),
@@ -1200,7 +1153,6 @@ impl SideEffectsParserPlugin {
             parser,
             self.analyze_side_effects_free,
             test,
-            self.unresolved_scope_id,
             parser.ast.comments,
             Some(&mut callees),
           ),
@@ -1223,7 +1175,6 @@ impl SideEffectsParserPlugin {
             parser,
             self.analyze_side_effects_free,
             expr,
-            self.unresolved_scope_id,
             parser.ast.comments,
             Some(&mut callees),
           ),
@@ -1245,7 +1196,6 @@ impl SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &expr_stmt.expr,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -1263,7 +1213,6 @@ impl SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           &switch_stmt.discriminant,
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -1281,7 +1230,6 @@ impl SideEffectsParserPlugin {
           parser,
           self.analyze_side_effects_free,
           class_stmt.class(),
-          self.unresolved_scope_id,
           parser.ast.comments,
           Some(&mut callees),
         ) {
@@ -1300,7 +1248,6 @@ impl SideEffectsParserPlugin {
             parser,
             self.analyze_side_effects_free,
             var_decl,
-            self.unresolved_scope_id,
             parser.ast.comments,
             Some(&mut callees),
           ) {
@@ -1364,7 +1311,6 @@ pub fn is_pure_pat<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   pat: &'a Pat,
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1376,7 +1322,6 @@ pub fn is_pure_pat<'a>(
           parser,
           analyze_side_effects_free,
           pat,
-          unresolved_ctxt,
           comments,
           callees.as_deref_mut(),
         ) {
@@ -1387,14 +1332,9 @@ pub fn is_pure_pat<'a>(
     }
     Pat::Rest(_) => true,
     Pat::Invalid(_) | Pat::Assign(_) | Pat::Object(_) => false,
-    Pat::Expr(expr) => is_pure_expression(
-      parser,
-      analyze_side_effects_free,
-      expr,
-      unresolved_ctxt,
-      comments,
-      callees,
-    ),
+    Pat::Expr(expr) => {
+      is_pure_expression(parser, analyze_side_effects_free, expr, comments, callees)
+    }
   }
 }
 
@@ -1407,7 +1347,6 @@ fn is_side_effects_free_var_decl(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   var_decl: &VarDecl,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
 ) -> bool {
   for declarator in &var_decl.decls {
@@ -1416,14 +1355,7 @@ fn is_side_effects_free_var_decl(
     }
 
     if let Some(init) = declarator.init.as_ref()
-      && !is_pure_expression(
-        parser,
-        analyze_side_effects_free,
-        init,
-        unresolved_ctxt,
-        comments,
-        None,
-      )
+      && !is_pure_expression(parser, analyze_side_effects_free, init, comments, None)
     {
       return false;
     }
@@ -1460,7 +1392,6 @@ fn is_side_effects_free_stmt(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   stmt: &Stmt,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
 ) -> bool {
   if !stmt_may_have_side_effects(parser, stmt) {
@@ -1472,28 +1403,17 @@ fn is_side_effects_free_stmt(
       parser,
       analyze_side_effects_free,
       &expr_stmt.expr,
-      unresolved_ctxt,
       comments,
       None,
     ),
-    Stmt::Return(return_stmt) => return_stmt.arg.as_ref().is_none_or(|arg| {
-      is_pure_expression(
-        parser,
-        analyze_side_effects_free,
-        arg,
-        unresolved_ctxt,
-        comments,
-        None,
-      )
-    }),
+    Stmt::Return(return_stmt) => return_stmt
+      .arg
+      .as_ref()
+      .is_none_or(|arg| is_pure_expression(parser, analyze_side_effects_free, arg, comments, None)),
     Stmt::Decl(decl) => match &**decl {
-      Decl::Var(var_decl) => is_side_effects_free_var_decl(
-        parser,
-        analyze_side_effects_free,
-        var_decl,
-        unresolved_ctxt,
-        comments,
-      ),
+      Decl::Var(var_decl) => {
+        is_side_effects_free_var_decl(parser, analyze_side_effects_free, var_decl, comments)
+      }
       _ => false,
     },
     _ => false,
@@ -1505,17 +1425,10 @@ fn is_side_effects_free_block_stmt(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   block_stmt: &BlockStmt,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
 ) -> bool {
   for stmt in &block_stmt.stmts {
-    if !is_side_effects_free_stmt(
-      parser,
-      analyze_side_effects_free,
-      stmt,
-      unresolved_ctxt,
-      comments,
-    ) {
+    if !is_side_effects_free_stmt(parser, analyze_side_effects_free, stmt, comments) {
       return false;
     }
   }
@@ -1528,7 +1441,6 @@ fn is_side_effects_free_function_body(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   function: &Function,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
 ) -> bool {
   if !function
@@ -1540,13 +1452,7 @@ fn is_side_effects_free_function_body(
   }
 
   function.body.as_ref().is_none_or(|body| {
-    is_side_effects_free_block_stmt(
-      parser,
-      analyze_side_effects_free,
-      body,
-      unresolved_ctxt,
-      comments,
-    )
+    is_side_effects_free_block_stmt(parser, analyze_side_effects_free, body, comments)
   })
 }
 
@@ -1555,7 +1461,6 @@ fn is_side_effects_free_arrow_body(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   arrow_expr: &ArrowExpr,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
 ) -> bool {
   if !arrow_expr.params.iter().all(is_side_effects_free_param) {
@@ -1563,21 +1468,12 @@ fn is_side_effects_free_arrow_body(
   }
 
   match &arrow_expr.body {
-    BlockStmtOrExpr::BlockStmt(block_stmt) => is_side_effects_free_block_stmt(
-      parser,
-      analyze_side_effects_free,
-      block_stmt,
-      unresolved_ctxt,
-      comments,
-    ),
-    BlockStmtOrExpr::Expr(expr) => is_pure_expression(
-      parser,
-      analyze_side_effects_free,
-      expr,
-      unresolved_ctxt,
-      comments,
-      None,
-    ),
+    BlockStmtOrExpr::BlockStmt(block_stmt) => {
+      is_side_effects_free_block_stmt(parser, analyze_side_effects_free, block_stmt, comments)
+    }
+    BlockStmtOrExpr::Expr(expr) => {
+      is_pure_expression(parser, analyze_side_effects_free, expr, comments, None)
+    }
   }
 }
 
@@ -1585,7 +1481,6 @@ pub fn is_pure_function<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   function: &'a Function,
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1594,7 +1489,6 @@ pub fn is_pure_function<'a>(
       parser,
       analyze_side_effects_free,
       &param.pat,
-      unresolved_ctxt,
       comments,
       callees.as_deref_mut(),
     ) {
@@ -1609,7 +1503,6 @@ pub fn is_pure_expression<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   expr: &'a Expr,
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
   callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1617,7 +1510,6 @@ pub fn is_pure_expression<'a>(
     parser: &mut JavascriptParser,
     analyze_side_effects_free: bool,
     expr: &'a Expr,
-    unresolved_ctxt: ScopeId,
     comments: &'a Comments<'a>,
     mut callees: Option<&mut Vec<(Atom, Span)>>,
   ) -> bool {
@@ -1630,25 +1522,13 @@ pub fn is_pure_expression<'a>(
         parser,
         analyze_side_effects_free,
         array_lit,
-        unresolved_ctxt,
         comments,
         callees.as_deref_mut(),
       ),
-      Expr::Call(_) => is_pure_call_expr(
-        parser,
-        analyze_side_effects_free,
-        expr,
-        unresolved_ctxt,
-        comments,
-        callees,
-      ),
-      Expr::New(_) => is_pure_new_expr(
-        parser,
-        analyze_side_effects_free,
-        expr,
-        unresolved_ctxt,
-        comments,
-      ),
+      Expr::Call(_) => {
+        is_pure_call_expr(parser, analyze_side_effects_free, expr, comments, callees)
+      }
+      Expr::New(_) => is_pure_new_expr(parser, analyze_side_effects_free, expr, comments),
       Expr::Paren(_) => unreachable!(),
       Expr::Seq(seq_expr) => {
         for expr in &seq_expr.exprs {
@@ -1656,7 +1536,6 @@ pub fn is_pure_expression<'a>(
             parser,
             analyze_side_effects_free,
             expr,
-            unresolved_ctxt,
             comments,
             callees.as_deref_mut(),
           ) {
@@ -1675,14 +1554,7 @@ pub fn is_pure_expression<'a>(
       }
     }
   }
-  _is_pure_expression(
-    parser,
-    analyze_side_effects_free,
-    expr,
-    unresolved_ctxt,
-    comments,
-    callees,
-  )
+  _is_pure_expression(parser, analyze_side_effects_free, expr, comments, callees)
 }
 
 #[inline(never)]
@@ -1690,7 +1562,6 @@ pub fn is_pure_class_member<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   member: &'a ClassMember,
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1702,7 +1573,6 @@ pub fn is_pure_class_member<'a>(
       parser,
       analyze_side_effects_free,
       &computed.expr,
-      unresolved_ctxt,
       comments,
       callees.as_deref_mut(),
     ),
@@ -1723,7 +1593,6 @@ pub fn is_pure_class_member<'a>(
           parser,
           analyze_side_effects_free,
           value,
-          unresolved_ctxt,
           comments,
           callees.as_deref_mut(),
         )
@@ -1733,14 +1602,7 @@ pub fn is_pure_class_member<'a>(
     }
     ClassMember::PrivateProp(prop) => {
       if let Some(ref value) = prop.value {
-        is_pure_expression(
-          parser,
-          analyze_side_effects_free,
-          value,
-          unresolved_ctxt,
-          comments,
-          callees,
-        )
+        is_pure_expression(parser, analyze_side_effects_free, value, comments, callees)
       } else {
         true
       }
@@ -1760,7 +1622,6 @@ pub fn is_pure_decl(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   stmt: &Decl,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1769,19 +1630,11 @@ pub fn is_pure_decl(
       parser,
       analyze_side_effects_free,
       &class.class,
-      unresolved_ctxt,
       comments,
       callees,
     ),
     Decl::Fn(_) => true,
-    Decl::Var(var) => is_pure_var_decl(
-      parser,
-      analyze_side_effects_free,
-      var,
-      unresolved_ctxt,
-      comments,
-      callees,
-    ),
+    Decl::Var(var) => is_pure_var_decl(parser, analyze_side_effects_free, var, comments, callees),
     Decl::Using(_) => false,
   }
 }
@@ -1791,7 +1644,6 @@ pub fn is_pure_class(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   class: &Class,
-  unresolved_ctxt: ScopeId,
   comments: &Comments<'_>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1800,7 +1652,6 @@ pub fn is_pure_class(
       parser,
       analyze_side_effects_free,
       super_class,
-      unresolved_ctxt,
       comments,
       callees.as_deref_mut(),
     )
@@ -1817,7 +1668,6 @@ pub fn is_pure_class(
         parser,
         analyze_side_effects_free,
         &computed.expr,
-        unresolved_ctxt,
         comments,
         callees,
       ),
@@ -1832,7 +1682,6 @@ pub fn is_pure_class(
         parser,
         analyze_side_effects_free,
         &Expr::PrivateName(method.key.clone_in(parser.ast.allocator)),
-        unresolved_ctxt,
         comments,
         callees.as_deref_mut(),
       ),
@@ -1844,7 +1693,6 @@ pub fn is_pure_class(
                 parser,
                 analyze_side_effects_free,
                 value,
-                unresolved_ctxt,
                 comments,
                 callees.as_deref_mut(),
               )
@@ -1857,7 +1705,6 @@ pub fn is_pure_class(
           parser,
           analyze_side_effects_free,
           &Expr::PrivateName(prop.key.clone_in(parser.ast.allocator)),
-          unresolved_ctxt,
           comments,
           callees.as_deref_mut(),
         ) && (!prop.is_static
@@ -1866,7 +1713,6 @@ pub fn is_pure_class(
               parser,
               analyze_side_effects_free,
               value,
-              unresolved_ctxt,
               comments,
               callees.as_deref_mut(),
             )
@@ -1890,7 +1736,6 @@ fn is_pure_var_decl<'a>(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   var: &'a VarDecl,
-  unresolved_ctxt: ScopeId,
   comments: &'a Comments<'a>,
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
@@ -1900,7 +1745,6 @@ fn is_pure_var_decl<'a>(
         parser,
         analyze_side_effects_free,
         init,
-        unresolved_ctxt,
         comments,
         callees.as_deref_mut(),
       )

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -453,7 +453,6 @@ impl<'parser> JavascriptParser<'parser> {
     let blocks = Vec::with_capacity(64);
     let presentational_dependencies = Vec::with_capacity(64);
     let parser_exports_state: Option<bool> = None;
-    let unresolved_scope_id = ast.semantic.unresolved_scope_id();
 
     let mut plugins: Vec<BoxJavascriptParserPlugin> = Vec::with_capacity(32 + parser_plugins.len());
 
@@ -558,14 +557,12 @@ impl<'parser> JavascriptParser<'parser> {
     )));
     if compiler_options.optimization.inner_graph {
       plugins.push(Box::new(parser_plugin::InnerGraphParserPlugin::new(
-        unresolved_scope_id,
         compiler_options.experiments.pure_functions,
       )));
     }
 
     if compiler_options.optimization.side_effects.is_true() {
       plugins.push(Box::new(parser_plugin::SideEffectsParserPlugin::new(
-        unresolved_scope_id,
         compiler_options.experiments.pure_functions,
       )));
     }


### PR DESCRIPTION
## Summary 
- remove the unused `unresolved_ctxt` parameter from side effects pure-check helpers 
- remove now-unused unresolved scope storage from `SideEffectsParserPlugin` and `InnerGraphParserPlugin` 
- simplify parser plugin construction after the SWC experimental semantic migration

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
