### PR TITLE
fix(split-chunks): align max size grouping with webpack

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -7,7 +7,7 @@
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
-use std::{borrow::Cow, hash::Hash, sync::LazyLock};
+use std::{borrow::Cow, hash::Hasher, sync::LazyLock};
 
 use regex::Regex;
 use rspack_core::{
@@ -121,7 +121,7 @@ fn get_size(module: &dyn Module, compilation: &Compilation) -> SplitChunkSizes {
 
 fn hash_filename(filename: &str, options: &CompilerOptions) -> String {
   let mut filename_hash = RspackHash::from(&options.output);
-  filename.hash(&mut filename_hash);
+  filename_hash.write(filename.as_bytes());
   let hash_digest: RspackHashDigest = filename_hash.digest(&options.output.hash_digest);
   hash_digest.rendered(8).to_string()
 }
@@ -260,9 +260,7 @@ fn deterministic_grouping_for_modules(
   min_size: &SplitChunkSizes,
   delimiter: &str,
 ) -> Vec<Group> {
-  let mut results: Vec<Group> = Default::default();
-
-  let mut nodes = items
+  let nodes = items
     .iter()
     .map(|module| {
       let module: &dyn Module = module.as_ref();
@@ -274,6 +272,16 @@ fn deterministic_grouping_for_modules(
       }
     })
     .collect::<Vec<_>>();
+
+  deterministic_grouping(nodes, allow_max_size, min_size)
+}
+
+fn deterministic_grouping(
+  mut nodes: Vec<GroupItem>,
+  allow_max_size: &SplitChunkSizes,
+  min_size: &SplitChunkSizes,
+) -> Vec<Group> {
+  let mut results: Vec<Group> = Default::default();
 
   nodes.sort_by(|a, b| a.key.cmp(&b.key));
 
@@ -380,8 +388,8 @@ fn deterministic_grouping_for_modules(
         while pos <= right + 1 {
           let similarity = group.similarities[pos as usize - 1];
           if similarity < best_similarity
-            && left_size.bigger_than(min_size)
-            && right_size.bigger_than(min_size)
+            && !left_size.smaller_than(min_size)
+            && !right_size.smaller_than(min_size)
           {
             best_similarity = similarity;
             best = pos;
@@ -461,6 +469,154 @@ fn similarity(a: &str, b: &str) -> usize {
     dist += std::cmp::max(0, 10 - (ca as i32 - cb as i32).abs());
   }
   dist as usize
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+
+  use super::*;
+
+  fn sizes(values: &[(&str, i32)]) -> SplitChunkSizes {
+    SplitChunkSizes(
+      values
+        .iter()
+        .map(|(ty, size)| (SourceType::from(*ty), f64::from(*size)))
+        .collect(),
+    )
+  }
+
+  fn item(index: usize, size: &[(&str, i32)]) -> GroupItem {
+    GroupItem {
+      module: ModuleIdentifier::from(index.to_string()),
+      size: sizes(size),
+      key: (100000 + index).to_string(),
+    }
+  }
+
+  fn normalize_size(size: &SplitChunkSizes) -> Vec<(String, i32)> {
+    size
+      .iter()
+      .map(|(ty, size)| (ty.to_string(), *size as i32))
+      .collect::<BTreeMap<_, _>>()
+      .into_iter()
+      .collect()
+  }
+
+  fn expected_size(values: &[(&str, i32)]) -> Vec<(String, i32)> {
+    values
+      .iter()
+      .map(|(ty, size)| ((*ty).to_string(), *size))
+      .collect()
+  }
+
+  fn group(
+    items: Vec<&[(&str, i32)]>,
+    min_size: &[(&str, i32)],
+    max_size: &[(&str, i32)],
+  ) -> Vec<(Vec<usize>, Vec<(String, i32)>)> {
+    deterministic_grouping(
+      items
+        .into_iter()
+        .enumerate()
+        .map(|(index, size)| item(index, size))
+        .collect(),
+      &sizes(max_size),
+      &sizes(min_size),
+    )
+    .into_iter()
+    .map(|group| {
+      (
+        group
+          .nodes
+          .iter()
+          .map(|node| node.module.as_str().parse().expect("module index"))
+          .collect(),
+        normalize_size(&group.size),
+      )
+    })
+    .collect()
+  }
+
+  #[test]
+  fn should_split_large_chunks_with_different_size_types() {
+    assert_eq!(
+      group(
+        vec![&[("a", 3), ("b", 3)], &[("b", 1)], &[("a", 3)]],
+        &[("a", 3), ("b", 3)],
+        &[("a", 5), ("b", 5)],
+      ),
+      vec![
+        (vec![0, 1], expected_size(&[("a", 3), ("b", 4)])),
+        (vec![2], expected_size(&[("a", 3)])),
+      ]
+    );
+  }
+
+  #[test]
+  fn should_separate_items_with_different_size_types_when_unsplittable() {
+    assert_eq!(
+      group(
+        vec![
+          &[("a", 1)],
+          &[("b", 1)],
+          &[("a", 1)],
+          &[("a", 1)],
+          &[("b", 1)],
+          &[("a", 1)],
+          &[("a", 1)],
+          &[("b", 1)],
+          &[("a", 1)],
+          &[("a", 1)],
+        ],
+        &[("a", 3), ("b", 3)],
+        &[("a", 5), ("b", 5)],
+      ),
+      vec![
+        (vec![0, 2, 3], expected_size(&[("a", 3)])),
+        (vec![1, 4, 7], expected_size(&[("b", 3)])),
+        (vec![5, 6, 8, 9], expected_size(&[("a", 4)])),
+      ]
+    );
+  }
+
+  #[test]
+  fn should_handle_entangled_size_types_case_1() {
+    assert_eq!(
+      group(
+        vec![
+          &[("c", 2), ("b", 2)],
+          &[("a", 2), ("c", 2)],
+          &[("a", 2), ("b", 2)]
+        ],
+        &[("a", 3), ("b", 3), ("c", 3)],
+        &[("a", 3), ("b", 3), ("c", 3)],
+      ),
+      vec![(
+        vec![0, 1, 2],
+        expected_size(&[("a", 4), ("b", 4), ("c", 4)])
+      )]
+    );
+  }
+
+  #[test]
+  fn should_handle_entangled_size_types_case_2() {
+    assert_eq!(
+      group(
+        vec![
+          &[("c", 2), ("b", 2)],
+          &[("a", 2), ("c", 2)],
+          &[("a", 2), ("b", 2)]
+        ],
+        &[("a", 3), ("b", 3)],
+        &[("c", 3)],
+      ),
+      vec![
+        (vec![0, 2], expected_size(&[("a", 2), ("b", 4), ("c", 2)])),
+        (vec![1], expected_size(&[("a", 2), ("c", 2)])),
+      ]
+    );
+  }
 }
 
 impl SplitChunksPlugin {

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -120,7 +120,7 @@ fn get_size(module: &dyn Module, compilation: &Compilation) -> SplitChunkSizes {
 }
 
 fn hash_filename(filename: &str, options: &CompilerOptions) -> String {
-  let mut filename_hash = RspackHash::from(&options.output);
+  let mut filename_hash = RspackHash::new(&options.output.hash_function);
   filename_hash.write(filename.as_bytes());
   let hash_digest: RspackHashDigest = filename_hash.digest(&options.output.hash_digest);
   hash_digest.rendered(8).to_string()

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -471,154 +471,6 @@ fn similarity(a: &str, b: &str) -> usize {
   dist as usize
 }
 
-#[cfg(test)]
-mod tests {
-  use std::collections::BTreeMap;
-
-  use super::*;
-
-  fn sizes(values: &[(&str, i32)]) -> SplitChunkSizes {
-    SplitChunkSizes(
-      values
-        .iter()
-        .map(|(ty, size)| (SourceType::from(*ty), f64::from(*size)))
-        .collect(),
-    )
-  }
-
-  fn item(index: usize, size: &[(&str, i32)]) -> GroupItem {
-    GroupItem {
-      module: ModuleIdentifier::from(index.to_string()),
-      size: sizes(size),
-      key: (100000 + index).to_string(),
-    }
-  }
-
-  fn normalize_size(size: &SplitChunkSizes) -> Vec<(String, i32)> {
-    size
-      .iter()
-      .map(|(ty, size)| (ty.to_string(), *size as i32))
-      .collect::<BTreeMap<_, _>>()
-      .into_iter()
-      .collect()
-  }
-
-  fn expected_size(values: &[(&str, i32)]) -> Vec<(String, i32)> {
-    values
-      .iter()
-      .map(|(ty, size)| ((*ty).to_string(), *size))
-      .collect()
-  }
-
-  fn group(
-    items: Vec<&[(&str, i32)]>,
-    min_size: &[(&str, i32)],
-    max_size: &[(&str, i32)],
-  ) -> Vec<(Vec<usize>, Vec<(String, i32)>)> {
-    deterministic_grouping(
-      items
-        .into_iter()
-        .enumerate()
-        .map(|(index, size)| item(index, size))
-        .collect(),
-      &sizes(max_size),
-      &sizes(min_size),
-    )
-    .into_iter()
-    .map(|group| {
-      (
-        group
-          .nodes
-          .iter()
-          .map(|node| node.module.as_str().parse().expect("module index"))
-          .collect(),
-        normalize_size(&group.size),
-      )
-    })
-    .collect()
-  }
-
-  #[test]
-  fn should_split_large_chunks_with_different_size_types() {
-    assert_eq!(
-      group(
-        vec![&[("a", 3), ("b", 3)], &[("b", 1)], &[("a", 3)]],
-        &[("a", 3), ("b", 3)],
-        &[("a", 5), ("b", 5)],
-      ),
-      vec![
-        (vec![0, 1], expected_size(&[("a", 3), ("b", 4)])),
-        (vec![2], expected_size(&[("a", 3)])),
-      ]
-    );
-  }
-
-  #[test]
-  fn should_separate_items_with_different_size_types_when_unsplittable() {
-    assert_eq!(
-      group(
-        vec![
-          &[("a", 1)],
-          &[("b", 1)],
-          &[("a", 1)],
-          &[("a", 1)],
-          &[("b", 1)],
-          &[("a", 1)],
-          &[("a", 1)],
-          &[("b", 1)],
-          &[("a", 1)],
-          &[("a", 1)],
-        ],
-        &[("a", 3), ("b", 3)],
-        &[("a", 5), ("b", 5)],
-      ),
-      vec![
-        (vec![0, 2, 3], expected_size(&[("a", 3)])),
-        (vec![1, 4, 7], expected_size(&[("b", 3)])),
-        (vec![5, 6, 8, 9], expected_size(&[("a", 4)])),
-      ]
-    );
-  }
-
-  #[test]
-  fn should_handle_entangled_size_types_case_1() {
-    assert_eq!(
-      group(
-        vec![
-          &[("c", 2), ("b", 2)],
-          &[("a", 2), ("c", 2)],
-          &[("a", 2), ("b", 2)]
-        ],
-        &[("a", 3), ("b", 3), ("c", 3)],
-        &[("a", 3), ("b", 3), ("c", 3)],
-      ),
-      vec![(
-        vec![0, 1, 2],
-        expected_size(&[("a", 4), ("b", 4), ("c", 4)])
-      )]
-    );
-  }
-
-  #[test]
-  fn should_handle_entangled_size_types_case_2() {
-    assert_eq!(
-      group(
-        vec![
-          &[("c", 2), ("b", 2)],
-          &[("a", 2), ("c", 2)],
-          &[("a", 2), ("b", 2)]
-        ],
-        &[("a", 3), ("b", 3)],
-        &[("c", 3)],
-      ),
-      vec![
-        (vec![0, 2], expected_size(&[("a", 2), ("b", 4), ("c", 2)])),
-        (vec![1], expected_size(&[("a", 2), ("c", 2)])),
-      ]
-    );
-  }
-}
-
 impl SplitChunksPlugin {
   /// Affected by `splitChunks.minSize`/`splitChunks.cacheGroups.{cacheGroup}.minSize`
   // #[tracing::instrument(skip_all)]
@@ -882,5 +734,156 @@ impl SplitChunksPlugin {
       })
     });
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::BTreeMap;
+
+  use super::*;
+
+  type NormalizedSize = Vec<(String, i32)>;
+  type GroupResult = Vec<(Vec<usize>, NormalizedSize)>;
+
+  fn sizes(values: &[(&str, i32)]) -> SplitChunkSizes {
+    SplitChunkSizes(
+      values
+        .iter()
+        .map(|(ty, size)| (SourceType::from(*ty), f64::from(*size)))
+        .collect(),
+    )
+  }
+
+  fn item(index: usize, size: &[(&str, i32)]) -> GroupItem {
+    GroupItem {
+      module: ModuleIdentifier::from(index.to_string()),
+      size: sizes(size),
+      key: (100_000 + index).to_string(),
+    }
+  }
+
+  fn normalize_size(size: &SplitChunkSizes) -> NormalizedSize {
+    size
+      .iter()
+      .map(|(ty, size)| (ty.to_string(), *size as i32))
+      .collect::<BTreeMap<_, _>>()
+      .into_iter()
+      .collect()
+  }
+
+  fn expected_size(values: &[(&str, i32)]) -> NormalizedSize {
+    values
+      .iter()
+      .map(|(ty, size)| ((*ty).to_string(), *size))
+      .collect()
+  }
+
+  fn group(
+    items: Vec<&[(&str, i32)]>,
+    min_size: &[(&str, i32)],
+    max_size: &[(&str, i32)],
+  ) -> GroupResult {
+    deterministic_grouping(
+      items
+        .into_iter()
+        .enumerate()
+        .map(|(index, size)| item(index, size))
+        .collect(),
+      &sizes(max_size),
+      &sizes(min_size),
+    )
+    .into_iter()
+    .map(|group| {
+      (
+        group
+          .nodes
+          .iter()
+          .map(|node| node.module.as_str().parse().expect("module index"))
+          .collect(),
+        normalize_size(&group.size),
+      )
+    })
+    .collect()
+  }
+
+  #[test]
+  fn should_split_large_chunks_with_different_size_types() {
+    assert_eq!(
+      group(
+        vec![&[("a", 3), ("b", 3)], &[("b", 1)], &[("a", 3)]],
+        &[("a", 3), ("b", 3)],
+        &[("a", 5), ("b", 5)],
+      ),
+      vec![
+        (vec![0, 1], expected_size(&[("a", 3), ("b", 4)])),
+        (vec![2], expected_size(&[("a", 3)])),
+      ]
+    );
+  }
+
+  #[test]
+  fn should_separate_items_with_different_size_types_when_unsplittable() {
+    assert_eq!(
+      group(
+        vec![
+          &[("a", 1)],
+          &[("b", 1)],
+          &[("a", 1)],
+          &[("a", 1)],
+          &[("b", 1)],
+          &[("a", 1)],
+          &[("a", 1)],
+          &[("b", 1)],
+          &[("a", 1)],
+          &[("a", 1)],
+        ],
+        &[("a", 3), ("b", 3)],
+        &[("a", 5), ("b", 5)],
+      ),
+      vec![
+        (vec![0, 2, 3], expected_size(&[("a", 3)])),
+        (vec![1, 4, 7], expected_size(&[("b", 3)])),
+        (vec![5, 6, 8, 9], expected_size(&[("a", 4)])),
+      ]
+    );
+  }
+
+  #[test]
+  fn should_handle_entangled_size_types_case_1() {
+    assert_eq!(
+      group(
+        vec![
+          &[("c", 2), ("b", 2)],
+          &[("a", 2), ("c", 2)],
+          &[("a", 2), ("b", 2)]
+        ],
+        &[("a", 3), ("b", 3), ("c", 3)],
+        &[("a", 3), ("b", 3), ("c", 3)],
+      ),
+      vec![(
+        vec![0, 1, 2],
+        expected_size(&[("a", 4), ("b", 4), ("c", 4)])
+      )]
+    );
+  }
+
+  #[test]
+  fn should_handle_entangled_size_types_case_2() {
+    assert_eq!(
+      group(
+        vec![
+          &[("c", 2), ("b", 2)],
+          &[("a", 2), ("c", 2)],
+          &[("a", 2), ("b", 2)]
+        ],
+        &[("a", 3), ("b", 3)],
+        &[("c", 3)],
+      ),
+      vec![
+        (vec![0, 2], expected_size(&[("a", 2), ("b", 4), ("c", 2)])),
+        (vec![1], expected_size(&[("a", 2), ("c", 2)])),
+      ]
+    );
   }
 }

--- a/tests/rspack-test/configCases/split-chunks/correct-order/a.js
+++ b/tests/rspack-test/configCases/split-chunks/correct-order/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/correct-order/index.js
+++ b/tests/rspack-test/configCases/split-chunks/correct-order/index.js
@@ -1,0 +1,11 @@
+var a = require("./a");
+
+it("should run", function() {
+	expect(a).toBe("a");
+});
+
+var mainModule = require.main;
+
+it("should be main", function() {
+	expect(mainModule).toBe(module);
+});

--- a/tests/rspack-test/configCases/split-chunks/correct-order/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/correct-order/rspack.config.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    vendor: ['./a'],
+    main: './index',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      minSize: 1,
+      name: 'vendor',
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/correct-order/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/correct-order/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./vendor.js", "./main.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/__snapshot__/css.txt
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/__snapshot__/css.txt
@@ -1,0 +1,11 @@
+Array [
+  body {
+  background: green;
+},
+  body {
+  background: red;
+},
+  body {
+  background: green;
+},
+]

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/index.js
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/index.js
@@ -1,0 +1,15 @@
+import "package/styles.css";
+import "./style.css";
+
+it("should work and enforce create vendor CSS chunk", () => {
+	const path = __non_webpack_require__("path");
+	const links = document.getElementsByTagName("link");
+	const css = [];
+
+	// Skip first because import it by default
+	for (const link of [...links].slice(1)) {
+		css.push(getLinkSheet(link));
+	}
+
+	expect(css).toMatchFileSnapshotSync(path.join(__SNAPSHOT__, "css.txt"));
+});

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/node_modules/package/package.json
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/node_modules/package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package",
+  "description": "description",
+  "version": "1.0.0"
+}

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/node_modules/package/styles.css
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/node_modules/package/styles.css
@@ -1,0 +1,3 @@
+body {
+  background: green;
+}

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/rspack.config.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  experiments: {
+    css: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/auto',
+      },
+    ],
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        vendors: {
+          name: 'vendors',
+          test: /node_modules/,
+          enforce: true,
+        },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/style.css
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/style.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/tests/rspack-test/configCases/split-chunks/css-enforce/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/css-enforce/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	},
+	moduleScope(scope) {
+		const link1 = scope.window.document.createElement("link");
+		link1.rel = "stylesheet";
+		link1.href = "main.css";
+		scope.window.document.head.appendChild(link1);
+		const link2 = scope.window.document.createElement("link");
+		link2.rel = "stylesheet";
+		link2.href = "vendors.css";
+		scope.window.document.head.appendChild(link2);
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/extract-async-from-entry/index.js
+++ b/tests/rspack-test/configCases/split-chunks/extract-async-from-entry/index.js
@@ -1,0 +1,1 @@
+it("should run successful", function() {});

--- a/tests/rspack-test/configCases/split-chunks/extract-async-from-entry/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/extract-async-from-entry/rspack.config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index',
+    second: './index',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      minSize: 1,
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/extract-async-from-entry/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/extract-async-from-entry/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./main.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/hot-multi/common.js
+++ b/tests/rspack-test/configCases/split-chunks/hot-multi/common.js
@@ -1,0 +1,1 @@
+module.exports = "common";

--- a/tests/rspack-test/configCases/split-chunks/hot-multi/first.js
+++ b/tests/rspack-test/configCases/split-chunks/hot-multi/first.js
@@ -1,0 +1,5 @@
+require("./common");
+
+it("should have the correct main flag for multi first module", function() {
+	expect(module.hot._main).toBe(true);
+});

--- a/tests/rspack-test/configCases/split-chunks/hot-multi/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/hot-multi/rspack.config.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const HotModuleReplacementPlugin =
+  require('@rspack/core').HotModuleReplacementPlugin;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    first: ['./shared', './first'],
+    second: ['./shared', './second'],
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          chunks: 'all',
+          name: 'vendor',
+          minChunks: 2,
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [new HotModuleReplacementPlugin()],
+};

--- a/tests/rspack-test/configCases/split-chunks/hot-multi/second.js
+++ b/tests/rspack-test/configCases/split-chunks/hot-multi/second.js
@@ -1,0 +1,5 @@
+require("./common");
+
+it("should have the correct main flag for multi second module", function() {
+	expect(module.hot._main).toBe(true);
+});

--- a/tests/rspack-test/configCases/split-chunks/hot-multi/shared.js
+++ b/tests/rspack-test/configCases/split-chunks/hot-multi/shared.js
@@ -1,0 +1,1 @@
+module.exports = "shared";

--- a/tests/rspack-test/configCases/split-chunks/hot-multi/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/hot-multi/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./vendor.js", "./first.js", "./second.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/hot/index.js
+++ b/tests/rspack-test/configCases/split-chunks/hot/index.js
@@ -1,0 +1,9 @@
+it("should have the correct main flag", function() {
+	var a = require("./vendor");
+	expect(a._main).toBe(false);
+	expect(module.hot._main).toBe(true);
+});
+
+it("should be main", function() {
+	expect(require.main).toBe(module);
+});

--- a/tests/rspack-test/configCases/split-chunks/hot/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/hot/rspack.config.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const HotModuleReplacementPlugin =
+  require('@rspack/core').HotModuleReplacementPlugin;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          chunks: 'all',
+          name: 'vendor',
+          test: /vendor/,
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [new HotModuleReplacementPlugin()],
+};

