### PR TITLE
perf: optimize compilation entrypoints getter

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -476,12 +476,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
    * Get a map of all entrypoints.
    */
   get entrypoints(): ReadonlyMap<string, Entrypoint> {
-    return new Map(
-      this.#inner.entrypoints.map((entrypoint) => [
-        entrypoint.name!,
-        entrypoint,
-      ]),
-    );
+    const entrypoints = new Map<string, Entrypoint>();
+    const rawEntryPoints = this.#inner.entrypoints;
+    for (let i = 0; i < rawEntryPoints.length; i++) {
+      const entrypoint = rawEntryPoints[i];
+      entrypoints.set(entrypoint.name!, entrypoint);
+    }
+    return entrypoints;
   }
 
   get chunkGroups(): readonly ChunkGroup[] {


### PR DESCRIPTION
## Summary

This PR avoids the intermediate `Array.prototype.map` pair allocation when materializing `Compilation.entrypoints`. 

Performance data:

| Variant | Rebuild 1 | Rebuild 2 | Rebuild 3 | Mean |
| --- | ---: | ---: | ---: | ---: |
| Baseline `entrypoints` path | `35.2ms` | `30.3ms` | `32.4ms` | `32.7ms` |
| Index-loop `entrypoints` path | `30.0ms` | `27.9ms` | `25.7ms` | `27.9ms` |

That is about a `4.8ms` mean reduction for this getter path, roughly `15%` in the measured profile.
