### PR TITLE
chore: add rspack perf codspeed goal skill

### DIFF
--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: rspack-perf-codspeed-goal
+description: Use when optimizing a benchmarked code path through a GitHub PR where success depends on GitHub Actions checks, CodSpeed PR comments, requested percentage thresholds, flaky CI reruns, rebases, review comments, or repeated performance iterations. For Rspack performance work, combine this workflow with the rspack-perf skill and keep changes within the user-specified plugin, file, crate, feature, compilation stage, benchmark, or hot path unless expanding scope is necessary for correctness or the measured optimization.
+---
+
+# Rspack Perf CodSpeed Goal
+
+Use this for performance work where success is judged by a GitHub PR, required correctness validation, review comments, and CodSpeed benchmark feedback.
+
+The agent owns the loop. After the user gives the target benchmark, threshold, and scope, keep making the next best engineering decision without asking for routine confirmation. Continue until CodSpeed confirms the target and correctness gates are green, a real blocker prevents progress, or the configured round limit is reached.
+
+## Invariants
+
+- Treat explicit user targets as binding: benchmark name, required percentage, scope, PR, and maximum rounds.
+- Default maximum is 10 optimization rounds unless the user specifies another limit.
+- One round means one local optimization attempt plus local correctness validation, review validation, push, CI/CodSpeed validation, review-comment triage, and a continue-or-stop decision.
+- When running under a persistent `/goal`, keep the original target intact across resumes. Do not redefine success around partial progress, a pending CI state, or a narrower benchmark.
+- Do not end a non-terminal round without scheduling the required 10-minute CI/CodSpeed follow-up.
+- Prefer the GitHub connector/plugin for GitHub operations; use `gh` only when the connector cannot perform the required action. Avoid the 1Password `gh` shell plugin unless explicitly requested.
+- Preserve behavior unless the user explicitly accepts a semantic change.
+- Keep changes scoped to the requested ownership boundary. Expand scope only when the measured bottleneck or correctness fix requires it, and explain the expansion.
+- Use local verification for correctness and CI/CodSpeed for final external validation. Do not run local CodSpeed benches or other local performance benchmarks; the local environment cannot run CodSpeed reliably, so performance evidence must come from CI/CodSpeed comments.
+- Use append-only commits for normal optimization rounds. Do not routinely amend previous commits or force-push; use history rewriting only for an explicit user-requested rebase or another unavoidable repository operation.
+
+## Initial Setup
+
+1. Establish a clean base.
+   - Check the working tree before changing code.
+   - Stop if uncommitted user changes would be overwritten or mixed into the optimization.
+   - Fetch latest `origin/main`.
+   - Use a clean branch or worktree based on fetched `origin/main`, unless the user explicitly asks to continue an existing PR branch.
+   - Confirm the optimization branch contains no unrelated commits or file changes.
+
+2. Establish the target.
+   - Record the benchmark name exactly as CodSpeed reports it.
+   - Record the required threshold, for example `+5%` on a specific benchmark.
+   - Record the requested optimization scope: plugin, file, crate, feature, compilation stage, benchmark, or hot path.
+   - Record the PR URL, branch, base, head SHA, and current round number.
+   - For Rspack work, use `$rspack-perf` to guide the optimization strategy before changing code.
+
+3. Create or identify the fixed progress comment.
+   - Maintain one persistent PR comment that records every round and every pushed commit.
+   - Reuse the existing progress comment if present; otherwise create one.
+   - Update this comment after every pushed round and after every terminal CodSpeed decision.
+   - Include commit SHA, round number, summary of code change, local correctness validation result, any ignored local flaky test cases, subagent review result, CI state, CodSpeed result, review-comment state, target threshold, pass/fail status, and next action.
+
+## Per-Round Checklist
+
+Run these steps in order for every round.
+
+1. Modify code locally.
+   - Identify the next likely bottleneck from CodSpeed history, CI evidence, profiling artifacts, or code inspection.
+   - Implement the smallest scoped change that plausibly improves the target benchmark.
+   - Avoid unrelated cleanup, formatting churn, snapshot updates, or generated output unless required by the scoped change.
+   - If a prior round failed due to correctness, review feedback, or CI, fix that before adding another performance idea.
+
+2. Verify correctness locally.
+   - Run targeted tests that cover the changed behavior.
+   - Run the relevant lint/check command for the touched language, including `clippy` or Rust check coverage for Rust changes.
+   - Run format verification, not broad formatting churn, unless formatting is already required.
+   - For Rspack, follow repository guidance: JavaScript/TypeScript changes need the relevant JS build before JS tests; Rust changes need the relevant Rust binding build before Rust tests; mixed changes need the full dev build.
+   - Do not attempt to run CodSpeed benches locally. They are not expected to work in the local environment; only run correctness-oriented build, test, lint/check, clippy, and format verification.
+   - Some local test cases, especially native watcher and swc-related cases, may be flaky in local runs. If such a known-flaky case fails and the failure is unrelated to the scoped change, record it as ignored local flakiness and continue; do not let it block the round.
+   - If a local correctness command fails, fix it locally and repeat local verification before pushing.
+   - Do not substitute CodSpeed performance data for correctness evidence.
+
+3. Run a correctness-focused subagent code review.
+   - Before every commit/push, dispatch an independent subagent over the current diff.
+   - Ask it to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
+   - If the subagent reports a real concern, fix it and repeat local verification plus subagent review.
+   - If the concern is not valid, record the technical reason in the progress comment.
+
+4. Commit and push.
+   - Review the diff for accidental unrelated edits.
+   - Commit with a focused title, usually `perf: ...`.
+   - Push the branch as a new commit on top of the prior round. Do not amend the previous optimization commit for normal iteration.
+   - Use `--force-with-lease` only after an explicit rebase or another unavoidable history rewrite, not as the default round workflow.
+   - Request or re-request GitHub Copilot code review for the latest head SHA.
+   - Update the fixed progress comment with the new commit SHA and pre-push validation summary.
+
+5. Start CI/CodSpeed tracking.
+   - Fetch workflow runs once after pushing to confirm CI started.
+   - Create a 10-minute timer/follow-up automation to recheck GitHub CI status and the latest CodSpeed PR comment for the same PR head SHA.
+   - Do not poll more frequently than the 10-minute cadence unless a result is already available and requires immediate action.
+   - If automation tools are unavailable, report that blocker explicitly instead of relying on manual follow-up silently.
+
+6. Classify CI status.
+   - Track the full GitHub checks/task list for the current head SHA, not only CodSpeed.
+   - Classify every CI task before judging success.
+   - Treat CodSpeed checks as performance evidence and interpret them in the CodSpeed step.
+   - Record `Binary Size Limit` separately; do not block correctness triage on it unless the user or repository policy makes it required.
+   - All test-related CI actions must pass before CodSpeed feedback is trusted for success or next-round performance decisions.
+   - All other required correctness CI tasks must pass before success can be reported.
+   - For any non-CodSpeed, non-Binary-Size failure, fetch job details and logs, analyze cause, and decide independently:
+     - If caused by the optimization or fixable in scope, fix locally and start a new round.
+     - If clearly unrelated and known flaky, rerun only the failed job or jobs once, then recheck the same head SHA.
+     - If caused by stale generated output or version mismatch, update the relevant source/generated files locally and start a new round.
+   - For any failed test-related action, fetch the failure logs, identify the failing test or build step, fix the cause when it is related or plausibly related to the optimization, and start a new round. Do not treat CI as trustworthy while any test-related action is failed, cancelled, missing, or still pending.
+   - If CI is still pending, update the progress comment and create another 10-minute follow-up before yielding.
+
+7. Handle code review comments before performance evaluation completes.
+   - Inspect unresolved code review comments and review threads for the latest PR head SHA before declaring the performance evaluation complete.
+   - Include Copilot and human reviewer comments.
+   - Resolve outdated threads directly.
+   - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new round with local verification and subagent review.
+   - If a live comment is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, update the progress comment, and continue the same evaluation if no code changed.
+   - Do not declare success while any non-outdated review comment or requested-change thread remains unresolved.
+
+8. Read and interpret CodSpeed feedback.
+   - Use the latest CodSpeed PR comment for the current head SHA.
+   - Before using CodSpeed to judge success or choose the next performance direction, confirm all test-related CI actions passed for the same head SHA.
+   - If any test-related CI action has not passed, record CodSpeed as provisional only, fix or wait on CI first, and do not declare the target reached.
+   - Compare the requested benchmark against the PR base used by CodSpeed.
+   - Record exact before/after values, percentage delta, environment warnings, and whether the requested threshold is met.
+   - Compare the current commit's performance result with the previous round's result when both are available.
+   - Check for meaningful regressions in other benchmarks before declaring success.
+   - Treat environment warnings as reportable context. Discard a result only when the comparison is unreliable.
+   - Update the fixed progress comment with the CodSpeed result and pass/fail status.
+
+9. Decide the next action independently.
+   - If local correctness, required CI, review comments, and CodSpeed target all pass, report success with exact commit SHA, benchmark values, percentage delta, and PR status.
+   - If the current commit does not improve performance versus the previous round, revert that commit's code changes with a new follow-up commit, update the progress comment, and start the next round from the reverted code state.
+   - If CodSpeed improves versus the previous round but remains below threshold and the round limit is not reached, immediately choose the next scoped optimization direction and start the next round.
+   - If review or CI requires code changes, start the next round focused on that fix before additional performance work.
+   - If the round limit is reached, stop and report the best observed result, all attempted directions, current CI/review state, and the reason for stopping.
+   - If resumed from a timer, goal continuation, or thread wakeup, inspect the current PR head SHA, fixed progress comment, CI state, review threads, and latest CodSpeed comment before deciding. Continue the same round when the head SHA is unchanged; start a new round only when code changes are required.
+   - Ask the user only for a true product or semantic decision, missing credentials/access, or a blocker that cannot be resolved through code, CI, GitHub, or review analysis.
+
+10. Perform terminal CodSpeed explain request.
+   - Run this only after the workflow is terminal: either the target is reached or the round limit has been reached.
+   - If the final trusted CodSpeed result shows any performance improvement, add a PR comment exactly: `@codspeedbot explain why this PR is faster`.
+   - Add this comment even when the target threshold was not reached, as long as the final trusted CodSpeed result is faster than the relevant base or previous retained round.
+   - Do not add the comment when the final CodSpeed result is provisional, unreliable, neutral, or slower.
+   - Record whether this comment was added in the fixed progress comment and final report.
+
+## Progress Comment Format
+
+Keep one fixed PR comment in this shape and refresh it throughout the work:
+
+```markdown
+## CodSpeed Optimization Log
+
+Target: `<benchmark>` >= `<threshold>`
+Scope: `<requested scope>`
+Current status: `<running|passed|failed|blocked>`
+Latest head: `<sha>`
+
+| Round | Commit | Change | Local correctness | Local flakiness | Subagent review | CI | Review comments | CodSpeed | Meets target | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `<sha>` | `<summary>` | `<tests/checks/format>` | `<none or ignored cases>` | `<pass/notes>` | `<state>` | `<resolved/pending>` | `<delta or pending>` | `<yes/no/pending>` | `<next>` |
+```
+
+Update, do not duplicate, this comment. Keep entries concise but specific enough that the full commit history and performance result history are visible.
+
+## Rspack Scope
+
+When the repository or task is Rspack-specific:
+
+- Use `$rspack-perf` before implementation to guide the optimization strategy.
+- Treat the user's requested plugin, file, crate, feature, compilation stage, or benchmark as the ownership boundary.
+- Optimize from Rspack's data cardinality model: dependencies and export infos are usually higher risk than modules, chunks, chunk groups, entries, or runtimes.
+- Prefer focused CPU and allocation reductions in the requested area over broad cleanup or unrelated refactors.
+- Do not touch unrelated plugins, compilation stages, tests, snapshots, or formatting outside the changed files unless required by the scoped optimization or CI result.
+- If the measured bottleneck crosses the requested boundary, explain the reason before expanding scope and keep the expansion minimal.
+
+## Correctness Guardrails
+
+- When caching derived state, verify that the state is stable for the whole pass where it is reused.
+- When adding a fast path, compare it against the original slow path for all relevant modes, not only the common case.
+- When changing data structures to reduce allocation, check ordering, deduplication, hashing, equality, and user-visible diagnostics.
+- When changing concurrency or scheduling, check determinism, cancellation, shared-state ownership, and cleanup.
+- When changing build artifacts or generated files, verify source and generated output stay consistent.
+- If a subagent, reviewer, CI job, or local command finds a correctness concern, either fix it or document why code/tests prove it harmless.
+
+## Reporting
+
+Keep updates short and decision-oriented:
+
+- State the PR URL, branch, head SHA, round number, and target.
+- State what changed in the current round and why it should affect the benchmark.
+- List local correctness validation: tests, clippy/check/lint, format verification, ignored local flaky cases, and subagent review result.
+- List required CI checks that passed, failed, or are pending.
+- State Copilot/human review-comment status and how comments were handled.
+- Summarize CodSpeed outcome with exact benchmark deltas and target pass/fail.
+- State whether the fixed progress comment was updated.
+- State whether `@codspeedbot explain why this PR is faster` was posted when the terminal CodSpeed result had an improvement.
+- State whether the next 10-minute CI/CodSpeed timer was created, unless the workflow is complete or immediately continuing into another local round.
+- If more work is needed, name the next optimization or correctness direction.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -19,7 +19,7 @@ The agent owns the loop. After the user gives the target benchmark, threshold, a
 - Prefer the GitHub connector/plugin for GitHub operations; use `gh` only when the connector cannot perform the required action. Avoid the 1Password `gh` shell plugin unless explicitly requested.
 - Preserve behavior unless the user explicitly accepts a semantic change.
 - Keep changes scoped to the requested ownership boundary. Expand scope only when the measured bottleneck or correctness fix requires it, and explain the expansion.
