### PR TITLE
docs: improve incremental config docs

### DIFF
--- a/website/docs/en/config/incremental.mdx
+++ b/website/docs/en/config/incremental.mdx
@@ -1,59 +1,82 @@
 ---
-description: 'Whether to enable incremental build, which significantly speeds up rebuilds and HMR by only rebuilding the changed parts'
+description: 'Whether to enable incremental builds. When enabled, Rspack reuses unaffected intermediate results during rebuilds and HMR to reduce the work that must be recomputed.'
 ---
-
-import { ApiMeta } from '../../../components/ApiMeta';
 
 # Incremental
 
-<ApiMeta addedVersion="1.1.0-beta.0" />
-
-Whether to enable incremental build, which significantly speeds up rebuilds and HMR by only rebuilding the changed parts.
+`incremental` controls Rspack's incremental build capability. When enabled, Rspack reuses unaffected intermediate results during rebuilds and Hot Module Replacement (HMR), and only recalculates the stages and assets affected by the change.
 
 - **Type:** `boolean | 'none' | 'safe' | 'advance' | 'advance-silent' | Incremental`
 - **Default:** `'advance-silent'`
 
-Two configuration ways are provided:
+:::tip
+When [`cache`](/config/cache) is disabled, Rspack disables the incremental build stages. Keep cache enabled if you want to use incremental builds during development, watch, or HMR.
+:::
 
-1. Presets: including `boolean | 'none' | 'safe' | 'advance' | 'advance-silent'`
-   - `false | 'none'`: Disable incremental, and it will not be enabled for any stage.
-   - `'safe'`: Enable incremental for the `buildModuleGraph` and `emitAssets` stages.
-   - `true | 'advance-silent'`: Enable incremental for all stages to maximize performance for rebuilds and HMR. This is the default behavior of Rspack.
-   - `'advance'`: The same as above, but it will detect cases that are unfriendly to incremental and throw warnings to users (e.g., incorrect configurations). This option can help you to identify potential issues affecting incremental build performance.
-2. **Detailed object configuration**: `Incremental`, which allows fine-grained control over whether the incremental is enabled for each stage.
+## Configuration
 
-   {/* prettier-ignore */}
-   <details>
-      <summary style={{ display: 'list-item' }}>Detailed type of `Incremental`</summary>
-      <blockquote>
-        <p>
-        ```ts
-        type Incremental = {
-          // Whether to throw a warning when encountering situations that are not friendly for incremental.
-          silent?: boolean;
-          // The following configuration is used to control whether the incremental of each stage is enabled.
-          buildModuleGraph?: boolean;
-          finishModules?: boolean;
-          optimizeDependencies?: boolean;
-          buildChunkGraph?: boolean;
-          moduleIds?: boolean;
-          chunkIds?: boolean;
-          modulesHashes?: boolean;
-          modulesCodegen?: boolean;
-          modulesRuntimeRequirements?: boolean;
-          chunksRuntimeRequirements?: boolean;
-          chunksHashes?: boolean;
-          chunkAsset?: boolean;
-          emitAssets?: boolean;
-        };
-        ```
-        </p>
-      </blockquote>
-    </details>
+`incremental` can be configured with presets or a detailed object.
 
-Usually, we recommend configuring in the preset way, and the detailed object configuration is only provided to facilitate bug troubleshooting.
+Most projects can use the default value; configure this option explicitly only when you need to disable incremental builds, fall back to a more conservative strategy, or diagnose incremental build issues.
 
