### PR TITLE
ci: upgrade rstack-ecosystem-ci actions to v0.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@3c3f0fed4a68529c2f230f915d079533970426f4 # main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@f0d685b33462055bb07a8a3620b753696ad5f515 # v0.3.3
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@3c3f0fed4a68529c2f230f915d079533970426f4 # main
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@3c3f0fed4a68529c2f230f915d079533970426f4 # main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@f0d685b33462055bb07a8a3620b753696ad5f515 # v0.3.3
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@3c3f0fed4a68529c2f230f915d079533970426f4 # main
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev


### PR DESCRIPTION
## Why

Bump the two `rstackjs/rstack-ecosystem-ci` actions from `0e65507` (v0.3.2) to `f0d685b` (v0.3.3) so our ecosystem-CI integration picks up the latest fixes (notably #61 "push ecosystem history from the downstream workflow").

## What

- `.github/workflows/ci.yml` — `ecosystem_ci_per_commit` → `f0d685b` (v0.3.3)
- `.github/workflows/ecosystem-ci.yml` — `ecosystem_ci_dispatch` → `f0d685b` (v0.3.3)

## PAT permission

The trigger token (`REPO_RSTACK_ECO_CI_GITHUB_TOKEN`) only needs **Actions: Read and write** on `rstackjs/rstack-ecosystem-ci`. **Contents read/write is NOT required** in the PAT setting and can be removed.

Verified by re-running the dispatch after removing Contents from the token — the downstream workflow was still dispatched and waited on successfully.

Reason: the secret token is consumed only by `convictional/trigger-workflow-and-wait` (dispatch = `Actions: write`, poll = `Actions: read`). All PR/commit commenting is performed by the workflow's built-in `GITHUB_TOKEN`, not by this PAT.
