### PR TITLE
fix(error): use theme-based styling instead of environment-sniffing `dim()` in graphical renderer

### DIFF
--- a/crates/rspack_error/src/displayer/renderer/graphical.rs
+++ b/crates/rspack_error/src/displayer/renderer/graphical.rs
@@ -13,8 +13,6 @@ use miette::{
 use owo_colors::{OwoColorize, Style};
 use unicode_width::UnicodeWidthChar;
 
-use crate::colors::dim;
-
 /**
 A [`ReportHandler`] that displays a given [`Report`](crate::Report) in a
 quasi-graphical way, using terminal colors, unicode drawing characters, and
@@ -178,7 +176,10 @@ impl GraphicalReportHandler {
     };
 
     let initial_indent = format!("  {} ", severity_icon.style(severity_style));
-    let rest_indent = format!("  {} ", dim(&self.theme.characters.vbar));
+    let rest_indent = format!(
+      "  {} ",
+      self.theme.characters.vbar.style(self.theme.styles.linum)
+    );
     let width = self.termwidth.saturating_sub(2);
     let opts = textwrap::Options::new(width)
       .initial_indent(&initial_indent)
@@ -203,16 +204,19 @@ impl GraphicalReportHandler {
         } else {
           self.theme.characters.lbot
         };
-        let initial_indent = dim(&format!(
+        let initial_indent = format!(
           "  {}{}{} ",
           char, self.theme.characters.hbar, self.theme.characters.rarrow
-        ))
+        )
+        .style(self.theme.styles.linum)
         .to_string();
 
         let rest_indent = if is_last {
           "      ".to_string()
         } else {
-          dim(&format!("  {}   ", self.theme.characters.vbar)).to_string()
+          format!("  {}   ", self.theme.characters.vbar)
+            .style(self.theme.styles.linum)
+            .to_string()
         };
 
         let opts = textwrap::Options::new(width)

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -238,8 +238,11 @@ impl From<anyhow::Error> for Error {
 
 #[cfg(test)]
 mod test {
+  use owo_colors::with_override;
+
   use super::{Error, ErrorData, Label};
   use crate::{Renderer, Severity};
+
   #[test]
   fn should_error_display() {
     let renderer = Renderer::new(false);
@@ -315,9 +318,12 @@ mod test {
          ╰────
         help: Maybe you should remove it.
 "#;
-    assert_eq!(
-      renderer.render(&root_err).unwrap().trim(),
-      expect_display.trim()
-    );
+    // Force color support to prove the renderer respects its own theme
+    with_override(true, || {
+      assert_eq!(
+        renderer.render(&root_err).unwrap().trim(),
+        expect_display.trim()
+      );
+    });
   }
 }


### PR DESCRIPTION

## Summary
The cause-chain chrome (├─▶, │, ╰─▶) was styled via `dim()` which calls `if_supports_color(Stdout, ...)`, bypassing the renderer's own color setting. This caused ANSI dim codes to leak into output even when `stats.colors: false`, if the environment reported color support. Details can be found in #14560

Closes #14560

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
