### PR TITLE
perf(benchmark): enable pureFunctions for production bundle benches

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3742,6 +3742,12 @@ impl ExperimentsBuilder {
     self
   }
 
+  /// Set whether to enable pure function annotations and hints.
+  pub fn pure_functions(&mut self, pure_functions: bool) -> &mut Self {
+    self.pure_functions = Some(pure_functions);
+    self
+  }
+
   /// Build [`Experiments`] from options.
   ///
   /// [`Experiments`]: rspack_core::options::Experiments
@@ -3855,6 +3861,46 @@ mod test {
           .iter()
           .any(|plugin| matches!(plugin, BuiltinPluginOptions::SideEffectsFlagPlugin(false)))
       );
+    })
+  }
+
+  #[test]
+  fn pure_functions_defaults_follow_mode() {
+    within_compiler_context_for_testing_sync(|| {
+      let mut context: BuilderContext = Default::default();
+      let compiler_options = CompilerOptions::builder()
+        .target(vec!["web".to_string()])
+        .experiments(Experiments::builder().css(true))
+        .build(&mut context)
+        .unwrap();
+      assert!(compiler_options.experiments.pure_functions);
+
+      let mut context: BuilderContext = Default::default();
+      let compiler_options = CompilerOptions::builder()
+        .mode(Mode::Production)
+        .target(vec!["web".to_string()])
+        .experiments(Experiments::builder().css(true))
+        .build(&mut context)
+        .unwrap();
+      assert!(compiler_options.experiments.pure_functions);
+
+      let mut context: BuilderContext = Default::default();
+      let compiler_options = CompilerOptions::builder()
+        .mode(Mode::Development)
+        .target(vec!["web".to_string()])
+        .experiments(Experiments::builder().css(true))
+        .build(&mut context)
+        .unwrap();
+      assert!(!compiler_options.experiments.pure_functions);
+
+      let mut context: BuilderContext = Default::default();
+      let compiler_options = CompilerOptions::builder()
+        .mode(Mode::Development)
+        .target(vec!["web".to_string()])
+        .experiments(Experiments::builder().css(true).pure_functions(true))
+        .build(&mut context)
+        .unwrap();
+      assert!(compiler_options.experiments.pure_functions);
     })
   }
 

--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -116,7 +116,7 @@ pub fn derive_projects(
             let mut builder = builder();
             builder.mode(Mode::Production);
             builder.devtool(rspack::builder::Devtool::SourceMap);
-            builder.experiments(Experiments::builder().css(true).pure_functions(true));
+            builder.experiments(Experiments::builder().css(true).pure_functions(false));
             builder
           }),
         ));

--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -116,6 +116,7 @@ pub fn derive_projects(
             let mut builder = builder();
             builder.mode(Mode::Production);
             builder.devtool(rspack::builder::Devtool::SourceMap);
+            builder.experiments(Experiments::builder().css(true).pure_functions(true));
             builder
           }),
         ));


### PR DESCRIPTION
## Summary

- add an `ExperimentsBuilder::pure_functions` setter on the Rust builder side
- enable `pure_functions` explicitly for production sourcemap bundle benchmarks
- add a focused builder test that locks `pure_functions` defaults to production/undefined mode, matching the JS default behavior

## Validation

- `cargo fmt -p rspack -p rspack_benchmark`
- `pnpm run build:binding:dev`

`cargo test -p rspack pure_functions_defaults_follow_mode` and `cargo check -p rspack_benchmark --benches` were started after rebasing onto latest `origin/main`, then stopped when requested to open the draft PR directly.