### PR TITLE
feat: harden persistent cache version cleanup with typed version

### DIFF
--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -24,7 +24,7 @@ use self::{
   context::CacheContext,
   occasion::{MakeOccasion, MetaOccasion, MinimizeOccasion},
   snapshot::{Snapshot, SnapshotOptions},
-  storage::{StorageOptions, create_storage},
+  storage::{StorageOptions, Version, create_storage},
 };
 use super::Cache;
 use crate::{Compilation, CompilationLogger, CompilationLogging, CompilerOptions, Logger};
@@ -91,7 +91,7 @@ impl PersistentCache {
       rspack_pkg_version!().hash(&mut hasher);
       compiler_options.name.hash(&mut hasher);
       compiler_options.mode.hash(&mut hasher);
-      hex::encode(hasher.finish().to_ne_bytes())
+      Version::new(hex::encode(hasher.finish().to_ne_bytes()))
     };
     let storage = create_storage(
       option.storage.clone(),

--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::{cacheable, utils::PortablePath, with::As};
 use rspack_fs::IntermediateFileSystem;
 use rspack_paths::Utf8PathBuf;
 pub use rspack_storage::{BoxStorage, MemoryStorage, Storage};
-use rspack_storage::{FileSystemOptions, FileSystemStorage};
+use rspack_storage::{FileSystemOptions, FileSystemStorage, Version};
 
 /// Storage Options
 ///
@@ -29,7 +29,7 @@ pub fn create_storage(
     StorageOptions::FileSystem { directory } => {
       let option = FileSystemOptions {
         directory,
-        version,
+        version: Version::new(version),
         max_versions,
         max_pack_size: 500 * 1024,
         expire: max_age,

--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use rspack_cacheable::{cacheable, utils::PortablePath, with::As};
 use rspack_fs::IntermediateFileSystem;
 use rspack_paths::Utf8PathBuf;
-pub use rspack_storage::{BoxStorage, MemoryStorage, Storage};
-use rspack_storage::{FileSystemOptions, FileSystemStorage, Version};
+pub use rspack_storage::{BoxStorage, MemoryStorage, Storage, Version};
+use rspack_storage::{FileSystemOptions, FileSystemStorage};
 
 /// Storage Options
 ///
@@ -20,7 +20,7 @@ pub enum StorageOptions {
 
 pub fn create_storage(
   options: StorageOptions,
-  version: String,
+  version: Version,
   max_age: u64,
   max_versions: u32,
   fs: Arc<dyn IntermediateFileSystem>,
@@ -29,7 +29,7 @@ pub fn create_storage(
     StorageOptions::FileSystem { directory } => {
       let option = FileSystemOptions {
         directory,
-        version: Version::new(version),
+        version,
         max_versions,
         max_pack_size: 500 * 1024,
         expire: max_age,

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::{ScopeFileSystem, Version};
 use crate::{Error, Result};
@@ -88,7 +88,7 @@ impl Meta {
     active_version: &Version,
     expire_seconds: u64,
     max_versions: u32,
-    existing_versions: &[Version],
+    existing_versions: &HashSet<Version>,
   ) -> Result<(Vec<Version>, u64)> {
     let now = Self::current_timestamp();
     self.access_times.insert(active_version.clone(), now);
@@ -145,7 +145,7 @@ impl Meta {
 
 #[cfg(test)]
 mod test {
-  use super::{Meta, Result, ScopeFileSystem, Version};
+  use super::{HashSet, Meta, Result, ScopeFileSystem, Version};
 
   const V1: &str = "rspack_v_0000000000000001";
   const V2: &str = "rspack_v_0000000000000002";
@@ -155,7 +155,7 @@ mod test {
     Version::parse(value).expect("valid test version")
   }
 
-  fn existing_versions(values: &[&str]) -> Vec<Version> {
+  fn existing_versions(values: &[&str]) -> HashSet<Version> {
     values.iter().filter_map(Version::parse).collect()
   }
 

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -2,7 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rustc_hash::FxHashMap as HashMap;
 
-use super::ScopeFileSystem;
+use super::{ScopeFileSystem, Version};
 use crate::{Error, Result};
 
 /// Metadata for tracking last access times of all DB versions.
@@ -16,7 +16,7 @@ use crate::{Error, Result};
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Meta {
   /// Map of DB version -> last access timestamp (seconds since UNIX_EPOCH)
-  access_times: HashMap<String, u64>,
+  access_times: HashMap<Version, u64>,
 }
 
 impl Meta {
@@ -57,7 +57,10 @@ impl Meta {
         ))
       })?;
 
-      meta.access_times.insert(version.to_string(), timestamp);
+      // Ignore malformed version ids before they can become cleanup targets.
+      if let Some(version) = Version::parse(version) {
+        meta.access_times.insert(version, timestamp);
+      }
     }
 
     Ok(meta)
@@ -82,13 +85,13 @@ impl Meta {
   /// - `next_check_time`: the earliest time the metadata needs another refresh.
   pub async fn refresh(
     &mut self,
-    active_version: &str,
+    active_version: &Version,
     expire_seconds: u64,
     max_versions: u32,
-    versions: &[String],
-  ) -> Result<(Vec<String>, u64)> {
+    existing_versions: &[Version],
+  ) -> Result<(Vec<Version>, u64)> {
     let now = Self::current_timestamp();
-    self.access_times.insert(active_version.into(), now);
+    self.access_times.insert(active_version.clone(), now);
 
     let mut next_check_time = now + 60 * 60;
     let mut removed_versions = vec![];
@@ -111,17 +114,13 @@ impl Meta {
     }
 
     if max_versions != 0 {
-      // `versions` is already scoped to the current storage directory, so every
-      // non-hidden, non-active entry is a version candidate.
-      let mut candidates = versions
+      // Only versions that are both tracked by `_meta` and present on disk are
+      // candidates. Untracked directory entries are ignored.
+      let mut candidates = self
+        .access_times
         .iter()
-        .filter(|version| version.as_str() != active_version && !version.starts_with(['_', '.']))
-        .map(|version| {
-          (
-            version.clone(),
-            self.access_times.get(version).copied().unwrap_or_default(),
-          )
-        })
+        .filter(|(version, _)| *version != active_version && existing_versions.contains(version))
+        .map(|(version, timestamp)| (version.clone(), *timestamp))
         .collect::<Vec<_>>();
       let retained_inactive_versions = max_versions.saturating_sub(1) as usize;
       let remove_count = candidates.len().saturating_sub(retained_inactive_versions);
@@ -146,7 +145,19 @@ impl Meta {
 
 #[cfg(test)]
 mod test {
-  use super::{Meta, Result, ScopeFileSystem};
+  use super::{Meta, Result, ScopeFileSystem, Version};
+
+  const V1: &str = "rspack_v_0000000000000001";
+  const V2: &str = "rspack_v_0000000000000002";
+  const V3: &str = "rspack_v_0000000000000003";
+
+  fn version(value: &str) -> Version {
+    Version::parse(value).expect("valid test version")
+  }
+
+  fn existing_versions(values: &[&str]) -> Vec<Version> {
+    values.iter().filter_map(Version::parse).collect()
+  }
 
   #[tokio::test]
   #[cfg_attr(miri, ignore)]
@@ -159,25 +170,87 @@ mod test {
     let mut meta = Meta::default();
     meta
       .access_times
-      .insert("v1".into(), Meta::current_timestamp() - 30);
+      .insert(version(V1), Meta::current_timestamp() - 30);
     meta
       .access_times
-      .insert("v2".into(), Meta::current_timestamp() - 30);
+      .insert(version(V2), Meta::current_timestamp() - 30);
     meta.save(&fs).await?;
 
     let mut meta = Meta::load(&fs).await?;
-    let (mut expired, _next_time) = meta.refresh("v3", 1, 0, &[]).await?;
+    let versions = existing_versions(&[V1, V2]);
+    let (mut expired, _next_time) = meta.refresh(&version(V3), 1, 0, &versions).await?;
     expired.sort();
-    assert_eq!(expired, vec![String::from("v1"), String::from("v2")]);
-    assert!(meta.access_times.contains_key("v3"));
+    assert_eq!(expired, vec![version(V1), version(V2)]);
+    assert!(meta.access_times.contains_key(&version(V3)));
     meta.save(&fs).await?;
 
     let meta = Meta::load(&fs).await?;
     assert_eq!(meta.access_times.len(), 1);
-    assert!(meta.access_times.contains_key("v3"));
+    assert!(meta.access_times.contains_key(&version(V3)));
 
     let contents = String::from_utf8(fs.read(Meta::FILE_NAME).await?).expect("valid metadata");
     assert!(contents.lines().all(|line| line.split(' ').count() == 2));
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn load_should_ignore_invalid_meta_entries() -> Result<()> {
+    let fs = ScopeFileSystem::new_memory_fs("/invalid_meta_entries".into());
+    fs.ensure_exist().await?;
+
+    let timestamp = Meta::current_timestamp() - 30;
+    fs.write(
+      Meta::FILE_NAME,
+      format!(
+        "../outside {timestamp}\nkeep-me {timestamp}\n0000000000000001 {timestamp}\n{V1} {timestamp}\n"
+      )
+      .as_bytes(),
+    )
+    .await?;
+
+    let mut meta = Meta::load(&fs).await?;
+    assert_eq!(meta.access_times.len(), 1);
+    assert!(meta.access_times.contains_key(&version(V1)));
+
+    let versions = existing_versions(&["../outside", "keep-me", "0000000000000001", V1]);
+    let (expired, _) = meta.refresh(&version(V2), 1, 0, &versions).await?;
+
+    assert_eq!(expired, vec![version(V1)]);
+    assert!(
+      meta
+        .access_times
+        .keys()
+        .all(|version| { version.as_str() != "../outside" && version.as_str() != "keep-me" })
+    );
+    assert!(meta.access_times.contains_key(&version(V2)));
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn max_versions_only_removes_tracked_cache_versions() -> Result<()> {
+    let untracked_version = "rspack_v_0000000000000004";
+    let mut meta = Meta::default();
+    meta.access_times.insert(version(V1), 1);
+    meta.access_times.insert(version(V2), 2);
+
+    let versions = existing_versions(&[untracked_version, "ordinary-directory", V1, V2]);
+    let (expired, _) = meta.refresh(&version(V3), 0, 2, &versions).await?;
+
+    assert_eq!(expired, vec![version(V1)]);
+    assert!(
+      !expired
+        .iter()
+        .any(|version| version.as_str() == untracked_version)
+    );
+    assert!(
+      !expired
+        .iter()
+        .any(|version| version.as_str() == "ordinary-directory")
+    );
+    assert!(meta.access_times.contains_key(&version(V2)));
+    assert!(meta.access_times.contains_key(&version(V3)));
 
     Ok(())
   }

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -114,13 +114,18 @@ impl Meta {
     }
 
     if max_versions != 0 {
-      // Only versions that are both tracked by `_meta` and present on disk are
-      // candidates. Untracked directory entries are ignored.
-      let mut candidates = self
-        .access_times
+      // Valid version directories on disk are candidates even when `_meta` has
+      // no timestamp for them. Treat missing timestamps as the oldest entries so
+      // orphaned cache versions can still be reclaimed by maxVersions cleanup.
+      let mut candidates = existing_versions
         .iter()
-        .filter(|(version, _)| *version != active_version && existing_versions.contains(version))
-        .map(|(version, timestamp)| (version.clone(), *timestamp))
+        .filter(|version| *version != active_version)
+        .map(|version| {
+          (
+            version.clone(),
+            self.access_times.get(version).copied().unwrap_or_default(),
+          )
+        })
         .collect::<Vec<_>>();
       let retained_inactive_versions = max_versions.saturating_sub(1) as usize;
       let remove_count = candidates.len().saturating_sub(retained_inactive_versions);
@@ -229,21 +234,16 @@ mod test {
   }
 
   #[tokio::test]
-  async fn max_versions_only_removes_tracked_cache_versions() -> Result<()> {
-    let untracked_version = "rspack_v_0000000000000004";
+  async fn max_versions_removes_valid_orphan_cache_versions() -> Result<()> {
+    let orphan_version = "rspack_v_0000000000000004";
     let mut meta = Meta::default();
     meta.access_times.insert(version(V1), 1);
     meta.access_times.insert(version(V2), 2);
 
-    let versions = existing_versions(&[untracked_version, "ordinary-directory", V1, V2]);
+    let versions = existing_versions(&[orphan_version, "ordinary-directory", V1, V2]);
     let (expired, _) = meta.refresh(&version(V3), 0, 2, &versions).await?;
 
-    assert_eq!(expired, vec![version(V1)]);
-    assert!(
-      !expired
-        .iter()
-        .any(|version| version.as_str() == untracked_version)
-    );
+    assert_eq!(expired, vec![version(V1), version(orphan_version)]);
     assert!(
       !expired
         .iter()

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -7,7 +7,7 @@ mod version;
 
 use std::sync::{Arc, Mutex};
 
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use self::{db::DB, meta::Meta, scope_fs::ScopeFileSystem, task_queue::TaskQueue};
 pub use self::{options::FileSystemOptions, version::Version};
@@ -42,7 +42,7 @@ async fn refresh_metadata(
     .unwrap_or_default()
     .into_iter()
     .filter_map(Version::parse)
-    .collect::<Vec<_>>();
+    .collect::<HashSet<_>>();
   let Ok((removed_versions, next_refresh_time)) = meta
     .refresh(&version, expire, max_versions, &existing_versions)
     .await
@@ -55,8 +55,8 @@ async fn refresh_metadata(
 
   // Persist metadata before deleting directories so concurrent refreshes can
   // recover even if removal is interrupted.
-  for version in removed_versions {
-    let _ = fs.child_fs(version.as_str()).remove().await;
+  for removed_version in removed_versions {
+    let _ = fs.child_fs(removed_version.as_str()).remove().await;
   }
   *next_meta_refresh_time.lock().expect("should get lock") = next_refresh_time;
 }

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -3,13 +3,14 @@ mod meta;
 mod options;
 mod scope_fs;
 mod task_queue;
+mod version;
 
 use std::sync::{Arc, Mutex};
 
 use rustc_hash::FxHashMap as HashMap;
 
-pub use self::options::FileSystemOptions;
 use self::{db::DB, meta::Meta, scope_fs::ScopeFileSystem, task_queue::TaskQueue};
+pub use self::{options::FileSystemOptions, version::Version};
 use crate::{Result, Storage};
 
 /// Type alias for in-memory update changes: key -> optional_value
@@ -17,7 +18,7 @@ type BucketChangesMap = HashMap<Vec<u8>, Option<Vec<u8>>>;
 
 async fn refresh_metadata(
   fs: ScopeFileSystem,
-  version: String,
+  version: Version,
   expire: u64,
   max_versions: u32,
   next_meta_refresh_time: Arc<Mutex<u64>>,
@@ -35,9 +36,15 @@ async fn refresh_metadata(
   };
   // Cleanup needs the current storage directory entries to keep metadata in
   // sync with versions that still exist on disk.
-  let versions = fs.list_child().await.unwrap_or_default();
+  let existing_versions = fs
+    .list_child()
+    .await
+    .unwrap_or_default()
+    .into_iter()
+    .filter_map(Version::parse)
+    .collect::<Vec<_>>();
   let Ok((removed_versions, next_refresh_time)) = meta
-    .refresh(&version, expire, max_versions, &versions)
+    .refresh(&version, expire, max_versions, &existing_versions)
     .await
   else {
     return;
@@ -49,7 +56,7 @@ async fn refresh_metadata(
   // Persist metadata before deleting directories so concurrent refreshes can
   // recover even if removal is interrupted.
   for version in removed_versions {
-    let _ = fs.child_fs(&version).remove().await;
+    let _ = fs.child_fs(version.as_str()).remove().await;
   }
   *next_meta_refresh_time.lock().expect("should get lock") = next_refresh_time;
 }
@@ -78,7 +85,7 @@ impl FileSystemStorage {
     let fs = ScopeFileSystem::new(options.directory.clone(), options.fs.clone());
 
     Self {
-      db: DB::new(fs.child_fs(&options.version)),
+      db: DB::new(fs.child_fs(options.version.as_str())),
       task_queue: TaskQueue::default(),
       updates: Default::default(),
       next_meta_refresh_time: Default::default(),

--- a/crates/rspack_storage/src/filesystem/options.rs
+++ b/crates/rspack_storage/src/filesystem/options.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use rspack_fs::IntermediateFileSystem;
 use rspack_paths::Utf8PathBuf;
 
+use super::Version;
+
 /// File system storage configuration options
 #[derive(Debug)]
 pub struct FileSystemOptions {
@@ -10,7 +12,7 @@ pub struct FileSystemOptions {
   /// `<directory>/<version>`.
   pub directory: Utf8PathBuf,
   /// Version identifier for the specific DB instance within directory
-  pub version: String,
+  pub version: Version,
   /// Maximum pack file size (bytes), creates new pack file when exceeded
   pub max_pack_size: usize,
   /// Data expiration time (seconds), 0 means never expire

--- a/crates/rspack_storage/src/filesystem/version.rs
+++ b/crates/rspack_storage/src/filesystem/version.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+
+/// Filesystem persistent-cache version directory name.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Version(String);
+
+impl Version {
+  const PREFIX: &str = "rspack_v_";
+  const HASH_LEN: usize = 16;
+
+  pub fn new(hash: impl AsRef<str>) -> Self {
+    let hash = hash.as_ref();
+    assert!(
+      Self::is_valid_hash(hash),
+      "invalid persistent cache version hash"
+    );
+    Self(format!("{}{hash}", Self::PREFIX))
+  }
+
+  pub fn parse(value: impl AsRef<str>) -> Option<Self> {
+    let value = value.as_ref();
+    Self::is_valid(value).then(|| Self(value.to_string()))
+  }
+
+  pub fn is_valid(value: impl AsRef<str>) -> bool {
+    let Some(hash) = value.as_ref().strip_prefix(Self::PREFIX) else {
+      return false;
+    };
+
+    Self::is_valid_hash(hash)
+  }
+
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+
+  fn is_valid_hash(hash: &str) -> bool {
+    hash.len() == Self::HASH_LEN
+      && hash
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+  }
+}
+
+impl fmt::Display for Version {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.0)
+  }
+}
+
+impl AsRef<str> for Version {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}

--- a/crates/rspack_storage/src/lib.rs
+++ b/crates/rspack_storage/src/lib.rs
@@ -10,7 +10,7 @@ mod memory;
 
 pub use self::{
   error::{Error, Result},
-  filesystem::{FileSystemOptions, FileSystemStorage},
+  filesystem::{FileSystemOptions, FileSystemStorage, Version},
   memory::MemoryStorage,
 };
 

--- a/crates/rspack_tools/src/compare/mod.rs
+++ b/crates/rspack_tools/src/compare/mod.rs
@@ -3,7 +3,9 @@ mod snapshot;
 
 use std::{collections::VecDeque, sync::Arc};
 
-use rspack_core::cache::persistent::storage::{BoxStorage, StorageOptions, create_storage};
+use rspack_core::cache::persistent::storage::{
+  BoxStorage, StorageOptions, Version, create_storage,
+};
 use rspack_error::{Result, error};
 use rspack_fs::{NativeFileSystem, ReadableFileSystem};
 use rspack_paths::Utf8PathBuf;
@@ -95,12 +97,15 @@ pub fn load_storages_from_path(path: &Utf8PathBuf) -> HashMap<String, BoxStorage
   };
 
   // Cache directories are laid out as `<version>`.
-  for version in versions {
-    if version.starts_with(['.', '_']) {
+  for version_name in versions {
+    if version_name.starts_with(['.', '_']) {
       continue;
     }
+    let Some(version) = Version::parse(&version_name) else {
+      continue;
+    };
     if !fs
-      .metadata_sync(&path.join(&version))
+      .metadata_sync(&path.join(&version_name))
       .is_ok_and(|metadata| metadata.is_directory)
     {
       continue;
@@ -110,13 +115,13 @@ pub fn load_storages_from_path(path: &Utf8PathBuf) -> HashMap<String, BoxStorage
       StorageOptions::FileSystem {
         directory: path.clone(),
       },
-      version.clone(),
+      version,
       0,
       0,
       fs.clone(),
     );
 
-    storages.insert(version, storage);
+    storages.insert(version_name, storage);
   }
 
   storages


### PR DESCRIPTION
## Summary
- Introduce a typed `Version` wrapper for filesystem-backed persistent cache directories.
- Validate cache version names at creation time and use typed versions throughout storage and metadata refresh flows.
- Ignore malformed metadata entries and restrict eviction to tracked versions that still exist on disk.
- Add regression tests for invalid metadata parsing and max-version cleanup behavior.

## Testing
- Added Rust unit tests covering invalid `_meta` entries and tracked-version eviction.
- Not run (not requested).