--- a/tests/rspack-test/configCases/split-chunks/hot/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/hot/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./vendor.js", "./main.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/hot/vendor.js
+++ b/tests/rspack-test/configCases/split-chunks/hot/vendor.js
@@ -1,0 +1,1 @@
+module.exports = module.hot;

--- a/tests/rspack-test/configCases/split-chunks/inverted-order/a.js
+++ b/tests/rspack-test/configCases/split-chunks/inverted-order/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/inverted-order/index.js
+++ b/tests/rspack-test/configCases/split-chunks/inverted-order/index.js
@@ -1,0 +1,11 @@
+var a = require("./a");
+
+it("should run", function() {
+	expect(a).toBe("a");
+});
+
+var mainModule = require.main;
+
+it("should be main", function() {
+	expect(mainModule).toBe(module);
+});

--- a/tests/rspack-test/configCases/split-chunks/inverted-order/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/inverted-order/rspack.config.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    vendor: ['./a'],
+    main: './index',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      minSize: 1,
+      name: 'vendor',
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/inverted-order/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/inverted-order/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./main.js", "./vendor.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/issue-12128/a.js
+++ b/tests/rspack-test/configCases/split-chunks/issue-12128/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/issue-12128/b.js
+++ b/tests/rspack-test/configCases/split-chunks/issue-12128/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/tests/rspack-test/configCases/split-chunks/issue-12128/index.js
+++ b/tests/rspack-test/configCases/split-chunks/issue-12128/index.js
@@ -1,0 +1,6 @@
+it("should be main", function () {
+	require("./a");
+	require("./b");
+
+	expect(window["rspackChunk"].length).toBe(1);
+});

