### PR TITLE
perf: reduce asset wrapper overhead

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -13,6 +13,7 @@ import type {
   ChunkGroup,
   Dependency,
   ExternalObject,
+  JsAsset,
   JsCompilation,
   JsPathData,
   JsSource,
@@ -693,16 +694,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
   getAssets(): readonly Asset[] {
     const assets = this.#inner.getAssets();
 
-    return assets.map((asset) => {
-      return Object.defineProperties(asset, {
-        info: {
-          value: asset.info,
-        },
-        source: {
-          get: () => this.__internal__getAssetSource(asset.name),
-        },
-      }) as unknown as Asset;
-    });
+    return assets.map((asset) => this.#createAsset(asset));
   }
 
   getAsset(name: string): Readonly<Asset> | void {
@@ -710,14 +702,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
     if (!asset) {
       return;
     }
-    return Object.defineProperties(asset, {
-      info: {
-        value: asset.info,
-      },
-      source: {
-        get: () => this.__internal__getAssetSource(asset.name),
-      },
-    }) as unknown as Asset;
+    return this.#createAsset(asset);
+  }
+
+  #createAsset(asset: JsAsset): Asset {
+    Object.defineProperty(asset, 'source', {
+      get: () => this.__internal__getAssetSource(asset.name),
+    });
+    return asset as unknown as Asset;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR reduces the JS-side overhead of materializing `Compilation.getAsset()` and `Compilation.getAssets()` results.

The binding asset object already contains `info`, so the wrapper only needs to attach the lazy `source` getter instead of redefining both `info` and `source` through `Object.defineProperties`.

Performance data:

| Scenario | Metric | Before | After | Delta |
| --- | --- | ---: | ---: | ---: |
| 5 rebuilds | `getAsset` path mean | `15.3ms` | `12.0ms` | `-21.4%` |
| 10 rebuilds | `getAsset` path mean | `16.4ms` | `12.3ms` | `-25.0%` |
| 10 rebuilds | `getAsset` path median | `17.5ms` | `12.6ms` | `-27.9%` |

Pure JS wrapper microbenchmark, 500k asset objects, 10 measured runs:

| Variant | Mean | Median | Delta mean |
| --- | ---: | ---: | ---: |
| `Object.defineProperties(info + source)` | `138.0ms` | `137.5ms` | - |
| `Object.defineProperty(source only)` | `33.3ms` | `34.0ms` | `-75.9%` |
