### PR TITLE
docs: update ESM config examples

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -317,16 +317,16 @@ export default {
 ```js title="rspack.config.mjs"
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
-var virtualModules = new VirtualModulesPlugin({
-  'virtual_entry.js': `
-    require("./src/another_virtual.js");
-    require("./src/disk_file.js")
+const virtualModules = new VirtualModulesPlugin({
+  'virtual-entry.js': `
+    import "./src/another-virtual.js";
+    import "./src/disk-file.js";
     `,
-  'src/another_virtual.js': 'module.exports = 42',
+  'src/another-virtual.js': 'export default 42;',
 });
 
 export default {
-  entry: './virtual_entry.js',
+  entry: './virtual-entry.js',
   plugins: [virtualModules],
   experiments: {
     useInputFileSystem: [/.*virtual.*\.js$/],
@@ -334,5 +334,5 @@ export default {
 };
 ```
 
-When access to `virtual_entry.js` and `src/another_virtual.js` which match the regular expressions of `experiments.useInputFileSystem`,
-Rspack will use the input file system wrapped by `VirtualModulesPlugin`; other than that, `src/disk_file.js` will be accessed by the native file system.
+When access to `virtual-entry.js` and `src/another-virtual.js` which match the regular expressions of `experiments.useInputFileSystem`,
+Rspack will use the input file system wrapped by `VirtualModulesPlugin`; other than that, `src/disk-file.js` will be accessed by the native file system.

--- a/website/docs/en/config/module-generator.mdx
+++ b/website/docs/en/config/module-generator.mdx
@@ -156,16 +156,13 @@ export default {
 When used as a function, it executes for every module and must return a data URI string.
 
 ```js title="rspack.config.mjs"
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
+import svgToMiniDataURI from 'mini-svg-data-uri';
 
 export default {
   module: {
     generator: {
       asset: {
         dataUrl: ({ content }) => {
-          const svgToMiniDataURI = require('mini-svg-data-uri');
           return svgToMiniDataURI(content);
         },
       },

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -318,16 +318,16 @@ export default {
 ```js title="rspack.config.mjs"
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
-var virtualModules = new VirtualModulesPlugin({
-  'virtual_entry.js': `
-    require("./src/another_virtual.js");
-    require("./src/disk_file.js")
+const virtualModules = new VirtualModulesPlugin({
+  'virtual-entry.js': `
+    import "./src/another-virtual.js";
+    import "./src/disk-file.js";
     `,
-  'src/another_virtual.js': 'module.exports = 42',
+  'src/another-virtual.js': 'export default 42;',
 });
 
 export default {
-  entry: './virtual_entry.js',
+  entry: './virtual-entry.js',
   plugins: [virtualModules],
   experiments: {
     useInputFileSystem: [/.*virtual.*\.js$/],
@@ -335,4 +335,4 @@ export default {
 };
 ```
 
-当访问 `virtual_entry.js` 和 `src/another_virtual.js` 时，它们匹配了 `experiments.useInputFileSystem` 中的正则规则，Rspack 会通过 `VirtualModulesPlugin` 包装的输入文件系统读取它们；而像 `src/disk_file.js`，则会使用原生文件系统读取。
+当访问 `virtual-entry.js` 和 `src/another-virtual.js` 时，它们匹配了 `experiments.useInputFileSystem` 中的正则规则，Rspack 会通过 `VirtualModulesPlugin` 包装的输入文件系统读取它们；而像 `src/disk-file.js`，则会使用原生文件系统读取。

--- a/website/docs/zh/config/module-generator.mdx
+++ b/website/docs/zh/config/module-generator.mdx
@@ -155,16 +155,13 @@ export default {
 当被作为一个函数使用，它必须为每个模块执行且并须返回一个 data URI 字符串。
 
 ```js title="rspack.config.mjs"
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
+import svgToMiniDataURI from 'mini-svg-data-uri';
 
 export default {
   module: {
     generator: {
       asset: {
         dataUrl: ({ content }) => {
-          const svgToMiniDataURI = require('mini-svg-data-uri');
           return svgToMiniDataURI(content);
         },
       },


### PR DESCRIPTION
## Summary

This PR updates the config docs so `rspack.config.mjs` examples consistently use ESM syntax. It replaces the `mini-svg-data-uri` example with a default ESM import, updates the `webpack-virtual-modules` example to use `import` / `export default`, and switches the virtual file names to kebab-case in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).