### PR TITLE
test: probe watcher FS_ACCURACY across macOS / Linux / Windows

### DIFF
--- a/.github/workflows/fs-accuracy-probe.yml
+++ b/.github/workflows/fs-accuracy-probe.yml
@@ -1,0 +1,51 @@
+name: FS Accuracy Probe
+
+# Measures the filesystem mtime accuracy (`FS_ACCURACY`) that each watcher
+# converges to, on macOS / Linux / Windows, for both implementations:
+#   - native watcher: rspack_watcher's real `safe_time`/`ensure_fs_accuracy`
+#   - watchpack: the real `watchpack` package via `getTimeInfoEntries().accuracy`
+# Look for `FS_ACCURACY_PROBE` lines in each job log.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/fs-accuracy-probe.yml'
+      - 'scripts/fs-accuracy-probe/**'
+      - 'crates/rspack_watcher/src/time_info.rs'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Probe (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          key: fs-accuracy-probe
+
+      - name: Probe native watcher (rspack_watcher)
+        run: cargo test -p rspack_watcher probe_fs_accuracy -- --ignored --nocapture
+
+      - name: Setup Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        with:
+          node-version: 20
+
+      - name: Install watchpack
+        working-directory: scripts/fs-accuracy-probe
+        run: npm install --no-audit --no-fund
+
+      - name: Probe watchpack
+        working-directory: scripts/fs-accuracy-probe
+        run: node probe-watchpack.mjs

--- a/crates/rspack_watcher/src/time_info.rs
+++ b/crates/rspack_watcher/src/time_info.rs
@@ -112,4 +112,64 @@ mod tests {
       "future mtime must be clamped to now + accuracy",
     );
   }
+
+  // Empirical probe: writes real files on the host filesystem, feeds their real
+  // mtimes through the production `safe_time`/`ensure_fs_accuracy` ladder, and
+  // prints the FS_ACCURACY the native watcher would converge to on this OS.
+  //
+  // `#[ignore]` so it never runs in normal `cargo test`. MUST be run in
+  // isolation (FS_ACCURACY is a process-global one-way ratchet — other tests in
+  // this binary would pre-narrow it):
+  //   cargo test -p rspack_watcher probe_fs_accuracy -- --ignored --nocapture
+  #[test]
+  #[ignore = "filesystem measurement probe; run explicitly in isolation"]
+  fn probe_fs_accuracy() {
+    use std::{fs, thread, time::Duration};
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let mut mtimes = Vec::new();
+
+    // Spread ~50 distinct files over ~1.1s of wall clock with sub-ms jitter so
+    // their mtimes land on whatever granularity the filesystem actually keeps.
+    for i in 0..50u64 {
+      let path = dir.path().join(format!("probe_{i}.txt"));
+      fs::write(&path, i.to_le_bytes()).expect("write probe file");
+      let mtime = system_time_to_millis(
+        fs::metadata(&path)
+          .and_then(|m| m.modified())
+          .expect("read mtime"),
+      );
+      mtimes.push(mtime);
+      thread::sleep(Duration::from_micros(21_000 + (i * 271) % 900));
+    }
+
+    // Drive the real ladder.
+    for &m in &mtimes {
+      let _ = safe_time(m);
+    }
+    let converged = fs_accuracy();
+
+    // Independent ground truth: the smallest non-zero gap between observed
+    // mtimes is the filesystem's effective tick.
+    let mut sorted: Vec<u64> = mtimes.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let min_delta = sorted
+      .windows(2)
+      .map(|w| w[1] - w[0])
+      .filter(|&d| d > 0)
+      .min()
+      .unwrap_or(0);
+    let non_mult_10 = mtimes.iter().filter(|m| **m % 10 != 0).count();
+    let non_mult_100 = mtimes.iter().filter(|m| **m % 100 != 0).count();
+    let non_mult_1000 = mtimes.iter().filter(|m| **m % 1000 != 0).count();
+
+    println!("FS_ACCURACY_PROBE native os={}", std::env::consts::OS);
+    println!("FS_ACCURACY_PROBE native converged_accuracy_ms={converged}");
+    println!("FS_ACCURACY_PROBE native empirical_min_mtime_delta_ms={min_delta}");
+    println!(
+      "FS_ACCURACY_PROBE native samples=50 distinct={} non_mult_10={non_mult_10} non_mult_100={non_mult_100} non_mult_1000={non_mult_1000}",
+      sorted.len()
+    );
+  }
 }

--- a/scripts/fs-accuracy-probe/package.json
+++ b/scripts/fs-accuracy-probe/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fs-accuracy-probe",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "watchpack": "2.5.1"
+  }
+}