-- Use local verification for correctness and CI/CodSpeed for final external validation. Do not run local CodSpeed benches or other local performance benchmarks; the local environment cannot run CodSpeed reliably, so performance evidence must come from CI/CodSpeed comments.
+- Use local verification for correctness and CI/CodSpeed for final external validation. Local performance benchmarks are optional triage signals only when the repository documents a reliable command for the requested benchmark; final performance evidence must still come from CI/CodSpeed comments.
 - Use append-only commits for normal optimization rounds. Do not routinely amend previous commits or force-push; use history rewriting only for an explicit user-requested rebase or another unavoidable repository operation.
 
 ## Initial Setup
@@ -28,7 +28,8 @@ The agent owns the loop. After the user gives the target benchmark, threshold, a
    - Check the working tree before changing code.
    - Stop if uncommitted user changes would be overwritten or mixed into the optimization.
    - Fetch latest `origin/main`.
-   - Use a clean branch or worktree based on fetched `origin/main`, unless the user explicitly asks to continue an existing PR branch.
+   - If the user supplies an existing PR URL, branch, or head SHA, continue from that PR head unless they explicitly ask for a fresh branch or PR.
+   - Otherwise use a clean branch or worktree based on fetched `origin/main`.
    - Confirm the optimization branch contains no unrelated commits or file changes.
 
 2. Establish the target.
@@ -42,7 +43,7 @@ The agent owns the loop. After the user gives the target benchmark, threshold, a
    - Maintain one persistent PR comment that records every round and every pushed commit.
    - Reuse the existing progress comment if present; otherwise create one.
    - Update this comment after every pushed round and after every terminal CodSpeed decision.
-   - Include commit SHA, round number, summary of code change, local correctness validation result, any ignored local flaky test cases, subagent review result, CI state, CodSpeed result, review-comment state, target threshold, pass/fail status, and next action.
+   - Include only the round number, commit SHA, summary of code change, and CodSpeed result.
 
 ## Per-Round Checklist
 
@@ -59,7 +60,7 @@ Run these steps in order for every round.
    - Run the relevant lint/check command for the touched language, including `clippy` or Rust check coverage for Rust changes.
    - Run format verification, not broad formatting churn, unless formatting is already required.
    - For Rspack, follow repository guidance: JavaScript/TypeScript changes need the relevant JS build before JS tests; Rust changes need the relevant Rust binding build before Rust tests; mixed changes need the full dev build.
-   - Do not attempt to run CodSpeed benches locally. They are not expected to work in the local environment; only run correctness-oriented build, test, lint/check, clippy, and format verification.
+   - Do not require local CodSpeed benches. When Rspack documents a reliable local benchmark command for the requested benchmark, you may run it as a pre-push signal to catch obvious slowdowns before spending CI/CodSpeed rounds.
    - Some local test cases, especially native watcher and swc-related cases, may be flaky in local runs. If such a known-flaky case fails and the failure is unrelated to the scoped change, record it as ignored local flakiness and continue; do not let it block the round.
    - If a local correctness command fails, fix it locally and repeat local verification before pushing.
    - Do not substitute CodSpeed performance data for correctness evidence.
@@ -68,7 +69,7 @@ Run these steps in order for every round.
    - Before every commit/push, dispatch an independent subagent over the current diff.
    - Ask it to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
    - If the subagent reports a real concern, fix it and repeat local verification plus subagent review.
-   - If the concern is not valid, record the technical reason in the progress comment.
+   - If the concern is not valid, record the technical reason in a review reply or final report.
 
 4. Commit and push.
    - Review the diff for accidental unrelated edits.
@@ -76,7 +77,7 @@ Run these steps in order for every round.
    - Push the branch as a new commit on top of the prior round. Do not amend the previous optimization commit for normal iteration.
    - Use `--force-with-lease` only after an explicit rebase or another unavoidable history rewrite, not as the default round workflow.
    - Request or re-request GitHub Copilot code review for the latest head SHA.
-   - Update the fixed progress comment with the new commit SHA and pre-push validation summary.
+   - Update the fixed progress comment with the new commit SHA and change summary.
 
 5. Start CI/CodSpeed tracking.
    - Fetch workflow runs once after pushing to confirm CI started.
@@ -96,14 +97,14 @@ Run these steps in order for every round.
      - If clearly unrelated and known flaky, rerun only the failed job or jobs once, then recheck the same head SHA.
      - If caused by stale generated output or version mismatch, update the relevant source/generated files locally and start a new round.
    - For any failed test-related action, fetch the failure logs, identify the failing test or build step, fix the cause when it is related or plausibly related to the optimization, and start a new round. Do not treat CI as trustworthy while any test-related action is failed, cancelled, missing, or still pending.
-   - If CI is still pending, update the progress comment and create another 10-minute follow-up before yielding.
+   - If CI is still pending, create another 10-minute follow-up before yielding.
 
 7. Handle code review comments before performance evaluation completes.
    - Inspect unresolved code review comments and review threads for the latest PR head SHA before declaring the performance evaluation complete.
    - Include Copilot and human reviewer comments.
    - Resolve outdated threads directly.
    - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new round with local verification and subagent review.
-   - If a live comment is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, update the progress comment, and continue the same evaluation if no code changed.
+   - If a live comment is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, and continue the same evaluation if no code changed.
    - Do not declare success while any non-outdated review comment or requested-change thread remains unresolved.
 
 8. Read and interpret CodSpeed feedback.
@@ -115,11 +116,12 @@ Run these steps in order for every round.
    - Compare the current commit's performance result with the previous round's result when both are available.
    - Check for meaningful regressions in other benchmarks before declaring success.
    - Treat environment warnings as reportable context. Discard a result only when the comparison is unreliable.
-   - Update the fixed progress comment with the CodSpeed result and pass/fail status.
+   - Update the fixed progress comment with the CodSpeed result.
 
 9. Decide the next action independently.
    - If local correctness, required CI, review comments, and CodSpeed target all pass, report success with exact commit SHA, benchmark values, percentage delta, and PR status.
-   - If the current commit does not improve performance versus the previous round, revert that commit's code changes with a new follow-up commit, update the progress comment, and start the next round from the reverted code state.
+   - If a performance-focused round does not improve performance versus the previous round, revert that commit's code changes with a new follow-up commit, update the progress comment with the reverted state, and start the next round from the reverted code state.
+   - If a round only fixes correctness, CI, or review feedback, keep the fix when validation improves even if the CodSpeed result is neutral.
    - If CodSpeed improves versus the previous round but remains below threshold and the round limit is not reached, immediately choose the next scoped optimization direction and start the next round.
    - If review or CI requires code changes, start the next round focused on that fix before additional performance work.
    - If the round limit is reached, stop and report the best observed result, all attempted directions, current CI/review state, and the reason for stopping.
@@ -146,12 +148,12 @@ Scope: `<requested scope>`
 Current status: `<running|passed|failed|blocked>`
 Latest head: `<sha>`
 
