### PR TITLE
perf: skip disabled portable cache compare prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,33 +146,16 @@ jobs:
 
   check-cache:
     name: Check Cache Portable
-    needs: [test-linux, test-windows]
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
-        with:
-          key: test_cache
-          save-if: true
-      - name: Download linux cache
-        uses: ./.github/actions/artifact/download
-        with:
-          name: testCase-persistentCache-linux
-          path: ./cache-linux
-          force-use-github-only: true
-      - name: Download windows cache
-        uses: ./.github/actions/artifact/download
-        with:
-          name: testCase-persistentCache-windows
-          path: ./cache-windows
-          force-use-github-only: true
       - name: Run compare kit
         run: |
-          echo "success"
           #  TODO open it after rspack portable cache implementation
+          #  Restore the linux/windows cache artifacts before enabling this compare.
           # cargo run -p rspack_tools -- compare ./cache-linux ./cache-windows
+          echo "Portable cache comparison is currently disabled."
 
   test_required_check:
     # this job will be used for GitHub actions to determine required job success or not;

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -150,14 +150,6 @@ jobs:
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
         run: pnpm run test:ci
 
-      - name: Upload linux test cache
-        if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && matrix.node == '24' }}
-        uses: ./.github/actions/artifact/upload
-        with:
-          name: testCase-persistentCache-linux
-          path: tests/rspack-test/js/temp/**/.cache
-          include-hidden-files: true
-
       ### *-apple-darwin
       - name: Test apple-darwin
         timeout-minutes: 20 # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
@@ -177,14 +169,6 @@ jobs:
         timeout-minutes: 10
         if: ${{ inputs.target == 'x86_64-pc-windows-msvc' }}
         run: pnpm run test:ci
-
-      - name: Upload windows test cache
-        if: ${{ inputs.target == 'x86_64-pc-windows-msvc' && matrix.node == '22' }}
-        uses: ./.github/actions/artifact/upload
-        with:
-          name: testCase-persistentCache-windows
-          path: tests/rspack-test/js/temp/**/.cache
-          include-hidden-files: true
 
       ### WASM
       - name: Test WASM


### PR DESCRIPTION
## Why

`Check Cache Portable` currently runs after the Linux and Windows test jobs and still spends time checking out the repo, installing Rust, and downloading linux/windows cache artifacts. The actual compare command is disabled and the job only echoes success, so that preparation work is dead time at the end of the CI required-check path.

Recent `main` CI runs show this job taking 85s (`27733305620`) and 71s (`27734656396`). Moving the placeholder job earlier and removing the unused artifact flow should remove roughly one minute from the CI tail without changing build or test coverage.

## What

- Run `Check Cache Portable` after `check-changed` on the mini Linux runner while the compare remains disabled.
- Remove checkout, Rust setup, and linux/windows cache downloads from the placeholder job.
- Remove the linux/windows test cache uploads, since the disabled compare no longer consumes those artifacts.
- Leave a note to restore those artifacts before re-enabling the portable cache compare.

## Impact

The portable cache comparison remains disabled before and after this change. Required test/build jobs still gate `Test Required Check`; only the currently unused preparation work is removed.

Checked locally with `prettier --check`, `git diff --check`, `actionlint`, and an `rg` sweep for remaining `testCase-persistentCache` references.
