### PR TITLE
perf(core): reduce source map serialization overhead

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -194,7 +194,7 @@ class JsSourceMap {
     return isNil(map) ? undefined : toObject(map);
   }
 
-  static __to_binding(map?: object) {
+  static __to_binding(map?: string | object | null) {
     return serializeObject(map);
   }
 }
@@ -1029,7 +1029,9 @@ export async function runLoaders(
       }
       case JsLoaderState.Normal: {
         let content = context.content;
-        let sourceMap = JsSourceMap.__from_binding(context.sourceMap);
+        const rawSourceMap = context.sourceMap;
+        let sourceMap: string | object | undefined;
+        let sourceMapParsed = false;
         let additionalData = context.additionalData;
 
         while (loaderContext.loaderIndex >= 0) {
@@ -1051,6 +1053,13 @@ export async function runLoaders(
             currentLoaderObject.normalExecuted = true;
           }
           if (!fn) continue;
+
+          // Parse source map lazily only when a JavaScript loader consumes it.
+          if (!sourceMapParsed) {
+            sourceMap = JsSourceMap.__from_binding(rawSourceMap);
+            sourceMapParsed = true;
+          }
+
           [content, sourceMap, additionalData] = await isomorphoicRun(fn, [
             content,
             sourceMap,
@@ -1059,7 +1068,9 @@ export async function runLoaders(
         }
 
         context.content = isNil(content) ? null : toBuffer(content);
-        context.sourceMap = JsSourceMap.__to_binding(sourceMap);
+        context.sourceMap = sourceMapParsed
+          ? JsSourceMap.__to_binding(sourceMap)
+          : rawSourceMap;
         context.additionalData = additionalData || undefined;
         context.__internal__utf8Hint = typeof content === 'string';
 

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -42,12 +42,12 @@ export function serializeObject(
 
   if (typeof map === 'string') {
     if (map) {
-      return toBuffer(map);
+      return Buffer.from(map);
     }
     return undefined;
   }
 
-  return toBuffer(JSON.stringify(map));
+  return Buffer.from(JSON.stringify(map));
 }
 
 export function indent(str: string, prefix: string) {


### PR DESCRIPTION
## Summary

Reduce source map serialization overhead in the JS loader runner:

- keep the raw binding source map until a JavaScript normal loader actually consumes it
- reuse the raw binding value when no JavaScript normal loader consumed the source map
- avoid the generic `toBuffer` branch in `serializeObject` after the source map has already been converted to a string/JSON payload

CPU profile on the same demo build, using Node inspector around `createRsbuild().build()`:

| serializeObject-related call | baseline | current | delta |
| --- | ---: | ---: | ---: |
| source map bridge (`__to_binding + __from_binding`) | 176.66ms (0.245%) | 163.88ms (0.197%) | -12.79ms |
| `JSON.parse` | 354.38ms (0.492%) | 314.21ms (0.378%) | -40.18ms |
