### PR TITLE
ci: keep reproduction label until close

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -18,6 +18,7 @@ jobs:
           days-before-pr-close: -1
           days-before-issue-close: 14
           stale-issue-label: 'need reproduction'
+          remove-issue-stale-when-updated: false
           close-issue-message: |
             Since the issue was labeled with `need reproduction`, but no response in 14 days. This issue will be closed. Feel free to comment and reopen it if you have any further questions.
 


### PR DESCRIPTION
## Summary

This PR fixes the inactive issue close workflow for `need reproduction` issues. That label triggers an automatic guidance comment from `github-actions[bot]`, so the scheduled stale job now keeps the label instead of removing it because of that workflow-driven update. Other inactive issue labels keep the default unstale behavior when an issue is updated or commented on.

## Related links

https://github.com/web-infra-dev/rspack/issues/14273

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).