### PR TITLE
docs: fix entry config docs

### DIFF
--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -199,7 +199,7 @@ The baseURI of the resource referenced by this entry.
 #### EntryDescription.filename
 
 <PropertyType
-  type="string"
+  type="string | ((pathData: PathData, assetInfo?: AssetInfo) => string)"
   defaultValueList={[{ defaultValue: 'undefined' }]}
 />
 
@@ -224,13 +224,13 @@ The entry that the current entry depends on. With `dependOn` option you can shar
 #### EntryDescription.wasmLoading
 
 <PropertyType
-  type="'fetch' | 'async-node'"
+  type="false | 'fetch' | 'async-node' | 'universal'"
   defaultValueList={[{ defaultValue: 'undefined' }]}
 />
 
-Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/WebWorker), `'async-node'` (Node.js), but others might be added by plugins.
+Option to set the method of loading WebAssembly Modules for this entry. When omitted, the value of [`output.wasmLoading`](/config/output#outputwasmloading) is used.
 
-The default value can be affected by different [target](/config/target):
+The default value of [`output.wasmLoading`](/config/output#outputwasmloading) can be affected by different [target](/config/target):
 
 - Defaults to `'fetch'` if target is set to `'web'`, `'webworker'`, `'electron-renderer'` or `'node-webkit'`.
 - Defaults to `'async-node'` if target is set to `'node'`, `'async-node'`, `'electron-main'` or `'electron-preload'`.

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -199,7 +199,7 @@ export default {
 #### EntryDescription.filename
 
 <PropertyType
-  type="string"
+  type="string | ((pathData: PathData, assetInfo?: AssetInfo) => string)"
   defaultValueList={[{ defaultValue: 'undefined' }]}
 />
 
@@ -224,13 +224,13 @@ export default {
 #### EntryDescription.wasmLoading
 
 <PropertyType
-  type="'fetch' | 'async-node'"
+  type="false | 'fetch' | 'async-node' | 'universal'"
   defaultValueList={[{ defaultValue: 'undefined' }]}
 />
 
-设置当前入口加载 WebAssembly 模块的方式。默认可使用的方式有 `'fetch'`（web/WebWorker），`'async-node'`（Node.js），其他额外方式可由插件提供。
+设置当前入口加载 WebAssembly 模块的方式。省略时使用 [`output.wasmLoading`](/config/output#outputwasmloading) 的值。
 
-其默认值会根据 [target](/config/target) 的变化而变化：
+[`output.wasmLoading`](/config/output#outputwasmloading) 的默认值会根据 [target](/config/target) 的变化而变化：
 
 - 如果 target 设置为 `'web'`，`'webworker'`，`'electron-renderer'` 或 `'node-webkit'` 其中之一，其默认值为 `'fetch'`。
 - 如果 target 设置为 `'node'`，`'async-node'`，`'electron-main'` 或 `'electron-preload'`，其默认值为 `'async-node'`。


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese `entry` config docs to match the current `EntryDescription` types. `EntryDescription.filename` now documents the callback form, and `EntryDescription.wasmLoading` is aligned with the runtime-supported wasm loading modes from the merged type fix.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).