### PR TITLE
fix: change default value of createRequire parsing to false

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -47,11 +47,10 @@ use rspack_core::{
   CssModuleGeneratorOptions, CssModuleParserOptions, CssParserOptions, DynamicImportMode,
   EntryDescription, EntryOptions, EntryRuntime, Environment, Experiments, ExternalItem,
   ExternalType, Filename, GeneratorOptions, GeneratorOptionsMap, ImportMeta,
-  JavascriptParserCommonjsExportsOption, JavascriptParserCommonjsOptions,
-  JavascriptParserCreateRequire, JavascriptParserOptions, JavascriptParserOrder,
-  JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName, LibraryNonUmdObject,
-  LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions,
-  ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
+  JavascriptParserCommonjsExportsOption, JavascriptParserCommonjsOptions, JavascriptParserOptions,
+  JavascriptParserOrder, JavascriptParserUrl, JsonGeneratorOptions, JsonParserOptions, LibraryName,
+  LibraryNonUmdObject, LibraryOptions, LibraryType, MangleExportsOption, Mode, ModuleNoParseRules,
+  ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleType, NodeDirnameOption, NodeFilenameOption,
   NodeGlobalOption, NodeOption, Optimization, OutputOptions, ParseOption, ParserOptions,
   ParserOptionsMap, PathInfo, PublicPath, Resolve, RuleSetCondition, RuleSetLogicalConditions,
   SideEffectOption, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType,
@@ -1745,9 +1744,7 @@ impl ModuleOptionsBuilder {
           }),
           import_dynamic: Some(true),
           commonjs_magic_comments: Some(false),
-          create_require: target_properties.node.filter(|node| *node).map(|_| {
-            JavascriptParserCreateRequire::Enabled("createRequire from module".to_string())
-          }),
+          create_require: None,
           jsx: Some(false),
           ..Default::default()
         }),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -569,6 +569,25 @@ fn should_replace_create_require_argument(parser: &mut JavascriptParser, arg: &E
 }
 
 #[inline(never)]
