### PR TITLE
chore(ci): set HOME for walltime bench codspeed runner install

### DIFF
--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -116,6 +116,9 @@ jobs:
         timeout-minutes: 30
         env:
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
+          # self-hosted physical runner runs as root but does not export HOME;
+          # the codspeed runner installer sources $HOME/.cargo/env
+          HOME: /root
         with:
           mode: walltime
           run: |


### PR DESCRIPTION
## Why

The `Rust Bench Walltime` job has been failing on every `main` push since #14432 with:

```
.../<id>.sh: line 23: /.cargo/env: No such file or directory
##[error]Process completed with exit code 1.
```

#14432 switched the codspeed `runner-version` from a release (`4.13.0`, prebuilt installer) to a git rev (`rev:...`), which installs the runner via cargo and runs `source $HOME/.cargo/env` first. The walltime job runs on a self-hosted physical runner that executes as root but does **not** export `HOME`, so it resolves to `/.cargo/env` and fails.

The simulation job is unaffected because it runs on a github-hosted runner where `HOME=/home/runner` is set.

## What

Set `HOME=/root` on the walltime step so the installer sources the real `/root/.cargo/env` (cargo is installed under `/root/.cargo` on that runner). Only the walltime step is touched.


verified here: https://github.com/web-infra-dev/rspack/actions/runs/28144483138/job/83348671775