-| Round | Commit  | Change      | Local correctness       | Local flakiness           | Subagent review | CI        | Review comments      | CodSpeed             | Meets target       | Next action |
-| ----- | ------- | ----------- | ----------------------- | ------------------------- | --------------- | --------- | -------------------- | -------------------- | ------------------ | ----------- |
-| 1     | `<sha>` | `<summary>` | `<tests/checks/format>` | `<none or ignored cases>` | `<pass/notes>`  | `<state>` | `<resolved/pending>` | `<delta or pending>` | `<yes/no/pending>` | `<next>`    |
+| Round | Commit  | Change      | CodSpeed             |
+| ----- | ------- | ----------- | -------------------- |
+| 1     | `<sha>` | `<summary>` | `<delta or pending>` |
 ```
 
-Update, do not duplicate, this comment. Keep entries concise but specific enough that the full commit history and performance result history are visible.
+Update, do not duplicate, this comment. Keep entries concise but specific enough that the commit history and performance result history are visible.
 
 ## Rspack Scope
 

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -127,7 +127,7 @@ Run these steps in order for every round.
 9. Decide the next action independently.
    - If local correctness, required CI, review comments, and CodSpeed target all pass, report success with exact commit SHA, benchmark values, percentage delta, and PR status.
    - Compare the first performance-focused round with the CodSpeed PR base. Compare each later performance-focused round with the previous retained performance-focused round.
-   - If a performance-focused round does not improve performance versus that comparison point, revert that commit's code changes with a new follow-up commit, update the progress comment with the reverted state, and start the next round from the reverted code state.
+   - If a performance-focused round does not improve performance versus that comparison point, revert that commit's code changes with a new follow-up commit and update the progress comment with the reverted state. If the round limit has been reached, stop after the revert; otherwise start the next round from the reverted code state.
    - If a round only fixes correctness, CI, or review feedback, keep the fix when validation improves even if the CodSpeed result is neutral.
    - If CodSpeed improves versus that comparison point but remains below threshold and the round limit is not reached, immediately choose the next scoped optimization direction and start the next round.
    - If review or CI requires code changes, start the next round focused on that fix before additional performance work.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -119,16 +119,16 @@ Run these steps in order for every round.
    - If any test-related CI action has not passed, record CodSpeed as provisional only, fix or wait on CI first, and do not declare the target reached.
    - Compare the requested benchmark against the PR base used by CodSpeed.
    - Record exact before/after values, percentage delta, environment warnings, and whether the requested threshold is met.
-   - Compare the current commit's performance result with the previous round's result when both are available.
+   - Compare the current commit's performance result with the most recent retained snapshot's result when both are available.
    - Check for meaningful regressions in other benchmarks before declaring success.
    - Treat environment warnings as reportable context. Discard a result only when the comparison is unreliable.
    - Update the fixed progress comment with the CodSpeed result.
 
 9. Decide the next action independently.
    - If local correctness, required CI, review comments, and CodSpeed target all pass, report success with exact commit SHA, benchmark values, percentage delta, and PR status.
-   - Compare the first performance-focused round with the CodSpeed PR base. Compare each later performance-focused round with the previous retained performance-focused round.
+   - Compare the first candidate with the CodSpeed PR base. Compare every later candidate with the most recent retained snapshot, including a retained correctness-only fix, because that snapshot is the candidate's actual code parent.
    - If a performance-focused round does not improve performance versus that comparison point, revert that commit's code changes with a new follow-up commit and update the progress comment with the reverted state. If the round limit has been reached, stop after the revert; otherwise start the next round from the reverted code state.
-   - If a round only fixes correctness, CI, or review feedback, keep the fix when validation improves even if the CodSpeed result is neutral.
+   - If a round only fixes correctness, CI, or review feedback, keep the fix when validation improves even if the CodSpeed result is neutral or slower. Record its trusted CodSpeed result as the comparison point for the next candidate.
    - If CodSpeed improves versus that comparison point but remains below threshold and the round limit is not reached, immediately choose the next scoped optimization direction and start the next round.
    - If review or CI requires code changes, start the next round focused on that fix before additional performance work.
    - If the round limit is reached, stop and report the best observed result, all attempted directions, current CI/review state, and the reason for stopping.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -127,11 +127,12 @@ Run these steps in order for every round.
    - Ask the user only for a true product or semantic decision, missing credentials/access, or a blocker that cannot be resolved through code, CI, GitHub, or review analysis.
 
 10. Perform terminal CodSpeed explain request.
-   - Run this only after the workflow is terminal: either the target is reached or the round limit has been reached.
-   - If the final trusted CodSpeed result shows any performance improvement, add a PR comment exactly: `@codspeedbot explain why this PR is faster`.
-   - Add this comment even when the target threshold was not reached, as long as the final trusted CodSpeed result is faster than the relevant base or previous retained round.
-   - Do not add the comment when the final CodSpeed result is provisional, unreliable, neutral, or slower.
-   - Record whether this comment was added in the fixed progress comment and final report.
+
+    - Run this only after the workflow is terminal: either the target is reached or the round limit has been reached.
+    - If the final trusted CodSpeed result shows any performance improvement, add a PR comment exactly: `@codspeedbot explain why this PR is faster`.
+    - Add this comment even when the target threshold was not reached, as long as the final trusted CodSpeed result is faster than the relevant base or previous retained round.
+    - Do not add the comment when the final CodSpeed result is provisional, unreliable, neutral, or slower.
+    - Record whether this comment was added in the fixed progress comment and final report.
 
 ## Progress Comment Format
 
@@ -145,9 +146,9 @@ Scope: `<requested scope>`
 Current status: `<running|passed|failed|blocked>`
 Latest head: `<sha>`
 
-| Round | Commit | Change | Local correctness | Local flakiness | Subagent review | CI | Review comments | CodSpeed | Meets target | Next action |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `<sha>` | `<summary>` | `<tests/checks/format>` | `<none or ignored cases>` | `<pass/notes>` | `<state>` | `<resolved/pending>` | `<delta or pending>` | `<yes/no/pending>` | `<next>` |
+| Round | Commit  | Change      | Local correctness       | Local flakiness           | Subagent review | CI        | Review comments      | CodSpeed             | Meets target       | Next action |
+| ----- | ------- | ----------- | ----------------------- | ------------------------- | --------------- | --------- | -------------------- | -------------------- | ------------------ | ----------- |
+| 1     | `<sha>` | `<summary>` | `<tests/checks/format>` | `<none or ignored cases>` | `<pass/notes>`  | `<state>` | `<resolved/pending>` | `<delta or pending>` | `<yes/no/pending>` | `<next>`    |
 ```
 
 Update, do not duplicate, this comment. Keep entries concise but specific enough that the full commit history and performance result history are visible.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -19,7 +19,7 @@ The agent owns the loop. After the user gives the target benchmark, threshold, a
 - Prefer the GitHub connector/plugin for GitHub operations; use `gh` only when the connector cannot perform the required action. Avoid the 1Password `gh` shell plugin unless explicitly requested.
 - Preserve behavior unless the user explicitly accepts a semantic change.
 - Keep changes scoped to the requested ownership boundary. Expand scope only when the measured bottleneck or correctness fix requires it, and explain the expansion.
-- Use local verification for correctness and CI/CodSpeed for final external validation. Local performance benchmarks are optional triage signals only when the repository documents a reliable command for the requested benchmark; final performance evidence must still come from CI/CodSpeed comments.
+- Use local verification only for correctness. Run all CodSpeed performance validation in CI and use the CI/CodSpeed result for the current PR head as the source of truth.
 - Use append-only commits for normal optimization rounds. Do not routinely amend previous commits or force-push; use history rewriting only for an explicit user-requested rebase or another unavoidable repository operation.
 
 ## Initial Setup
@@ -60,7 +60,7 @@ Run these steps in order for every round.
    - Run the relevant lint/check command for the touched language, including `clippy` or Rust check coverage for Rust changes.
    - Run format verification, not broad formatting churn, unless formatting is already required.
    - For Rspack, follow repository guidance: JavaScript/TypeScript changes need the relevant JS build before JS tests; Rust changes need the relevant Rust binding build before Rust tests; mixed changes need the full dev build.
-   - Do not require local CodSpeed benches. When Rspack documents a reliable local benchmark command for the requested benchmark, you may run it as a pre-push signal to catch obvious slowdowns before spending CI/CodSpeed rounds.
+   - Do not run CodSpeed locally. All performance validation and comparisons must come from CI/CodSpeed for the current PR head.
    - Some local test cases, especially native watcher and swc-related cases, may be flaky in local runs. If such a known-flaky case fails and the failure is unrelated to the scoped change, record it as ignored local flakiness and continue; do not let it block the round.
    - If a local correctness command fails, fix it locally and repeat local verification before pushing.
    - Do not substitute CodSpeed performance data for correctness evidence.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -65,11 +65,10 @@ Run these steps in order for every round.
    - If a local correctness command fails, fix it locally and repeat local verification before pushing.
    - Do not substitute CodSpeed performance data for correctness evidence.
 
-3. Run a correctness-focused independent review.
-   - Before every commit/push, dispatch an independent subagent over the current diff when subagents are available and allowed by the current environment and delegation rules.
-   - If subagents are unavailable or not allowed, perform a local diff review with the same correctness focus and record that fallback.
-   - Ask the review to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
-   - If the review reports a real concern, fix it and repeat local verification plus review.
+3. Run a correctness-focused subagent code review.
+   - Before every commit/push, dispatch an independent subagent over the current diff.
+   - Ask it to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
+   - If the subagent reports a real concern, fix it and repeat local verification plus subagent review.
    - If the concern is not valid, record the technical reason in a review reply or final report.
 
 4. Commit and push.
@@ -103,7 +102,7 @@ Run these steps in order for every round.
 7. Handle code review comments before performance evaluation completes.
    - Inspect unresolved code review comments and review threads for the latest PR head SHA before declaring the performance evaluation complete.
    - Include Copilot and human reviewer comments.
-   - For outdated threads, inspect the comment and current code before resolving; resolve only after confirming the concern was addressed or no longer applies.
+   - Resolve outdated threads directly.
    - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new round with local verification and subagent review.
    - If a live comment is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, and continue the same evaluation if no code changed.
    - Do not declare success while any non-outdated review comment or requested-change thread remains unresolved.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -65,10 +65,11 @@ Run these steps in order for every round.
    - If a local correctness command fails, fix it locally and repeat local verification before pushing.
    - Do not substitute CodSpeed performance data for correctness evidence.
 
-3. Run a correctness-focused subagent code review.
-   - Before every commit/push, dispatch an independent subagent over the current diff.
-   - Ask it to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
-   - If the subagent reports a real concern, fix it and repeat local verification plus subagent review.
+3. Run a correctness-focused independent review.
+   - Before every commit/push, dispatch an independent subagent over the current diff when subagents are available and allowed by the current environment and delegation rules.
+   - If subagents are unavailable or not allowed, perform a local diff review with the same correctness focus and record that fallback.
+   - Ask the review to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
+   - If the review reports a real concern, fix it and repeat local verification plus review.
    - If the concern is not valid, record the technical reason in a review reply or final report.
 
 4. Commit and push.
@@ -102,7 +103,7 @@ Run these steps in order for every round.
 7. Handle code review comments before performance evaluation completes.
    - Inspect unresolved code review comments and review threads for the latest PR head SHA before declaring the performance evaluation complete.
    - Include Copilot and human reviewer comments.
-   - Resolve outdated threads directly.
+   - For outdated threads, inspect the comment and current code before resolving; resolve only after confirming the concern was addressed or no longer applies.
    - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new round with local verification and subagent review.
    - If a live comment is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, and continue the same evaluation if no code changed.
    - Do not declare success while any non-outdated review comment or requested-change thread remains unresolved.

--- a/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-codspeed-goal/SKILL.md
@@ -39,7 +39,11 @@ The agent owns the loop. After the user gives the target benchmark, threshold, a
    - Record the PR URL, branch, base, head SHA, and current round number.
    - For Rspack work, use `$rspack-perf` to guide the optimization strategy before changing code.
 
-3. Create or identify the fixed progress comment.
+3. Ensure PR-dependent actions wait for an open PR.
+   - Reuse the supplied PR when one exists.
+   - For a fresh branch, create the PR after the first scoped change is committed and pushed, before requesting review, creating the progress comment, or starting CI/CodSpeed tracking.
+
+4. Create or identify the fixed progress comment after the PR exists.
    - Maintain one persistent PR comment that records every round and every pushed commit.
    - Reuse the existing progress comment if present; otherwise create one.
    - Update this comment after every pushed round and after every terminal CodSpeed decision.
@@ -65,10 +69,11 @@ Run these steps in order for every round.
    - If a local correctness command fails, fix it locally and repeat local verification before pushing.
    - Do not substitute CodSpeed performance data for correctness evidence.
 
