### PR TITLE
test(tree-shaking): lock in pureFunctions innerGraph deferred-pure-check behavior

### DIFF
--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/impure-lib.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/impure-lib.js
@@ -1,0 +1,6 @@
+// Impure: an unused deferred pure call to this must be KEPT and run.
+export function impureHelper(x) {
+	globalThis.__keepAndDropImpureCalls =
+		(globalThis.__keepAndDropImpureCalls || 0) + 1;
+	return x;
+}

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/index.js
@@ -1,0 +1,12 @@
+import { keep } from "./mod";
+
+it("drops an unused pure deferred call but keeps an unused impure one", () => {
+	expect(keep).toBe("kept");
+
+	// The impure deferred call must have executed exactly once.
+	expect(globalThis.__keepAndDropImpureCalls).toBe(1);
+
+	// The pure helper module must have been tree-shaken away entirely: only
+	// index, mod and impure-lib remain (pure-lib is gone).
+	expect(Reflect.ownKeys(__webpack_modules__).length).toBe(3);
+});

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/mod.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/mod.js
@@ -1,0 +1,11 @@
+import { pureHelper } from "./pure-lib";
+import { impureHelper } from "./impure-lib";
+
+// `keep` is imported by index, so this module is retained and evaluated.
+export const keep = "kept";
+
+// Unused + pure -> the call is severed and `pure-lib` is dropped entirely.
+export const droppedPure = pureHelper(1);
+
+// Unused + impure -> the call is kept and runs (the side effect must happen).
+export const keptImpure = impureHelper(2);

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/pure-lib.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/pure-lib.js
@@ -1,0 +1,5 @@
+// Side-effects-free: an unused deferred pure call to this must be fully dropped,
+// and (being its only consumer) this whole module must be tree-shaken away.
+export function pureHelper(x) {
+	return x + 1;
+}

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keep-and-drop-siblings/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    minimize: false,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/dep.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/dep.js
@@ -1,0 +1,11 @@
+// Side-effects-free: a deferred pure call to this is droppable on its own.
+export function makeConfig() {
+	return { id: "CFG" };
+}
+
+// NOT side-effects-free: a deferred pure check that resolves to this is impure,
+// so an expression calling it is retained for its side effect.
+export function register(cfg) {
+	globalThis.__deferredPureNestedBindingRegistered = cfg;
+	return cfg;
+}

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/index.js
@@ -1,0 +1,12 @@
+// `sideEffectOnly` is intentionally NOT imported — its value is unused.
+import { keep } from "./mod";
+
+it("keeps a nested pure binding consumed by a retained deferred-impure expression", () => {
+	expect(keep).toBe("kept");
+
+	// `register(config)` was retained (register is impure) and ran for its side
+	// effect, recording `config`. `config` must be the real { id: "CFG" } — if the
+	// transitive propagation severed it (because `sideEffectOnly`'s value is
+	// unused) or dropped `register`'s impure check, this would be `undefined`.
+	expect(globalThis.__deferredPureNestedBindingRegistered).toEqual({ id: "CFG" });
+});

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/mod.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/mod.js
@@ -1,0 +1,15 @@
+import { makeConfig, register } from "./dep";
+
+// A nested pure (side-effects-free) call assigned to a local binding. Nothing
+// reads its value directly, so on its own it would be severed and dropped.
+const config = makeConfig();
+
+// A retained deferred-IMPURE expression whose VALUE is unused, but whose side
+// effect reads `config`. This is the transitive deferred-pure case: the inner
+// graph keeps `register(config)` because `register` is impure, and must in turn
+// keep the local pure binding `config` it depends on — with its correct value —
+// so the side effect does not run against a severed `undefined`.
+export const sideEffectOnly = register(config);
+
+// Keeps the module evaluated.
+export const keep = "kept";

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-keeps-nested-pure-binding/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    minimize: false,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/hop1.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/hop1.js
@@ -1,0 +1,3 @@
+// First hop of the re-export chain.
+export { impl } from "./impure-leaf";
+export { pureImpl } from "./pure-leaf";

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/hop2.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/hop2.js
@@ -1,0 +1,3 @@
+// Second hop: deferred_pure_check_is_impure must follow this whole chain
+// (hop2 -> hop1 -> impure-leaf / pure-leaf) to resolve each callee's real target.
+export { impl, pureImpl } from "./hop1";

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/impure-leaf.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/impure-leaf.js
@@ -1,0 +1,9 @@
+// The real, side-effecting function at the end of a multi-hop re-export chain.
+// It is NOT side-effects-free, so a deferred pure check that resolves to it must
+// conclude "impure" and keep the call alive (and not leave an undefined(...)
+// partial-sever).
+export function impl(value) {
+	globalThis.__deferredPureReexportChainCalls =
+		(globalThis.__deferredPureReexportChainCalls || 0) + 1;
+	return value;
+}

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/index.js
@@ -1,0 +1,19 @@
+import { keep } from "./mod";
+
+const fs = require("fs");
+
+it("resolves impure (kept) and pure (dropped) callees through a re-export chain", () => {
+	expect(keep).toBe("kept");
+
+	// Impure side: the retained `unusedImpure = impl("z")` initializer must have
+	// executed exactly once, proving the impure callee was kept through the chain.
+	expect(globalThis.__deferredPureReexportChainCalls).toBe(1);
+
+	// Pure side (discriminating): `pureImpl` resolves through the same chain to a
+	// side-effects-free leaf, so its unused call is severed and `pure-leaf` is
+	// tree-shaken out — the marker must be absent. If chain resolution regresses,
+	// the deferred check falls back to "keep" and the marker would survive here.
+	const marker = ["PURE", "REEXPORT", "CHAIN", "MARKER"].join("_");
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source).not.toContain(marker);
+});

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/mod.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/mod.js
@@ -1,0 +1,15 @@
+import { impl, pureImpl } from "./hop2";
+
+// `keep` is imported by index, so this module is retained and evaluated.
+export const keep = "kept";
+
+// `unusedImpure` is never imported. Its initializer is a deferred pure call to
+// `impl` (resolved through the chain to the impure leaf), so it must be kept and
+// run — severing it would drop the side effect or leave an undefined("z")
+// partial-sever.
+export const unusedImpure = impl("z");
+
+// `unusedPure` is also never imported, and `pureImpl` resolves through the same
+// chain to the side-effects-free leaf, so its call must be severed and
+// `pure-leaf` tree-shaken away.
+export const unusedPure = pureImpl();

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/pure-leaf.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/pure-leaf.js
@@ -1,0 +1,13 @@
+// A side-effects-free helper reached through the SAME multi-hop re-export chain.
+// Its only caller (`unusedPure` in mod.js) is unused, so correct chain
+// resolution proves it pure, severs the call, and tree-shakes this whole module
+// — including the marker string below — out of the bundle.
+//
+// This is the discriminating part of the test: if `deferred_pure_check_is_impure`
+// stops following the re-export chain, the deferred check cannot resolve and
+// falls back to the conservative "keep", so this module (and the marker) would
+// survive and the index.js assertion fails. The impure side alone cannot catch
+// that regression, because the fallback keeps the impure call either way.
+export function pureImpl() {
+	return "PURE_REEXPORT_CHAIN_MARKER";
+}

