### PR TITLE
feat(core): expose the real Chunk instance to filename functions

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1020,13 +1020,7 @@ export interface JsPathData {
   runtime?: string
   url?: string
   id?: string
-  chunk?: JsPathDataChunkLike
-}
-
-export interface JsPathDataChunkLike {
-  name?: string
-  hash?: string
-  id?: string
+  chunk?: Chunk
 }
 
 export interface JsResolveData {

--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -2,7 +2,8 @@ use std::{cell::RefCell, ptr::NonNull};
 
 use napi::{
   Either, Env, JsString,
-  bindgen_prelude::{Either3, Object, ToNapiValue},
+  bindgen_prelude::{Either3, FromNapiValue, Object, ToNapiValue},
+  sys,
 };
 use napi_derive::napi;
 use rspack_core::{Compilation, CompilationId, chunk_graph_chunk::ChunkId};
@@ -280,6 +281,18 @@ pub struct ChunkWrapper {
 }
 
 unsafe impl Send for ChunkWrapper {}
+
+impl FromNapiValue for ChunkWrapper {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    let chunk: &Chunk = unsafe { FromNapiValue::from_napi_value(env, napi_val)? };
+    let compilation = unsafe { chunk.compilation.as_ref() };
+    Ok(Self {
+      chunk_ukey: chunk.chunk_ukey,
+      compilation_id: compilation.id(),
+      compilation: chunk.compilation,
+    })
+  }
+}
 
 impl ChunkWrapper {
   pub fn new(chunk_ukey: rspack_core::ChunkUkey, compilation: &Compilation) -> Self {

--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -523,8 +523,10 @@ impl JsCompilation {
   pub fn get_asset_path(&self, filename: String, data: JsPathData) -> Result<String> {
     let compilation = self.as_ref()?;
     #[allow(clippy::disallowed_methods)]
-    futures::executor::block_on(compilation.get_asset_path(&filename.into(), data.to_path_data()))
-      .to_napi_result()
+    futures::executor::block_on(
+      compilation.get_asset_path(&filename.into(), data.to_path_data(compilation)?),
+    )
+    .to_napi_result()
   }
 
   #[napi]
@@ -537,7 +539,7 @@ impl JsCompilation {
 
     #[allow(clippy::disallowed_methods)]
     let res = futures::executor::block_on(
-      compilation.get_asset_path_with_info(&filename.into(), data.to_path_data()),
+      compilation.get_asset_path_with_info(&filename.into(), data.to_path_data(compilation)?),
     )
     .to_napi_result()?;
     Ok(res.into())
@@ -547,8 +549,10 @@ impl JsCompilation {
   pub fn get_path(&self, filename: String, data: JsPathData) -> Result<String> {
     let compilation = self.as_ref()?;
     #[allow(clippy::disallowed_methods)]
-    futures::executor::block_on(compilation.get_path(&filename.into(), data.to_path_data()))
-      .to_napi_result()
+    futures::executor::block_on(
+      compilation.get_path(&filename.into(), data.to_path_data(compilation)?),
+    )
+    .to_napi_result()
   }
 
   #[napi]
@@ -560,7 +564,7 @@ impl JsCompilation {
     #[allow(clippy::disallowed_methods)]
     let path = futures::executor::block_on(compilation.get_path_with_info(
       &filename.into(),
-      data.to_path_data(),
+      data.to_path_data(compilation)?,
       &mut asset_info,
     ))
     .to_napi_result()?;

--- a/crates/rspack_binding_api/src/path_data.rs
+++ b/crates/rspack_binding_api/src/path_data.rs
@@ -1,8 +1,15 @@
+use napi::{
+  Either,
+  bindgen_prelude::{FromNapiValue, Object, ToNapiValue},
+  sys,
+};
 use napi_derive::napi;
 
-use crate::asset::AssetInfo;
+use crate::{asset::AssetInfo, chunk::ChunkWrapper};
 
-#[napi(object)]
+type JsPathDataId = Either<String, u32>;
+
+#[napi(object, object_from_js = false)]
 pub struct JsPathData {
   pub filename: Option<String>,
   pub hash: Option<String>,
@@ -10,14 +17,8 @@ pub struct JsPathData {
   pub runtime: Option<String>,
   pub url: Option<String>,
   pub id: Option<String>,
-  pub chunk: Option<JsPathDataChunkLike>,
-}
-
-#[napi(object)]
-pub struct JsPathDataChunkLike {
-  pub name: Option<String>,
-  pub hash: Option<String>,
-  pub id: Option<String>,
+  #[napi(ts_type = "Chunk")]
+  pub chunk: Option<ChunkWrapper>,
 }
 
 impl JsPathData {
@@ -29,30 +30,80 @@ impl JsPathData {
       runtime: path_data.runtime.map(|s| s.to_string()),
       url: path_data.url.map(|s| s.to_string()),
       id: path_data.id.map(|s| s.to_string()),
-      chunk: (path_data.chunk_name.is_some()
-        || path_data.chunk_id.is_some()
-        || path_data.chunk_name.is_some())
-      .then(|| JsPathDataChunkLike {
-        name: path_data.chunk_name.map(|s| s.to_string()),
-        hash: path_data.chunk_hash.map(|s| s.to_string()),
-        id: path_data.chunk_id.map(|s| s.to_string()),
-      }),
+      chunk: path_data
+        .chunk
+        .map(|chunk| ChunkWrapper::new(chunk.chunk_ukey, chunk.compilation)),
     }
   }
 
-  pub fn to_path_data(&self) -> rspack_core::PathData<'_> {
-    rspack_core::PathData {
+  pub fn to_path_data<'a>(
+    &'a self,
+    compilation: &'a rspack_core::Compilation,
+  ) -> napi::Result<rspack_core::PathData<'a>> {
+    let chunk_ukey = self.chunk.as_ref().map(|chunk| chunk.chunk_ukey);
+    let chunk = match chunk_ukey {
+      Some(chunk_ukey) => {
+        Some(
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_by_ukey
+            .get(&chunk_ukey)
+            .ok_or_else(|| {
+              napi::Error::from_reason(format!(
+                "Unable to access chunk with id = {chunk_ukey:?} now. The chunk has been removed on the Rust side.",
+              ))
+            })?,
+        )
+      }
+      None => None,
+    };
+    let chunk_hash = chunk.and_then(|chunk| {
+      chunk.rendered_hash(
+        &compilation.chunk_hashes_artifact,
+        compilation.options.output.hash_digest_length,
+      )
+    });
+
+    Ok(rspack_core::PathData {
       filename: self.filename.as_deref(),
-      chunk_name: self.chunk.as_ref().and_then(|c| c.name.as_deref()),
-      chunk_hash: self.chunk.as_ref().and_then(|c| c.hash.as_deref()),
-      chunk_id: self.chunk.as_ref().and_then(|c| c.id.as_deref()),
+      chunk: chunk_ukey.map(|chunk_ukey| rspack_core::PathDataChunk {
+        chunk_ukey,
+        compilation,
+      }),
+      chunk_name: chunk.and_then(|chunk| chunk.name_for_filename_template()),
+      chunk_hash,
+      chunk_id: chunk.and_then(|chunk| chunk.id().map(|id| id.as_str())),
       module_id: None,
       hash: self.hash.as_deref(),
       content_hash: self.content_hash.as_deref(),
       runtime: self.runtime.as_deref(),
       url: self.url.as_deref(),
       id: self.id.as_deref(),
+    })
+  }
+}
+
+impl FromNapiValue for JsPathData {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    unsafe {
+      let object = Object::from_napi_value(env, napi_val)?;
+      Ok(JsPathData {
+        filename: object.get::<String>("filename")?,
+        hash: object.get::<String>("hash")?,
+        content_hash: object.get::<String>("contentHash")?,
+        runtime: object.get::<String>("runtime")?,
+        url: object.get::<String>("url")?,
+        id: object.get::<JsPathDataId>("id")?.map(id_to_string),
+        chunk: object.get::<ChunkWrapper>("chunk")?,
+      })
     }
+  }
+}
+
+fn id_to_string(id: JsPathDataId) -> String {
+  match id {
+    Either::A(id) => id,
+    Either::B(id) => id.to_string(),
   }
 }
 

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -17,7 +17,7 @@ use rspack_paths::Utf8PathBuf;
 use rspack_util::allocative;
 
 use super::CleanOptions;
-use crate::{Chunk, ChunkGroupByUkey, ChunkKind, Compilation, Filename};
+use crate::{Chunk, ChunkGroupByUkey, ChunkKind, ChunkUkey, Compilation, Filename};
 
 #[derive(Debug)]
 pub enum PathInfo {
@@ -224,6 +224,7 @@ impl fmt::Display for CrossOriginLoading {
 #[derive(Default, Clone, Copy, Debug)]
 pub struct PathData<'a> {
   pub filename: Option<&'a str>,
+  pub chunk: Option<PathDataChunk<'a>>,
   pub chunk_name: Option<&'a str>,
   pub chunk_hash: Option<&'a str>,
   pub chunk_id: Option<&'a str>,
@@ -233,6 +234,12 @@ pub struct PathData<'a> {
   pub runtime: Option<&'a str>,
   pub url: Option<&'a str>,
   pub id: Option<&'a str>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PathDataChunk<'a> {
+  pub chunk_ukey: ChunkUkey,
+  pub compilation: &'a Compilation,
 }
 
 static MATCH_ID_REGEX: LazyLock<Regex> =
@@ -254,6 +261,14 @@ impl<'a> PathData<'a> {
 
   pub fn filename(mut self, v: &'a str) -> Self {
     self.filename = Some(v);
+    self
+  }
+
+  pub fn chunk(mut self, chunk_ukey: ChunkUkey, compilation: &'a Compilation) -> Self {
+    self.chunk = Some(PathDataChunk {
+      chunk_ukey,
+      compilation,
+    });
     self
   }
 

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -182,6 +182,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         .get_path(
           &Filename::from(banner),
           PathData::default()
+            .chunk(chunk.ukey(), compilation)
             .chunk_hash_optional(chunk.rendered_hash(
               &compilation.chunk_hashes_artifact,
               compilation.options.output.hash_digest_length,

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -549,6 +549,7 @@ async fn render_manifest(
     .get_path_with_info(
       filename_template,
       PathData::default()
+        .chunk(*chunk_ukey, compilation)
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -110,6 +110,7 @@ async fn render_module_content(
     return Ok(());
   };
   let path_data = PathData::default()
+    .chunk(chunk.ukey(), compilation)
     .chunk_id_optional(chunk.id().map(|id| id.as_str()))
     .chunk_name_optional(chunk.name())
     .chunk_hash_optional(chunk.rendered_hash(

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -164,6 +164,7 @@ async fn render_module_content(
           }
         });
         let path_data = PathData::default()
+          .chunk(chunk.ukey(), compilation)
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_name_optional(chunk.name())
           .chunk_hash_optional(chunk.rendered_hash(

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -571,15 +571,17 @@ impl SourceMapDevToolPlugin {
                 .await?;
 
               let chunk = file_to_chunk.get(asset_filename.as_ref());
-              let path_data = PathData::default()
-                .chunk_id_optional(chunk.and_then(|c| c.id().map(|id| id.as_str())))
-                .chunk_name_optional(chunk.and_then(|c| c.name()))
-                .chunk_hash_optional(chunk.and_then(|c| {
-                  c.rendered_hash(
+              let path_data = match chunk {
+                Some(chunk) => PathData::default()
+                  .chunk(chunk.ukey(), compilation)
+                  .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+                  .chunk_name_optional(chunk.name())
+                  .chunk_hash_optional(chunk.rendered_hash(
                     &compilation.chunk_hashes_artifact,
                     compilation.options.output.hash_digest_length,
-                  )
-                }));
+                  )),
+                None => PathData::default(),
+              };
 
               let filename = Filename::from(plugin.namespace.clone());
               let namespace = compilation.get_path(&filename, path_data).await?;
@@ -1024,6 +1026,7 @@ impl SourceMapDevToolPlugin {
       let data = PathData::default().filename(&filename);
       let data = match chunk {
         Some(chunk) => data
+          .chunk(chunk.ukey(), compilation)
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -66,6 +66,7 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       .get_path(
         &self.options.path,
         PathData::default()
+          .chunk(chunk.ukey(), compilation)
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,
@@ -85,6 +86,7 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
           .get_path(
             name,
             PathData::default()
+              .chunk(chunk.ukey(), compilation)
               .chunk_id_optional(chunk.id().map(|id| id.as_str()))
               .chunk_hash_optional(chunk.rendered_hash(
                 &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1405,6 +1405,7 @@ var {} = {{}};
         .get_path_with_info(
           &filename_template,
           PathData::default()
+            .chunk(chunk.ukey(), compilation)
             .chunk_hash_optional(chunk.rendered_hash(
               &compilation.chunk_hashes_artifact,
               compilation.options.output.hash_digest_length,

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -174,6 +174,7 @@ impl EsmLibraryPlugin {
       .get_path_with_info(
         &filename_template,
         PathData::default()
+          .chunk(chunk.ukey(), compilation)
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,
             compilation.options.output.hash_digest_length,

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -680,6 +680,7 @@ async fn render_manifest(
     .get_path_with_info(
       filename_template,
       PathData::default()
+        .chunk(*chunk_ukey, compilation)
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -595,6 +595,7 @@ async fn render_manifest(
     .get_path_with_info(
       &filename_template,
       PathData::default()
+        .chunk(*chunk_ukey, compilation)
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -140,6 +140,7 @@ async fn render(
       .get_path(
         &Filename::from(name),
         PathData::default()
+          .chunk(chunk.ukey(), compilation)
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -156,6 +156,7 @@ impl AssignLibraryPlugin {
           .get_path(
             &Filename::from(v),
             PathData::default()
+              .chunk(chunk.ukey(), compilation)
               .chunk_id_optional(chunk.id().map(|id| id.as_str()))
               .chunk_hash_optional(chunk.rendered_hash(
                 &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -88,6 +88,7 @@ async fn render(
     .get_path(
       &Filename::from(options.name),
       PathData::default()
+        .chunk(chunk.ukey(), compilation)
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -96,15 +96,17 @@ async fn render(
       .chunk_by_ukey
       .get(chunk_ukey);
     let filename = Filename::from(name);
-    let path_data = PathData::default()
-      .chunk_id_optional(chunk.and_then(|c| c.id().map(|id| id.as_str())))
-      .chunk_name_optional(chunk.and_then(|c| c.name()))
-      .chunk_hash_optional(chunk.and_then(|c| {
-        c.rendered_hash(
+    let path_data = match chunk {
+      Some(chunk) => PathData::default()
+        .chunk(chunk.ukey(), compilation)
+        .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+        .chunk_name_optional(chunk.name())
+        .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,
           compilation.options.output.hash_digest_length,
-        )
-      }));
+        )),
+      None => PathData::default(),
+    };
     let name = compilation.get_path(&filename, path_data).await?;
     let name_str = rspack_util::json_stringify_str(&name);
     format!("{name_str}, ")

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -379,6 +379,7 @@ async fn replace_keys(v: String, chunk: &Chunk, compilation: &Compilation) -> Re
     .get_path(
       &Filename::from(v),
       PathData::default()
+        .chunk(chunk.ukey(), compilation)
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
@@ -6,9 +6,9 @@
 
 use async_trait::async_trait;
 use rspack_core::{
-  BooleanMatcher, Chunk, Compilation, RuntimeCodeTemplate, RuntimeModule,
-  RuntimeModuleGenerateContext, RuntimeModuleStage, RuntimeTemplate, compile_boolean_matcher,
-  get_js_chunk_filename_template, get_undo_path, impl_runtime_module,
+  BooleanMatcher, Chunk, Compilation, PathData, RuntimeCodeTemplate, RuntimeModule,
+  RuntimeModuleGenerateContext, RuntimeModuleStage, RuntimeTemplate, SourceType,
+  compile_boolean_matcher, get_js_chunk_filename_template, get_undo_path, impl_runtime_module,
 };
 use rspack_error::Result;
 use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
@@ -87,7 +87,23 @@ chunkMatcher: function(chunkId) {{
       &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
     );
     let output_name = compilation
-      .get_path(&filename, Default::default())
+      .get_path(
+        &filename,
+        PathData::default()
+          .chunk(chunk.ukey(), compilation)
+          .chunk_hash_optional(chunk.rendered_hash(
+            &compilation.chunk_hashes_artifact,
+            compilation.options.output.hash_digest_length,
+          ))
+          .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+          .chunk_name_optional(chunk.name_for_filename_template())
+          .content_hash_optional(chunk.rendered_content_hash_by_source_type(
+            &compilation.chunk_hashes_artifact,
+            &SourceType::JavaScript,
+            compilation.options.output.hash_digest_length,
+          ))
+          .runtime(chunk.runtime().as_str()),
+      )
       .await
       .expect("failed to get output path");
     get_undo_path(

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -372,6 +372,7 @@ pub async fn get_chunk_output_name(chunk: &Chunk, compilation: &Compilation) -> 
     .get_path(
       &filename,
       PathData::default()
+        .chunk(chunk.ukey(), compilation)
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -46,6 +46,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
       .get_path(
         &filename,
         PathData::default()
+          .chunk(chunk.ukey(), compilation)
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_hash_optional(chunk.rendered_hash(
             &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -385,6 +385,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                 fake_filename
                   .render(
                     PathData::default()
+                      .chunk(*chunk_ukey, compilation)
                       .chunk_name_optional(chunk.name())
                       .chunk_id_optional(chunk.id().map(|id| id.as_str())),
                     None,
@@ -394,6 +395,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
               )
             }),
             PathData::default()
+              .chunk(*chunk_ukey, compilation)
               .chunk_id_optional(chunk_id.as_deref())
               .chunk_hash_optional(chunk_hash.as_deref())
               .chunk_name_optional(chunk_name.as_deref())

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -60,6 +60,7 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
         .get_path(
           &self.filename,
           PathData::default()
+            .chunk(chunk.ukey(), compilation)
             .chunk_id_optional(chunk.id().map(|id| id.as_str()))
             .chunk_hash_optional(chunk.rendered_hash(
               &compilation.chunk_hashes_artifact,

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -98,6 +98,7 @@ pub async fn get_output_dir(
     .get_path(
       &filename,
       PathData::default()
+        .chunk(chunk.ukey(), compilation)
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_hash_optional(chunk.rendered_hash(
           &compilation.chunk_hashes_artifact,

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -25,7 +25,7 @@ export type { AssetInfo } from '@rspack/binding';
 import * as liteTapable from '@rspack/lite-tapable';
 import type { Source } from 'webpack-sources';
 import type { EntryOptions, EntryPlugin } from './builtin-plugin';
-import type { Chunk } from './Chunk';
+import { Chunk } from './Chunk';
 import type { ChunkGraph } from './ChunkGraph';
 import type { Compiler } from './Compiler';
 import type { ContextModuleFactory } from './ContextModuleFactory';
@@ -61,8 +61,6 @@ import { createFakeCompilationDependencies } from './util/fake';
 import type { InputFileSystem } from './util/fs';
 import type Hash from './util/hash';
 import { SourceAdapter } from './util/source';
-// patch Chunk
-import './Chunk';
 // patch Chunks
 import './Chunks';
 // patch ChunkGraph
@@ -79,13 +77,6 @@ export interface Asset {
   info: AssetInfo;
 }
 
-export type ChunkPathData = {
-  id?: string | number;
-  name?: string;
-  hash?: string;
-  contentHash?: Record<string, string>;
-};
-
 export type PathData = {
   filename?: string;
   hash?: string;
@@ -93,7 +84,7 @@ export type PathData = {
   runtime?: string;
   url?: string;
   id?: string | number;
-  chunk?: Chunk | ChunkPathData;
+  chunk?: Chunk;
   contentHashType?: string;
 };
 
@@ -110,12 +101,8 @@ function normalizePathData(data: PathData = {}): JsPathData {
     pathData.id = String(data.id);
   }
 
-  if (data.chunk) {
-    pathData.chunk = {
-      id: data.chunk.id !== undefined ? String(data.chunk.id) : undefined,
-      name: data.chunk.name,
-      hash: data.chunk.hash,
-    };
+  if (data.chunk instanceof Chunk) {
+    pathData.chunk = data.chunk;
   }
 
   return pathData;

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -6,7 +6,6 @@ export type {
   Asset,
   AssetInfo,
   Assets,
-  ChunkPathData,
   CompilationParams,
   LogEntry,
   PathData,

--- a/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/index.js
+++ b/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/index.js
@@ -1,0 +1,4 @@
+it("should compile", () => {
+  expect(true).toBe(true);
+});
+

--- a/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/module.js
+++ b/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/module.js
@@ -1,0 +1,2 @@
+export default "module";
+

--- a/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/rspack.config.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const { ModuleFederationPlugin } = require('@rspack/core').container;
+
+function filename(pathData) {
+  return pathData.chunk
+    ? 'real-chunk/[name].js'
+    : 'missing-chunk/deep/[name].js';
+}
+
+class Plugin {
+  apply(compiler) {
+    compiler.hooks.done.tap(
+      'federation-root-output-dir-filename-function',
+      (stats) => {
+        const assets = stats.compilation.getAssets();
+        const runtimeAssets = assets.filter((asset) =>
+          String(asset.source.source()).includes('rootOutputDir'),
+        );
+
+        assert(runtimeAssets.length > 0);
+        for (const asset of runtimeAssets) {
+          assert(
+            asset.name.startsWith('real-chunk/'),
+            `unexpected asset name: ${asset.name}`,
+          );
+
+          const source = String(asset.source.source());
+          assert(
+            source.includes('rootOutputDir: "../"'),
+            source.match(/rootOutputDir: "[^"]*"/)?.[0] ?? source,
+          );
+          assert(!source.includes('rootOutputDir: "../../"'));
+        }
+      },
+    );
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: './index.js',
+  output: {
+    filename,
+    chunkFilename: filename,
+    uniqueName: 'federation-root-output-dir-filename-function',
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'container',
+      filename: 'real-chunk/container.js',
+      exposes: {
+        './module': './module.js',
+      },
+    }),
+    new Plugin(),
+  ],
+};

--- a/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/test.config.js
+++ b/tests/rspack-test/configCases/container-1-5/federation-root-output-dir-filename-function/test.config.js
@@ -1,0 +1,5 @@
+/** @type {import("@rspack/test-tools").TConfigCaseConfig} */
+module.exports = {
+  noTests: true
+};
+

--- a/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/a.js
+++ b/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/a.js
@@ -1,0 +1,2 @@
+import './shared';
+

--- a/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/b.js
+++ b/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/b.js
@@ -1,0 +1,2 @@
+import './shared';
+

--- a/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/rspack.config.js
+++ b/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/rspack.config.js
@@ -1,0 +1,65 @@
+const assert = require('assert');
+
+function isEntryChunk(chunk) {
+  for (const group of chunk.groupsIterable) {
+    if (group.isInitial() && group.getEntrypointChunk() === chunk) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function filename(pathData) {
+  assert(pathData.chunk);
+  assert.strictEqual(
+    typeof pathData.chunk.groupsIterable[Symbol.iterator],
+    'function',
+  );
+  assert.strictEqual(pathData.chunk.canBeInitial(), true);
+
+  return isEntryChunk(pathData.chunk) ? '[name].js' : '[name]-initial-chunk.js';
+}
+
+class Plugin {
+  apply(compiler) {
+    compiler.hooks.done.tap('filename-function-entry-chunk', (stats) => {
+      const assetNames = stats
+        .toJson({ all: false, assets: true })
+        .assets.map((asset) => asset.name)
+        .sort();
+
+      assert.deepStrictEqual(assetNames, [
+        'a.js',
+        'b.js',
+        'shared-initial-chunk.js',
+      ]);
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  entry: {
+    a: './a',
+    b: './b',
+  },
+  output: {
+    filename,
+  },
+  optimization: {
+    chunkIds: 'named',
+    splitChunks: {
+      chunks: 'initial',
+      minSize: 0,
+      cacheGroups: {
+        shared: {
+          name: 'shared',
+          minChunks: 2,
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [new Plugin()],
+};

--- a/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/shared.js
+++ b/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/shared.js
@@ -1,0 +1,2 @@
+export default 'shared';
+

--- a/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/test.config.js
+++ b/tests/rspack-test/configCases/filename-template/filename-function-entry-chunk/test.config.js
@@ -1,0 +1,5 @@
+/** @type {import('@rspack/test-tools').TConfigCaseConfig} */
+module.exports = {
+  noTests: true,
+};
+

--- a/tests/rspack-test/configCases/filename-template/filename-function/rspack.config.js
+++ b/tests/rspack-test/configCases/filename-template/filename-function/rspack.config.js
@@ -1,3 +1,12 @@
+const assert = require('assert');
+
+function assertRealChunk(data, name) {
+  assert(data.chunk);
+  assert.strictEqual(data.chunk.name, name);
+  assert.strictEqual(typeof data.chunk.getEntryOptions, 'function');
+  assert.strictEqual(typeof data.chunk.canBeInitial, 'function');
+}
+
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   mode: 'development',
@@ -6,15 +15,18 @@ module.exports = {
     b: {
       import: './b',
       filename: (data) => {
+        assertRealChunk(data, 'b');
         return data.chunk.name + data.chunk.name + data.chunk.name + '.js';
       },
     },
   },
   output: {
     filename: (data) => {
+      assertRealChunk(data, data.chunk.name);
       return data.chunk.name + data.chunk.name + '.js';
     },
     chunkFilename: (data) => {
+      assertRealChunk(data, data.chunk.name);
       return data.chunk.name + data.chunk.name + '.js';
     },
   },

--- a/tests/rspack-test/configCases/hooks/get-path-custom-chunk/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/get-path-custom-chunk/rspack.config.js
@@ -4,33 +4,38 @@ class Plugin {
   apply(compiler) {
     let called = false;
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
-      called = true;
-      expect(
-        compilation.getPath('[id]-[name]-[chunkhash]-[contenthash]', {
-          chunk: {
-            name: 'chunkname',
-            id: 'chunkid',
-            hash: 'chunkhash',
-            contentHash: {
-              javascript: 'contenthash',
-            },
-          },
-          contentHashType: 'javascript',
-        }),
-      ).toBe('chunkid-chunkname-chunkhash-contenthash');
+      compilation.hooks.processAssets.tap(pluginName, () => {
+        called = true;
+        const mainChunk = Array.from(compilation.chunks).find(
+          (chunk) => chunk.name === 'main',
+        );
+        expect(mainChunk).toBeDefined();
+        const contentHash = mainChunk.contentHash.javascript.slice(0, 20);
 
-      expect(
-        compilation.getPath('[name]-[chunkhash]-[contenthash]', {
-          chunk: {
-            id: 'chunkid',
-            hash: 'chunkhash',
-            contentHash: {
-              javascript: 'contenthash',
+        expect(
+          compilation.getPath('[id]-[name]-[chunkhash]-[contenthash]', {
+            chunk: mainChunk,
+            contentHashType: 'javascript',
+          }),
+        ).toBe(
+          `${mainChunk.id}-${mainChunk.name}-${mainChunk.renderedHash}-${contentHash}`,
+        );
+
+        expect(
+          compilation.getPath('[name]-[chunkhash]-[contenthash]', {
+            chunk: mainChunk,
+            contentHashType: 'javascript',
+          }),
+        ).toBe(`${mainChunk.name}-${mainChunk.renderedHash}-${contentHash}`);
+
+        expect(
+          compilation.getPath('[name]', {
+            chunk: {
+              name: 'main',
             },
-          },
-          contentHashType: 'javascript',
-        }),
-      ).toBe('chunkid-chunkhash-contenthash');
+          }),
+        ).toBe('[name]');
+      });
     });
     compiler.hooks.done.tap(pluginName, (stats) => {
       let json = stats.toJson();

--- a/website/docs/en/config/filename-placeholders.mdx
+++ b/website/docs/en/config/filename-placeholders.mdx
@@ -197,14 +197,7 @@ type PathData = {
   runtime?: string;
   url?: string;
   id?: string | number;
-  chunk?: Chunk | ChunkPathData;
+  chunk?: Chunk;
   contentHashType?: string;
-};
-
-type ChunkPathData = {
-  id?: string | number;
-  name?: string;
-  hash?: string;
-  contentHash?: Record<string, string>;
 };
 ```

--- a/website/docs/en/types/path-data.mdx
+++ b/website/docs/en/types/path-data.mdx
@@ -8,7 +8,7 @@ type PathData = {
   runtime?: string;
   url?: string;
   id?: string | number;
-  chunk?: JsChunkPathData;
+  chunk?: Chunk;
 };
 ```
 

--- a/website/docs/zh/config/filename-placeholders.mdx
+++ b/website/docs/zh/config/filename-placeholders.mdx
@@ -197,14 +197,7 @@ type PathData = {
   runtime?: string;
   url?: string;
   id?: string | number;
-  chunk?: Chunk | ChunkPathData;
+  chunk?: Chunk;
   contentHashType?: string;
-};
-
-type ChunkPathData = {
-  id?: string | number;
-  name?: string;
-  hash?: string;
-  contentHash?: Record<string, string>;
 };
 ```

--- a/website/docs/zh/types/path-data.mdx
+++ b/website/docs/zh/types/path-data.mdx
@@ -8,7 +8,7 @@ type PathData = {
   runtime?: string; // 关联 runtime，对应 [runtime]
   url?: string; // 路径信息，对应 [url]
   id?: string | number; // 产物的ID，对应 [id]
-  chunk?: JsChunkPathData; // 关联 chunk 信息，对应 [chunkhash]
+  chunk?: Chunk; // 关联 chunk 信息，对应 [chunkhash]
 };
 ```
 


### PR DESCRIPTION
## Summary

`pathData.chunk` for filename-related APIs is now a **real `Chunk` instance** whenever a chunk is available, instead of a plain `{ name, id, hash }` snapshot object.

This applies consistently to both directions:

- filename callbacks such as `output.filename` / `output.chunkFilename`
- `Compilation.getPath(...)` / `getAssetPath(...)` input data

This lets filename functions distinguish, for example, the entry chunk from other chunks by walking chunk groups:

```js
output: {
  filename: (pathData) => {
    const chunk = pathData.chunk;
    const isEntry = chunk && [...chunk.groupsIterable].some(
      g => g.isInitial() && g.getEntrypointChunk() === chunk
    );
    return isEntry ? "[name].js" : "chunks/[name].js";
  }
}
```

### How

- `ChunkWrapper` can now be converted both ways across napi: native -> JS and JS -> native.
- `JsPathData` is the single binding DTO for filename path data; its `chunk` field is `Chunk`, not a snapshot object.
- `rspack_core::PathData` stays a pure string/snapshot carrier. A small `RenderChunk` context is threaded through the filename render path for native-owned chunks.
- Filename call sites that compute paths for real chunks pass the chunk context through `get_path*_for_chunk` helpers.

### Behavior change

`pathData.chunk` is now the real `Chunk`, so direct property reads are webpack-aligned:

- `chunk.name` is the raw chunk name and may be `undefined` for unnamed chunks. Use `chunk.name ?? chunk.id` if a fallback is needed.
- `chunk.hash` is the full encoded hash. Use `chunk.renderedHash` for the rendered hash truncated to `output.hashDigestLength`.
- `chunk.id`, `chunk.contentHash`, and chunk methods such as `groupsIterable` / `getEntryOptions()` are available.

`Compilation.getPath(...)` and related APIs no longer accept a synthetic chunk-like object such as `{ name, id, hash }`; pass a real chunk from `compilation.chunks` instead.

Template placeholders such as `[name]`, `[id]`, `[chunkhash]`, and `[contenthash]` continue to render from the internal `PathData` values, so returning template strings from filename callbacks keeps the expected placeholder behavior.

### Notes

`hotUpdateChunkFilename` is excluded from real-chunk exposure for the temporary hot-update chunk because that chunk is removed from `chunk_by_ukey` before the filename is computed. Its template placeholders still work, but `pathData.chunk` is `undefined` there instead of a dead wrapper.

## Related links

_None._

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
