### PR TITLE
docs: document dev server options

### DIFF
--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -502,7 +502,7 @@ Specifying local-ipv6 as host will try to resolve the host option as your local 
 
 Listen on an IPC socket instead of a host and port.
 
-When set to `true`, `@rspack/dev-server` uses a default socket path named `webpack-dev-server.sock` in the operating system temporary directory, or a Windows named pipe path on Windows. When set to a string, that string is used as the custom socket path.
+When set to `true`, `@rspack/dev-server` uses a default socket path named `rspack-dev-server.sock` in the operating system temporary directory, or a Windows named pipe path on Windows. When set to a string, that string is used as the custom socket path.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -74,6 +74,30 @@ export default {
 };
 ```
 
+## devServer.app
+
+- **Type:**
+
+```ts
+type DevServerApp = () => Promise<ConnectApplication>;
+```
+
+- **Default:** a [`connect-next`](https://github.com/rstackjs/connect-next) app
+
+Provide a custom application instance for the dev server middleware stack.
+
+By default, `@rspack/dev-server` creates a `connect-next` app. If you need Express-only APIs such as `app.get()`, `app.post()`, or `res.send()`, provide your own Express app explicitly:
+
+```js title="rspack.config.mjs"
+import express from 'express';
+
+export default {
+  devServer: {
+    app: async () => express(),
+  },
+};
+```
+
 ## devServer.client
 
 - **Type:** `object`
@@ -471,6 +495,33 @@ Specifying `local-ipv4` as host will try to resolve the host option as your loca
 
 Specifying local-ipv6 as host will try to resolve the host option as your local IPv6 address.
 
+## devServer.ipc
+
+- **Type:** `boolean | string`
+- **Default:** `undefined`
+
+Listen on an IPC socket instead of a host and port.
+
+When set to `true`, `@rspack/dev-server` uses a default socket path named `webpack-dev-server.sock` in the operating system temporary directory, or a Windows named pipe path on Windows. When set to a string, that string is used as the custom socket path.
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    ipc: true,
+  },
+};
+```
+
+Use a custom socket path:
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    ipc: '/tmp/rspack-dev-server.sock',
+  },
+};
+```
+
 ## devServer.hot
 
 - **Type:** `boolean | 'only'`
@@ -837,6 +888,23 @@ module.exports = {
   </Tab>
 </Tabs>
 
+## devServer.setupExitSignals
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether `@rspack/dev-server` registers `SIGINT` and `SIGTERM` handlers to gracefully stop the dev server and close the compiler before exiting the process.
+
+Set it to `false` when another process manager or test runner owns signal handling.
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    setupExitSignals: false,
+  },
+};
+```
+
 ## devServer.setupMiddlewares
 
 - **Type:** `function (middlewares, devServer)`
@@ -882,18 +950,6 @@ export default {
 
       return middlewares;
     },
-  },
-};
-```
-
-By default, `@rspack/dev-server` creates a [`connect-next`](https://github.com/rstackjs/connect-next) app. If you need Express-only APIs, provide your own app explicitly:
-
-```js title="rspack.config.mjs"
-import express from 'express';
-
-export default {
-  devServer: {
-    app: async () => express(),
   },
 };
 ```

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -74,6 +74,30 @@ export default {
 };
 ```
 
+## devServer.app
+
+- **类型：**
+
+```ts
+type DevServerApp = () => Promise<ConnectApplication>;
+```
+
+- **默认值：** [`connect-next`](https://github.com/rstackjs/connect-next) 应用
+
+为开发服务器的中间件栈提供自定义应用实例。
+
+默认情况下，`@rspack/dev-server` 会创建 `connect-next` 应用。如果你需要使用 Express 专有 API，例如 `app.get()`、`app.post()` 或 `res.send()`，请显式提供你自己的 Express 应用：
+
+```js title="rspack.config.mjs"
+import express from 'express';
+
+export default {
+  devServer: {
+    app: async () => express(),
+  },
+};
+```
+
 ## devServer.client
 
 - **类型：** `object`
@@ -461,6 +485,33 @@ export default {
 
 将 host 指定为 `local-ipv6` 会尝试将 host 选项解析为你的本地 `IPv6` 地址。
 
+## devServer.ipc
+
+- **类型：** `boolean | string`
+- **默认值：** `undefined`
+
+监听 IPC socket，而不是监听主机名和端口。
+
+设置为 `true` 时，`@rspack/dev-server` 会使用默认 socket 路径：在操作系统临时目录下创建名为 `webpack-dev-server.sock` 的 socket，Windows 上则使用命名管道路径。设置为字符串时，该字符串会作为自定义 socket 路径。
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    ipc: true,
+  },
+};
+```
+
+使用自定义 socket 路径：
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    ipc: '/tmp/rspack-dev-server.sock',
+  },
+};
+```
+
 ## devServer.hot
 
 - **类型：** `boolean | 'only'`
@@ -827,6 +878,23 @@ module.exports = {
   </Tab>
 </Tabs>
 
+## devServer.setupExitSignals
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否让 `@rspack/dev-server` 注册 `SIGINT` 和 `SIGTERM` 处理器，在进程退出前优雅地停止开发服务器并关闭 compiler。
+
+当其他进程管理器或测试运行器负责处理退出信号时，可以将它设置为 `false`。
+
+```js title="rspack.config.mjs"
+export default {
+  devServer: {
+    setupExitSignals: false,
+  },
+};
+```
+
 ## devServer.setupMiddlewares
 
 - **类型：** `function (middlewares, devServer)`
@@ -872,18 +940,6 @@ export default {
 
       return middlewares;
     },
-  },
-};
-```
-
-默认情况下，`@rspack/dev-server` 创建的是 [`connect-next`](https://github.com/rstackjs/connect-next) 应用。如果你需要使用 Express 专有 API，请显式提供你自己的 app：
-
-```js title="rspack.config.mjs"
-import express from 'express';
-
-export default {
-  devServer: {
-    app: async () => express(),
   },
 };
 ```

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -492,7 +492,7 @@ export default {
 
 监听 IPC socket，而不是监听主机名和端口。
 
-设置为 `true` 时，`@rspack/dev-server` 会使用默认 socket 路径：在操作系统临时目录下创建名为 `webpack-dev-server.sock` 的 socket，Windows 上则使用命名管道路径。设置为字符串时，该字符串会作为自定义 socket 路径。
+设置为 `true` 时，`@rspack/dev-server` 会使用默认 socket 路径：在操作系统临时目录下创建名为 `rspack-dev-server.sock` 的 socket，Windows 上则使用命名管道路径。设置为字符串时，该字符串会作为自定义 socket 路径。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR adds docs for `devServer.app`, `devServer.ipc`, and `devServer.setupExitSignals`.

The descriptions are aligned with the current `DevServerOptions` type in `@rspack/core` and the implementation in `@rspack/dev-server`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).