### PR TITLE
perf(deps): bump camino to 1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
 dependencies = [
  "serde_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ base64-simd     = { version = "0.8.0", default-features = false, features = ["al
 bitflags        = { version = "2.11.1", default-features = false }
 browserslist-rs = { version = "0.19.0", default-features = false }
 bytes           = { version = "1.11.1", default-features = false }
-camino          = { version = "1.2.2", default-features = false }
+camino          = { version = "1.2.3", default-features = false }
 cargo_toml      = { version = "0.22.3", default-features = false }
 cfg-if          = { version = "1.0.4", default-features = false }
 chrono          = { version = "0.4.45", default-features = false }


### PR DESCRIPTION
## Why

[camino 1.2.3](https://github.com/camino-rs/camino/blob/main/CHANGELOG.md) reimplements `<Utf8Path as Hash>::hash`. `Utf8Path` is `#[repr(transparent)]` over `std::path::Path`, so it now delegates straight to `Path::hash`:

```rust
// 1.2.2 — materialize every Utf8Component, hash each
fn hash<H: Hasher>(&self, state: &mut H) {
    for component in self.components() {
        component.hash(state)
    }
}

// 1.2.3 — delegate to std Path::hash (self.0: Path)
#[inline]
fn hash<H: Hasher>(&self, state: &mut H) {
    self.0.hash(state)
}
```

`std::path::Path::hash` is a single optimized byte-scan that is consistent with component-based `PartialEq`, so the `Hash`/`Eq` contract is preserved while per-component materialization is removed.

rspack uses `Utf8PathBuf` as `HashMap`/`DashMap`/`HashSet` keys throughout (`rspack_paths`, identifier / module / dependency maps), so path hashing sits on hot paths.

## Verification

Isolated criterion microbench hashing 9,600 rspack-like absolute paths with `FxHasher` (release, Apple M-series):

| camino | time |
| ------ | ---- |
| 1.2.2  | 654.7 µs |
| 1.2.3  | 371.0 µs |

**−43.7% (p < 0.05)** — a ~1.8x speedup, consistent with the upstream "~2x fewer instructions" note.

Macro impact on the full rspack benches is expected to be small (path hashing is only a fraction of total work); the gain is in per-hash cost. Function-level callgrind on the rspack bench suite can confirm the `<Utf8Path as Hash>::hash` Ir drop if desired.
