### PR TITLE
perf(core): lazily allocate build info dependency sets

### DIFF
--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -102,18 +102,26 @@ impl BuildModuleGraphArtifact {
     // clean module build info
     let build_info = module.build_info();
     let resource_id = ResourceId::from(module_identifier);
-    self
-      .file_dependencies
-      .remove_files(&resource_id, &build_info.file_dependencies);
-    self
-      .context_dependencies
-      .remove_files(&resource_id, &build_info.context_dependencies);
-    self
-      .missing_dependencies
-      .remove_files(&resource_id, &build_info.missing_dependencies);
-    self
-      .build_dependencies
-      .remove_files(&resource_id, &build_info.build_dependencies);
+    if let Some(file_dependencies) = build_info.file_dependencies.as_ref() {
+      self
+        .file_dependencies
+        .remove_files(&resource_id, file_dependencies);
+    }
+    if let Some(context_dependencies) = build_info.context_dependencies.as_ref() {
+      self
+        .context_dependencies
+        .remove_files(&resource_id, context_dependencies);
+    }
+    if let Some(missing_dependencies) = build_info.missing_dependencies.as_ref() {
+      self
+        .missing_dependencies
+        .remove_files(&resource_id, missing_dependencies);
+    }
+    if let Some(build_dependencies) = build_info.build_dependencies.as_ref() {
+      self
+        .build_dependencies
+        .remove_files(&resource_id, build_dependencies);
+    }
     self.make_failed_module.remove(module_identifier);
 
     // clean incoming & all_dependencies(outgoing) factorize info

--- a/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/mod.rs
@@ -100,10 +100,18 @@ impl Occasion for MakeOccasion {
     for (mid, module) in mg.modules() {
       let build_info = module.build_info();
       let resource_id = ResourceId::from(*mid);
-      file_dep.add_files(&resource_id, &build_info.file_dependencies);
-      context_dep.add_files(&resource_id, &build_info.context_dependencies);
-      missing_dep.add_files(&resource_id, &build_info.missing_dependencies);
-      build_dep.add_files(&resource_id, &build_info.build_dependencies);
+      if let Some(file_dependencies) = build_info.file_dependencies.as_ref() {
+        file_dep.add_files(&resource_id, file_dependencies);
+      }
+      if let Some(context_dependencies) = build_info.context_dependencies.as_ref() {
+        context_dep.add_files(&resource_id, context_dependencies);
+      }
+      if let Some(missing_dependencies) = build_info.missing_dependencies.as_ref() {
+        missing_dep.add_files(&resource_id, missing_dependencies);
+      }
+      if let Some(build_dependencies) = build_info.build_dependencies.as_ref() {
+        build_dep.add_files(&resource_id, build_dependencies);
+      }
       if !module.diagnostics().is_empty() {
         make_failed_module.insert(*mid);
       }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -121,22 +121,30 @@ impl Task<TaskContext> for BuildResultTask {
       .get_optimization_bailout_mut(&module.identifier())
       .extend(build_result.optimization_bailouts);
     let resource_id = ResourceId::from(module.identifier());
-    context
-      .artifact
-      .file_dependencies
-      .add_files(&resource_id, &build_info.file_dependencies);
-    context
-      .artifact
-      .context_dependencies
-      .add_files(&resource_id, &build_info.context_dependencies);
-    context
-      .artifact
-      .missing_dependencies
-      .add_files(&resource_id, &build_info.missing_dependencies);
-    context
-      .artifact
-      .build_dependencies
-      .add_files(&resource_id, &build_info.build_dependencies);
+    if let Some(file_dependencies) = build_info.file_dependencies.as_ref() {
+      context
+        .artifact
+        .file_dependencies
+        .add_files(&resource_id, file_dependencies);
+    }
+    if let Some(context_dependencies) = build_info.context_dependencies.as_ref() {
+      context
+        .artifact
+        .context_dependencies
+        .add_files(&resource_id, context_dependencies);
+    }
+    if let Some(missing_dependencies) = build_info.missing_dependencies.as_ref() {
+      context
+        .artifact
+        .missing_dependencies
+        .add_files(&resource_id, missing_dependencies);
+    }
+    if let Some(build_dependencies) = build_info.build_dependencies.as_ref() {
+      context
+        .artifact
+        .build_dependencies
+        .add_files(&resource_id, build_dependencies);
+    }
 
     let module_graph = &mut context.artifact.module_graph;
     let mut lazy_dependencies = LazyDependencies::default();

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1496,7 +1496,7 @@ impl Module for ContextModule {
     if !self.options.resource.as_str().is_empty() {
       let mut context_dependencies: ArcPathSet = Default::default();
       context_dependencies.insert(self.options.resource.as_std_path().into());
-      self.build_info.context_dependencies = context_dependencies;
+      self.build_info.context_dependencies = context_dependencies.into();
     }
 
     Ok(BuildResult {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -16,7 +16,7 @@ use rspack_collections::{Identifiable, Identifier, IdentifierMap, IdentifierSet}
 use rspack_error::{Diagnosable, Result};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::RspackHashDigest;
-use rspack_paths::ArcPathSet;
+use rspack_paths::{ArcPath, ArcPathSet};
 use rspack_sources::BoxSource;
 use rspack_util::{
   atom::Atom,
@@ -253,6 +253,55 @@ pub struct AssetBuildInfo {
 }
 
 #[cacheable]
+#[derive(Debug, Clone, Default)]
+pub struct BuildInfoDependencySet {
+  inner: Option<ArcPathSet>,
+}
+
+impl BuildInfoDependencySet {
+  pub fn is_allocated(&self) -> bool {
+    self.inner.is_some()
+  }
+
+  pub fn as_ref(&self) -> Option<&ArcPathSet> {
+    self.inner.as_ref()
+  }
+
+  pub fn iter(&self) -> impl Iterator<Item = &ArcPath> {
+    self.inner.iter().flat_map(|set| set.iter())
+  }
+
+  pub fn clone_inner(&self) -> ArcPathSet {
+    self.inner.clone().unwrap_or_default()
+  }
+}
+
+impl From<ArcPathSet> for BuildInfoDependencySet {
+  fn from(value: ArcPathSet) -> Self {
+    if value.is_empty() {
+      Self::default()
+    } else {
+      Self { inner: Some(value) }
+    }
+  }
+}
+
+impl FromIterator<ArcPath> for BuildInfoDependencySet {
+  fn from_iter<T: IntoIterator<Item = ArcPath>>(iter: T) -> Self {
+    let inner = ArcPathSet::from_iter(iter);
+    inner.into()
+  }
+}
+
+impl Extend<ArcPath> for BuildInfoDependencySet {
+  fn extend<T: IntoIterator<Item = ArcPath>>(&mut self, iter: T) {
+    for item in iter {
+      self.inner.get_or_insert_default().insert(item);
+    }
+  }
+}
+
+#[cacheable]
 #[derive(Debug, Clone)]
 pub struct BuildInfo {
   /// Whether the result is cacheable, i.e shared between builds.
@@ -261,10 +310,10 @@ pub struct BuildInfo {
   pub strict: bool,
   pub module_argument: ModuleArgument,
   pub exports_argument: ExportsArgument,
-  pub file_dependencies: ArcPathSet,
-  pub context_dependencies: ArcPathSet,
-  pub missing_dependencies: ArcPathSet,
-  pub build_dependencies: ArcPathSet,
+  pub file_dependencies: BuildInfoDependencySet,
+  pub context_dependencies: BuildInfoDependencySet,
+  pub missing_dependencies: BuildInfoDependencySet,
+  pub build_dependencies: BuildInfoDependencySet,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]
   pub esm_named_exports: HashSet<Atom>,
@@ -302,10 +351,10 @@ impl Default for BuildInfo {
       strict: false,
       module_argument: Default::default(),
       exports_argument: Default::default(),
-      file_dependencies: ArcPathSet::default(),
-      context_dependencies: ArcPathSet::default(),
-      missing_dependencies: ArcPathSet::default(),
-      build_dependencies: ArcPathSet::default(),
+      file_dependencies: BuildInfoDependencySet::default(),
+      context_dependencies: BuildInfoDependencySet::default(),
+      missing_dependencies: BuildInfoDependencySet::default(),
+      build_dependencies: BuildInfoDependencySet::default(),
       value_dependencies: HashMap::default(),
       esm_named_exports: HashSet::default(),
       all_star_exports: Vec::default(),
@@ -326,6 +375,36 @@ impl Default for BuildInfo {
       extras: Default::default(),
       deferred_pure_checks: HashSet::default(),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+
+  use rspack_paths::ArcPath;
+
+  use super::*;
+
+  #[test]
+  fn build_info_dependency_sets_are_created_lazily() {
+    let mut build_info = BuildInfo::default();
+
+    assert!(!build_info.file_dependencies.is_allocated());
+    assert_eq!(build_info.file_dependencies.iter().count(), 0);
+
+    let dependency: ArcPath = PathBuf::from("fixture.js").into();
+    build_info.file_dependencies.extend([dependency.clone()]);
+
+    assert!(build_info.file_dependencies.is_allocated());
+    assert_eq!(
+      build_info
+        .file_dependencies
+        .iter()
+        .cloned()
+        .collect::<ArcPathSet>(),
+      ArcPathSet::from_iter([dependency])
+    );
   }
 }
 

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -72,10 +72,10 @@ impl CssModule {
       build_info: BuildInfo {
         cacheable: dep.cacheable,
         strict: true,
-        file_dependencies: dep.file_dependencies,
-        context_dependencies: dep.context_dependencies,
-        missing_dependencies: dep.missing_dependencies,
-        build_dependencies: dep.build_dependencies,
+        file_dependencies: dep.file_dependencies.into(),
+        context_dependencies: dep.context_dependencies.into(),
+        missing_dependencies: dep.missing_dependencies.into(),
+        build_dependencies: dep.build_dependencies.into(),
         ..Default::default()
       },
       build_meta: Default::default(),

--- a/crates/rspack_plugin_extract_css/src/parser_plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/parser_plugin.rs
@@ -72,10 +72,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for PluginCssExtractParserPlugin {
                 *identifier_index,
                 DependencyRange::new(index as u32, (index + 1) as u32),
                 parser.build_info.cacheable,
-                parser.build_info.file_dependencies.clone(),
-                parser.build_info.context_dependencies.clone(),
-                parser.build_info.missing_dependencies.clone(),
-                parser.build_info.build_dependencies.clone(),
+                parser.build_info.file_dependencies.clone_inner(),
+                parser.build_info.context_dependencies.clone_inner(),
+                parser.build_info.missing_dependencies.clone_inner(),
+                parser.build_info.build_dependencies.clone_inner(),
               )) as BoxDependency
             },
           )


### PR DESCRIPTION
## Summary

- Lazily allocate the four `BuildInfo` dependency sets (`file_dependencies`, `context_dependencies`, `missing_dependencies`, `build_dependencies`) with a thin wrapper around `Option<ArcPathSet>`.
- Preserve existing iteration/collection behavior for module build results and CSS extraction.
- Skip dependency counter add/remove work when a module has no dependency set allocated.

## Validation

- `cargo test -p rspack_core build_info_dependency_sets_are_created_lazily`
- `cargo fmt --all -- --check`
- `cargo check -p rspack_plugin_extract_css`
- `cargo lint`
- `pnpm run build:cli:dev`
- `pnpm run test:unit`