### PR TITLE
chore(ci): use mini runner for ecosystem ci dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,10 @@ jobs:
       contents: write
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
+      - name: Ensure Docker
+        if: runner.environment == 'self-hosted'
+        run: docker ps || nohup sudo dockerd >/dev/null 2>&1 &
+
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,20 +217,21 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/size-limit.yml
 
-  ecosystem_ci_per_commit:
-    name: Run ecosystem CI per commit
+  setup_ecosystem_ci_runner:
+    name: Setup ecosystem CI runner
     needs: [check-changed, build-linux]
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    timeout-minutes: 40
-    permissions:
-      contents: write
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Start Docker daemon
         if: runner.environment == 'self-hosted'
         shell: bash
         run: |
-          nohup sudo dockerd >/tmp/dockerd.log 2>&1 &
+          if docker info >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          nohup sudo env -u RUNNER_TRACKING_ID dockerd >/tmp/dockerd.log 2>&1 &
 
           for _ in {1..30}; do
             if docker info >/dev/null 2>&1; then
@@ -242,6 +243,15 @@ jobs:
           cat /tmp/dockerd.log
           exit 1
 
+  ecosystem_ci_per_commit:
+    name: Run ecosystem CI per commit
+    needs: [check-changed, build-linux, setup_ecosystem_ci_runner]
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
+    timeout-minutes: 40
+    permissions:
+      contents: write
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
+    steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,6 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Ensure Docker
-        if: runner.environment == 'self-hosted'
         run: docker ps || nohup sudo dockerd >/dev/null 2>&1 &
 
       - name: Trigger Ecosystem CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,22 @@ jobs:
       contents: write
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
+      - name: Start Docker daemon
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          nohup sudo dockerd >/tmp/dockerd.log 2>&1 &
+
+          for _ in {1..30}; do
+            if docker info >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat /tmp/dockerd.log
+          exit 1
+
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,35 +217,9 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/size-limit.yml
 
-  setup_ecosystem_ci_runner:
-    name: Setup ecosystem CI runner
-    needs: [check-changed, build-linux]
-    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
-    steps:
-      - name: Start Docker daemon
-        if: runner.environment == 'self-hosted'
-        shell: bash
-        run: |
-          if docker info >/dev/null 2>&1; then
-            exit 0
-          fi
-
-          nohup sudo env -u RUNNER_TRACKING_ID dockerd >/tmp/dockerd.log 2>&1 &
-
-          for _ in {1..30}; do
-            if docker info >/dev/null 2>&1; then
-              exit 0
-            fi
-            sleep 1
-          done
-
-          cat /tmp/dockerd.log
-          exit 1
-
   ecosystem_ci_per_commit:
     name: Run ecosystem CI per commit
-    needs: [check-changed, build-linux, setup_ecosystem_ci_runner]
+    needs: [check-changed, build-linux]
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     timeout-minutes: 40
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
   ecosystem_ci_per_commit:
     name: Run ecosystem CI per commit
     needs: [check-changed, build-linux]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     timeout-minutes: 40
     permissions:
       contents: write

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ed47321be3393a381954f13d97bd1971e19d3b15
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@0d8b599e67cb5201ce1f7f2faddfaafbac273d56
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@0d8b599e67cb5201ce1f7f2faddfaafbac273d56
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@c741cf0a73d362fe92710975e695fa2d6a78d94e
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   ecosystem_ci_dispatch:
     name: Dispatch ecosystem CI
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     if: github.repository == 'web-infra-dev/rspack'
     steps:
       - name: Get PR info

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -51,6 +51,22 @@ jobs:
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     if: github.repository == 'web-infra-dev/rspack'
     steps:
+      - name: Start Docker daemon
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          nohup sudo dockerd >/tmp/dockerd.log 2>&1 &
+
+          for _ in {1..30}; do
+            if docker info >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat /tmp/dockerd.log
+          exit 1
+
       - name: Get PR info
         id: pr-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -51,9 +51,6 @@ jobs:
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     if: github.repository == 'web-infra-dev/rspack'
     steps:
-      - name: Ensure Docker
-        run: docker ps || nohup sudo dockerd >/dev/null 2>&1 &
-
       - name: Get PR info
         id: pr-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -68,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ci/dockerless-workflow-dispatch
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ci/dockerless-workflow-dispatch
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ed47321be3393a381954f13d97bd1971e19d3b15
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -46,34 +46,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  setup_ecosystem_ci_runner:
-    name: Setup ecosystem CI runner
-    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    if: github.repository == 'web-infra-dev/rspack'
-    steps:
-      - name: Start Docker daemon
-        if: runner.environment == 'self-hosted'
-        shell: bash
-        run: |
-          if docker info >/dev/null 2>&1; then
-            exit 0
-          fi
-
-          nohup sudo env -u RUNNER_TRACKING_ID dockerd >/tmp/dockerd.log 2>&1 &
-
-          for _ in {1..30}; do
-            if docker info >/dev/null 2>&1; then
-              exit 0
-            fi
-            sleep 1
-          done
-
-          cat /tmp/dockerd.log
-          exit 1
-
   ecosystem_ci_dispatch:
     name: Dispatch ecosystem CI
-    needs: setup_ecosystem_ci_runner
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     if: github.repository == 'web-infra-dev/rspack'
     steps:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -52,7 +52,6 @@ jobs:
     if: github.repository == 'web-infra-dev/rspack'
     steps:
       - name: Ensure Docker
-        if: runner.environment == 'self-hosted'
         run: docker ps || nohup sudo dockerd >/dev/null 2>&1 &
 
       - name: Get PR info

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -46,8 +46,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  ecosystem_ci_dispatch:
-    name: Dispatch ecosystem CI
+  setup_ecosystem_ci_runner:
+    name: Setup ecosystem CI runner
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     if: github.repository == 'web-infra-dev/rspack'
     steps:
@@ -55,7 +55,11 @@ jobs:
         if: runner.environment == 'self-hosted'
         shell: bash
         run: |
-          nohup sudo dockerd >/tmp/dockerd.log 2>&1 &
+          if docker info >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          nohup sudo env -u RUNNER_TRACKING_ID dockerd >/tmp/dockerd.log 2>&1 &
 
           for _ in {1..30}; do
             if docker info >/dev/null 2>&1; then
@@ -67,6 +71,12 @@ jobs:
           cat /tmp/dockerd.log
           exit 1
 
+  ecosystem_ci_dispatch:
+    name: Dispatch ecosystem CI
+    needs: setup_ecosystem_ci_runner
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
+    if: github.repository == 'web-infra-dev/rspack'
+    steps:
       - name: Get PR info
         id: pr-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -51,6 +51,10 @@ jobs:
     runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     if: github.repository == 'web-infra-dev/rspack'
     steps:
+      - name: Ensure Docker
+        if: runner.environment == 'self-hosted'
+        run: docker ps || nohup sudo dockerd >/dev/null 2>&1 &
+
       - name: Get PR info
         id: pr-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
## Summary

- Run the `ecosystem_ci_per_commit` job on `vars.CI_LINUX_MINI_RUNNER` instead of always using `ubuntu-latest`.
- Keep the existing `ubuntu-latest` fallback when the repository variable is not configured.

## Why

This job mostly triggers and polls ecosystem CI. Moving it to the existing mini runner pool reduces GitHub-hosted runner usage for main-branch CI without changing the external ecosystem CI behavior.
