### PR TITLE
[codex] fix: track loader files as build dependencies

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -305,6 +305,11 @@ export async function runLoaders(
   loaderContext.loaders = context.loaderItems.map((item) => {
     return LoaderObject.__from_binding(item, compiler);
   });
+  for (const loader of loaderContext.loaders) {
+    if (loader.path && !loader.path.startsWith(BUILTIN_LOADER_PREFIX)) {
+      buildDependencies.push(loader.path);
+    }
+  }
 
   loaderContext.hot = context.hot;
   loaderContext.context = contextDirectory;

--- a/tests/rspack-test/cacheCases/common/build-dependencies-resolve/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-resolve/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (4 tracked)
+<i> build dependencies are valid (5 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/build-dependencies-resolve/__snapshots__/stats-4.txt
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-resolve/__snapshots__/stats-4.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (4 tracked)
+<i> build dependencies are valid (5 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/build-dependencies-resolve/__snapshots__/stats-6.txt
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-resolve/__snapshots__/stats-6.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (4 tracked)
+<i> build dependencies are valid (5 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/build-dependencies/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/build-dependencies/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (3 tracked)
+<i> build dependencies are valid (4 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/build-dependencies/__snapshots__/stats-4.txt
+++ b/tests/rspack-test/cacheCases/common/build-dependencies/__snapshots__/stats-4.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (3 tracked)
+<i> build dependencies are valid (4 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/loader-build-dependency/__snapshots__/stats-0.txt
+++ b/tests/rspack-test/cacheCases/common/loader-build-dependency/__snapshots__/stats-0.txt
@@ -1,13 +1,10 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (1 tracked)
+<i> build dependencies are valid (0 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms
 <t> read snapshot from persistent cache: xx ms
-<i> snapshot restored with detected changed dependencies:
-<i> modified paths (1):
-<i>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/basic/file.js
 <i> make persistent cache recovery succeeded
 <t> read make from persistent cache: xx ms
 <t> write make to persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/loader-build-dependency/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/loader-build-dependency/__snapshots__/stats-1.txt
@@ -1,0 +1,12 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<w> persistent cache invalidated because build dependencies changed:
+<w> modified paths (1):
+<w>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/loader-build-dependency/loader.js
+<t> validate build dependencies: xx ms
+<t> write make to persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/loader-build-dependency/file.js
+++ b/tests/rspack-test/cacheCases/common/loader-build-dependency/file.js
@@ -1,0 +1,1 @@
+export default "source";

--- a/tests/rspack-test/cacheCases/common/loader-build-dependency/index.js
+++ b/tests/rspack-test/cacheCases/common/loader-build-dependency/index.js
@@ -1,0 +1,11 @@
+import value from "./file";
+
+it("should invalidate persistent cache when loader changes", async () => {
+	if (COMPILER_INDEX === 0) {
+		expect(value).toBe(1);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX === 1) {
+		expect(value).toBe(2);
+	}
+});

--- a/tests/rspack-test/cacheCases/common/loader-build-dependency/loader.js
+++ b/tests/rspack-test/cacheCases/common/loader-build-dependency/loader.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+
+module.exports = function () {
+	const content = fs.readFileSync(__filename, "utf-8");
+	const match = /LOADER_VALUE = (\d+)/.exec(content);
+	return `export default ${match[1]};`;
+};
+
+// LOADER_VALUE = 1
+---
+const fs = require("fs");
+
+module.exports = function () {
+	const content = fs.readFileSync(__filename, "utf-8");
+	const match = /LOADER_VALUE = (\d+)/.exec(content);
+	return `export default ${match[1]};`;
+};
+
+// LOADER_VALUE = 2

--- a/tests/rspack-test/cacheCases/common/loader-build-dependency/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/loader-build-dependency/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  module: {
+    rules: [
+      {
+        test: /file\.js$/,
+        loader: './loader.js',
+      },
+    ],
+  },
+  cache: {
+    type: 'persistent',
+  },
+};

--- a/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-3.txt
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-3.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-4.txt
+++ b/tests/rspack-test/cacheCases/common/minimize-cache/__snapshots__/stats-4.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/module-asset/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/module-asset/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-3.txt
+++ b/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-3.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-4.txt
+++ b/tests/rspack-test/cacheCases/common/readonly/__snapshots__/stats-4.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/rstest-virtual-module-mock-build-cache/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/update-file/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/update-file/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/update-file/__snapshots__/stats-3.txt
+++ b/tests/rspack-test/cacheCases/common/update-file/__snapshots__/stats-3.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/update-file/__snapshots__/stats-4.txt
+++ b/tests/rspack-test/cacheCases/common/update-file/__snapshots__/stats-4.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/invalidation/lib-symlink/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/invalidation/lib-symlink/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/define-plugin/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/make/define-plugin/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/define-plugin/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/define-plugin/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/define-plugin/__snapshots__/stats-3.txt
+++ b/tests/rspack-test/cacheCases/make/define-plugin/__snapshots__/stats-3.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/isolated_module/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/isolated_module/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/issuer-update/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/issuer-update/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/keep-module-error/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/make/keep-module-error/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/lazy-barrel/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/lazy-barrel/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/lazy-barrel/__snapshots__/stats-4.txt
+++ b/tests/rspack-test/cacheCases/make/lazy-barrel/__snapshots__/stats-4.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/provide-plugin/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/make/provide-plugin/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/provide-plugin/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/provide-plugin/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/provide-plugin/__snapshots__/stats-3.txt
+++ b/tests/rspack-test/cacheCases/make/provide-plugin/__snapshots__/stats-3.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/mf/issue-9150/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/mf/issue-9150/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/portable/basic/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/portable/basic/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/portable/basic/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/portable/basic/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/context-dependencies/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/snapshot/context-dependencies/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/context-dependencies/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/snapshot/context-dependencies/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (2 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/default_value/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/snapshot/default_value/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/immutable-paths/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/snapshot/immutable-paths/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/managed-paths/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/snapshot/managed-paths/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/missing_dependencies/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/snapshot/missing_dependencies/__snapshots__/stats-1.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/snapshot/unmanaged-paths/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/snapshot/unmanaged-paths/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/storage/directory/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/storage/directory/__snapshots__/stats-2.txt
@@ -1,6 +1,6 @@
 DEBUG LOG from rspack.persistentCache
 <i> persistent cache enabled
-<i> build dependencies are valid (0 tracked)
+<i> build dependencies are valid (1 tracked)
 <t> validate build dependencies: xx ms
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms


### PR DESCRIPTION
## Summary

- Automatically register resolved non-builtin loader files as build dependencies during JS loader execution.
- Add a persistent cache regression case proving a changed loader invalidates cached module output.
- Refresh cache stats snapshots to account for loader files now being tracked.

## Why

Webpack tracks loader files in `NormalModule` build dependencies, so changing a loader invalidates the persistent cache for affected modules. Rspack exposed `this.addBuildDependency`, but did not automatically add the loader file itself, which could allow stale persistent cache results after loader changes.

## Validation

- `pnpm run build:js`
- `pnpm --filter @rspack/tests test Cache.test.js`
