### PR TITLE
fix(core): set rslib runtime chunk names

### DIFF
--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -79,6 +79,20 @@ const commonLibConfig: LibConfig = {
   },
 };
 
+// TODO: Remove this workaround once rslib/rspack fixes runtime chunk naming
+// for bundled multi-lib builds.
+const withRuntimeChunk = (name: string): Pick<LibConfig, 'tools'> => ({
+  tools: {
+    rspack: {
+      optimization: {
+        runtimeChunk: {
+          name,
+        },
+      },
+    },
+  },
+});
+
 const mfRuntimePlugin: RsbuildPlugin = {
   name: 'mf-runtime',
   setup(api) {
@@ -224,6 +238,7 @@ export default defineConfig({
       output: {
         externals: [externalAlias, './moduleFederationDefaultRuntime.js'],
       },
+      ...withRuntimeChunk('rslib-runtime-index'),
     }),
     merge(commonLibConfig, {
       source: {
@@ -246,6 +261,7 @@ export default defineConfig({
           worker: './src/loader-runner/worker.ts',
         },
       },
+      ...withRuntimeChunk('rslib-runtime-worker'),
     }),
   ],
 });

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -506,7 +506,7 @@ export default {
 
 这个选项决定了输出的 JavaScript bundle 文件名称。这些 bundle 将会被写入 [`output.path`](#outputpath) 指定的目录下。
 
-对于单个 [Entry](/config/entry 来说，你可以使用一个固定名称，如：
+对于单个 [Entry](/config/entry) 来说，你可以使用一个固定名称，如：
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR works around an Rslib/Rspack runtime chunk naming collision in the `@rspack/core` multi-lib build. The bundled `index` and `worker` libs now set explicit runtime chunk names through `tools.rspack`, so they emit separate runtime files instead of sharing and potentially overwriting the same async runtime chunk.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).