### PR TITLE
fix(rstest): preserve mocks in module chunk loading

### DIFF
--- a/crates/rspack_plugin_rstest/src/plugin.rs
+++ b/crates/rspack_plugin_rstest/src/plugin.rs
@@ -334,10 +334,18 @@ impl RstestPlugin {
     }
 
     source
+      // require_chunk_loading.ejs declares `moduleId` in the loop initializer.
       .cow_replace(
         "for (var moduleId in moreModules) {",
         &format!("for (var moduleId in moreModules) {{\n\t\t{rstest_mock_chunk_loading_guard}"),
       )
+      // module_chunk_loading.ejs declares `moduleId` before the loop.
+      .cow_replace(
+        "for (moduleId in moreModules) {",
+        &format!("for (moduleId in moreModules) {{\n\t\t{rstest_mock_chunk_loading_guard}"),
+      )
+      // Covers runtimeMode: "rspack" and other generated code that iterates
+      // the module factories registry directly.
       .cow_replace(
         &format!("for (moduleId in {module_factories}) {{"),
         &format!("for (moduleId in {module_factories}) {{\n\t\t{rstest_mock_chunk_loading_guard}"),

--- a/tests/rspack-test/RuntimeModeConfig.part1.test.js
+++ b/tests/rspack-test/RuntimeModeConfig.part1.test.js
@@ -25,7 +25,7 @@ describeByWalk(
 			/^builtin-swc-loader\/preact-refresh$/,
 			/^container-1-5\/tree-shaking-shared-(infer|server)-mode$/,
 			/^hooks\/(modify-extract-css-loading-runtime|rspack-issue-5571|runtime-module|runtime-requirement-in-tree)$/,
-			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|module-path-names|new-url-wasm)$/,
+			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|mock-shared-runtime|module-path-names|new-url-wasm)$/,
 			/^runtime\/add-runtime-module/,
 			/^sharing\/tree-shaking-shared$/
 		]

--- a/tests/rspack-test/RuntimeModeConfig.part2.test.js
+++ b/tests/rspack-test/RuntimeModeConfig.part2.test.js
@@ -27,7 +27,7 @@ describeByWalk(
 			/^builtin-swc-loader\/preact-refresh$/,
 			/^container-1-5\/tree-shaking-shared-(infer|server)-mode$/,
 			/^hooks\/(modify-extract-css-loading-runtime|rspack-issue-5571|runtime-module|runtime-requirement-in-tree)$/,
-			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|module-path-names|new-url-wasm)$/,
+			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|mock-shared-runtime|module-path-names|new-url-wasm)$/,
 			/^runtime\/add-runtime-module/,
 			/^sharing\/tree-shaking-shared$/
 		]

--- a/tests/rspack-test/RuntimeModeConfig.part3.test.js
+++ b/tests/rspack-test/RuntimeModeConfig.part3.test.js
@@ -24,7 +24,7 @@ describeByWalk(
 			/^builtin-swc-loader\/preact-refresh$/,
 			/^container-1-5\/tree-shaking-shared-(infer|server)-mode$/,
 			/^hooks\/(modify-extract-css-loading-runtime|rspack-issue-5571|runtime-module|runtime-requirement-in-tree)$/,
-			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|module-path-names|new-url-wasm)$/,
+			/^rstest\/(dynamic-import-origin|mock|mock-dynamic-import-external|mock-shared-runtime|module-path-names|new-url-wasm)$/,
 			/^runtime\/add-runtime-module/,
 			/^sharing\/tree-shaking-shared$/
 		]

--- a/tests/rspack-test/configCases/rstest/mock-shared-runtime/index.js
+++ b/tests/rspack-test/configCases/rstest/mock-shared-runtime/index.js
@@ -1,0 +1,28 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+it('keeps setup mocks when a later test chunk installs its module factories', () => {
+  const runtimeSource = fs.readFileSync(
+    path.resolve(__dirname, 'rstest-runtime.mjs'),
+    'utf-8',
+  );
+
+  expect(runtimeSource).toContain(
+    '__webpack_require__.rstest_original_modules || {}',
+  );
+  expect(runtimeSource).toContain('for (moduleId in moreModules) {');
+
+  execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `await import(${JSON.stringify(pathToFileURL(path.resolve(__dirname, 'rstest-runtime.mjs')).href)});\n` +
+        `await import(${JSON.stringify(pathToFileURL(path.resolve(__dirname, 'setup.mjs')).href)});\n` +
+        `await import(${JSON.stringify(pathToFileURL(path.resolve(__dirname, 'test.mjs')).href)});`,
+    ],
+    { stdio: 'pipe' },
+  );
+});