--- a/scripts/fs-accuracy-probe/probe-watchpack.mjs
+++ b/scripts/fs-accuracy-probe/probe-watchpack.mjs
@@ -1,0 +1,71 @@
+// Empirical probe: writes real files, watches them with the *real* watchpack
+// (the same version rspack depends on), then reads the per-entry `accuracy`
+// that watchpack's `ensureFsAccuracy` ladder converged to on this OS.
+//
+// Note: watchpack feeds `+stats.mtime` (integer ms) into the ladder, so its
+// `% 1` branch never fires in practice — the effective floor is 10ms, matching
+// the native (Rust) watcher.
+import Watchpack from 'watchpack';
+import { mkdtempSync, writeFileSync, statSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const COUNT = 50;
+
+const dir = mkdtempSync(join(tmpdir(), 'fs-accuracy-'));
+const files = [];
+
+// Spread files over ~1.1s of wall clock so their mtimes reveal the filesystem's
+// real granularity.
+for (let i = 0; i < COUNT; i++) {
+  const file = join(dir, `probe_${i}.txt`);
+  writeFileSync(file, String(i));
+  files.push(file);
+  await sleep(21 + ((i * 271) % 900) / 1000);
+}
+
+const mtimes = files.map((f) => +statSync(f).mtime);
+
+const wp = new Watchpack({ aggregateTimeout: 100, poll: false });
+
+const aggregated = new Promise((resolve) => wp.once('aggregated', resolve));
+wp.watch({ files, startTime: Date.now() - 10_000 });
+
+// Touch every file once so watchpack rescans and populates time-info entries.
+await sleep(200);
+for (const f of files) appendFileSync(f, '\n');
+
+await Promise.race([aggregated, sleep(3000)]);
+
+const entries = wp.getTimeInfoEntries();
+const accuracies = [];
+for (const f of files) {
+  const entry = entries.get(f);
+  if (entry && typeof entry.accuracy === 'number')
+    accuracies.push(entry.accuracy);
+}
+wp.close();
+
+const converged = accuracies.length ? Math.min(...accuracies) : null;
+
+const sorted = [...new Set(mtimes)].sort((a, b) => a - b);
+let minDelta = 0;
+for (let i = 1; i < sorted.length; i++) {
+  const d = sorted[i] - sorted[i - 1];
+  if (d > 0 && (minDelta === 0 || d < minDelta)) minDelta = d;
+}
+const nonMult10 = mtimes.filter((m) => m % 10 !== 0).length;
+const nonMult100 = mtimes.filter((m) => m % 100 !== 0).length;
+const nonMult1000 = mtimes.filter((m) => m % 1000 !== 0).length;
+
+console.log(`FS_ACCURACY_PROBE watchpack os=${process.platform}`);
+console.log(`FS_ACCURACY_PROBE watchpack converged_accuracy_ms=${converged}`);
+console.log(
+  `FS_ACCURACY_PROBE watchpack empirical_min_mtime_delta_ms=${minDelta}`,
+);
+console.log(
+  `FS_ACCURACY_PROBE watchpack samples=${COUNT} distinct=${sorted.length} entries_with_accuracy=${accuracies.length} non_mult_10=${nonMult10} non_mult_100=${nonMult100} non_mult_1000=${nonMult1000}`,
+);
+
+process.exit(0);


### PR DESCRIPTION
Draft / measurement only — not for merge.

## Why

We want to know the actual filesystem mtime accuracy (`FS_ACCURACY`) that the watcher converges to on each OS, for **both** watcher implementations:

- **native watcher** — `rspack_watcher`'s real `safe_time` / `ensure_fs_accuracy` ladder (`crates/rspack_watcher/src/time_info.rs`)
- **watchpack** — the real `watchpack` package, read via `getTimeInfoEntries().accuracy`

## How

`.github/workflows/fs-accuracy-probe.yml` runs a matrix over `ubuntu-latest`, `macos-latest`, `windows-latest`. Each job writes ~50 real files spread over ~1.1s of wall clock and reports the converged accuracy plus the empirical min mtime delta (ground truth).

- native probe: an `#[ignore]`d test `probe_fs_accuracy` (run in isolation so the process-global `FS_ACCURACY` ratchet stays pristine)
- watchpack probe: `scripts/fs-accuracy-probe/probe-watchpack.mjs`

Read results by grepping `FS_ACCURACY_PROBE` in each job log. Trigger via the workflow_dispatch button or by pushing to this branch.

## Note

watchpack feeds `+stats.mtime` (integer ms) into its ladder, so its `% 1` branch never fires in practice — the effective floor is **10ms**, same as the native watcher. Local macOS run: both converge to **10ms** (empirical min delta ~21ms).