### PR TITLE
feat(cache): make stale version cleanup fire-and-forget

### DIFF
--- a/crates/rspack_core/src/cache/persistent/context.rs
+++ b/crates/rspack_core/src/cache/persistent/context.rs
@@ -55,6 +55,13 @@ impl CacheContext {
     &self.logger
   }
 
+  pub fn cleanup_stale(&self) {
+    if self.readonly {
+      return;
+    }
+    self.storage.cleanup_stale();
+  }
+
   /// Validates build dependencies and sets `invalid` + `load_failed` on
   /// failure.  Resets the BUILD scope when invalid and not readonly.
   ///

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -130,6 +130,7 @@ impl PersistentCache {
       return;
     }
     self.initialized = true;
+    self.ctx.cleanup_stale();
 
     // build_deps is the first validation step. If it fails or the build
     // dependencies have changed, only the BUILD scope is reset here; each

--- a/crates/rspack_fs/src/memory_fs.rs
+++ b/crates/rspack_fs/src/memory_fs.rs
@@ -136,13 +136,63 @@ impl MemoryFileSystem {
 
   fn _rename_file(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
     if !self.contains_file(from)? {
-      return Err(new_error("from dir not exist"));
+      return Err(new_error("from file not exist"));
     }
+    self._remove_file(to)?;
+
     let mut files = self.files.lock().expect("should get lock");
     let file = files.remove(from).expect("should have file");
     files.insert(to.into(), file);
 
     Ok(())
+  }
+
+  fn _rename_dir(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+    if to.starts_with(from) {
+      return Err(new_error("cannot rename into itself"));
+    }
+    if !self.contains_dir(from)? {
+      return Err(new_error("from dir not exist"));
+    }
+    if self.metadata_sync(to).is_ok() {
+      return Err(new_error("target path already exist"));
+    }
+
+    let mut files = self.files.lock().expect("should get lock");
+    let entries = files
+      .keys()
+      .filter(|path| path.starts_with(from))
+      .cloned()
+      .collect::<Vec<_>>();
+    for path in entries {
+      let file = files.remove(&path).expect("should have file");
+      let relative = path.strip_prefix(from).expect("should strip prefix");
+      files.insert(to.join(relative), file);
+    }
+
+    Ok(())
+  }
+
+  fn _rename(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+    if from == to {
+      return Ok(());
+    }
+
+    let parent = to
+      .parent()
+      .ok_or_else(|| new_error("target parent dir not exist"))?;
+    if !self.contains_dir(parent)? {
+      return Err(new_error("target parent dir not exist"));
+    }
+
+    let metadata = self.metadata_sync(from)?;
+    if metadata.is_file {
+      self._rename_file(from, to)
+    } else if metadata.is_directory {
+      self._rename_dir(from, to)
+    } else {
+      Err(new_error("unsupported source path type"))
+    }
   }
 }
 #[async_trait::async_trait]
