### PR TITLE
feat(swc): expose collected ts info to loaders

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -21,6 +21,7 @@ export const BUILD_INFO_FILE_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL: unique symbol;
 export const COMMIT_CUSTOM_FIELDS_SYMBOL: unique symbol;
 
 export const RUST_ERROR_SYMBOL: unique symbol;
@@ -29,12 +30,19 @@ export const CIRCULAR_CONNECTION_SYMBOL: unique symbol;
 export const TRANSITIVE_ONLY_SYMBOL: unique symbol;
 export type ConnectionState = boolean | typeof CIRCULAR_CONNECTION_SYMBOL | typeof TRANSITIVE_ONLY_SYMBOL;
 
+interface RawCollectedTypeScriptInfo {
+	typeExports: string[],
+	exports: string[],
+	importedModules: string[],
+}
+
 interface KnownBuildInfo {
 	[BUILD_INFO_ASSETS_SYMBOL]: Assets,
 	[BUILD_INFO_FILE_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL]: RawCollectedTypeScriptInfo | undefined,
 	[COMMIT_CUSTOM_FIELDS_SYMBOL](): void;
 }
 

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -21,6 +21,7 @@ export const BUILD_INFO_FILE_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL: unique symbol;
 export const BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL: unique symbol;
+export const BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL: unique symbol;
 export const COMMIT_CUSTOM_FIELDS_SYMBOL: unique symbol;
 
 export const RUST_ERROR_SYMBOL: unique symbol;
@@ -29,12 +30,19 @@ export const CIRCULAR_CONNECTION_SYMBOL: unique symbol;
 export const TRANSITIVE_ONLY_SYMBOL: unique symbol;
 export type ConnectionState = boolean | typeof CIRCULAR_CONNECTION_SYMBOL | typeof TRANSITIVE_ONLY_SYMBOL;
 
+interface RawCollectedTypeScriptInfo {
+	typeExports: string[],
+	exports: string[],
+	importedModules: string[],
+}
+
 interface KnownBuildInfo {
 	[BUILD_INFO_ASSETS_SYMBOL]: Assets,
 	[BUILD_INFO_FILE_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL]: string[],
 	[BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL]: string[],
+	[BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL]: RawCollectedTypeScriptInfo | undefined,
 	[COMMIT_CUSTOM_FIELDS_SYMBOL](): void;
 }
 

--- a/crates/rspack_binding_api/src/build_info.rs
+++ b/crates/rspack_binding_api/src/build_info.rs
@@ -18,6 +18,7 @@ define_symbols! {
   BUILD_INFO_CONTEXT_DEPENDENCIES_SYMBOL => "rspack.buildInfo.contextDependencies",
   BUILD_INFO_MISSING_DEPENDENCIES_SYMBOL => "rspack.buildInfo.missingDependencies",
   BUILD_INFO_BUILD_DEPENDENCIES_SYMBOL => "rspack.buildInfo.buildDependencies",
+  BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL => "rspack.buildInfo.collectedTypeScriptInfo",
   COMMIT_CUSTOM_FIELDS_SYMBOL => "rspack.buildInfo.commitCustomFields",
 }
 
@@ -65,6 +66,7 @@ static KNOWN_BUILD_INFO_FIELD_NAMES: LazyLock<FxHashSet<&'static str>> = LazyLoc
     "contextDependencies",
     "missingDependencies",
     "buildDependencies",
+    "collectedTypeScriptInfo",
   ])
 });
 
@@ -254,6 +256,50 @@ fn create_known_private_properties(env: &Env, properties: &mut Vec<Property>) ->
               .iter()
               .map(|dependency| env_ref.create_string(dependency.to_string_lossy().as_ref()))
               .collect::<napi::Result<Vec<JsString>>>()
