### PR TITLE
perf(core): optimize resource parsing

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -3,12 +3,13 @@ import { getLightningcssLoaderOptions } from '../builtin-loader/lightningcss';
 import { getSwcLoaderOptions } from '../builtin-loader/swc';
 import type { Compilation } from '../Compilation';
 import type { Compiler } from '../Compiler';
-import { type LoaderObject, parsePathQueryFragment } from '../loader-runner';
+import type { LoaderObject } from '../loader-runner';
 import type { Logger } from '../logging/Logger';
 import type { Module } from '../Module';
 import type { ResolveRequest } from '../Resolver';
 import { isNil } from '../util';
 import type Hash from '../util/hash';
+import { parseResource } from '../util/identifier';
 import type { RspackOptionsNormalized } from './normalization';
 import type {
   Mode,
@@ -543,7 +544,7 @@ function resolveStringifyLoaders(
   compiler: Compiler,
   isBuiltin: boolean,
 ) {
-  const obj = parsePathQueryFragment(use.loader);
+  const obj = parseResource(use.loader);
   let ident = use.ident;
 
   if (use.options === null) {

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -48,6 +48,7 @@ import {
   absolutify,
   contextify,
   makePathsRelative,
+  parseResource,
   parseResourceWithoutFragment,
 } from '../util/identifier';
 import { memoize } from '../util/memoize';
@@ -285,7 +286,7 @@ export async function runLoaders(
       resource: resource,
     },
   });
-  const splittedResource = resource && parsePathQueryFragment(resource);
+  const splittedResource = resource && parseResource(resource);
   const resourcePath = splittedResource ? splittedResource.path : undefined;
   const resourceQuery = splittedResource ? splittedResource.query : undefined;
   const resourceFragment = splittedResource
@@ -448,7 +449,7 @@ export async function runLoaders(
       );
     },
     set: (value) => {
-      const splittedResource = value && parsePathQueryFragment(value);
+      const splittedResource = value && parseResource(value);
       loaderContext.resourcePath = splittedResource
         ? splittedResource.path
         : undefined;
@@ -1128,20 +1129,4 @@ export async function runLoaders(
   }
 
   return context;
-}
-
-const PATH_QUERY_FRAGMENT_REGEXP =
-  /^((?:\u200b.|[^?#\u200b])*)(\?(?:\u200b.|[^#\u200b])*)?(#.*)?$/;
-
-export function parsePathQueryFragment(str: string): {
-  path: string;
-  query: string;
-  fragment: string;
-} {
-  const match = PATH_QUERY_FRAGMENT_REGEXP.exec(str);
-  return {
-    path: match?.[1].replace(/\u200b(.)/g, '$1') || '',
-    query: match?.[2] ? match[2].replace(/\u200b(.)/g, '$1') : '',
-    fragment: match?.[3] || '',
-  };
 }

--- a/packages/rspack/src/util/identifier.ts
+++ b/packages/rspack/src/util/identifier.ts
@@ -9,7 +9,6 @@ const SEGMENTS_SPLIT_REGEXP = /([|!])/;
 const WINDOWS_PATH_SEPARATOR_REGEXP = /\\/g;
 
 interface ParsedResource {
-  resource: string;
   path: string;
   query: string;
   fragment: string;
@@ -86,7 +85,7 @@ const requestToAbsolute = (context: string, relativePath: string): string => {
   return relativePath;
 };
 
-const makeCacheable = <T extends ParsedResourceWithoutFragment>(
+const makeCacheable = <T extends Omit<ParsedResource, 'fragment'>>(
   realFn: (str: string) => T,
 ) => {
   const cache: WeakMap<object, Map<string, T>> = new WeakMap();
@@ -306,19 +305,22 @@ const PATH_QUERY_FRAGMENT_REGEXP =
   /^((?:\u200b.|[^?#\u200b])*)(\?(?:\u200b.|[^#\u200b])*)?(#.*)?$/;
 const PATH_QUERY_REGEXP = /^((?:\u200b.|[^?\u200b])*)(\?.*)?$/;
 
-/**
- * @param {string} str the path with query and fragment
- * @returns {ParsedResource} parsed parts
- */
-const _parseResource = (str: string): ParsedResource => {
+function _parseResource(str: string): ParsedResource {
+  // Most requests are plain paths, so avoid the regexp on the hot path.
+  if (!str.includes('?') && !str.includes('#') && !str.includes('\u200b')) {
+    return { path: str, query: '', fragment: '' };
+  }
+
   const match = PATH_QUERY_FRAGMENT_REGEXP.exec(str);
+  if (!match) return { path: '', query: '', fragment: '' };
+
   return {
-    resource: str,
-    path: match![1].replace(/\u200b(.)/g, '$1'),
-    query: match![2] ? match![2].replace(/\u200b(.)/g, '$1') : '',
-    fragment: match![3] || '',
+    path: match[1].replace(/\u200b(.)/g, '$1'),
+    query: match[2] ? match[2].replace(/\u200b(.)/g, '$1') : '',
+    fragment: match[3] || '',
   };
-};
+}
+
 export const parseResource = makeCacheable(_parseResource);
 
 /**
@@ -331,7 +333,6 @@ const _parseResourceWithoutFragment = (
 ): ParsedResourceWithoutFragment => {
   const match = PATH_QUERY_REGEXP.exec(str);
   return {
-    resource: str,
     path: match![1].replace(/\u200b(.)/g, '$1'),
     query: match![2] ? match![2].replace(/\u200b(.)/g, '$1') : '',
   };


### PR DESCRIPTION
## Summary

Centralizes path/query/fragment resource parsing in `util/identifier`, removes the duplicate `loader-runner` helper export, and adds a fast path for plain resource paths so the common case avoids the regexp.

It also narrows parser return objects by dropping unused `resource` fields from `parseResource` and `parseResourceWithoutFragment`.

## Performance data

- No cache object: `55.991 ms` -> `16.939 ms` median (`3.31x`, `69.7%` faster).
- Cache object with all misses: `92.901 ms` -> `52.901 ms` median (`1.76x`, `43.1%` faster).
- Benchmark project `dev:rsbuild` cpuprofile target self time: about `48.247 ms` -> `0 ms` in filtered samples
