### PR TITLE
fix(css): add guard for link.parentNode in css runtime

### DIFF
--- a/crates/rspack_plugin_css/src/runtime/css_loading.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading.ejs
@@ -42,7 +42,7 @@ var loadStylesheet = <%- basicFunction("chunkId, url, done, hmr, fetchPriority")
 		link.onerror = link.onload = null;
 		link.removeAttribute(loadingAttribute);
 		clearTimeout(timeout);
-		if (event && event.type != "load") link.parentNode.removeChild(link);
+		if (event && event.type != "load" && link.parentNode) link.parentNode.removeChild(link);
 		done(event);
 		if (prev) return prev(event);
 	};


### PR DESCRIPTION
## Summary

Add guard for link.parentNode before invoking `link.parentNode.removeChild()` in css runtime.

In some race condition, the `link.parentNode` will be null, and invoking `link.parentNode.removeChild()` will throw `TypeError: Cannot read properties of null (reading 'removeChild')`.

In fact, `css_loading_with_hmr.ejs` already has a guard, but `css_loading.ejs` doesn't. Let's add it too.

https://github.com/web-infra-dev/rspack/blob/c1df696eada13faaeda8c77cda8deb034d62a364/crates/rspack_plugin_css/src/runtime/css_loading_with_hmr.ejs#L62

`mini-css-extract-plugin@0.10.1` has the same problem but it's out of my scope. Also for `webpack@5.89.0`'s `webpack/lib/css/CssLoadingRuntimeModule.js`.

## Related links

none

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
