### PR TITLE
refactor(core): remove unused TS exports

### DIFF
--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -8,7 +8,6 @@ import './BuildInfo';
 export type ResourceDataWithData = ResourceData & {
   data?: Record<string, any>;
 };
-export type CreateData = binding.JsCreateData;
 export type ContextInfo = binding.ContextInfo;
 export type ResolveData = binding.JsResolveData;
 

--- a/packages/rspack/src/RuntimeGlobals.ts
+++ b/packages/rspack/src/RuntimeGlobals.ts
@@ -466,12 +466,6 @@ export const isReservedRuntimeGlobal = (
   compilerRuntimeGlobals: Record<string, string>,
 ) => Object.values(compilerRuntimeGlobals).includes(r);
 
-export function renderModulePrefix(
-  _compilerOptions: RspackOptionsNormalized,
-): string {
-  return 'webpack/runtime/';
-}
-
 export enum RuntimeVariable {
   Require,
   Context,

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -5,7 +5,6 @@ import type {
   JscConfig,
   ModuleConfig,
   ParserConfig,
-  TerserEcmaVersion,
   TransformConfig,
   TsParserConfig,
 } from '@swc/types';
@@ -72,63 +71,4 @@ export interface ReactServerComponentsOptions {
    * components. Defaults to `false`.
    */
   disableClientApiChecks?: boolean;
-}
-
-export interface TerserCompressOptions {
-  arguments?: boolean;
-  arrows?: boolean;
-  booleans?: boolean;
-  booleans_as_integers?: boolean;
-  collapse_vars?: boolean;
-  comparisons?: boolean;
-  computed_props?: boolean;
-  conditionals?: boolean;
-  dead_code?: boolean;
-  defaults?: boolean;
-  directives?: boolean;
-  drop_console?: boolean;
-  drop_debugger?: boolean;
-  ecma?: TerserEcmaVersion;
-  evaluate?: boolean;
-  expression?: boolean;
-  global_defs?: any;
-  hoist_funs?: boolean;
-  hoist_props?: boolean;
-  hoist_vars?: boolean;
-  ie8?: boolean;
-  if_return?: boolean;
-  inline?: 0 | 1 | 2 | 3;
-  join_vars?: boolean;
-  keep_classnames?: boolean;
-  keep_fargs?: boolean;
-  keep_fnames?: boolean;
-  keep_infinity?: boolean;
-  loops?: boolean;
-  negate_iife?: boolean;
-  passes?: number;
-  properties?: boolean;
-  pure_getters?: any;
-  pure_funcs?: string[];
-  reduce_funcs?: boolean;
-  reduce_vars?: boolean;
-  sequences?: any;
-  side_effects?: boolean;
-  switches?: boolean;
-  top_retain?: any;
-  toplevel?: any;
-  typeofs?: boolean;
-  unsafe?: boolean;
-  unsafe_passes?: boolean;
-  unsafe_arrows?: boolean;
-  unsafe_comps?: boolean;
-  unsafe_function?: boolean;
-  unsafe_math?: boolean;
-  unsafe_symbols?: boolean;
-  unsafe_methods?: boolean;
-  unsafe_proto?: boolean;
-  unsafe_regexp?: boolean;
-  unsafe_undefined?: boolean;
-  unused?: boolean;
-  const_to_let?: boolean;
-  module?: boolean;
 }

--- a/packages/rspack/src/lib/HookWebpackError.ts
+++ b/packages/rspack/src/lib/HookWebpackError.ts
@@ -33,8 +33,6 @@ export class HookWebpackError extends WebpackError {
   }
 }
 