-3. Run a correctness-focused subagent code review.
-   - Before every commit/push, dispatch an independent subagent over the current diff.
-   - Ask it to focus on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
-   - If the subagent reports a real concern, fix it and repeat local verification plus subagent review.
+3. Run a correctness-focused independent review.
+   - Before every commit/push, review the current diff independently from the implementation pass.
+   - Use a subagent only when it is available and explicitly allowed by the current environment and delegation rules; otherwise perform a local diff review.
+   - Focus the review on correctness, behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
+   - If the review reports a real concern, fix it and repeat local verification plus independent review.
    - If the concern is not valid, record the technical reason in a review reply or final report.
 
 4. Commit and push.
@@ -76,8 +81,9 @@ Run these steps in order for every round.
    - Commit with a focused title, usually `perf: ...`.
    - Push the branch as a new commit on top of the prior round. Do not amend the previous optimization commit for normal iteration.
    - Use `--force-with-lease` only after an explicit rebase or another unavoidable history rewrite, not as the default round workflow.
+   - If this is a fresh branch without a PR, create the PR now before any PR-dependent action.
    - Request or re-request GitHub Copilot code review for the latest head SHA.
-   - Update the fixed progress comment with the new commit SHA and change summary.
+   - Create or update the fixed progress comment with the new commit SHA and change summary.
 
 5. Start CI/CodSpeed tracking.
    - Fetch workflow runs once after pushing to confirm CI started.
@@ -102,8 +108,8 @@ Run these steps in order for every round.
 7. Handle code review comments before performance evaluation completes.
    - Inspect unresolved code review comments and review threads for the latest PR head SHA before declaring the performance evaluation complete.
    - Include Copilot and human reviewer comments.
-   - Resolve outdated threads directly.
-   - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new round with local verification and subagent review.
+   - Inspect outdated threads against the current code and resolve them only after confirming the concern was addressed or no longer applies.
+   - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new round with local verification and independent review.
    - If a live comment is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, and continue the same evaluation if no code changed.
    - Do not declare success while any non-outdated review comment or requested-change thread remains unresolved.
 
@@ -120,9 +126,10 @@ Run these steps in order for every round.
 
 9. Decide the next action independently.
    - If local correctness, required CI, review comments, and CodSpeed target all pass, report success with exact commit SHA, benchmark values, percentage delta, and PR status.
-   - If a performance-focused round does not improve performance versus the previous round, revert that commit's code changes with a new follow-up commit, update the progress comment with the reverted state, and start the next round from the reverted code state.
+   - Compare the first performance-focused round with the CodSpeed PR base. Compare each later performance-focused round with the previous retained performance-focused round.
+   - If a performance-focused round does not improve performance versus that comparison point, revert that commit's code changes with a new follow-up commit, update the progress comment with the reverted state, and start the next round from the reverted code state.
    - If a round only fixes correctness, CI, or review feedback, keep the fix when validation improves even if the CodSpeed result is neutral.
-   - If CodSpeed improves versus the previous round but remains below threshold and the round limit is not reached, immediately choose the next scoped optimization direction and start the next round.
+   - If CodSpeed improves versus that comparison point but remains below threshold and the round limit is not reached, immediately choose the next scoped optimization direction and start the next round.
    - If review or CI requires code changes, start the next round focused on that fix before additional performance work.
    - If the round limit is reached, stop and report the best observed result, all attempted directions, current CI/review state, and the reason for stopping.
    - If resumed from a timer, goal continuation, or thread wakeup, inspect the current PR head SHA, fixed progress comment, CI state, review threads, and latest CodSpeed comment before deciding. Continue the same round when the head SHA is unchanged; start a new round only when code changes are required.
@@ -131,9 +138,9 @@ Run these steps in order for every round.
 10. Perform terminal CodSpeed explain request.
 
     - Run this only after the workflow is terminal: either the target is reached or the round limit has been reached.
-    - If the final trusted CodSpeed result shows any performance improvement, add a PR comment exactly: `@codspeedbot explain why this PR is faster`.
-    - Add this comment even when the target threshold was not reached, as long as the final trusted CodSpeed result is faster than the relevant base or previous retained round.
-    - Do not add the comment when the final CodSpeed result is provisional, unreliable, neutral, or slower.
+    - If the final trusted CodSpeed result shows a net performance improvement over the CodSpeed PR base, add a PR comment exactly: `@codspeedbot explain why this PR is faster`.
+    - Add this comment even when the target threshold was not reached, as long as the final trusted CodSpeed result is faster than the PR base.
+    - Do not add the comment when the final CodSpeed result is provisional, unreliable, neutral, or slower than the PR base.
     - Record whether this comment was added in the fixed progress comment and final report.
 
 ## Progress Comment Format
@@ -181,7 +188,7 @@ Keep updates short and decision-oriented:
 
 - State the PR URL, branch, head SHA, round number, and target.
 - State what changed in the current round and why it should affect the benchmark.
-- List local correctness validation: tests, clippy/check/lint, format verification, ignored local flaky cases, and subagent review result.
+- List local correctness validation: tests, clippy/check/lint, format verification, ignored local flaky cases, and independent review result.
 - List required CI checks that passed, failed, or are pending.
 - State Copilot/human review-comment status and how comments were handled.
 - Summarize CodSpeed outcome with exact benchmark deltas and target pass/fail.