-Incremental only improves the rebuild performance and have no impact on the initial build. However, when persistent cache is available, initial builds are also treated as rebuilds too, and can benefit from incremental for performance.
+| Value                       | Behavior                                                                                                                                                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `false` / `'none'`          | Disable incremental builds for all stages.                                                                                                                                                                             |
+| `'safe'`                    | Enable incremental builds only for the `buildModuleGraph`, `buildChunkGraph`, and `emitAssets` stages.                                                                                                                 |
+| `true` / `'advance-silent'` | Enable all incremental stages and silently handle cases that are not friendly to incremental builds. This is the default behavior of Rspack.                                                                           |
+| `'advance'`                 | Enable the same stages as `'advance-silent'`, but emit warnings when configuration or plugin behavior causes Rspack to disable incremental passes. This helps identify what is limiting incremental build performance. |
+
+## Examples
+
+By default, you do not need to configure `incremental` explicitly. To surface warnings when configuration or plugin behavior disables incremental passes during development, use `'advance'`:
+
+```js title="rspack.config.mjs"
+export default {
+  incremental: 'advance',
+};
+```
+
+You can also configure `incremental` with an object to control each build stage individually. Object configuration is mainly intended for debugging or temporary workarounds; presets are recommended for normal usage.
+
+```js title="rspack.config.mjs"
+export default {
+  incremental: {
+    silent: false,
+    modulesCodegen: false,
+  },
+};
+```
+
+## Type definition
+
+```ts
+type Incremental = {
+  // Whether to suppress warnings for cases that are not friendly to incremental builds.
+  // Set this to false to emit warnings.
+  silent?: boolean;
+  // The following options control whether incremental builds are enabled for each stage.
+  buildModuleGraph?: boolean;
+  finishModules?: boolean;
+  optimizeDependencies?: boolean;
+  buildChunkGraph?: boolean;
+  optimizeChunkModules?: boolean;
+  moduleIds?: boolean;
+  chunkIds?: boolean;
+  modulesHashes?: boolean;
+  modulesCodegen?: boolean;
+  modulesRuntimeRequirements?: boolean;
+  chunksRuntimeRequirements?: boolean;
+  chunksHashes?: boolean;
+  chunkAsset?: boolean;
+  emitAssets?: boolean;
+};
+```
+
+## Performance impact
+
+Incremental builds mainly improve rebuilds and HMR when reusable compilation state already exists. They do not make an initial build faster when no state can be reused.
+
+When persistent cache is enabled and hit, Rspack can restore part of the compilation state from cache, so the build after startup can also benefit from incremental builds.
 
 The table below shows the results of incremental in different scenarios:
 
@@ -65,4 +88,4 @@ The table below shows the results of incremental in different scenarios:
 |  cold start  |          ❌          |
 | rebuild/HMR  |          ✅          |
 
-Starting from v1.4.0, Rspack enables incremental builds using `'advance-silent'` mode by default. In previous versions, it only activated incremental builds for the `buildModuleGraph` and `emitAssets` phase by default with `'safe'` mode.
+In the table, "hot" means reusable compilation state or persistent cache is available, while "cold" means no reusable state is available.

--- a/website/docs/zh/config/incremental.mdx
+++ b/website/docs/zh/config/incremental.mdx
@@ -1,59 +1,81 @@
 ---
-description: '控制是否启用增量构建功能，该功能通过只重新构建变更的部分来显著加快重构建和热模块替换（HMR）的速度。'
+description: '控制是否启用增量构建；开启后，Rspack 会在重构建和 HMR 中复用未受影响的中间结果，减少需要重新计算的内容。'
 ---
-
-import { ApiMeta } from '../../../components/ApiMeta';
 
 # Incremental
 
-<ApiMeta addedVersion="1.1.0-beta.0" />
-
-控制是否启用增量构建功能，该功能通过只重新构建变更的部分来显著加快重构建和热模块替换（HMR）的速度。
+`incremental` 用于控制 Rspack 的增量构建能力。开启后，Rspack 会在重构建和热模块替换（HMR）过程中复用未受影响的中间结果，只重新计算受变更影响的阶段和产物，从而降低重构建和 HMR 的耗时。
 
 - **类型：** `boolean | 'none' | 'safe' | 'advance' | 'advance-silent' | Incremental`
 - **默认值：** `'advance-silent'`
 
-提供两种配置方式：
+:::tip
+当 [`cache`](/config/cache) 被禁用时，Rspack 会关闭增量构建相关阶段。如果希望在开发、watch 或 HMR 场景使用增量构建，需要保持缓存开启。
+:::
 
-1. 预设配置：包括 `boolean | 'none' | 'safe' | 'advance' | 'advance-silent'`
-   - `false | 'none'`：关闭增量，不对任何阶段开启
-   - `'safe'`：开启 `buildModuleGraph` 和 `emitAssets` 阶段的增量
-   - `true | 'advance-silent'`：开启所有阶段的增量构建，最大程度优化重构建和 HMR 的性能。这是 Rspack 的默认行为
-   - `'advance'`：功能同上，但会检测对增量构建不友好的情况，并发出警告提示用户（例如一些不正确的配置）。该选项可以帮助你排查潜在的影响增量构建性能的问题。
-2. 细粒度的对象配置：`Incremental`，允许精细控制各个构建阶段的增量功能是否开启
+## 配置方式
 
