### PR TITLE
perf(ci): drop debuginfo from the whole ci profile

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -101,10 +101,6 @@ jobs:
       - name: Setup Rust Target
         run: rustup target add ${{ inputs.target }}
 
-      - name: Disable debuginfo for Windows CI build
-        if: ${{ runner.os == 'Windows' && inputs.profile == 'ci' }}
-        run: echo "CARGO_PROFILE_CI_DEBUG=false" >> "$GITHUB_ENV"
-
       - name: Run Cargo codegen
         run: cargo codegen
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ opt-level = "s"
 # This is for CI build based on release but with faster build time
 [profile.ci]
 codegen-units = 256
-debug         = "limited"
+debug         = false
 inherits      = "release"
 lto           = false
 ## reduce little optimization to reduce build time


### PR DESCRIPTION
## Why

The `ci` profile builds the binding with `debug = "limited"`. After #14479 only
Windows was overridden to `false`; **Linux / Mac / WASM still embed "limited"
debuginfo into the `.node`**, which inflates the artifact that every test shard
downloads.

`debug` does not affect runtime codegen (profile `inherits = "release"`), so Test
jobs' behavior is unaffected.

## What

- `[profile.ci]` `debug = "limited"` → `debug = false`
- Remove the now-redundant Windows-only `CARGO_PROFILE_CI_DEBUG=false` override
  (#14479). Windows behavior is unchanged (still `false`); the special case is just
  no longer needed once the profile default is `false`.

## Measured — binding `.node` size (deterministic)

Size is reproducible: 3 separate `main` runs all produced **118 / 115 / 25 / 19 MB**.

| job | main | this PR | Δ |
|---|---|---|---|
| Build Linux x86_64 | 118MB | **32MB** | **−86MB (−73%)** |
| Build WASM | 115MB | **40MB** | **−75MB (−65%)** |
| Build Mac ARM64 | 25MB | 23MB | −2MB (−8%) |
| Build Windows | 19MB | 19MB | 0 (already `false`) |

Mac barely moves (macOS splits debuginfo to `.dSYM`, not the `.node`); Windows was
already `false`. The win is Linux/WASM, and it compounds downstream — each test
shard downloads the binding (Linux `[node 20, 24]`, WASM/Mac/Win one each), so the
Linux `.node` alone is uploaded once + downloaded by every Linux test shard at
−86MB each.

## Build time — within runner noise, no claim made

Build-job wall time is dominated by runner/cache variance. Across 8 recent `main`
runs: Linux 331–609s, WASM 332–574s, Mac 331–554s, Win 518–907s — a ±50–80% spread.
This PR's single run (Linux 357s, WASM 340s, Mac 818s, Win 1065s) sits inside that
band, so no reliable wall-time improvement is claimed. The deterministic, repeatable
win is artifact size.

## Trade-off

CI binding panics on Linux/Mac/WASM lose `file:line` backtraces (Windows already
had none). If backtraces matter, `debug = "line-tables-only"` is the middle ground
(keeps `file:line`, much smaller than `"limited"`). Supersedes #14478.
