### PR TITLE
perf: cache concatenated module references

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -51,11 +51,12 @@ use crate::{
   ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta, ImportedByDeferModulesArtifact,
   InitFragment, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT,
-  ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
-  SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, escape_identifier, fast_set,
-  filter_runtime, find_target, get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
+  ModuleIdentifier, ModuleLayer, ModuleReferenceOptions, ModuleStaticCache, ModuleType,
+  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
+  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
+  escape_identifier, fast_set, filter_runtime, find_target, get_runtime_key,
+  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
+  module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -315,6 +316,7 @@ pub struct ConcatenatedModuleInfo {
   pub idents: Vec<ConcatenatedModuleIdent>,
   pub all_used_names: HashSet<Atom>,
   pub binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>>,
+  pub module_references: Option<FxIndexMap<Atom, ModuleReferenceOptions>>,
 
   pub public_path_auto_replacement: Option<bool>,
   pub static_url_replacement: bool,
@@ -1440,72 +1442,65 @@ impl Module for ConcatenatedModule {
         let ModuleInfo::Concatenated(info) = info else {
           return None;
         };
-        let module = module_graph
-          .module_by_identifier(&info.module)
-          .expect("should have module");
-        let build_meta = module.build_meta();
-        let mut refs = vec![];
+        if info.global_scope_ident.is_empty() {
+          return None;
+        }
+        let module_references = info.module_references.as_ref();
+        let mut strict_esm_module = None;
+        let mut changes = None;
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
-          let match_result = ConcatenationScope::match_module_reference(name.as_str());
-          if let Some(match_info) = match_result {
-            let referenced_info_id = &references_info[match_info.index].0;
-            refs.push((
-              reference.clone(),
-              referenced_info_id,
-              match_info
-                .ids
-                .into_iter()
-                .map(|item| Atom::from(item.as_str()))
-                .collect::<Vec<_>>(),
-              match_info.call,
-              !match_info.direct_import,
-              match_info.deferred_import,
-              build_meta.strict_esm_module,
-              match_info.asi_safe,
-            ));
-          }
-        }
-
-        let mut changes = vec![];
-        for (
-          reference_ident,
-          referenced_info_id,
-          export_name,
-          call,
-          call_context,
-          deferred_import,
-          strict_esm_module,
-          asi_safe,
-        ) in refs
-        {
+          let cached_match_info = module_references.and_then(|references| references.get(name));
+          let parsed_match_info;
+          let match_info = if let Some(match_info) = cached_match_info {
+            match_info
+          } else {
+            if !ConcatenationScope::is_module_reference(name.as_str()) {
+              continue;
+            }
+            parsed_match_info = ConcatenationScope::match_module_reference(name.as_str());
+            let Some(match_info) = &parsed_match_info else {
+              continue;
+            };
+            match_info
+          };
+          let referenced_info_id = &references_info[match_info.index].0;
+          let strict_esm_module = *strict_esm_module.get_or_insert_with(|| {
+            module_graph
+              .module_by_identifier(&info.module)
+              .expect("should have module")
+              .build_meta()
+              .strict_esm_module
+          });
           let final_name = Self::get_final_name(
-            compilation.get_module_graph(),
+            module_graph,
             &compilation.module_graph_cache_artifact,
             &compilation.exports_info_artifact,
             &compilation.module_static_cache,
             referenced_info_id,
-            export_name,
+            match_info.ids.clone(),
             &module_to_info_map,
             runtime,
-            deferred_import,
-            call,
-            call_context,
+            match_info.deferred_import,
+            match_info.call,
+            !match_info.direct_import,
             strict_esm_module,
-            asi_safe,
+            match_info.asi_safe,
             &context,
           );
 
           // We assume this should be concatenated module info because previous loop
-          let span = reference_ident.id.span();
+          let span = reference.id.span();
           let low = span.real_lo();
           let high = span.real_hi();
           // let source = info.source.as_mut().expect("should have source");
           // range is extended by 2 chars to cover the appended "._"
           // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L1411-L1412
-          changes.push((final_name, (low, high + 2)));
+          changes
+            .get_or_insert_with(Vec::new)
+            .push((final_name, (low, high + 2)));
         }
-        Some((info.module, changes))
+        changes.map(|changes| (info.module, changes))
       })
       .collect::<Vec<_>>();
 
