### PR TITLE
ci: replace rust-cache with sccache (TOS) on self-hosted runners

### DIFF
--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -23,13 +23,29 @@ runs:
         cache-workspace-crates: 'true'
         cache-all-crates: 'true'
 
-    - name: Cache to local
-      uses: rstackjs/rust-cache@294670d9b2e7123011ba691897c24a5ee48cb816 # v0.0.3
+    - name: Setup sccache env
       if: ${{ runner.environment == 'self-hosted' }}
-      with:
-        prefix-key: 'RCache-L-9'
-        shared-key: ${{ inputs.key }}
-        save-if: ${{ inputs.save-if }}
-        fullmatch-only: 'true'
-        cache-workspace-crates: 'true'
-        cache-all-crates: 'true'
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_KEY_PREFIX=caches/${{ github.repository }}-sccache-V-1/${{ runner.os }}" >> "$GITHUB_ENV"
+
+        # Force vergen's output to be idempotent to improve cache hit rate
+        echo "VERGEN_IDEMPOTENT=1" >> "$GITHUB_ENV"
+
+        # Windows: keep proc-macro DLLs and rmeta (single-thread frontend)
+        # reproducible cross-pod
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          echo "LINK=-Brepro" >> "$GITHUB_ENV"
+          sed -i 's/-Zthreads=8/-Zthreads=1/' .cargo/config.toml
+        fi
+
+    - name: Setup sccache
+      if: ${{ runner.environment == 'self-hosted' }}
+      uses: rstackjs/sccache-action@8ece41fd13fd5d944a38144ac9eb98a7455fe438 # v0.1.0
+
+    - name: Reset sccache server
+      if: ${{ runner.environment == 'self-hosted' }}
+      shell: bash
+      run: |
+        "${SCCACHE_PATH:-sccache}" --stop-server || true


### PR DESCRIPTION
## Why

Self-hosted runners are ephemeral pods with a cold `target/`; the coarse
rust-cache archive doesn't keep the rspack workspace warm across pods, so every
run recompiles it. sccache is content-addressed and caches the workspace
cross-pod via a shared TOS (S3-compatible) backend.

## What

Self-hosted runners cache with `sccache` + TOS (`rstackjs/sccache-action`);
github-hosted keeps `Swatinem/rust-cache`. Reproducibility fixes needed for a
high cross-pod hit rate:

- `VERGEN_IDEMPOTENT` + `SOURCE_DATE_EPOCH` — stabilize swc_core's vergen build script
- `LINK=-Brepro` (Windows) — deterministic proc-macro DLL timestamps
- `-Zthreads=1` (Windows) — deterministic rmeta from the parallel frontend
- per-OS `SCCACHE_S3_KEY_PREFIX`

## Result (warm, cross-pod)

| platform | before | after |
|---|---|---|
| Linux | 88.95% / 308s | 99.71% / 60s |
| Windows | 16% / 420s | 99.71% / 96s |
| macOS / WASM / riscv64 | — | ~99.7% |

Follow-ups (separate PRs): a main-branch cache-warming job (TOS LRU eviction);
a retry for the rare Windows proc-macro DLL load flake.
