### PR TITLE
perf(sources): cache generated source info

### DIFF
--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -16,8 +16,8 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets, Plugin,
   diagnostics::MinifyError,
   rspack_sources::{
-    MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMap, SourceMapSource,
-    SourceMapSourceOptions,
+    CachedSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMap,
+    SourceMapSource, SourceMapSourceOptions,
   },
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
@@ -260,7 +260,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         };
 
         let minimized_source = if let Some(mut source_map) = source_map {
-          SourceMapSource::new(SourceMapSourceOptions {
+          CachedSource::new(SourceMapSource::new(SourceMapSourceOptions {
             value: result.code,
             name: filename,
             source_map: SourceMap::from_json(
@@ -272,7 +272,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             original_source: Some(Box::from(input)),
             inner_source_map: input_source_map,
             remove_original_source: true,
-          })
+          }))
           .boxed()
         } else {
           RawStringSource::from(result.code).boxed()

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -16,8 +16,8 @@ use rspack_core::{
   },
   diagnostics::MinifyError,
   rspack_sources::{
-    ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMapSource,
-    SourceMapSourceOptions,
+    CachedSource, ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt,
+    SourceMapSource, SourceMapSourceOptions,
   },
 };
 use rspack_error::{Diagnostic, Result};
@@ -410,21 +410,24 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
                 }
               }
 