--- a/tests/rspack-test/configCases/split-chunks/issue-12128/index2.js
+++ b/tests/rspack-test/configCases/split-chunks/issue-12128/index2.js
@@ -1,0 +1,6 @@
+it("should run", function() {
+	var a = require("./a");
+	var b = require("./b");
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+});

--- a/tests/rspack-test/configCases/split-chunks/issue-12128/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/issue-12128/rspack.config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index',
+    main2: './index2',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        common: {
+          chunks: 'initial',
+          minSize: 0,
+          name: 'common',
+        },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/issue-12128/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/issue-12128/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./common.js", "./main.js", "./main2.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/library/a.js
+++ b/tests/rspack-test/configCases/split-chunks/library/a.js
@@ -1,0 +1,5 @@
+var path = require("path");
+module.exports = {
+	vendor: require("fs").readFileSync(path.join(__dirname, "vendor.js"), "utf-8"),
+	main: require("fs").readFileSync(path.join(__dirname, "main.js"), "utf-8")
+};

--- a/tests/rspack-test/configCases/split-chunks/library/index.js
+++ b/tests/rspack-test/configCases/split-chunks/library/index.js
@@ -1,0 +1,11 @@
+if (Math.random() < 0) require("external1");
+require.ensure([], function() {
+	if (Math.random() < 0) require("external2");
+});
+
+it("should have externals in main file", function() {
+	var a = require("./a");
+	expect(a.vendor).toMatch('require("external0")');
+	expect(a.main).toMatch('require("external1")');
+	expect(a.main).toMatch('require("external2")');
+});

