### PR TITLE
docs: add Rslint 0.6.3 to Rstack section

### DIFF
--- a/website/docs/zh/blog/announcing-2-1.mdx
+++ b/website/docs/zh/blog/announcing-2-1.mdx
@@ -69,6 +69,7 @@ import { PackageManagerTabs } from '@theme';
   - [Rsbuild 2.1](#rsbuild-2-1)
   - [Rslib 0.23](#rslib-0-23)
   - [rspack-merge](#rspack-merge)
+  - [Rslint 0.6.3](#rslint-0-6-3)
 
 ## 性能提升
 
@@ -460,3 +461,23 @@ export default defineConfig({
 我们发布了 [rspack-merge](https://github.com/rstackjs/rspack-merge)，这是一个面向 Rspack 配置合并场景打造的轻量级工具。它保留了开发者熟悉的 `merge`、`mergeWithCustomize`、`mergeWithRules`、`unique` 等能力，可以覆盖从基础配置拼接到 loader、plugin 规则级合并的需求。
 
 `rspack-merge` 使用 TypeScript 编写，发布现代 ESM 构建产物，并保持运行时零依赖，让配置合并保持简单、可靠且足够轻量。
+
+### Rslint 0.6.3 \{#rslint-0-6-3}
+
+Rslint 现在可以直接运行社区 ESLint 插件的规则，与内置原生规则一同工作。你只需在配置中以自定义前缀挂载插件，插件产生的诊断会合并进同一份报告，autofix 也能通过 `--fix` 和编辑器的 `source.fixAll` 一并应用，并且在 CLI 与 VS Code 扩展中表现一致。
+
+```js title="rslint.config.mjs"
+import examplePlugin from 'eslint-plugin-example';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    plugins: { example: examplePlugin },
+    rules: {
+      'example/some-rule': 'error',
+    },
+  },
+];
+```
+
+更多用法和当前限制参考 [ESLint 插件兼容指南](https://rslint.rs/guide/eslint-plugins)。


### PR DESCRIPTION
Adds an `### Rslint 0.6.3` section (and TOC entry) to the Rstack part of the Rspack 2.1 blog, highlighting ESLint plugin compatibility.