+          });
+          unsafe { ToNapiValue::to_napi_value(env.raw(), result) }
+        })
+        .with_property_attributes(PropertyAttributes::Configurable),
+    );
+    Ok::<(), napi::Error>(())
+  })?;
+
+  BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL.with(|once_cell| {
+    #[allow(clippy::unwrap_used)]
+    let symbol = once_cell.get().unwrap();
+    properties.push(
+      Property::new()
+        .with_name(env, symbol)?
+        .with_getter_closure(|env, this| {
+          let wrapped_value = unsafe { KnownBuildInfo::from_napi_mut_ref(env.raw(), this.raw())? };
+          let env_ref = &env;
+          let result = wrapped_value.with_ref(|module| {
+            let Some(collected_typescript_info) = &module.build_info().collected_typescript_info
+            else {
+              return Ok(None);
+            };
+            let type_exports = collected_typescript_info
+              .type_exports
+              .iter()
+              .map(|export| env_ref.create_string(export.as_str()))
+              .collect::<napi::Result<Vec<JsString>>>()?;
+            let exports = collected_typescript_info
+              .exports
+              .iter()
+              .map(|export| env_ref.create_string(export.as_str()))
+              .collect::<napi::Result<Vec<JsString>>>()?;
+            let imported_modules = collected_typescript_info
+              .imported_modules
+              .iter()
+              .map(|request| env_ref.create_string(request.as_str()))
+              .collect::<napi::Result<Vec<JsString>>>()?;
+
+            let mut result = Object::new(env_ref)?;
+            result.set_named_property("typeExports", type_exports)?;
+            result.set_named_property("exports", exports)?;
+            result.set_named_property("importedModules", imported_modules)?;
+
+            Ok(Some(result))
           });
           unsafe { ToNapiValue::to_napi_value(env.raw(), result) }
         })

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -50,6 +50,10 @@ pub struct ParseContext<'a> {
 pub struct CollectedTypeScriptInfo {
   #[cacheable(with=AsVec<AsPreset>)]
   pub type_exports: FxHashSet<Atom>,
+  #[cacheable(with=AsVec<AsPreset>)]
+  pub exports: FxHashSet<Atom>,
+  #[cacheable(with=AsVec<AsPreset>)]
+  pub imported_modules: FxHashSet<Atom>,
   #[cacheable(with=AsMap<AsPreset>)]
   pub exported_enums: FxHashMap<Atom, TSEnumValue>,
 }

--- a/crates/rspack_loader_swc/src/collect_ts_info.rs
+++ b/crates/rspack_loader_swc/src/collect_ts_info.rs
@@ -1,6 +1,6 @@
 use rspack_core::{CollectedTypeScriptInfo, EvaluatedInlinableValue, TSEnumValue};
 use rspack_swc_plugin_ts_collector::{
-  EnumMemberValue, ExportedEnumCollector, TypeExportsCollector,
+  EnumMemberValue, ExportedEnumCollector, ImportsExportsCollector, TypeExportsCollector,
 };
 use rustc_hash::FxHashMap;
 use swc::atoms::{Atom, Wtf8Atom};
@@ -16,6 +16,13 @@ pub fn collect_typescript_info(
   unresolved_ctxt: SyntaxContext,
   options: &CollectTypeScriptInfoOptions,
 ) -> CollectedTypeScriptInfo {
+  let mut exports = Default::default();
+  let mut imported_modules = Default::default();
+  program.visit_with(&mut ImportsExportsCollector::new(
+    &mut exports,
+    &mut imported_modules,
+  ));
+
   let mut type_exports = Default::default();
   if options.type_exports.unwrap_or_default() {
     program.visit_with(&mut TypeExportsCollector::new(&mut type_exports));
@@ -31,6 +38,8 @@ pub fn collect_typescript_info(
   }
   CollectedTypeScriptInfo {
     type_exports,
+    exports,
+    imported_modules,
     exported_enums: exported_enums
       .into_iter()
       .map(|(k, members)| {

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -264,6 +264,11 @@ impl SwcLoader {
     }
 
     if let Some(collected_ts_info) = collected_ts_info {
+      loader_context
+        .context
+        .module
+        .build_info_mut()
+        .collected_typescript_info = Some(collected_ts_info.clone());
       loader_context.parse_meta.insert(
         COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY.to_string(),
         Box::new(collected_ts_info),

--- a/crates/swc_plugin_ts_collector/src/imports_exports.rs
+++ b/crates/swc_plugin_ts_collector/src/imports_exports.rs
@@ -1,0 +1,158 @@
+use rustc_hash::FxHashSet;
+use swc_core::{
+  atoms::Atom,
+  ecma::{
+    ast::{
+      CallExpr, Callee, Decl, ExportAll, ExportDecl, ExportDefaultDecl, ExportDefaultExpr,
+      ExportSpecifier, Expr, ImportDecl, Lit, ModuleExportName, NamedExport, ObjectPatProp, Pat,
+      TsExternalModuleRef, TsImportType,
+    },
+    visit::{Visit, VisitWith},
+  },
+};
+
+fn module_export_name_to_atom(name: &ModuleExportName) -> Atom {
+  name.atom().into_owned()
+}
+
+fn visit_pat_binding_names(pat: &Pat, f: &mut impl FnMut(Atom)) {
+  match pat {
+    Pat::Ident(ident) => f(Atom::from(ident.id.sym.as_str())),
+    Pat::Array(array) => {
+      for elem in array.elems.iter().flatten() {
+        visit_pat_binding_names(elem, f);
+      }
+    }
+    Pat::Object(object) => {
+      for prop in &object.props {
+        match prop {
+          ObjectPatProp::KeyValue(prop) => visit_pat_binding_names(&prop.value, f),
+          ObjectPatProp::Assign(prop) => f(Atom::from(prop.key.id.sym.as_str())),
+          ObjectPatProp::Rest(prop) => visit_pat_binding_names(&prop.arg, f),
+        }
+      }
+    }
+    Pat::Assign(assign) => visit_pat_binding_names(&assign.left, f),
+    Pat::Rest(rest) => visit_pat_binding_names(&rest.arg, f),
+    Pat::Expr(_) | Pat::Invalid(_) => {}
+  }
+}
+
+#[derive(Debug)]
+pub struct ImportsExportsCollector<'a> {
+  exports: &'a mut FxHashSet<Atom>,
+  imported_modules: &'a mut FxHashSet<Atom>,
+}
+
+impl<'a> ImportsExportsCollector<'a> {
+  pub fn new(exports: &'a mut FxHashSet<Atom>, imported_modules: &'a mut FxHashSet<Atom>) -> Self {
+    Self {
+      exports,
+      imported_modules,
+    }
+  }
+
+  fn add_imported_module(&mut self, value: String) {
+    self.imported_modules.insert(Atom::from(value));
+  }
+}
+
+impl Visit for ImportsExportsCollector<'_> {
+  fn visit_import_decl(&mut self, node: &ImportDecl) {
+    self.add_imported_module(node.src.value.to_string_lossy().into_owned());
+  }
+
+  fn visit_named_export(&mut self, node: &NamedExport) {
+    if let Some(src) = &node.src {
+      self.add_imported_module(src.value.to_string_lossy().into_owned());
+    }
+
+    for specifier in &node.specifiers {
+      match specifier {
+        ExportSpecifier::Namespace(specifier) => {
+          self
+            .exports
+            .insert(module_export_name_to_atom(&specifier.name));
+        }
+        ExportSpecifier::Default(specifier) => {
+          self
+            .exports
+            .insert(Atom::from(specifier.exported.sym.as_str()));
+        }
+        ExportSpecifier::Named(specifier) => {
+          let exported = specifier.exported.as_ref().unwrap_or(&specifier.orig);
+          self.exports.insert(module_export_name_to_atom(exported));
+        }
+      }
+    }
+  }
+
+  fn visit_export_all(&mut self, node: &ExportAll) {
+    self.add_imported_module(node.src.value.to_string_lossy().into_owned());
+  }
+
+  fn visit_export_decl(&mut self, node: &ExportDecl) {
+    match &node.decl {
+      Decl::Class(decl) => {
+        self.exports.insert(Atom::from(decl.ident.sym.as_str()));
+      }
+      Decl::Fn(decl) => {
+        self.exports.insert(Atom::from(decl.ident.sym.as_str()));
+      }
+      Decl::Var(decl) => {
+        for declarator in &decl.decls {
+          visit_pat_binding_names(&declarator.name, &mut |name| {
+            self.exports.insert(name);
+          });
+        }
+      }
+      Decl::TsInterface(decl) => {
+        self.exports.insert(decl.id.sym.clone());
+      }
+      Decl::TsTypeAlias(decl) => {
+        self.exports.insert(decl.id.sym.clone());
+      }
+      Decl::TsEnum(decl) => {
+        self.exports.insert(decl.id.sym.clone());
+      }
+      Decl::TsModule(decl) => {
+        if let Some(ident) = decl.id.as_ident() {
+          self.exports.insert(ident.sym.clone());
+        }
+      }
+      _ => {}
+    }
+
+    node.visit_children_with(self);
+  }
+
+  fn visit_export_default_decl(&mut self, node: &ExportDefaultDecl) {
+    self.exports.insert("default".into());
+    node.visit_children_with(self);
+  }
+
+  fn visit_export_default_expr(&mut self, node: &ExportDefaultExpr) {
+    self.exports.insert("default".into());
+    node.visit_children_with(self);
+  }
+
+  fn visit_ts_import_type(&mut self, node: &TsImportType) {
+    self.add_imported_module(node.arg.value.to_string_lossy().into_owned());
+    node.visit_children_with(self);
+  }
+
+  fn visit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef) {
+    self.add_imported_module(node.expr.value.to_string_lossy().into_owned());
+  }
+
+  fn visit_call_expr(&mut self, node: &CallExpr) {
+    if matches!(node.callee, Callee::Import(_))
+      && let Some(arg) = node.args.first()
+      && let Expr::Lit(Lit::Str(src)) = arg.expr.as_ref()
+    {
+      self.add_imported_module(src.value.to_string_lossy().into_owned());
+    }
+
+    node.visit_children_with(self);
+  }
+}

--- a/crates/swc_plugin_ts_collector/src/lib.rs
+++ b/crates/swc_plugin_ts_collector/src/lib.rs
@@ -1,5 +1,7 @@
 mod enums;
+mod imports_exports;
 mod type_exports;
 
 pub use enums::{EnumMemberValue, ExportedEnumCollector};
+pub use imports_exports::ImportsExportsCollector;
 pub use type_exports::TypeExportsCollector;

--- a/packages/rspack/src/BuildInfo.ts
+++ b/packages/rspack/src/BuildInfo.ts
@@ -4,6 +4,12 @@ import type { Source } from 'webpack-sources';
 
 const $assets: unique symbol = Symbol('assets');
 
+type CollectedTypeScriptInfo = {
+  typeExports: Set<string>;
+  exports: Set<string>;
+  importedModules: Set<string>;
+};
+
 declare module '@rspack/binding' {
   interface Assets {
     [$assets]: Record<string, Source>;
@@ -15,6 +21,7 @@ declare module '@rspack/binding' {
     contextDependencies: Set<string>;
     missingDependencies: Set<string>;
     buildDependencies: Set<string>;
+    collectedTypeScriptInfo?: CollectedTypeScriptInfo;
   }
 }
 
@@ -29,6 +36,7 @@ Object.defineProperty(binding.KnownBuildInfo.prototype, util.inspect.custom, {
       contextDependencies: this.contextDependencies,
       missingDependencies: this.missingDependencies,
       buildDependencies: this.buildDependencies,
+      collectedTypeScriptInfo: this.collectedTypeScriptInfo,
     };
   },
 });
@@ -92,6 +100,27 @@ Object.defineProperty(binding.KnownBuildInfo.prototype, 'buildDependencies', {
   },
 });
 
+Object.defineProperty(
+  binding.KnownBuildInfo.prototype,
+  'collectedTypeScriptInfo',
+  {
+    enumerable: true,
+    configurable: true,
+    get(this: binding.KnownBuildInfo): CollectedTypeScriptInfo | undefined {
+      const collectedTypeScriptInfo =
+        this[binding.BUILD_INFO_COLLECTED_TYPESCRIPT_INFO_SYMBOL];
+      if (collectedTypeScriptInfo === undefined) {
+        return undefined;
+      }
+      return {
+        typeExports: new Set(collectedTypeScriptInfo.typeExports),
+        exports: new Set(collectedTypeScriptInfo.exports),
+        importedModules: new Set(collectedTypeScriptInfo.importedModules),
+      };
+    },
+  },
+);
+
 export type { BuildInfo } from '@rspack/binding';
 
 const knownBuildInfoFields: Set<string> = new Set([
@@ -100,6 +129,7 @@ const knownBuildInfoFields: Set<string> = new Set([
   'contextDependencies',
   'missingDependencies',
   'buildDependencies',
+  'collectedTypeScriptInfo',
 ]);
 
 export const commitCustomFieldsToRust = (buildInfo: binding.BuildInfo) => {

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/assert-loader.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/assert-loader.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const path = require('path');
+
+module.exports = function (content) {
+  if (path.basename(this.resourcePath) !== 'lib.ts') {
+    return content;
+  }
+
+  const info = this._module.buildInfo.collectedTypeScriptInfo;
+
+  assert.ok(info, 'collectedTypeScriptInfo should be exposed to JS loaders');
+  assert.ok(info.typeExports instanceof Set, 'typeExports should be a Set');
+  assert.ok(info.exports instanceof Set, 'exports should be a Set');
+  assert.ok(info.importedModules instanceof Set, 'importedModules should be a Set');
+  assert.deepStrictEqual(
+    Array.from(info.typeExports).sort(),
+    ['Bar', 'Baz', 'Foo', 'Inline', 'ReExportedType', 'default'],
+  );
+  assert.deepStrictEqual(
+    Array.from(info.exports).sort(),
+    [
+      'Bar',
+      'Baz',
+      'Foo',
+      'Inline',
+      'ReExportedType',
+      'default',
+      'loadDynamic',
+      'namespace',
+      'renamedValue',
+      'value',
+    ],
+  );
+  assert.deepStrictEqual(
+    Array.from(info.importedModules).sort(),
+    ['./dep', './dynamic', './inline-type', './namespace', './star', './types'],
+  );
+  assert.ok(!info.typeExports.has('value'), 'value exports should not be included');
+
+  return content;
+};

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/dep.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/dep.ts
@@ -1,0 +1,1 @@
+export const depValue = 2;

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/dynamic.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/dynamic.ts
@@ -1,0 +1,1 @@
+export const dynamicValue = 3;

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/index.js
@@ -1,0 +1,4 @@
+it('should expose type exports to the following JS loader', () => {
+  const { value } = require('./lib');
+  expect(value).toBe(1);
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/inline-type.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/inline-type.ts
@@ -1,0 +1,3 @@
+export interface InlineType {
+  value: number;
+}

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/lib.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/lib.ts
@@ -1,0 +1,26 @@
+import type { ImportedType } from './types';
+
+export interface Foo {
+  value: number;
+}
+
+export type Bar = string;
+
+export enum Baz {
+  A,
+}
+
+export default interface DefaultType {
+  value: string;
+}
+
+export type { ImportedType as ReExportedType } from './types';
+export { depValue as renamedValue } from './dep';
+export * as namespace from './namespace';
+export * from './star';
+
+export type Inline = import('./inline-type').InlineType;
+
+export const value = 1;
+
+export const loadDynamic = () => import('./dynamic');

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/namespace.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/namespace.ts
@@ -1,0 +1,1 @@
+export const namespaceValue = 4;

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/rspack.config.js
@@ -1,0 +1,26 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  resolve: {
+    extensions: ['...', '.ts'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: [
+          './assert-loader.js',
+          {
+            loader: 'builtin:swc-loader',
+            options: {
+              detectSyntax: 'auto',
+              collectTypeScriptInfo: {
+                typeExports: true,
+              },
+            },
+          },
+        ],
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/star.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/star.ts
@@ -1,0 +1,1 @@
+export const starValue = 5;

--- a/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/types.ts
+++ b/tests/rspack-test/configCases/builtin-swc-loader/type-exports-build-info/types.ts
@@ -1,0 +1,3 @@
+export interface ImportedType {
+  value: number;
+}


### PR DESCRIPTION
## Summary

Expose TypeScript collection results from `builtin:swc-loader` to subsequent JS loaders through `module.buildInfo.collectedTypeScriptInfo`.

This includes:
- storing `CollectedTypeScriptInfo` on module build info before parser execution
- exposing `typeExports`, `exports`, and `importedModules` to JS as `Set<string>` values
- collecting export symbol names and raw imported module request strings in the SWC TypeScript collector
- adding a config case that asserts a JS loader can read the build info after `builtin:swc-loader`

## Why

`typeExports` was only available through parser metadata, so JS loaders that run after `builtin:swc-loader` could not observe the collected TypeScript information. The new build-info field makes the data available during the loader pipeline, before parsing.

## Validation

- `cargo fmt --package rspack_core --package rspack_binding_api --package rspack_loader_swc --package rspack_swc_plugin_ts_collector`
- `cargo check -p rspack_binding_api -p rspack_loader_swc -p rspack_swc_plugin_ts_collector`
- `pnpm --filter @rspack/binding run build:dev`
- `pnpm --filter @rspack/core run build`
- `pnpm --filter @rspack/binding run test`
- `pnpm exec prettier --check` on touched JS/TS/d.ts files
- `pnpm exec rstest run -c rstest.config.mts Config.part1.test.js -t type-exports-build-info --project base --pool forks --pool.maxWorkers 1`