### PR TITLE
fix(core): exclude node_modules files from require.context map

### DIFF
--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -770,7 +770,13 @@ fn alternative_requests(
   }
 
   for item in std::mem::take(&mut items) {
-    items.push(item.clone());
+    // webpack's `hideOriginal`: when the request points into a relative
+    // resolve.modules directory (e.g. `./node_modules/`), hide the original
+    // `./<dir>/...` request and emit only the bare specifier. The bare
+    // specifier can still be added under its own key if the context regExp
+    // matches it (same as webpack); but for the common `import('./dir/' + x)`
+    // the default `^\./` matcher rejects it, so the file drops out of the map.
+    let mut hide_original = false;
     for module in resolve_options.modules() {
       let dir = module.cow_replace('\\', "/");
       if item.request.starts_with(&format!("./{dir}/")) {
@@ -778,7 +784,11 @@ fn alternative_requests(
           item.context.clone(),
           item.request[dir.len() + 3..].to_string(),
         ));
+        hide_original = true;
       }
+    }
+    if !hide_original {
+      items.push(item);
     }
   }
 

--- a/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/ctx/node_modules/some-dep/package.json
+++ b/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/ctx/node_modules/some-dep/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "some-dep",
+  "version": "1.0.0",
+  "main": "src/from-dependency.stories.js"
+}

--- a/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/ctx/node_modules/some-dep/src/from-dependency.stories.js
+++ b/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/ctx/node_modules/some-dep/src/from-dependency.stories.js
@@ -1,0 +1,1 @@
+export const FromDependency = "from-dependency";

--- a/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/ctx/src/first-party.stories.js
+++ b/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/ctx/src/first-party.stories.js
@@ -1,0 +1,1 @@
+export const FirstParty = "first-party";

--- a/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/index.js
+++ b/tests/rspack-test/normalCases/context/dynamic-import-exclude-node-modules/index.js
@@ -1,0 +1,19 @@
+// webpack excludes files under `./ctx/node_modules/**` from the context map
+// built by `import('./ctx/' + name)` (RequireContextPlugin `hideOriginal`).
+// rspack must match. See `alternative_requests` in context_module_factory.rs.
+function load(name) {
+	return import(/* webpackInclude: /\.stories\.js$/ */ "./ctx/" + name);
+}
+
+it("should keep first-party stories in the context map", async () => {
+	const { FirstParty } = await load("src/first-party.stories.js");
+	expect(FirstParty).toBe("first-party");
+});
+
+it("should not pull node_modules files into the context map", async () => {
+	await expect(
+		load("node_modules/some-dep/src/from-dependency.stories.js")
+	).rejects.toThrow(
+		"Cannot find module './node_modules/some-dep/src/from-dependency.stories.js'"
+	);
+});


### PR DESCRIPTION
## Summary

A dynamic `import('./dir/' + name)` (or `require.context`) builds a build-time map of every matching file under `./dir`. rspack was also pulling in files that live under a `node_modules` directory inside that folder, while webpack excludes them.

**Use case:** a Storybook-style loader batch-loads every story with `import('./components/' + path)` and `webpackInclude: /\.stories\.js$/`. If a third-party package under `./components/node_modules/**` ships a `*.stories.js`, rspack would leak that dependency's stories into the user's story list (and bundle them); webpack does not.

The fix aligns context module's `alternative_requests` with webpack's `RequireContextPlugin` `hideOriginal`: when a context request resolves into a relative `resolve.modules` directory (e.g. `./node_modules/`), only the bare specifier is kept and the original relative path is hidden, so files under those directories no longer enter the context map.

## Related links

- Reproduction: https://github.com/fi3ework-reproduction/rspack-require-context-includes-node-modules
- webpack reference: `lib/dependencies/RequireContextPlugin.js` (`alternativeRequests` / `hideOriginal`)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
