### PR TITLE
fix(esm-library): name split runtime chunk to avoid cross-lib filename collision

### DIFF
--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -509,8 +509,17 @@ pub(crate) fn optimize_runtime_chunks(compilation: &mut Compilation) {
       unreachable!("entry_chunk and new_chunk should both exist")
     };
 
+    // Name the split runtime chunk after its entrypoint (like webpack's
+    // `optimization.runtimeChunk` which names it `runtime~<entry>`). Without a
+    // name it falls back to its numeric chunk id, and two compilations that
+    // share an output directory (e.g. multiple rslib libs) can both emit the
+    // same `<id>.js` and clobber each other.
+    let runtime_chunk_name = entry_chunk.name().map(|name| format!("{name}_runtime"));
     new_chunk.set_runtime(entry_chunk.runtime().clone());
     new_chunk.add_id_name_hints("runtime".to_string());
+    if let Some(runtime_chunk_name) = runtime_chunk_name {
+      new_chunk.set_name(Some(runtime_chunk_name));
+    }
     new_chunk.set_prevent_integration(true);
     new_chunk.add_group(entrypoint_ukey);
   }

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/a.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/a.js
@@ -1,0 +1,3 @@
+import dep from './dep.cjs';
+export const a = dep.value;
+export const loadAsync = () => import('./async-a.js');

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/async-a.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/async-a.js
@@ -1,0 +1,1 @@
+export const valueA = 'a';

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/async-b.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/async-b.js
@@ -1,0 +1,1 @@
+export const valueB = 'b';

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/b.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/b.js
@@ -1,0 +1,3 @@
+import dep from './dep.cjs';
+export const b = dep.value;
+export const loadAsync = () => import('./async-b.js');

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/dep.cjs
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/dep.cjs
@@ -1,0 +1,1 @@
+module.exports = { value: 1 };

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/index.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/index.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+it('names the split runtime chunk after its entry to avoid cross-lib collisions', () => {
+	const files = fs.readdirSync(__dirname);
+
+	// Each entry's runtime chunk is named after the entry, so two libs that share
+	// this output directory cannot both emit the same `<id>.js` and clobber each
+	// other (see https://github.com/web-infra-dev/rspack/pull/14508).
+	expect(files).toContain('a_runtime.js');
+	expect(files).toContain('b_runtime.js');
+
+	// no bare id-named chunk remains that two libs could collide on
+	expect(files.some((f) => /^\d+\.js$/.test(f))).toBe(false);
+});

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/rspack.config.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/rspack.config.js
@@ -1,0 +1,35 @@
+const rspack = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+const basic = {
+  output: {
+    filename: '[name].js',
+    module: true,
+    library: {
+      type: 'modern-module',
+    },
+  },
+  plugins: [new rspack.experiments.RslibPlugin()],
+  optimization: {
+    concatenateModules: true,
+    avoidEntryIife: true,
+    minimize: false,
+    // Force the esm-library's own runtime split (the rslib scenario) instead of
+    // the test harness default `runtimeChunk: { name: 'runtime~<index>' }`.
+    runtimeChunk: false,
+  },
+};
+
+// Two libs share one output directory. Each pulls in a CommonJS dep (cannot be
+// scope-hoisted, so the runtime registers it via `__webpack_require__.add`) and
+// a dynamic import (so the runtime is split into a separate *initial* chunk).
+// That runtime chunk must be named after its entry, otherwise it falls back to
+// a numeric id and the two libs collide on the same `<id>.js`.
+module.exports = [
+  { entry: { a: './a.js' }, ...basic },
+  { entry: { b: './b.js' }, ...basic },
+  {
+    entry: { index: './index.js' },
+    output: { module: true, filename: 'index.mjs' },
+  },
+];

--- a/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/test.config.js
+++ b/tests/rspack-test/configCases/library/modern-module-runtime-chunk-naming/test.config.js
@@ -1,0 +1,4 @@
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
+module.exports = {
+	findBundle: () => ['index.mjs'],
+};

--- a/tests/rspack-test/esmOutputCases/basic/split-runtime-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/split-runtime-chunk/__snapshots__/esm.snap.txt
@@ -1,5 +1,5 @@
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
+import { __webpack_require__ } from "./main_runtime.mjs";
 import "./other.mjs";
 
 // ./index.js