-export default HookWebpackError;
-
 /**
  * @param error an error
  * @param hook name of the hook

--- a/packages/rspack/src/lib/cache/getLazyHashedEtag.ts
+++ b/packages/rspack/src/lib/cache/getLazyHashedEtag.ts
@@ -93,5 +93,3 @@ export const getter = (
   innerMap.set(obj, newHash);
   return newHash;
 };
-
-export default getter;

--- a/packages/rspack/src/lib/cache/mergeEtags.ts
+++ b/packages/rspack/src/lib/cache/mergeEtags.ts
@@ -76,5 +76,3 @@ export const mergeEtags = (first: Etag, second: Etag): Etag => {
   }
   return mergedEtag;
 };
-
-export default mergeEtags;

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -172,4 +172,3 @@ function rspack(
 
 // deliberately alias rspack as webpack
 export { createCompiler, createMultiCompiler, MultiStats, rspack, Stats };
-export default rspack;

--- a/packages/rspack/src/sharing/IndependentSharedPlugin.ts
+++ b/packages/rspack/src/sharing/IndependentSharedPlugin.ts
@@ -24,9 +24,6 @@ const VIRTUAL_ENTRY = './virtual-entry.js';
 const VIRTUAL_ENTRY_NAME = 'virtual-entry';
 const BUILD_SHARED_FALLBACK_STAGE = 102;
 
-export type MakeRequired<T, K extends keyof T> = Required<Pick<T, K>> &
-  Omit<T, K>;
-
 const filterPlugin = (plugin: Plugins[0], excludedPlugins: string[] = []) => {
   if (!plugin) {
     return true;

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -135,12 +135,6 @@ export type KnownStatsModule = {
   source?: string | Buffer;
 };
 
-export type KnownStatsProfile = {
-  total: number;
-  resolving: number;
-  building: number;
-};
-
 export type StatsModule = KnownStatsModule & Record<string, any>;
 
 export type KnownStatsModuleIssuer = {
@@ -730,13 +724,4 @@ export const errorsSpaceLimit = (errors: StatsError[], max: number) => {
     errors: result,
     filtered,
   };
-};
-
-export const warningFromStatsWarning = (
-  warning: binding.JsStatsError,
-): Error => {
-  const res = new Error(warning.message);
-  res.name = warning.name || 'StatsWarning';
-  Object.assign(res, warning);
-  return res;
 };

--- a/packages/rspack/src/util/comparators.ts
+++ b/packages/rspack/src/util/comparators.ts
@@ -75,6 +75,8 @@ export const compareIds = <T = string | number>(a: T, b: T): -1 | 0 | 1 => {
   return 0;
 };
 
+export const compareNumbers = compareIds<number>;
+
 const compareSelectCache: TwoKeyWeakMap<
   Selector<any, any>,
   Comparator,
@@ -104,13 +106,4 @@ export const compareSelect = <T, R>(
   };
   compareSelectCache.set(getter, comparator, result);
   return result;
-};
-
-export const compareNumbers = (a: number, b: number) => {
-  if (typeof a !== typeof b) {
-    return typeof a < typeof b ? -1 : 1;
-  }
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
 };

--- a/packages/rspack/src/util/fake.ts
+++ b/packages/rspack/src/util/fake.ts
@@ -1,7 +1,5 @@
 import MergeCaller from './MergeCaller';
 
-export type FakeHook<T> = T & { _fakeHook: true };
-
 export function createFakeCompilationDependencies(
   getDeps: () => string[],
   addDeps: (deps: string[]) => void,

--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -162,7 +162,6 @@ export type JsonObject = { [Key in string]: JsonValue } & {
   [Key in string]?: JsonValue | undefined;
 };
 
-export type NoParamCallback = (err: NodeJS.ErrnoException | null) => void;
 export type StringCallback = (
   err: NodeJS.ErrnoException | null,
   data?: string,
@@ -202,10 +201,6 @@ export type BigIntStatsCallback = (
 export type StatsOrBigIntStatsCallback = (
   err: NodeJS.ErrnoException | null,
   stats?: IStats | IBigIntStats,
-) => void;
-export type NumberCallback = (
-  err: NodeJS.ErrnoException | null,
-  data?: number,
 ) => void;
 export type ReadJsonCallback = (
   err: NodeJS.ErrnoException | Error | null,
@@ -520,25 +515,6 @@ export type InputFileSystem = {
 export type IntermediateFileSystem = InputFileSystem &
   OutputFileSystem &
   IntermediateFileSystemExtras;
-
-export type WriteStreamOptions = {
-  flags?: string;
-  encoding?:
-    | 'ascii'
-    | 'utf8'
-    | 'utf-8'
-    | 'utf16le'
-    | 'utf-16le'
-    | 'ucs2'
-    | 'ucs-2'
-    | 'latin1'
-    | 'binary'
-    | 'base64'
-    | 'base64url'
-    | 'hex';
-  fd?: any;
-  mode?: number;
-};
 
 export type MakeDirectoryOptions = {
   recursive?: boolean;


### PR DESCRIPTION
## Summary

This PR trims unused internal TypeScript exports in `@rspack/core` without changing the public root API surface. It removes dead type/helper/default exports and keeps the generated root `index.d.ts` unchanged.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).