### PR TITLE
chore: limit walltime bench triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
   bench-rust-walltime:
     name: Rust Bench Walltime
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
     uses: ./.github/workflows/bench-rust.yml
     with:
       target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary

Limit the `bench-rust-walltime` CI job so it only runs when CI is triggered manually or after changes are pushed to `main`.

## Why

The walltime benchmark uses the dedicated physical runner and should not run for regular PR, merge queue, or `v1.x` push CI events. Keeping it to manual dispatches and post-merge `main` runs reduces unnecessary benchmark usage while preserving the signal after code lands.

## Validation

- Inspected the workflow diff to confirm only the `bench-rust-walltime` job condition changed.
- Committed through the repository pre-commit hook, which ran prettier on the staged workflow file.