--- a/.agents/skills/rspack-perf-codspeed-goal/agents/openai.yaml
+++ b/.agents/skills/rspack-perf-codspeed-goal/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: 'Rspack Perf CodSpeed Goal'
+  short_description: 'Optimize Rspack through CI CodSpeed goal loops'
+  default_prompt: 'Use $rspack-perf-codspeed-goal to optimize the requested Rspack benchmark through repeated CI and CodSpeed validation.'
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: rspack-perf-valgrind-goal
+description: Use when optimizing a benchmarked Rspack code path against a requested percentage target with reproducible local Docker and Valgrind measurements instead of GitHub Actions or CodSpeed cloud results. Combine this workflow with the rspack-perf skill for repeated performance rounds, local correctness validation, review-comment handling, retained-versus-reverted decisions, and PR progress reporting while keeping changes within the user-specified plugin, file, crate, feature, compilation stage, benchmark, or hot path.
+---
+
+# Rspack Perf Valgrind Goal
+
+Use this for Rspack performance work where success is judged by the Callgrind instruction count of an exact benchmark stage measured locally in a pinned native-architecture Docker environment. Build the existing Rust benchmark target with ordinary Cargo, execute the selected binary directly under Valgrind, and decide only from local Callgrind profiles. Do not run a CodSpeed CLI, use a token, upload results, read CodSpeed PR comments, or wait for GitHub Actions.
+
+The agent owns the loop. After the user gives the target benchmark stage, threshold, and scope, continue until local Valgrind confirms the target and correctness validation passes, a real blocker prevents progress, or the configured round limit is reached.
+
+## Invariants
+
+- Treat explicit user targets as binding: exact measured stage, required percentage, scope, PR, and maximum rounds.
+- Default to at most 10 optimization rounds unless the user specifies another limit.
+- One round means one optimization attempt, local correctness validation, correctness-focused review, a committed snapshot, local Docker/Valgrind measurement, a retain-or-revert decision, and progress reporting.
+- For Rspack work, use `$rspack-perf` to guide optimization strategy before changing code.
+- Preserve behavior unless the user explicitly accepts a semantic change.
+- Keep changes within the requested ownership boundary. Expand scope only when the measured bottleneck or a correctness fix requires it, and explain the expansion.
+- Use only local measurements from the same native Docker platform, image ID, fixture directory, benchmark target, benchmark filter, environment, and measurement mode for comparisons.
+- A usable run must execute only the intended benchmark filter and produce a Callgrind profile with a nonzero `instruction_count`. Benchmark harness labels, cloud percentages, and wall time are not performance evidence for this workflow.
+- Do not use GitHub Actions status or CodSpeed PR comments to judge performance or correctness. CI may run after a push, but this workflow neither waits for nor monitors it.
+- Use append-only commits for normal rounds. Do not routinely amend or force-push; rewrite history only for an explicit rebase or another unavoidable repository operation.
+- When running under a persistent `/goal`, retain the original target across resumes. Do not redefine success around partial progress.
+
+## Local Measurement Contract
+
+Use `scripts/run_local_valgrind.sh` from this skill. It builds a reusable native-architecture image containing the repository's pinned Rust toolchain and Debian's standard Valgrind package. The helper mounts source and fixtures read-only, stores build caches in Docker volumes, builds with ordinary Cargo, executes only the selected benchmark binary under Callgrind, captures raw logs and profiles, and records an environment manifest.
+
+The helper passes the repository's existing `--cfg codspeed` compile-time switch to ordinary `cargo build` so the benchmark adapter exposes its Valgrind client-request boundaries. This is only a source configuration name: no CodSpeed executable, service, token, API, upload, PR comment, or benchmark result participates in the workflow. Valgrind starts instrumentation at the selected benchmark boundary, and `run-*.instructions` plus the local Callgrind profiles are the only performance source of truth.
+
+From the optimization checkout, initialize the environment once:
+
+```bash
+SKILL_DIR="<absolute path to .agents/skills/rspack-perf-valgrind-goal>"
+"$SKILL_DIR/scripts/run_local_valgrind.sh" build-image
+"$SKILL_DIR/scripts/run_local_valgrind.sh" prepare --repo "<optimization checkout>"
+```
+
+Prepare fixtures only once for a goal. Pass that exact fixture directory to both base and candidate measurements:
+
+```bash
+"$SKILL_DIR/scripts/run_local_valgrind.sh" measure \
+  --repo "<checkout to measure>" \
+  --fixtures "<optimization checkout>/.bench/rspack-benchcases" \
+  --bench "<benches or rspack_sources>" \
+  --filter "<exact benchmark filter>" \
+  --output "<absolute result directory>"
+```
+
+The helper defaults to two repetitions. Read each exact instruction count from `run-*.instructions`. If the stage differs by more than 0.5% between repetitions, run a third repetition with `--repeat 3` and use the median. Keep raw logs and Callgrind profiles; do not copy a number manually without retaining its source artifact.
+
+## Initial Setup
+
+1. Establish a clean optimization checkout.
+   - Check the working tree before changing code.
+   - Stop if uncommitted user changes would be overwritten or mixed into the optimization.
+   - Fetch the latest base branch.
+   - If the user supplies an existing PR URL, branch, or head SHA, continue from that head unless they explicitly request a fresh branch or PR.
+   - Otherwise use a clean branch or worktree based on the fetched base.
+   - Confirm the branch contains no unrelated commits or file changes.
+
+2. Establish the target.
+   - Record the exact local benchmark name/filter, the Callgrind instruction metric, and the requested threshold.
+   - Default to Valgrind instruction count, where lower is better. Do not silently compare wall time, percentages from a cloud report, or a differently named stage.
+   - Record the Cargo benchmark target (`benches` or `rspack_sources`) and the narrowest filter that includes the stage.
+   - Record the requested optimization scope, PR URL if any, branch, base SHA, head SHA, and current round number.
+   - If the user supplies only a cloud benchmark label, run a local discovery pass and map it to one exact local benchmark filter before optimizing. Never reuse the cloud percentage or absolute value.
+
+3. Freeze the local environment.
+   - Build the image once and record its image ID from `environment.txt`.
+   - Use Docker's native platform: `linux/arm64` on Apple Silicon and Arm hosts, or `linux/amd64` on x86-64 hosts. Valgrind must not run through cross-architecture QEMU emulation.
+   - Do not compare absolute instruction counts across architectures. Base and candidate must use the same native platform and image ID.
+   - Prepare fixtures once. Use the same absolute fixture directory for every comparison and do not refresh it mid-goal.
+   - Keep the benchmark target, filter, tool versions, `GLIBC_TUNABLES`, allocator settings, and measurement mode unchanged.
+   - If any frozen input changes, invalidate all prior comparisons and remeasure the base plus the latest retained round.
+
+4. Create an immutable base measurement.
+   - Create or reuse a clean worktree at the PR base SHA or fetched base branch.
+   - Measure the target through the helper before implementing an optimization.
+   - Save results outside both Git worktrees, for example under a goal-specific directory in `/tmp`.
+   - Read the exact stage value from each `run-*.instructions`, confirm each corresponding log ran the intended filter, and apply the repetition rule above.
+   - Record the base SHA, median value, individual values, result directory, image ID, and fixture directory.
+   - Never replace the original base with a later candidate. Remeasure it only when frozen inputs were invalidated.
+
+5. Create or identify the fixed progress report.
+   - When a PR exists, maintain one persistent PR comment for every round and pushed commit. Reuse an existing log instead of creating duplicates.
+   - For work without a PR, maintain the same table in the task updates and final report.
+   - Create a fresh PR after the first scoped change is committed and pushed if the task requires a PR.
+
+## Per-Round Checklist
+
+Run these steps in order for every round.
+
+1. Modify code locally.
+   - Choose the next likely bottleneck from the local Valgrind stage result, retained-round history, profiling artifacts, or code inspection.
+   - Implement the smallest scoped change that plausibly improves the exact target stage.
+   - Avoid unrelated cleanup, formatting churn, snapshot updates, and generated output unless required.
+   - If the prior round found a correctness or review issue, fix it before adding another optimization idea.
+
+2. Verify correctness locally.
+   - Run targeted tests covering the changed behavior.
+   - Run the relevant lint/check command for the touched language, including Rust check or clippy coverage for Rust changes.
+   - Run format verification rather than broad formatting churn.
+   - Follow repository build order: build JS before JS tests, build the Rust binding before Rust tests, and use the full dev build for mixed changes.
+   - Treat known unrelated local watcher or SWC flakiness as reportable context, not silent success.
+   - Fix any related failure and repeat validation before continuing.
+   - Do not treat a faster Valgrind result as correctness evidence.
+
+3. Run a correctness-focused independent review.
+   - Review the current diff independently from the implementation pass before committing.
+   - Use a subagent only when it is available and explicitly allowed; otherwise perform a fresh local diff review.
+   - Focus on behavior preservation, ordering, deduplication, hashing/equality, diagnostics, concurrency, cancellation, and cache lifetime where relevant.
+   - Fix valid concerns and repeat correctness validation plus review. Record the technical reason when a concern is invalid.
+
+4. Commit the candidate snapshot.
+   - Review the diff for unrelated edits.
+   - Commit with a focused title, usually `perf: ...`.
+   - Do not push yet. Measure a committed SHA so every result maps to immutable source.
+
+5. Measure the candidate locally.
+   - Run the helper against the candidate checkout with the frozen fixture directory, benchmark target, filter, image, platform, and environment.
+   - Require the exact target stage in every repetition and retain all raw logs.
+   - Use the median under the repetition rule.
+   - Compute improvement for a lower-is-better instruction count as `(comparison - candidate) / comparison * 100`.
+   - Compare the first performance round with the immutable base. Compare later performance rounds with the previous retained performance round.
+   - Also compute the candidate's total improvement from the immutable base for the goal threshold.
+   - If another stage may have regressed, measure it separately with its own exact filter. Do not combine multiple stages into one instruction count.
+
+6. Decide whether to retain the round.
+   - Retain a performance round only when it improves on its comparison point and passes correctness/review validation.
+   - If it is neutral or slower, revert the candidate with a new follow-up commit. Do not erase the failed attempt by amending or resetting history.
+   - Keep a correctness-only fix when validation improves even if the performance result is neutral.
+   - If the target is met, stop performance iteration after reporting and handling currently available review comments.
+   - If the result improves but remains below target and rounds remain, choose the next scoped direction immediately.
+   - If the round limit is reached, stop after reverting a non-improving final round and report the best retained result.
+
+7. Push and report the decided state.
+   - Push the retained candidate or the follow-up revert commit.
+   - Create the PR if required and it does not yet exist.
+   - Request or re-request code review when the repository workflow supports it.
+   - Update the fixed progress report with the candidate commit, retained/reverted decision, exact local values, delta, correctness result, and result directory.
+   - Do not start a CI timer, wait for GitHub Actions, or read CodSpeed feedback.
+
+8. Handle available code review comments.
+   - Inspect unresolved human and automated review threads that are currently available before declaring the workflow terminal and at the start of a resumed round.
+   - Do not wait or poll for future comments as part of the measurement loop.
+   - If a live comment is reasonable, implement the fix, reply with what changed, resolve the thread, and start a new locally validated round.
+   - If it is not reasonable, reply with the technical reason and supporting evidence, resolve the thread, and continue without changing code.
+   - Inspect outdated threads against current code before resolving them.
+   - Do not report completion while a current requested-change thread remains unresolved.
+
+## Measurement Interpretation
+
+- Use only the exact integer from each local `run-*.instructions` file. It is the sum of Callgrind `totals:` values produced while the selected benchmark boundary was instrumented.
+- Use individual repeated values plus their median; never average together different stage names, benchmark filters, fixtures, image IDs, or source SHAs.
+- Treat a missing stage, mismatched filter, missing/zero instruction count, Valgrind error, or changed environment as invalid rather than as a regression.
+- If base and candidate repetitions are inconsistent, first check that the same image and fixture directory were used. Rebuild neither source nor fixture selectively.
+- A performance claim must name the base SHA and value, candidate SHA and value, percentage delta, image ID, benchmark target/filter, exact stage, and result paths.
+- The local result determines the optimization goal. CI results may be mentioned as unrelated repository status only when the user explicitly asks for them.
+
+## Progress Report Format
+
+Keep one fixed PR comment, or the equivalent task report when there is no PR:
+
+```markdown
+## Local Valgrind Optimization Log
+
+Target: `<exact measured stage>` >= `<threshold>` improvement
+Scope: `<requested scope>`
+Environment: `<image id>`, `<native Docker platform>`, `<benchmark target> <filter>`
+Base: `<sha>` at `<instruction count>`
+Current status: `<running|passed|failed|blocked>`
+Latest head: `<sha>`
+
+| Round | Commit | Change | Local Valgrind | Decision | Correctness |
+| ----- | ------ | ------ | -------------- | -------- | ----------- |
+| 1 | `<sha>` | `<summary>` | `<base -> candidate; delta>` | `<retained|reverted>` | `<summary>` |
+```
+
+Update this report rather than duplicating it. Keep entries concise and include links or paths to raw local logs.
+
+## Correctness Guardrails
+
+- When caching derived state, verify it remains stable for the full pass where it is reused.
+- When adding a fast path, compare it with the original path in every relevant mode.
+- When changing data structures, check ordering, deduplication, hashing, equality, and user-visible diagnostics.
+- When changing concurrency or scheduling, check determinism, cancellation, shared-state ownership, and cleanup.
+- When changing generated files, verify source and generated output remain consistent.
+- Fix or technically dismiss every correctness concern from local commands or review before retaining the round.
+
+## Reporting
+
+Keep updates short and decision-oriented:
+
+- State the PR URL when present, branch, head SHA, round, exact stage, threshold, and scope.
+- State the code change and why it should affect the measured stage.
+- List local correctness commands, ignored unrelated flakiness, and independent review result.
+- State the Docker image ID, platform, fixture directory, benchmark target/filter, result paths, repeated values, median, base delta, and retained-round delta.
+- State whether the round was retained or reverted and whether the fixed progress report was updated.
+- State the status of currently available review comments and how each was handled.
+- State explicitly that CI and CodSpeed cloud feedback were not used or monitored.
+- If more work is needed, name the next optimization or correctness direction.

--- a/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
@@ -148,14 +148,14 @@ Run these steps in order for every round.
    - Require the exact target stage in every repetition and retain all raw logs.
    - Use the median under the repetition rule.
    - Compute improvement for a lower-is-better instruction count as `(comparison - candidate) / comparison * 100`.
-   - Compare the first performance round with the immutable base. Compare later performance rounds with the previous retained performance round.
+   - Compare the first candidate with the immutable base. Compare every later candidate with the most recent retained snapshot, including a retained correctness-only fix, because that snapshot is the candidate's actual code parent.
    - Also compute the candidate's total improvement from the immutable base for the goal threshold.
    - If another stage may have regressed, measure it separately with its own exact filter. Do not combine multiple stages into one instruction count.
 
 6. Decide whether to retain the round.
    - Retain a performance round only when it improves on its comparison point and passes correctness/review validation.
    - If it is neutral or slower, revert the candidate with a new follow-up commit. Do not erase the failed attempt by amending or resetting history.
-   - Keep a correctness-only fix when validation improves even if the performance result is neutral.
+   - Keep a correctness-only fix when validation improves even if the performance result is neutral or slower. Record its measured value as the comparison point for the next candidate.
    - If the target is met, stop performance iteration after reporting and handling currently available review comments.
    - If the result improves but remains below target and rounds remain, choose the next scoped direction immediately.
    - If the round limit is reached, stop after reverting a non-improving final round and report the best retained result.

--- a/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
@@ -29,6 +29,29 @@ Use `scripts/run_local_valgrind.sh` from this skill. It builds a reusable native
 
 The helper passes the repository's existing `--cfg codspeed` compile-time switch to ordinary `cargo build` so the benchmark adapter exposes its Valgrind client-request boundaries. This is only a source configuration name: no CodSpeed executable, service, token, API, upload, PR comment, or benchmark result participates in the workflow. Valgrind starts instrumentation at the selected benchmark boundary, and `run-*.instructions` plus the local Callgrind profiles are the only performance source of truth.
 
