### PR TITLE
docs: update React Compiler guide

### DIFF
--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -181,6 +181,9 @@ export default {
             detectSyntax: 'auto',
             jsc: {
               transform: {
+                react: {
+                  runtime: 'automatic',
+                },
                 reactCompiler: {
                   compilationMode: 'annotation',
                 },

--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -105,8 +105,9 @@ Before you start using React Compiler, it's recommended to read the [React Compi
 
 The steps to use React Compiler in Rspack:
 
-1. Upgrade versions of `react` and `react-dom` to 19. If you are unable to upgrade, you can install the extra [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) package which will allow the compiled code to run on versions prior to 19.
-2. Enable React Compiler in `builtin:swc-loader` through `jsc.transform.reactCompiler`:
+1. Upgrade `@rspack/core` to v2.1.0 or later.
+2. Upgrade versions of `react` and `react-dom` to 19. If you are unable to upgrade, you can install the extra [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) package which will allow the compiled code to run on versions prior to 19.
+3. Enable React Compiler in `builtin:swc-loader` through `jsc.transform.reactCompiler`:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -166,7 +167,34 @@ export default {
 };
 ```
 
-The `reactCompiler` options are aligned with the React Compiler configuration. For example, you can use [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) to control which functions are compiled. For more options, refer to the official [React Compiler configuration documentation](https://react.dev/reference/react-compiler/configuration).
+The `reactCompiler` options are aligned with the React Compiler configuration. For example, you can use [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) to control which functions are compiled.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:js|jsx|ts|tsx)$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                reactCompiler: {
+                  compilationMode: 'annotation',
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+For more options, refer to the official [React Compiler configuration documentation](https://react.dev/reference/react-compiler/configuration).
 
 ### Using Babel
 

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -103,8 +103,9 @@ React Compiler 是 React 19 引入的一个实验性编译器，它可以自动�
 
 在 Rspack 中使用 React Compiler 的步骤如下：
 
-1. 升级 `react` 和 `react-dom` 版本到 19。如果你暂时无法升级，可以在 React 17 或 18 项目中安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，以允许编译后的代码在 19 之前的版本上运行。
-2. 通过 `builtin:swc-loader` 的 `jsc.transform.reactCompiler` 启用 React Compiler：
+1. 升级 `@rspack/core` 到 v2.1.0 及以上版本。
+2. 升级 `react` 和 `react-dom` 版本到 19。如果你暂时无法升级，可以在 React 17 或 18 项目中安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，以允许编译后的代码在 19 之前的版本上运行。
+3. 通过 `builtin:swc-loader` 的 `jsc.transform.reactCompiler` 启用 React Compiler：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -164,7 +165,34 @@ export default {
 };
 ```
 
-`reactCompiler` 的选项与 React Compiler 配置对齐。例如，你可以通过 [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) 控制哪些函数会被编译。更多选项请参考官方 [React Compiler 配置说明](https://react.dev/reference/react-compiler/configuration)。
+`reactCompiler` 的选项与 React Compiler 配置对齐。例如，你可以通过 [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) 控制哪些函数会被编译。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:js|jsx|ts|tsx)$/,
+        use: {
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+            jsc: {
+              transform: {
+                reactCompiler: {
+                  compilationMode: 'annotation',
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+更多选项请参考官方 [React Compiler 配置说明](https://react.dev/reference/react-compiler/configuration)。
 
 ### 使用 Babel
 

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -179,6 +179,9 @@ export default {
             detectSyntax: 'auto',
             jsc: {
               transform: {
+                react: {
+                  runtime: 'automatic',
+                },
                 reactCompiler: {
                   compilationMode: 'annotation',
                 },


### PR DESCRIPTION
## Summary

This PR updates the React Compiler guide to clarify that `@rspack/core` must be v2.1.0 or later before enabling the built-in SWC transform. It also adds a full concise `compilationMode` configuration example in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).