### PR TITLE
perf: reduce module ids assignment overhead

### DIFF
--- a/crates/rspack_core/src/compilation/module_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/module_ids/mod.rs
@@ -68,15 +68,22 @@ impl PassExt for ModuleIdsPass {
     }
 
     // Call beforeModuleIds hook - allows plugins to assign custom IDs
-    let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
-    compilation
+    if !compilation
       .plugin_driver
-      .clone()
       .compilation_hooks
       .before_module_ids
-      .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
-      .await
-      .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.beforeModuleIds"))?;
+      .is_empty()
+    {
+      let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
+      compilation
+        .plugin_driver
+        .clone()
+        .compilation_hooks
+        .before_module_ids
+        .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
+        .await
+        .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.beforeModuleIds"))?;
+    }
 
     // Put artifact back so moduleIds plugins can see custom IDs from beforeModuleIds
     // when they call get_used_module_ids_and_modules

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use rayon::prelude::*;
 use rspack_core::{
   ChunkByUkey, ChunkNamedIdArtifact, CompilationChunkIds, Plugin, incremental::IncrementalPasses,
@@ -90,12 +88,10 @@ async fn chunk_ids(
   assign_deterministic_ids(
     chunks,
     |chunk| {
-      Cow::Borrowed(
-        chunk_names
-          .get(&chunk.ukey())
-          .expect("should have generated full chunk name")
-          .as_str(),
-      )
+      chunk_names
+        .get(&chunk.ukey())
+        .expect("should have generated full chunk name")
+        .as_str()
     },
     |a, b| {
       compare_chunks_natural(

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -1,8 +1,5 @@
-use std::borrow::Cow;
-
 use derive_more::Debug;
 use rayon::prelude::*;
-use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkGraph, Compilation, CompilationModuleIds, ModuleIdsArtifact, Plugin,
   incremental::IncrementalPasses,
@@ -102,29 +99,22 @@ async fn module_ids(
     .collect::<Vec<_>>();
   let used_ids_len = used_ids.len();
 
-  let module_names = modules
-    .par_iter()
-    .map(|m| (m.identifier(), get_full_module_name(m, context)))
-    .collect::<IdentifierMap<String>>();
+  let modules_with_names = modules
+    .into_par_iter()
+    .map(|m| (m, get_full_module_name(m, context)))
+    .collect::<Vec<_>>();
 
   assign_deterministic_ids(
-    modules,
-    |m| {
-      Cow::Borrowed(
-        module_names
-          .get(&m.identifier())
-          .expect("should have generated full module name")
-          .as_str(),
-      )
-    },
-    |a, b| {
+    modules_with_names,
+    |(_, name)| name.as_str(),
+    |(a, _), (b, _)| {
       compare_modules_by_pre_order_index_or_identifier(
         module_graph,
         &a.identifier(),
         &b.identifier(),
       )
     },
-    |module, id| {
+    |(module, _), id| {
       if !used_ids.insert(id.to_string()) {
         conflicts += 1;
         return false;

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -166,9 +166,9 @@ pub fn get_hash(s: impl Hash, length: usize) -> String {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn assign_deterministic_ids<'a, T>(
+pub fn assign_deterministic_ids<T>(
   mut items: Vec<T>,
-  get_name: impl Fn(&T) -> Cow<'a, str>,
+  get_name: impl for<'b> Fn(&'b T) -> &'b str,
   comparator: impl FnMut(&T, &T) -> Ordering,
   mut assign_id: impl FnMut(&T, usize) -> bool,
   ranges: &[usize],
@@ -196,10 +196,10 @@ pub fn assign_deterministic_ids<'a, T>(
   for item in items {
     let ident = get_name(&item);
     let mut i = salt;
-    let mut id = get_number_hash_combined(ident.as_ref(), i, range);
+    let mut id = get_number_hash_combined(ident, i, range);
     while !assign_id(&item, id) {
       i += 1;
-      id = get_number_hash_combined(ident.as_ref(), i, range);
+      id = get_number_hash_combined(ident, i, range);
     }
   }
 }
@@ -251,20 +251,19 @@ mod tests {
 
   #[test]
   fn assign_deterministic_ids_accepts_borrowed_names() {
-    let items = vec![1usize, 2usize, 3usize];
-    let names = FxHashMap::from_iter([
+    let items = vec![
       (1usize, "module-a".to_string()),
       (2usize, "module-b".to_string()),
       (3usize, "module-c".to_string()),
-    ]);
+    ];
     let mut assigned = FxHashMap::default();
 
     assign_deterministic_ids(
       items,
-      |item| std::borrow::Cow::Borrowed(names.get(item).expect("should have name").as_str()),
+      |(_, name)| name.as_str(),
       |a, b| a.cmp(b),
       |item, id| {
-        assigned.insert(*item, id);
+        assigned.insert(item.0, id);
         true
       },
       &[1000],

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -318,7 +318,7 @@ fn mangle_exports_info(
     let mut export_info_used_name = FxHashMap::default();
     assign_deterministic_ids(
       mangleable_exports,
-      |e| Cow::Borrowed(e.name.as_str()),
+      |e| e.name.as_str(),
       |a, b| compare_strings_numeric(a.name, b.name),
       |e, id| {
         let name = number_to_identifier(id as u32);

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -1399,14 +1399,21 @@ fn get_modules_needing_ids(
 
 async fn run_module_ids_hook(compilation: &mut Compilation) -> Result<()> {
   let mut module_ids_artifact = compilation.module_ids_artifact.steal();
-  let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
-  compilation
+  if !compilation
     .plugin_driver
-    .clone()
     .compilation_hooks
     .before_module_ids
-    .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
-    .await?;
+    .is_empty()
+  {
+    let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
+    compilation
+      .plugin_driver
+      .clone()
+      .compilation_hooks
+      .before_module_ids
+      .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
+      .await?;
+  }
   compilation.module_ids_artifact = module_ids_artifact.into();
 
   let mut diagnostics = vec![];


### PR DESCRIPTION
## Summary

- Skip collecting modules for `beforeModuleIds` when the hook has no taps.
- Keep deterministic module names beside their modules instead of materializing and looking up a temporary identifier map.
- Tighten the deterministic id helper to borrow names directly as `&str`.

## Expected impact

This reduces one full module scan on the common deterministic module id path and removes extra hash-map allocation/lookups while assigning module ids. The benchmark helper mirrors the production fast path so CodSpeed can measure `rust@create_module_ids` directly.