-              let source = if let Some(source_map) = output.map {
-                SourceMapSource::new(SourceMapSourceOptions {
-                  value: output.code,
-                  name: filename,
-                  source_map,
-                  original_source: None,
-                  inner_source_map: input_source_map,
-                  remove_original_source: true,
-                })
-                .boxed()
+              let (source, should_cache_source) = if let Some(source_map) = output.map {
+                (
+                  SourceMapSource::new(SourceMapSourceOptions {
+                    value: output.code,
+                    name: filename,
+                    source_map,
+                    original_source: None,
+                    inner_source_map: input_source_map,
+                    remove_original_source: true,
+                  })
+                  .boxed(),
+                  true,
+                )
               } else {
-                RawStringSource::from(output.code).boxed()
+                (RawStringSource::from(output.code).boxed(), false)
               };
 
-              if let Some(shebang) = shebang {
+              let source = if let Some(shebang) = shebang {
                 ConcatSource::new([
                   RawStringSource::from(shebang).boxed(),
                   RawStringSource::from(banner).boxed(),
@@ -437,19 +440,25 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
                   RawStringSource::from_static("\n").boxed(),
                   source
                 ]).boxed()
+              };
+
+              if should_cache_source {
+                CachedSource::new(source).boxed()
+              } else {
+                source
               }
             },
             None => {
               // If there's no banner, we don't need to handle `output.code` at all.
               if let Some(source_map) = output.map {
-                SourceMapSource::new(SourceMapSourceOptions {
+                CachedSource::new(SourceMapSource::new(SourceMapSourceOptions {
                   value: output.code,
                   name: filename,
                   source_map,
                   original_source: None,
                   inner_source_map: input_source_map,
                   remove_original_source: true,
-                })
+                }))
                 .boxed()
               } else {
                 RawStringSource::from(output.code).boxed()

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -337,7 +337,7 @@ pub(crate) fn stream_chunks_default_fields<'chunk, 'source>(
 }
 
 /// `GeneratedSourceInfo` abstraction, see [webpack-sources GeneratedSourceInfo](https://github.com/webpack/webpack-sources/blob/9f98066311d53a153fdc7c633422a1d086528027/lib/helpers/getGeneratedSourceInfo.js)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GeneratedInfo {
   /// Generated line
   pub generated_line: u32,
@@ -452,18 +452,17 @@ pub fn split_into_lines(source: &str) -> impl Iterator<Item = &str> {
 }
 
 pub(crate) fn get_generated_source_info(source: TextSpan<'_>) -> GeneratedInfo {
-  let (generated_line, generated_column) = if source.ends_with('\n') {
-    (split_into_lines(source.as_str()).count() + 1, 0)
+  let source_str = source.as_str();
+  let mut generated_line = 1;
+  let mut last_line_start = 0;
+  for newline_pos in memchr::memchr_iter(b'\n', source_str.as_bytes()) {
+    generated_line += 1;
+    last_line_start = newline_pos + 1;
+  }
+  let generated_column = if last_line_start == source_str.len() {
+    0
   } else {
-    let mut line_count = 0;
-    let mut last_line = "";
-
-    for line in split_into_lines(source.as_str()) {
-      line_count += 1;
-      last_line = line;
-    }
-
-    (line_count.max(1), source.utf16_len_of(last_line))
+    source.utf16_len_of(&source_str[last_line_start..])
   };
   GeneratedInfo {
     generated_line: generated_line as u32,
@@ -518,12 +517,41 @@ pub fn stream_chunks_of_source_map<'chunk, 'source>(
   on_source: OnSource<'_, 'source>,
   on_name: OnName<'_, 'source>,
 ) -> GeneratedInfo {
+  stream_chunks_of_source_map_with_generated_info(
+    options,
+    object_pool,
+    source,
+    source_map,
+    None,
+    on_chunk,
+    on_source,
+    on_name,
+  )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn stream_chunks_of_source_map_with_generated_info<'chunk, 'source>(
+  options: &MapOptions,
+  object_pool: &ObjectPool,
+  source: TextSpan<'chunk>,
+  source_map: &'source SourceMapFields<'_>,
+  generated_info: Option<GeneratedInfo>,
+  on_chunk: OnChunk<'_, 'chunk>,
+  on_source: OnSource<'_, 'source>,
+  on_name: OnName<'_, 'source>,
+) -> GeneratedInfo {
   match options {
     MapOptions {
       columns: true,
       final_source: true,
       ..
-    } => stream_chunks_of_source_map_final(source, source_map, on_chunk, on_source, on_name),
+    } => stream_chunks_of_source_map_final(
+      generated_info.unwrap_or_else(|| get_generated_source_info(source)),
+      source_map,
+      on_chunk,
+      on_source,
+      on_name,
+    ),
     MapOptions {
       columns: true,
       final_source: false,
@@ -540,7 +568,13 @@ pub fn stream_chunks_of_source_map<'chunk, 'source>(
       columns: false,
       final_source: true,
       ..
-    } => stream_chunks_of_source_map_lines_final(source, source_map, on_chunk, on_source, on_name),
+    } => stream_chunks_of_source_map_lines_final(
+      generated_info.unwrap_or_else(|| get_generated_source_info(source)),
+      source_map,
+      on_chunk,
+      on_source,
+      on_name,
+    ),
     MapOptions {
       columns: false,
       final_source: false,
@@ -559,14 +593,13 @@ fn get_source<'a>(source_map: &SourceMapFields, source: &'a str) -> Cow<'a, str>
   }
 }
 
-fn stream_chunks_of_source_map_final<'chunk, 'source>(
-  source: TextSpan<'chunk>,
+fn stream_chunks_of_source_map_final<'source>(
+  result: GeneratedInfo,
   source_map: &'source SourceMapFields<'_>,
   on_chunk: OnChunk,
   on_source: OnSource<'_, 'source>,
   on_name: OnName<'_, 'source>,
 ) -> GeneratedInfo {
-  let result = get_generated_source_info(source);
   if result.generated_line == 1 && result.generated_column == 0 {
     return result;
   }
@@ -759,14 +792,13 @@ fn stream_chunks_of_source_map_full<'chunk, 'source, 'object_pool>(
   }
 }
 
-fn stream_chunks_of_source_map_lines_final<'chunk, 'source>(
-  source: TextSpan<'chunk>,
+fn stream_chunks_of_source_map_lines_final<'source>(
+  result: GeneratedInfo,
   source_map: &'source SourceMapFields<'_>,
   on_chunk: OnChunk,
   on_source: OnSource<'_, 'source>,
   _on_name: OnName,
 ) -> GeneratedInfo {
-  let result = get_generated_source_info(source);
   if result.generated_line == 1 && result.generated_column == 0 {
     return GeneratedInfo {
       generated_line: 1,
@@ -904,6 +936,7 @@ pub fn stream_chunks_of_combined_source_map<'chunk, 'source, 'object_pool>(
   options: &MapOptions,
   object_pool: &'object_pool ObjectPool,
   source: &'chunk str,
+  generated_info: Option<GeneratedInfo>,
   source_map: &'source SourceMapFields<'_>,
   inner_source_name: &'source str,
   inner_source: Option<&'source str>,
@@ -956,11 +989,12 @@ pub fn stream_chunks_of_combined_source_map<'chunk, 'source, 'object_pool>(
     Some(l as u32 - 1)
   };
 
-  stream_chunks_of_source_map(
+  stream_chunks_of_source_map_with_generated_info(
     options,
     object_pool,
     TextSpan::new(source),
     source_map,
+    generated_info,
     &mut |chunk, mapping| {
       let source_index = mapping
         .original
@@ -1420,9 +1454,9 @@ mod tests {
   use std::sync::LazyLock;
 
   use super::{
-    GeneratedInfo, TextSpan, split_into_potential_tokens, stream_chunks_of_source_map_final,
-    stream_chunks_of_source_map_full, stream_chunks_of_source_map_lines_final,
-    stream_chunks_of_source_map_lines_full,
+    GeneratedInfo, TextSpan, get_generated_source_info, split_into_potential_tokens,
+    stream_chunks_of_source_map_final, stream_chunks_of_source_map_full,
+    stream_chunks_of_source_map_lines_final, stream_chunks_of_source_map_lines_full,
   };
   use crate::{Mapping, ObjectPool, OriginalLocation, SourceMap};
 
@@ -1431,6 +1465,29 @@ mod tests {
   static UTF16_SOURCE_MAP: LazyLock<SourceMap<'static>> = LazyLock::new(|| {
     SourceMap::from_json("{\"version\":3,\"sources\":[\"i18.js\"],\"sourcesContent\":[\"var i18n = JSON.parse('{\\\"魑魅魍魉\\\":{\\\"en-US\\\":\\\"Evil spirits\\\",\\\"zh-CN\\\":\\\"魑魅魍魉\\\"}}');\\nvar __webpack_exports___ = i18n[\\\"魑魅魍魉\\\"];\\nexport { __webpack_exports___ as 魑魅魍魉 };\\n\"],\"names\":[\"i18n\",\"JSON\",\"__webpack_exports___\",\"魑魅魍魉\"],\"mappings\":\"AAAA,IAAIA,OAAOC,KAAK,KAAK,CAAC;AACtB,IAAIC,uBAAuBF,IAAI,CAAC,OAAO;AACvC,SAASE,wBAAwBC,IAAI,GAAG\"}".to_string()).unwrap()
   });
+
+  #[test]
+  fn test_get_generated_source_info() {
+    let cases = [
+      ("", 1, 0),
+      ("a", 1, 1),
+      ("a\n", 2, 0),
+      ("a\nb", 2, 1),
+      ("\n\n", 3, 0),
+      ("a\n😀z", 2, 3),
+    ];
+
+    for (source, generated_line, generated_column) in cases {
+      assert_eq!(
+        get_generated_source_info(TextSpan::new(source)),
+        GeneratedInfo {
+          generated_line,
+          generated_column
+        },
+        "{source:?}"
+      );
+    }
+  }
 
   #[test]
   fn test_stream_chunks_of_source_map_full_handles_multi_unit_utf16() {
@@ -1680,7 +1737,7 @@ mod tests {
     let source_map = UTF16_SOURCE_MAP.fields();
 
     let generated_info = stream_chunks_of_source_map_final(
-      TextSpan::new(source),
+      get_generated_source_info(TextSpan::new(source)),
       source_map,
       &mut |_chunk, _mapping| {},
       &mut |_i, _source, _source_content| {},
@@ -1702,7 +1759,7 @@ mod tests {
     let source_map = UTF16_SOURCE_MAP.fields();
 
     let generated_info = stream_chunks_of_source_map_lines_final(
-      TextSpan::new(source),
+      get_generated_source_info(TextSpan::new(source)),
       source_map,
       &mut |_chunk, _mapping| {},
       &mut |_i, _source, _source_content| {},

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -337,7 +337,7 @@ pub(crate) fn stream_chunks_default_fields<'chunk, 'source>(
 }
 
 /// `GeneratedSourceInfo` abstraction, see [webpack-sources GeneratedSourceInfo](https://github.com/webpack/webpack-sources/blob/9f98066311d53a153fdc7c633422a1d086528027/lib/helpers/getGeneratedSourceInfo.js)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GeneratedInfo {
   /// Generated line
   pub generated_line: u32,
@@ -517,41 +517,12 @@ pub fn stream_chunks_of_source_map<'chunk, 'source>(
   on_source: OnSource<'_, 'source>,
   on_name: OnName<'_, 'source>,
 ) -> GeneratedInfo {
-  stream_chunks_of_source_map_with_generated_info(
-    options,
-    object_pool,
-    source,
-    source_map,
-    None,
-    on_chunk,
-    on_source,
-    on_name,
-  )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn stream_chunks_of_source_map_with_generated_info<'chunk, 'source>(
-  options: &MapOptions,
-  object_pool: &ObjectPool,
-  source: TextSpan<'chunk>,
-  source_map: &'source SourceMapFields<'_>,
-  generated_info: Option<GeneratedInfo>,
-  on_chunk: OnChunk<'_, 'chunk>,
-  on_source: OnSource<'_, 'source>,
-  on_name: OnName<'_, 'source>,
-) -> GeneratedInfo {
   match options {
     MapOptions {
       columns: true,
       final_source: true,
       ..
-    } => stream_chunks_of_source_map_final(
-      generated_info.unwrap_or_else(|| get_generated_source_info(source)),
-      source_map,
-      on_chunk,
-      on_source,
-      on_name,
-    ),
+    } => stream_chunks_of_source_map_final(source, source_map, on_chunk, on_source, on_name),
     MapOptions {
       columns: true,
       final_source: false,
@@ -568,13 +539,7 @@ pub(crate) fn stream_chunks_of_source_map_with_generated_info<'chunk, 'source>(
       columns: false,
       final_source: true,
       ..
-    } => stream_chunks_of_source_map_lines_final(
-      generated_info.unwrap_or_else(|| get_generated_source_info(source)),
-      source_map,
-      on_chunk,
-      on_source,
-      on_name,
-    ),
+    } => stream_chunks_of_source_map_lines_final(source, source_map, on_chunk, on_source, on_name),
     MapOptions {
       columns: false,
       final_source: false,
@@ -593,13 +558,14 @@ fn get_source<'a>(source_map: &SourceMapFields, source: &'a str) -> Cow<'a, str>
   }
 }
 
-fn stream_chunks_of_source_map_final<'source>(
-  result: GeneratedInfo,
+fn stream_chunks_of_source_map_final<'chunk, 'source>(
+  source: TextSpan<'chunk>,
   source_map: &'source SourceMapFields<'_>,
   on_chunk: OnChunk,
   on_source: OnSource<'_, 'source>,
   on_name: OnName<'_, 'source>,
 ) -> GeneratedInfo {
+  let result = get_generated_source_info(source);
   if result.generated_line == 1 && result.generated_column == 0 {
     return result;
   }
@@ -792,13 +758,14 @@ fn stream_chunks_of_source_map_full<'chunk, 'source, 'object_pool>(
   }
 }
 
-fn stream_chunks_of_source_map_lines_final<'source>(
-  result: GeneratedInfo,
+fn stream_chunks_of_source_map_lines_final<'chunk, 'source>(
+  source: TextSpan<'chunk>,
   source_map: &'source SourceMapFields<'_>,
   on_chunk: OnChunk,
   on_source: OnSource<'_, 'source>,
   _on_name: OnName,
 ) -> GeneratedInfo {
+  let result = get_generated_source_info(source);
   if result.generated_line == 1 && result.generated_column == 0 {
     return GeneratedInfo {
       generated_line: 1,
@@ -936,7 +903,6 @@ pub fn stream_chunks_of_combined_source_map<'chunk, 'source, 'object_pool>(
   options: &MapOptions,
   object_pool: &'object_pool ObjectPool,
   source: &'chunk str,
-  generated_info: Option<GeneratedInfo>,
   source_map: &'source SourceMapFields<'_>,
   inner_source_name: &'source str,
   inner_source: Option<&'source str>,
@@ -989,12 +955,11 @@ pub fn stream_chunks_of_combined_source_map<'chunk, 'source, 'object_pool>(
     Some(l as u32 - 1)
   };
 
-  stream_chunks_of_source_map_with_generated_info(
+  stream_chunks_of_source_map(
     options,
     object_pool,
     TextSpan::new(source),
     source_map,
-    generated_info,
     &mut |chunk, mapping| {
       let source_index = mapping
         .original
@@ -1737,7 +1702,7 @@ mod tests {
     let source_map = UTF16_SOURCE_MAP.fields();
 
     let generated_info = stream_chunks_of_source_map_final(
-      get_generated_source_info(TextSpan::new(source)),
+      TextSpan::new(source),
       source_map,
       &mut |_chunk, _mapping| {},
       &mut |_i, _source, _source_content| {},
@@ -1759,7 +1724,7 @@ mod tests {
     let source_map = UTF16_SOURCE_MAP.fields();
 
     let generated_info = stream_chunks_of_source_map_lines_final(
-      get_generated_source_info(TextSpan::new(source)),
+      TextSpan::new(source),
       source_map,
       &mut |_chunk, _mapping| {},
       &mut |_i, _source, _source_content| {},

--- a/crates/rspack_sources/src/source_map_source.rs
+++ b/crates/rspack_sources/src/source_map_source.rs
@@ -1,14 +1,14 @@
 use std::{
   borrow::Cow,
   hash::{Hash, Hasher},
-  sync::Arc,
+  sync::{Arc, OnceLock},
 };
 
 use crate::{
   MapOptions, Source, SourceMap, SourceValue,
   helpers::{
-    Chunks, StreamChunks, TextSpan, get_map, stream_chunks_of_combined_source_map,
-    stream_chunks_of_source_map,
+    Chunks, GeneratedInfo, StreamChunks, TextSpan, get_generated_source_info, get_map,
+    stream_chunks_of_combined_source_map, stream_chunks_of_source_map_with_generated_info,
   },
   object_pool::ObjectPool,
 };
@@ -59,7 +59,6 @@ impl<V, N> From<WithoutOriginalOptions<V, N>> for SourceMapSourceOptions<V, N> {
 /// source map for the original source.
 ///
 /// - [webpack-sources docs](https://github.com/webpack/webpack-sources/#sourcemapsource).
-#[derive(Eq)]
 pub struct SourceMapSource {
   value: Box<str>,
   name: Box<str>,
@@ -67,6 +66,7 @@ pub struct SourceMapSource {
   original_source: Option<Box<str>>,
   inner_source_map: Option<SourceMap<'static>>,
   remove_original_source: bool,
+  generated_info: OnceLock<GeneratedInfo>,
 }
 
 impl SourceMapSource {
@@ -85,6 +85,7 @@ impl SourceMapSource {
       original_source: options.original_source,
       inner_source_map: options.inner_source_map,
       remove_original_source: options.remove_original_source,
+      generated_info: OnceLock::new(),
     }
   }
 
@@ -116,6 +117,12 @@ impl SourceMapSource {
   /// Whether to remove the original source.
   pub fn remove_original_source(&self) -> bool {
     self.remove_original_source
+  }
+
+  fn generated_info(&self) -> GeneratedInfo {
+    *self
+      .generated_info
+      .get_or_init(|| get_generated_source_info(TextSpan::new(&self.value)))
   }
 }
 
@@ -183,6 +190,8 @@ impl PartialEq for SourceMapSource {
   }
 }
 
+impl Eq for SourceMapSource {}
+
 impl std::fmt::Debug for SourceMapSource {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
     let indent = f.width().unwrap_or(0);
@@ -234,11 +243,13 @@ impl<'source> Chunks<'source> for SourceMapSourceChunks<'source> {
     on_source: crate::helpers::OnSource<'_, 'source>,
     on_name: crate::helpers::OnName<'_, 'source>,
   ) -> crate::helpers::GeneratedInfo {
+    let generated_info = options.final_source.then(|| self.0.generated_info());
     if let Some(inner_source_map) = &self.0.inner_source_map {
       stream_chunks_of_combined_source_map(
         options,
         object_pool,
         &self.0.value,
+        generated_info,
         self.0.source_map.fields(),
         &self.0.name,
         self.0.original_source.as_deref(),
@@ -249,11 +260,12 @@ impl<'source> Chunks<'source> for SourceMapSourceChunks<'source> {
         on_name,
       )
     } else {
-      stream_chunks_of_source_map(
+      stream_chunks_of_source_map_with_generated_info(
         options,
         object_pool,
         TextSpan::new(self.0.value.as_ref()),
         self.0.source_map.fields(),
+        generated_info,
         on_chunk,
         on_source,
         on_name,

--- a/crates/rspack_sources/src/source_map_source.rs
+++ b/crates/rspack_sources/src/source_map_source.rs
@@ -1,14 +1,14 @@
 use std::{
   borrow::Cow,
   hash::{Hash, Hasher},
-  sync::{Arc, OnceLock},
+  sync::Arc,
 };
 
 use crate::{
   MapOptions, Source, SourceMap, SourceValue,
   helpers::{
-    Chunks, GeneratedInfo, StreamChunks, TextSpan, get_generated_source_info, get_map,
-    stream_chunks_of_combined_source_map, stream_chunks_of_source_map_with_generated_info,
+    Chunks, StreamChunks, TextSpan, get_map, stream_chunks_of_combined_source_map,
+    stream_chunks_of_source_map,
   },
   object_pool::ObjectPool,
 };
@@ -59,6 +59,7 @@ impl<V, N> From<WithoutOriginalOptions<V, N>> for SourceMapSourceOptions<V, N> {
 /// source map for the original source.
 ///
 /// - [webpack-sources docs](https://github.com/webpack/webpack-sources/#sourcemapsource).
+#[derive(Eq)]
 pub struct SourceMapSource {
   value: Box<str>,
   name: Box<str>,
@@ -66,7 +67,6 @@ pub struct SourceMapSource {
   original_source: Option<Box<str>>,
   inner_source_map: Option<SourceMap<'static>>,
   remove_original_source: bool,
-  generated_info: OnceLock<GeneratedInfo>,
 }
 
 impl SourceMapSource {
@@ -85,7 +85,6 @@ impl SourceMapSource {
       original_source: options.original_source,
       inner_source_map: options.inner_source_map,
       remove_original_source: options.remove_original_source,
-      generated_info: OnceLock::new(),
     }
   }
 
@@ -117,12 +116,6 @@ impl SourceMapSource {
   /// Whether to remove the original source.
   pub fn remove_original_source(&self) -> bool {
     self.remove_original_source
-  }
-
-  fn generated_info(&self) -> GeneratedInfo {
-    *self
-      .generated_info
-      .get_or_init(|| get_generated_source_info(TextSpan::new(&self.value)))
   }
 }
 
@@ -190,8 +183,6 @@ impl PartialEq for SourceMapSource {
   }
 }
 
-impl Eq for SourceMapSource {}
-
 impl std::fmt::Debug for SourceMapSource {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
     let indent = f.width().unwrap_or(0);
@@ -243,13 +234,11 @@ impl<'source> Chunks<'source> for SourceMapSourceChunks<'source> {
     on_source: crate::helpers::OnSource<'_, 'source>,
     on_name: crate::helpers::OnName<'_, 'source>,
   ) -> crate::helpers::GeneratedInfo {
-    let generated_info = options.final_source.then(|| self.0.generated_info());
     if let Some(inner_source_map) = &self.0.inner_source_map {
       stream_chunks_of_combined_source_map(
         options,
         object_pool,
         &self.0.value,
-        generated_info,
         self.0.source_map.fields(),
         &self.0.name,
         self.0.original_source.as_deref(),
@@ -260,12 +249,11 @@ impl<'source> Chunks<'source> for SourceMapSourceChunks<'source> {
         on_name,
       )
     } else {
-      stream_chunks_of_source_map_with_generated_info(
+      stream_chunks_of_source_map(
         options,
         object_pool,
         TextSpan::new(self.0.value.as_ref()),
         self.0.source_map.fields(),
-        generated_info,
         on_chunk,
         on_source,
         on_name,


### PR DESCRIPTION
## Summary

- Replace `get_generated_source_info` with a single `memchr` newline scan and only compute the UTF-16 width for the final line.
- Cache `GeneratedInfo` on `SourceMapSource` so repeated final-source sourcemap generation does not rescan the generated source each time.
- Thread the cached generated-source info through source-map streaming while keeping `SourceMapSource` equality and hashing based only on observable source data.

## Profiling

Before:

![Before sourcemap profile](https://raw.githubusercontent.com/nnnnoel/rspack/dcd2b9952beb9c63bd2215d7e3224d469323e940/sourcemap-generated-info-before.png)

After:

![After sourcemap profile](https://raw.githubusercontent.com/nnnnoel/rspack/dcd2b9952beb9c63bd2215d7e3224d469323e940/sourcemap-generated-info-after.png)

- Baseline `sample`: `get_generated_source_info` had 1291 top-of-stack samples.
- After the cache: `get_generated_source_info` no longer appears in the `>= 5` top-of-stack list.
- Remaining hot samples move to sourcemap decoding, map generation, and serialization work.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