+## Docker Prerequisite and Installation
+
+Verify Docker before preparing fixtures or building the measurement image:
+
+```bash
+command -v docker
+docker version
+docker info
+docker compose version
+docker run --rm hello-world
+```
+
+If Docker is missing or the engine is unavailable, install and validate it before continuing. When the local task history is available, read task `019f7e27-50ba-7ac1-8ab4-3cdc868818fe` (`安装 Docker 并运行 Valgrind`) and follow its tested installation flow. Do not replace the Docker measurement environment with host-side Valgrind.
+
+Apply these installation requirements even when that task cannot be read:
+
+- Detect the host OS and native architecture before downloading anything. On Apple Silicon macOS, install the official arm64 Docker Desktop application, start Docker Desktop, and wait for the Linux engine to become ready.
+- Treat license acceptance, administrator privileges, and first-launch permission dialogs as user-owned gates. Ask the user to complete them when the operating system requires interaction; do not bypass them.
+- Ensure the Docker CLI, Compose plugin, and credential helper are reachable from the current shell. If Docker Desktop was installed by copying the application and did not update `PATH`, add its supported CLI directory to the shell configuration, start a new shell, and re-run the verification commands above.
+- Use `docker run --rm hello-world` to verify image pulling, credentials, networking, and container execution rather than accepting an installed application as sufficient evidence.
+- On macOS, allocate about 16 GiB to Docker Desktop when the host has enough memory. The Rspack optimized benchmark build has been observed to receive `SIGKILL` with the default 8 GiB allocation. If that happens, increase Docker memory, restart the engine, preserve the Docker volumes, and resume the cached build.
+- Confirm the organization permits Docker Desktop use under its applicable commercial license. On Linux, install the official Docker Engine packages appropriate for the distribution and apply the same engine and `hello-world` verification.
+
 From the optimization checkout, initialize the environment once:
 
 ```bash

--- a/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
+++ b/.agents/skills/rspack-perf-valgrind-goal/SKILL.md
@@ -25,7 +25,9 @@ The agent owns the loop. After the user gives the target benchmark stage, thresh
 
 ## Local Measurement Contract
 
-Use `scripts/run_local_valgrind.sh` from this skill. It builds a reusable native-architecture image containing the repository's pinned Rust toolchain and Debian's standard Valgrind package. The helper mounts source and fixtures read-only, stores build caches in Docker volumes, builds with ordinary Cargo, executes only the selected benchmark binary under Callgrind, captures raw logs and profiles, and records an environment manifest.
+Use `scripts/run_local_valgrind.sh` from this skill. It builds a reusable native-architecture image containing the repository's pinned Rust toolchain and Debian's standard Valgrind package. The helper mounts source and canonical fixtures read-only, stores build caches in Docker volumes keyed by checkout path, image ID, and native platform, builds with ordinary Cargo, executes only the selected benchmark binary under Callgrind, captures raw logs and profiles, and records an environment manifest.
+
+For persistent-cache benchmark filters, the helper copies the read-only fixtures into ephemeral writable container storage before execution because those benchmarks create temporary workspaces beneath `RSPACK_BENCHCASES_DIR`. The copy preserves fixture symlinks and is discarded with the container; never make the canonical host fixture directory writable.
 
 The helper passes the repository's existing `--cfg codspeed` compile-time switch to ordinary `cargo build` so the benchmark adapter exposes its Valgrind client-request boundaries. This is only a source configuration name: no CodSpeed executable, service, token, API, upload, PR comment, or benchmark result participates in the workflow. Valgrind starts instrumentation at the selected benchmark boundary, and `run-*.instructions` plus the local Callgrind profiles are the only performance source of truth.
 
@@ -196,9 +198,9 @@ Base: `<sha>` at `<instruction count>`
 Current status: `<running|passed|failed|blocked>`
 Latest head: `<sha>`
 
-| Round | Commit | Change | Local Valgrind | Decision | Correctness |
-| ----- | ------ | ------ | -------------- | -------- | ----------- |
-| 1 | `<sha>` | `<summary>` | `<base -> candidate; delta>` | `<retained|reverted>` | `<summary>` |
+| Round | Commit  | Change      | Local Valgrind               | Decision              | Correctness |
+| ----- | ------- | ----------- | ---------------------------- | --------------------- | ----------- |
+| 1     | `<sha>` | `<summary>` | `<base -> candidate; delta>` | `<retained/reverted>` | `<summary>` |
 ```
 
 Update this report rather than duplicating it. Keep entries concise and include links or paths to raw local logs.

--- a/.agents/skills/rspack-perf-valgrind-goal/agents/openai.yaml
+++ b/.agents/skills/rspack-perf-valgrind-goal/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: 'Rspack Perf Valgrind Goal'
   short_description: 'Optimize Rspack with local Docker Valgrind measurements'
   default_prompt: 'Use $rspack-perf-valgrind-goal to optimize the requested Rspack benchmark stage with reproducible local Docker and Valgrind measurements.'
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/rspack-perf-valgrind-goal/agents/openai.yaml
+++ b/.agents/skills/rspack-perf-valgrind-goal/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Rspack Perf Valgrind Goal'
+  short_description: 'Optimize Rspack with local Docker Valgrind measurements'
+  default_prompt: 'Use $rspack-perf-valgrind-goal to optimize the requested Rspack benchmark stage with reproducible local Docker and Valgrind measurements.'

--- a/.agents/skills/rspack-perf-valgrind-goal/scripts/Dockerfile
+++ b/.agents/skills/rspack-perf-valgrind-goal/scripts/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:bookworm
+
+ARG RUST_TOOLCHAIN=nightly-2026-04-16
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    git \
+    jq \
+    libssl-dev \
+    pkg-config \
+    python3 \
+    valgrind \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN rustup toolchain install "${RUST_TOOLCHAIN}" \
+      --profile minimal \
+      --component rust-src \
+  && rustup default "${RUST_TOOLCHAIN}"
+
+ENV CARGO_INCREMENTAL=0 \
+    RUSTUP_TOOLCHAIN=nightly-2026-04-16

