### PR TITLE
feat(rsdoctor): add dependencyId and loc to export usage edges

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1189,7 +1189,7 @@ export interface JsRsdoctorModuleGraph {
   dependencies: Array<JsRsdoctorDependency>
   chunkModules: Array<JsRsdoctorChunkModules>
   connectionsOnlyImports: Array<JsRsdoctorConnectionsOnlyImport>
-  exportUsageEdges: Array<[number, Array<string> | null, number, Array<string> | null]>
+  exportUsageEdges: Array<[number, Array<string> | null, number, Array<string> | null, string, string | null]>
 }
 
 export interface JsRsdoctorModuleGraphModule {

--- a/crates/rspack_binding_api/src/rsdoctor.rs
+++ b/crates/rspack_binding_api/src/rsdoctor.rs
@@ -87,7 +87,17 @@ impl From<RsdoctorDependency> for JsRsdoctorDependency {
   }
 }
 
-pub type JsRsdoctorExportUsageEdge = (i32, Option<Vec<String>>, i32, Option<Vec<String>>);
+// Edge: [originModule, originExport, targetModule, targetExport, dependencyId, loc]
+// (origin=consumer, target=provider). The trailing dependencyId/loc are appended so existing
+// positional `[a, b, c, d]` consumers keep working; loc is the consuming reference site.
+pub type JsRsdoctorExportUsageEdge = (
+  i32,
+  Option<Vec<String>>,
+  i32,
+  Option<Vec<String>>,
+  String,
+  Option<String>,
+);
 
 #[napi(object)]
 pub struct JsRsdoctorConnection {
@@ -396,7 +406,9 @@ pub struct JsRsdoctorModuleGraph {
   pub dependencies: Vec<JsRsdoctorDependency>,
   pub chunk_modules: Vec<JsRsdoctorChunkModules>,
   pub connections_only_imports: Vec<JsRsdoctorConnectionsOnlyImport>,
-  #[napi(ts_type = "Array<[number, Array<string> | null, number, Array<string> | null]>")]
+  #[napi(
+    ts_type = "Array<[number, Array<string> | null, number, Array<string> | null, string, string | null]>"
+  )]
   pub export_usage_edges: Vec<JsRsdoctorExportUsageEdge>,
 }
 
@@ -420,6 +432,8 @@ impl From<RsdoctorModuleGraph> for JsRsdoctorModuleGraph {
             edge.origin_export,
             edge.target_module,
             edge.target_export,
+            edge.dependency_id,
+            edge.loc,
           )
         })
         .collect(),

--- a/crates/rspack_binding_api/src/rsdoctor.rs
+++ b/crates/rspack_binding_api/src/rsdoctor.rs
@@ -89,7 +89,9 @@ impl From<RsdoctorDependency> for JsRsdoctorDependency {
 
 // Edge: [originModule, originExport, targetModule, targetExport, dependencyId, loc]
 // (origin=consumer, target=provider). The trailing dependencyId/loc are appended so existing
-// positional `[a, b, c, d]` consumers keep working; loc is the consuming reference site.
+// positional `[a, b, c, d]` consumers keep working. `loc` is the consuming reference site as
+// rspack's standard location string (`line:col`, `line:col-endCol`, or `line:col-endLine:endCol`),
+// or null when unavailable.
 pub type JsRsdoctorExportUsageEdge = (
   i32,
   Option<Vec<String>>,

--- a/crates/rspack_plugin_rsdoctor/src/data.rs
+++ b/crates/rspack_plugin_rsdoctor/src/data.rs
@@ -79,6 +79,7 @@ pub struct RsdoctorExportUsageDependency {
   pub target_module_identifier: Identifier,
   pub origin_export: Option<Vec<String>>,
   pub target_export: Option<Vec<String>>,
+  pub loc: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -87,6 +88,8 @@ pub struct RsdoctorExportUsageEdge {
   pub origin_export: Option<Vec<String>>,
   pub target_module: ModuleUkey,
   pub target_export: Option<Vec<String>>,
+  pub dependency_id: String,
+  pub loc: Option<String>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -648,6 +648,7 @@ pub fn collect_export_usage_dependencies(
           }
 
           let dependency_id = conn.dependency_id;
+          let loc = dependency.loc().map(|l| l.to_string());
           let origin_module_identifier = conn.original_module_identifier.unwrap_or(*module_id);
           let target_module_identifier = *conn.module_identifier();
 
@@ -660,6 +661,7 @@ pub fn collect_export_usage_dependencies(
                 target_module_identifier,
                 origin_export,
                 target_export,
+                loc: loc.clone(),
               },
             )
             .collect::<Vec<_>>()
@@ -754,6 +756,8 @@ pub fn collect_export_usage_edges(
         origin_export: dependency.origin_export,
         target_module,
         target_export: dependency.target_export,
+        dependency_id: dependency.dependency_id.as_u32().to_string(),
+        loc: dependency.loc,
       })
     })
     .collect::<Vec<_>>()