@@ -287,7 +337,7 @@ impl ReadableFileSystem for MemoryFileSystem {
 #[async_trait::async_trait]
 impl IntermediateFileSystemExtras for MemoryFileSystem {
   async fn rename(&self, from: &Utf8Path, to: &Utf8Path) -> Result<()> {
-    self._rename_file(from, to)?;
+    self._rename(from, to)?;
     Ok(())
   }
 

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -80,8 +80,8 @@ impl Meta {
 
   /// Updates the active version and removes versions rejected by age or version limits.
   ///
-  /// Returns `(removed_versions, next_check_time)`.
-  /// - `removed_versions`: version directories that should be deleted.
+  /// Returns `(stale_versions, next_check_time)`.
+  /// - `stale_versions`: version directories that should be deleted.
   /// - `next_check_time`: the earliest time the metadata needs another refresh.
   pub async fn refresh(
     &mut self,
@@ -94,7 +94,7 @@ impl Meta {
     self.access_times.insert(active_version.clone(), now);
 
     let mut next_check_time = now + 60 * 60;
-    let mut removed_versions = vec![];
+    let mut stale_versions = vec![];
 
     if expire_seconds != 0 {
       // Check again after roughly a quarter of the configured max age, unless
@@ -103,7 +103,7 @@ impl Meta {
       self.access_times.retain(|version, time| {
         let expiry_time = *time + expire_seconds;
         if expiry_time < now {
-          removed_versions.push(version.clone());
+          stale_versions.push(version.clone());
           return false;
         }
         if expiry_time < next_check_time {
@@ -142,14 +142,14 @@ impl Meta {
 
       for (version, _) in candidates.into_iter().take(remove_count) {
         self.access_times.remove(&version);
-        removed_versions.push(version);
+        stale_versions.push(version);
       }
     }
 
-    removed_versions.sort_unstable();
-    removed_versions.dedup();
+    stale_versions.sort_unstable();
+    stale_versions.dedup();
 
-    Ok((removed_versions, next_check_time))
+    Ok((stale_versions, next_check_time))
   }
 }
 

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use super::{ScopeFileSystem, Version};
 use crate::{Error, Result};
@@ -85,10 +85,10 @@ impl Meta {
   /// - `next_check_time`: the earliest time the metadata needs another refresh.
   pub async fn refresh(
     &mut self,
+    fs: &ScopeFileSystem,
     active_version: &Version,
     expire_seconds: u64,
     max_versions: u32,
-    existing_versions: &HashSet<Version>,
   ) -> Result<(Vec<Version>, u64)> {
     let now = Self::current_timestamp();
     self.access_times.insert(active_version.clone(), now);
@@ -117,14 +117,19 @@ impl Meta {
       // Valid version directories on disk are candidates even when `_meta` has
       // no timestamp for them. Treat missing timestamps as the oldest entries so
       // orphaned cache versions can still be reclaimed by maxVersions cleanup.
-      let mut candidates = existing_versions
-        .iter()
-        .filter(|version| *version != active_version)
-        .map(|version| {
-          (
-            version.clone(),
-            self.access_times.get(version).copied().unwrap_or_default(),
-          )
+      let mut candidates = fs
+        .list_child()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|version| {
+          let version = Version::parse(version)?;
+          if &version == active_version {
+            return None;
+          }
+
+          let timestamp = self.access_times.get(&version).copied().unwrap_or_default();
+          Some((version, timestamp))
         })
         .collect::<Vec<_>>();
       let retained_inactive_versions = max_versions.saturating_sub(1) as usize;
@@ -150,7 +155,7 @@ impl Meta {
 
 #[cfg(test)]
 mod test {
-  use super::{HashSet, Meta, Result, ScopeFileSystem, Version};
+  use super::{Meta, Result, ScopeFileSystem, Version};
 
   const V1: &str = "rspack_v_0000000000000001";
   const V2: &str = "rspack_v_0000000000000002";
@@ -160,8 +165,11 @@ mod test {
     Version::parse(value).expect("valid test version")
   }
 
-  fn existing_versions(values: &[&str]) -> HashSet<Version> {
-    values.iter().filter_map(Version::parse).collect()
+  async fn create_child_dirs(fs: &ScopeFileSystem, values: &[&str]) -> Result<()> {
+    for value in values {
+      fs.child_fs(*value).ensure_exist().await?;
+    }
+    Ok(())
   }
 
   #[tokio::test]
@@ -182,8 +190,7 @@ mod test {
     meta.save(&fs).await?;
 
     let mut meta = Meta::load(&fs).await?;
-    let versions = existing_versions(&[V1, V2]);
-    let (mut expired, _next_time) = meta.refresh(&version(V3), 1, 0, &versions).await?;
+    let (mut expired, _next_time) = meta.refresh(&fs, &version(V3), 1, 0).await?;
     expired.sort();
     assert_eq!(expired, vec![version(V1), version(V2)]);
     assert!(meta.access_times.contains_key(&version(V3)));
@@ -218,8 +225,7 @@ mod test {
     assert_eq!(meta.access_times.len(), 1);
     assert!(meta.access_times.contains_key(&version(V1)));
 
-    let versions = existing_versions(&["../outside", "keep-me", "0000000000000001", V1]);
-    let (expired, _) = meta.refresh(&version(V2), 1, 0, &versions).await?;
+    let (expired, _) = meta.refresh(&fs, &version(V2), 1, 0).await?;
 
     assert_eq!(expired, vec![version(V1)]);
     assert!(
@@ -236,12 +242,15 @@ mod test {
   #[tokio::test]
   async fn max_versions_removes_valid_orphan_cache_versions() -> Result<()> {
     let orphan_version = "rspack_v_0000000000000004";
+    let fs = ScopeFileSystem::new_memory_fs("/max_versions_orphan".into());
+    fs.ensure_exist().await?;
+    create_child_dirs(&fs, &[orphan_version, "ordinary-directory", V1, V2]).await?;
+
     let mut meta = Meta::default();
     meta.access_times.insert(version(V1), 1);
     meta.access_times.insert(version(V2), 2);
 
-    let versions = existing_versions(&[orphan_version, "ordinary-directory", V1, V2]);
-    let (expired, _) = meta.refresh(&version(V3), 0, 2, &versions).await?;
+    let (expired, _) = meta.refresh(&fs, &version(V3), 0, 2).await?;
 
     assert_eq!(expired, vec![version(V1), version(orphan_version)]);
     assert!(

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -11,13 +11,49 @@ use rustc_hash::FxHashMap as HashMap;
 
 use self::{db::DB, meta::Meta, scope_fs::ScopeFileSystem, task_queue::TaskQueue};
 pub use self::{options::FileSystemOptions, version::Version};
-use crate::{Result, Storage};
+use crate::{Error, Result, Storage};
 
 /// Type alias for in-memory update changes: key -> optional_value
 type BucketChangesMap = HashMap<Vec<u8>, Option<Vec<u8>>>;
 
+const STALE_DIR_NAME: &str = "_stale";
+
+fn spawn_cleanup_stale_versions(stale_fs: ScopeFileSystem) {
+  tokio::spawn(async move {
+    stale_fs.ensure_exist().await?;
+
+    let stale_versions = stale_fs
+      .list_child()
+      .await
+      .unwrap_or_default()
+      .into_iter()
+      .filter(|child| Version::parse(child).is_some())
+      .map(|child| stale_fs.child_fs(child));
+
+    for stale_version in stale_versions {
+      let _ = stale_version.remove().await;
+    }
+
+    Ok::<_, Error>(())
+  });
+}
+
+async fn move_stale_versions(
+  fs: &ScopeFileSystem,
+  stale_fs: &ScopeFileSystem,
+  stale_versions: Vec<Version>,
+) -> Result<()> {
+  stale_fs.ensure_exist().await?;
+
+  for version in stale_versions {
+    ScopeFileSystem::move_to(fs, &stale_fs, version.as_str()).await?;
+  }
+  Ok(())
+}
+
 async fn refresh_metadata(
   fs: ScopeFileSystem,
+  stale_fs: ScopeFileSystem,
   version: Version,
   expire: u64,
   max_versions: u32,
@@ -34,7 +70,7 @@ async fn refresh_metadata(
     Err(error) if error.is_not_found() => Meta::default(),
     Err(_) => return,
   };
-  let Ok((removed_versions, next_refresh_time)) =
+  let Ok((stale_versions, next_refresh_time)) =
     meta.refresh(&fs, &version, expire, max_versions).await
   else {
     return;
@@ -43,11 +79,15 @@ async fn refresh_metadata(
     return;
   }
 
-  // Persist metadata before deleting directories so concurrent refreshes can
-  // recover even if removal is interrupted.
-  for removed_version in removed_versions {
-    let _ = fs.child_fs(removed_version.as_str()).remove().await;
+  // Persist metadata before renaming directories so concurrent refreshes can
+  // recover even if stale cleanup is interrupted.
+  if move_stale_versions(&fs, &stale_fs, stale_versions)
+    .await
+    .is_err()
+  {
+    return;
   }
+  spawn_cleanup_stale_versions(stale_fs);
   *next_meta_refresh_time.lock().expect("should get lock") = next_refresh_time;
 }
 
@@ -83,10 +123,18 @@ impl FileSystemStorage {
       options,
     }
   }
+
+  pub fn stale_fs(&self) -> ScopeFileSystem {
+    self.fs.child_fs(STALE_DIR_NAME)
+  }
 }
 
 #[async_trait::async_trait]
 impl Storage for FileSystemStorage {
+  fn cleanup_stale(&self) {
+    spawn_cleanup_stale_versions(self.stale_fs());
+  }
+
   async fn load(&self, scope: &'static str) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
     let data = self.db.load(scope).await?;
     Ok(data)
@@ -115,6 +163,7 @@ impl Storage for FileSystemStorage {
       .collect();
     let max_pack_size = self.options.max_pack_size;
     let fs = self.fs.clone();
+    let stale_fs = self.stale_fs();
     let version = self.options.version.clone();
     let expire = self.options.expire;
     let max_versions = self.options.max_versions;
@@ -122,7 +171,15 @@ impl Storage for FileSystemStorage {
 
     self.task_queue.add_task(async move {
       if db.save(changes, max_pack_size).await {
-        refresh_metadata(fs, version, expire, max_versions, next_meta_refresh_time).await;
+        refresh_metadata(
+          fs,
+          stale_fs,
+          version,
+          expire,
+          max_versions,
+          next_meta_refresh_time,
+        )
+        .await;
       }
     });
   }

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -7,7 +7,7 @@ mod version;
 
 use std::sync::{Arc, Mutex};
 
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use self::{db::DB, meta::Meta, scope_fs::ScopeFileSystem, task_queue::TaskQueue};
 pub use self::{options::FileSystemOptions, version::Version};
@@ -34,18 +34,8 @@ async fn refresh_metadata(
     Err(error) if error.is_not_found() => Meta::default(),
     Err(_) => return,
   };
-  // Cleanup needs the current storage directory entries to keep metadata in
-  // sync with versions that still exist on disk.
-  let existing_versions = fs
-    .list_child()
-    .await
-    .unwrap_or_default()
-    .into_iter()
-    .filter_map(Version::parse)
-    .collect::<HashSet<_>>();
-  let Ok((removed_versions, next_refresh_time)) = meta
-    .refresh(&version, expire, max_versions, &existing_versions)
-    .await
+  let Ok((removed_versions, next_refresh_time)) =
+    meta.refresh(&fs, &version, expire, max_versions).await
   else {
     return;
   };

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -46,7 +46,7 @@ async fn move_stale_versions(
   stale_fs.ensure_exist().await?;
 
   for version in stale_versions {
-    ScopeFileSystem::move_to(fs, &stale_fs, version.as_str()).await?;
+    ScopeFileSystem::move_to(fs, stale_fs, version.as_str()).await?;
   }
   Ok(())
 }

--- a/crates/rspack_storage/src/filesystem/scope_fs.rs
+++ b/crates/rspack_storage/src/filesystem/scope_fs.rs
@@ -58,12 +58,12 @@ impl ScopeFileSystem {
     Ok(())
   }
 
-  /// Moves a file between two scoped file systems
+  /// Moves a file or directory between two scoped file systems
   ///
   /// # Arguments
   /// * `from` - Source scoped file system
   /// * `to` - Target scoped file system
-  /// * `relative_path` - Relative path of the file
+  /// * `relative_path` - Relative path of the file or directory
   pub async fn move_to(
     from: &ScopeFileSystem,
     to: &ScopeFileSystem,

--- a/crates/rspack_storage/src/lib.rs
+++ b/crates/rspack_storage/src/lib.rs
@@ -40,6 +40,11 @@ pub trait Storage: std::fmt::Debug + Sync + Send {
   /// Must be called before process exit to ensure no background I/O is lost.
   async fn flush(&self);
 
+  /// Starts best-effort cleanup for stale storage internals.
+  ///
+  /// This cleanup is intentionally detached from [`Storage::flush`].
+  fn cleanup_stale(&self) {}
+
   /// Resets the specified scope, clearing all its data.
   ///
   /// The clean is performed asynchronously in the background. Call [`Storage::flush`]


### PR DESCRIPTION
## Summary

Old version cache recursive deletion is now **fire-and-forget + best-effort**.

- **Fire-and-forget**: after `Meta::save` succeeds, old cache directories are first renamed from `rspack_v_<16hex>` to `_stale/rspack_v_<16hex>`. After the rename succeeds, a background cleanup task is started with `tokio::spawn`. This task is not added to `task_queue`, so `flush()` / `close()` do not wait for recursive deletion to finish, and process exits (compilation ends) is not blocked by deletion.
- **Best-effort**: if the cleanup task fails, is cancelled, or the process exits when compilation ends, the directory remains under `_stale`. On the next compilation initialization, `_stale` is scanned again and a new background cleanup task is started with `tokio::spawn`.
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