--- a/tests/rspack-test/configCases/split-chunks/library/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/library/rspack.config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    vendor: ['external0', './a'],
+    main: './index',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+    library: {
+      type: 'umd',
+    },
+  },
+  externals: ['external0', 'external1', 'external2', 'fs', 'path'],
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: 'vendor',
+          name: 'vendor',
+          enforce: true,
+        },
+      },
+    },
+  },
+  node: {
+    __filename: false,
+    __dirname: false,
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/library/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/library/test.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./vendor.js", "./main.js"];
+	},
+	modules: {
+		external0: "module 0",
+		external1: "module 1",
+		external2: "module 2"
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/max-size-fit/index.js
+++ b/tests/rspack-test/configCases/split-chunks/max-size-fit/index.js
@@ -48,12 +48,13 @@ it('should ensure max size fit', () => {
 		chunks.set(c.id, c)
 	}
 
-	expect(chunks.size).toBe(4)
+	expect(chunks.size).toBe(3)
 
 	expect(chunks.get('main-1')).toBeDefined()
-	expect(chunks.get('main-1').modules.length).toBe(3)
-	expect(chunks.get('main-2')).toBeDefined()
-	expect(chunks.get('main-2').modules.length).toBe(3)
-	expect(chunks.get('main-3')).toBeDefined()
-	expect(chunks.get('main-3').modules.length).toBe(1)
+	expect(chunks.get('main-1').modules.length).toBe(4)
+	expect(chunks.get('main-cde42ecf')).toBeDefined()
+	expect(chunks.get('main-cde42ecf').modules.length).toBe(1)
+	expect(chunks.get('main-cde42ecf').modules[0].name).toBe('./index.js + 5 modules')
+	expect(chunks.get('main-f5c11e54')).toBeDefined()
+	expect(chunks.get('main-f5c11e54').modules.length).toBe(1)
 })

--- a/tests/rspack-test/configCases/split-chunks/max-size-fit/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/max-size-fit/test.config.js
@@ -2,6 +2,6 @@
 module.exports = {
 	writeStatsJson: true,
 	findBundle: function (i, options) {
-		return ["main-1.js", "main-2.js", "main-3.js", "main-400f55e3.js"];
+		return ["main-1.js", "main-cde42ecf.js", "main-f5c11e54.js"];
 	}
 };

--- a/tests/rspack-test/configCases/split-chunks/max-size-split-with-css/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/max-size-split-with-css/test.config.js
@@ -7,9 +7,8 @@ module.exports = {
 			// are split and try again to see if the reset size satisfied the minSize
 			// then its okay, so the js can be split
 			"fragment-src_aaa_index_js.js",
-			"fragment-src_aaa_small_css-src_bbb_index_js.js",
+			"fragment-src_aaa_small_css-src_bbb_50k-1_js-src_bbb_50k-2_js-src_bbb_50k-3_js-src_bbb_50k-4_js.js",
 			"fragment-src_aaa_small_css-src_small_css.css",
-			"fragment-src_ccc_50k-1_js-src_ccc_50k-2_js-src_ccc_50k-3_js-src_ccc_50k-4_js.js",
 			"fragment-src_index_js.js",
 			"main.js"
 		];

--- a/tests/rspack-test/configCases/split-chunks/move-entry/a.js
+++ b/tests/rspack-test/configCases/split-chunks/move-entry/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/move-entry/index.js
+++ b/tests/rspack-test/configCases/split-chunks/move-entry/index.js
@@ -1,0 +1,3 @@
+it("should not be moved", function() {
+	expect(new Error().stack).not.toMatch(/webpackBootstrap/);
+});

--- a/tests/rspack-test/configCases/split-chunks/move-entry/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/move-entry/rspack.config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index?0',
+    second: './index?1',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        commons: {
+          chunks: 'initial',
+          minSize: 0,
+          name: 'commons',
+        },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/move-entry/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/move-entry/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./commons.js", "./main.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/index.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/index.js
@@ -1,0 +1,12 @@
+it("should correctly include indirect children in common chunk", function(done) {
+	Promise.all([
+		import('./pageA'),
+		import('./pageB')
+	]).then((imports) => {
+		expect(imports[0].default).toBe("reuse");
+		expect(imports[1].default).toBe("reuse");
+		done();
+	}).catch(e => {
+		done(e);
+	})
+});

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/pageA.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/pageA.js
@@ -1,0 +1,3 @@
+var reusableComponent = require("./reusableComponent");
+
+export default reusableComponent.default;

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/pageB.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/pageB.js
@@ -1,0 +1,1 @@
+module.exports = import('./pageC')

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/pageC.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/pageC.js
@@ -1,0 +1,3 @@
+var reusableComponent = require("./reusableComponent");
+
+export default reusableComponent.default;

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/reusableComponent.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/reusableComponent.js
@@ -1,0 +1,3 @@
+const reuse = "reuse";
+
+export default reuse;

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/rspack.config.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index',
+    misc: './second',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      minSize: 0,
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/second.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/second.js
@@ -1,0 +1,8 @@
+it("should handle indirect children with multiple parents correctly", function(done) {
+  import('./pageB').then(b => {
+    expect(b.default).toBe("reuse");
+    done()
+  }).catch(e => {
+		done();
+	})
+})

--- a/tests/rspack-test/configCases/split-chunks/move-to-grandparent/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/move-to-grandparent/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./main.js", "./misc.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/simple/a.js
+++ b/tests/rspack-test/configCases/split-chunks/simple/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/simple/index.js
+++ b/tests/rspack-test/configCases/split-chunks/simple/index.js
@@ -1,0 +1,8 @@
+it("should run", function() {
+	var a = require("./a");
+	expect(a).toBe("a");
+});
+
+it("should be main", function() {
+	expect(require.main).toBe(module);
+});

--- a/tests/rspack-test/configCases/split-chunks/simple/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/simple/rspack.config.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    vendor: ['./a'],
+    main: './index',
+  },
+  target: 'web',
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    splitChunks: {
+      minSize: 1,
+      name: 'vendor',
+    },
+  },
+};

--- a/tests/rspack-test/configCases/split-chunks/simple/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/simple/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./vendor.js", "./main.js"];
+	}
+};

--- a/tests/rspack-test/configCases/split-chunks/target-node/index.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/index.js
@@ -1,0 +1,14 @@
+it("should run", function() {
+	var a = require("a");
+	expect(a).toBe("a");
+	var b = require("b");
+	expect(b).toBe("b");
+	var c = require("c");
+	expect(c).toBe("c");
+	var d = require("d");
+	expect(d).toBe("d");
+});
+
+it("should be main", function() {
+	expect(require.main).toBe(module);
+});

--- a/tests/rspack-test/configCases/split-chunks/target-node/node_modules/a.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/node_modules/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/tests/rspack-test/configCases/split-chunks/target-node/node_modules/b.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/node_modules/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/tests/rspack-test/configCases/split-chunks/target-node/node_modules/c.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/node_modules/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/tests/rspack-test/configCases/split-chunks/target-node/node_modules/d.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/node_modules/d.js
@@ -1,0 +1,1 @@
+module.exports = "d";

--- a/tests/rspack-test/configCases/split-chunks/target-node/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/rspack.config.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+  {
+    name: 'default',
+    entry: './index',
+    target: 'node',
+    output: {
+      filename: 'default-[name].js',
+      libraryTarget: 'commonjs2',
+    },
+    optimization: {
+      splitChunks: {
+        minSize: 1,
+        chunks: 'all',
+      },
+    },
+  },
+  {
+    name: 'many-vendors',
+    entry: './index',
+    target: 'node',
+    output: {
+      filename: 'many-vendors-[name].js',
+      libraryTarget: 'commonjs2',
+    },
+    optimization: {
+      splitChunks: {
+        minSize: 1,
+        chunks: 'all',
+        maxInitialRequests: Infinity,
+        cacheGroups: {
+          default: false,
+          defaultVendors: false,
+          vendors: {
+            test: /node_modules/,
+            name: (m) => {
+              const match =
+                /** @type {string} */
+                (m.nameForCondition()).match(/([b-d]+)\.js$/);
+              if (match) return `vendors-${match[1]}`;
+            },
+          },
+        },
+      },
+    },
+  },
+];

--- a/tests/rspack-test/configCases/split-chunks/target-node/test.config.js
+++ b/tests/rspack-test/configCases/split-chunks/target-node/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(i, options) {
+		return [`./${options.name}-main.js`];
+	}
+};

--- a/tests/rspack-test/statsOutputCases/split-chunks-max-size/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/split-chunks-max-size/__snapshots__/stats.txt
@@ -1,13 +1,16 @@
 production:
