### PR TITLE
perf: optimize module concatenation hot paths

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1416,16 +1416,23 @@ impl Module for ConcatenatedModule {
         let ModuleInfo::Concatenated(info) = info else {
           return None;
         };
-        let module = module_graph
-          .module_by_identifier(&info.module)
-          .expect("should have module");
-        let build_meta = module.build_meta();
+        let mut strict_esm_module = None;
         let mut changes = None;
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
+          if !ConcatenationScope::is_module_reference(name.as_str()) {
+            continue;
+          }
           let match_result = ConcatenationScope::match_module_reference(name.as_str());
           if let Some(match_info) = match_result {
             let referenced_info_id = &references_info[match_info.index].0;
+            let strict_esm_module = *strict_esm_module.get_or_insert_with(|| {
+              module_graph
+                .module_by_identifier(&info.module)
+                .expect("should have module")
+                .build_meta()
+                .strict_esm_module
+            });
             let final_name = Self::get_final_name(
               compilation.get_module_graph(),
               &compilation.module_graph_cache_artifact,
@@ -1438,7 +1445,7 @@ impl Module for ConcatenatedModule {
               match_info.deferred_import,
               match_info.call,
               !match_info.direct_import,
-              build_meta.strict_esm_module,
+              strict_esm_module,
               match_info.asi_safe,
               &context,
             );

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1072,79 +1072,84 @@ impl Module for ConcatenatedModule {
     let module_graph = compilation.get_module_graph();
     let mut import_stmts = FxIndexMap::<(String, Option<String>), ImportSpec>::default();
 
-    let (escaped_name_entries, escaped_identifier_entries) = module_to_info_map
+    let (
+      escaped_name_entries,
+      escaped_module_identifier_entries,
+      escaped_import_identifier_entries,
+    ) = module_to_info_map
       .par_values()
-      .map(|info| {
-        let (name_capacity, identifier_capacity) = match info {
-          ModuleInfo::Concatenated(info) => {
-            let import_map = info.import_map.as_ref();
-            let import_sources = import_map.map_or(0, |map| map.len());
-            let imported_names = import_map.map_or(0, |map| {
-              map
-                .values()
-                .map(|imported| {
-                  imported.specifiers.len() + usize::from(imported.namespace.is_some())
-                })
-                .sum::<usize>()
-            });
-            (
-              info.binding_to_ref.len() + imported_names,
-              1 + import_sources,
-            )
-          }
-          ModuleInfo::External(_) => (0, 1),
-        };
-        let mut escaped_names =
-          HashMap::with_capacity_and_hasher(name_capacity, Default::default());
-        let mut escaped_identifiers = Vec::with_capacity(identifier_capacity);
-        let readable_identifier = get_cached_readable_identifier(
-          &info.id(),
-          module_graph,
-          &compilation.module_static_cache,
-          &context,
-        );
-        let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
-        escaped_identifiers.push((readable_identifier, splitted_readable_identifier));
-
-        match info {
-          ModuleInfo::Concatenated(info) => {
-            for (id, _) in info.binding_to_ref.iter() {
-              escaped_names
-                .entry(id.0.clone())
-                .or_insert_with(|| escape_name_atom_ref(&id.0));
+      .fold(
+        || (Vec::new(), Vec::new(), Vec::new()),
+        |mut entries, info| {
+          let (name_capacity, identifier_capacity) = match info {
+            ModuleInfo::Concatenated(info) => {
+              let import_map = info.import_map.as_ref();
+              let import_sources = import_map.map_or(0, |map| map.len());
+              let imported_names = import_map.map_or(0, |map| {
+                map
+                  .values()
+                  .map(|imported| {
+                    imported.specifiers.len() + usize::from(imported.namespace.is_some())
+                  })
+                  .sum::<usize>()
+              });
+              (info.binding_to_ref.len() + imported_names, import_sources)
             }
+            ModuleInfo::External(_) => (0, 0),
+          };
+          let mut escaped_names =
+            HashMap::with_capacity_and_hasher(name_capacity, Default::default());
+          let mut escaped_identifiers = Vec::with_capacity(identifier_capacity);
+          let readable_identifier = get_cached_readable_identifier(
+            &info.id(),
+            module_graph,
+            &compilation.module_static_cache,
+            &context,
+          );
+          let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
+          let module_identifier_entry = (info.id(), splitted_readable_identifier);
 
-            if let Some(import_map) = &info.import_map {
-              for ((source, _), imported) in import_map.iter() {
-                let specifiers = &imported.specifiers;
-                escaped_identifiers
-                  .push((source.clone(), split_readable_identifier(source.as_str())));
-                for atom in specifiers {
-                  escaped_names
-                    .entry(atom.clone())
-                    .or_insert_with(|| escape_name_atom_ref(atom));
-                }
+          match info {
+            ModuleInfo::Concatenated(info) => {
+              for (id, _) in info.binding_to_ref.iter() {
+                escaped_names
+                  .entry(id.0.clone())
+                  .or_insert_with(|| escape_name_atom_ref(&id.0));
+              }
 
-                if let Some(ns_symbol) = &imported.namespace {
-                  escaped_names
-                    .entry(ns_symbol.clone())
-                    .or_insert_with(|| escape_name_atom_ref(ns_symbol));
+              if let Some(import_map) = &info.import_map {
+                for ((source, _), imported) in import_map.iter() {
+                  let specifiers = &imported.specifiers;
+                  escaped_identifiers
+                    .push((source.clone(), split_readable_identifier(source.as_str())));
+                  for atom in specifiers {
+                    escaped_names
+                      .entry(atom.clone())
+                      .or_insert_with(|| escape_name_atom_ref(atom));
+                  }
+
+                  if let Some(ns_symbol) = &imported.namespace {
+                    escaped_names
+                      .entry(ns_symbol.clone())
+                      .or_insert_with(|| escape_name_atom_ref(ns_symbol));
+                  }
                 }
               }
             }
+            ModuleInfo::External(_) => (),
           }
-          ModuleInfo::External(_) => (),
-        }
-        (
-          escaped_names.into_iter().collect::<Vec<_>>(),
-          escaped_identifiers,
-        )
-      })
+          entries.0.extend(escaped_names);
+          entries.1.push(module_identifier_entry);
+          entries.2.extend(escaped_identifiers);
+          entries
+        },
+      )
       .reduce(
-        || (Vec::new(), Vec::new()),
+        || (Vec::new(), Vec::new(), Vec::new()),
         |mut a, mut b| {
           a.0.append(&mut b.0);
           a.1.append(&mut b.1);
+          a.2.append(&mut b.2);
           a
         },
       );
@@ -1153,10 +1158,19 @@ impl Module for ConcatenatedModule {
     for (name, escaped_name) in escaped_name_entries {
       escaped_names.insert(name, escaped_name);
     }
-    let mut escaped_identifiers =
-      HashMap::with_capacity_and_hasher(escaped_identifier_entries.len(), Default::default());
-    for (identifier, parts) in escaped_identifier_entries {
-      escaped_identifiers.insert(identifier, parts);
+    let mut escaped_module_identifiers = IdentifierMap::with_capacity_and_hasher(
+      escaped_module_identifier_entries.len(),
+      Default::default(),
+    );
+    for (module, parts) in escaped_module_identifier_entries {
+      escaped_module_identifiers.insert(module, parts);
+    }
+    let mut escaped_import_identifiers = HashMap::with_capacity_and_hasher(
+      escaped_import_identifier_entries.len(),
+      Default::default(),
+    );
+    for (identifier, parts) in escaped_import_identifier_entries {
+      escaped_import_identifiers.insert(identifier, parts);
     }
 
     let mut name_allocator = NameAllocator::new(all_used_names);
@@ -1167,12 +1181,10 @@ impl Module for ConcatenatedModule {
       let module = module_graph
         .module_by_identifier(&info.id())
         .expect("should have module identifier");
-      let readable_identifier = get_cached_readable_identifier(
-        &info.id(),
-        module_graph,
-        &compilation.module_static_cache,
-        &context,
-      );
+      let module_id = info.id();
+      let escaped_module_identifier = escaped_module_identifiers
+        .get(&module_id)
+        .expect("should have escaped module identifier");
       let exports_type: BuildMetaExportsType = module.build_meta().exports_type;
       let default_object: BuildMetaDefaultObject = module.build_meta().default_object;
       match info {
@@ -1193,9 +1205,7 @@ impl Module for ConcatenatedModule {
                   .get(name)
                   .expect("should have escaped name")
                   .as_ref(),
-                escaped_identifiers
-                  .get(&readable_identifier)
-                  .expect("should have escaped identifier"),
+                escaped_module_identifier,
               );
               info.internal_names.insert(name.clone(), new_name.clone());
               top_level_declarations.insert(new_name.clone());
@@ -1225,7 +1235,7 @@ impl Module for ConcatenatedModule {
           // Iterate over imported symbols
           if let Some(import_map) = info.import_map.take() {
             for ((source, attr), imported) in import_map {
-              let source_parts = escaped_identifiers
+              let source_parts = escaped_import_identifiers
                 .get(&source)
                 .expect("should have escaped identifier");
               let total_imported_atoms = import_stmts.entry((source, attr)).or_default();
@@ -1277,9 +1287,7 @@ impl Module for ConcatenatedModule {
                         .get(&atom)
                         .expect("should have escaped name")
                         .as_ref(),
-                      escaped_identifiers
-                        .get(&readable_identifier)
-                        .expect("should have escaped identifier"),
+                      escaped_module_identifier,
                     )
                   };
                   // if the imported symbol is exported, we rename the export as well
@@ -1326,14 +1334,7 @@ impl Module for ConcatenatedModule {
             if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {
               info.internal_names.get(namespace_export_symbol).cloned()
             } else {
-              Some(
-                name_allocator.find_new_name(
-                  "namespaceObject",
-                  escaped_identifiers
-                    .get(&readable_identifier)
-                    .expect("should have escaped identifier"),
-                ),
-              )
+              Some(name_allocator.find_new_name("namespaceObject", escaped_module_identifier))
             };
           if let Some(namespace_object_name) = namespace_object_name {
             info.namespace_object_name = Some(namespace_object_name.clone());
@@ -1352,31 +1353,17 @@ impl Module for ConcatenatedModule {
 
         // Handle external type
         ModuleInfo::External(info) => {
-          let external_name: Atom = name_allocator.find_new_name(
-            "",
-            escaped_identifiers
-              .get(&readable_identifier)
-              .expect("should have escaped identifier"),
-          );
+          let external_name: Atom = name_allocator.find_new_name("", escaped_module_identifier);
           info.name = Some(external_name.clone());
           top_level_declarations.insert(external_name.clone());
 
           if info.deferred {
-            let external_name = name_allocator.find_new_name(
-              "deferred",
-              escaped_identifiers
-                .get(&readable_identifier)
-                .expect("should have escaped identifier"),
-            );
+            let external_name = name_allocator.find_new_name("deferred", escaped_module_identifier);
             info.deferred_name = Some(external_name.clone());
             top_level_declarations.insert(external_name.clone());
 
-            let external_name_interop = name_allocator.find_new_name(
-              "deferredNamespaceObject",
-              escaped_identifiers
-                .get(&readable_identifier)
-                .expect("should have escaped identifier"),
-            );
+            let external_name_interop =
+              name_allocator.find_new_name("deferredNamespaceObject", escaped_module_identifier);
             info.deferred_namespace_object_name = Some(external_name_interop.clone());
             top_level_declarations.insert(external_name_interop.clone());
           }
@@ -1384,12 +1371,8 @@ impl Module for ConcatenatedModule {
       }
       // Handle additional logic based on module build meta
       if exports_type != BuildMetaExportsType::Namespace {
-        let external_name_interop: Atom = name_allocator.find_new_name(
-          "namespaceObject",
-          escaped_identifiers
-            .get(&readable_identifier)
-            .expect("should have escaped identifier"),
-        );
+        let external_name_interop: Atom =
+          name_allocator.find_new_name("namespaceObject", escaped_module_identifier);
         info.set_interop_namespace_object_name(Some(external_name_interop.clone()));
         top_level_declarations.insert(external_name_interop.clone());
       }
@@ -1397,12 +1380,8 @@ impl Module for ConcatenatedModule {
       if exports_type == BuildMetaExportsType::Default
         && !matches!(default_object, BuildMetaDefaultObject::Redirect)
       {
-        let external_name_interop: Atom = name_allocator.find_new_name(
-          "namespaceObject2",
-          escaped_identifiers
-            .get(&readable_identifier)
-            .expect("should have escaped identifier"),
-        );
+        let external_name_interop: Atom =
+          name_allocator.find_new_name("namespaceObject2", escaped_module_identifier);
         info.set_interop_namespace_object2_name(Some(external_name_interop.clone()));
         top_level_declarations.insert(external_name_interop.clone());
       }
@@ -1411,22 +1390,19 @@ impl Module for ConcatenatedModule {
         exports_type,
         BuildMetaExportsType::Dynamic | BuildMetaExportsType::Unset
       ) {
-        let external_name_interop: Atom = name_allocator.find_new_name(
-          "default",
-          escaped_identifiers
-            .get(&readable_identifier)
-            .expect("should have escaped identifier"),
-        );
+        let external_name_interop: Atom =
+          name_allocator.find_new_name("default", escaped_module_identifier);
         info.set_interop_default_access_name(Some(external_name_interop.clone()));
         top_level_declarations.insert(external_name_interop.clone());
       }
     }
 
-    // `escaped_names` / `escaped_identifiers` can retain a large amount of
+    // `escaped_names` / escaped identifier maps can retain a large amount of
     // temporary escaped naming state. Move them off the critical path once
     // naming is complete.
     fast_set(&mut escaped_names, HashMap::default());
-    fast_set(&mut escaped_identifiers, HashMap::default());
+    fast_set(&mut escaped_module_identifiers, IdentifierMap::default());
+    fast_set(&mut escaped_import_identifiers, HashMap::default());
 
     // `NameAllocator` can retain a large amount of temporary name state.
     // Move it off the critical path once naming is complete.

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1420,7 +1420,7 @@ impl Module for ConcatenatedModule {
           .module_by_identifier(&info.module)
           .expect("should have module");
         let build_meta = module.build_meta();
-        let mut changes = vec![];
+        let mut changes = None;
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
           let match_result = ConcatenationScope::match_module_reference(name.as_str());
@@ -1432,11 +1432,7 @@ impl Module for ConcatenatedModule {
               &compilation.exports_info_artifact,
               &compilation.module_static_cache,
               referenced_info_id,
-              match_info
-                .ids
-                .into_iter()
-                .map(|item| Atom::from(item.as_str()))
-                .collect::<Vec<_>>(),
+              match_info.ids,
               &module_to_info_map,
               runtime,
               match_info.deferred_import,
@@ -1454,10 +1450,12 @@ impl Module for ConcatenatedModule {
             // let source = info.source.as_mut().expect("should have source");
             // range is extended by 2 chars to cover the appended "._"
             // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L1411-L1412
-            changes.push((final_name, (low, high + 2)));
+            changes
+              .get_or_insert_with(Vec::new)
+              .push((final_name, (low, high + 2)));
           }
         }
-        Some((info.module, changes))
+        changes.map(|changes| (info.module, changes))
       })
       .collect::<Vec<_>>();
 

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1425,12 +1425,21 @@ impl Module for ConcatenatedModule {
           if !ConcatenationScope::is_module_reference(name.as_str()) {
             continue;
           }
-          let match_result = info
+          let cached_match_info = info
             .module_references
             .as_ref()
-            .and_then(|references| references.get(name.as_str()).cloned())
-            .or_else(|| ConcatenationScope::match_module_reference(name.as_str()));
-          if let Some(match_info) = match_result {
+            .and_then(|references| references.get(name.as_str()));
+          let parsed_match_info;
+          let match_info = if let Some(match_info) = cached_match_info {
+            match_info
+          } else if let Some(match_info) = ConcatenationScope::match_module_reference(name.as_str())
+          {
+            parsed_match_info = match_info;
+            &parsed_match_info
+          } else {
+            continue;
+          };
+          {
             let referenced_info_id = &references_info[match_info.index].0;
             let strict_esm_module = *strict_esm_module.get_or_insert_with(|| {
               module_graph
@@ -1445,7 +1454,7 @@ impl Module for ConcatenatedModule {
               &compilation.exports_info_artifact,
               &compilation.module_static_cache,
               referenced_info_id,
-              match_info.ids,
+              &match_info.ids,
               &module_to_info_map,
               runtime,
               match_info.deferred_import,
@@ -1534,7 +1543,7 @@ impl Module for ConcatenatedModule {
           &compilation.exports_info_artifact,
           &compilation.module_static_cache,
           &root_module_id,
-          [name.clone()].to_vec(),
+          std::slice::from_ref(&name),
           &module_to_info_map,
           runtime,
           false,
@@ -1690,13 +1699,14 @@ impl Module for ConcatenatedModule {
         }
 
         if let Some(UsedNameItem::Str(used_name)) = export_info.get_used_name(None, runtime) {
+          let export_name = export_info.name().cloned().unwrap_or_else(|| "".into());
           let final_name = Self::get_final_name(
             compilation.get_module_graph(),
             &compilation.module_graph_cache_artifact,
             &compilation.exports_info_artifact,
             &compilation.module_static_cache,
             &module_info_id,
-            vec![export_info.name().cloned().unwrap_or_else(|| "".into())],
+            std::slice::from_ref(&export_name),
             &module_to_info_map,
             runtime,
             false,
@@ -2658,7 +2668,7 @@ impl ConcatenatedModule {
     exports_info_artifact: &ExportsInfoArtifact,
     module_static_cache: &ModuleStaticCache,
     info: &ModuleIdentifier,
-    export_name: Vec<Atom>,
+    export_name: &[Atom],
     module_to_info_map: &IdentifierIndexMap<ModuleInfo>,
     runtime: Option<&RuntimeSpec>,
     dep_deferred: bool,
@@ -2673,7 +2683,7 @@ impl ConcatenatedModule {
       module_graph_cache,
       exports_info_artifact,
       info,
-      export_name,
+      export_name.to_vec(),
       module_to_info_map,
       runtime,
       as_call,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1422,9 +1422,6 @@ impl Module for ConcatenatedModule {
         let mut changes = None;
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
-          if !ConcatenationScope::is_module_reference(name.as_str()) {
-            continue;
-          }
           let cached_match_info = info
             .module_references
             .as_ref()
@@ -2604,7 +2601,6 @@ impl ConcatenatedModule {
       let mut all_used_names = HashSet::default();
       all_used_names.reserve(ids.len());
       module_info.idents.reserve(ids.len());
-      module_info.global_scope_ident.reserve(ids.len());
       let mut binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>> =
         FxIndexMap::default();
       binding_to_ref.reserve(ids.len());

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1418,14 +1418,16 @@ impl Module for ConcatenatedModule {
         let ModuleInfo::Concatenated(info) = info else {
           return None;
         };
+        if info.global_scope_ident.is_empty() {
+          return None;
+        }
+        let module_references = info.module_references.as_ref();
         let mut strict_esm_module = None;
         let mut changes = None;
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
-          let cached_match_info = info
-            .module_references
-            .as_ref()
-            .and_then(|references| references.get(name.as_str()));
+          let cached_match_info =
+            module_references.and_then(|references| references.get(name.as_str()));
           let parsed_match_info;
           let match_info = if let Some(match_info) = cached_match_info {
             match_info
@@ -1446,7 +1448,7 @@ impl Module for ConcatenatedModule {
                 .strict_esm_module
             });
             let final_name = Self::get_final_name(
-              compilation.get_module_graph(),
+              module_graph,
               &compilation.module_graph_cache_artifact,
               &compilation.exports_info_artifact,
               &compilation.module_static_cache,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -51,11 +51,12 @@ use crate::{
   ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta, ImportedByDeferModulesArtifact,
   InitFragment, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT,
-  ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
-  SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set,
-  filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
+  ModuleIdentifier, ModuleLayer, ModuleReferenceOptions, ModuleStaticCache, ModuleType,
+  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
+  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
+  escape_identifier, fast_set, filter_runtime, find_target, get_runtime_key,
+  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
+  module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -315,6 +316,7 @@ pub struct ConcatenatedModuleInfo {
   pub idents: Vec<ConcatenatedModuleIdent>,
   pub all_used_names: HashSet<Atom>,
   pub binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>>,
+  pub module_references: Option<FxIndexMap<String, ModuleReferenceOptions>>,
 
   pub public_path_auto_replacement: Option<bool>,
   pub static_url_replacement: bool,
@@ -1423,7 +1425,11 @@ impl Module for ConcatenatedModule {
           if !ConcatenationScope::is_module_reference(name.as_str()) {
             continue;
           }
-          let match_result = ConcatenationScope::match_module_reference(name.as_str());
+          let match_result = info
+            .module_references
+            .as_ref()
+            .and_then(|references| references.get(name.as_str()).cloned())
+            .or_else(|| ConcatenationScope::match_module_reference(name.as_str()));
           if let Some(match_info) = match_result {
             let referenced_info_id = &references_info[match_info.index].0;
             let strict_esm_module = *strict_esm_module.get_or_insert_with(|| {
@@ -2519,7 +2525,25 @@ impl ConcatenatedModule {
         .remove(&SourceType::JavaScript)
         .expect("should have javascript source");
       let source_code = source.source().into_string_lossy();
-      let mut module_info = concatenation_scope.current_module;
+      let ConcatenationScope {
+        current_module: mut module_info,
+        refs,
+        ..
+      } = concatenation_scope;
+      if !refs.is_empty() {
+        let len = refs.values().map(FxIndexMap::len).sum();
+        let mut module_references = FxIndexMap::default();
+        module_references.reserve(len);
+        for (_, references) in refs {
+          for (mut reference, options) in references {
+            if reference.ends_with("._") {
+              reference.truncate(reference.len() - 2);
+            }
+            module_references.insert(reference, options);
+          }
+        }
+        module_info.module_references = Some(module_references);
+      }
 
       let jsx = module
         .as_ref()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1420,66 +1420,42 @@ impl Module for ConcatenatedModule {
           .module_by_identifier(&info.module)
           .expect("should have module");
         let build_meta = module.build_meta();
-        let mut refs = vec![];
+        let mut changes = vec![];
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
           let match_result = ConcatenationScope::match_module_reference(name.as_str());
           if let Some(match_info) = match_result {
             let referenced_info_id = &references_info[match_info.index].0;
-            refs.push((
-              reference.clone(),
+            let final_name = Self::get_final_name(
+              compilation.get_module_graph(),
+              &compilation.module_graph_cache_artifact,
+              &compilation.exports_info_artifact,
+              &compilation.module_static_cache,
               referenced_info_id,
               match_info
                 .ids
                 .into_iter()
                 .map(|item| Atom::from(item.as_str()))
                 .collect::<Vec<_>>(),
+              &module_to_info_map,
+              runtime,
+              match_info.deferred_import,
               match_info.call,
               !match_info.direct_import,
-              match_info.deferred_import,
               build_meta.strict_esm_module,
               match_info.asi_safe,
-            ));
+              &context,
+            );
+
+            // We assume this should be concatenated module info because previous loop
+            let span = reference.id.span();
+            let low = span.real_lo();
+            let high = span.real_hi();
+            // let source = info.source.as_mut().expect("should have source");
+            // range is extended by 2 chars to cover the appended "._"
+            // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L1411-L1412
+            changes.push((final_name, (low, high + 2)));
           }
-        }
-
-        let mut changes = vec![];
-        for (
-          reference_ident,
-          referenced_info_id,
-          export_name,
-          call,
-          call_context,
-          deferred_import,
-          strict_esm_module,
-          asi_safe,
-        ) in refs
-        {
-          let final_name = Self::get_final_name(
-            compilation.get_module_graph(),
-            &compilation.module_graph_cache_artifact,
-            &compilation.exports_info_artifact,
-            &compilation.module_static_cache,
-            referenced_info_id,
-            export_name,
-            &module_to_info_map,
-            runtime,
-            deferred_import,
-            call,
-            call_context,
-            strict_esm_module,
-            asi_safe,
-            &context,
-          );
-
-          // We assume this should be concatenated module info because previous loop
-          let span = reference_ident.id.span();
-          let low = span.real_lo();
-          let high = span.real_hi();
-          // let source = info.source.as_mut().expect("should have source");
-          // range is extended by 2 chars to cover the appended "._"
-          // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L1411-L1412
-          changes.push((final_name, (low, high + 2)));
         }
         Some((info.module, changes))
       })

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -316,7 +316,7 @@ pub struct ConcatenatedModuleInfo {
   pub idents: Vec<ConcatenatedModuleIdent>,
   pub all_used_names: HashSet<Atom>,
   pub binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>>,
-  pub module_references: Option<FxIndexMap<String, ModuleReferenceOptions>>,
+  pub module_references: Option<FxIndexMap<Atom, ModuleReferenceOptions>>,
 
   pub public_path_auto_replacement: Option<bool>,
   pub static_url_replacement: bool,
@@ -1426,8 +1426,7 @@ impl Module for ConcatenatedModule {
         let mut changes = None;
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
-          let cached_match_info =
-            module_references.and_then(|references| references.get(name.as_str()));
+          let cached_match_info = module_references.and_then(|references| references.get(name));
           let parsed_match_info;
           let match_info = if let Some(match_info) = cached_match_info {
             match_info
@@ -2548,7 +2547,7 @@ impl ConcatenatedModule {
             if reference.ends_with("._") {
               reference.truncate(reference.len() - 2);
             }
-            module_references.insert(reference, options);
+            module_references.insert(reference.into(), options);
           }
         }
         module_info.module_references = Some(module_references);

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2614,7 +2614,9 @@ impl ConcatenatedModule {
         let is_global = SyntaxContext::from_u32(scope.raw()) == module_info.global_ctxt;
         let legacy = if is_global {
           let leg = ident.to_legacy(&semantic);
-          module_info.global_scope_ident.push(leg.clone());
+          if ConcatenationScope::is_module_reference(leg.id.sym.as_str()) {
+            module_info.global_scope_ident.push(leg.clone());
+          }
           all_used_names.insert(leg.id.sym.clone());
           Some(leg)
         } else {

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -222,6 +222,13 @@ impl ConcatenationScope {
     })
   }
 
+  pub fn is_module_reference(name: &str) -> bool {
+    name
+      .strip_suffix(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX)
+      .unwrap_or(name)
+      .starts_with(MODULE_REFERENCE_PREFIX)
+  }
+
   pub fn is_module_concatenated(&self, module: &ModuleIdentifier) -> bool {
     matches!(
       self.modules_map.get(module).expect("should have module"),

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -121,12 +121,13 @@ impl ConcatenationScope {
   pub fn create_module_reference(
     &mut self,
     module: &ModuleIdentifier,
-    options: ModuleReferenceOptions,
+    mut options: ModuleReferenceOptions,
   ) -> String {
     let info = self
       .modules_map
       .get(module)
       .expect("should have module info");
+    options.index = info.index();
 
     let export_data = if !options.ids.is_empty() {
       hex::encode(simd_json::to_string(&options.ids).expect("should serialize to json string"))
@@ -294,14 +295,15 @@ mod tests {
       .get(&referenced_module_id)
       .and_then(|refs| refs.get(&module_ref))
       .expect("should store created module reference");
-    assert_module_reference_options_eq(stored, &options);
 
-    let parsed = ConcatenationScope::match_module_reference(&module_ref)
-      .expect("should parse full module reference");
     let expected = ModuleReferenceOptions {
       index: 7,
       ..options
     };
+    assert_module_reference_options_eq(stored, &expected);
+
+    let parsed = ConcatenationScope::match_module_reference(&module_ref)
+      .expect("should parse full module reference");
     assert_module_reference_options_eq(&parsed, &expected);
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -309,13 +309,6 @@ impl ModuleConcatenationPlugin {
       statistics.cache_hit += 1;
       Arc::clone(incomings)
     } else {
-      let module_readable_identifier = get_cached_readable_identifier(
-        module_id,
-        module_graph,
-        &compilation.module_static_cache,
-        &compilation.options.context,
-      );
-
       if !possible_modules.contains(module_id) {
         statistics.invalid_module += 1;
         let problem = Warning::Id(*module_id);
@@ -333,6 +326,12 @@ impl ModuleConcatenationPlugin {
 
       if !missing_chunks.is_empty() {
         let problem_string = {
+          let module_readable_identifier = get_cached_readable_identifier(
+            module_id,
+            module_graph,
+            &compilation.module_static_cache,
+            &compilation.options.context,
+          );
           let mut missing_chunks_list = missing_chunks
             .iter()
             .map(|&chunk| {
@@ -387,6 +386,12 @@ impl ModuleConcatenationPlugin {
         // TODO: ADD module connection explanations
         if has_active_non_modules_connections {
           let problem = {
+            let module_readable_identifier = get_cached_readable_identifier(
+              module_id,
+              module_graph,
+              &compilation.module_static_cache,
+              &compilation.options.context,
+            );
             // let importing_explanations = active_non_modules_connections
             //   .iter()
             //   .flat_map(|&c| c.explanation())
@@ -582,6 +587,12 @@ impl ModuleConcatenationPlugin {
 
           if !other_runtime_connections.is_empty() {
             let problem = {
+              let module_readable_identifier = get_cached_readable_identifier(
+                module_id,
+                module_graph,
+                &compilation.module_static_cache,
+                &compilation.options.context,
+              );
               format!(
                 "Module {} is runtime-dependent referenced by these modules: {}",
                 module_readable_identifier,
@@ -616,6 +627,12 @@ impl ModuleConcatenationPlugin {
 
       if !other_chunk_modules.is_empty() {
         let problem = {
+          let module_readable_identifier = get_cached_readable_identifier(
+            module_id,
+            module_graph,
+            &compilation.module_static_cache,
+            &compilation.options.context,
+          );
           let mut names: Vec<_> = other_chunk_modules
             .into_iter()
             .map(|mid| {
@@ -643,6 +660,12 @@ impl ModuleConcatenationPlugin {
 
       if !non_esm_modules.is_empty() {
         let problem = {
+          let module_readable_identifier = get_cached_readable_identifier(
+            module_id,
+            module_graph,
+            &compilation.module_static_cache,
+            &compilation.options.context,
+          );
           let names: Vec<_> = non_esm_modules
             .iter()
             .map(|origin_module| {
@@ -964,8 +987,6 @@ impl ModuleConcatenationPlugin {
 
     let module_graph = compilation.get_module_graph();
     let module_graph_cache = &compilation.module_graph_cache_artifact;
-    let module_static_cache = &compilation.module_static_cache;
-    let compilation_context = &compilation.options.context;
     let cache_modules = relevant_modules
       .iter()
       .chain(possible_inners.iter())
@@ -996,13 +1017,6 @@ impl ModuleConcatenationPlugin {
             .expect_get(chunk)
             .runtime()
         }));
-
-        let _ = get_cached_readable_identifier(
-          &module_id,
-          module_graph,
-          module_static_cache,
-          compilation_context,
-        );
 
         let connections = module
           .get_dependencies()
@@ -1131,7 +1145,6 @@ impl ModuleConcatenationPlugin {
 
       let mut current_configuration =
         ConcatConfiguration::new(*current_root, active_runtime.clone());
-      let root_chunks = root_chunks.clone();
 
       let mut failure_cache = IdentifierMap::default();
       let mut success_cache = RuntimeIdentifierCache::default();

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -26,6 +26,13 @@ fn format_bailout_reason(msg: &str) -> String {
   format!("ModuleConcatenation bailout: {msg}")
 }
 
+fn push_bailout_reason(
+  bailout_reason: &mut Option<Vec<Cow<'static, str>>>,
+  reason: Cow<'static, str>,
+) {
+  bailout_reason.get_or_insert_with(Vec::new).push(reason);
+}
+
 #[derive(Clone, Debug)]
 enum Warning {
   Id(ModuleIdentifier),
@@ -777,7 +784,7 @@ impl ModuleConcatenationPlugin {
       .map(|module_id| {
         let mut can_be_root = true;
         let mut can_be_inner = true;
-        let mut bailout_reason = vec![];
+        let mut bailout_reason: Option<Vec<Cow<'static, str>>> = None;
         let number_of_module_chunks = compilation
           .build_chunk_graph_artifact
           .chunk_graph
@@ -795,21 +802,21 @@ impl ModuleConcatenationPlugin {
           module_graph,
           &compilation.build_chunk_graph_artifact.chunk_graph,
         ) {
-          bailout_reason.push(reason);
+          push_bailout_reason(&mut bailout_reason, reason);
           return (false, false, module_id, bailout_reason);
         }
 
         if ModuleGraph::is_async(&compilation.async_modules_artifact, &module_id) {
-          bailout_reason.push("Module is async".into());
+          push_bailout_reason(&mut bailout_reason, "Module is async".into());
           return (false, false, module_id, bailout_reason);
         }
 
         if !m.build_info().strict {
-          bailout_reason.push("Module is not in strict mode".into());
+          push_bailout_reason(&mut bailout_reason, "Module is not in strict mode".into());
           return (false, false, module_id, bailout_reason);
         }
         if number_of_module_chunks == 0 {
-          bailout_reason.push("Module is not in any chunk".into());
+          push_bailout_reason(&mut bailout_reason, "Module is not in any chunk".into());
           return (false, false, module_id, bailout_reason);
         }
 
@@ -847,7 +854,8 @@ impl ModuleConcatenationPlugin {
           //   &mut module_graph,
           // );
 
-          bailout_reason.push(
+          push_bailout_reason(
+            &mut bailout_reason,
             format!("Reexports in this module do not have a static target ({cur_bailout_reason})")
               .into(),
           );
@@ -878,8 +886,10 @@ impl ModuleConcatenationPlugin {
           //   format!("List of module exports is dynamic ({bailout_reason})"),
           //   &mut module_graph,
           // );
-          bailout_reason
-            .push(format!("List of module exports is dynamic ({cur_bailout_reason})").into());
+          push_bailout_reason(
+            &mut bailout_reason,
+            format!("List of module exports is dynamic ({cur_bailout_reason})").into(),
+          );
           can_be_root = false;
         }
 
@@ -890,11 +900,11 @@ impl ModuleConcatenationPlugin {
           //   &mut module_graph,
           // );
           can_be_inner = false;
-          bailout_reason.push("Module is an entry point".into());
+          push_bailout_reason(&mut bailout_reason, "Module is an entry point".into());
         }
 
         if module_graph.is_deferred(&compilation.imported_by_defer_modules_artifact, &module_id) {
-          bailout_reason.push("Module is deferred".into());
+          push_bailout_reason(&mut bailout_reason, "Module is deferred".into());
           can_be_inner = false;
         }
 
@@ -917,8 +927,10 @@ impl ModuleConcatenationPlugin {
       if can_be_inner {
         possible_inners.insert(module_id);
       }
-      for bailout_reason in bailout_reason {
-        self.set_bailout_reason(&module_id, bailout_reason, module_graph);
+      if let Some(bailout_reason) = bailout_reason {
+        for bailout_reason in bailout_reason {
+          self.set_bailout_reason(&module_id, bailout_reason, module_graph);
+        }
       }
     }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1184,7 +1184,7 @@ impl ModuleConcatenationPlugin {
         match Self::try_to_add(
           compilation,
           &mut current_configuration,
-          &root_chunks,
+          root_chunks,
           &imp,
           Some(runtime),
           active_runtime.as_ref(),


### PR DESCRIPTION
## Summary
- reduce allocation on the common no-bailout path while selecting module concatenation candidates
- split concatenated-module codegen escaped identifier caches by module id and import source
- aggregate escaped naming state per Rayon worker to reduce temporary containers
- round 2: avoid eager readable-identifier work during candidate setup and skip an intermediate reference collection in concatenated codegen
- round 2 follow-up: fix a clippy needless-borrow failure in the module concatenation candidate loop
- round 3: remove redundant `Atom` re-collection for parsed module references and avoid empty per-module rewrite vectors in concatenated codegen
- round 4: skip non-module-reference global identifiers before parsing module references and lazily read `strict_esm_module` only for matched references
- round 5: carry generated module-reference options into concatenated module codegen so global rewrites can reuse recorded options instead of reparsing/decoding placeholders
- round 6: borrow cached module-reference options during global reference rewrites, avoiding an extra `Vec<Atom>` clone on cached module-reference hits
- round 7: collect only module-reference placeholder globals into the rewrite scan list while preserving all global names for deconfliction
- round 8: remove the now-redundant rewrite-loop module-reference precheck and avoid over-reserving the filtered rewrite scan list
- round 9: trim remaining rewrite-loop overhead by skipping empty scan lists early, reusing the cached module-reference map reference, and passing the already-bound module graph into final-name resolution
- round 10: store cached module-reference keys as `Atom` and look them up directly with the AST identifier atom during rewrites

## Performance intent
Targets CodSpeed compilation-stage benchmarks:
- rust@create_concatenate_module: +10%
- rust@concatenate_module_code_generation: +10%

## Final CI/CodSpeed state
- Round 1 head `ee0a0cd`: correctness CI passed; CodSpeed reported `rust@concatenate_module_code_generation` at 45.2 ms -> 43.5 ms (+3.94%) and did not report the create-concatenate target as improved.
- Round 2 head `da907cbd53`: CI-Rust failed on clippy needless-borrow in `module_concatenation_plugin.rs`.
- Round 2 follow-up head `e4e33dda1b`: correctness CI passed; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.93%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 43.1 ms (+4.78%).
- Round 3 head `71d82a409c`: CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.79%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 42.8 ms (+5.71%); Node 20 CI rerun hit an unrelated `afterAll` timeout flaky.
- Round 4 head `ef2f75fd52`: correctness CI passed; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.79%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 42.9 ms (+5.43%).
- Round 5 head `844635b977`: correctness CI passed; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.61%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 41.3 ms (+9.37%).
- Round 6 head `bf96c7d674`: correctness CI passed; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.61%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 41.3 ms (+9.47%).
- Round 7 head `374845bed2`: correctness CI passed; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.61%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 41.4 ms (+9.19%).
- Round 8 head `9ddabe75c7`: correctness CI passed; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 13.3 ms (+17.22%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 41.2 ms (+9.79%); CodSpeed reported a different-runtime-environment warning.
- Round 9 head `fa4d4c05b5`: correctness CI passed; Copilot review found no correctness issue; CodSpeed reported `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.73%) and `rust@concatenate_module_code_generation` at 45.2 ms -> 41.2 ms (+9.8%). This was the best observed codegen result.
- Round 10 head `ecaad73fd4`: correctness CI passed (`CI`, `CI-Lint`, `CI-Dylint`, `CI-Rust`, and `CI Diff` all green). Main CI jobs including Rust Bench simulation, WASM build/test, Linux build/tests/E2E, Windows build/test, Mac ARM64 build/test, Check Cache Portable, and Test Required Check passed. Binary Size Limit job passed, though the size-limit comment reports +28.00 KB (+0.04%). Pre-push correctness subagent found no issues, Copilot reviewed the latest head and found no correctness issue, and review threads are empty. CodSpeed reported overall +10.52%, `rust@create_concatenate_module` at 15.6 ms -> 12.8 ms (+21.87%), and `rust@concatenate_module_code_generation` at 45.2 ms -> 41.3 ms (+9.42%).

Outcome: the configured 10 optimization/CI rounds are exhausted. `rust@create_concatenate_module` met the +10% target, but `rust@concatenate_module_code_generation` did not; best observed codegen improvement was +9.8% on round 9.

Expected mechanism: less per-module allocation, fewer repeated readable-identifier string lookups during module concatenation creation, fewer temporary containers during concatenated module code generation, fewer per-reference `Atom` allocations while rewriting module references, less parser/build-meta work for ordinary global identifiers that are not module-reference placeholders, reuse of already-recorded module-reference options to avoid repeated placeholder hex/JSON parsing in the codegen rewrite loop, borrowed cached module-reference options to avoid cloning export id vectors before final binding resolution, a smaller global module-reference rewrite scan list after AST collection, less residual checking/allocation after that scan list is already filtered, less per-reference loop overhead during final module-reference rewriting, and direct `Atom`-keyed cache lookup for generated module-reference placeholders.