### PR TITLE
feat: bump swc to support react compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1558,6 +1559,158 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "forked_react_compiler"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6970d9da2347af882a10b88480d6b2f44caca55567d85c2b1fa35420b53c1cc"
+dependencies = [
+ "forked_react_compiler_ast",
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_inference",
+ "forked_react_compiler_lowering",
+ "forked_react_compiler_optimization",
+ "forked_react_compiler_reactive_scopes",
+ "forked_react_compiler_ssa",
+ "forked_react_compiler_typeinference",
+ "forked_react_compiler_validation",
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_ast"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f9465a3f9934ef1c1e76bdbab8e70c86b41016a8e7ca1b51fede63e47a6036"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_diagnostics"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e282f5f7b9506e5055758e4ec9857cdc4873e530d3d381d3ecd0d0321e139ec"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "forked_react_compiler_hir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df1312f02a4e7a90686a0fc301fb0dfb58a99cdf53a375922e65b8678dc9df7"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_inference"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd9a5bd84db67b0958c414da69f38184fb60e7a55a63ce9f95b367497939b892"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_lowering",
+ "forked_react_compiler_optimization",
+ "forked_react_compiler_ssa",
+ "forked_react_compiler_utils",
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_lowering"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036e4fb36420ed59df1f20a5bb4ae08b095e8e3e1e1c047b7ca4cb0abebd04d9"
+dependencies = [
+ "forked_react_compiler_ast",
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "indexmap",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_optimization"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ec9f8dfb36bcfab25f3f476ccdada95f55f1071e45d25f4549c7c3395aaffc"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_lowering",
+ "forked_react_compiler_ssa",
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_reactive_scopes"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc54d3b97369ae60549db1d7f792f585920ee451b09946a247cc25087eb384d"
+dependencies = [
+ "forked_react_compiler_ast",
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "hmac",
+ "indexmap",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "forked_react_compiler_ssa"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edcb5fac346f6ad59478ca4b373a930bdc41fd073dccbb10ff69461bdc94423"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_lowering",
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_typeinference"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3191b89198d502e11f624a15086ba54ce2828ede7d56eb2b78650da7aef06c1"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_ssa",
+]
+
+[[package]]
+name = "forked_react_compiler_utils"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005055ef8bfe84dd5f766302bb39fc2d4a361c30abb8a49384d6aff9cc479028"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_validation"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2699f361db2993828d9194af7f6942a8ae746a3688eb5847c70d28da672f4269"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "indexmap",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1871,6 +2024,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hstr"
@@ -5762,6 +5924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "sugar_path"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5804,9 +5972,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "66.0.0"
+version = "66.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9a4605a241c3bf4e178f4d105dc9f7316905db0f94c3081f5072b6ed774366"
+checksum = "bf753a8b097f626faf0d5de24de60399c6e7b64017b2a00fd0885e9e51ebca45"
 dependencies = [
  "anyhow",
  "base64",
@@ -5834,6 +6002,7 @@ dependencies = [
  "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_preset_env",
+ "swc_ecma_react_compiler",
  "swc_ecma_transforms",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
@@ -5974,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "68.0.3"
+version = "68.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e334164098cdc45418500e4cfddfa5a07c8d544cb0288f3354bba749358a0ea"
+checksum = "cbf1cc6ec61c560d1b46eedb3a00945b48dd4d322ee3dfc5871191b9a463fd19"
 dependencies = [
  "par-core",
  "swc",
@@ -6380,6 +6549,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_react_compiler"
+version = "19.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188d56584eeb093e8d8634093ef963e10d53dc729dc92078aab66d93a2ce9ada"
+dependencies = [
+ "forked_react_compiler",
+ "forked_react_compiler_ast",
+ "forked_react_compiler_hir",
+ "indexmap",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_ecma_regexp"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,9 +6651,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "55.0.0"
+version = "55.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff1fb50c523e803c86a603ef7ea7d71f03e1b574d097b4c9a967c01e408dfc9"
+checksum = "57b285782b376bcd243b56b640be8032487f6877d73a2a18f7333a2e1885cabe"
 dependencies = [
  "par-core",
  "swc_common",
@@ -6608,9 +6798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040069bcd652e96d314bee44d544c2235d73ba4d426545d829ee12eb853f38e6"
+checksum = "131de164ae6d7f25b6477346363ae33d533fe972b68c932767dffe216e270154"
 dependencies = [
  "either",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,11 +132,11 @@ rkyv      = { version = "=0.8.16", default-features = false, features = ["std", 
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.9", default-features = false }
-swc                 = { version = "66.0.0", default-features = false }
+swc                 = { version = "66.1.0", default-features = false }
 swc_atoms           = { version = "9.0.3", default-features = false }
 swc_config          = { version = "5.0.0", default-features = false }
-swc_core            = { version = "68.0.3", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "55.0.0", default-features = false }
+swc_core            = { version = "68.1.2", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "55.0.2", default-features = false }
 swc_error_reporters = { version = "25.0.0", default-features = false }
 swc_html            = { version = "35.0.0", default-features = false }
 swc_html_minifier   = { version = "55.0.0", default-features = false }

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "68.0.3"
+  "68.1.2"
 }
 
 /// The version of the JavaScript `@rspack/core` package.

--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -36,7 +36,7 @@
     "@emnapi/runtime": "1.11.1",
     "@napi-rs/wasm-runtime": "1.1.5",
     "@rspack/lite-tapable": "1.1.2",
-    "@swc/types": "0.1.26",
+    "@swc/types": "0.1.27",
     "memfs": "4.57.7",
     "webpack-sources": "3.3.4"
   },

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -48,7 +48,7 @@
     "@rsbuild/plugin-node-polyfill": "^1.4.6",
     "@rslib/core": "^0.22.1",
     "@rspack/lite-tapable": "1.1.2",
-    "@swc/types": "0.1.26",
+    "@swc/types": "0.1.27",
     "@types/node": "^20.19.43",
     "browserslist-load-config": "^1.0.3",
     "browserslist-to-es-version": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,8 +260,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       '@swc/types':
-        specifier: 0.1.26
-        version: 0.1.26
+        specifier: 0.1.27
+        version: 0.1.27
       '@types/node':
         specifier: ^20.19.43
         version: 20.19.43
@@ -317,8 +317,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       '@swc/types':
-        specifier: 0.1.26
-        version: 0.1.26
+        specifier: 0.1.27
+        version: 0.1.27
       memfs:
         specifier: 4.57.7
         version: 4.57.7
@@ -3038,8 +3038,8 @@ packages:
   '@swc/plugin-remove-console@12.9.0':
     resolution: {integrity: sha512-Ve64fWHghdhMHMYAmKlIdyV0aIbj8PX6mlUwXyf1dJXsBirkDm3HYtGw+XIpyNtIUfg1Rojyqc+TXATrqgRdhg==}
 
-  '@swc/types@0.1.26':
-    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
@@ -9391,7 +9391,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/types@0.1.26':
+  '@swc/types@0.1.27':
     dependencies:
       '@swc/counter': 0.1.3
 

--- a/tests/rspack-test/configCases/builtin-swc-loader/react-compiler/index.jsx
+++ b/tests/rspack-test/configCases/builtin-swc-loader/react-compiler/index.jsx
@@ -1,0 +1,10 @@
+function MyApp() {
+  return <div>Hello World</div>;
+}
+
+it("should emit react compiler output with swc-loader", () => {
+  const fs = require("fs");
+  const source = fs.readFileSync(__filename, "utf-8");
+  expect(source).toContain(["react", "compiler-runtime"].join("/"));
+  expect(source).toContain(["react", "memo_cache_sentinel"].join("."));
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/react-compiler/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/react-compiler/rspack.config.js
@@ -1,0 +1,30 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: './index.jsx',
+  mode: 'development',
+  resolve: {
+    extensions: ['...', '.ts', '.tsx', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                reactCompiler: true,
+                react: {
+                  runtime: 'automatic',
+                },
+              },
+            },
+          },
+        },
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};

--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -135,7 +135,7 @@ export default {
 };
 ```
 
-For React 17 and 18 projects, install [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) and set the compiler target:
+For React 17 and 18 projects, set the compiler target:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -101,23 +101,85 @@ React Compiler is an experimental compiler introduced in React 19 that can autom
 
 Before you start using React Compiler, it's recommended to read the [React Compiler documentation](https://react.dev/learn/react-compiler) to understand the functionality, current state, and usage of the React Compiler.
 
-:::tip
-At present, React Compiler only supports Babel compilation, which may slow down the build time.
-:::
-
-### How to use
+### Using `builtin:swc-loader`
 
 The steps to use React Compiler in Rspack:
 
 1. Upgrade versions of `react` and `react-dom` to 19. If you are unable to upgrade, you can install the extra [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) package which will allow the compiled code to run on versions prior to 19.
-2. React Compiler currently only provides a Babel plugin, you need to install:
+2. Enable React Compiler in `builtin:swc-loader` through `jsc.transform.reactCompiler`:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:js|jsx|ts|tsx)$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
+                reactCompiler: true,
+              },
+            },
+          },
+        },
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};
+```
+
+For React 17 and 18 projects, install [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) and set the compiler target:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:js|jsx|ts|tsx)$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
+                reactCompiler: {
+                  target: '18',
+                },
+              },
+            },
+          },
+        },
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};
+```
+
+The `reactCompiler` options are aligned with the React Compiler configuration. For example, you can use [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) to control which functions are compiled. For more options, refer to the official [React Compiler configuration documentation](https://react.dev/reference/react-compiler/configuration).
+
+### Using Babel
+
+You can also use the Babel plugin published by React Compiler. This is useful if you need Babel-specific integration or options that are not available in the SWC transform yet.
+
+To use Babel, install:
 
 - [@babel/core](https://www.npmjs.com/package/@babel/core)
 - [babel-loader](https://www.npmjs.com/package/babel-loader)
 - [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
 - [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
 
-3. Register `babel-loader` in your Rspack config file:
+Register `babel-loader` in your Rspack config file:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -151,7 +213,7 @@ export default {
 };
 ```
 
-4. Create a `babel.config.js` and configure the plugins:
+Create a `babel.config.js` and configure the plugins:
 
 ```js title="babel.config.js"
 const ReactCompilerConfig = {

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -133,7 +133,7 @@ export default {
 };
 ```
 
-对于 React 17 和 18 项目，需要安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，并指定编译目标：
+对于 React 17 和 18 项目，需要指定编译目标：
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -99,23 +99,85 @@ React Compiler 是 React 19 引入的一个实验性编译器，它可以自动�
 
 在开始使用 React Compiler 之前，建议阅读 [React Compiler 文档](https://zh-hans.react.dev/learn/react-compiler)，以了解 React Compiler 的功能、当前状态和使用方法。
 
-:::tip
-React Compiler 目前仅支持 Babel 编译，这会导致构建时间变慢。
-:::
-
-### 如何使用
+### 使用 `builtin:swc-loader`
 
 在 Rspack 中使用 React Compiler 的步骤如下：
 
 1. 升级 `react` 和 `react-dom` 版本到 19。如果你暂时无法升级，可以在 React 17 或 18 项目中安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，以允许编译后的代码在 19 之前的版本上运行。
-2. 目前 React Compiler 仅提供了 Babel 插件，你需要安装：
+2. 通过 `builtin:swc-loader` 的 `jsc.transform.reactCompiler` 启用 React Compiler：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:js|jsx|ts|tsx)$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
+                reactCompiler: true,
+              },
+            },
+          },
+        },
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};
+```
+
+对于 React 17 和 18 项目，需要安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，并指定编译目标：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:js|jsx|ts|tsx)$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
+                reactCompiler: {
+                  target: '18',
+                },
+              },
+            },
+          },
+        },
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};
+```
+
+`reactCompiler` 的选项与 React Compiler 配置对齐。例如，你可以通过 [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) 控制哪些函数会被编译。更多选项请参考官方 [React Compiler 配置说明](https://react.dev/reference/react-compiler/configuration)。
+
+### 使用 Babel
+
+你也可以使用 React Compiler 发布的 Babel 插件。如果你需要 Babel 特有的集成方式，或需要使用 SWC transform 尚未支持的选项，可以选择该方案。
+
+使用 Babel 时，需要安装：
 
 - [@babel/core](https://www.npmjs.com/package/@babel/core)
 - [babel-loader](https://www.npmjs.com/package/babel-loader)
 - [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
 - [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
 
-3. 在你的 Rspack 配置中注册 `babel-loader`：
+在你的 Rspack 配置中注册 `babel-loader`：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -149,7 +211,7 @@ export default {
 };
 ```
 
-4. 创建 `babel.config.js` 并配置插件：
+创建 `babel.config.js` 并配置插件：
 
 ```js title="babel.config.js"
 const ReactCompilerConfig = {


### PR DESCRIPTION
## Summary

This PR enables and documents React Compiler usage through `builtin:swc-loader`.

Changes include:

- Bump SWC-related dependencies and `@swc/types` so `jsc.transform.reactCompiler` is supported by the loader configuration types.
- Add a focused `builtin:swc-loader` config case that verifies React Compiler output is emitted.
- Update React documentation in English and Chinese:
  - Make `builtin:swc-loader` the primary React Compiler setup.
  - Keep the Babel plugin setup as an alternative path.
  - Link to React Compiler official configuration docs for advanced options such as `compilationMode`.

## Testing

```bash
cd tests/rspack-test
pnpm test Config.part1.test.js -t "builtin-swc-loader/react-compiler"
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
