### PR TITLE
perf(ci): drop redundant cargo check from rust CI

### DIFF
--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -55,16 +55,12 @@ jobs:
         if: ${{ inputs.cargo-check-strategy == 'separated' }}
         run: cargo binstall --no-confirm cargo-workspaces@0.4.0 --force
 
-      - name: Run Cargo Check (all strategy)
-        if: ${{ inputs.cargo-check-strategy == 'all' }}
-        run: cargo check --workspace --all-targets --locked
-
       - name: Run Cargo Check (separated strategy)
         if: ${{ inputs.cargo-check-strategy == 'separated' }}
         run: cargo workspaces exec --ignore-private cargo check --lib --locked
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-targets --tests -- -D warnings
+        run: cargo clippy --workspace --all-targets --tests --locked -- -D warnings
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Why

`Rust check` is the long pole of CI-Rust — over the last 20 `main` runs it has a
p50 of **7m38s** and gates the whole workflow's wall-clock. Inside that job,
`cargo check --workspace --all-targets` (p50 **2m17s**) runs right before
`cargo clippy --workspace --all-targets` (p50 **3m55s**).

Clippy already runs the full type-check pass over the whole workspace, and it
uses a different driver so it shares no build cache with `cargo check`. The
standalone `cargo check` therefore just recompiles everything a second time and
catches nothing clippy doesn't.

## What

- Drop the `all`-strategy `cargo check` step; rely on clippy for type-checking.
- Move `--locked` onto the clippy invocation to keep the Cargo.lock enforcement
  the removed step provided.
- The per-crate `separated` strategy (release crate path) is left untouched.

## Impact (last 20 `main` runs)

| | before | after (est.) |
|---|---|---|
| `Rust check` job p50 | 7m38s | ~5m20s |
| CI-Rust wall-clock p50 | 9m53s | ~7m30s (≈ -24%) |