-  Entrypoint main xx KiB = prod-650.js xx bytes prod-34.js xx KiB prod-main-0.js xx bytes prod-main-1.js xx bytes prod-main-dd072d6d.js xx KiB prod-main-ad4f269d.js xx KiB prod-main-4.js xx bytes prod-main-5.js xx bytes prod-main-6.js xx bytes prod-main-7.js xx bytes prod-main-2e0c1aa9.js xx KiB prod-main-131c667d.js xx KiB prod-main-77b81ee8.js xx KiB + 13 assets
-  chunk (runtime: main) prod-main-dd072d6d.js (main-dd072d6d) xx KiB ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  Entrypoint main xx KiB = prod-650.js xx bytes prod-34.js xx KiB prod-main-0.js xx bytes prod-main-1.js xx bytes prod-main-c777bd29.js xx KiB prod-main-e6c990e6.js xx KiB prod-main-4.js xx bytes prod-main-5.js xx bytes prod-main-6.js xx bytes prod-main-7.js xx bytes prod-main-7e6cc53d.js xx KiB prod-main-9b3d5737.js xx KiB prod-main-ce4ec317.js xx KiB + 13 assets
+  chunk (runtime: main) prod-main-e6c990e6.js (main-e6c990e6) xx KiB ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
-    ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) prod-main-6.js (main-6) xx bytes ={187}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+    ./index.js xx KiB [built] [code generated]
+  chunk (runtime: main) prod-main-6.js (main-6) xx bytes ={167}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./subfolder/big.js?1 xx bytes [built] [code generated]
     ./subfolder/big.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) prod-main-5.js (main-5) xx bytes ={187}= ={250}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) prod-main-7e6cc53d.js (main-7e6cc53d) xx KiB ={167}= ={250}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?2 xx KiB [built] [code generated]
+  chunk (runtime: main) prod-main-5.js (main-5) xx bytes ={167}= ={250}= ={290}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./small.js?1 xx bytes [built] [code generated]
     ./small.js?2 xx bytes [built] [code generated]
@@ -18,38 +21,32 @@ production:
     ./small.js?7 xx bytes [built] [code generated]
     ./small.js?8 xx bytes [built] [code generated]
     ./small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) prod-main-77b81ee8.js (main-77b81ee8) xx KiB (javascript) xx KiB (runtime) ={187}= ={250}= ={303}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [entry] [rendered]
-    > ./ main
-    ./very-big.js?3 xx KiB [built] [code generated]
-  chunk (runtime: main) prod-34.js (id hint: vendors) xx KiB ={187}= ={250}= ={303}= ={321}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) prod-34.js (id hint: vendors) xx KiB ={167}= ={250}= ={290}= ={303}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) prod-main-1.js (main-1) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) prod-main-1.js (main-1) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./in-some-directory/big.js?1 xx bytes [built] [code generated]
     ./in-some-directory/small.js?1 xx bytes [built] [code generated]
     ./in-some-directory/small.js?2 xx bytes [built] [code generated]
     ./in-some-directory/small.js?3 xx bytes [built] [code generated]
     ./in-some-directory/small.js?4 xx bytes [built] [code generated]
-  chunk (runtime: main) prod-main-131c667d.js (main-131c667d) xx KiB ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) prod-main-c777bd29.js (main-c777bd29) xx KiB ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
-    ./very-big.js?2 xx KiB [built] [code generated]
-  chunk (runtime: main) prod-main-0.js (main-0) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+    ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) prod-main-0.js (main-0) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./big.js?1 xx bytes [built] [code generated]
     ./big.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) prod-650.js (id hint: vendors) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) prod-650.js (id hint: vendors) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/big.js?1 xx bytes [built] [code generated]
     ./node_modules/small.js?1 xx bytes [built] [code generated]
     ./node_modules/small.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) prod-main-ad4f269d.js (main-ad4f269d) xx KiB ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) prod-main-ce4ec317.js (main-ce4ec317) xx KiB (javascript) xx KiB (runtime) ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={793}= ={8}= ={876}= [entry] [rendered]
     > ./ main
-    ./index.js xx KiB [built] [code generated]
-  chunk (runtime: main) prod-main-2e0c1aa9.js (main-2e0c1aa9) xx KiB ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={793}= ={8}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) prod-main-7.js (main-7) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={8}= [initial] [rendered]
+    ./very-big.js?3 xx KiB [built] [code generated]
+  chunk (runtime: main) prod-main-7.js (main-7) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./subfolder/small.js?1 xx bytes [built] [code generated]
     ./subfolder/small.js?2 xx bytes [built] [code generated]
@@ -60,7 +57,7 @@ production:
     ./subfolder/small.js?7 xx bytes [built] [code generated]
     ./subfolder/small.js?8 xx bytes [built] [code generated]
     ./subfolder/small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) prod-main-4.js (main-4) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= [initial] [rendered]
+  chunk (runtime: main) prod-main-4.js (main-4) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={876}= [initial] [rendered]
     > ./ main
     ./inner-module/small.js?1 xx bytes [built] [code generated]
     ./inner-module/small.js?2 xx bytes [built] [code generated]
@@ -71,22 +68,25 @@ production:
     ./inner-module/small.js?7 xx bytes [built] [code generated]
     ./inner-module/small.js?8 xx bytes [built] [code generated]
     ./inner-module/small.js?9 xx bytes [built] [code generated]
+  chunk (runtime: main) prod-main-9b3d5737.js (main-9b3d5737) xx KiB ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?1 xx KiB [built] [code generated]
   production (Rspack x.x.x) compiled successfully
 
 development:
-  Entrypoint main xx KiB = dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js xx bytes dev-vendors-node_modules_very-big_js_1.js xx KiB dev-main-0.js xx bytes dev-main-1.js xx KiB dev-main-in-some-directory_very-big_js-4febc798.js xx KiB dev-main-index_js-fb10b2a7.js xx KiB dev-main-4.js xx KiB dev-main-5.js xx KiB dev-main-6.js xx bytes dev-main-7.js xx KiB dev-main-very-big_js-219ca2dd.js xx KiB dev-main-very-big_js-2480b080.js xx KiB dev-main-very-big_js-de1029b2.js xx KiB + 13 assets
-  chunk (runtime: main) dev-main-0.js (main-0) xx bytes ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  Entrypoint main xx KiB = dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js xx bytes dev-vendors-node_modules_very-big_js_1.js xx KiB dev-main-0.js xx bytes dev-main-1.js xx KiB dev-main-in-some-directory_very-big_js-72ca98bc.js xx KiB dev-main-index_js-bff0b8c4.js xx KiB dev-main-4.js xx KiB dev-main-5.js xx KiB dev-main-6.js xx bytes dev-main-7.js xx KiB dev-main-very-big_js-0f140adf.js xx KiB dev-main-very-big_js-11080375.js xx KiB dev-main-very-big_js-ccb7762f.js xx KiB + 13 assets
+  chunk (runtime: main) dev-main-0.js (main-0) xx bytes ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./big.js?1 xx bytes [built] [code generated]
     ./big.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-main-1.js (main-1) xx bytes ={main-0}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-1.js (main-1) xx bytes ={main-0}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./in-some-directory/big.js?1 xx bytes [built] [code generated]
     ./in-some-directory/small.js?1 xx bytes [built] [code generated]
     ./in-some-directory/small.js?2 xx bytes [built] [code generated]
     ./in-some-directory/small.js?3 xx bytes [built] [code generated]
     ./in-some-directory/small.js?4 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-main-4.js (main-4) xx bytes ={main-0}= ={main-1}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-4.js (main-4) xx bytes ={main-0}= ={main-1}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./inner-module/small.js?1 xx bytes [built] [code generated]
     ./inner-module/small.js?2 xx bytes [built] [code generated]
@@ -97,7 +97,7 @@ development:
     ./inner-module/small.js?7 xx bytes [built] [code generated]
     ./inner-module/small.js?8 xx bytes [built] [code generated]
     ./inner-module/small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-main-5.js (main-5) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-5.js (main-5) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./small.js?1 xx bytes [built] [code generated]
     ./small.js?2 xx bytes [built] [code generated]
@@ -108,11 +108,11 @@ development:
     ./small.js?7 xx bytes [built] [code generated]
     ./small.js?8 xx bytes [built] [code generated]
     ./small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-main-6.js (main-6) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-6.js (main-6) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./subfolder/big.js?1 xx bytes [built] [code generated]
     ./subfolder/big.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-main-7.js (main-7) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-7.js (main-7) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./subfolder/small.js?1 xx bytes [built] [code generated]
     ./subfolder/small.js?2 xx bytes [built] [code generated]
@@ -123,69 +123,46 @@ development:
     ./subfolder/small.js?7 xx bytes [built] [code generated]
     ./subfolder/small.js?8 xx bytes [built] [code generated]
     ./subfolder/small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-main-in-some-directory_very-big_js-4febc798.js (main-in-some-directory_very-big_js-4febc798) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-in-some-directory_very-big_js-72ca98bc.js (main-in-some-directory_very-big_js-72ca98bc) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) dev-main-index_js-fb10b2a7.js (main-index_js-fb10b2a7) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-index_js-bff0b8c4.js (main-index_js-bff0b8c4) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./index.js xx KiB [built] [code generated]
