### PR TITLE
chore(ci): pause portable cache check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,11 @@ jobs:
       target: wasm32-wasip1-threads
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
 
+  # TODO: Enable this job after Rspack portable cache is implemented.
   check-cache:
     name: Check Cache Portable
     needs: [test-linux, test-windows]
+    if: ${{ false }}
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
     steps:
       - name: Checkout
@@ -169,10 +171,7 @@ jobs:
           path: ./cache-windows
           force-use-github-only: true
       - name: Run compare kit
-        run: |
-          echo "success"
-          #  TODO open it after rspack portable cache implementation
-          # cargo run -p rspack_tools -- compare ./cache-linux ./cache-windows
+        run: cargo run -p rspack_tools -- compare ./cache-linux ./cache-windows
 
   test_required_check:
     # this job will be used for GitHub actions to determine required job success or not;
@@ -199,13 +198,13 @@ jobs:
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name == 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,skipped,success' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,skipped,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: No check to Run test


### PR DESCRIPTION
## Summary

- pause the portable cache comparison job until portable cache support is implemented
- move the existing TODO above the job so the disabled state is explicit
- update the required-check expectations to accept the skipped job on pull requests and main pushes
- keep the real comparison command ready for re-enabling the job

## Why

The job currently allocates a runner, downloads Linux and Windows cache artifacts, and installs Rust, but only executes a placeholder success command. Pausing it avoids that resource usage without removing the future portable-cache validation flow.

## Validation

- `git diff --check`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- verified the expected `needs.*.result` sequences for pull requests and main pushes

`actionlint` was not run because it is not installed locally.