### PR TITLE
feat: support JS custom runtime modules in rspack mode

### DIFF
--- a/crates/rspack_plugin_javascript/src/custom_runtime_module_compat.rs
+++ b/crates/rspack_plugin_javascript/src/custom_runtime_module_compat.rs
@@ -1,0 +1,480 @@
+use rspack_core::{
+  ChunkCodeTemplate, MODULE_GLOBALS, RuntimeGlobals, RuntimeVariable, property_access,
+  runtime_variable_name,
+};
+use rspack_error::{Result, error};
+use rspack_util::SpanExt;
+use swc_experimental_allocator::Allocator;
+use swc_experimental_ecma_ast::{
+  AssignExpr, AssignTarget, CallExpr, Callee, Expr, GetSpan, Ident, MemberExpr, MemberProp,
+  SimpleAssignTarget, UnaryExpr, UnaryOp, UpdateExpr, Visit, VisitWith,
+};
+use swc_experimental_ecma_parser::{EsSyntax, Lexer, Parser, StringSource, Syntax};
+use swc_experimental_ecma_semantic::resolver::{Semantic, resolver};
+
+pub(crate) struct CustomRuntimeModuleCompat {
+  pub source: String,
+  pub runtime_requirements: RuntimeGlobals,
+  pub write_runtime_requirements: RuntimeGlobals,
+}
+
+pub(crate) fn replace_custom_runtime_module_compat(
+  source: String,
+  runtime_template: &ChunkCodeTemplate,
+) -> Result<CustomRuntimeModuleCompat> {
+  let table = RuntimeCompatTable::new(runtime_template);
+  let mut replacements = {
+    let allocator = Allocator::new();
+    let lexer = Lexer::new(
+      &allocator,
+      Syntax::Es(EsSyntax {
+        allow_return_outside_function: true,
+        ..Default::default()
+      }),
+      swc_experimental_ecma_ast::EsVersion::EsNext,
+      StringSource::new(source.as_ref()),
+      None,
+    );
+    let mut parser = Parser::new_from(&allocator, lexer);
+    let program = parser.parse_program().map_err(|e| {
+      let mut errors = parser.take_errors();
+      errors.push(e);
+      error!("Failed to parse custom runtime module source: {errors:?}")
+    })?;
+
+    let parse_errors = parser.take_errors();
+    if !parse_errors.is_empty() {
+      return Err(error!(
+        "Failed to parse custom runtime module source: {parse_errors:?}"
+      ));
+    }
+
+    let semantic = resolver(&program);
+    let mut collector = RuntimeCompatCollector {
+      semantic: &semantic,
+      source: &source,
+      table: &table,
+      replacements: Vec::new(),
+      runtime_requirements: RuntimeGlobals::default(),
+      write_runtime_requirements: RuntimeGlobals::default(),
+    };
+    program.visit_with(&mut collector);
+    (
+      collector.replacements,
+      collector.runtime_requirements,
+      collector.write_runtime_requirements,
+    )
+  };
+
+  let mut result = source;
+  replacements
+    .0
+    .sort_unstable_by(|a, b| b.start.cmp(&a.start));
+  for replacement in replacements.0 {
+    result.replace_range(replacement.start..replacement.end, &replacement.value);
+  }
+
+  Ok(CustomRuntimeModuleCompat {
+    source: result,
+    runtime_requirements: replacements.1,
+    write_runtime_requirements: replacements.2,
+  })
+}
+
+struct RuntimeCompatTable {
+  require_scope: String,
+  require_sources: Vec<String>,
+  runtime_variables: Vec<RuntimeVariableCompat>,
+  runtime_globals: Vec<RuntimeGlobalCompat>,
+}
+
+struct RuntimeVariableCompat {
+  source: &'static str,
+  target: String,
+  runtime_global: Option<RuntimeGlobals>,
+}
+
+struct RuntimeGlobalCompat {
+  runtime_global: RuntimeGlobals,
+  sources: Vec<String>,
+  target: String,
+}
+
+impl RuntimeCompatTable {
+  fn new(runtime_template: &ChunkCodeTemplate) -> Self {
+    let require_scope = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE_SCOPE);
+    let mut runtime_variables = Vec::new();
+    for (runtime_variable, runtime_global) in [
+      (RuntimeVariable::Require, Some(RuntimeGlobals::REQUIRE)),
+      (
+        RuntimeVariable::Context,
+        Some(RuntimeGlobals::REQUIRE_SCOPE),
+      ),
+      (
+        RuntimeVariable::Modules,
+        Some(RuntimeGlobals::MODULE_FACTORIES),
+      ),
+      (
+        RuntimeVariable::ModuleCache,
+        Some(RuntimeGlobals::MODULE_CACHE),
+      ),
+      (RuntimeVariable::Module, Some(RuntimeGlobals::MODULE)),
+      (RuntimeVariable::Exports, Some(RuntimeGlobals::EXPORTS)),
+      (RuntimeVariable::StartupExec, None),
+    ] {
+      runtime_variables.push(RuntimeVariableCompat {
+        source: runtime_variable_name(&runtime_variable),
+        target: runtime_template.render_runtime_variable(&runtime_variable),
+        runtime_global,
+      });
+    }
+
+    let mut runtime_globals = Vec::new();
+    for (_, runtime_global) in RuntimeGlobals::all().iter_names() {
+      let Some(target) = render_runtime_global(runtime_template, runtime_global) else {
+        continue;
+      };
+      let mut sources = vec![render_webpack_runtime_global(runtime_global)];
+      let current_rendered = runtime_template.render_runtime_globals(&runtime_global);
+      if !sources.iter().any(|source| source == &current_rendered) {
+        sources.push(current_rendered);
+      }
+      runtime_globals.push(RuntimeGlobalCompat {
+        runtime_global,
+        sources,
+        target,
+      });
+    }
+
+    let require_sources = runtime_globals
+      .iter()
+      .find(|item| item.runtime_global == RuntimeGlobals::REQUIRE)
+      .map(|item| item.sources.clone())
+      .unwrap_or_else(|| vec![runtime_variable_name(&RuntimeVariable::Require).to_string()]);
+
+    Self {
+      require_scope,
+      require_sources,
+      runtime_variables,
+      runtime_globals,
+    }
+  }
+
+  fn runtime_variable(&self, name: &str) -> Option<&RuntimeVariableCompat> {
+    self
+      .runtime_variables
+      .iter()
+      .find(|item| item.source == name)
+  }
+
+  fn runtime_global_by_source(&self, source: &str) -> Option<&RuntimeGlobalCompat> {
+    self
+      .runtime_globals
+      .iter()
+      .find(|item| item.sources.iter().any(|candidate| candidate == source))
+  }
+
+  fn runtime_global_by_property(&self, property: &str) -> Option<&RuntimeGlobalCompat> {
+    let runtime_global = RuntimeGlobals::from_property_name(property)?;
+    self
+      .runtime_globals
+      .iter()
+      .find(|item| item.runtime_global == runtime_global)
+  }
+
+  fn is_require_source(&self, source: &str) -> bool {
+    self
+      .require_sources
+      .iter()
+      .any(|candidate| candidate == source)
+  }
+}
+
+fn render_webpack_runtime_global(runtime_global: RuntimeGlobals) -> String {
+  if runtime_global == RuntimeGlobals::EXPORTS {
+    return runtime_variable_name(&RuntimeVariable::Exports).to_string();
+  }
+  if runtime_global == RuntimeGlobals::REQUIRE {
+    return runtime_variable_name(&RuntimeVariable::Require).to_string();
+  }
+  if runtime_global == RuntimeGlobals::MODULE {
+    return "module".to_string();
+  }
+  if runtime_global == RuntimeGlobals::REQUIRE_SCOPE {
+    return format!("{}.*", runtime_variable_name(&RuntimeVariable::Require));
+  }
+  let name = runtime_global
+    .property_name()
+    .expect("runtime global should have a property name");
+  if runtime_global.renderable_require_scope() == runtime_global {
+    return format!(
+      "{}{}",
+      runtime_variable_name(&RuntimeVariable::Require),
+      property_access([name], 0)
+    );
+  }
+  if MODULE_GLOBALS.contains(runtime_global) {
+    return format!("module{}", property_access([name], 0));
+  }
+  name.to_string()
+}
+
+fn render_runtime_global(
+  runtime_template: &ChunkCodeTemplate,
+  runtime_global: RuntimeGlobals,
+) -> Option<String> {
+  if runtime_global == RuntimeGlobals::REQUIRE {
+    return Some(runtime_template.render_runtime_variable(&RuntimeVariable::Require));
+  }
+  if runtime_global == RuntimeGlobals::REQUIRE_SCOPE {
+    return Some(runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE_SCOPE));
+  }
+  if runtime_global == RuntimeGlobals::MODULE_FACTORIES {
+    return Some(runtime_template.render_runtime_variable(&RuntimeVariable::Modules));
+  }
+  if runtime_global == RuntimeGlobals::EXPORTS {
+    return Some(runtime_template.render_runtime_variable(&RuntimeVariable::Exports));
+  }
+  if runtime_global == RuntimeGlobals::MODULE {
+    return Some(runtime_template.render_runtime_variable(&RuntimeVariable::Module));
+  }
+  if runtime_global.renderable_require_scope() == runtime_global {
+    return runtime_global
+      .to_lexical_name()
+      .map(str::to_string)
+      .or_else(|| Some(runtime_template.render_runtime_globals(&runtime_global)));
+  }
+  Some(runtime_template.render_runtime_globals(&runtime_global))
+}
+
+struct RuntimeCompatCollector<'a> {
+  semantic: &'a Semantic,
+  source: &'a str,
+  table: &'a RuntimeCompatTable,
+  replacements: Vec<RuntimeCompatReplacement>,
+  runtime_requirements: RuntimeGlobals,
+  write_runtime_requirements: RuntimeGlobals,
+}
+
+struct RuntimeCompatReplacement {
+  start: usize,
+  end: usize,
+  value: String,
+}
+
+#[derive(Clone, Copy)]
+enum RuntimeUsage {
+  Read,
+  Write,
+}
+
+impl<'a> RuntimeCompatCollector<'a> {
+  fn collect_ident(&mut self, ident: &Ident<'a>, usage: RuntimeUsage) {
+    let Some(runtime_variable) = self.table.runtime_variable(ident.sym.as_str()) else {
+      return;
+    };
+    if self.semantic.node_scope(ident) != self.semantic.unresolved_scope_id() {
+      return;
+    }
+    self.collect_runtime_requirement(runtime_variable.runtime_global, usage);
+    self.replacements.push(RuntimeCompatReplacement {
+      start: ident.span.real_lo() as usize,
+      end: ident.span.real_hi() as usize,
+      value: runtime_variable.target.clone(),
+    });
+  }
+
+  fn collect_member_expr(&mut self, expr: &MemberExpr<'a>, usage: RuntimeUsage) -> bool {
+    let Some(object_source) = self.expr_source(&expr.obj) else {
+      return false;
+    };
+    if !self.table.is_require_source(object_source) {
+      return false;
+    }
+    let runtime_global = self
+      .member_property_name(&expr.prop)
+      .and_then(|property| self.table.runtime_global_by_property(property));
+    let value = runtime_global.map(|item| item.target.clone()).or_else(|| {
+      self
+        .member_property_access(&expr.prop)
+        .map(|property_access| format!("{}{}", self.table.require_scope, property_access))
+    });
+    let Some(value) = value else {
+      return false;
+    };
+    self.collect_runtime_requirement(runtime_global.map(|item| item.runtime_global), usage);
+    self.replacements.push(RuntimeCompatReplacement {
+      start: expr.span.real_lo() as usize,
+      end: expr.span.real_hi() as usize,
+      value,
+    });
+    true
+  }
+
+  fn collect_expr_by_source(&mut self, expr: &Expr<'a>, usage: RuntimeUsage) -> bool {
+    let Some(source) = self.expr_source(expr) else {
+      return false;
+    };
+    if let Some(runtime_global) = self.table.runtime_global_by_source(source) {
+      self.collect_runtime_requirement(Some(runtime_global.runtime_global), usage);
+      self.replacements.push(RuntimeCompatReplacement {
+        start: expr.span().real_lo() as usize,
+        end: expr.span().real_hi() as usize,
+        value: runtime_global.target.clone(),
+      });
+      return true;
+    }
+    false
+  }
+
+  fn collect_member_expr_by_source(&mut self, expr: &MemberExpr<'a>, usage: RuntimeUsage) -> bool {
+    let start = expr.span.real_lo() as usize;
+    let end = expr.span.real_hi() as usize;
+    let Some(source) = self.source.get(start..end) else {
+      return false;
+    };
+    if let Some(runtime_global) = self.table.runtime_global_by_source(source) {
+      self.collect_runtime_requirement(Some(runtime_global.runtime_global), usage);
+      self.replacements.push(RuntimeCompatReplacement {
+        start,
+        end,
+        value: runtime_global.target.clone(),
+      });
+      return true;
+    }
+    false
+  }
+
+  fn collect_runtime_requirement(
+    &mut self,
+    runtime_global: Option<RuntimeGlobals>,
+    usage: RuntimeUsage,
+  ) {
+    let Some(runtime_global) = runtime_global else {
+      return;
+    };
+    self.runtime_requirements.insert(runtime_global);
+    if matches!(usage, RuntimeUsage::Write) {
+      self.write_runtime_requirements.insert(runtime_global);
+    }
+  }
+
+  fn expr_source(&self, expr: &Expr<'a>) -> Option<&str> {
+    let start = expr.span().real_lo() as usize;
+    let end = expr.span().real_hi() as usize;
+    self.source.get(start..end)
+  }
+
+  fn member_property_name<'b>(&self, prop: &'b MemberProp<'a>) -> Option<&'b str> {
+    match prop {
+      MemberProp::Ident(ident) => Some(ident.sym.as_str()),
+      MemberProp::Computed(computed) => match &computed.expr {
+        Expr::Lit(lit) => lit.as_str().and_then(|value| value.value.as_str()),
+        _ => None,
+      },
+      MemberProp::PrivateName(_) => None,
+    }
+  }
+
+  fn member_property_access(&self, prop: &MemberProp<'a>) -> Option<String> {
+    match prop {
+      MemberProp::Ident(ident) => Some(property_access([ident.sym.as_str()], 0)),
+      MemberProp::Computed(_) => {
+        let start = prop.span().real_lo() as usize;
+        let end = prop.span().real_hi() as usize;
+        self.source.get(start..end).map(str::to_string)
+      }
+      MemberProp::PrivateName(_) => None,
+    }
+  }
+
+  fn visit_assignment_target(&mut self, target: &AssignTarget<'a>) {
+    match target {
+      AssignTarget::Simple(target) => match target.as_ref() {
+        SimpleAssignTarget::Ident(ident) => {
+          self.collect_ident(&ident.id, RuntimeUsage::Write);
+        }
+        SimpleAssignTarget::Member(expr) => {
+          if !self.collect_member_expr(expr, RuntimeUsage::Write)
+            && !self.collect_member_expr_by_source(expr, RuntimeUsage::Write)
+          {
+            expr.visit_children_with(self);
+          }
+        }
+        _ => target.visit_with(self),
+      },
+      _ => target.visit_with(self),
+    }
+  }
+}
+
+impl<'a> Visit<'a> for RuntimeCompatCollector<'a> {
+  fn visit_member_expr(&mut self, expr: &MemberExpr<'a>) {
+    if self.collect_member_expr(expr, RuntimeUsage::Read) {
+      return;
+    }
+    expr.visit_children_with(self);
+  }
+
+  fn visit_assign_expr(&mut self, expr: &AssignExpr<'a>) {
+    self.visit_assignment_target(&expr.left);
+    expr.right.visit_with(self);
+  }
+
+  fn visit_update_expr(&mut self, expr: &UpdateExpr<'a>) {
+    match &expr.arg {
+      Expr::Ident(ident) => self.collect_ident(ident, RuntimeUsage::Write),
+      Expr::Member(member) => {
+        if !self.collect_member_expr(member, RuntimeUsage::Write)
+          && !self.collect_member_expr_by_source(member, RuntimeUsage::Write)
+        {
+          expr.arg.visit_with(self);
+        }
+      }
+      _ => expr.arg.visit_with(self),
+    }
+  }
+
+  fn visit_unary_expr(&mut self, expr: &UnaryExpr<'a>) {
+    if expr.op == UnaryOp::Delete {
+      match &expr.arg {
+        Expr::Ident(ident) => {
+          self.collect_ident(ident, RuntimeUsage::Write);
+          return;
+        }
+        Expr::Member(member) => {
+          if self.collect_member_expr(member, RuntimeUsage::Write)
+            || self.collect_member_expr_by_source(member, RuntimeUsage::Write)
+          {
+            return;
+          }
+        }
+        _ => {}
+      }
+    }
+    expr.arg.visit_with(self);
+  }
+
+  fn visit_call_expr(&mut self, expr: &CallExpr<'a>) {
+    if let Callee::Expr(callee) = &expr.callee
+      && self.collect_expr_by_source(callee, RuntimeUsage::Read)
+    {
+      for arg in &expr.args {
+        arg.visit_with(self);
+      }
+      return;
+    }
+    expr.visit_children_with(self);
+  }
+
+  fn visit_expr(&mut self, expr: &Expr<'a>) {
+    if let Expr::Ident(ident) = expr {
+      self.collect_ident(ident, RuntimeUsage::Read);
+      return;
+    }
+    if self.collect_expr_by_source(expr, RuntimeUsage::Read) {
+      return;
+    }
+    expr.visit_children_with(self);
+  }
+}

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate self as rspack_plugin_javascript;
 
