### PR TITLE
docs: fix stats config types

### DIFF
--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -313,11 +313,9 @@ Whether to display information about runtime modules.
 
 > The runtime modules are built-in modules of Rspack, used to provide various runtime capabilities.
 
-### stats.runtime
-
-<PropertyType type="boolean" />
-
-Compatibility shorthand for `stats.runtimeModules`. It only takes effect when `stats.runtimeModules` is not specified; if both are set, `stats.runtimeModules` takes precedence.
+:::tip
+`stats.runtime` is a compatibility alias for `stats.runtimeModules`. It only takes effect when `stats.runtimeModules` is not specified; if both are set, `stats.runtimeModules` takes precedence.
+:::
 
 ### stats.cachedModules
 
@@ -325,11 +323,9 @@ Compatibility shorthand for `stats.runtimeModules`. It only takes effect when `s
 
 Whether to display information about cached (not built) modules.
 
-### stats.cached
-
-<PropertyType type="boolean" />
-
-Compatibility shorthand for `stats.cachedModules`. It only takes effect when `stats.cachedModules` is not specified; if both are set, `stats.cachedModules` takes precedence.
+:::tip
+`stats.cached` is a compatibility alias for `stats.cachedModules`. It only takes effect when `stats.cachedModules` is not specified; if both are set, `stats.cachedModules` takes precedence.
+:::
 
 ### stats.excludeModules
 

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -317,7 +317,7 @@ Whether to display information about runtime modules.
 
 <PropertyType type="boolean" />
 
-Fallback value for `stats.runtimeModules` when `stats.runtimeModules` is not specified.
+Compatibility shorthand for `stats.runtimeModules`. It only takes effect when `stats.runtimeModules` is not specified; if both are set, `stats.runtimeModules` takes precedence.
 
 ### stats.cachedModules
 
@@ -329,7 +329,7 @@ Whether to display information about cached (not built) modules.
 
 <PropertyType type="boolean" />
 
-Fallback value for `stats.cachedModules` when `stats.cachedModules` is not specified.
+Compatibility shorthand for `stats.cachedModules`. It only takes effect when `stats.cachedModules` is not specified; if both are set, `stats.cachedModules` takes precedence.
 
 ### stats.excludeModules
 

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -168,6 +168,12 @@ Whether to display information about the built modules to information about the 
 
 How many items of chunk modules should be displayed (groups will be collapsed to fit this space).
 
+### stats.chunkModulesSort
+
+<PropertyType type="string" defaultValueList={[{ defaultValue: '"name"' }]} />
+
+Sort the chunk modules by a given field. All of the [sorting fields](/config/stats#sorting-fields) are allowed to be used. Use `!` prefix in the value to reverse the sort order by a given field.
+
 ### stats.dependentModules
 
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
@@ -307,11 +313,23 @@ Whether to display information about runtime modules.
 
 > The runtime modules are built-in modules of Rspack, used to provide various runtime capabilities.
 
+### stats.runtime
+
+<PropertyType type="boolean" />
+
+Fallback value for `stats.runtimeModules` when `stats.runtimeModules` is not specified.
+
 ### stats.cachedModules
 
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
 
 Whether to display information about cached (not built) modules.
+
+### stats.cached
+
+<PropertyType type="boolean" />
+
+Fallback value for `stats.cachedModules` when `stats.cachedModules` is not specified.
 
 ### stats.excludeModules
 
@@ -333,6 +351,12 @@ Whether to display information about modules nested in other modules (like with 
 <PropertyType type="number" defaultValueList={[{ defaultValue: '10' }]} />
 
 How many items of nested modules should be displayed (groups will be collapsed to fit this space).
+
+### stats.nestedModulesSort
+
+<PropertyType type="string" />
+
+Sort the nested modules by a given field. All of the [sorting fields](/config/stats#sorting-fields) are allowed to be used. Use `!` prefix in the value to reverse the sort order by a given field.
 
 ## Module grouping options
 
@@ -493,11 +517,26 @@ Whether to display stack traces in the logging output for errors, warnings and t
 
 ### stats.colors
 
-<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
+- **Type:**
+
+```ts
+type StatsColorOptions = {
+  bold?: string;
+  cyan?: string;
+  green?: string;
+  magenta?: string;
+  red?: string;
+  yellow?: string;
+};
+
+type StatsColors = boolean | StatsColorOptions;
+```
+
+- **Default:** environment-dependent
 
 Whether to output in the different colors.
 
-Defaults to `true` when executing `rspack build` in an environment that supports color output.
+When an object is provided, it customizes the ANSI escape sequences used for each supported color. By default, Rspack enables colors when the current environment supports color output.
 
 ## Compilation options
 
@@ -524,12 +563,6 @@ Whether to display the build date and the build time information.
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
 
 Whether to add information about the Rspack version used.
-
-### stats.context
-
-<PropertyType type="string" />
-
-Whether to display the [base directory](/config/context) as an absolute path for shortening the module specifier.
 
 ### stats.publicPath
 

--- a/website/docs/zh/config/stats.mdx
+++ b/website/docs/zh/config/stats.mdx
@@ -313,11 +313,9 @@ type Stats = boolean | StatsOptions | StatsPresets;
 
 > 运行时模块为 Rspack 内置模块，用于提供各种运行时能力。
 
-### stats.runtime
-
-<PropertyType type="boolean" />
-
-`stats.runtimeModules` 的兼容性简写。只有在没有指定 `stats.runtimeModules` 时才会生效；如果两者都设置，以 `stats.runtimeModules` 为准。
+:::tip
+`stats.runtime` 是 `stats.runtimeModules` 的兼容性别名。只有在没有指定 `stats.runtimeModules` 时才会生效；如果两者都设置，以 `stats.runtimeModules` 为准。
+:::
 
 ### stats.cachedModules
 
@@ -325,11 +323,9 @@ type Stats = boolean | StatsOptions | StatsPresets;
 
 是否展示被缓存的模块。
 
-### stats.cached
-
-<PropertyType type="boolean" />
-
-`stats.cachedModules` 的兼容性简写。只有在没有指定 `stats.cachedModules` 时才会生效；如果两者都设置，以 `stats.cachedModules` 为准。
+:::tip
+`stats.cached` 是 `stats.cachedModules` 的兼容性别名。只有在没有指定 `stats.cachedModules` 时才会生效；如果两者都设置，以 `stats.cachedModules` 为准。
+:::
 
 ### stats.excludeModules
 

--- a/website/docs/zh/config/stats.mdx
+++ b/website/docs/zh/config/stats.mdx
@@ -317,7 +317,7 @@ type Stats = boolean | StatsOptions | StatsPresets;
 
 <PropertyType type="boolean" />
 
-当没有指定 `stats.runtimeModules` 时，作为 `stats.runtimeModules` 的兜底值。
+`stats.runtimeModules` 的兼容性简写。只有在没有指定 `stats.runtimeModules` 时才会生效；如果两者都设置，以 `stats.runtimeModules` 为准。
 
 ### stats.cachedModules
 
@@ -329,7 +329,7 @@ type Stats = boolean | StatsOptions | StatsPresets;
 
 <PropertyType type="boolean" />
 
-当没有指定 `stats.cachedModules` 时，作为 `stats.cachedModules` 的兜底值。
+`stats.cachedModules` 的兼容性简写。只有在没有指定 `stats.cachedModules` 时才会生效；如果两者都设置，以 `stats.cachedModules` 为准。
 
 ### stats.excludeModules
 

--- a/website/docs/zh/config/stats.mdx
+++ b/website/docs/zh/config/stats.mdx
@@ -168,6 +168,12 @@ type Stats = boolean | StatsOptions | StatsPresets;
 
 展示的 Chunk 内模块数量（超过的部分将以分组方式折叠）。
 
+### stats.chunkModulesSort
+
+<PropertyType type="string" defaultValueList={[{ defaultValue: '"name"' }]} />
+
+基于指定的字段对 Chunk 内模块排序。可用的排序字段见[字段排序](/config/stats#字段排序)。使用 `!` 作为前缀可以反转排序结果。
+
 ### stats.dependentModules
 
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
@@ -307,11 +313,23 @@ type Stats = boolean | StatsOptions | StatsPresets;
 
 > 运行时模块为 Rspack 内置模块，用于提供各种运行时能力。
 
+### stats.runtime
+
+<PropertyType type="boolean" />
+
+当没有指定 `stats.runtimeModules` 时，作为 `stats.runtimeModules` 的兜底值。
+
 ### stats.cachedModules
 
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
 
 是否展示被缓存的模块。
+
+### stats.cached
+
+<PropertyType type="boolean" />
+
+当没有指定 `stats.cachedModules` 时，作为 `stats.cachedModules` 的兜底值。
 
 ### stats.excludeModules
 
@@ -333,6 +351,12 @@ type Stats = boolean | StatsOptions | StatsPresets;
 <PropertyType type="number" defaultValueList={[{ defaultValue: '10' }]} />
 
 展示的被嵌套模块数量（超过的部分将以分组方式折叠）。
+
+### stats.nestedModulesSort
+
+<PropertyType type="string" />
+
+基于指定的字段对嵌套模块排序。可用的排序字段见[字段排序](/config/stats#字段排序)。使用 `!` 作为前缀可以反转排序结果。
 
 ## 模块分组选项
 
@@ -493,11 +517,26 @@ export default {
 
 ### stats.colors
 
-<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
+- **类型：**
+
+```ts
+type StatsColorOptions = {
+  bold?: string;
+  cyan?: string;
+  green?: string;
+  magenta?: string;
+  red?: string;
+  yellow?: string;
+};
+
+type StatsColors = boolean | StatsColorOptions;
+```
+
+- **默认值：** 根据当前环境决定
 
 是否在展示日志时添加颜色。
 
-在支持颜色输出的环境中执行 `rspack build` 时，它被默认设置为 `true`。
+当传入对象时，可以自定义每种支持颜色使用的 ANSI 转义序列。默认情况下，Rspack 会在当前环境支持颜色输出时启用颜色。
 
 ## Compilation 选项
 
@@ -524,12 +563,6 @@ export default {
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
 
 是否展示 Rspack 的版本号。
-
-### stats.context
-
-<PropertyType type="string" />
-
-是否展示构建的 [基础目录](/config/context) 为绝对路径，可用来缩短模块标识符的长度。
 
 ### stats.publicPath
 


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese `stats` config docs to match the current `StatsOptions` implementation. It documents the missing `chunkModulesSort` and `nestedModulesSort` options, fixes `stats.colors` to show `boolean | StatsColorOptions`, adds tips for the `stats.runtime` and `stats.cached` compatibility aliases under their canonical options, and removes `stats.context` because it is not a public `StatsOptions` field.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).