### PR TITLE
perf(ci): drop debuginfo from ci profile build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ opt-level = "s"
 # This is for CI build based on release but with faster build time
 [profile.ci]
 codegen-units = 256
-debug         = "limited"
+debug         = false
 inherits      = "release"
 lto           = false
 ## reduce little optimization to reduce build time


### PR DESCRIPTION
## Why

The `ci` profile builds the binding with `debug = "limited"` (level 1). That debug
info inflates three things on every build job:

- **compile time** — extra debuginfo codegen
- **cargo target-dir cache** — bigger target dir → slower restore/save (on Windows
  the ~2m56s "Install Rust Toolchain" step is mostly this cargo cache restore)
- **.node artifact size** — slower upload + every test job's download

`debug` does not affect runtime, so the Test jobs are not slowed.

## Experiment

Drop `debug` to `false` and measure build-step time (Windows / Linux / Mac / WASM)
and artifact size vs main (`debug = "limited"`).

## Trade-off

CI binding panics lose file:line backtraces. If the win is worth it but backtraces
matter, `"line-tables-only"` is the middle ground — keeps file:line, smaller than
"limited".

Draft — measuring only.