--- a/tests/rspack-test/configCases/rstest/mock-shared-runtime/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-shared-runtime/rspack.config.js
@@ -1,0 +1,116 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+class RstestSimpleRuntimePlugin {
+  apply(compiler) {
+    const { RuntimeModule } = compiler.rspack;
+    class RstestRuntimeModule extends RuntimeModule {
+      constructor() {
+        super('rstest runtime');
+      }
+
+      generate() {
+        return `
+const originalRequire = __webpack_require__;
+__webpack_require__ = function(...args) {
+  return originalRequire(...args);
+};
+
+Object.keys(originalRequire).forEach(key => {
+  __webpack_require__[key] = originalRequire[key];
+});
+
+__webpack_require__.rstest_original_modules = {};
+__webpack_require__.rstest_original_module_factories = {};
+
+__webpack_require__.rstest_mock = (id, modFactory) => {
+  __webpack_require__.rstest_original_modules[id] = __webpack_require__(id);
+  __webpack_require__.rstest_original_module_factories[id] = __webpack_modules__[id];
+
+  __webpack_modules__[id] = function(
+    __unused_webpack_module,
+    __webpack_exports__,
+    __webpack_require__,
+  ) {
+    __webpack_require__.r(__webpack_exports__);
+    const res = modFactory();
+    for (const key in res) {
+      __webpack_require__.d(__webpack_exports__, {
+        [key]: () => res[key],
+      });
+    }
+  };
+
+  delete __webpack_module_cache__[id];
+};
+`;
+      }
+    }
+
+    compiler.hooks.thisCompilation.tap(
+      'RstestSimpleRuntimePlugin',
+      (compilation) => {
+        compilation.hooks.additionalTreeRuntimeRequirements.tap(
+          'RstestSimpleRuntimePlugin',
+          (chunk) => {
+            compilation.addRuntimeModule(chunk, new RstestRuntimeModule());
+          },
+        );
+      },
+    );
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = [
+  {
+    entry: {
+      setup: './src/setup.js',
+      test: './src/test.js',
+    },
+    target: 'node',
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: '[name].mjs',
+      chunkFilename: '[name].mjs',
+      chunkFormat: 'module',
+      module: true,
+    },
+    optimization: {
+      usedExports: false,
+      mangleExports: false,
+      concatenateModules: false,
+      minimize: false,
+      moduleIds: 'named',
+      chunkIds: 'named',
+      runtimeChunk: {
+        name: 'rstest-runtime',
+      },
+    },
+    plugins: [
+      new RstestSimpleRuntimePlugin(),
+      new RstestPlugin({
+        injectModulePathName: false,
+        importMetaPathName: false,
+        hoistMockModule: false,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+      }),
+    ],
+  },
+  {
+    entry: {
+      main: './index.js',
+    },
+    target: 'node',
+    output: {
+      filename: '[name].js',
+    },
+    externalsPresets: {
+      node: true,
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rstest/mock-shared-runtime/src/a.js
+++ b/tests/rspack-test/configCases/rstest/mock-shared-runtime/src/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/rspack-test/configCases/rstest/mock-shared-runtime/src/setup.js
+++ b/tests/rspack-test/configCases/rstest/mock-shared-runtime/src/setup.js
@@ -1,0 +1,7 @@
+import { a } from './a';
+
+__webpack_require__.rstest_mock('./src/a.js', () => ({ a: 2 }));
+
+if (a !== 1) {
+  throw new Error(`setup should import original value before mocking, got ${a}`);
+}

--- a/tests/rspack-test/configCases/rstest/mock-shared-runtime/src/test.js
+++ b/tests/rspack-test/configCases/rstest/mock-shared-runtime/src/test.js
@@ -1,0 +1,5 @@
+import { a } from './a';
+
+if (a !== 2) {
+  throw new Error(`mocked value should survive loading the test chunk, got ${a}`);
+}

--- a/tests/rspack-test/configCases/rstest/mock-shared-runtime/test.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-shared-runtime/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import('../../../..').TConfigCaseConfig} */
+module.exports = {
+  findBundle() {
+    return ['main.js'];
+  },
+};


### PR DESCRIPTION
## Summary

Fixes Rstest mock preservation for module chunk loading after the module chunk runtime template started using `for (moduleId in moreModules)`. The Rstest plugin now injects its mock guard into that loop shape as well, preventing later test chunks from overwriting mocked module factories installed by setup files.

## Related links

https://github.com/web-infra-dev/rspack/pull/14254
https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/27539855655/job/81398624673

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
