### PR TITLE
docs(website): fix Rspress summary style

### DIFF
--- a/website/theme/index.css
+++ b/website/theme/index.css
@@ -1,7 +1,3 @@
-summary {
-  display: block;
-}
-
 :root {
   --rp-c-brand: #ff5e00;
   --rp-c-brand-dark: #ff704d;


### PR DESCRIPTION
## Summary

This PR fixes the styling of the `summary` component generated by Rspress by removing the global `summary { display: block; }` override from the website theme. The override prevented the generated component from using its expected display behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).