-   {/* prettier-ignore */}
-   <details>
-      <summary style={{ display: 'list-item' }}>`Incremental` 详细类型</summary>
-      <blockquote>
-        <p>
-        ```ts
-        type Incremental = {
-          // 是否在遇到对增量不友好的情况下抛出警告
-          silent?: boolean;
-          // 以下配置用来控制各个阶段的增量是否开启
-          buildModuleGraph?: boolean;
-          finishModules?: boolean;
-          optimizeDependencies?: boolean;
-          buildChunkGraph?: boolean;
-          moduleIds?: boolean;
-          chunkIds?: boolean;
-          modulesHashes?: boolean;
-          modulesCodegen?: boolean;
-          modulesRuntimeRequirements?: boolean;
-          chunksRuntimeRequirements?: boolean;
-          chunksHashes?: boolean;
-          chunkAsset?: boolean;
-          emitAssets?: boolean;
-        };
-        ```
-        </p>
-      </blockquote>
-    </details>
+`incremental` 支持预设值和对象两种配置方式。
 
-通常情况下我们推荐使用预设的方式进行配置，详细的对象配置仅作为方便排查 bug 提供。
+大多数项目可以使用默认值；只有在需要关闭增量构建、回退到更保守的策略，或定位增量构建相关问题时，才需要显式配置。
 
-增量构建主要用于优化重构建速度，对首次构建不会带来性能提升。不过，当持久化缓存可用时，即使是首次构建也会被视为重构建，从而能够利用增量构建提高性能。
+| 配置                        | 行为                                                                                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `false` / `'none'`          | 禁用增量构建，不对任何阶段启用增量能力。                                                                                   |
+| `'safe'`                    | 仅启用 `buildModuleGraph`、`buildChunkGraph` 和 `emitAssets` 阶段的增量能力。                                              |
+| `true` / `'advance-silent'` | 启用所有增量阶段，并静默处理不利于增量构建的情况。这是 Rspack 的默认行为。                                                 |
+| `'advance'`                 | 与 `'advance-silent'` 启用相同的增量阶段，但会在遇到不利于增量构建的配置或插件行为时输出警告，便于定位影响增量效果的原因。 |
+
+## 配置示例
+
+默认情况下无需显式配置 `incremental`。如果希望在开发过程中发现哪些配置或插件行为会导致增量阶段被关闭，可以使用 `'advance'`：
+
+```js title="rspack.config.mjs"
+export default {
+  incremental: 'advance',
+};
+```
+
+也可以通过对象形式配置 `incremental`，对每个构建阶段的增量能力进行细粒度控制。对象配置主要用于调试或临时规避问题，常规场景推荐使用预设值。
+
+```js title="rspack.config.mjs"
+export default {
+  incremental: {
+    silent: false,
+    modulesCodegen: false,
+  },
+};
+```
+
+## 类型定义
+
+```ts
+type Incremental = {
+  // 是否静默处理不利于增量构建的情况；设置为 false 时会输出警告
+  silent?: boolean;
+  // 以下配置用来控制各个阶段的增量是否开启
+  buildModuleGraph?: boolean;
+  finishModules?: boolean;
+  optimizeDependencies?: boolean;
+  buildChunkGraph?: boolean;
+  optimizeChunkModules?: boolean;
+  moduleIds?: boolean;
+  chunkIds?: boolean;
+  modulesHashes?: boolean;
+  modulesCodegen?: boolean;
+  modulesRuntimeRequirements?: boolean;
+  chunksRuntimeRequirements?: boolean;
+  chunksHashes?: boolean;
+  chunkAsset?: boolean;
+  emitAssets?: boolean;
+};
+```
+
+## 性能影响
+
+增量构建主要用于优化已有编译状态下的重构建和 HMR，对没有任何可复用状态的首次构建不会带来性能提升。
+
+当启用并命中持久化缓存时，Rspack 可以从缓存中恢复部分构建状态，因此首次启动后的编译也可能受益于增量构建。
 
 下表概述了不同场景下增量构建的效果：
 
@@ -65,4 +87,4 @@ import { ApiMeta } from '../../../components/ApiMeta';
 |   冷启动   |    ❌    |
 | 重构建/HMR |    ✅    |
 
-Rspack 在 v1.4.0 后默认使用 `'advance-silent'` 开启所有阶段的增量构建；之前的版本默认使用 `'safe'` 仅开启 `buildModuleGraph` 和 `emitAssets` 阶段的增量。
+表中的“热”表示存在可复用的编译状态或持久化缓存，“冷”表示没有可复用状态。


### PR DESCRIPTION
## Summary

This PR updates the incremental configuration docs to better explain preset and object configuration in both English and Chinese. It removes outdated 1.1 metadata from the 2.0 docs, links to the cache docs, adds configuration examples, and clarifies how incremental builds affect rebuild and HMR performance.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).