@@ -2562,7 +2557,25 @@ impl ConcatenatedModule {
         .remove(&SourceType::JavaScript)
         .expect("should have javascript source");
       let source_code = source.source().into_string_lossy();
-      let mut module_info = concatenation_scope.current_module;
+      let ConcatenationScope {
+        current_module: mut module_info,
+        refs,
+        ..
+      } = concatenation_scope;
+      if !refs.is_empty() {
+        let len = refs.values().map(FxIndexMap::len).sum();
+        let mut module_references = FxIndexMap::default();
+        module_references.reserve(len);
+        for references in refs.into_values() {
+          for (mut reference, options) in references {
+            if reference.ends_with("._") {
+              reference.truncate(reference.len() - 2);
+            }
+            module_references.insert(reference.into(), options);
+          }
+        }
+        module_info.module_references = Some(module_references);
+      }
 
       let jsx = module
         .as_ref()

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -121,12 +121,13 @@ impl ConcatenationScope {
   pub fn create_module_reference(
     &mut self,
     module: &ModuleIdentifier,
-    options: ModuleReferenceOptions,
+    mut options: ModuleReferenceOptions,
   ) -> String {
     let info = self
       .modules_map
       .get(module)
       .expect("should have module info");
+    options.index = info.index();
 
     let export_data = if !options.ids.is_empty() {
       hex::encode(simd_json::to_string(&options.ids).expect("should serialize to json string"))
@@ -222,6 +223,13 @@ impl ConcatenationScope {
     })
   }
 
+  pub fn is_module_reference(name: &str) -> bool {
+    name
+      .strip_suffix(MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX)
+      .unwrap_or(name)
+      .starts_with(MODULE_REFERENCE_PREFIX)
+  }
+
   pub fn is_module_concatenated(&self, module: &ModuleIdentifier) -> bool {
     matches!(
       self.modules_map.get(module).expect("should have module"),
@@ -287,14 +295,15 @@ mod tests {
       .get(&referenced_module_id)
       .and_then(|refs| refs.get(&module_ref))
       .expect("should store created module reference");
-    assert_module_reference_options_eq(stored, &options);
 
-    let parsed = ConcatenationScope::match_module_reference(&module_ref)
-      .expect("should parse full module reference");
     let expected = ModuleReferenceOptions {
       index: 7,
       ..options
     };
+    assert_module_reference_options_eq(stored, &expected);
+
+    let parsed = ConcatenationScope::match_module_reference(&module_ref)
+      .expect("should parse full module reference");
     assert_module_reference_options_eq(&parsed, &expected);
   }
 


### PR DESCRIPTION
## Summary

- Cache generated concatenated module reference options on `ConcatenatedModuleInfo` during module code generation.
- Reuse the cached options during concatenated module reference rewrites instead of reparsing every `__rspack_module_ref...` identifier.
- Avoid allocating intermediate reference/change vectors when a concatenated module has no generated module-reference rewrites.

## Performance rationale

The target benchmark is `rust@concatenate_module_code_generation` with a +5% goal. This path scales with concatenated modules and their global-scope identifiers. The change moves stable reference parsing work to the point where references are generated, then reuses that compact metadata in the rewrite pass, reducing repeated string parsing, JSON/hex decoding, and temporary allocation in code generation.

## Local validation

- `cargo check -p rspack_core`
- `cargo test -p rspack_core concatenation_scope`
- `cargo fmt --all --check`
- `pnpm run build:binding:dev` using Node 24 + pnpm 11.8.0
- `pnpm run build:js` using Node 24 + pnpm 11.8.0
- `cd tests/rspack-test && pnpm run test -t "normalCases/scope-hoisting"` using Node 24 + pnpm 11.8.0
- `cargo clippy -p rspack_core --all-targets -- -D warnings`

Subagent correctness review found no issues.