### PR TITLE
chore: release version 2.1.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "rspack"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "bitflags 2.11.1",
  "derive_more",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_allocator"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "mimalloc",
  "sftrace-setup",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_benchmark"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_api"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3918,21 +3918,21 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_build"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "napi-build",
 ]
 
 [[package]]
 name = "rspack_binding_builder"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_binding_api",
 ]
 
 [[package]]
 name = "rspack_binding_builder_macros"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_builder_testing"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "napi",
  "napi-derive",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_browserslist"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "browserslist-rs",
  "lightningcss",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "camino",
  "dashmap",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_macros"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_test"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "camino",
  "dashmap",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_collections"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "dashmap",
  "hashlink",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_core"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anymap3",
  "async-recursion",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_error"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_fs"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hash"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "base64-simd 0.8.0",
  "md4",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hook"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_error",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_ids"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_javascript_compiler"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_lightningcss"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_preact_refresh"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_react_refresh"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_runner"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_swc"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "either",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_testing"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_location"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "itoa",
  "memchr",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros_test"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "napi",
  "oneshot",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi_macros"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_node"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "napi-derive",
  "rspack_binding_api",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_parallel"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rayon",
  "rspack_tasks",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_paths"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "camino",
  "dashmap",
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_asset"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "mime_guess",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_banner"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "futures",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_case_sensitive"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "itertools 0.14.0",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_circular_dependencies"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_copy"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4534,7 +4534,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css_chunking"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "indexmap",
  "rspack_collections",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_devtool"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dll"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dynamic_entry"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "atomic_refcell",
  "derive_more",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ensure_chunk_conditions"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_entry"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_esm_library"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_externals"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "regex",
  "rspack_core",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_extract_css"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_hmr"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_html"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
  "atomic_refcell",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ignore"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_javascript"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4818,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_json"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lazy_compilation"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_library"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "futures",
  "regex",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lightning_css_minimizer"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "lightningcss",
  "parcel_sourcemap",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_limit_chunk_count"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_merge_duplicate_chunks"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rayon",
  "rspack_core",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_mf"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "camino",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_info_header"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_cacheable",
  "rspack_core",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_replacement"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_no_emit_on_errors"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_progress"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "futures",
  "indicatif",
@@ -4993,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_real_content_hash"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "aho-corasick",
  "atomic_refcell",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_duplicate_modules"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rayon",
  "rspack_collections",
@@ -5027,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_empty_chunks"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsc"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsdoctor"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "atomic_refcell",
  "futures",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rslib"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rstest"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "camino",
  "cow-utils",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime_chunk"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "futures",
  "rspack_core",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_schemes"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5202,7 +5202,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_size_limits"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_split_chunks"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -5238,7 +5238,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_sri"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5270,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_swc_js_minimizer"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "once_cell",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_wasm"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_worker"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5323,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_regex"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "napi",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "memchr",
  "regex",
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_storage"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_import"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "heck",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_ts_collector"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "glob",
  "insta",