--- a/tests/rspack-test/configCases/rsdoctor/exportUsageGraph/rspack.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/exportUsageGraph/rspack.config.js
@@ -398,6 +398,28 @@ module.exports = {
                   ),
                   targetExport: null,
                 });
+
+                // Each edge appends [dependencyId, loc] (Part A). dependencyId is always a
+                // non-empty string; loc is the consuming reference site (`line:col`), populated
+                // for real specifier references such as the named imports used inside lib.js#foo().
+                const rawEdges = moduleGraph.exportUsageEdges;
+                expect(
+                  rawEdges.every(
+                    (e) => typeof e[4] === 'string' && e[4].length > 0,
+                  ),
+                ).toBe(true);
+                const libPath = normalizeRequest(
+                  path.join(__dirname, 'lib.js'),
+                );
+                const libFooEdgesWithLoc = rawEdges.filter(
+                  (e) =>
+                    modulePathByUkey.get(e[0]) === libPath &&
+                    Array.isArray(e[1]) &&
+                    e[1].indexOf('foo') !== -1 &&
+                    typeof e[5] === 'string' &&
+                    e[5].length > 0,
+                );
+                expect(libFooEdgesWithLoc.length).toBeGreaterThan(0);
               },
             );
           },

--- a/tests/rspack-test/configCases/rsdoctor/exportUsageGraph/rspack.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/exportUsageGraph/rspack.config.js
@@ -400,8 +400,9 @@ module.exports = {
                 });
 
                 // Each edge appends [dependencyId, loc] (Part A). dependencyId is always a
-                // non-empty string; loc is the consuming reference site (`line:col`), populated
-                // for real specifier references such as the named imports used inside lib.js#foo().
+                // non-empty string; loc is the consuming reference site as rspack's location
+                // string (`line:col` / `line:col-endLine:endCol`), populated for real specifier
+                // references such as the named imports used inside lib.js#foo().
                 const rawEdges = moduleGraph.exportUsageEdges;
                 expect(
                   rawEdges.every(


### PR DESCRIPTION
## Summary

Append `dependencyId` and the consuming reference `loc` to each `exportUsageEdges` tuple emitted by the builtin Rsdoctor plugin, so an export-usage edge can be attributed to the **specific reference site (and enclosing statement)** in the consuming module. Combined with the existing `originExport` (the gating export/symbol name), this is the basis for tracing which root statement/symbol keeps a dependency subtree alive.

The edge grows from a 4-tuple to:

```
[originModule, originExport, targetModule, targetExport, dependencyId, loc]
```

- `dependencyId`: `DependencyId.as_u32().to_string()` — stable id, lets consumers group/dedupe edges sharing a dependency.
- `loc`: the consuming reference site as rspack's canonical location string (`line:col`, `line:col-endCol`, or `line:col-endLine:endCol`; via `Dependency::loc()`), or `null` when unavailable. This is the same loc format used by rspack diagnostics/stats.

The two new elements are **appended**, so existing positional `[a, b, c, d]` consumers keep working unchanged.

## Why it's low-impact

- The data already exists: `loc`/`id` live on the dependency (computed every build), and the gating export name is already on the edge.
- Changes touch only `rspack_plugin_rsdoctor` + the binding — **no `rspack_core` change**.
- The new reads run only under the opt-in `RsdoctorPlugin({ exportUsageGraph: true })` path, so **normal builds are unaffected** (no new computation, no `build_info`/cacheable schema change).

## Implementation notes

- `RsdoctorExportUsageEdge` / `RsdoctorExportUsageDependency` gain `dependency_id` + `loc`; populated in `collect_export_usage_*` where the dependency is already in scope.
- The `.d.ts` type for `exportUsageEdges` is pinned by a manual `#[napi(ts_type = "...")]` override on the field (it is **not** derived from the `JsRsdoctorExportUsageEdge` tuple alias), so that string is updated alongside the alias.

## Test

Extends the `rsdoctor/exportUsageGraph` configCase: asserts every edge carries a non-empty `dependencyId`, and that named-import references inside a function body (e.g. `lib.js#foo`) carry a `loc`. Existing 4-tuple destructuring assertions are left untouched to confirm backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)