### PR TITLE
chore(ci): lift rust cache utilization

### DIFF
--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -15,9 +15,9 @@ runs:
   steps:
     - name: Cache to github
       if: ${{ runner.environment == 'github-hosted' }}
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
-        prefix-key: 'RCache-G-2'
+        prefix-key: 'RCache-G-3'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         cache-workspace-crates: 'true'
@@ -27,7 +27,7 @@ runs:
       uses: rstackjs/rust-cache@294670d9b2e7123011ba691897c24a5ee48cb816 # v0.0.3
       if: ${{ runner.environment == 'self-hosted' }}
       with:
-        prefix-key: 'RCache-L-6-test1'
+        prefix-key: 'RCache-L-8'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         fullmatch-only: 'true'

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -20,12 +20,16 @@ runs:
         prefix-key: 'RCache-G-2'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
+        cache-workspace-crates: 'true'
+        cache-all-crates: 'true'
 
     - name: Cache to local
-      uses: rstackjs/rust-cache@8269079380bc35105b3ed8b0f1f7c9557c6dec93 # v2.7.8
+      uses: rstackjs/rust-cache@63150d5565b253e99497cbe4226561b3297fd0dc # feat/cache-workspace-crates
       if: ${{ runner.environment == 'self-hosted' }}
       with:
-        prefix-key: 'RCache-L-5'
+        prefix-key: 'RCache-L-6-test1'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         fullmatch-only: 'true'
+        cache-workspace-crates: 'true'
+        cache-all-crates: 'true'

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -17,7 +17,7 @@ runs:
       if: ${{ runner.environment == 'github-hosted' }}
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
-        prefix-key: 'RCache-G-3'
+        prefix-key: 'RCache-G-exp.1'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         cache-workspace-crates: 'true'
@@ -27,7 +27,7 @@ runs:
       uses: rstackjs/rust-cache@294670d9b2e7123011ba691897c24a5ee48cb816 # v0.0.3
       if: ${{ runner.environment == 'self-hosted' }}
       with:
-        prefix-key: 'RCache-L-8'
+        prefix-key: 'RCache-L-exp.1'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         fullmatch-only: 'true'

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -17,7 +17,7 @@ runs:
       if: ${{ runner.environment == 'github-hosted' }}
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
-        prefix-key: 'RCache-G-5'
+        prefix-key: 'RCache-G-6'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         cache-workspace-crates: 'true'
@@ -27,7 +27,7 @@ runs:
       uses: rstackjs/rust-cache@294670d9b2e7123011ba691897c24a5ee48cb816 # v0.0.3
       if: ${{ runner.environment == 'self-hosted' }}
       with:
-        prefix-key: 'RCache-L-8'
+        prefix-key: 'RCache-L-9'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         fullmatch-only: 'true'

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -24,7 +24,7 @@ runs:
         cache-all-crates: 'true'
 
     - name: Cache to local
-      uses: rstackjs/rust-cache@63150d5565b253e99497cbe4226561b3297fd0dc # feat/cache-workspace-crates
+      uses: rstackjs/rust-cache@294670d9b2e7123011ba691897c24a5ee48cb816 # v0.0.3
       if: ${{ runner.environment == 'self-hosted' }}
       with:
         prefix-key: 'RCache-L-6-test1'

--- a/.github/actions/rustup/cargo/action.yml
+++ b/.github/actions/rustup/cargo/action.yml
@@ -17,7 +17,7 @@ runs:
       if: ${{ runner.environment == 'github-hosted' }}
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
-        prefix-key: 'RCache-G-exp.1'
+        prefix-key: 'RCache-G-5'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         cache-workspace-crates: 'true'
@@ -27,7 +27,7 @@ runs:
       uses: rstackjs/rust-cache@294670d9b2e7123011ba691897c24a5ee48cb816 # v0.0.3
       if: ${{ runner.environment == 'self-hosted' }}
       with:
-        prefix-key: 'RCache-L-exp.1'
+        prefix-key: 'RCache-L-8'
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
         fullmatch-only: 'true'

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -28,6 +28,7 @@ env:
   # Since CI builds are more akin to from-scratch builds, incremental compilation adds unnecessary dependency-tracking and IO overhead, reducing caching effectiveness.
   # https://github.com/rust-lang/rust-analyzer/blob/25368d24308d6a94ffe8b99f0122bcf5a2175322/.github/workflows/ci.yaml#L11
   CARGO_INCREMENTAL: 0
+  MEASURE_CARGO_FRESH: ${{ inputs.profile == 'ci' && '1' || '' }}
 
 jobs:
   build:

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -110,6 +110,10 @@ jobs:
           echo $'\n' >> .cargo/config.toml
           echo 'trim-paths = true' >> .cargo/config.toml
 