@@ -5415,14 +5415,14 @@ dependencies = [
 
 [[package]]
 name = "rspack_tasks"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rspack_tools"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "clap",
  "itertools 0.14.0",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "chrono",
  "rspack_tracing_perfetto",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing_perfetto"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "bytes",
  "micromegas-perfetto",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_util"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
  "base64-simd 0.8.0",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_watcher"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 dependencies = [
  "cow-utils",
  "dashmap",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_workspace"
-version = "0.101.0-beta.0"
+version = "0.101.0-rc.0"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition       = "2024"
 homepage      = "https://rspack.rs/"
 license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
-version       = "0.101.0-beta.0"
+version       = "0.101.0-rc.0"
 
 [workspace.metadata.dylint]
 libraries = [{ path = "linting/*" }]
@@ -157,92 +157,92 @@ wasmtime      = { version = "36.0.10", default-features = false }
 
 
 # all rspack workspace dependencies
-rspack                                 = { version = "=0.101.0-beta.0", path = "crates/rspack", default-features = false }
-rspack_allocator                       = { version = "=0.101.0-beta.0", path = "crates/rspack_allocator", default-features = false }
-rspack_binding_api                     = { version = "=0.101.0-beta.0", path = "crates/rspack_binding_api", default-features = false }
-rspack_binding_build                   = { version = "=0.101.0-beta.0", path = "crates/rspack_binding_build", default-features = false }
-rspack_binding_builder                 = { version = "=0.101.0-beta.0", path = "crates/rspack_binding_builder", default-features = false }
-rspack_binding_builder_macros          = { version = "=0.101.0-beta.0", path = "crates/rspack_binding_builder_macros", default-features = false }
-rspack_browserslist                    = { version = "=0.101.0-beta.0", path = "crates/rspack_browserslist", default-features = false }
-rspack_cacheable                       = { version = "=0.101.0-beta.0", path = "crates/rspack_cacheable", default-features = false }
-rspack_cacheable_macros                = { version = "=0.101.0-beta.0", path = "crates/rspack_cacheable_macros", default-features = false }
-rspack_collections                     = { version = "=0.101.0-beta.0", path = "crates/rspack_collections", default-features = false }
-rspack_core                            = { version = "=0.101.0-beta.0", path = "crates/rspack_core", default-features = false }
-rspack_error                           = { version = "=0.101.0-beta.0", path = "crates/rspack_error", default-features = false }
-rspack_fs                              = { version = "=0.101.0-beta.0", path = "crates/rspack_fs", default-features = false }
-rspack_hash                            = { version = "=0.101.0-beta.0", path = "crates/rspack_hash", default-features = false }
-rspack_hook                            = { version = "=0.101.0-beta.0", path = "crates/rspack_hook", default-features = false }
-rspack_ids                             = { version = "=0.101.0-beta.0", path = "crates/rspack_ids", default-features = false }
-rspack_javascript_compiler             = { version = "=0.101.0-beta.0", path = "crates/rspack_javascript_compiler", default-features = false }
-rspack_loader_lightningcss             = { version = "=0.101.0-beta.0", path = "crates/rspack_loader_lightningcss", default-features = false }
-rspack_loader_preact_refresh           = { version = "=0.101.0-beta.0", path = "crates/rspack_loader_preact_refresh", default-features = false }
-rspack_loader_react_refresh            = { version = "=0.101.0-beta.0", path = "crates/rspack_loader_react_refresh", default-features = false }
-rspack_loader_runner                   = { version = "=0.101.0-beta.0", path = "crates/rspack_loader_runner", default-features = false }
-rspack_loader_swc                      = { version = "=0.101.0-beta.0", path = "crates/rspack_loader_swc", default-features = false }
-rspack_loader_testing                  = { version = "=0.101.0-beta.0", path = "crates/rspack_loader_testing", default-features = false }
-rspack_location                        = { version = "=0.101.0-beta.0", path = "crates/rspack_location", default-features = false }
-rspack_macros                          = { version = "=0.101.0-beta.0", path = "crates/rspack_macros", default-features = false }
-rspack_napi                            = { version = "=0.101.0-beta.0", path = "crates/rspack_napi", default-features = false }
-rspack_napi_macros                     = { version = "=0.101.0-beta.0", path = "crates/rspack_napi_macros", default-features = false }
-rspack_parallel                        = { version = "=0.101.0-beta.0", path = "crates/rspack_parallel", default-features = false }
-rspack_paths                           = { version = "=0.101.0-beta.0", path = "crates/rspack_paths", default-features = false }
-rspack_plugin_asset                    = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_asset", default-features = false }
-rspack_plugin_banner                   = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_banner", default-features = false }
-rspack_plugin_case_sensitive           = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_case_sensitive", default-features = false }
-rspack_plugin_circular_dependencies    = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
-rspack_plugin_copy                     = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_copy", default-features = false }
-rspack_plugin_css                      = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_css", default-features = false }
-rspack_plugin_css_chunking             = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_css_chunking", default-features = false }
-rspack_plugin_devtool                  = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_devtool", default-features = false }
-rspack_plugin_dll                      = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_dll", default-features = false }
-rspack_plugin_dynamic_entry            = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
-rspack_plugin_ensure_chunk_conditions  = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
-rspack_plugin_entry                    = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_entry", default-features = false }
-rspack_plugin_esm_library              = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_esm_library", default-features = false }
-rspack_plugin_externals                = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_externals", default-features = false }
-rspack_plugin_extract_css              = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_extract_css", default-features = false }
-rspack_plugin_hmr                      = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_hmr", default-features = false }
-rspack_plugin_html                     = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_html", default-features = false }
-rspack_plugin_ignore                   = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_ignore", default-features = false }
-rspack_plugin_javascript               = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_javascript", default-features = false }
-rspack_plugin_json                     = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_json", default-features = false }
-rspack_plugin_lazy_compilation         = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
-rspack_plugin_library                  = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_library", default-features = false }
-rspack_plugin_lightning_css_minimizer  = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
-rspack_plugin_limit_chunk_count        = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
-rspack_plugin_merge_duplicate_chunks   = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
-rspack_plugin_mf                       = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_mf", default-features = false }
-rspack_plugin_module_info_header       = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_module_info_header", default-features = false }
-rspack_plugin_module_replacement       = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_module_replacement", default-features = false }
-rspack_plugin_no_emit_on_errors        = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
-rspack_plugin_progress                 = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_progress", default-features = false }
-rspack_plugin_real_content_hash        = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_real_content_hash", default-features = false }
-rspack_plugin_remove_duplicate_modules = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
-rspack_plugin_remove_empty_chunks      = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
-rspack_plugin_rsc                      = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_rsc", default-features = false }
-rspack_plugin_rsdoctor                 = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_rsdoctor", default-features = false }
-rspack_plugin_rslib                    = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_rslib", default-features = false }
-rspack_plugin_rstest                   = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_rstest", default-features = false }
-rspack_plugin_runtime                  = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_runtime", default-features = false }
-rspack_plugin_runtime_chunk            = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
-rspack_plugin_schemes                  = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_schemes", default-features = false }
-rspack_plugin_size_limits              = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_size_limits", default-features = false }
-rspack_plugin_split_chunks             = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_split_chunks", default-features = false }
-rspack_plugin_sri                      = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_sri", default-features = false }
-rspack_plugin_swc_js_minimizer         = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
-rspack_plugin_wasm                     = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_wasm", default-features = false }
-rspack_plugin_worker                   = { version = "=0.101.0-beta.0", path = "crates/rspack_plugin_worker", default-features = false }
-rspack_regex                           = { version = "=0.101.0-beta.0", path = "crates/rspack_regex", default-features = false }
-rspack_sources                         = { version = "=0.101.0-beta.0", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
-rspack_storage                         = { version = "=0.101.0-beta.0", path = "crates/rspack_storage", default-features = false }
-rspack_swc_plugin_import               = { version = "=0.101.0-beta.0", path = "crates/swc_plugin_import", default-features = false }
-rspack_swc_plugin_ts_collector         = { version = "=0.101.0-beta.0", path = "crates/swc_plugin_ts_collector", default-features = false }
-rspack_tasks                           = { version = "=0.101.0-beta.0", path = "crates/rspack_tasks", default-features = false }
-rspack_tracing                         = { version = "=0.101.0-beta.0", path = "crates/rspack_tracing", default-features = false }
-rspack_tracing_perfetto                = { version = "=0.101.0-beta.0", path = "crates/rspack_tracing_perfetto", default-features = false }
-rspack_util                            = { version = "=0.101.0-beta.0", path = "crates/rspack_util", default-features = false }
-rspack_watcher                         = { version = "=0.101.0-beta.0", path = "crates/rspack_watcher", default-features = false }
-rspack_workspace                       = { version = "=0.101.0-beta.0", path = "crates/rspack_workspace", default-features = false }
+rspack                                 = { version = "=0.101.0-rc.0", path = "crates/rspack", default-features = false }
+rspack_allocator                       = { version = "=0.101.0-rc.0", path = "crates/rspack_allocator", default-features = false }
+rspack_binding_api                     = { version = "=0.101.0-rc.0", path = "crates/rspack_binding_api", default-features = false }
+rspack_binding_build                   = { version = "=0.101.0-rc.0", path = "crates/rspack_binding_build", default-features = false }
+rspack_binding_builder                 = { version = "=0.101.0-rc.0", path = "crates/rspack_binding_builder", default-features = false }
+rspack_binding_builder_macros          = { version = "=0.101.0-rc.0", path = "crates/rspack_binding_builder_macros", default-features = false }
+rspack_browserslist                    = { version = "=0.101.0-rc.0", path = "crates/rspack_browserslist", default-features = false }
+rspack_cacheable                       = { version = "=0.101.0-rc.0", path = "crates/rspack_cacheable", default-features = false }
+rspack_cacheable_macros                = { version = "=0.101.0-rc.0", path = "crates/rspack_cacheable_macros", default-features = false }
+rspack_collections                     = { version = "=0.101.0-rc.0", path = "crates/rspack_collections", default-features = false }
+rspack_core                            = { version = "=0.101.0-rc.0", path = "crates/rspack_core", default-features = false }
+rspack_error                           = { version = "=0.101.0-rc.0", path = "crates/rspack_error", default-features = false }
+rspack_fs                              = { version = "=0.101.0-rc.0", path = "crates/rspack_fs", default-features = false }
+rspack_hash                            = { version = "=0.101.0-rc.0", path = "crates/rspack_hash", default-features = false }
+rspack_hook                            = { version = "=0.101.0-rc.0", path = "crates/rspack_hook", default-features = false }
+rspack_ids                             = { version = "=0.101.0-rc.0", path = "crates/rspack_ids", default-features = false }
+rspack_javascript_compiler             = { version = "=0.101.0-rc.0", path = "crates/rspack_javascript_compiler", default-features = false }
+rspack_loader_lightningcss             = { version = "=0.101.0-rc.0", path = "crates/rspack_loader_lightningcss", default-features = false }
+rspack_loader_preact_refresh           = { version = "=0.101.0-rc.0", path = "crates/rspack_loader_preact_refresh", default-features = false }
+rspack_loader_react_refresh            = { version = "=0.101.0-rc.0", path = "crates/rspack_loader_react_refresh", default-features = false }
+rspack_loader_runner                   = { version = "=0.101.0-rc.0", path = "crates/rspack_loader_runner", default-features = false }
+rspack_loader_swc                      = { version = "=0.101.0-rc.0", path = "crates/rspack_loader_swc", default-features = false }
+rspack_loader_testing                  = { version = "=0.101.0-rc.0", path = "crates/rspack_loader_testing", default-features = false }
+rspack_location                        = { version = "=0.101.0-rc.0", path = "crates/rspack_location", default-features = false }
+rspack_macros                          = { version = "=0.101.0-rc.0", path = "crates/rspack_macros", default-features = false }
+rspack_napi                            = { version = "=0.101.0-rc.0", path = "crates/rspack_napi", default-features = false }
+rspack_napi_macros                     = { version = "=0.101.0-rc.0", path = "crates/rspack_napi_macros", default-features = false }
+rspack_parallel                        = { version = "=0.101.0-rc.0", path = "crates/rspack_parallel", default-features = false }
+rspack_paths                           = { version = "=0.101.0-rc.0", path = "crates/rspack_paths", default-features = false }
+rspack_plugin_asset                    = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_asset", default-features = false }
+rspack_plugin_banner                   = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_banner", default-features = false }
+rspack_plugin_case_sensitive           = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_case_sensitive", default-features = false }
+rspack_plugin_circular_dependencies    = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
+rspack_plugin_copy                     = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_copy", default-features = false }
+rspack_plugin_css                      = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_css", default-features = false }
+rspack_plugin_css_chunking             = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_css_chunking", default-features = false }
+rspack_plugin_devtool                  = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_devtool", default-features = false }
+rspack_plugin_dll                      = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_dll", default-features = false }
+rspack_plugin_dynamic_entry            = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
+rspack_plugin_ensure_chunk_conditions  = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
+rspack_plugin_entry                    = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_entry", default-features = false }
+rspack_plugin_esm_library              = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_esm_library", default-features = false }
+rspack_plugin_externals                = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_externals", default-features = false }
+rspack_plugin_extract_css              = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_extract_css", default-features = false }
+rspack_plugin_hmr                      = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_hmr", default-features = false }
+rspack_plugin_html                     = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_html", default-features = false }
+rspack_plugin_ignore                   = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_ignore", default-features = false }
+rspack_plugin_javascript               = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_javascript", default-features = false }
+rspack_plugin_json                     = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_json", default-features = false }
+rspack_plugin_lazy_compilation         = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
+rspack_plugin_library                  = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_library", default-features = false }
+rspack_plugin_lightning_css_minimizer  = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
+rspack_plugin_limit_chunk_count        = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
+rspack_plugin_merge_duplicate_chunks   = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
+rspack_plugin_mf                       = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_mf", default-features = false }
+rspack_plugin_module_info_header       = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_module_info_header", default-features = false }
+rspack_plugin_module_replacement       = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_module_replacement", default-features = false }
+rspack_plugin_no_emit_on_errors        = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
+rspack_plugin_progress                 = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_progress", default-features = false }
+rspack_plugin_real_content_hash        = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_real_content_hash", default-features = false }
+rspack_plugin_remove_duplicate_modules = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
+rspack_plugin_remove_empty_chunks      = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
+rspack_plugin_rsc                      = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_rsc", default-features = false }
+rspack_plugin_rsdoctor                 = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_rsdoctor", default-features = false }
+rspack_plugin_rslib                    = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_rslib", default-features = false }
+rspack_plugin_rstest                   = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_rstest", default-features = false }
+rspack_plugin_runtime                  = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_runtime", default-features = false }
+rspack_plugin_runtime_chunk            = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
+rspack_plugin_schemes                  = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_schemes", default-features = false }
+rspack_plugin_size_limits              = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_size_limits", default-features = false }
+rspack_plugin_split_chunks             = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_split_chunks", default-features = false }
+rspack_plugin_sri                      = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_sri", default-features = false }
+rspack_plugin_swc_js_minimizer         = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
+rspack_plugin_wasm                     = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_wasm", default-features = false }
+rspack_plugin_worker                   = { version = "=0.101.0-rc.0", path = "crates/rspack_plugin_worker", default-features = false }
+rspack_regex                           = { version = "=0.101.0-rc.0", path = "crates/rspack_regex", default-features = false }
+rspack_sources                         = { version = "=0.101.0-rc.0", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
+rspack_storage                         = { version = "=0.101.0-rc.0", path = "crates/rspack_storage", default-features = false }
+rspack_swc_plugin_import               = { version = "=0.101.0-rc.0", path = "crates/swc_plugin_import", default-features = false }
+rspack_swc_plugin_ts_collector         = { version = "=0.101.0-rc.0", path = "crates/swc_plugin_ts_collector", default-features = false }
+rspack_tasks                           = { version = "=0.101.0-rc.0", path = "crates/rspack_tasks", default-features = false }
+rspack_tracing                         = { version = "=0.101.0-rc.0", path = "crates/rspack_tracing", default-features = false }
+rspack_tracing_perfetto                = { version = "=0.101.0-rc.0", path = "crates/rspack_tracing_perfetto", default-features = false }
+rspack_util                            = { version = "=0.101.0-rc.0", path = "crates/rspack_util", default-features = false }
+rspack_watcher                         = { version = "=0.101.0-rc.0", path = "crates/rspack_watcher", default-features = false }
+rspack_workspace                       = { version = "=0.101.0-rc.0", path = "crates/rspack_workspace", default-features = false }
 
 
 [workspace.metadata.release]

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -6,10 +6,10 @@ pub const fn rspack_swc_core_version() -> &'static str {
 
 /// The version of the JavaScript `@rspack/core` package.
 pub const fn rspack_pkg_version() -> &'static str {
-  "2.1.0-beta.0"
+  "2.1.0-rc.0"
 }
 
 /// The version of the Rust workspace in the root `Cargo.toml` of the repository.
 pub const fn rspack_workspace_version() -> &'static str {
-  "0.101.0-beta.0"
+  "0.101.0-rc.0"
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-gnu",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-gnu.node",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-musl",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-musl.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-musl",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-musl.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-arm64-msvc",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-arm64-msvc.node",

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-ia32-msvc",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-ia32-msvc.node",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/browser",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Rspack for running in the browser. This is still in early stage and may not follow the semver.",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "description": "Test tools for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-rc.0",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",


### PR DESCRIPTION
## Release Information

- Released By: LingyuCoder
- Release Date: 2026-06-23
- JavaScript Packages Version: 2.1.0-rc.0
- Rust Crates Version: 0.101.0-rc.0