### PR TITLE
ci: pin release artifact download action

### DIFF
--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/pnpm/install-dependencies
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -93,7 +93,7 @@ jobs:
         uses: ./.github/actions/pnpm/install-dependencies
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
           pattern: bindings-*

--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/pnpm/install-dependencies
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
           pattern: bindings-*

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/pnpm/install-dependencies
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
           pattern: bindings-*


### PR DESCRIPTION
## Summary

- Pin release workflow `actions/download-artifact` references to the same commit used on `main`
- Fix the preview/release workflow policy failure on `v1.x`

## Tests

- `git diff --check HEAD~1 HEAD`
- YAML parse check for the changed workflow files
- Confirmed no direct `uses: actions/download-artifact@v4.1.7` remains in `.github/workflows` or `.github/actions`