### PR TITLE
fix: default html script loading to module for module output

### DIFF
--- a/packages/rspack/src/builtin-plugin/html-plugin/options.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/options.ts
@@ -57,7 +57,7 @@ export type HtmlRspackPluginOptions = {
    * Modern browsers support non-blocking JavaScript loading ([`defer` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer)) to improve the page startup performance.
    *
    * Setting this option to `'module'` adds attribute `type="module"` to the `script`. This also implies `defer` attribute on the `script`, since modules are automatically deferred.
-   * @default "defer"
+   * @default "module" when `output.module` is enabled, otherwise "defer"
    * */
   scriptLoading?: 'blocking' | 'defer' | 'module' | 'systemjs-module';
 

--- a/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
+++ b/packages/rspack/src/builtin-plugin/html-plugin/plugin.ts
@@ -54,7 +54,8 @@ const HtmlRspackPluginImpl = create(
         };
       }
     }
-    const scriptLoading = c.scriptLoading ?? 'defer';
+    const scriptLoading =
+      c.scriptLoading ?? (this.options.output.module ? 'module' : 'defer');
     const configInject = c.inject ?? true;
     const inject =
       configInject === true

--- a/tests/rspack-test/configCases/builtins/html-inject/index.js
+++ b/tests/rspack-test/configCases/builtins/html-inject/index.js
@@ -38,3 +38,13 @@ it("false-index.html inject", () => {
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
 	expect(htmlContent.includes('<script src="bundle4.js"')).toBe(false);
 });
+
+it("output-module-index.html inject", () => {
+	const htmlPath = path.join(__dirname, "./output-module-index.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(
+		htmlContent.includes(
+			'<script src="bundle5.mjs" type="module"></script></head>'
+		)
+	).toBe(true);
+});

--- a/tests/rspack-test/configCases/builtins/html-inject/rspack.config.js
+++ b/tests/rspack-test/configCases/builtins/html-inject/rspack.config.js
@@ -43,9 +43,6 @@ module.exports = [
     ],
   },
   {
-    experiments: {
-      outputModule: true,
-    },
     output: {
       module: true,
       chunkFormat: 'module',

--- a/tests/rspack-test/configCases/builtins/html-inject/rspack.config.js
+++ b/tests/rspack-test/configCases/builtins/html-inject/rspack.config.js
@@ -42,4 +42,18 @@ module.exports = [
       }),
     ],
   },
+  {
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      module: true,
+      chunkFormat: 'module',
+    },
+    plugins: [
+      new HtmlRspackPlugin({
+        filename: 'output-module-index.html',
+      }),
+    ],
+  },
 ];

--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -250,7 +250,8 @@ type HtmlRspackPluginOptions = {
     {
       name: '`scriptLoading`',
       type: '`"blocking" | "defer" | "module" | "systemjs-module" | undefined`',
-      default: '`"defer"`',
+      default:
+        '`"module"` when `output.module` is enabled, otherwise `"defer"`',
       description:
         'Modern browsers support non-blocking JavaScript loading ([`defer` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer)) to improve the page startup performance. Setting this option to `"module"` adds attribute `type="module"` to the `script`. This also implies `defer` attribute on the `script`, since modules are automatically deferred.',
     },

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -249,7 +249,7 @@ type HtmlRspackPluginOptions = {
     {
       name: '`scriptLoading`',
       type: '`"blocking" | "defer" | "module" | "systemjs-module" | undefined`',
-      default: '`"defer"`',
+      default: '启用 `output.module` 时为 `"module"`，否则为 `"defer"`',
       description:
         '现代浏览器支持使用 `defer` 来异步加载 JavaScript，设置为 `"module"` 则会添加 `type="module"` 同时使用 `defer`',
     },


### PR DESCRIPTION
## Summary

- Default `HtmlRspackPlugin` `scriptLoading` to `module` when `output.module` is enabled.
- Keep the existing `defer` default for non-module output and preserve explicit `scriptLoading` values.
- Add coverage for the generated module script tag and update the English/Chinese plugin docs.

## Testing

- `pnpm run build:js`
- `env RUSTC_WRAPPER= pnpm run build:binding:dev`
- `pnpm run test -t "builtins/html-inject"`

---
_by OpenAI Codex_