+      - name: Enable checksum-freshness (CI profile only)
+        if: ${{ inputs.profile == 'ci' }}
+        run: echo 'checksum-freshness = true' >> .cargo/config.toml
+
       # Fix: Resolve disk space error "ENOSPC: no space left on device" on GitHub Actions runners
       - name: Free disk cache
         if: ${{ runner.environment == 'github-hosted' && inputs.target == 'x86_64-unknown-linux-gnu' }}

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -1,5 +1,5 @@
 const path = require("node:path");
-const { readFileSync, writeFileSync, renameSync } = require("node:fs");
+const { readFileSync, writeFileSync, renameSync, appendFileSync } = require("node:fs");
 const { values, positionals } = require("node:util").parseArgs({
 	args: process.argv.slice(2),
 	options: {
@@ -17,6 +17,8 @@ const NAPI_BINDING_DTS = "napi-binding.d.ts"
 const CARGO_SAFELY_EXIT_CODE = 0;
 
 const watch = process.argv.includes("--watch");
+
+const measureFresh = process.env.MEASURE_CARGO_FRESH === "1" && !watch;
 
 build().then((value) => {
 	// Regarding cargo's non-zero exit code as an error.
@@ -103,7 +105,7 @@ async function build() {
 			args.push(`--features ${features.join(",")}`);
 		}
 
-		if (positionals.length > 0 || rustflags.length > 0 || use_build_std) {
+		if (positionals.length > 0 || rustflags.length > 0 || use_build_std || measureFresh) {
 			// napi need `--` to separate options and positional arguments.
 			args.push("--");
 
@@ -119,6 +121,10 @@ async function build() {
 				args.push("-Zbuild-std=panic_abort,std");
 			}
 
+			if (measureFresh) {
+				args.push("--message-format=json-render-diagnostics");
+			}
+
 			if (positionals.length > 0) {
 				args.push(...positionals);
 			}
@@ -127,13 +133,15 @@ async function build() {
 		console.log(`Run command: napi ${args.join(" ")}`);
 
 		const cp = spawn("napi", args, {
-			stdio: "inherit",
+			stdio: measureFresh ? ["inherit", "pipe", "inherit"] : "inherit",
 			shell: true,
 			env: envs,
 		});
 
+		const freshStats = measureFresh ? collectFreshStats(cp.stdout) : null;
+
 		cp.on("error", reject);
-		cp.on("exit", (code) => {
+		cp.on("close", (code) => {
 			if (code === CARGO_SAFELY_EXIT_CODE) {
 				// Fix an issue where napi cli does not generate `string_enum` with `enum`s.
 				const dts = path.resolve(__dirname, "..", NAPI_BINDING_DTS);
@@ -161,8 +169,59 @@ async function build() {
 						shell: true,
 					})
 				}
+
+				if (freshStats) {
+					reportFreshStats(freshStats);
+				}
 			}
 			resolve(code);
 		});
 	});
+}
+
+function collectFreshStats(stdout) {
+	const stats = { fresh: 0, total: 0, notFresh: [] };
+	stdout.setEncoding("utf8");
+	let buffer = "";
+	stdout.on("data", chunk => {
+		buffer += chunk;
+		let nl;
+		while ((nl = buffer.indexOf("\n")) !== -1) {
+			const line = buffer.slice(0, nl).replace(/\r$/, "");
+			buffer = buffer.slice(nl + 1);
+			let msg;
+			try {
+				msg = JSON.parse(line);
+			} catch {
+				process.stdout.write(line + "\n");
+				continue;
+			}
+			if (msg.reason === "compiler-artifact" && typeof msg.fresh === "boolean") {
+				stats.total += 1;
+				if (msg.fresh) stats.fresh += 1;
+				else if (msg.target && msg.target.name) stats.notFresh.push(msg.target.name);
+			}
+		}
+	});
+	return stats;
+}
+
+function reportFreshStats({ fresh, total, notFresh = [] }) {
+	const target = process.env.RUST_TARGET || "host";
+	const pct = total ? ((fresh / total) * 100).toFixed(1) : "0.0";
+	const summary = `${target}: ${fresh}/${total} units fresh = ${pct}% rust cache utilization`;
+	const escapedSummary = summary.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+	console.log(`\n::notice title=Rust Cache Utilization::${escapedSummary}`);
+	const recompiled = [...new Set(notFresh)].sort();
+	console.log(`::notice title=Recompiled Units::${target}: ${recompiled.join(", ")}`);
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		appendFileSync(
+			process.env.GITHUB_STEP_SUMMARY,
+			`### Rust cache utilization — \`${target}\`\n\n` +
+				`| fresh | recompiled | total | utilization |\n` +
+				`| ----: | ---------: | ----: | ----------: |\n` +
+				`| ${fresh} | ${total - fresh} | ${total} | **${pct}%** |\n\n` +
+				`<details><summary>${recompiled.length} recompiled units</summary>\n\n${recompiled.join(", ")}\n\n</details>\n\n`
+		);
+	}
 }


### PR DESCRIPTION
## Why

Lift CI Rust cache utilization from **~88% to ~99.7%** by completing the cache recipe: cache first-party workspace crates *and* switch cargo to content-checksum freshness so restored artifacts aren't wrongly treated as stale.

Measured on this PR via the per-target metric (#14559), a 2-round cold→warm cycle:

| target | cold (R1) | warm (R2) |
| --- | --- | --- |
| x86_64-unknown-linux-gnu | 0% | **99.7%** |
| riscv64gc-unknown-linux-gnu | 0% | **99.7%** |
| wasm32-wasip1-threads | 0% | **99.7%** |
| x86_64-pc-windows-msvc | 0% | **99.7%** |
| aarch64-apple-darwin | 0% | **99.7%** |

`cache-workspace-crates` alone plateaued at **~88%** — the residual misses were all first-party `rspack_*` workspace crates. A fresh CI checkout gives source files newer mtimes than the restored artifacts, so cargo's mtime-based freshness marks every workspace crate dirty. `checksum-freshness` switches cargo to content-hash freshness and closes that gap. The remaining ~0.3% is just `rspack_binding_api` + `rspack_node` (the final `.node` cdylib, always relinked).

## Is the bigger cache worth it? (yes — net positive)

`cache-all-crates` + `cache-workspace-crates` make the saved cache larger. That extra storage buys a much larger build-time reduction. Numbers below compare **main (`RCache-L-5`, deps-only cache)** vs **this PR (all-crates + workspace-crates + checksum-freshness)**; build-time baseline is the median of the 10 most recent successful `main` CI runs, this PR is the warm run [`28154419092`](https://github.com/web-infra-dev/rspack/actions/runs/28154419092) (example job: [WASM build](https://github.com/web-infra-dev/rspack/actions/runs/28154419092/job/83387041237)).

**Cost — cache size grows ~+30% (~+130–160 MB/platform):**

| platform | main | this PR | Δ |
| --- | ---: | ---: | ---: |
| linux | 581 MB | 739 MB | +158 (+27%) |
| wasm | 474 MB | 625 MB | +151 (+32%) |
| riscv64 | 599 MB | 761 MB | +162 (+27%) |
| windows | 479 MB | 611 MB | +132 (+28%) |
| macos | 418 MB | 552 MB | +134 (+32%) |

**Benefit — warm build time drops 17–48%:**

| platform | main warm (median, min) | this PR warm (min) | Δ |
| --- | ---: | ---: | ---: |
| linux | 6.72 | 4.20 | **−37%** |
| wasm | 6.51 | 3.73 | **−43%** |
| riscv64 | 7.75 | 4.56 | **−41%** |
| windows | 11.32 | 9.36 | −17% |
| macos | 13.38 | 7.00 | **−48%** |

For reference, this PR's own cold→warm (full cache value): linux 9.86→4.20, wasm 13.16→3.73, riscv64 15.13→4.56, windows 20.21→9.36, macos 28.56→7.00 min.

**Trade-off: ~+30% cache storage → −17–48% warm build time.** On self-hosted runners disk is cheap, and the minutes saved on every CI run dominate the storage cost — clearly net positive.

## What

**`.github/actions/rustup/cargo/action.yml`** — both cache steps enable `cache-workspace-crates` + `cache-all-crates` and bump to newer rust-cache builds:

| step | action | before | after |
| --- | --- | --- | --- |
| Cache to github (hosted) | `Swatinem/rust-cache` | `e18b497` (v2) | `c193711` (v2.9.1) |
| Cache to local (self-hosted) | `rstackjs/rust-cache` | `8269079` (v2.7.8) | `294670d` (v0.0.3) |

Prefix-keys bumped to `RCache-G-5` / `RCache-L-8` (cache format changed, needs a fresh key).

**`.github/workflows/reusable-build-build.yml`** — enable `checksum-freshness` **CI-only** (the toolchain is nightly), appended to `.cargo/config.toml` in a profile-gated step so local dev / release / profiling builds are unaffected:

```yaml
- name: Enable checksum-freshness (CI profile only)
  if: ${{ inputs.profile == 'ci' }}
  run: echo 'checksum-freshness = true' >> .cargo/config.toml
```
