### PR TITLE
perf(core): reduce allocations in runtime requirements processing

### DIFF
--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -337,6 +337,7 @@ pub async fn process_chunks_runtime_requirements(
     })
     .collect::<FxHashMap<_, _>>();
 
+  let mut runtime_modules_to_add = Vec::new();
   for (chunk_ukey, mut set) in chunk_requirements {
     let mut additional_runtime_modules = Vec::new();
     plugin_driver
@@ -359,7 +360,7 @@ pub async fn process_chunks_runtime_requirements(
       compilation.add_runtime_module(&chunk_ukey, module)?;
     }
 
-    let mut runtime_modules_to_add = Vec::new();
+    runtime_modules_to_add.clear();
     process_runtime_requirement_hook_mut(compilation, &mut set, &mut runtime_modules_to_add, {
       let plugin_driver = plugin_driver.clone();
       move |compilation,
@@ -401,7 +402,8 @@ pub async fn process_chunks_runtime_requirements(
       set = set.with_require_scope();
     }
 
-    for module in runtime_modules_to_add {
+    let runtime_modules_to_add_len = runtime_modules_to_add.len();
+    for module in runtime_modules_to_add.drain(0..runtime_modules_to_add_len) {
       compilation.add_runtime_module(&chunk_ukey, module)?;
     }
 
@@ -410,9 +412,10 @@ pub async fn process_chunks_runtime_requirements(
   logger.time_end(start);
 
   let start = logger.time("runtime requirements.entries");
+  let mut runtime_modules_to_add: Vec<(ChunkUkey, Box<dyn RuntimeModule>)> = Vec::new();
   for &entry_ukey in &entries {
     let mut all_runtime_requirements = RuntimeGlobals::default();
-    let mut runtime_modules_to_add: Vec<(ChunkUkey, Box<dyn RuntimeModule>)> = Vec::new();
+    runtime_modules_to_add.clear();
 
     let entry = compilation
       .build_chunk_graph_artifact
@@ -491,7 +494,8 @@ pub async fn process_chunks_runtime_requirements(
     }
 
     ChunkGraph::set_tree_runtime_requirements(compilation, entry_ukey, all_runtime_requirements);
-    for (chunk_ukey, module) in runtime_modules_to_add {
+    let runtime_modules_to_add_len = runtime_modules_to_add.len();
+    for (chunk_ukey, module) in runtime_modules_to_add.drain(0..runtime_modules_to_add_len) {
       compilation.add_runtime_module(&chunk_ukey, module)?;
     }
   }


### PR DESCRIPTION
## Summary

- Reuse the `runtime_modules_to_add` buffers across chunk and entry runtime requirement loops instead of allocating a new `Vec` for each iteration.
- Drain the modules collected for the current iteration before adding them to the compilation, preserving the existing runtime module behavior while reducing transient allocations in `process_chunks_runtime_requirements`.

## Related links

- None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
