### PR TITLE
fix: normalize options.context to native separators

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -65,6 +65,9 @@ export const applyRspackOptionsDefaults = (
   compilerIndex?: number,
 ) => {
   F(options, 'context', () => process.cwd());
+  // Normalize to native separators so a forward-slash context (e.g. jiti's
+  // `__dirname` on Windows) doesn't yield unmatchable watch paths. See #14446.
+  options.context = path.resolve(options.context!);
   F(options, 'target', () => {
     return getDefaultTarget(options.context!);
   });

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -65,9 +65,6 @@ export const applyRspackOptionsDefaults = (
   compilerIndex?: number,
 ) => {
   F(options, 'context', () => process.cwd());
-  // Normalize to native separators so a forward-slash context (e.g. jiti's
-  // `__dirname` on Windows) doesn't yield unmatchable watch paths. See #14446.
-  // Skip an empty context so it stays invalid for the relative-output-path check.
   if (options.context) {
     options.context = path.resolve(options.context);
   }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -67,7 +67,10 @@ export const applyRspackOptionsDefaults = (
   F(options, 'context', () => process.cwd());
   // Normalize to native separators so a forward-slash context (e.g. jiti's
   // `__dirname` on Windows) doesn't yield unmatchable watch paths. See #14446.
-  options.context = path.resolve(options.context!);
+  // Skip an empty context so it stays invalid for the relative-output-path check.
+  if (options.context) {
+    options.context = path.resolve(options.context);
+  }
   F(options, 'target', () => {
     return getDefaultTarget(options.context!);
   });

--- a/tests/rspack-test/compilerCases/context-normalization.js
+++ b/tests/rspack-test/compilerCases/context-normalization.js
@@ -1,0 +1,54 @@
+const path = require("node:path");
+const rspack = require("@rspack/core");
+
+const close = compiler =>
+	new Promise((resolve, reject) => {
+		compiler.close(error => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+	{
+		description:
+			"should normalize a non-empty context to native separators (#14446)",
+		options(context) {
+			return {
+				context: context.getSource(),
+				output: {
+					path: context.getDist()
+				}
+			};
+		},
+		async check({ context }) {
+			const src = context.getSource();
+
+			const unnormalized = `${src}${path.sep}sub${path.sep}..`;
+			const compiler = rspack({
+				entry: context.getSource("a.js"),
+				context: unnormalized,
+				output: { path: context.getDist() }
+			});
+			expect(compiler.options.context).toBe(path.resolve(unnormalized));
+			expect(compiler.options.context).toBe(src);
+			await close(compiler);
+
+			if (process.platform === "win32") {
+				const forwardSlash = src.replace(/\\/g, "/");
+				const winCompiler = rspack({
+					entry: context.getSource("a.js"),
+					context: forwardSlash,
+					output: { path: context.getDist() }
+				});
+				expect(winCompiler.options.context).toBe(src);
+				expect(winCompiler.options.context).not.toContain("/");
+				await close(winCompiler);
+			}
+		}
+	}
+];


### PR DESCRIPTION
### Why

Fixes #14446 — on Windows, file watching stops after the first change (the dev server keeps running but ignores all later edits). It works on Linux/macOS.

Root cause (confirmed on a Windows runner): the repro's config uses `context: __dirname`, and the rspack CLI loads the config via **jiti**, whose `__dirname` is **forward-slash** on Windows (e.g. `D:/a/project`). rspack only *defaults* `context` and never normalizes a user-provided one, so the forward-slash value becomes the resolver base and the resolver emits **mixed-separator** dependency paths (e.g. `D:/a\project\src\App.tsx`).

watchpack registers file watchers keyed by the raw path but reconstructs incoming OS-event paths via `path.join` (native `\`), so the registered key and the event key differ and the change is dropped:

```
registered: d:/a\project\src\app.tsx   (mixed, from a forward-slash context)
fs event  : d:\a\project\src\app.tsx   (path.join => all backslash)
=> mismatch => change ignored
```

Single-separator platforms (Linux/macOS) are unaffected.

### What

Normalize `options.context` to the OS-native separator in `applyRspackOptionsDefaults` (`path.resolve`), so the resolver base — and therefore every watch dependency path — uses one consistent separator.

```diff
  F(options, 'context', () => process.cwd());
+ options.context = path.resolve(options.context!);
```

No-op on POSIX and for already-native absolute contexts (existing defaults snapshots unchanged).

### Verification

Reproduced and fixed on a real Windows runner (instrumented diagnostics in #14524):

| scenario (Windows) | result |
|---|---|
| `rspack serve`, context as-is | watch stops after 1st change (REPRODUCED) |
| `rspack serve`, context normalized to native sep | every change recompiles (FIXED) |

Workaround for users on current releases: `context: path.resolve(__dirname)`.
