### PR TITLE
chore(test): stabilize watch-detection on Windows with synchronous writes

### DIFF
--- a/tests/rspack-test/compilerCases/watch-detection.js
+++ b/tests/rspack-test/compilerCases/watch-detection.js
@@ -72,19 +72,14 @@ function createTestCase(changeTimeout, invalidate) {
               expect(compiler.removedFiles).not.toBe(undefined);
             };
 
-            fs.writeFile(
-              filePath,
-              "require('./file2'); again",
-              "utf-8",
-              handleError
-            );
+            writeFileStep(filePath, "require('./file2'); again");
 
             setTimeout(step3, changeTimeout);
           }
 
           function step3() {
             if (invalidate) watcher.invalidate();
-            fs.writeFile(file2Path, "wrong", "utf-8", handleError);
+            writeFileStep(file2Path, "wrong");
 
             setTimeout(step4, changeTimeout);
           }
@@ -102,7 +97,7 @@ function createTestCase(changeTimeout, invalidate) {
                 step5();
             };
 
-            fs.writeFile(file2Path, "correct", "utf-8", handleError);
+            writeFileStep(file2Path, "correct");
           }
 
           function step5() {
@@ -113,8 +108,12 @@ function createTestCase(changeTimeout, invalidate) {
             });
           }
 
-          function handleError(err) {
-            if (err) reject(err);
+          function writeFileStep(file, content) {
+            try {
+              fs.writeFileSync(file, content, "utf-8");
+            } catch (err) {
+              reject(err);
+            }
           }
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
## Why

`compilerCases/watch-detection` is flaky on Windows CI (e.g. [run 27419342276](https://github.com/web-infra-dev/rspack/actions/runs/27419342276/job/81042400021)): the `time between changes 10ms` case times out at 60s and all 3 retries fail too.

Root cause: steps 3 and 4 rewrite the same `file2.js` (`"wrong"` → `"correct"`) 10ms apart using async `fs.writeFile`. On a slow Windows runner the two async writes can complete out of order, leaving `"wrong"` as the final on-disk state. The test then waits forever for a bundle containing `"correct"` and times out.

## What

Make the step writes synchronous (`fs.writeFileSync`) so write ordering is deterministic. Behaviour is otherwise unchanged — errors still reject the build promise.

> Draft: kept open for Windows CI stress before review.