-  chunk (runtime: main) dev-main-very-big_js-219ca2dd.js (main-very-big_js-219ca2dd) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) dev-main-very-big_js-2480b080.js (main-very-big_js-2480b080) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+  chunk (runtime: main) dev-main-very-big_js-0f140adf.js (main-very-big_js-0f140adf) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./very-big.js?2 xx KiB [built] [code generated]
-  chunk (runtime: main) dev-main-very-big_js-de1029b2.js (main-very-big_js-de1029b2) xx KiB (javascript) xx KiB (runtime) ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
+  chunk (runtime: main) dev-main-very-big_js-11080375.js (main-very-big_js-11080375) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) dev-main-very-big_js-ccb7762f.js (main-very-big_js-ccb7762f) xx KiB (javascript) xx KiB (runtime) ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
     > ./ main
     ./very-big.js?3 xx KiB [built] [code generated]
-  chunk (runtime: main) dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js (id hint: vendors) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js (id hint: vendors) xx bytes ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/big.js?1 xx bytes [built] [code generated]
     ./node_modules/small.js?1 xx bytes [built] [code generated]
     ./node_modules/small.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) dev-vendors-node_modules_very-big_js_1.js (id hint: vendors) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-4febc798}= ={main-index_js-fb10b2a7}= ={main-very-big_js-219ca2dd}= ={main-very-big_js-2480b080}= ={main-very-big_js-de1029b2}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) dev-vendors-node_modules_very-big_js_1.js (id hint: vendors) xx KiB ={main-0}= ={main-1}= ={main-4}= ={main-5}= ={main-6}= ={main-7}= ={main-in-some-directory_very-big_js-72ca98bc}= ={main-index_js-bff0b8c4}= ={main-very-big_js-0f140adf}= ={main-very-big_js-11080375}= ={main-very-big_js-ccb7762f}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/very-big.js?1 xx KiB [built] [code generated]
   development (Rspack x.x.x) compiled successfully
 
 switched:
