### PR TITLE
docs: add instructions for unsupported platforms

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -34,6 +34,21 @@ You can refer to the following installation guides and choose one runtime:
 
 :::
 
+> [!DETAILS] For unsupported platforms
+> If you are working on an unsupported platform, please manually install the `@rspack/binding-wasm32-wasi` package as a fallback. The WebAssembly (Wasm) build should work on any platform.
+> 
+> Currently supported platforms:
+> - `darwin-arm64`
+> - `darwin-x64`
+> - `linux-arm64-gnu`
+> - `linux-arm64-musl`
+> - `linux-x64-gnu`
+> - `linux-x64-musl`
+> - `win32-arm64-msvc`
+> - `win32-ia32-msvc`
+> - `win32-x64-msvc`
+
+
 ## Create a new project
 
 ### Using Rsbuild

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -36,7 +36,7 @@ You can refer to the following installation guides and choose one runtime:
 
 :::details For unsupported platforms
 
-If you are using a niche platform, Rspack may not provide native support for it. In this case, please manually install `@rspack/binding-wasm32-wasi` as a fallback. The WebAssembly (Wasm) build can run on any platform, so it can be used as a universal fallback.
+If you are using a niche platform, Rspack may not provide native support for it. In this case, please manually install `@rspack/binding-wasm32-wasi` as a fallback. The Wasm build is compatible with most platforms.
 
 Currently supported platforms:
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -34,20 +34,23 @@ You can refer to the following installation guides and choose one runtime:
 
 :::
 
-> [!DETAILS] For unsupported platforms
-> If you are working on an unsupported platform, please manually install the `@rspack/binding-wasm32-wasi` package as a fallback. The WebAssembly (Wasm) build should work on any platform.
-> 
-> Currently supported platforms:
-> - `darwin-arm64`
-> - `darwin-x64`
-> - `linux-arm64-gnu`
-> - `linux-arm64-musl`
-> - `linux-x64-gnu`
-> - `linux-x64-musl`
-> - `win32-arm64-msvc`
-> - `win32-ia32-msvc`
-> - `win32-x64-msvc`
+:::details For unsupported platforms
 
+If you are using a niche platform, Rspack may not provide native support for it. In this case, please manually install `@rspack/binding-wasm32-wasi` as a fallback. The WebAssembly (Wasm) build can run on any platform, so it can be used as a universal fallback.
+
+Currently supported platforms:
+
+- `darwin-arm64`
+- `darwin-x64`
+- `linux-arm64-gnu`
+- `linux-arm64-musl`
+- `linux-x64-gnu`
+- `linux-x64-musl`
+- `win32-arm64-msvc`
+- `win32-ia32-msvc`
+- `win32-x64-msvc`
+
+:::
 
 ## Create a new project
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -34,20 +34,23 @@ Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) �
 
 :::
 
-> [!DETAILS] 针对不支持的平台
-> 如果你在使用不支持的平台，请手动安装 `@rspack/binding-wasm32-wasi` 包作为备用（fallback）方案。WebAssembly (Wasm) 构建版本可以在任何平台上运行。
-> 
-> 当前支持的平台：
-> - `darwin-arm64`
-> - `darwin-x64`
-> - `linux-arm64-gnu`
-> - `linux-arm64-musl`
-> - `linux-x64-gnu`
-> - `linux-x64-musl`
-> - `win32-arm64-msvc`
-> - `win32-ia32-msvc`
-> - `win32-x64-msvc`
+:::details 针对不支持的平台
 
+如果您正在使用小众平台，rspack 可能没有提供针对该平台的原生支持，此时请手动安装 `@rspack/binding-wasm32-wasi` 作为备用（fallback）方案。WebAssembly（Wasm）版本可以在任何平台上运行，因此可作为通用替代方案使用。
+
+当前支持的平台：
+
+- `darwin-arm64`
+- `darwin-x64`
+- `linux-arm64-gnu`
+- `linux-arm64-musl`
+- `linux-x64-gnu`
+- `linux-x64-musl`
+- `win32-arm64-msvc`
+- `win32-ia32-msvc`
+- `win32-x64-msvc`
+
+:::
 
 ## 创建新项目
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -36,7 +36,7 @@ Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) �
 
 :::details 针对不支持的平台
 
-如果您正在使用小众平台，rspack 可能没有提供针对该平台的原生支持，此时请手动安装 `@rspack/binding-wasm32-wasi` 作为备用（fallback）方案。WebAssembly（Wasm）版本可以在任何平台上运行，因此可作为通用替代方案使用。
+如果您正在使用小众平台，Rspack 可能没有提供原生支持。在这种情况下，请手动安装 `@rspack/binding-wasm32-wasi` 作为备用方案。Wasm 版本可以在大多数平台上运行。
 
 当前支持的平台：
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -34,6 +34,21 @@ Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) �
 
 :::
 
+> [!DETAILS] 针对不支持的平台
+> 如果你在使用不支持的平台，请手动安装 `@rspack/binding-wasm32-wasi` 包作为备用（fallback）方案。WebAssembly (Wasm) 构建版本可以在任何平台上运行。
+> 
+> 当前支持的平台：
+> - `darwin-arm64`
+> - `darwin-x64`
+> - `linux-arm64-gnu`
+> - `linux-arm64-musl`
+> - `linux-x64-gnu`
+> - `linux-x64-musl`
+> - `win32-arm64-msvc`
+> - `win32-ia32-msvc`
+> - `win32-x64-msvc`
+
+
 ## 创建新项目
 
 ### 使用 Rsbuild


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Add instructions for working on unsupported platforms.

Tested on my machine, uninstalled the native binding package and install the wasm version, rspack automatically use the wasm version as a fallback.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
