### PR TITLE
chore(ci): align hookTimeout with testTimeout to fix flaky afterAll close timeout

### DIFF
--- a/tests/rspack-test/rstest.config.mts
+++ b/tests/rspack-test/rstest.config.mts
@@ -58,6 +58,7 @@ if (process.env.GITHUB_ACTIONS || process.env.GITHUB_STEP_SUMMARY) {
 const sharedConfig = defineProject({
   setupFiles: setupFilesAfterEnv,
   testTimeout: process.env.CI ? 60000 : 30000,
+  hookTimeout: process.env.CI ? 60000 : 30000,
   include: [
     "*.test.js",
   ],


### PR DESCRIPTION
## Why

`Config.part2` / `RuntimeModeConfig.part2` intermittently fail on CI with `afterAll hook timed out in 10000ms`. All assertions pass — only the per-case cleanup (`compiler.close()` in `afterAll`) times out.

`compiler.close()` resolves on a native (napi) completion callback that is delivered through the worker's event loop. Under the suite's normal concurrent-build load on the constrained CI runner, the worker's main thread is starved for several seconds, so the callback can't be delivered in time. Instrumented CI runs showed the event loop frozen for ~8–18s while the close was pending with `reqs=0` — the close work was already done, only the callback delivery was blocked. It became frequent once #14254 added the RuntimeMode test files, roughly doubling the concurrent config-build load.

The config already raises `testTimeout` to 60s on CI for exactly this reason, but `hookTimeout` was left at the 10s default — giving cleanup 6× less budget than a test body despite being equally starvation-prone. This aligns them.

Lowering within-worker concurrency (`--maxConcurrency`) was tested and does not reliably help: the starvation is driven by cross-process load, which that setting does not control.
