### PR TITLE
fix(types): align wasm loading types

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -55,6 +55,7 @@ import type {
   Performance,
   ResolveOptions,
   RuleSetRules,
+  WasmLoadingType,
 } from './types';
 
 const ERROR_PREFIX = 'Invalid Rspack configuration:';
@@ -1004,7 +1005,7 @@ const applyOutputDefaults = (
     return Array.from(enabledChunkLoadingTypes);
   });
   A(output, 'enabledWasmLoadingTypes', () => {
-    const enabledWasmLoadingTypes = new Set<string>();
+    const enabledWasmLoadingTypes = new Set<WasmLoadingType>();
     if (output.wasmLoading) {
       enabledWasmLoadingTypes.add(output.wasmLoading);
     }

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -308,7 +308,7 @@ export type StrictModuleErrorHandling = boolean;
 export type GlobalObject = string;
 
 /** List of wasm loading types enabled for use by entry points. */
-export type EnabledWasmLoadingTypes = string[];
+export type EnabledWasmLoadingTypes = ('...' | WasmLoadingType)[];
 
 /** The name of the native import() function. */
 export type ImportFunctionName = string;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -71,10 +71,7 @@ export type ChunkLoading = false | ChunkLoadingType;
 export type AsyncChunks = boolean;
 
 /** Option to set the method of loading WebAssembly Modules. */
-export type WasmLoadingType = LiteralUnion<
-  'fetch-streaming' | 'fetch' | 'async-node',
-  string
->;
+export type WasmLoadingType = 'fetch' | 'async-node' | 'universal';
 
 /** Option to set the method of loading WebAssembly Modules. */
 export type WasmLoading = false | WasmLoadingType;

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1725,18 +1725,12 @@ Tell Rspack to remove a module from the module instance cache (require.cache) if
 
 Controls [Trusted Types](https://web.dev/trusted-types) compatibility. When enabled, Rspack will detect Trusted Types support and, if they are supported, use Trusted Types policies to create script URLs it loads dynamically. Use when the application runs under a [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) Content Security Policy directive.
 
-It is disabled by default (no compatibility, script URLs are strings).
-
-- When set to `true`, Rspack will use [`output.uniqueName`](#outputuniquename) as the Trusted Types policy name.
-- When set to a non-empty string, its value will be used as a policy name.
-- When set to an object, the policy name is taken from the object's `policyName` property.
+It is disabled by default (no compatibility, script URLs are strings). Set it to `true` to enable Trusted Types with a policy name derived from [`output.uniqueName`](#outputuniquename).
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
-    trustedTypes: {
-      policyName: 'my-application#rspack',
-    },
+    trustedTypes: true,
   },
 };
 ```
@@ -1746,11 +1740,9 @@ export default {
 - **Type:** `string`
 - **Default:** Derived from [`output.uniqueName`](#outputuniquename)
 
-The name of the Trusted Types policy created by Rspack to serve bundle chunks.
+The name of the Trusted Types policy created by Rspack to serve bundle chunks. Use this option when the policy name must match a CSP `trusted-types` allowlist.
 
-When [`output.trustedTypes`](#outputtrustedtypes) is set to `true`, Rspack derives the policy name from [`output.uniqueName`](#outputuniquename), replacing unsupported characters with `_`. If the derived name is empty, it falls back to `'rspack'`.
-
-When [`output.trustedTypes`](#outputtrustedtypes) is set to a non-empty string, that string is used as `policyName`.
+If `policyName` is omitted, Rspack derives it from [`output.uniqueName`](#outputuniquename), replacing unsupported characters with `_`. If the derived name is empty, it falls back to `'rspack'`. The string shorthand `trustedTypes: 'my-policy'` is equivalent to setting `trustedTypes.policyName`.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1811,10 +1811,10 @@ export default {
 
 ## output.wasmLoading
 
-- **Type:** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
+- **Type:** `false | 'fetch' | 'async-node' | 'universal'`
 - **Default:** `'fetch'`
 
-Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/webworker), `'async-node'` (Node.js), but others might be added by plugins.
+Option to set the method of loading WebAssembly Modules. Supported methods are `'fetch'` (web/webworker), `'async-node'` (Node.js), and `'universal'`.
 
 The default value can be affected by different [`target`](/config/target):
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -414,7 +414,7 @@ export default {
 
 ## output.enabledWasmLoadingTypes
 
-- **Type:** `string[]`
+- **Type:** `('...' | 'fetch' | 'async-node' | 'universal')[]`
 - **Default:** Determined by [`output.wasmLoading`](#outputwasmloading) and [`output.workerWasmLoading`](#outputworkerwasmloading)
 
 List of Wasm loading types enabled for use by entry points.

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1884,7 +1884,7 @@ export default {
 
 ## output.workerWasmLoading
 
-- **Type:** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
+- **Type:** `false | 'fetch' | 'async-node' | 'universal'`
 - **Default:** `false`
 
 Option to set the method of loading WebAssembly Modules in workers, defaults to the value of [output.wasmLoading](#outputwasmloading).

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -414,7 +414,7 @@ export default {
 
 ## output.enabledWasmLoadingTypes
 
-- **Type:** `('fetch-streaming' | 'fetch' | 'async-node' | string | false)[]`
+- **Type:** `string[]`
 - **Default:** Determined by [`output.wasmLoading`](#outputwasmloading) and [`output.workerWasmLoading`](#outputworkerwasmloading)
 
 List of Wasm loading types enabled for use by entry points.
@@ -1671,7 +1671,7 @@ See [Asset base path](/guide/features/asset-base-path) for more details.
 
 ## output.scriptType
 
-- **Type:** `'module' | 'text/javascript' | boolean`
+- **Type:** `false | 'text/javascript' | 'module'`
 - **Default:** `false`
 
 This option allows loading asynchronous chunks with a custom script type, such as `<script type="module" ...>`.
@@ -1741,6 +1741,27 @@ export default {
 };
 ```
 
+### output.trustedTypes.policyName
+
+- **Type:** `string`
+- **Default:** Derived from [`output.uniqueName`](#outputuniquename)
+
+The name of the Trusted Types policy created by Rspack to serve bundle chunks.
+
+When [`output.trustedTypes`](#outputtrustedtypes) is set to `true`, Rspack derives the policy name from [`output.uniqueName`](#outputuniquename), replacing unsupported characters with `_`. If the derived name is empty, it falls back to `'rspack'`.
+
+When [`output.trustedTypes`](#outputtrustedtypes) is set to a non-empty string, that string is used as `policyName`.
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    trustedTypes: {
+      policyName: 'my-application#rspack',
+    },
+  },
+};
+```
+
 ### output.trustedTypes.onPolicyCreationFailure
 
 <ApiMeta addedVersion={'1.1.6'} />
@@ -1776,7 +1797,7 @@ This option is used to identify a unique name for the current build. It mainly h
 - [output.chunkLoadingGlobal](#outputchunkloadingglobal)
 - [output.hotUpdateGlobal](#outputhotupdateglobal)
 - [output.devtoolNamespace](#outputdevtoolnamespace)
-- [output.trustedTypes.policyName](#outputtrustedtypes)
+- [output.trustedTypes.policyName](#outputtrustedtypespolicyname)
 
 To override the default value:
 
@@ -1790,7 +1811,7 @@ export default {
 
 ## output.wasmLoading
 
-- **Type:** `false | 'fetch', 'async-node'`
+- **Type:** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
 - **Default:** `'fetch'`
 
 Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/webworker), `'async-node'` (Node.js), but others might be added by plugins.
@@ -1829,7 +1850,7 @@ See [Filename placeholders](/config/filename-placeholders) for more information.
 
 ## output.workerChunkLoading
 
-- **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
+- **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | string`
 - **Default:** `false`
 
 The new option `workerChunkLoading` controls the chunk loading of workers.

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -410,7 +410,7 @@ export default {
 
 ## output.enabledWasmLoadingTypes
 
-- **类型：** `('fetch-streaming' | 'fetch' | 'async-node' | string | false)[]`
+- **类型：** `string[]`
 - **默认值：** 根据 [`output.wasmLoading`](#outputwasmloading) 及 [`output.workerWasmLoading`](#outputworkerwasmloading) 的配置推断
 
 开启可用的 Wasm 加载类型的运行时模块打包。
@@ -1662,7 +1662,7 @@ export default {
 
 ## output.scriptType
 
-- **类型：** `'module' | 'text/javascript' | boolean`
+- **类型：** `false | 'text/javascript' | 'module'`
 - **默认值：** `false`
 
 该选项允许使用自定义脚本类型（例如 `<script type="module" ...>`）来加载异步块。
@@ -1732,6 +1732,27 @@ export default {
 };
 ```
 
+### output.trustedTypes.policyName
+
+- **类型：** `string`
+- **默认值：** 从 [`output.uniqueName`](#outputuniquename) 推导
+
+Rspack 创建用于加载 bundle chunk 的 Trusted Types 策略名称。
+
+当 [`output.trustedTypes`](#outputtrustedtypes) 设置为 `true` 时，Rspack 会从 [`output.uniqueName`](#outputuniquename) 推导策略名称，并将不支持的字符替换为 `_`。如果推导结果为空，则回退为 `'rspack'`。
+
+当 [`output.trustedTypes`](#outputtrustedtypes) 设置为非空字符串时，该字符串会作为 `policyName` 使用。
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    trustedTypes: {
+      policyName: 'my-application#rspack',
+    },
+  },
+};
+```
+
 ### output.trustedTypes.onPolicyCreationFailure
 
 <ApiMeta addedVersion={'1.1.6'} />
@@ -1767,7 +1788,7 @@ export default {
 - [output.chunkLoadingGlobal](#outputchunkloadingglobal)
 - [output.hotUpdateGlobal](#outputhotupdateglobal)
 - [output.devtoolNamespace](#outputdevtoolnamespace)
-- [output.trustedTypes.policyName](#outputtrustedtypes)
+- [output.trustedTypes.policyName](#outputtrustedtypespolicyname)
 
 你也可以覆盖默认值：
 
@@ -1781,7 +1802,7 @@ export default {
 
 ## output.wasmLoading
 
-- **类型：** `false | 'fetch', 'async-node'`
+- **类型：** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
 - **默认值：** `'fetch'`
 
 用于设置加载 WebAssembly 模块的方式。默认方式包括 `'fetch'`（web/webworker）、`'async-node'`（Node.js）
@@ -1820,7 +1841,7 @@ export default {
 
 ## output.workerChunkLoading
 
-- **类型：** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
+- **类型：** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | string`
 - **默认值：** `false`
 
 `workerChunkLoading` 控制 chunk 加载方式。

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1802,10 +1802,10 @@ export default {
 
 ## output.wasmLoading
 
-- **类型：** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
+- **类型：** `false | 'fetch' | 'async-node' | 'universal'`
 - **默认值：** `'fetch'`
 
-用于设置加载 WebAssembly 模块的方式。默认方式包括 `'fetch'`（web/webworker）、`'async-node'`（Node.js）
+用于设置加载 WebAssembly 模块的方式。支持的方式包括 `'fetch'`（web/webworker）、`'async-node'`（Node.js）和 `'universal'`。
 
 默认值会受不同 [`target`](/config/target) 的影响：
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -410,7 +410,7 @@ export default {
 
 ## output.enabledWasmLoadingTypes
 
-- **类型：** `string[]`
+- **类型：** `('...' | 'fetch' | 'async-node' | 'universal')[]`
 - **默认值：** 根据 [`output.wasmLoading`](#outputwasmloading) 及 [`output.workerWasmLoading`](#outputworkerwasmloading) 的配置推断
 
 开启可用的 Wasm 加载类型的运行时模块打包。

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1875,7 +1875,7 @@ export default {
 
 ## output.workerWasmLoading
 
-- **类型：** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
+- **类型：** `false | 'fetch' | 'async-node' | 'universal'`
 - **默认值：** `false`
 
 用来设置在 Worker 中加载 WebAssembly 模块的方式，默认为 [`output.wasmLoading`](#outputwasmloading) 的值。

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1716,18 +1716,12 @@ export default {
 
 控制 [Trusted Types](https://web.dev/trusted-types) 兼容性。启用此选项，Rspack 将检测已实现了 Trusted Types，并使用 Trusted Types 来创建它动态加载的脚本 URL。应用在运行带有 [require-trusted-types-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) 内容安全策略指令下的应用程序。
 
-默认情况下是不启用。
-
-- 当设置为 `true` 时，Rspack 将使用 [`output.uniqueName`](#outputuniquename) 作为 Trusted Types 策略名称。
-- 当设置为非空字符串时，其值将被用作策略名称。
-- 当设置为对象时，策略名称将从对象的 `policyName` 属性中获取。
+默认情况下是不启用。将其设置为 `true` 时，Rspack 会启用 Trusted Types，并从 [`output.uniqueName`](#outputuniquename) 推导策略名称。
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
-    trustedTypes: {
-      policyName: 'my-application#rspack',
-    },
+    trustedTypes: true,
   },
 };
 ```
@@ -1737,11 +1731,9 @@ export default {
 - **类型：** `string`
 - **默认值：** 从 [`output.uniqueName`](#outputuniquename) 推导
 
-Rspack 创建用于加载 bundle chunk 的 Trusted Types 策略名称。
+Rspack 创建用于加载 bundle chunk 的 Trusted Types 策略名称。当策略名称需要匹配 CSP `trusted-types` 允许列表时，可以使用此选项。
 
-当 [`output.trustedTypes`](#outputtrustedtypes) 设置为 `true` 时，Rspack 会从 [`output.uniqueName`](#outputuniquename) 推导策略名称，并将不支持的字符替换为 `_`。如果推导结果为空，则回退为 `'rspack'`。
-
-当 [`output.trustedTypes`](#outputtrustedtypes) 设置为非空字符串时，该字符串会作为 `policyName` 使用。
+如果省略 `policyName`，Rspack 会从 [`output.uniqueName`](#outputuniquename) 推导策略名称，并将不支持的字符替换为 `_`。如果推导结果为空，则回退为 `'rspack'`。字符串简写 `trustedTypes: 'my-policy'` 等价于设置 `trustedTypes.policyName`。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR aligns the public Wasm loading type definitions with the runtime-supported loading modes: `fetch`, `async-node`, and `universal`. `EnabledWasmLoadingTypes` now also rejects arbitrary strings while keeping the supported `...` array-default placeholder.

It also updates the `output` config docs for Wasm loading, enabled Wasm loading types, worker Wasm loading, worker chunk loading, script type, and Trusted Types policy names so the documented types match the implementation.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).