+fn should_clear_create_require_call(parser: &mut JavascriptParser, args: &[ExprOrSpread]) -> bool {
+  args.len() == 1
+    && !matches!(parser.javascript_options.require_resolve, Some(false))
+    && args[0].spread.is_none()
+    && args[0]
+      .expr
+      .as_member()
+      .is_some_and(|member| is_meta_url(parser, member))
+}
+
+#[inline(never)]
+fn clear_create_require_call(parser: &mut JavascriptParser, span: Span) {
+  parser.add_presentational_dependency(Box::new(ConstDependency::new(
+    span.into(),
+    "/* createRequire() */ undefined".into(),
+  )));
+}
+
+#[inline(never)]
 fn is_valid_ignored_url_base_arg(parser: &mut JavascriptParser, base: &ExprOrSpread) -> bool {
   if base.spread.is_some() {
     return false;
@@ -895,6 +914,8 @@ fn add_unsupported_create_require_member_warning(parser: &mut JavascriptParser, 
 fn tag_created_require_declarator(
   parser: &mut JavascriptParser,
   binding: &Ident,
+  call_span: Span,
+  clear_call: bool,
   args: &[ExprOrSpread],
   argument: CreateRequireArgument,
 ) {
@@ -913,7 +934,9 @@ fn tag_created_require_declarator(
       side_effects: String::new(),
     }),
   );
-  if replace_argument {
+  if clear_call {
+    clear_create_require_call(parser, call_span);
+  } else if replace_argument {
     parser.add_presentational_dependency(Box::new(ConstDependency::new(
       args[0].expr.span().into(),
       json_stringify_str(&value).into(),
@@ -1727,8 +1750,18 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         || is_create_require_namespace_member(parser, callee))
       && let Some(argument) = parse_create_require_argument(parser, call, false)
     {
-      tag_created_require_declarator(parser, &binding.id, &call.args, argument);
-      walk_create_require_callee(parser, call);
+      let clear_call = should_clear_create_require_call(parser, &call.args);
+      tag_created_require_declarator(
+        parser,
+        &binding.id,
+        call.span,
+        clear_call,
+        &call.args,
+        argument,
+      );
+      if !clear_call {
+        walk_create_require_callee(parser, call);
+      }
       return Some(true);
     }
 
@@ -1738,7 +1771,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_new_argument(parser, init, false)
       && let Some(args) = init.args.as_deref()
     {
-      tag_created_require_declarator(parser, &binding.id, args, argument);
+      tag_created_require_declarator(parser, &binding.id, init.span, false, args, argument);
       parser.walk_expression(&init.callee);
       return Some(true);
     }
@@ -2070,7 +2103,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       self.require_handler(parser, CallOrNewExpr::Call(call_expr), None)
     } else if should_handle_create_require_call(parser, for_name, call_expr.callee.as_expr()) {
       if let Some(argument) = parse_create_require_argument(parser, call_expr, true) {
-        if argument.replace_argument {
+        let clear_call = should_clear_create_require_call(parser, &call_expr.args);
+        if clear_call {
+          clear_create_require_call(parser, call_expr.span);
+        } else if argument.replace_argument {
           parser.add_presentational_dependency(Box::new(ConstDependency::new(
             call_expr.args[0].expr.span().into(),
             json_stringify_str(&argument.value).into(),
@@ -2078,7 +2114,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         } else {
           walk_create_require_argument_side_effects(parser, &call_expr.args[0].expr);
         }
-        walk_create_require_callee(parser, call_expr);
+        if !clear_call {
+          walk_create_require_callee(parser, call_expr);
+        }
         walk_create_require_ignored_args(parser, call_expr);
         Some(true)
       } else {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -521,9 +521,12 @@ impl JavascriptParser<'_> {
           self.walk_expression(init);
           continue;
         }
-        if drive
-          .can_rename(self, &renamed_identifier)
-          .unwrap_or_default()
+        if !(self.javascript_options.is_create_require_enabled()
+          && renamed_identifier == CREATE_REQUIRE_EVALUATED_TAG
+          && matches!(init, Expr::Call(_) | Expr::New(_)))
+          && drive
+            .can_rename(self, &renamed_identifier)
+            .unwrap_or_default()
         {
           if !drive
             .rename(self, init, &renamed_identifier)

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -316,12 +316,10 @@ const applyJavascriptParserOptionsDefaults = (
     deferImport,
     sourceImport,
     outputModule,
-    targetProperties,
   }: {
     deferImport?: boolean;
     sourceImport?: boolean;
     outputModule: RspackOptionsNormalized['output']['module'];
-    targetProperties: false | TargetProperties;
   },
 ) => {
   D(parserOptions, 'dynamicImportMode', 'lazy');
@@ -347,11 +345,7 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'deferImport', deferImport);
   D(parserOptions, 'sourceImport', sourceImport);
   D(parserOptions, 'importMetaResolve', false);
-  D(
-    parserOptions,
-    'createRequire',
-    Boolean(targetProperties && targetProperties.node),
-  );
+  D(parserOptions, 'createRequire', false);
 };
 
 const applyCssGeneratorOptionsDefaults = (
@@ -465,7 +459,6 @@ const applyModuleDefaults = (
     deferImport,
     sourceImport,
     outputModule,
-    targetProperties,
   });
 
   F(module.parser, JSON_MODULE_TYPE, () => ({}));

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1272,7 +1272,7 @@ export type JavascriptParserOptions = {
 
   /**
    * Enable or disable parsing `import { createRequire } from "module"` and evaluating createRequire().
-   * @default true for Node-like targets, false otherwise
+   * @default false
    */
   createRequire?: boolean | string;
 

--- a/tests/rspack-test/configCases/require/module-require-posix-file-url-host/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require-posix-file-url-host/rspack.config.js
@@ -1,4 +1,11 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   target: 'node',
+  module: {
+    parser: {
+      javascript: {
+        createRequire: true,
+      },
+    },
+  },
 };

--- a/tests/rspack-test/configCases/require/module-require/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require/rspack.config.js
@@ -46,6 +46,13 @@ it("should treat POSIX absolute paths ending in backslash as files", () => {
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   target: 'node',
+  module: {
+    parser: {
+      javascript: {
+        createRequire: true,
+      },
+    },
+  },
   optimization: {
     inlineExports: true,
     moduleIds: 'named',

--- a/tests/rspack-test/defaultsCases/target_/electron-main.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-main.js
@@ -37,9 +37,6 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
-			-         "createRequire": false,
-			+         "createRequire": true,
-			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/electron-preload.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-preload.js
@@ -35,9 +35,6 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
-			-         "createRequire": false,
-			+         "createRequire": true,
-			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/node.js
+++ b/tests/rspack-test/defaultsCases/target_/node.js
@@ -32,9 +32,6 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
-			-         "createRequire": false,
-			+         "createRequire": true,
-			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/nwjs.js
+++ b/tests/rspack-test/defaultsCases/target_/nwjs.js
@@ -31,9 +31,6 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
-			-         "createRequire": false,
-			+         "createRequire": true,
-			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-cjs/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-cjs/__snapshots__/esm.snap.txt
@@ -35,36 +35,6 @@ return module.exports;
 
 }
 
-// webpack/runtime/compat_get_default_export
-(() => {
-// getDefaultExport function for compatibility with non-ESM modules
-__webpack_require__.n = (module) => {
-	var getter = module && module.__esModule ?
-		() => (module['default']) :
-		() => (module);
-	__webpack_require__.d(getter, { a: getter });
-	return getter;
-};
-
-})();
-// webpack/runtime/define_property_getters
-(() => {
-__webpack_require__.d = (exports, getters, values) => {
-	var define = (defs, kind) => {
-		for(var key in defs) {
-			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
-				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
-			}
-		}
-	};
-	define(getters, "get");
-	define(values, "value");
-};
-})();
-// webpack/runtime/has_own_property
-(() => {
-__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-})();
 var __webpack_exports__ = {};
 // This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
@@ -76,19 +46,18 @@ var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: external "module"
 const external_module_namespaceObject = require("module");
-var external_module_default = /*#__PURE__*/__webpack_require__.n(external_module_namespaceObject);
 ;// CONCATENATED MODULE: ./index.js
 
 
 
 it("should parse createRequire import.meta.url in CJS output", () => {
-	const requireFromAlias = external_module_namespaceObject.createRequire("<ROOT>/tests/rspack-test/esmOutputCases/create-require/import-meta-url-cjs/index.js");
+	const requireFromAlias = /* createRequire() */ undefined;
 	expect(__webpack_require__(/*! ./a */ "./a.js")).toBe("root");
 
-	const requireFromNamespace = external_module_namespaceObject.createRequire("<ROOT>/tests/rspack-test/esmOutputCases/create-require/import-meta-url-cjs/index.js");
+	const requireFromNamespace = /* createRequire() */ undefined;
 	expect(__webpack_require__(/*! ./a */ "./a.js")).toBe("root");
 
-	const requireFromDefault = (external_module_default()).createRequire("<ROOT>/tests/rspack-test/esmOutputCases/create-require/import-meta-url-cjs/index.js");
+	const requireFromDefault = /* createRequire() */ undefined;
 	expect(__webpack_require__(/*! ./a */ "./a.js")).toBe("root");
 });
 

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/esm.snap.txt
@@ -1,0 +1,87 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
+import {fileURLToPath as __rspack_fileURLToPath} from "node:url";
+import {dirname as __rspack_dirname} from "node:path";
+var __rspack_import_meta_dirname__ = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));
+import { createRequire as __rspack_createRequire } from "node:module";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+__webpack_require__.add({
+"./libCssExtractLoader.js"
+/*!********************************!*\
+  !*** ./libCssExtractLoader.js ***!
+  \********************************/
+(module) {
+module.exports = "loader";
+
+
+},
+});
+// node:module
+const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+// ./index.js
+
+
+const req = /* createRequire() */ undefined;
+
+const value = __webpack_require__(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+const loader = /*require.resolve*/(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+
+it("should consume createRequire(import.meta.url) like webpack", () => {
+	const fs = __rspack_createRequire_require("fs");
+	const path = __rspack_createRequire_require("path");
+	const source = fs.readFileSync(path.join(__rspack_import_meta_dirname__, "main.mjs"), "utf-8");
+	const fileUrlScheme = "file:" + "//";
+	const normalizedRoot = "<" + "ROOT>";
+	const unresolvedCreateRequire =
+		"external_node_module_namespaceObject." + "createRequire(import.meta.url)";
+
+	expect(source).not.toContain(fileUrlScheme);
+	expect(source).not.toContain("createRequire('" + normalizedRoot);
+	expect(source).not.toContain('createRequire("' + normalizedRoot);
+	expect(source).not.toContain(unresolvedCreateRequire);
+	expect(source).toContain("/* createRequire() */ undefined");
+	expect(source).toContain("__webpack_require__(");
+	expect(source).toContain("/*require.resolve*/");
+	expect(value).toBe("loader");
+	expect(loader).toBe("./libCssExtractLoader.js");
+});
+
+export { loader, value };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/index.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/index.js
@@ -1,0 +1,26 @@
+import { createRequire } from "node:module";
+
+const req = createRequire(import.meta.url);
+
+export const value = req("./libCssExtractLoader.js");
+export const loader = req.resolve("./libCssExtractLoader.js");
+
+it("should consume createRequire(import.meta.url) like webpack", () => {
+	const fs = __non_webpack_require__("fs");
+	const path = __non_webpack_require__("path");
+	const source = fs.readFileSync(path.join(__dirname, "main.mjs"), "utf-8");
+	const fileUrlScheme = "file:" + "//";
+	const normalizedRoot = "<" + "ROOT>";
+	const unresolvedCreateRequire =
+		"external_node_module_namespaceObject." + "createRequire(import.meta.url)";
+
+	expect(source).not.toContain(fileUrlScheme);
+	expect(source).not.toContain("createRequire('" + normalizedRoot);
+	expect(source).not.toContain('createRequire("' + normalizedRoot);
+	expect(source).not.toContain(unresolvedCreateRequire);
+	expect(source).toContain("/* createRequire() */ undefined");
+	expect(source).toContain("__webpack_require__(");
+	expect(source).toContain("/*require.resolve*/");
+	expect(value).toBe("loader");
+	expect(loader).toBe("./libCssExtractLoader.js");
+});

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/libCssExtractLoader.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/libCssExtractLoader.js
@@ -1,0 +1,1 @@
+module.exports = "loader";

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/rspack.config.js
@@ -1,6 +1,4 @@
-/** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  target: 'node',
   module: {
     parser: {
       javascript: {

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/test.config.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/test.config.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	afterExecute(options) {
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8"
+		);
+
+		expect(source).not.toContain("file://");
+		expect(source).not.toContain("createRequire('<ROOT>");
+		expect(source).not.toContain('createRequire("<ROOT>');
+		expect(source).not.toContain(
+			"external_node_module_namespaceObject.createRequire(import.meta.url)"
+		);
+		expect(source).toContain("/* createRequire() */ undefined");
+		expect(source).toContain("__webpack_require__(");
+		expect(source).toContain("/*require.resolve*/");
+	}
+};

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -850,6 +850,31 @@ export default {
 This option is experimental in Rspack and may change or be removed.
 :::
 
+### javascript.createRequire
+
+<PropertyType
+  type="boolean | string"
+  defaultValueList={[{ defaultValue: 'false' }]}
+/>
+
+Enable parsing `import { createRequire } from 'module'` and evaluating `createRequire()` calls as CommonJS `require` functions.
+
+When enabled, Rspack can statically process calls such as `createRequire(import.meta.url)('./module')` and `createRequire(import.meta.url).resolve('./module')`.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        createRequire: true,
+      },
+    },
+  },
+};
+```
+
+You can also pass a string in the form `"specifier from module"` to customize the imported specifier and module name, for example `"createRequire from node:module"`.
+
 ### javascript.importMetaResolve
 
 <ApiMeta stability={Stability.Experimental} addedVersion="2.0.0" />

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -850,6 +850,31 @@ export default {
 该选项目前仅在 Rspack 中实验性提供，未来可能调整或移除。
 :::
 
+### javascript.createRequire
+
+<PropertyType
+  type="boolean | string"
+  defaultValueList={[{ defaultValue: 'false' }]}
+/>
+
+启用对 `import { createRequire } from 'module'` 的解析，并将 `createRequire()` 调用按 CommonJS `require` 函数处理。
+
+启用后，Rspack 可以静态处理 `createRequire(import.meta.url)('./module')` 和 `createRequire(import.meta.url).resolve('./module')` 这类调用。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        createRequire: true,
+      },
+    },
+  },
+};
+```
+
+你也可以传入 `"specifier from module"` 形式的字符串来自定义导入的 specifier 和模块名，例如 `"createRequire from node:module"`。
+
 ### javascript.importMetaResolve
 
 <ApiMeta stability={Stability.Experimental} addedVersion="2.0.0" />


### PR DESCRIPTION
## Summary

- Align `createRequire(import.meta.url)` parsing with webpack by clearing the `createRequire(...)` call and consuming created require calls statically.
- Disable `module.parser.javascript.createRequire` by default across JS defaults and the Rust builder, and document the new default.
- Add ESM output coverage for `createRequire(import.meta.url)` so the source-file `file://` form is not emitted.

## Root cause

`createRequire(import.meta.url)` was previously converted into a runtime `createRequire(file://<source>)` shape. That made downstream relative requires resolve from the source file location instead of the emitted bundle location, which can break loaders emitted into `dist`.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack --lib`
- `pnpm run build:js`
- `pnpm --dir tests/rspack-test exec rstest --project base Defaults.test.js -- -t "target"`
- `pnpm --dir tests/rspack-test exec rstest --project base EsmOutput.test.js -- -t "esmOutputCases/create-require/import-meta-url-resolve"`
- `pnpm --dir tests/rspack-test exec rstest --project base Config.part3.test.js -- -t "configCases/require"`
- `git diff --check`