--- a/.agents/skills/rspack-perf-valgrind-goal/scripts/run_local_valgrind.sh
+++ b/.agents/skills/rspack-perf-valgrind-goal/scripts/run_local_valgrind.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly DEFAULT_IMAGE="rspack-perf-valgrind:nightly-2026-04-16"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+usage() {
+  cat <<'EOF'
+Run reproducible local Rspack benchmark measurements in Docker-backed
+Valgrind simulation mode.
+
+Usage:
+  run_local_valgrind.sh build-image [--image IMAGE] [--platform PLATFORM]
+  run_local_valgrind.sh prepare --repo PATH
+  run_local_valgrind.sh measure --repo PATH --fixtures PATH --bench TARGET \
+    --filter FILTER --output PATH [--repeat N] [--image IMAGE] \
+    [--platform PLATFORM]
+
+Commands:
+  build-image  Build the pinned local measurement image.
+  prepare      Run `pnpm run bench:prepare` once in the selected checkout.
+  measure      Build and measure one benchmark target/filter, retaining logs.
+
+Defaults:
+  IMAGE     rspack-perf-valgrind:nightly-2026-04-16
+  PLATFORM  Native Docker architecture (`linux/arm64` or `linux/amd64`)
+  REPEAT    2
+
+A valid measurement produces a nonzero Callgrind instruction total. The
+output directory must not contain prior run data.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+canonical_directory() {
+  local directory="$1"
+  [[ -d "$directory" ]] || fail "directory does not exist: $directory"
+  (cd "$directory" && pwd -P)
+}
+
+hash_text() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | cut -c1-16
+  else
+    printf '%s' "$1" | shasum -a 256 | cut -c1-16
+  fi
+}
+
+native_docker_platform() {
+  local architecture
+  architecture="$(docker info --format '{{.Architecture}}')"
+  case "$architecture" in
+    amd64|x86_64)
+      echo "linux/amd64"
+      ;;
+    arm64|aarch64)
+      echo "linux/arm64"
+      ;;
+    *)
+      fail "unsupported Docker architecture: $architecture"
+      ;;
+  esac
+}
+
+command_name="${1:-}"
+[[ -n "$command_name" ]] || {
+  usage
+  exit 2
+}
+if [[ "$command_name" == "-h" || "$command_name" == "--help" ]]; then
+  usage
+  exit 0
+fi
+shift
+
+image="$DEFAULT_IMAGE"
+platform=""
+repo=""
+fixtures=""
+bench_target=""
+bench_filter=""
+output_directory=""
+repeat_count=2
+
+while (($# > 0)); do
+  case "$1" in
+    --image)
+      (($# >= 2)) || fail "--image requires a value"
+      image="$2"
+      shift 2
+      ;;
+    --platform)
+      (($# >= 2)) || fail "--platform requires a value"
+      platform="$2"
+      shift 2
+      ;;
+    --repo)
+      (($# >= 2)) || fail "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    --fixtures)
+      (($# >= 2)) || fail "--fixtures requires a value"
+      fixtures="$2"
+      shift 2
+      ;;
+    --bench)
+      (($# >= 2)) || fail "--bench requires a value"
+      bench_target="$2"
+      shift 2
+      ;;
+    --filter)
+      (($# >= 2)) || fail "--filter requires a value"
+      bench_filter="$2"
+      shift 2
+      ;;
+    --output)
+      (($# >= 2)) || fail "--output requires a value"
+      output_directory="$2"
+      shift 2
+      ;;
+    --repeat)
+      (($# >= 2)) || fail "--repeat requires a value"
+      repeat_count="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ "$command_name" != "prepare" ]]; then
+  require_command docker
+  native_platform="$(native_docker_platform)"
+  platform="${platform:-$native_platform}"
+  [[ "$platform" == "$native_platform" ]] \
+    || fail "Valgrind requires Docker's native platform ($native_platform), not emulated $platform"
+fi
+
+case "$command_name" in
+  build-image)
+    docker build \
+      --platform "$platform" \
+      --tag "$image" \
+      --file "$SCRIPT_DIR/Dockerfile" \
+      "$SCRIPT_DIR"
+    ;;
+
+  prepare)
+    [[ -n "$repo" ]] || fail "prepare requires --repo"
+    repo="$(canonical_directory "$repo")"
+    require_command pnpm
+    pnpm --dir "$repo" run bench:prepare
+    ;;
+
+  measure)
+    [[ -n "$repo" ]] || fail "measure requires --repo"
+    [[ -n "$fixtures" ]] || fail "measure requires --fixtures"
+    [[ -n "$bench_target" ]] || fail "measure requires --bench"
+    [[ -n "$bench_filter" ]] || fail "measure requires --filter"
+    [[ -n "$output_directory" ]] || fail "measure requires --output"
+    [[ "$bench_target" == "benches" || "$bench_target" == "rspack_sources" ]] \
+      || fail "--bench must be benches or rspack_sources"
+    [[ "$repeat_count" =~ ^[1-9][0-9]*$ ]] || fail "--repeat must be a positive integer"
+
+    repo="$(canonical_directory "$repo")"
+    fixtures="$(canonical_directory "$fixtures")"
+    output_directory="$(mkdir -p "$output_directory" && canonical_directory "$output_directory")"
+    [[ -z "$(find "$output_directory" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+      || fail "output directory is not empty: $output_directory"
+    [[ -f "$repo/Cargo.toml" && -f "$repo/rust-toolchain.toml" ]] \
+      || fail "--repo is not an Rspack checkout: $repo"
+    [[ -f "$fixtures/package.json" ]] \
+      || fail "fixture directory is not prepared: $fixtures"
+    docker image inspect "$image" >/dev/null 2>&1 \
+      || fail "Docker image is missing; run build-image first: $image"
+
+    source_sha="$(git -C "$repo" rev-parse HEAD)"
+    source_status="$(git -C "$repo" status --short)"
+    [[ -z "$source_status" ]] \
+      || fail "measure requires a committed, clean source snapshot: $repo"
+    git_common_directory="$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir)"
+    git_common_directory="$(canonical_directory "$git_common_directory")"
+    repo_cache_key="$(hash_text "$repo")"
+    target_volume="rspack-perf-valgrind-target-${repo_cache_key}"
+    registry_volume="rspack-perf-valgrind-cargo-registry"
+    git_volume="rspack-perf-valgrind-cargo-git"
+    image_id="$(docker image inspect "$image" --format '{{.Id}}')"
+    glibc_tunables=""
+    if [[ "$platform" == "linux/amd64" ]]; then
+      glibc_tunables="glibc.cpu.hwcaps=-AVX512F,-AVX2,-AVX,-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_ERMS,-SSE4_2,-SSSE3"
+    fi
+
+    {
+      echo "source_sha=$source_sha"
+      echo "source_status=${source_status:-clean}"
+      echo "repo=$repo"
+      echo "fixtures=$fixtures"
+      echo "git_common_directory=$git_common_directory"
+      echo "image=$image"
+      echo "image_id=$image_id"
+      echo "platform=$platform"
+      echo "bench_target=$bench_target"
+      echo "bench_filter=$bench_filter"
+      echo "repeat=$repeat_count"
+      echo "target_volume=$target_volume"
+      echo "measurement=callgrind-instructions"
+      echo "CARGO_INCREMENTAL=0"
+      echo "RUSTFLAGS=--cfg codspeed"
+      echo "VALGRIND_FAIR_SCHED=yes"
+      echo "MIMALLOC_PURGE_DELAY=-1"
+      echo "GLIBC_TUNABLES=$glibc_tunables"
+    } >"$output_directory/environment.txt"
+
+    docker run \
+      --rm \
+      --platform "$platform" \
+      --cap-add SYS_PTRACE \
+      --security-opt seccomp=unconfined \
+      --volume "$repo:/rspack:ro" \
+      --volume "$git_common_directory:$git_common_directory:ro" \
+      --volume "$fixtures:/benchcases:ro" \
+      --volume "$output_directory:/results" \
+      --volume "$target_volume:/target" \
+      --volume "$registry_volume:/usr/local/cargo/registry" \
+      --volume "$git_volume:/usr/local/cargo/git" \
+      --workdir /rspack \
+      --env CARGO_INCREMENTAL=0 \
+      --env CARGO_TARGET_DIR=/target \
+      --env "GLIBC_TUNABLES=$glibc_tunables" \
+      --env MIMALLOC_PURGE_DELAY=-1 \
+      --env RSPACK_BENCHCASES_DIR=/benchcases \
+      "$image" \
+      bash -c '
+        set -euo pipefail
+        trap "chmod -R a+rwX /results || true" EXIT
+
+        bench_target="$1"
+        bench_filter="$2"
+        repeat_count="$3"
+
+        {
+          rustc --version
+          cargo --version
+          valgrind --version
+        } | tee /results/tool-versions.txt
+
+        if ! RUSTFLAGS="--cfg codspeed" cargo build \
+          --profile codspeed \
+          -p rspack_benchmark \
+          --bench "$bench_target" \
+          --message-format=json-render-diagnostics \
+          > /results/build.jsonl; then
+          jq -r \
+            "select(.reason == \"compiler-message\") | .message.rendered // empty" \
+            /results/build.jsonl >&2
+          exit 1
+        fi
+
+        benchmark_binary="$(jq -r \
+          --arg target "$bench_target" \
+          "select( \
+            .reason == \"compiler-artifact\" \
+            and .target.name == \$target \
+            and (.target.kind | index(\"bench\")) \
+          ) | .executable // empty" \
+          /results/build.jsonl \
+          | tail -n 1)"
+        [[ -x "$benchmark_binary" ]] || {
+          echo "benchmark binary not found: $benchmark_binary" >&2
+          exit 1
+        }
+
+        for ((run_index = 1; run_index <= repeat_count; run_index++)); do
+          run_directory="/results/run-${run_index}"
+          mkdir -p "$run_directory/tmp"
+          TMPDIR="$run_directory/tmp" \
+          BENCH_MODE=simulation \
+          CODSPEED_CARGO_WORKSPACE_ROOT=/rspack \
+          valgrind \
+            --tool=callgrind \
+            --instr-atstart=no \
+            --fair-sched=yes \
+            --error-exitcode=86 \
+            --callgrind-out-file="$run_directory/callgrind.%p.out" \
+            "$benchmark_binary" \
+            "$bench_filter" \
+            2>&1 | tee "$run_directory.log"
+
+          mapfile -t measured_stages \
+            < <(grep -F "Measured: " "$run_directory.log" || true)
+          ((${#measured_stages[@]} == 1)) || {
+            echo "benchmark filter must measure exactly one stage; got ${#measured_stages[@]}" >&2
+            exit 1
+          }
+          [[ "${measured_stages[0]}" == *"$bench_filter"* ]] || {
+            echo "measured stage does not match filter: ${measured_stages[0]}" >&2
+            exit 1
+          }
+          measured_stage="${measured_stages[0]#Measured: }"
+
+          shopt -s nullglob
+          profile_files=("$run_directory"/callgrind.*.out*)
+          ((${#profile_files[@]} > 0)) || {
+            echo "no Callgrind profile produced for run $run_index" >&2
+            exit 1
+          }
+          stage_profiles=()
+          for profile_file in "${profile_files[@]}"; do
+            if grep -Fqx \
+              "desc: Trigger: Client Request: $measured_stage" \
+              "$profile_file"; then
+              stage_profiles+=("$profile_file")
+            fi
+          done
+          ((${#stage_profiles[@]} == 1)) || {
+            echo "expected one Callgrind profile for $measured_stage; got ${#stage_profiles[@]}" >&2
+            exit 1
+          }
+          instruction_count=0
+          while read -r totals_label totals_value; do
+            [[ "$totals_label" == "totals:" ]] || continue
+            [[ "$totals_value" =~ ^[0-9]+$ ]] || continue
+            instruction_count=$((instruction_count + totals_value))
+          done < <(grep -h "^totals:" "${stage_profiles[0]}" || true)
+          [[ "$instruction_count" =~ ^[1-9][0-9]*$ ]] || {
+            echo "invalid instruction count for run $run_index: $instruction_count" >&2
+            exit 1
+          }
+          echo "instruction_count=$instruction_count" \
+            | tee "$run_directory.instructions"
+        done
+      ' bash "$bench_target" "$bench_filter" "$repeat_count"
+
+    echo "measurement results: $output_directory"
+    ;;
+
+  *)
+    usage
+    fail "unknown command: $command_name"
+    ;;
+esac

--- a/.agents/skills/rspack-perf-valgrind-goal/scripts/run_local_valgrind.sh
+++ b/.agents/skills/rspack-perf-valgrind-goal/scripts/run_local_valgrind.sh
@@ -207,11 +207,19 @@ case "$command_name" in
       || fail "measure requires a committed, clean source snapshot: $repo"
     git_common_directory="$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir)"
     git_common_directory="$(canonical_directory "$git_common_directory")"
-    repo_cache_key="$(hash_text "$repo")"
-    target_volume="rspack-perf-valgrind-target-${repo_cache_key}"
+    image_id="$(docker image inspect "$image" --format '{{.Id}}')"
+    target_cache_key="$(hash_text "$repo|$image_id|$platform")"
+    target_volume="rspack-perf-valgrind-target-${target_cache_key}"
     registry_volume="rspack-perf-valgrind-cargo-registry"
     git_volume="rspack-perf-valgrind-cargo-git"
-    image_id="$(docker image inspect "$image" --format '{{.Id}}')"
+    container_fixtures="/benchcases-source"
+    fixture_mode="read-only"
+    copy_fixtures="false"
+    if [[ "$bench_target" == "benches" && "$bench_filter" == *persistent_cache* ]]; then
+      container_fixtures="/benchcases"
+      fixture_mode="writable-copy"
+      copy_fixtures="true"
+    fi
     glibc_tunables=""
     if [[ "$platform" == "linux/amd64" ]]; then
       glibc_tunables="glibc.cpu.hwcaps=-AVX512F,-AVX2,-AVX,-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_ERMS,-SSE4_2,-SSSE3"
@@ -228,6 +236,7 @@ case "$command_name" in
       echo "platform=$platform"
       echo "bench_target=$bench_target"
       echo "bench_filter=$bench_filter"
+      echo "fixture_mode=$fixture_mode"
       echo "repeat=$repeat_count"
       echo "target_volume=$target_volume"
       echo "measurement=callgrind-instructions"
@@ -245,7 +254,7 @@ case "$command_name" in
       --security-opt seccomp=unconfined \
       --volume "$repo:/rspack:ro" \
       --volume "$git_common_directory:$git_common_directory:ro" \
-      --volume "$fixtures:/benchcases:ro" \
+      --volume "$fixtures:/benchcases-source:ro" \
       --volume "$output_directory:/results" \
       --volume "$target_volume:/target" \
       --volume "$registry_volume:/usr/local/cargo/registry" \
@@ -255,7 +264,7 @@ case "$command_name" in
       --env CARGO_TARGET_DIR=/target \
       --env "GLIBC_TUNABLES=$glibc_tunables" \
       --env MIMALLOC_PURGE_DELAY=-1 \
-      --env RSPACK_BENCHCASES_DIR=/benchcases \
+      --env "RSPACK_BENCHCASES_DIR=$container_fixtures" \
       "$image" \
       bash -c '
         set -euo pipefail
@@ -264,6 +273,7 @@ case "$command_name" in
         bench_target="$1"
         bench_filter="$2"
         repeat_count="$3"
+        copy_fixtures="$4"
 
         {
           rustc --version
@@ -296,6 +306,11 @@ case "$command_name" in
           echo "benchmark binary not found: $benchmark_binary" >&2
           exit 1
         }
+
+        if [[ "$copy_fixtures" == "true" ]]; then
+          mkdir -p /benchcases
+          cp -a /benchcases-source/. /benchcases/
+        fi
 
         for ((run_index = 1; run_index <= repeat_count; run_index++)); do
           run_directory="/results/run-${run_index}"
@@ -356,7 +371,7 @@ case "$command_name" in
           echo "instruction_count=$instruction_count" \
             | tee "$run_directory.instructions"
         done
-      ' bash "$bench_target" "$bench_filter" "$repeat_count"
+      ' bash "$bench_target" "$bench_filter" "$repeat_count" "$copy_fixtures"
 
     echo "measurement results: $output_directory"
     ;;

--- a/.agents/skills/rspack-perf-valgrind-goal/scripts/run_local_valgrind.sh
+++ b/.agents/skills/rspack-perf-valgrind-goal/scripts/run_local_valgrind.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 readonly DEFAULT_IMAGE="rspack-perf-valgrind:nightly-2026-04-16"
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly DOCKER_INSTALL_TASK="019f7e27-50ba-7ac1-8ab4-3cdc868818fe"
 
 usage() {
   cat <<'EOF'
@@ -27,6 +28,10 @@ Defaults:
   PLATFORM  Native Docker architecture (`linux/arm64` or `linux/amd64`)
   REPEAT    2
 
+Prerequisite:
+  Docker CLI and Engine must be installed and running. If they are missing,
+  follow installation task 019f7e27-50ba-7ac1-8ab4-3cdc868818fe first.
+
 A valid measurement produces a nonzero Callgrind instruction total. The
 output directory must not contain prior run data.
 EOF
@@ -39,6 +44,13 @@ fail() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+require_docker() {
+  command -v docker >/dev/null 2>&1 \
+    || fail "Docker is not installed; follow installation task $DOCKER_INSTALL_TASK before continuing"
+  docker info >/dev/null 2>&1 \
+    || fail "Docker Engine is unavailable; start and verify Docker using installation task $DOCKER_INSTALL_TASK"
 }
 
 canonical_directory() {
@@ -143,8 +155,8 @@ while (($# > 0)); do
   esac
 done
 
+require_docker
 if [[ "$command_name" != "prepare" ]]; then
-  require_command docker
   native_platform="$(native_docker_platform)"
   platform="${platform:-$native_platform}"
   [[ "$platform" == "$native_platform" ]] \

--- a/.agents/skills/rspack-perf/SKILL.md
+++ b/.agents/skills/rspack-perf/SKILL.md
@@ -123,20 +123,12 @@ Functional validation:
 - Run `pnpm run build:cli:dev` before `pnpm run test:unit`.
 - Always complete `pnpm run test:unit` after the optimization.
 
-Performance validation:
-
-- Run CodSpeed performance validation only in GitHub CI. Do not run CodSpeed locally or use local benchmark results for performance decisions.
-- Use the CodSpeed result for the current PR head as the source of truth.
-- Prefer the CodSpeed `compilation stages` case that directly covers the optimized feature.
-- If no matching compilation-stage case exists, use the closest existing CodSpeed case for the affected feature and explain the coverage gap.
-- If adding or changing benchmark coverage is necessary, keep the case focused on the optimized stage and avoid unrelated noise such as minimization unless it is the target.
-
 Before submitting:
 
 - Run `pnpm run format:rs`.
 - Run `pnpm run format:js`.
 - Run `cargo clippy --workspace --all-targets --all-features`.
-- Summarize the hot path, the data cardinality risk, the chosen CPU/memory optimization technique, functional test result, CI CodSpeed performance result, format result, and clippy result.
+- Summarize the hot path, the data cardinality risk, the chosen CPU/memory optimization technique, functional test result, Ecosystem Benchmark result, format result, and clippy result.
 
 ## PR and Benchmark Follow-up
 
@@ -165,7 +157,7 @@ Use the PR number as the workflow input. A run on `main` does not benchmark the 
 If the user allows waiting for GitHub CI:
 
 1. Wait for the relevant GitHub checks and the Ecosystem Benchmark run to finish.
-2. Fetch the PR comments and locate the CodSpeed performance report.
+2. Fetch the Ecosystem Benchmark report.
 3. Compare improvements and regressions in the report.
 4. If the report shows regressions, analyze likely causes from the changed hot path, data structure cardinality, CPU work, and allocation behavior.
 5. Perform one additional optimization iteration when there is a plausible fix, then update the PR branch, push again, and rerun the Ecosystem Benchmark workflow.
@@ -177,4 +169,3 @@ If the user allows waiting for GitHub CI:
 - Making a hot structure larger to save one rare computation.
 - Adding parallelism before removing repeated serial work.
 - Trading a CPU bottleneck for large temporary allocations.
-- Verifying only output snapshots without checking the relevant CI CodSpeed result.

--- a/.agents/skills/rspack-perf/SKILL.md
+++ b/.agents/skills/rspack-perf/SKILL.md
@@ -128,7 +128,7 @@ Before submitting:
 - Run `pnpm run format:rs`.
 - Run `pnpm run format:js`.
 - Run `cargo clippy --workspace --all-targets --all-features`.
-- Summarize the hot path, the data cardinality risk, the chosen CPU/memory optimization technique, functional test result, Ecosystem Benchmark result, format result, and clippy result.
+- Summarize the hot path, the data cardinality risk, the chosen CPU/memory optimization technique, functional test result, format result, and clippy result.
 
 ## PR and Benchmark Follow-up
 
@@ -161,6 +161,7 @@ If the user allows waiting for GitHub CI:
 3. Compare improvements and regressions in the report.
 4. If the report shows regressions, analyze likely causes from the changed hot path, data structure cardinality, CPU work, and allocation behavior.
 5. Perform one additional optimization iteration when there is a plausible fix, then update the PR branch, push again, and rerun the Ecosystem Benchmark workflow.
+6. Summarize the final Ecosystem Benchmark result after the workflow completes.
 
 ## Common Mistakes
 

--- a/.agents/skills/rspack-perf/SKILL.md
+++ b/.agents/skills/rspack-perf/SKILL.md
@@ -125,7 +125,8 @@ Functional validation:
 
 Performance validation:
 
-- Validate with CodSpeed cases.
+- Run CodSpeed performance validation only in GitHub CI. Do not run CodSpeed locally or use local benchmark results for performance decisions.
+- Use the CodSpeed result for the current PR head as the source of truth.
 - Prefer the CodSpeed `compilation stages` case that directly covers the optimized feature.
 - If no matching compilation-stage case exists, use the closest existing CodSpeed case for the affected feature and explain the coverage gap.
 - If adding or changing benchmark coverage is necessary, keep the case focused on the optimized stage and avoid unrelated noise such as minimization unless it is the target.
@@ -135,7 +136,7 @@ Before submitting:
 - Run `pnpm run format:rs`.
 - Run `pnpm run format:js`.
 - Run `cargo clippy --workspace --all-targets --all-features`.
-- Summarize the hot path, the data cardinality risk, the chosen CPU/memory optimization technique, functional test result, CodSpeed performance result, format result, and clippy result.
+- Summarize the hot path, the data cardinality risk, the chosen CPU/memory optimization technique, functional test result, CI CodSpeed performance result, format result, and clippy result.
 
 ## PR and Benchmark Follow-up
 
@@ -176,4 +177,4 @@ If the user allows waiting for GitHub CI:
 - Making a hot structure larger to save one rare computation.
 - Adding parallelism before removing repeated serial work.
 - Trading a CPU bottleneck for large temporary allocations.
-- Verifying only output snapshots without checking the relevant CodSpeed case.
+- Verifying only output snapshots without checking the relevant CI CodSpeed result.

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -23,11 +23,9 @@ pub async fn create_module_assets(
   compilation: &mut Compilation,
   _plugin_driver: SharedPluginDriver,
 ) {
+  let mut chunk_asset_map = vec![];
   let mut module_assets = vec![];
-  let mg = compilation.build_module_graph_artifact.get_module_graph();
-  let chunk_graph_artifact = &mut compilation.build_chunk_graph_artifact;
-  let chunk_graph = &chunk_graph_artifact.chunk_graph;
-  let chunk_by_ukey = &mut chunk_graph_artifact.chunk_by_ukey;
+  let mg = compilation.get_module_graph();
   for (identifier, module) in mg.modules() {
     let assets = &module.build_info().assets;
     if assets.is_empty() {
@@ -38,11 +36,20 @@ pub async fn create_module_assets(
       module_assets.push((name.clone(), asset.clone()));
     }
     // assets of executed modules are not in this compilation
-    if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
-      for chunk in chunks {
-        let chunk = chunk_by_ukey.expect_get_mut(chunk);
+    if compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .chunk_graph_module_by_module_identifier
+      .contains_key(identifier)
+    {
+      for chunk in compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_module_chunks(*identifier)
+        .iter()
+      {
         for name in assets.keys() {
-          chunk.add_auxiliary_file(name.clone());
+          chunk_asset_map.push((*chunk, name.clone()))
         }
       }
     }
@@ -50,5 +57,13 @@ pub async fn create_module_assets(
 
   for (name, asset) in module_assets {
     compilation.emit_asset(name, asset);
+  }
+
+  for (chunk, asset_name) in chunk_asset_map {
+    let chunk = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get_mut(&chunk);
+    chunk.add_auxiliary_file(asset_name);
   }
 }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -23,9 +23,11 @@ pub async fn create_module_assets(
   compilation: &mut Compilation,
   _plugin_driver: SharedPluginDriver,
 ) {
-  let mut chunk_asset_map = vec![];
   let mut module_assets = vec![];
-  let mg = compilation.get_module_graph();
+  let mg = compilation.build_module_graph_artifact.get_module_graph();
+  let chunk_graph_artifact = &mut compilation.build_chunk_graph_artifact;
+  let chunk_graph = &chunk_graph_artifact.chunk_graph;
+  let chunk_by_ukey = &mut chunk_graph_artifact.chunk_by_ukey;
   for (identifier, module) in mg.modules() {
     let assets = &module.build_info().assets;
     if assets.is_empty() {
@@ -36,20 +38,11 @@ pub async fn create_module_assets(
       module_assets.push((name.clone(), asset.clone()));
     }
     // assets of executed modules are not in this compilation
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .chunk_graph_module_by_module_identifier
-      .contains_key(identifier)
-    {
-      for chunk in compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_module_chunks(*identifier)
-        .iter()
-      {
+    if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
+      for chunk in chunks {
+        let chunk = chunk_by_ukey.expect_get_mut(chunk);
         for name in assets.keys() {
-          chunk_asset_map.push((*chunk, name.clone()))
+          chunk.add_auxiliary_file(name.clone());
         }
       }
     }
@@ -57,13 +50,5 @@ pub async fn create_module_assets(
 
   for (name, asset) in module_assets {
     compilation.emit_asset(name, asset);
-  }
-
-  for (chunk, asset_name) in chunk_asset_map {
-    let chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get_mut(&chunk);
-    chunk.add_auxiliary_file(asset_name);
   }
 }


### PR DESCRIPTION
## Summary

Add complementary goal-oriented workflows for Rspack performance optimization.

- Add `rspack-perf-codspeed-goal` for iterative optimization validated by GitHub Actions and CodSpeed results, including retained-round comparisons, correctness gates, review handling, and persistent PR progress reporting.
- Add `rspack-perf-valgrind-goal` for the same optimization, correctness, review, and reporting loop using reproducible local Docker and standard Valgrind Callgrind measurements.
- Make local performance decisions directly from the selected stage's Callgrind instruction totals. The local workflow does not run a CodSpeed CLI, require a token, upload results, consume CodSpeed comments, or wait for CI.
- Provide a reusable helper that builds committed clean snapshots, requires exactly one matching benchmark stage, repeats measurements, preserves raw profiles and logs, and records the Docker image, platform, fixtures, toolchain, and benchmark inputs.
- Keep `rspack-perf` focused on general optimization techniques and the Ecosystem Benchmark workflow by moving goal-specific CodSpeed guidance into the dedicated workflow.

This separation supports stable CI-based comparisons when needed while also providing a faster local Valgrind loop that avoids CI polling and uses instruction counts as its sole performance signal.

## Validation

- Skill structure validated with `quick_validate.py`.
- Shell syntax and staged diff checks pass.
- The local helper built and ran `rspack_sources cached_source_hash` under standard Valgrind 3.19.0 on native `linux/arm64`.
- Two repeated Callgrind measurements produced identical instruction totals (`463`, `463`).
- A filter matching no benchmark stage is rejected instead of being reported as a zero-cost result.

## Related links

N/A

## Checklist

- [x] Tests updated (not required; skill-only changes).
- [x] Documentation updated.