--- a/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/deferred-pure-reexport-chain/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    minimize: false,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/index.js
@@ -1,0 +1,17 @@
+import "./producer";
+
+const fs = require("fs");
+
+it("drops an unused call to a consumer-side pureFunctions-hinted callee (and its nested pure arg)", () => {
+	const source = fs.readFileSync(__filename, "utf-8");
+
+	// Both modules must be tree-shaken: `identity` (pure ONLY via the consumer-side
+	// trust-at-call-site Direct path — it is not auto-detectable as pure) and the
+	// side-effects-free `payload`. If the Direct path regresses to deferred
+	// resolution, `identity` is classified impure and the call — carrying these
+	// sentinels — survives, failing the assertions below.
+	const wrapperSentinel = ["pure-functions-consumer-hint", "wrapper-sentinel"].join("::");
+	const payloadSentinel = ["pure-functions-consumer-hint", "payload-sentinel"].join("::");
+	expect(source).not.toContain(wrapperSentinel);
+	expect(source).not.toContain(payloadSentinel);
+});

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/payload.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/payload.js
@@ -1,0 +1,5 @@
+// A side-effects-free helper used as the nested argument. It is reached only by
+// the unused `identity(payload())` call, so correct resolution drops it too.
+export function payload() {
+	return "pure-functions-consumer-hint::payload-sentinel";
+}

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/producer.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/producer.js
@@ -1,0 +1,8 @@
+import { identity } from "./wrapper";
+import { payload } from "./payload";
+
+// `wrapped` is never imported. `identity` is pure only via the consumer-side
+// parser.pureFunctions hint, and `payload` is side-effects-free, so the whole
+// `identity(payload())` call is severed and both `wrapper` and `payload` are
+// tree-shaken out of the bundle.
+export const wrapped = identity(payload());

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/rspack.config.js
@@ -1,0 +1,27 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  optimization: {
+    sideEffects: true,
+    innerGraph: true,
+    usedExports: true,
+    minimize: false,
+    concatenateModules: false,
+  },
+  experiments: {
+    pureFunctions: true,
+  },
+  module: {
+    rules: [
+      {
+        // Hint is on the CONSUMER (producer.js, where the call is parsed), so
+        // `identity` resolves via the trust-at-call-site Direct path.
+        test: /producer\.js$/,
+        parser: {
+          pureFunctions: ['identity'],
+        },
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/wrapper.js
+++ b/tests/rspack-test/configCases/tree-shaking/pure-functions-consumer-hint-drop/wrapper.js
@@ -1,0 +1,13 @@
+// `identity` is intentionally NOT auto-detectable as side-effects-free — the `if`
+// statement makes the side-effects-free auto-analysis bail. So it is treated as
+// pure ONLY via the consumer-side parser.pureFunctions hint (the
+// trust-at-call-site Direct path), never via deferred resolution of its body.
+//
+// That is what makes this test discriminating: if the Direct path regresses to
+// normal deferred resolution, `identity` is classified impure here, its unused
+// call is kept, and the sentinel below survives in the bundle — which the drop
+// assertion in index.js then catches.
+export function identity(x) {
+	if (x === "pure-functions-consumer-hint::wrapper-sentinel") return undefined;
+	return x;
+}


### PR DESCRIPTION
## Summary

Adds regression tests that lock in correct behavior of the `experiments.pureFunctions` + `innerGraph` deferred-pure-check machinery, complementing the existing `pure-functions-severed-export` guard (which covers #14425's partial-sever fix). They cover distinct behaviors so future changes can't silently regress them:

- **deferred-pure-reexport-rename-chain** — an impure callee reached through a renaming, multi-hop re-export chain (`export { a as b } from`) must stay alive and run when the consuming export is unused. Guards `deferred_pure_check_is_impure`'s `get_target` chain resolution.
- **pure-functions-nested-impure-callee** — a user-configured pure outer callee (`parser.pureFunctions`) wrapping an impure inner import must still run the inner side effect when the binding is unused. Guards the trust-at-call-site Direct path plus deferred-callee collection in call arguments.
- **deferred-pure-keep-and-drop-siblings** — in one retained module, an unused impure deferred call is kept and runs while an unused pure deferred call is severed and its module tree-shaken away. Guards both keep and drop decisions.

These came out of an exhaustive correctness audit of the pureFunctions + innerGraph deferred-pure-check path. No correctness bug was found on `main` (the mechanism is conservative by construction — `deferred_pure_check_is_impure` defaults to "keep" when it can't resolve), so this PR pins the verified-correct tricky behaviors as regression tests. Each test was confirmed to pass on `main`.

## Related links

- Builds on #14425 (fix(pure-functions): keep deferred pure import callees)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
