### PR TITLE
fix: preserve source phase for wasm externals

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -137,8 +137,12 @@ fn get_source_for_import(
   attributes: &Option<ImportAttributes>,
   phase: ImportPhase,
 ) -> String {
-  let import_function = if phase.is_source() {
-    format!("{}.source", compilation.options.output.import_function_name)
+  let import_function = if phase != ImportPhase::Evaluation {
+    format!(
+      "{}.{}",
+      compilation.options.output.import_function_name,
+      phase.as_str()
+    )
   } else {
     compilation.options.output.import_function_name.clone()
   };

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -14,8 +14,8 @@ use crate::{
   BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey,
   CodeGenerationDataUrl, CodeGenerationResult, Compilation, ConcatenationScope, Context,
   DependenciesBlock, DependencyId, ExportProvided, ExternalType, FactoryMeta, ImportAttributes,
-  InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
+  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module,
+  ModuleArgument, ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
   NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
   StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports, UsedNameItem,
   extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
@@ -135,10 +135,17 @@ fn get_source_for_import(
   module_and_specifiers: Option<&ExternalRequestValue>,
   compilation: &Compilation,
   attributes: &Option<ImportAttributes>,
+  phase: ImportPhase,
 ) -> String {
+  let import_function = if phase.is_source() {
+    format!("{}.source", compilation.options.output.import_function_name)
+  } else {
+    compilation.options.output.import_function_name.clone()
+  };
+
   format!(
     "{}({}).then(function(module) {{ return module{}; }})",
-    compilation.options.output.import_function_name,
+    import_function,
     {
       let attributes_str = if let Some(attributes) = attributes {
         format!(
@@ -167,16 +174,54 @@ fn get_source_for_import(
   )
 }
 
-fn module_external_fragment_key(base: &str, attributes: &Option<ImportAttributes>) -> String {
+fn module_external_fragment_key(
+  base: &str,
+  attributes: &Option<ImportAttributes>,
+  phase: ImportPhase,
+) -> String {
+  let phase_str = if phase == ImportPhase::Evaluation {
+    String::new()
+  } else {
+    format!("|phase={}", phase.as_str())
+  };
   if let Some(attributes) = attributes {
     format!(
-      "{}|{}",
+      "{}{}|{}",
       base,
+      phase_str,
       simd_json::to_string(attributes).expect("json stringify failed")
     )
   } else {
-    base.to_string()
+    format!("{base}{phase_str}")
   }
+}
+
+fn module_external_import_statement(
+  module_and_specifiers: &ExternalRequestValue,
+  ident: &str,
+  attributes: &Option<ImportAttributes>,
+  phase: ImportPhase,
+) -> String {
+  let request = json_stringify_str(module_and_specifiers.primary());
+  let mut import_statement = String::from("import");
+  if phase != ImportPhase::Evaluation {
+    import_statement.push(' ');
+    import_statement.push_str(phase.as_str());
+  }
+  import_statement.push(' ');
+  if !phase.is_source() {
+    import_statement.push_str("* as ");
+  }
+  import_statement.push_str("__rspack_external_");
+  import_statement.push_str(ident);
+  import_statement.push_str(" from ");
+  import_statement.push_str(&request);
+  if let Some(attributes) = attributes {
+    import_statement.push_str(" with ");
+    import_statement.push_str(&simd_json::to_string(attributes).expect("json stringify failed"));
+  }
+  import_statement.push_str(";\n");
+  import_statement
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -278,39 +323,31 @@ fn module_external_remapping_property_key(exposed_name: &str) -> String {
 fn get_source_for_module_external(
   module_and_specifiers: &ExternalRequestValue,
   ident: &str,
-  attributes: &Option<ImportAttributes>,
+  dependency_meta: &DependencyMeta,
   exports_info_artifact: &crate::ExportsInfoArtifact,
   exports_info: &crate::ExportsInfoData,
   runtime: Option<&RuntimeSpec>,
   runtime_template: &mut ModuleCodeTemplate,
 ) -> (Option<String>, String, ChunkInitFragments) {
-  let mut chunk_init_fragments: ChunkInitFragments = Default::default();
-  let attributes_str = if let Some(attributes) = attributes {
-    format!(
-      " with {}",
-      simd_json::to_string(attributes).expect("json stringify failed"),
-    )
-  } else {
-    String::new()
-  };
-
-  chunk_init_fragments.push(
+  let chunk_init_fragments: ChunkInitFragments = vec![
     NormalInitFragment::new(
-      format!(
-        "import * as __rspack_external_{ident} from {}{};\n",
-        json_stringify_str(module_and_specifiers.primary()),
-        attributes_str
+      module_external_import_statement(
+        module_and_specifiers,
+        ident,
+        &dependency_meta.attributes,
+        dependency_meta.phase,
       ),
       InitFragmentStage::StageESMImports,
       0,
       InitFragmentKey::ModuleExternal(module_external_fragment_key(
         module_and_specifiers.primary(),
-        attributes,
+        &dependency_meta.attributes,
+        dependency_meta.phase,
       )),
       None,
     )
     .boxed(),
-  );
+  ];
 
   let base_access = format!(
     "__rspack_external_{ident}{}",
@@ -422,6 +459,7 @@ pub type MetaExternalType = Option<ExternalTypeEnum>;
 pub struct DependencyMeta {
   pub external_type: MetaExternalType,
   pub attributes: Option<ImportAttributes>,
+  pub phase: ImportPhase,
   pub source_type: Option<SourceType>,
 }
 
@@ -448,7 +486,12 @@ impl ExternalModule {
               simd_json::to_string(attrs).expect("invalid json to_string")
             )
           });
-        format!("external {resolved_type} {request_str}{attrs_str}")
+        let phase_str = if dependency_meta.phase == ImportPhase::Evaluation {
+          String::new()
+        } else {
+          format!(" phase={}", dependency_meta.phase.as_str())
+        };
+        format!("external {resolved_type} {request_str}{attrs_str}{phase_str}")
       }),
       request,
       external_type,
@@ -627,7 +670,12 @@ impl ExternalModule {
       "import" => format!(
         "{} = {};",
         get_namespace_object_export(concatenation_scope, supports_const, runtime_template),
-        get_source_for_import(request, compilation, &self.dependency_meta.attributes)
+        get_source_for_import(
+          request,
+          compilation,
+          &self.dependency_meta.attributes,
+          self.dependency_meta.phase,
+        )
       ),
       "var" | "promise" | "const" | "let" | "assign" => {
         let external_variable = if let Some(request) = request {
@@ -759,7 +807,7 @@ impl ExternalModule {
                 safe_to_optimize
               };
 
-            let force_namespace = request.has_rest();
+            let force_namespace = request.has_rest() || self.dependency_meta.phase.is_source();
 
             match used_exports {
               UsedExports::UsedNamespace(true) | UsedExports::Unknown => {
@@ -800,7 +848,7 @@ impl ExternalModule {
                       get_source_for_module_external(
                         request,
                         id.as_ref(),
-                        &self.dependency_meta.attributes,
+                        &self.dependency_meta,
                         &compilation.exports_info_artifact,
                         exports_info,
                         runtime,
@@ -818,11 +866,11 @@ impl ExternalModule {
                   } else {
                     chunk_init_fragments.push(
                       NormalInitFragment::new(
-                        format!(
-                          "import * as __rspack_external_{} from {}{};\n",
+                        module_external_import_statement(
+                          request,
                           id.as_ref(),
-                          json_stringify_str(request.primary()),
-                          attributes.unwrap_or_default()
+                          &self.dependency_meta.attributes,
+                          self.dependency_meta.phase,
                         ),
                         InitFragmentStage::StageESMImports,
                         module_graph
@@ -831,6 +879,7 @@ impl ExternalModule {
                         InitFragmentKey::ModuleExternal(module_external_fragment_key(
                           request.primary(),
                           &self.dependency_meta.attributes,
+                          self.dependency_meta.phase,
                         )),
                         None,
                       )
@@ -871,7 +920,7 @@ impl ExternalModule {
             let (init, expression, module_external_fragments) = get_source_for_module_external(
               request,
               id.as_ref(),
-              &self.dependency_meta.attributes,
+              &self.dependency_meta,
               &compilation.exports_info_artifact,
               exports_info,
               runtime,
@@ -894,7 +943,12 @@ impl ExternalModule {
           format!(
             "{} = {};",
             get_namespace_object_export(concatenation_scope, supports_const, runtime_template),
-            get_source_for_import(request, compilation, &self.dependency_meta.attributes)
+            get_source_for_import(
+              request,
+              compilation,
+              &self.dependency_meta.attributes,
+              self.dependency_meta.phase,
+            )
           )
         }
       }

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -127,6 +127,7 @@ impl ExternalsPlugin {
 
     let mut dependency_meta: DependencyMeta = DependencyMeta {
       attributes: dependency.get_attributes().cloned(),
+      phase: dependency.get_phase(),
       external_type: {
         if is_import_dependency
           || matches!(

--- a/tests/rspack-test/configCases/externals/wasm-source-phase/a.js
+++ b/tests/rspack-test/configCases/externals/wasm-source-phase/a.js
@@ -1,0 +1,4 @@
+import source wasmModule from "./static.wasm";
+
+globalThis.staticModule = wasmModule;
+globalThis.dynamicModule = import.source("./dynamic.wasm");

--- a/tests/rspack-test/configCases/externals/wasm-source-phase/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/wasm-source-phase/rspack.config.js
@@ -1,0 +1,73 @@
+const {
+  Compilation,
+  sources: { RawSource },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: ['web', 'es2020'],
+  entry: {
+    a: './a',
+  },
+  output: {
+    filename: '[name].mjs',
+    module: true,
+  },
+  experiments: {
+    sourceImport: true,
+  },
+  externalsType: 'module-import',
+  externals: [
+    ({ request }, callback) => {
+      if (request === './static.wasm') {
+        return callback(null, './external/static.wasm');
+      }
+      if (request === './dynamic.wasm') {
+        return callback(null, './external/dynamic.wasm');
+      }
+      callback();
+    },
+  ],
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.compilation.tap(
+          'check-source-phase-externals',
+          (compilation) => {
+            compilation.hooks.processAssets.tap(
+              {
+                name: 'check-source-phase-externals',
+                stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+              },
+              () => {
+                const content = compilation
+                  .getAssets()
+                  .filter((asset) => /\.(?:mjs|js)$/.test(asset.name))
+                  .map((asset) => asset.source.source())
+                  .join('\n');
+                expect(content).toMatch(
+                  /import source __rspack_external_.+ from "\.\/external\/static\.wasm";/,
+                );
+                expect(content).toContain(
+                  'import.source("./external/dynamic.wasm").then',
+                );
+                expect(content).not.toContain(
+                  'import("./external/static.wasm").then',
+                );
+                expect(content).not.toContain(
+                  'import("./external/dynamic.wasm").then',
+                );
+                expect(content).not.toContain('import * as __rspack_external_');
+
+                compilation.emitAsset(
+                  'assertions.txt',
+                  new RawSource('source phase externals preserved'),
+                );
+              },
+            );
+          },
+        );
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/externals/wasm-source-phase/test.config.js
+++ b/tests/rspack-test/configCases/externals/wasm-source-phase/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	noTests: true
+};


### PR DESCRIPTION
## Summary

- Preserve `ImportPhase::Source` when externalizing WASM source phase imports.
- Render source phase externals as `import source ... from ...` for ESM module externals and `import.source(...)` for dynamic import externals.
- Add a configCase covering static and dynamic externalized WASM source phase imports.

## Root Cause

External module metadata only carried import attributes, so source phase information was lost after externalization. Module external rendering and concatenation optimizations then emitted ordinary import syntax.

## Validation

- `cargo fmt --all`
- `cargo check -p rspack_core -p rspack_plugin_externals`
- `pnpm run build:js`
- `pnpm run build:binding:dev`
- `pnpm run test -t "configCases/externals/wasm-source-phase"`
- `pnpm run test -t "configCases/externals/module-import"`

Fixes #14454

---
_by OpenAI Codex_