### PR TITLE
perf(loader-runner): reduce loader object construction overhead

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -64,74 +64,12 @@ import {
 
 const LOADER_PROCESS_NAME = 'Loader Analysis';
 
-function createLoaderObject(
-  loader: JsLoaderItem,
-  compiler: Compiler,
-): LoaderObject {
-  const obj: any = {
-    path: null,
-    query: null,
-    fragment: null,
-    options: null,
-    ident: null,
-    normal: null,
-    pitch: null,
-    raw: null,
-    data: null,
-    pitchExecuted: false,
-    normalExecuted: false,
-  };
-  Object.defineProperty(obj, 'request', {
-    enumerable: true,
-    get: () =>
-      obj.path.replace(/#/g, '\u200b#') +
-      obj.query.replace(/#/g, '\u200b#') +
-      obj.fragment,
-    set: (value: JsLoaderItem) => {
-      const splittedRequest = parseResourceWithoutFragment(value.loader);
-      obj.path = splittedRequest.path;
-      obj.query = splittedRequest.query;
-      obj.fragment = '';
-      obj.options =
-        obj.options === null
-          ? splittedRequest.query
-            ? splittedRequest.query.slice(1)
-            : undefined
-          : obj.options;
+type LoaderObjectOptions = string | (object & { ident?: unknown }) | null;
 
-      if (typeof obj.options === 'string' && obj.options[0] === '?') {
-        const ident = obj.options.slice(1);
-        if (ident === '[[missing ident]]') {
-          throw new Error(
-            'No ident is provided by referenced loader. ' +
-              'When using a function for Rule.use in config you need to ' +
-              "provide an 'ident' property for referenced loader options.",
-          );
-        }
-        obj.options = compiler.__internal__ruleSet.references.get(ident);
-        if (obj.options === undefined) {
-          throw new Error('Invalid ident is provided by referenced loader');
-        }
-        obj.ident = ident;
-      }
-
-      // CHANGE: `rspack_core` returns empty string for `undefined` type.
-      // Comply to webpack test case: tests/webpack-test/cases/loaders/cjs-loader-type/index.js
-      obj.type = value.type === '' ? undefined : value.type;
-      if (obj.options === null) obj.query = '';
-      else if (obj.options === undefined) obj.query = '';
-      else if (typeof obj.options === 'string') obj.query = `?${obj.options}`;
-      else if (obj.ident) obj.query = `??${obj.ident}`;
-      else if (typeof obj.options === 'object' && obj.options.ident)
-        obj.query = `??${obj.options.ident}`;
-      else obj.query = `?${JSON.stringify(obj.options)}`;
-    },
-  });
-  obj.request = loader;
-  if (Object.preventExtensions) {
-    Object.preventExtensions(obj);
-  }
-  return obj;
+function stringifyLoaderRequest(path: string, query: string, fragment: string) {
+  return (
+    path.replace(/#/g, '\u200b#') + query.replace(/#/g, '\u200b#') + fragment
+  );
 }
 
 export class LoaderObject {
@@ -139,11 +77,11 @@ export class LoaderObject {
   path: string;
   query: string;
   fragment: string;
-  options?: string | object;
-  ident: string;
-  normal?: Function;
-  pitch?: Function;
-  raw?: boolean;
+  options?: LoaderObjectOptions;
+  ident: string | null;
+  normal?: Function | null;
+  pitch?: Function | null;
+  raw?: boolean | null;
   type?: 'module' | 'commonjs';
   parallel?: boolean | { maxWorkers?: number };
   /**
@@ -152,30 +90,53 @@ export class LoaderObject {
   loaderItem: JsLoaderItem;
 
   constructor(loaderItem: JsLoaderItem, compiler: Compiler) {
-    const {
-      request,
-      path,
-      query,
-      fragment,
-      options,
-      ident,
-      normal,
-      pitch,
-      raw,
-      type,
-    } = createLoaderObject(loaderItem, compiler);
-    this.request = request;
-    this.path = path;
-    this.query = query;
-    this.fragment = fragment;
-    this.options = options;
-    this.ident = ident;
-    this.normal = normal;
-    this.pitch = pitch;
-    this.raw = raw;
-    this.type = type;
-    this.parallel = ident
-      ? compiler.__internal__ruleSet.references.get(`${ident}$$parallelism`)
+    const splittedRequest = parseResourceWithoutFragment(loaderItem.loader);
+    this.path = splittedRequest.path;
+    this.fragment = '';
+    this.options = splittedRequest.query
+      ? splittedRequest.query.slice(1)
+      : undefined;
+    this.ident = null;
+    this.normal = null;
+    this.pitch = null;
+    this.raw = null;
+
+    if (typeof this.options === 'string' && this.options[0] === '?') {
+      const ident = this.options.slice(1);
+      if (ident === '[[missing ident]]') {
+        throw new Error(
+          'No ident is provided by referenced loader. ' +
+            'When using a function for Rule.use in config you need to ' +
+            "provide an 'ident' property for referenced loader options.",
+        );
+      }
+      this.options = compiler.__internal__ruleSet.references.get(ident) as
+        | LoaderObjectOptions
+        | undefined;
+      if (this.options === undefined) {
+        throw new Error('Invalid ident is provided by referenced loader');
+      }
+      this.ident = ident;
+    }
+
+    // CHANGE: `rspack_core` returns empty string for `undefined` type.
+    // Comply to webpack test case: tests/webpack-test/cases/loaders/cjs-loader-type/index.js
+    this.type =
+      loaderItem.type === ''
+        ? undefined
+        : (loaderItem.type as LoaderObject['type']);
+    if (this.options === null) this.query = '';
+    else if (this.options === undefined) this.query = '';
+    else if (typeof this.options === 'string') this.query = `?${this.options}`;
+    else if (this.ident) this.query = `??${this.ident}`;
+    else if (this.options.ident) this.query = `??${this.options.ident}`;
+    else this.query = `?${JSON.stringify(this.options)}`;
+
+    this.request = stringifyLoaderRequest(this.path, this.query, this.fragment);
+    this.parallel = this.ident
+      ? (compiler.__internal__ruleSet.references.get(
+          `${this.ident}$$parallelism`,
+        ) as LoaderObject['parallel'])
       : false;
     this.loaderItem = loaderItem;
     this.loaderItem.data = this.loaderItem.data ?? {};


### PR DESCRIPTION
## Summary

This PR reduces loader-runner overhead on the hot `runLoaders` path by removing the temporary `createLoaderObject` shape.

Performance data from benchmark:

- `LoaderObject` constructor self time median: **133.836 ms -> 67.085 ms (-49.9%)**
- Removed request accessor getter/setter self time median: **59.127 ms -> 0 ms**
- Combined targeted self time: **192.794 ms -> 65.874 ms (-65.8%)**

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).