### PR TITLE
docs: fix resolve config types

### DIFF
--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -14,7 +14,12 @@ Used to configure the Rspack module resolution logic.
 
 ## resolve.alias
 
-- **Type:** `Record<string, false | string | (string | false)[]>`
+- **Type:**
+
+```ts
+type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
+```
+
 - **Default:** `{}`
 
 Path alias, e.g.
@@ -368,7 +373,12 @@ export default {
 
 ## resolve.fallback
 
-- **Type:** `Record<string, false | string>`
+- **Type:**
+
+```ts
+type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
+```
+
 - **Default:** `{}`
 
 Redirect module requests when normal resolving fails.

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -49,6 +49,18 @@ When you use `resolve.alias` to redirect a package import (for example, `import 
 If you want packages within a monorepo to retain the same resolution behavior as regular npm packages, avoid using `alias` to point a package name directly to its source directory.
 The recommended approach is to use your package manager's workspace feature to symlink sub-packages into `node_modules`, so they can be resolved just like normal dependencies.
 
+### Disable aliases
+
+Set `resolve.alias` to `false` to clear all aliases from the merged resolve options. This is different from leaving it `undefined` or setting it to `{}`, which does not add aliases but still keeps aliases merged from other resolve options.
+
+```js title="rspack.config.mjs"
+export default {
+  resolve: {
+    alias: false,
+  },
+};
+```
+
 ## resolve.aliasFields
 
 - **Type:** `string[]`

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -376,7 +376,9 @@ export default {
 - **Type:**
 
 ```ts
-type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
+type ResolveFallback =
+  | false
+  | Record<string, false | string | (false | string)[]>;
 ```
 
 - **Default:** `{}`

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -376,7 +376,9 @@ export default {
 - **类型：**
 
 ```ts
-type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
+type ResolveFallback =
+  | false
+  | Record<string, false | string | (false | string)[]>;
 ```
 
 - **默认值：** `{}`

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -14,7 +14,12 @@ import WebpackLicense from '@components/WebpackLicense';
 
 ## resolve.alias
 
-- **类型：** `Record<string, false | string | (string | false)[]>`
+- **类型：**
+
+```ts
+type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
+```
+
 - **默认值：** `{}`
 
 路径别名，例如：
@@ -368,7 +373,12 @@ export default {
 
 ## resolve.fallback
 
-- **类型：** `Record<string, false | string>`
+- **类型：**
+
+```ts
+type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
+```
+
 - **默认值：** `{}`
 
 当常规解析失败时重定向模块请求。

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -49,6 +49,18 @@ type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
 如果希望 monorepo 中的各个包依然保持和正常 npm 包一致的解析方式，不建议通过 `alias` 将包名直接指向源码目录。
 推荐的做法是使用包管理器的工作区功能，将子包符号链接到 `node_modules` 中，让它们像普通依赖一样被解析。
 
+### 禁用别名
+
+将 `resolve.alias` 设置为 `false` 会清空合并后的 resolve 选项中的所有别名。它不同于不配置 `resolve.alias` 或设置为 `{}`，后者只是不会新增别名，不会清除从其他 resolve 选项合并来的别名。
+
+```js title="rspack.config.mjs"
+export default {
+  resolve: {
+    alias: false,
+  },
+};
+```
+
 ## resolve.aliasFields
 
 - **类型：** `string[]`


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese `resolve` config docs to match the current `ResolveOptions` implementation:

- `resolve.alias` now documents that the whole alias map can be `false`.
- `resolve.alias` adds a dedicated section explaining that `false` clears aliases from merged resolve options, unlike `undefined` or `{}`.
- `resolve.fallback` now documents the same supported value shape with a fallback-specific type name, including `false` for the whole map and array values for entries.
- `resolveLoader` continues to reference the same `resolve` option type, so it inherits the corrected docs.

## Testing

- `node_modules/.bin/prettier --check website/docs/en/config/resolve.mdx website/docs/zh/config/resolve.mdx`
- `git diff --check`
- commit hook: `pnpm --dir website run check:spell`