### PR TITLE
perf(core): reduce module assets pass buffering

### DIFF
--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -23,9 +23,11 @@ pub async fn create_module_assets(
   compilation: &mut Compilation,
   _plugin_driver: SharedPluginDriver,
 ) {
-  let mut chunk_asset_map = vec![];
   let mut module_assets = vec![];
-  let mg = compilation.get_module_graph();
+  let mg = compilation.build_module_graph_artifact.get_module_graph();
+  let chunk_graph_artifact = &mut compilation.build_chunk_graph_artifact;
+  let chunk_graph = &chunk_graph_artifact.chunk_graph;
+  let chunk_by_ukey = &mut chunk_graph_artifact.chunk_by_ukey;
   for (identifier, module) in mg.modules() {
     let assets = &module.build_info().assets;
     if assets.is_empty() {
@@ -36,20 +38,11 @@ pub async fn create_module_assets(
       module_assets.push((name.clone(), asset.clone()));
     }
     // assets of executed modules are not in this compilation
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .chunk_graph_module_by_module_identifier
-      .contains_key(identifier)
-    {
-      for chunk in compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_module_chunks(*identifier)
-        .iter()
-      {
+    if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
+      for chunk in chunks {
+        let chunk = chunk_by_ukey.expect_get_mut(chunk);
         for name in assets.keys() {
-          chunk_asset_map.push((*chunk, name.clone()))
+          chunk.add_auxiliary_file(name.clone());
         }
       }
     }
@@ -57,13 +50,5 @@ pub async fn create_module_assets(
 
   for (name, asset) in module_assets {
     compilation.emit_asset(name, asset);
-  }
-
-  for (chunk, asset_name) in chunk_asset_map {
-    let chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get_mut(&chunk);
-    chunk.add_auxiliary_file(asset_name);
   }
 }


### PR DESCRIPTION
## Summary

- reduce temporary buffering in `create_module_assets`
- add chunk auxiliary files while scanning module assets instead of collecting a separate chunk asset map
- keep module asset emission order and duplicate handling behavior unchanged

## Target

CodSpeed benchmark: `rust@create_module_assets`
Goal: at least `+10%`

## Validation

- `cargo check -p rspack_core`
- `cargo fmt --all --check`

This PR is split from `origin/main` so it does not mix the performance change into the existing skill PR.