-  Entrypoint main xx KiB = switched-650.js xx bytes switched-34.js xx KiB switched-main-e5050b88.js xx KiB switched-main-dd072d6d.js xx KiB switched-main-ad4f269d.js xx KiB switched-main-017a98ac.js xx KiB switched-main-2e0c1aa9.js xx KiB switched-main-131c667d.js xx KiB switched-main-77b81ee8.js xx KiB + 9 assets
-  chunk (runtime: main) switched-main-dd072d6d.js (main-dd072d6d) xx KiB ={200}= ={321}= ={34}= ={589}= ={650}= ={728}= ={734}= ={877}= [initial] [rendered]
-    > ./ main
-    ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) switched-main-017a98ac.js (main-017a98ac) xx KiB ={187}= ={321}= ={34}= ={589}= ={650}= ={728}= ={734}= ={877}= [initial] [rendered]
-    > ./ main
-    modules by path ./subfolder/*.js xx KiB
-      ./subfolder/big.js?1 xx bytes [built] [code generated]
-      ./subfolder/big.js?2 xx bytes [built] [code generated]
-      ./subfolder/small.js?1 xx bytes [built] [code generated]
-      + 8 modules
-    modules by path ./*.js xx bytes
-      ./small.js?1 xx bytes [built] [code generated]
-      ./small.js?2 xx bytes [built] [code generated]
-      ./small.js?3 xx bytes [built] [code generated]
-      + 6 modules
-  chunk (runtime: main) switched-main-77b81ee8.js (main-77b81ee8) xx KiB (javascript) xx KiB (runtime) ={187}= ={200}= ={34}= ={589}= ={650}= ={728}= ={734}= ={877}= [entry] [rendered]
-    > ./ main
-    ./very-big.js?3 xx KiB [built] [code generated]
-  chunk (runtime: main) switched-34.js (id hint: vendors) xx KiB ={187}= ={200}= ={321}= ={589}= ={650}= ={728}= ={734}= ={877}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./ main
-    ./node_modules/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) switched-main-131c667d.js (main-131c667d) xx KiB ={187}= ={200}= ={321}= ={34}= ={650}= ={728}= ={734}= ={877}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?2 xx KiB [built] [code generated]
-  chunk (runtime: main) switched-650.js (id hint: vendors) xx bytes ={187}= ={200}= ={321}= ={34}= ={589}= ={728}= ={734}= ={877}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./ main
-    ./node_modules/big.js?1 xx bytes [built] [code generated]
-    ./node_modules/small.js?1 xx bytes [built] [code generated]
-    ./node_modules/small.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) switched-main-ad4f269d.js (main-ad4f269d) xx KiB ={187}= ={200}= ={321}= ={34}= ={589}= ={650}= ={734}= ={877}= [initial] [rendered]
+  Entrypoint main xx KiB = switched-650.js xx bytes switched-34.js xx KiB switched-main-c200f1b1.js xx KiB switched-main-c777bd29.js xx KiB switched-main-e6c990e6.js xx KiB switched-main-1c26c0a2.js xx KiB switched-main-7e6cc53d.js xx KiB switched-main-9b3d5737.js xx KiB switched-main-ce4ec317.js xx KiB + 9 assets
+  chunk (runtime: main) switched-main-e6c990e6.js (main-e6c990e6) xx KiB ={290}= ={34}= ={593}= ={595}= ={650}= ={719}= ={876}= ={982}= [initial] [rendered]
     > ./ main
     ./index.js xx KiB [built] [code generated]
-  chunk (runtime: main) switched-main-2e0c1aa9.js (main-2e0c1aa9) xx KiB ={187}= ={200}= ={321}= ={34}= ={589}= ={650}= ={728}= ={877}= [initial] [rendered]
+  chunk (runtime: main) switched-main-7e6cc53d.js (main-7e6cc53d) xx KiB ={167}= ={34}= ={593}= ={595}= ={650}= ={719}= ={876}= ={982}= [initial] [rendered]
     > ./ main
-    ./very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) switched-main-e5050b88.js (main-e5050b88) xx KiB ={187}= ={200}= ={321}= ={34}= ={589}= ={650}= ={728}= ={734}= [initial] [rendered]
+    ./very-big.js?2 xx KiB [built] [code generated]
+  chunk (runtime: main) switched-34.js (id hint: vendors) xx KiB ={167}= ={290}= ={593}= ={595}= ={650}= ={719}= ={876}= ={982}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) switched-main-c777bd29.js (main-c777bd29) xx KiB ={167}= ={290}= ={34}= ={595}= ={650}= ={719}= ={876}= ={982}= [initial] [rendered]
+    > ./ main
+    ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) switched-main-c200f1b1.js (main-c200f1b1) xx KiB ={167}= ={290}= ={34}= ={593}= ={650}= ={719}= ={876}= ={982}= [initial] [rendered]
     > ./ main
     modules by path ./inner-module/*.js xx bytes
       ./inner-module/small.js?1 xx bytes [built] [code generated]
@@ -197,18 +174,44 @@ switched:
     modules by path ./*.js xx bytes
       ./big.js?1 xx bytes [built] [code generated]
       ./big.js?2 xx bytes [built] [code generated]
+  chunk (runtime: main) switched-650.js (id hint: vendors) xx bytes ={167}= ={290}= ={34}= ={593}= ={595}= ={719}= ={876}= ={982}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/big.js?1 xx bytes [built] [code generated]
+    ./node_modules/small.js?1 xx bytes [built] [code generated]
+    ./node_modules/small.js?2 xx bytes [built] [code generated]
+  chunk (runtime: main) switched-main-ce4ec317.js (main-ce4ec317) xx KiB (javascript) xx KiB (runtime) ={167}= ={290}= ={34}= ={593}= ={595}= ={650}= ={876}= ={982}= [entry] [rendered]
+    > ./ main
+    ./very-big.js?3 xx KiB [built] [code generated]
+  chunk (runtime: main) switched-main-9b3d5737.js (main-9b3d5737) xx KiB ={167}= ={290}= ={34}= ={593}= ={595}= ={650}= ={719}= ={982}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) switched-main-1c26c0a2.js (main-1c26c0a2) xx KiB ={167}= ={290}= ={34}= ={593}= ={595}= ={650}= ={719}= ={876}= [initial] [rendered]
+    > ./ main
+    modules by path ./subfolder/*.js xx KiB
+      ./subfolder/big.js?1 xx bytes [built] [code generated]
+      ./subfolder/big.js?2 xx bytes [built] [code generated]
+      ./subfolder/small.js?1 xx bytes [built] [code generated]
+      + 8 modules
+    modules by path ./*.js xx bytes
+      ./small.js?1 xx bytes [built] [code generated]
+      ./small.js?2 xx bytes [built] [code generated]
+      ./small.js?3 xx bytes [built] [code generated]
+      + 6 modules
   switched (Rspack x.x.x) compiled successfully
 
 zero-min:
-  Entrypoint main xx KiB = zero-min-650.js xx bytes zero-min-34.js xx KiB zero-min-main-0.js xx bytes zero-min-main-1.js xx bytes zero-min-main-dd072d6d.js xx KiB zero-min-main-ad4f269d.js xx KiB zero-min-main-4.js xx bytes zero-min-main-5.js xx bytes zero-min-main-6.js xx bytes zero-min-main-7.js xx bytes zero-min-main-2e0c1aa9.js xx KiB zero-min-main-131c667d.js xx KiB zero-min-main-77b81ee8.js xx KiB + 13 assets
-  chunk (runtime: main) zero-min-main-dd072d6d.js (main-dd072d6d) xx KiB ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  Entrypoint main xx KiB = zero-min-650.js xx bytes zero-min-34.js xx KiB zero-min-main-0.js xx bytes zero-min-main-1.js xx bytes zero-min-main-c777bd29.js xx KiB zero-min-main-e6c990e6.js xx KiB zero-min-main-4.js xx bytes zero-min-main-5.js xx bytes zero-min-main-6.js xx bytes zero-min-main-7.js xx bytes zero-min-main-7e6cc53d.js xx KiB zero-min-main-9b3d5737.js xx KiB zero-min-main-ce4ec317.js xx KiB + 13 assets
+  chunk (runtime: main) zero-min-main-e6c990e6.js (main-e6c990e6) xx KiB ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
-    ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-6.js (main-6) xx bytes ={187}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+    ./index.js xx KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-6.js (main-6) xx bytes ={167}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./subfolder/big.js?1 xx bytes [built] [code generated]
     ./subfolder/big.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-5.js (main-5) xx bytes ={187}= ={250}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-7e6cc53d.js (main-7e6cc53d) xx KiB ={167}= ={250}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?2 xx KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-5.js (main-5) xx bytes ={167}= ={250}= ={290}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./small.js?1 xx bytes [built] [code generated]
     ./small.js?2 xx bytes [built] [code generated]
@@ -219,38 +222,32 @@ zero-min:
     ./small.js?7 xx bytes [built] [code generated]
     ./small.js?8 xx bytes [built] [code generated]
     ./small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-77b81ee8.js (main-77b81ee8) xx KiB (javascript) xx KiB (runtime) ={187}= ={250}= ={303}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [entry] [rendered]
-    > ./ main
-    ./very-big.js?3 xx KiB [built] [code generated]
-  chunk (runtime: main) zero-min-34.js (id hint: vendors) xx KiB ={187}= ={250}= ={303}= ={321}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) zero-min-34.js (id hint: vendors) xx KiB ={167}= ={250}= ={290}= ={303}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-1.js (main-1) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-1.js (main-1) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./in-some-directory/big.js?1 xx bytes [built] [code generated]
     ./in-some-directory/small.js?1 xx bytes [built] [code generated]
     ./in-some-directory/small.js?2 xx bytes [built] [code generated]
     ./in-some-directory/small.js?3 xx bytes [built] [code generated]
     ./in-some-directory/small.js?4 xx bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-131c667d.js (main-131c667d) xx KiB ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={612}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-c777bd29.js (main-c777bd29) xx KiB ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={612}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
-    ./very-big.js?2 xx KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-0.js (main-0) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={650}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered]
+    ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-0.js (main-0) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={650}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./big.js?1 xx bytes [built] [code generated]
     ./big.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) zero-min-650.js (id hint: vendors) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={728}= ={734}= ={793}= ={8}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) zero-min-650.js (id hint: vendors) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={719}= ={793}= ={8}= ={876}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/big.js?1 xx bytes [built] [code generated]
     ./node_modules/small.js?1 xx bytes [built] [code generated]
     ./node_modules/small.js?2 xx bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-ad4f269d.js (main-ad4f269d) xx KiB ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={734}= ={793}= ={8}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-ce4ec317.js (main-ce4ec317) xx KiB (javascript) xx KiB (runtime) ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={793}= ={8}= ={876}= [entry] [rendered]
     > ./ main
-    ./index.js xx KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-2e0c1aa9.js (main-2e0c1aa9) xx KiB ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={793}= ={8}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-7.js (main-7) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={8}= [initial] [rendered]
+    ./very-big.js?3 xx KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-7.js (main-7) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={8}= ={876}= [initial] [rendered]
     > ./ main
     ./subfolder/small.js?1 xx bytes [built] [code generated]
     ./subfolder/small.js?2 xx bytes [built] [code generated]
@@ -261,7 +258,7 @@ zero-min:
     ./subfolder/small.js?7 xx bytes [built] [code generated]
     ./subfolder/small.js?8 xx bytes [built] [code generated]
     ./subfolder/small.js?9 xx bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-4.js (main-4) xx bytes ={187}= ={250}= ={303}= ={321}= ={34}= ={571}= ={589}= ={612}= ={650}= ={728}= ={734}= ={793}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-4.js (main-4) xx bytes ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={876}= [initial] [rendered]
     > ./ main
     ./inner-module/small.js?1 xx bytes [built] [code generated]
     ./inner-module/small.js?2 xx bytes [built] [code generated]
@@ -272,68 +269,109 @@ zero-min:
     ./inner-module/small.js?7 xx bytes [built] [code generated]
     ./inner-module/small.js?8 xx bytes [built] [code generated]
     ./inner-module/small.js?9 xx bytes [built] [code generated]
+  chunk (runtime: main) zero-min-main-9b3d5737.js (main-9b3d5737) xx KiB ={167}= ={250}= ={290}= ={303}= ={34}= ={571}= ={593}= ={612}= ={650}= ={719}= ={793}= ={8}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?1 xx KiB [built] [code generated]
   zero-min (Rspack x.x.x) compiled successfully
 
 max-async-size:
   Entrypoint main xx KiB = max-async-size-main.js
-  chunk (runtime: main) max-async-size-async-b-131c667d.js (async-b-131c667d) xx KiB <{889}> ={53}= ={536}= ={826}= [rendered]
+  chunk (runtime: main) max-async-size-async-b-9b3d5737.js (async-b-9b3d5737) xx KiB <{889}> ={294}= ={536}= ={819}= [rendered]
+    > ./b ./async/index.js 10:3-50
+    > ./a ./async/index.js 9:3-50
+    ./very-big.js?1 xx KiB [built] [code generated]
+  chunk (runtime: main) max-async-size-async-b-7e6cc53d.js (async-b-7e6cc53d) xx KiB <{889}> ={160}= ={536}= ={819}= [rendered]
     > ./b ./async/index.js 10:3-50
     > ./a ./async/index.js 9:3-50
     ./very-big.js?2 xx KiB [built] [code generated]
-  chunk (runtime: main) max-async-size-async-b-77b81ee8.js (async-b-77b81ee8) xx KiB <{889}> ={409}= ={536}= ={826}= [rendered]
-    > ./b ./async/index.js 10:3-50
-    > ./a ./async/index.js 9:3-50
-    ./very-big.js?3 xx KiB [built] [code generated]
-  chunk (runtime: main) max-async-size-async-b-0.js (async-b-0) xx bytes <{889}> ={409}= ={53}= ={826}= [rendered]
+  chunk (runtime: main) max-async-size-async-b-0.js (async-b-0) xx bytes <{889}> ={160}= ={294}= ={819}= [rendered]
     > ./b ./async/index.js 10:3-50
     > ./a ./async/index.js 9:3-50
     dependent modules xx bytes [dependent] 9 modules
     cacheable modules xx bytes
       ./async/a.js xx bytes [built] [code generated]
       ./async/b.js xx bytes [built] [code generated]
-  chunk (runtime: main) max-async-size-async-b-2e0c1aa9.js (async-b-2e0c1aa9) xx KiB <{889}> ={409}= ={53}= ={536}= [rendered]
+  chunk (runtime: main) max-async-size-async-b-ce4ec317.js (async-b-ce4ec317) xx KiB <{889}> ={160}= ={294}= ={536}= [rendered]
     > ./b ./async/index.js 10:3-50
     > ./a ./async/index.js 9:3-50
-    ./very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) max-async-size-main.js (main) xx KiB (javascript) xx KiB (runtime) >{409}< >{53}< >{536}< >{826}< [entry] [rendered]
+    ./very-big.js?3 xx KiB [built] [code generated]
+  chunk (runtime: main) max-async-size-main.js (main) xx KiB (javascript) xx KiB (runtime) >{160}< >{294}< >{536}< >{819}< [entry] [rendered]
     > ./async main
     dependent modules xx KiB [dependent] 6 modules
     ./async/index.js xx bytes [built] [code generated]
   max-async-size (Rspack x.x.x) compiled successfully
 
 enforce-min-size:
-  Entrypoint main xx KiB = enforce-min-size-67.js xx KiB enforce-min-size-664.js xx KiB enforce-min-size-310.js xx KiB enforce-min-size-34.js xx KiB enforce-min-size-503.js xx KiB enforce-min-size-386.js xx KiB enforce-min-size-345.js xx KiB enforce-min-size-main.js xx KiB + 8 assets
-  chunk (runtime: main) enforce-min-size-310.js (id hint: all) xx KiB ={34}= ={345}= ={386}= ={503}= ={664}= ={67}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  Entrypoint main xx KiB = enforce-min-size-591.js xx bytes enforce-min-size-97.js xx bytes enforce-min-size-664.js xx KiB enforce-min-size-310.js xx KiB enforce-min-size-923.js xx KiB enforce-min-size-34.js xx KiB enforce-min-size-219.js xx bytes enforce-min-size-177.js xx bytes enforce-min-size-448.js xx bytes enforce-min-size-386.js xx KiB enforce-min-size-503.js xx KiB enforce-min-size-345.js xx KiB enforce-min-size-main.js xx KiB + 13 assets
+  chunk (runtime: main) enforce-min-size-177.js (id hint: all) xx bytes ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./subfolder/big.js?1 xx bytes [built] [code generated]
+    ./subfolder/big.js?2 xx bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-219.js (id hint: all) xx bytes ={177}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./small.js?1 xx bytes [built] [code generated]
+    ./small.js?2 xx bytes [built] [code generated]
+    ./small.js?3 xx bytes [built] [code generated]
+    ./small.js?4 xx bytes [built] [code generated]
+    ./small.js?5 xx bytes [built] [code generated]
+    ./small.js?6 xx bytes [built] [code generated]
+    ./small.js?7 xx bytes [built] [code generated]
+    ./small.js?8 xx bytes [built] [code generated]
+    ./small.js?9 xx bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-310.js (id hint: all) xx KiB ={177}= ={219}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./index.js xx KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-34.js (id hint: all) xx KiB ={310}= ={345}= ={386}= ={503}= ={664}= ={67}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-34.js (id hint: all) xx KiB ={177}= ={219}= ={310}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./node_modules/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-345.js (id hint: all) xx KiB ={310}= ={34}= ={386}= ={503}= ={664}= ={67}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-345.js (id hint: all) xx KiB ={177}= ={219}= ={310}= ={34}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./very-big.js?3 xx KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-386.js (id hint: all) xx KiB ={310}= ={34}= ={345}= ={503}= ={664}= ={67}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-386.js (id hint: all) xx KiB ={177}= ={219}= ={310}= ={34}= ={345}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./very-big.js?2 xx KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-503.js (id hint: all) xx KiB ={310}= ={34}= ={345}= ={386}= ={664}= ={67}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-448.js (id hint: all) xx bytes ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={503}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./subfolder/small.js?1 xx bytes [built] [code generated]
+    ./subfolder/small.js?2 xx bytes [built] [code generated]
+    ./subfolder/small.js?3 xx bytes [built] [code generated]
+    ./subfolder/small.js?4 xx bytes [built] [code generated]
+    ./subfolder/small.js?5 xx bytes [built] [code generated]
+    ./subfolder/small.js?6 xx bytes [built] [code generated]
+    ./subfolder/small.js?7 xx bytes [built] [code generated]
+    ./subfolder/small.js?8 xx bytes [built] [code generated]
+    ./subfolder/small.js?9 xx bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-503.js (id hint: all) xx KiB ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={591}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-664.js (id hint: all) xx KiB ={310}= ={34}= ={345}= ={386}= ={503}= ={67}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-591.js (id hint: all) xx bytes ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={664}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./big.js?1 xx bytes [built] [code generated]
+    ./big.js?2 xx bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-664.js (id hint: all) xx KiB ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={889}= ={923}= ={97}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./in-some-directory/very-big.js?1 xx KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-67.js (id hint: all) xx KiB ={310}= ={34}= ={345}= ={386}= ={503}= ={664}= ={889}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-main.js (main) xx KiB ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={923}= ={97}= [entry] [rendered]
     > ./ main
-    modules by path ./*.js xx KiB 11 modules
-    modules by path ./subfolder/*.js xx KiB 11 modules
-    modules by path ./inner-module/*.js xx bytes 9 modules
-    modules by path ./in-some-directory/*.js xx bytes
-      ./in-some-directory/big.js?1 xx bytes [built] [code generated]
-      + 4 modules
+  chunk (runtime: main) enforce-min-size-923.js (id hint: all) xx bytes ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={97}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    modules by path ./inner-module/*.js xx bytes
+      ./inner-module/small.js?1 xx bytes [built] [code generated]
+      ./inner-module/small.js?2 xx bytes [built] [code generated]
+      ./inner-module/small.js?3 xx bytes [built] [code generated]
+      ./inner-module/small.js?4 xx bytes [built] [code generated]
+      + 5 modules
     modules by path ./node_modules/*.js xx bytes
       ./node_modules/big.js?1 xx bytes [built] [code generated]
-      + 2 modules
-  chunk (runtime: main) enforce-min-size-main.js (main) xx KiB ={310}= ={34}= ={345}= ={386}= ={503}= ={664}= ={67}= [entry] [rendered]
+      ./node_modules/small.js?1 xx bytes [built] [code generated]
+      ./node_modules/small.js?2 xx bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-97.js (id hint: all) xx bytes ={177}= ={219}= ={310}= ={34}= ={345}= ={386}= ={448}= ={503}= ={591}= ={664}= ={889}= ={923}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
+    ./in-some-directory/big.js?1 xx bytes [built] [code generated]
+    ./in-some-directory/small.js?1 xx bytes [built] [code generated]
+    ./in-some-directory/small.js?2 xx bytes [built] [code generated]
+    ./in-some-directory/small.js?3 xx bytes [built] [code generated]
+    ./in-some-directory/small.js?4 xx bytes [built] [code generated]
   enforce-min-size (Rspack x.x.x) compiled successfully
 
 only-async:


### PR DESCRIPTION
## Summary

- Align splitChunks `maxSize` filename-key hashing with webpack by hashing raw module identifier bytes.
- Avoid Rust `str::hash` framing bytes when building max-size deterministic grouping keys.
- Do not apply `output.hashSalt` to splitChunks max-size filename keys. Webpack's `SplitChunksPlugin#hashFilename` uses `output.hashFunction` and `output.hashDigest`, but does not update the hash with `output.hashSalt`.
- Port webpack deterministic grouping coverage and splitChunks config cases used to lock this behavior.

## Root Cause

Rspack previously initialized the max-size filename hasher from full `OutputOptions`, which also writes `output.hashSalt`. Webpack's splitChunks max-size helper is an internal deterministic key/name helper and only hashes the identifier string with the configured hash function/digest. Including salt changes the key space, which can change lexical ordering, similarity scores, split boundaries, and generated chunk names.

## Validation

- `cargo fmt --all --check`
- `cargo lint`
- `cargo test --workspace --exclude rspack_binding_api --exclude rspack_node --exclude rspack_binding_builder --exclude rspack_binding_builder_macros --exclude rspack_binding_builder_testing --exclude rspack_binding_build --exclude rspack_napi --exclude rspack_watcher --exclude rspack_storage -- --nocapture`
- `pnpm run build:binding:dev`
- `CI=true pnpm --filter "@rspack/*" --filter "!@rspack/tests" --workspace-concurrency=1 test`
- `CI=true pnpm --filter "@rspack/tests" exec rstest <non-watcher top-level tests>`
- `CI=true pnpm --filter "@rspack/tests" exec rstest --project hottest`
- `CI=true pnpm --filter "@rspack/tests" exec rstest -t "configCases/split-chunks/max-size-fit"`
- `CI=true testFilter=split-chunks-max-size pnpm --filter "@rspack/tests" exec rstest StatsOutput.test.js`

Note: a full `CI=true pnpm run test:unit` run enters native watcher/watch cases and hit sandbox `EMFILE: too many open files, watch`; those are skipped per local AGENTS instructions.

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

---
_by OpenAI Codex_