+mod custom_runtime_module_compat;
 pub mod dependency;
 mod magic_comment;
 pub mod parser_and_generator;

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -16,7 +16,10 @@ pub use crate::runtime_context::{
   render_rspack_runtime_modules, render_runtime_context_declaration,
   render_runtime_context_require_assignment,
 };
-use crate::{JavascriptModulesPluginHooks, RenderSource};
+use crate::{
+  JavascriptModulesPluginHooks, RenderSource,
+  custom_runtime_module_compat::replace_custom_runtime_module_compat,
+};
 
 pub const AUTO_PUBLIC_PATH_PLACEHOLDER: &str = "__RSPACK_PLUGIN_ASSET_AUTO_PUBLIC_PATH__";
 
@@ -351,13 +354,12 @@ pub async fn render_runtime_modules(
   }
 }
 
-pub(crate) type RuntimeModuleSourceItem = (BoxSource, RuntimeGlobals);
+pub(crate) type RuntimeModuleSourceItem = (BoxSource, RuntimeGlobals, RuntimeGlobals);
 
 pub(crate) async fn render_runtime_module_sources(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
   runtime_template: &ChunkCodeTemplate,
-  reject_custom_runtime_modules: bool,
 ) -> Result<Vec<RuntimeModuleSourceItem>> {
   let runtime_module_sources = rspack_parallel::scope::<_, Result<_>>(|token| {
     compilation
@@ -378,43 +380,77 @@ pub(crate) async fn render_runtime_module_sources(
         s.spawn(
           move |(compilation, source, module, runtime_template)| async move {
             if source.size() == 0 {
-              return Ok((ConcatSource::default().boxed(), RuntimeGlobals::default()));
-            }
-            let generated_requirements =
-              module.additional_write_runtime_requirements(compilation);
-            if reject_custom_runtime_modules
-              && module.get_constructor_name() == "RuntimeModuleFromJs"
-            {
-              return Err(rspack_error::error!(
-                "Custom runtime modules are not supported when `experiments.runtimeMode` is \"rspack\" (runtime module: {}).",
-                module.identifier()
+              return Ok((
+                ConcatSource::default().boxed(),
+                RuntimeGlobals::default(),
+                RuntimeGlobals::default(),
               ));
             }
+            let mut runtime_requirements = module.additional_runtime_requirements(compilation);
+            let mut write_runtime_requirements =
+              module.additional_write_runtime_requirements(compilation);
             let supports_arrow_function = compilation
               .options
               .output
               .environment
               .supports_arrow_function();
+            let should_replace_custom_runtime_module =
+              compilation.options.experiments.runtime_mode == RuntimeMode::Rspack;
             let source = if !(module.full_hash()
               || module.dependent_hash()
               || (runtime_template.uses_runtime_context()
                 && !runtime_template.uses_lexical_runtime_globals()))
             {
               if let Some(custom_source) = module.get_custom_source() {
-                RawStringSource::from(custom_source).boxed()
+                if should_replace_custom_runtime_module {
+                  let result =
+                    replace_custom_runtime_module_compat(custom_source, runtime_template)?;
+                  runtime_requirements.insert(result.runtime_requirements);
+                  write_runtime_requirements.insert(result.write_runtime_requirements);
+                  RawStringSource::from(result.source).boxed()
+                } else {
+                  RawStringSource::from(custom_source).boxed()
+                }
+              } else if should_replace_custom_runtime_module
+                && module.get_constructor_name() == "RuntimeModuleFromJs"
+              {
+                let result = replace_custom_runtime_module_compat(
+                  source.source().into_string_lossy().into_owned(),
+                  runtime_template,
+                )?;
+                runtime_requirements.insert(result.runtime_requirements);
+                write_runtime_requirements.insert(result.write_runtime_requirements);
+                RawStringSource::from(result.source).boxed()
               } else {
                 source.clone()
               }
             } else {
               if let Some(custom_source) = module.get_custom_source() {
-                RawStringSource::from(custom_source).boxed()
+                if should_replace_custom_runtime_module {
+                  let result =
+                    replace_custom_runtime_module_compat(custom_source, runtime_template)?;
+                  runtime_requirements.insert(result.runtime_requirements);
+                  write_runtime_requirements.insert(result.write_runtime_requirements);
+                  RawStringSource::from(result.source).boxed()
+                } else {
+                  RawStringSource::from(custom_source).boxed()
+                }
               } else {
-                let runtime_template = compilation.runtime_template.create_runtime_code_template();
+                let runtime_code_template =
+                  compilation.runtime_template.create_runtime_code_template();
                 let context = RuntimeModuleGenerateContext {
                   compilation,
-                  runtime_template: &runtime_template,
+                  runtime_template: &runtime_code_template,
                 };
-                let source_str = module.generate(&context).await?;
+                let mut source_str = module.generate(&context).await?;
+                if should_replace_custom_runtime_module
+                  && module.get_constructor_name() == "RuntimeModuleFromJs"
+                {
+                  let result = replace_custom_runtime_module_compat(source_str, runtime_template)?;
+                  runtime_requirements.insert(result.runtime_requirements);
+                  write_runtime_requirements.insert(result.write_runtime_requirements);
+                  source_str = result.source;
+                }
                 if module.get_source_map_kind().enabled() {
                   OriginalSource::new(source_str, module.identifier().as_str()).boxed()
                 } else {
@@ -428,7 +464,7 @@ pub(crate) async fn render_runtime_module_sources(
               module.should_isolate(),
               supports_arrow_function,
             );
-            Ok((sources, generated_requirements))
+            Ok((sources, runtime_requirements, write_runtime_requirements))
           },
         );
       })
@@ -447,10 +483,10 @@ async fn render_webpack_runtime_modules(
   runtime_template: &ChunkCodeTemplate,
 ) -> Result<BoxSource> {
   let runtime_module_sources =
-    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, false).await?;
+    render_runtime_module_sources(compilation, chunk_ukey, runtime_template).await?;
   let mut sources = ConcatSource::default();
 
-  for (runtime_module_source, _) in runtime_module_sources {
+  for (runtime_module_source, _, _) in runtime_module_sources {
     sources.add(runtime_module_source);
   }
 

--- a/crates/rspack_plugin_javascript/src/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/runtime_context.rs
@@ -94,15 +94,30 @@ pub async fn render_rspack_runtime_modules(
   runtime_template: &ChunkCodeTemplate,
 ) -> Result<BoxSource> {
   let runtime_module_sources =
-    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true).await?;
+    render_runtime_module_sources(compilation, chunk_ukey, runtime_template).await?;
   let mut sources = ConcatSource::default();
   let mut metadata = runtime_context_current_chunk_metadata(compilation, chunk_ukey);
+  for (_, runtime_requirements, write_runtime_requirements) in &runtime_module_sources {
+    if runtime_requirements.is_empty() && write_runtime_requirements.is_empty() {
+      continue;
+    }
+    let metadata = metadata.get_or_insert_default();
+    metadata
+      .tree_runtime_requirements
+      .insert(*runtime_requirements | *write_runtime_requirements);
+    metadata
+      .runtime_module_requirements
+      .insert(*runtime_requirements);
+    metadata
+      .context_setter_fields
+      .insert(*write_runtime_requirements);
+  }
   let script_nonce = RuntimeGlobals::SCRIPT_NONCE
     .to_lexical_name()
     .expect("script nonce should have lexical name");
   if runtime_module_sources
     .iter()
-    .any(|(source, _)| source.source().into_string_lossy().contains(script_nonce))
+    .any(|(source, _, _)| source.source().into_string_lossy().contains(script_nonce))
   {
     metadata
       .get_or_insert_default()
@@ -110,7 +125,7 @@ pub async fn render_rspack_runtime_modules(
       .insert(RuntimeGlobals::SCRIPT_NONCE);
   }
   let base_metadata = get_runtime_context_metadata(compilation, chunk_ukey);
-  let should_render_context = base_metadata.is_some_and(|metadata| {
+  let should_render_context = metadata.as_ref().or(base_metadata).is_some_and(|metadata| {
     metadata
       .tree_runtime_requirements
       .contains(RuntimeGlobals::REQUIRE_SCOPE)
@@ -305,7 +320,7 @@ pub async fn render_rspack_runtime_modules(
       "var {require}={runtime_context}.r,{modules}={runtime_context}.m,{module_cache}={runtime_context}.c;\n"
     )));
   }
-  for (runtime_module_source, generated_requirements) in runtime_module_sources {
+  for (runtime_module_source, _, generated_requirements) in runtime_module_sources {
     sources.add(runtime_module_source);
     if !runtime_template.uses_lexical_runtime_globals() {
       continue;

--- a/crates/rspack_plugin_rstest/src/import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/import_dependency.rs
@@ -122,13 +122,12 @@ fn module_namespace_promise_rstest(
 
   let module_id_expr = module_id_rstest(compilation, runtime_template, dep_id, request, weak);
 
+  let require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE);
+  let require_scope = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE_SCOPE);
   let final_require = if is_import_actual {
-    format!(
-      "{}.rstest_import_actual",
-      runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
-    )
+    format!("{require_scope}.rstest_import_actual")
   } else {
-    runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE)
+    require_name.clone()
   };
 
   // Externalized specifiers exhibit a two-id split: rspack mints a distinct id
@@ -173,7 +172,7 @@ fn module_namespace_promise_rstest(
         // falls back to plain require for an older @rstest/core lacking the helper;
         // drop it once the minimum @rstest/core always ships it.
         appending = format!(
-          ".then({final_require}.rstest_dynamic_require ? {final_require}.rstest_dynamic_require.bind({final_require}.rstest_dynamic_require, {module_id_expr}, {}) : {final_require}.bind({final_require}, {module_id_expr}))",
+          ".then({require_scope}.rstest_dynamic_require ? {require_scope}.rstest_dynamic_require.bind({require_scope}.rstest_dynamic_require, {module_id_expr}, {}) : {final_require}.bind({final_require}, {module_id_expr}))",
           json_stringify_str(request)
         );
       } else {

--- a/crates/rspack_plugin_rstest/src/lib.rs
+++ b/crates/rspack_plugin_rstest/src/lib.rs
@@ -6,6 +6,7 @@ mod mock_module_id_dependency;
 mod module_path_name_dependency;
 mod parser_plugin;
 mod plugin;
+mod require_actual_dependency;
 mod require_resolve_origin_dependency;
 mod url_dependency;
 

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -124,7 +124,7 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
       .expect("MockMethodDependencyTemplate can only be applied to MockMethodDependency");
 
     let request = &dep.request;
-    let require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE);
+    let require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE_SCOPE);
     let hoist_id = dep.hoist_id();
 
     let hoist_flag = Self::get_hoist_flag(&dep.method);

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -25,6 +25,7 @@ use crate::{
   mock_method_dependency::{MockMethod, MockMethodDependency},
   mock_module_id_dependency::MockModuleIdDependency,
   module_path_name_dependency::{ModulePathNameDependency, NameType},
+  require_actual_dependency::RstestRequireActualDependency,
   require_resolve_origin_dependency::RstestRequireResolveOriginDependency,
 };
 
@@ -178,14 +179,9 @@ impl RstestParserPlugin {
 
           let callee_range = call_expr.callee.span().into();
           let loc = parser.to_dependency_location(callee_range);
-          parser.add_presentational_dependency(Box::new(RequireHeaderDependency::new(
+          parser.add_presentational_dependency(Box::new(RstestRequireActualDependency::new(
             callee_range,
             loc,
-          )));
-
-          parser.add_presentational_dependency(Box::new(ConstDependency::new(
-            callee_range,
-            ".rstest_require_actual".into(),
           )));
 
           return Some(true);

--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -41,6 +41,7 @@ use crate::{
   mock_module_id_dependency::{MockModuleIdDependency, MockModuleIdDependencyTemplate},
   module_path_name_dependency::ModulePathNameDependencyTemplate,
   parser_plugin::{MOCK_TARGET_REQUEST_PREFIX, RstestParserPlugin},
+  require_actual_dependency::RstestRequireActualDependencyTemplate,
   require_resolve_origin_dependency::RstestRequireResolveOriginDependencyTemplate,
   url_dependency::RstestUrlDependencyTemplate,
 };
@@ -452,6 +453,11 @@ async fn compilation(
   compilation.set_dependency_template(
     MockModuleIdDependencyTemplate::template_type(),
     Arc::new(MockModuleIdDependencyTemplate::default()),
+  );
+
+  compilation.set_dependency_template(
+    RstestRequireActualDependencyTemplate::template_type(),
+    Arc::new(RstestRequireActualDependencyTemplate),
   );
 
   if let Some(Some(callee)) = self.dynamic_import_origin_callee.get() {

--- a/crates/rspack_plugin_rstest/src/require_actual_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/require_actual_dependency.rs
@@ -1,0 +1,89 @@
+use rspack_cacheable::{cacheable, cacheable_dyn};
+use rspack_core::{
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCodeGeneration, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource,
+};
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct RstestRequireActualDependency {
+  id: DependencyId,
+  range: DependencyRange,
+  loc: Option<DependencyLocation>,
+}
+
+impl RstestRequireActualDependency {
+  pub fn new(range: DependencyRange, loc: Option<DependencyLocation>) -> Self {
+    Self {
+      id: DependencyId::new(),
+      range,
+      loc,
+    }
+  }
+}
+
+#[cacheable_dyn]
+impl Dependency for RstestRequireActualDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  fn loc(&self) -> Option<DependencyLocation> {
+    self.loc.clone()
+  }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
+}
+
+impl AsModuleDependency for RstestRequireActualDependency {}
+impl AsContextDependency for RstestRequireActualDependency {}
+
+#[cacheable_dyn]
+impl DependencyCodeGeneration for RstestRequireActualDependency {
+  fn dependency_template(&self) -> Option<DependencyTemplateType> {
+    Some(RstestRequireActualDependencyTemplate::template_type())
+  }
+}
+
+#[cacheable]
+#[derive(Debug, Clone, Default)]
+pub struct RstestRequireActualDependencyTemplate;
+
+impl RstestRequireActualDependencyTemplate {
+  pub fn template_type() -> DependencyTemplateType {
+    DependencyTemplateType::Custom("RstestRequireActualDependency")
+  }
+}
+
+impl DependencyTemplate for RstestRequireActualDependencyTemplate {
+  fn render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    let dep = dep
+      .as_any()
+      .downcast_ref::<RstestRequireActualDependency>()
+      .expect(
+        "RstestRequireActualDependencyTemplate should only be used for \
+         RstestRequireActualDependency",
+      );
+
+    let TemplateContext {
+      runtime_template, ..
+    } = code_generatable_context;
+    source.replace(
+      dep.range.start,
+      dep.range.end,
+      format!(
+        "{}.rstest_require_actual",
+        runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE_SCOPE)
+      ),
+      None,
+    );
+  }
+}

--- a/packages/rspack/src/taps/compilation.ts
+++ b/packages/rspack/src/taps/compilation.ts
@@ -143,11 +143,6 @@ export const createCompilationHooksRegisters: CreatePartialRegisters<
           queried.call(runtimeModule, chunk);
           const newSource = module.source?.source;
           if (newSource && newSource !== originSource) {
-            if (getCompiler().options.experiments?.runtimeMode === 'rspack') {
-              throw new Error(
-                'Compilation.hooks.runtimeModule source modifications are not supported when experiments.runtimeMode is "rspack".',
-              );
-            }
             return module;
           }
           return;

--- a/tests/rspack-test/RuntimeModeConfig.part1.test.js
+++ b/tests/rspack-test/RuntimeModeConfig.part1.test.js
@@ -20,14 +20,7 @@ describeByWalk(
 		exclude: [
 			// Exclude e-z and non-ascii
 			/^[e-z]/,
-			/^[^a-d]/,
-			// Custom runtime sources are not supported in rspack runtime mode.
-			/^builtin-swc-loader\/preact-refresh$/,
-			/^container-1-5\/tree-shaking-shared-(infer|server)-mode$/,
-			/^hooks\/(modify-extract-css-loading-runtime|rspack-issue-5571|runtime-module|runtime-requirement-in-tree)$/,
-			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|module-path-names|new-url-wasm)$/,
-			/^runtime\/add-runtime-module/,
-			/^sharing\/tree-shaking-shared$/
+			/^[^a-d]/
 		]
 	}
 );

--- a/tests/rspack-test/RuntimeModeConfig.part2.test.js
+++ b/tests/rspack-test/RuntimeModeConfig.part2.test.js
@@ -22,14 +22,7 @@ describeByWalk(
 			/^[a-d]/,
 			// Exclude p-z and non-ascii
 			/^[p-z]/,
-			/^[^a-o]/,
-			// Custom runtime sources are not supported in rspack runtime mode.
-			/^builtin-swc-loader\/preact-refresh$/,
-			/^container-1-5\/tree-shaking-shared-(infer|server)-mode$/,
-			/^hooks\/(modify-extract-css-loading-runtime|rspack-issue-5571|runtime-module|runtime-requirement-in-tree)$/,
-			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|module-path-names|new-url-wasm)$/,
-			/^runtime\/add-runtime-module/,
-			/^sharing\/tree-shaking-shared$/
+			/^[^a-o]/
 		]
 	}
 );

--- a/tests/rspack-test/RuntimeModeConfig.part3.test.js
+++ b/tests/rspack-test/RuntimeModeConfig.part3.test.js
@@ -19,14 +19,7 @@ describeByWalk(
 		dist: path.resolve(__dirname, "./js/runtime-mode-config"),
 		exclude: [
 			// Exclude a-o
-			/^[a-o]/,
-			// Custom runtime sources are not supported in rspack runtime mode.
-			/^builtin-swc-loader\/preact-refresh$/,
-			/^container-1-5\/tree-shaking-shared-(infer|server)-mode$/,
-			/^hooks\/(modify-extract-css-loading-runtime|rspack-issue-5571|runtime-module|runtime-requirement-in-tree)$/,
-			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|module-path-names|new-url-wasm)$/,
-			/^runtime\/add-runtime-module/,
-			/^sharing\/tree-shaking-shared$/
+			/^[a-o]/
 		]
 	}
 );

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/index.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/index.js
@@ -44,14 +44,14 @@ it('routes external dynamic import() of a mocked module through rstest_dynamic_r
 	// guard, every external dynamic import() (even unmocked) would crash a stale
 	// runtime.
 	expect(content).toMatch(
-		/rstest_dynamic_require\s*\?[\s\S]*?:\s*__webpack_require__\.bind\(__webpack_require__,/,
+		/rstest_dynamic_require\s*\?[\s\S]*?:\s*(?:__webpack_require__|__rspack_context\.r)\.bind\((?:__webpack_require__|__rspack_context\.r),/,
 	);
 
 	// The INTERNAL dynamic import must remain a bare `__webpack_require__.bind`
 	// (byte-identical to upstream) — internal modules never split, so the gate
 	// must leave their codegen untouched.
 	expect(content).toMatch(
-		/\.then\(__webpack_require__\.bind\(__webpack_require__,\s*"\.\/src\/internal\.js"\)\)/,
+		/\.then\((?:__webpack_require__|__rspack_context\.r)\.bind\((?:__webpack_require__|__rspack_context\.r),\s*"\.\/src\/internal\.js"\)\)/,
 	);
 	expect(content).not.toMatch(/rstest_dynamic_require\.bind\([^)]*internal/);
 });

--- a/tests/rspack-test/configCases/runtime/add-runtime-module-stage/index.js
+++ b/tests/rspack-test/configCases/runtime/add-runtime-module-stage/index.js
@@ -3,7 +3,21 @@ it("should inject trigger runtime module after normal runtime module", async fun
   expect(__webpack_require__.mockTrigger).toBe("trigger");
   const fs = require("fs");
   const content = fs.readFileSync(__filename, 'utf-8');
-  const triggerIndex = content.indexOf(`__webpack_require__.mockTrigger = "trigger"`);
-  const normalIndex = content.indexOf(`__webpack_require__.mockNormal = "normal"`);
+  const statements = [
+    {
+      normal: `__webpack_require__.mockNormal = "normal";`,
+      trigger: `__webpack_require__.mockTrigger = "trigger";`
+    },
+    {
+      normal: `__rspack_context.mockNormal = "normal";`,
+      trigger: `__rspack_context.mockTrigger = "trigger";`
+    }
+  ];
+  const statement = statements.find(({ normal, trigger }) => {
+    return content.includes(normal) && content.includes(trigger);
+  });
+  expect(statement).toBeTruthy();
+  const triggerIndex = content.indexOf(statement.trigger);
+  const normalIndex = content.indexOf(statement.normal);
   expect(normalIndex).toBeLessThan(triggerIndex);
 });

--- a/tests/rspack-test/configCases/runtime/custom-runtime-module-runtime-variables/index.js
+++ b/tests/rspack-test/configCases/runtime/custom-runtime-module-runtime-variables/index.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+
+it("should replace runtime variables and collect runtime requirements", () => {
+	expect(__webpack_require__.runtimeCompat()).toEqual({
+		publicPath: "runtime-public/",
+		cache: true
+	});
+
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		const content = fs.readFileSync(__filename, "utf-8");
+		const rspackContext = "__rspack" + "_context";
+		const webpackModuleCache = "__webpack" + "_module_cache__";
+		expect(content).toContain(
+			`Object.defineProperty(${rspackContext}, "p"`
+		);
+		expect(content).toContain("publicPath =");
+		expect(content).toContain("moduleCache.runtimeCompat");
+		expect(content).toContain(`${rspackContext}.runtimeCompat`);
+		expect(content).not.toContain(webpackModuleCache);
+	}
+});

--- a/tests/rspack-test/configCases/runtime/custom-runtime-module-runtime-variables/rspack.config.js
+++ b/tests/rspack-test/configCases/runtime/custom-runtime-module-runtime-variables/rspack.config.js
@@ -1,0 +1,49 @@
+const { RuntimeModule } = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: './index.js',
+  mode: 'development',
+  devtool: false,
+  optimization: {
+    minimize: false,
+    moduleIds: 'named',
+    chunkIds: 'named',
+  },
+  plugins: [
+    (compiler) => {
+      const RuntimeGlobals = compiler.rspack.RuntimeGlobals;
+      class RuntimeVariableModule extends RuntimeModule {
+        constructor() {
+          super('runtime-variable-compat');
+        }
+
+        generate() {
+          return `
+${RuntimeGlobals.publicPath} = "runtime-public/";
+${RuntimeGlobals.moduleCache}.runtimeCompat = { exports: { ok: true } };
+${RuntimeGlobals.require}.runtimeCompat = function() {
+	return {
+		publicPath: ${RuntimeGlobals.publicPath},
+		cache: ${RuntimeGlobals.moduleCache}.runtimeCompat.exports.ok
+	};
+};
+`;
+        }
+      }
+
+      compiler.hooks.thisCompilation.tap(
+        'RuntimeVariableCompatPlugin',
+        (compilation) => {
+          compilation.hooks.additionalTreeRuntimeRequirements.tap(
+            'RuntimeVariableCompatPlugin',
+            (chunk, runtimeRequirements) => {
+              runtimeRequirements.add(RuntimeGlobals.moduleCache);
+              compilation.addRuntimeModule(chunk, new RuntimeVariableModule());
+            },
+          );
+        },
+      );
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/runtime/runtime-mode-custom-runtime-module-error/errors.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-custom-runtime-module-error/errors.js
@@ -1,3 +1,1 @@
-module.exports = [
-	/Custom runtime modules are not supported when `experiments\.runtimeMode` is "rspack"/
-];
+module.exports = [];

--- a/tests/rspack-test/configCases/runtime/runtime-mode-custom-runtime-module-error/index.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-custom-runtime-module-error/index.js
@@ -1,1 +1,6 @@
 export default 1;
+
+it('should support custom runtime modules in rspack runtime mode', () => {
+  expect(globalThis.__custom_runtime_module_value__).toBe(1);
+  expect(globalThis.__custom_runtime_module_shadow__).toBe(2);
+});

--- a/tests/rspack-test/configCases/runtime/runtime-mode-custom-runtime-module-error/rspack.config.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-custom-runtime-module-error/rspack.config.js
@@ -6,7 +6,21 @@ class CustomRuntimeModule extends RuntimeModule {
   }
 
   generate() {
-    return '__webpack_require__.custom = 1;';
+    return `
+const originalRequire = __webpack_require__;
+__webpack_require__ = function(...args) {
+  return originalRequire(...args);
+};
+for (const key in originalRequire) {
+  __webpack_require__[key] = originalRequire[key];
+}
+function localShadow(__webpack_require__) {
+  return __webpack_require__.custom;
+}
+__webpack_require__.custom = 1;
+globalThis.__custom_runtime_module_value__ = __webpack_require__.custom;
+globalThis.__custom_runtime_module_shadow__ = localShadow({ custom: 2 });
+`;
   }
 }
 

--- a/tests/rspack-test/errorCases/runtime-module-source-rspack-mode.js
+++ b/tests/rspack-test/errorCases/runtime-module-source-rspack-mode.js
@@ -3,7 +3,7 @@ const path = require("path");
 /** @type {import('@rspack/test-tools').TErrorCaseConfig} */
 module.exports = {
 	description:
-		"should reject runtime module source changes from JS hooks in rspack mode",
+		"should support runtime module source changes from JS hooks in rspack mode",
 	options() {
 		let modified = false;
 		class Plugin {
@@ -29,6 +29,7 @@ module.exports = {
 				chunk: "./chunk.js"
 			},
 			context: path.resolve(__dirname, "../configCases/hooks/runtime-module"),
+			target: "node",
 			experiments: {
 				runtimeMode: "rspack"
 			},
@@ -36,10 +37,7 @@ module.exports = {
 		};
 	},
 	async check(diagnostics) {
-		expect(diagnostics.errors).toHaveLength(1);
-		expect(diagnostics.errors[0].message).toContain(
-			'Compilation.hooks.runtimeModule source modifications are not supported when experiments.runtimeMode is "rspack"'
-		);
+		expect(diagnostics.errors).toHaveLength(0);
 		expect(diagnostics.warnings).toHaveLength(0);
 	}
 };


### PR DESCRIPTION
## Summary

- allow JS-added custom runtime modules and JS hook-modified runtime module sources in `experiments.runtimeMode: "rspack"`
- perform the `__webpack_require__` compatibility replacement in Rust runtime module rendering using SWC parser/resolver spans
- keep the workaround centralized in `rspack_plugin_javascript::runtime` so it can be removed cleanly later

## Validation

- `cargo check -p rspack_plugin_javascript`
- `cargo fmt --all --check`
- `git diff --check`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "runtime-mode-custom-runtime-module-error"`
- `cd tests/rspack-test && pnpm run test -t "runtime-module-source-rspack-mode"`
- `cd tests/rspack-test && pnpm run test -t "runtime/add-runtime-module"`