### PR TITLE
ci: disable debuginfo for the windows ci binding build

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -102,7 +102,7 @@ jobs:
         run: rustup target add ${{ inputs.target }}
 
       - name: Disable debuginfo for Windows CI build
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ runner.os == 'Windows' && inputs.profile == 'ci' }}
         run: echo "CARGO_PROFILE_CI_DEBUG=false" >> "$GITHUB_ENV"
 
       - name: Run Cargo codegen

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -101,6 +101,10 @@ jobs:
       - name: Setup Rust Target
         run: rustup target add ${{ inputs.target }}
 
+      - name: Disable debuginfo for Windows CI build
+        if: ${{ runner.os == 'Windows' }}
+        run: echo "CARGO_PROFILE_CI_DEBUG=false" >> "$GITHUB_ENV"
+
       - name: Run Cargo codegen
         run: cargo codegen
 


### PR DESCRIPTION
## Why

The `ci` profile builds the binding with `debug = "limited"`. On Windows that debug
info goes into a **separate `.pdb`**, which the build job **never uploads** (it only
ships `*.node`). So on Windows the debug info is pure waste — ~5 min of PDB generation
during linking for a file that is thrown away, and Windows test jobs never get
backtrace symbols anyway.

Measured via the debug-off experiment (#14478):

| | Windows build step | Windows `.node` |
|---|---|---|
| `debug = "limited"` (baseline) | 11m46s | 19.5 MB |
| debug off | **6m28s (-45%)** | 19.5 MB (unchanged) |

Windows is the wall-clock long pole of CI, so this is the biggest single saving — with
**zero downside** (same artifact, no backtrace loss).

## What

Set `CARGO_PROFILE_CI_DEBUG=false` only on the Windows build step:

- only the `ci` profile (release builds use `release`, unaffected)
- only Windows (`runner.os == 'Windows'`) — Linux / Mac / WASM keep `"limited"`, since
  their debug is embedded in the `.node` and used for native CI backtraces
- only CI — local Windows `dev` builds are unaffected