@@ -13,24 +13,7 @@ export {};
 
 ```
 
-```mjs title=other.mjs
-import { __webpack_require__ } from "./runtime.mjs";
-
-__webpack_require__.add({
-"./other.js"
-/*!******************!*\
-  !*** ./other.js ***!
-  \******************/
-(__unused_rspack_module, exports) {
-exports.U = () => 42
-
-},
-});
-export {};
-
-```
-
-```mjs title=runtime.mjs
+```mjs title=main_runtime.mjs
 
 var __webpack_modules__ = {};
 // The module cache
@@ -62,5 +45,22 @@ __webpack_require__.add = function registerModules(modules) { Object.assign(__we
 })();
 
 export { __webpack_require__ };
+
+```
+
+```mjs title=other.mjs
+import { __webpack_require__ } from "./main_runtime.mjs";
+
+__webpack_require__.add({
+"./other.js"
+/*!******************!*\
+  !*** ./other.js ***!
+  \******************/
+(__unused_rspack_module, exports) {
+exports.U = () => 42
+
+},
+});
+export {};
 
 ```

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/esm.snap.txt
@@ -1,5 +1,5 @@
 ```mjs title=dynamic.mjs
-import { __webpack_require__ } from "./runtime.mjs";
+import { __webpack_require__ } from "./main_runtime.mjs";
 
 __webpack_require__.add({
 "./dynamic.js"
@@ -34,7 +34,7 @@ export default dynamic_default_0;
 ```
 
 ```mjs title=main.mjs
-import { __webpack_require__ } from "./runtime.mjs";
+import { __webpack_require__ } from "./main_runtime.mjs";
 
 // ./index.js
 it("should split runtime for Promise.all with external and bundled async chunks", async () => {
@@ -51,7 +51,7 @@ export {};
 
 ```
 
-```mjs title=runtime.mjs
+```mjs title=main_runtime.mjs
 
 var __webpack_modules__ = {};
 // The module cache

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/test.config.js
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/test.config.js
@@ -8,12 +8,12 @@ module.exports = {
 
 		const entry = readAsset("main.mjs");
 		const dynamic = readAsset("dynamic.mjs");
-		const runtime = readAsset("runtime.mjs");
+		const runtime = readAsset("main_runtime.mjs");
 
 		expect(fs.existsSync(path.join(options.output.path, "index_js.mjs"))).toBe(
 			false,
 		);
-		expect(entry).toContain('import { __webpack_require__ } from "./runtime.mjs";');
+		expect(entry).toContain('import { __webpack_require__ } from "./main_runtime.mjs";');
 		expect(entry).toContain("Promise.all");
 		expect(entry).toContain(
 			'__webpack_require__.t(module.createRequire(import.meta.url)("node:stream"), 22)'
@@ -23,6 +23,6 @@ module.exports = {
 		expect(entry).not.toContain("export { __webpack_require__");
 		expect(entry).not.toContain("as __webpack_require__");
 		expect(dynamic).not.toContain('from "./main.mjs"');
-		expect(dynamic).toContain('import { __webpack_require__ } from "./runtime.mjs";');
+		expect(dynamic).toContain('import { __webpack_require__ } from "./main_runtime.mjs";');
 	},
 };


### PR DESCRIPTION
## Why

CI flakily fails on Linux with nearly every test crashing on the self-built `@rspack/core`:

```
packages/rspack/dist/index.js
__webpack_require__.add({  →  TypeError: __webpack_require__.add is not a function
```

rslib builds `@rspack/core` as several libraries into one shared `dist/`. The esm-library (`optimize_runtime_chunks`) splits each lib's runtime into a separate chunk but leaves it **unnamed**, so its filename falls back to the numeric chunk id. The `index` lib and the `worker` lib both produce `dist/612.js` — with different content (only `index`'s defines `__webpack_require__.add`). The libs build concurrently, so the two writes to `dist/612.js` race; when `worker`'s wins, `index.js` imports a runtime without `.add` and everything importing `@rspack/core` crashes.

webpack names its runtime chunk `runtime~<entry>` (unique per entry); the esm-library's split just forgot to name it.

Example failing job: https://github.com/web-infra-dev/rspack/actions/runs/27828246494/job/82359330267

## What

Name the split runtime chunk after its entrypoint so it can't collide across libs sharing a directory.

| two modern-module libs → one `dist/` | index runtime | worker runtime |
|---|---|---|
| before | `612.js` | `612.js` ← collide |
| after | `index_runtime.js` | `worker_runtime.js` |

Test: `configCases/library/modern-module-runtime-chunk-naming` — two libs sharing a dir both emitted `612.js` before, now emit `a_runtime.js` / `b_runtime.js` (red without the fix, green with it).