### PR TITLE
docs: fix duplicate createRequire parser docs

### DIFF
--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -615,7 +615,6 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-- **Default:** `false`.
 
 Control whether Rspack parses `createRequire()` from Node.js `module` and turns the created `require` function into a statically analyzable dependency context.
 

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -615,7 +615,6 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-
 Control whether Rspack parses `createRequire()` from Node.js `module` and turns the created `require` function into a statically analyzable dependency context.
 
 When set to `true`, it is equivalent to `"createRequire from module"`. Rspack recognizes imports from both `module` and `node:module` for this default form.

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -610,9 +610,12 @@ export default {
 
 ### javascript.createRequire
 
-<PropertyType type="boolean | string" />
+<PropertyType
+  type="boolean | string"
+  defaultValueList={[{ defaultValue: 'false' }]}
+/>
 
-- **Default:** `true` for Node-like targets, `false` otherwise.
+- **Default:** `false`.
 
 Control whether Rspack parses `createRequire()` from Node.js `module` and turns the created `require` function into a statically analyzable dependency context.
 
@@ -849,31 +852,6 @@ export default {
 :::warning
 This option is experimental in Rspack and may change or be removed.
 :::
-
-### javascript.createRequire
-
-<PropertyType
-  type="boolean | string"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
-
-Enable parsing `import { createRequire } from 'module'` and evaluating `createRequire()` calls as CommonJS `require` functions.
-
-When enabled, Rspack can statically process calls such as `createRequire(import.meta.url)('./module')` and `createRequire(import.meta.url).resolve('./module')`.
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      javascript: {
-        createRequire: true,
-      },
-    },
-  },
-};
-```
-
-You can also pass a string in the form `"specifier from module"` to customize the imported specifier and module name, for example `"createRequire from node:module"`.
 
 ### javascript.importMetaResolve
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -610,9 +610,12 @@ export default {
 
 ### javascript.createRequire
 
-<PropertyType type="boolean | string" />
+<PropertyType
+  type="boolean | string"
+  defaultValueList={[{ defaultValue: 'false' }]}
+/>
 
-- **默认值：** Node-like target 下为 `true`，其他 target 下为 `false`。
+- **默认值：** `false`。
 
 控制 Rspack 是否解析来自 Node.js `module` 的 `createRequire()`，并将创建出的 `require` 函数转换为可静态分析的依赖上下文。
 
@@ -849,31 +852,6 @@ export default {
 :::warning
 该选项目前仅在 Rspack 中实验性提供，未来可能调整或移除。
 :::
-
-### javascript.createRequire
-
-<PropertyType
-  type="boolean | string"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
-
-启用对 `import { createRequire } from 'module'` 的解析，并将 `createRequire()` 调用按 CommonJS `require` 函数处理。
-
-启用后，Rspack 可以静态处理 `createRequire(import.meta.url)('./module')` 和 `createRequire(import.meta.url).resolve('./module')` 这类调用。
-
-```js title="rspack.config.mjs"
-export default {
-  module: {
-    parser: {
-      javascript: {
-        createRequire: true,
-      },
-    },
-  },
-};
-```
-
-你也可以传入 `"specifier from module"` 形式的字符串来自定义导入的 specifier 和模块名，例如 `"createRequire from node:module"`。
 
 ### javascript.importMetaResolve
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -615,7 +615,6 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-- **默认值：** `false`。
 
 控制 Rspack 是否解析来自 Node.js `module` 的 `createRequire()`，并将创建出的 `require` 函数转换为可静态分析的依赖上下文。
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -615,7 +615,6 @@ export default {
   defaultValueList={[{ defaultValue: 'false' }]}
 />
 
-
 控制 Rspack 是否解析来自 Node.js `module` 的 `createRequire()`，并将创建出的 `require` 函数转换为可静态分析的依赖上下文。
 
 当设置为 `true` 时，等价于 `"createRequire from module"`。对于这种默认形式，Rspack 会同时识别来自 `module` 和 `node:module` 的导入。


### PR DESCRIPTION
## Summary

- update the existing `javascript.createRequire` docs section to document the new default `false`
- remove the duplicate `javascript.createRequire` section from EN/ZH module parser docs

## Related

Addresses the docs review feedback from #14482 about duplicate `javascript.createRequire` anchors and conflicting defaults.

## Testing

- `pnpm exec prettier --check website/docs/en/config/module-parser.mdx website/docs/zh/config/module-parser.mdx`
- `git diff --check`
- verified each docs file has exactly one `### javascript.createRequire` section
