### PR TITLE
docs: fix module config types

### DIFF
--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -245,7 +245,7 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-beta.1" />
 
-- **Type:** `string`
+- **Type:** [`Condition`](#condition)
 - **Default:** `undefined`
 
 Matches all modules that match this resource, and will match against layer of the module that issued the current module.
@@ -660,11 +660,17 @@ There are two phases that all loaders enter one after the other:
 
 ## rules[].type
 
-- **Type:**
+- **Type:** `string`
+
+Common built-in values:
 
 ```ts
-type RuleType =
+type BuiltinRuleType =
   | 'asset'
+  | 'asset/source'
+  | 'asset/resource'
+  | 'asset/inline'
+  | 'asset/bytes'
   | 'css'
   | 'css/auto'
   | 'css/global'
@@ -741,6 +747,15 @@ type RuleSetUse =
   | RuleSetUseItem
   | RuleSetUseItem[]
   | ((ctx: RawFuncUseCtx) => RuleSetUseItem[]);
+
+type RuleSetUseItem = string | RuleSetLoaderWithOptions;
+
+type RuleSetLoaderWithOptions = {
+  ident?: string;
+  loader: string;
+  options?: string | Record<string, any>;
+  parallel?: boolean | { maxWorkers?: number };
+};
 ```
 
 An array to pass the Loader package name and its options. `string[]` e.g.: `use: ['svgr-loader']` is shorthand for `use: [ { loader: 'svgr-loader' } ]`.

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -62,7 +62,16 @@ Use `module.generator` to define output generation options for each module type,
 
 ## module.noParse
 
-- **Type:** `string | RegExp | ((request: string) => boolean) | (string | RegExp | ((request: string) => boolean))[]`
+- **Type:**
+
+```ts
+type NoParseOption =
+  | string
+  | RegExp
+  | ((request: string) => boolean)
+  | (string | RegExp | ((request: string) => boolean))[];
+```
+
 - **Default:** `undefined`
 
 Keep module mechanism of the matched modules as-is, such as `module.exports`, `require`, `import`.

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -15,7 +15,7 @@ Used to decide how to handle different types of modules in a project.
 
 ## module.defaultRules
 
-- **Type:** `(Rule | Falsy)[]`
+- **Type:** `('...' | Rule | Falsy)[]`
 
 `defaultRules` configures the built-in module resolution and processing rules that Rspack enables by default. These rules are applied automatically to ensure that common resource types such as JavaScript, JSON, CSS, and Wasm can be correctly resolved and bundled.
 
@@ -62,7 +62,7 @@ Use `module.generator` to define output generation options for each module type,
 
 ## module.noParse
 
-- **Type:** `string | string[] | RegExp | RegExp[] | ((request: string) => boolean)`
+- **Type:** `string | RegExp | ((request: string) => boolean) | (string | RegExp | ((request: string) => boolean))[]`
 - **Default:** `undefined`
 
 Keep module mechanism of the matched modules as-is, such as `module.exports`, `require`, `import`.

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -245,7 +245,7 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-beta.1" />
 
-- **Type:** `string`
+- **类型：** [`Condition`](#condition)
 - **默认值：** `undefined`
 
 匹配所有符合这个资源的模块，会与"引入当前模块"的模块的 layer 进行匹配。
@@ -658,11 +658,17 @@ export default {
 
 ## rules[].type
 
-- **类型：**
+- **类型：** `string`
+
+常见的内置值：
 
 ```ts
-type RuleType =
+type BuiltinRuleType =
   | 'asset'
+  | 'asset/source'
+  | 'asset/resource'
+  | 'asset/inline'
+  | 'asset/bytes'
   | 'css'
   | 'css/auto'
   | 'css/global'
@@ -740,6 +746,15 @@ type RuleSetUse =
   | RuleSetUseItem
   | RuleSetUseItem[]
   | ((ctx: RawFuncUseCtx) => RuleSetUseItem[]);
+
+type RuleSetUseItem = string | RuleSetLoaderWithOptions;
+
+type RuleSetLoaderWithOptions = {
+  ident?: string;
+  loader: string;
+  options?: string | Record<string, any>;
+  parallel?: boolean | { maxWorkers?: number };
+};
 ```
 
 用于传递 Loader 包名与其选项的数组。`string[]` 如: `use: ['svgr-loader']` 是 `use: [ { loader: 'svgr-loader' } ]` 的简写。Loader 会按照从右到左的顺序执行。

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -62,7 +62,16 @@ export default {
 
 ## module.noParse
 
-- **类型：** `string | RegExp | ((request: string) => boolean) | (string | RegExp | ((request: string) => boolean))[]`
+- **类型：**
+
+```ts
+type NoParseOption =
+  | string
+  | RegExp
+  | ((request: string) => boolean)
+  | (string | RegExp | ((request: string) => boolean))[];
+```
+
 - **默认值：** `undefined`
 
 匹配的文件代码不会被 Rspack 转换，包括 `module.exports`, `require`, `import` 这些模块系统相关的语法。

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -15,7 +15,7 @@ import WebpackLicense from '@components/WebpackLicense';
 
 ## module.defaultRules
 
-- **类型：** `(Rule | Falsy)[]`
+- **类型：** `('...' | Rule | Falsy)[]`
 
 `defaultRules` 用于配置 Rspack 在内部默认启用的模块解析与处理规则。这些规则是自动生效的，用于确保常见资源类型（如 JavaScript、JSON、CSS、Wasm 等）能够被正常解析和打包。
 
@@ -62,7 +62,7 @@ export default {
 
 ## module.noParse
 
-- **类型：** `string | string[] | RegExp | RegExp[] | ((request: string) => boolean)`
+- **类型：** `string | RegExp | ((request: string) => boolean) | (string | RegExp | ((request: string) => boolean))[]`
 - **默认值：** `undefined`
 
 匹配的文件代码不会被 Rspack 转换，包括 `module.exports`, `require`, `import` 这些模块系统相关的语法。


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese `module` and `module.rules` config docs to match the current TypeScript implementation. It corrects `defaultRules`, `noParse`, `issuerLayer`, `type`, and `use` type documentation, including the `ident` and `parallel` fields on loader objects.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).