### PR TITLE
perf(core): reduce module assets pass buffering

### DIFF
--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -23,11 +23,17 @@ pub async fn create_module_assets(
   compilation: &mut Compilation,
   _plugin_driver: SharedPluginDriver,
 ) {
-  let mg = compilation.build_module_graph_artifact.get_module_graph();
-  let mut module_assets = vec![];
-  let chunk_graph_artifact = &mut compilation.build_chunk_graph_artifact;
-  let chunk_graph = &chunk_graph_artifact.chunk_graph;
-  let chunk_by_ukey = &mut chunk_graph_artifact.chunk_by_ukey;
+  let Compilation {
+    build_module_graph_artifact,
+    build_chunk_graph_artifact,
+    assets: compilation_assets,
+    assets_related_in,
+    diagnostics,
+    ..
+  } = compilation;
+  let mg = build_module_graph_artifact.get_module_graph();
+  let chunk_graph = &build_chunk_graph_artifact.chunk_graph;
+  let chunk_by_ukey = &mut build_chunk_graph_artifact.chunk_by_ukey;
   for (identifier, module) in mg.modules() {
     let build_info = module.build_info();
     let assets = build_info.assets.as_ref();
@@ -35,11 +41,14 @@ pub async fn create_module_assets(
       continue;
     }
 
-    if assets.len() > 1 {
-      module_assets.reserve(assets.len());
-    }
     for (name, asset) in assets {
-      module_assets.push((name.clone(), asset.clone()));
+      emit_module_asset(
+        compilation_assets,
+        assets_related_in,
+        diagnostics,
+        name.clone(),
+        asset.clone(),
+      );
     }
     // assets of executed modules are not in this compilation
     if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
@@ -51,8 +60,69 @@ pub async fn create_module_assets(
       }
     }
   }
+}
 
-  for (name, asset) in module_assets {
-    compilation.emit_asset(name, asset);
+fn emit_module_asset(
+  compilation_assets: &mut CompilationAssets,
+  assets_related_in: &mut HashMap<String, HashSet<String>>,
+  diagnostics: &mut Vec<Diagnostic>,
+  filename: String,
+  asset: CompilationAsset,
+) {
+  if let Some(mut original) = compilation_assets.remove(&filename)
+    && let Some(original_source) = &original.source
+    && let Some(asset_source) = asset.get_source()
+  {
+    let is_source_equal = is_source_equal(original_source, asset_source);
+    if !is_source_equal {
+      tracing::error!(
+        "Emit Duplicate Filename({}), is_source_equal: {:?}",
+        filename,
+        is_source_equal
+      );
+      diagnostics.push(
+        rspack_error::error!(
+          "Conflict: Multiple assets emit different content to the same filename {}{}",
+          filename,
+          // TODO: source file name
+          ""
+        )
+        .into(),
+      );
+      set_module_asset_info(assets_related_in, &filename, Some(asset.get_info()), None);
+      compilation_assets.insert(filename, asset);
+      return;
+    }
+    set_module_asset_info(
+      assets_related_in,
+      &filename,
+      Some(asset.get_info()),
+      Some(original.get_info()),
+    );
+    original.info = asset.info;
+    compilation_assets.insert(filename, original);
+  } else {
+    set_module_asset_info(assets_related_in, &filename, Some(asset.get_info()), None);
+    compilation_assets.insert(filename, asset);
+  }
+}
+
+fn set_module_asset_info(
+  assets_related_in: &mut HashMap<String, HashSet<String>>,
+  name: &str,
+  new_info: Option<&AssetInfo>,
+  old_info: Option<&AssetInfo>,
+) {
+  if let Some(old_info) = old_info
+    && let Some(source_map) = &old_info.related.source_map
+    && let Some(entry) = assets_related_in.get_mut(source_map)
+  {
+    entry.remove(name);
+  }
+  if let Some(new_info) = new_info
+    && let Some(source_map) = new_info.related.source_map.clone()
+  {
+    let entry = assets_related_in.entry(source_map).or_default();
+    entry.insert(name.to_string());
   }
 }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -35,23 +35,9 @@ pub async fn create_module_assets(
       continue;
     }
 
-    if assets.len() == 1 {
-      let (name, asset) = assets
-        .iter()
-        .next()
-        .expect("assets should contain exactly one item");
-      module_assets.push((name.clone(), asset.clone()));
-      // assets of executed modules are not in this compilation
-      if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
-        for chunk in chunks {
-          let chunk = chunk_by_ukey.expect_get_mut(chunk);
-          chunk.add_auxiliary_file(name.clone());
-        }
-      }
-      continue;
+    if assets.len() > 1 {
+      module_assets.reserve(assets.len());
     }
-
-    module_assets.reserve(assets.len());
     for (name, asset) in assets {
       module_assets.push((name.clone(), asset.clone()));
     }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -35,9 +35,23 @@ pub async fn create_module_assets(
       continue;
     }
 
-    if assets.len() > 1 {
-      module_assets.reserve(assets.len());
+    if assets.len() == 1 {
+      let (name, asset) = assets
+        .iter()
+        .next()
+        .expect("assets should contain exactly one item");
+      module_assets.push((name.clone(), asset.clone()));
+      // assets of executed modules are not in this compilation
+      if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
+        for chunk in chunks {
+          let chunk = chunk_by_ukey.expect_get_mut(chunk);
+          chunk.add_auxiliary_file(name.clone());
+        }
+      }
+      continue;
     }
+
+    module_assets.reserve(assets.len());
     for (name, asset) in assets {
       module_assets.push((name.clone(), asset.clone()));
     }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -23,18 +23,20 @@ pub async fn create_module_assets(
   compilation: &mut Compilation,
   _plugin_driver: SharedPluginDriver,
 ) {
-  let mut module_assets = vec![];
   let mg = compilation.build_module_graph_artifact.get_module_graph();
+  let mut module_assets = vec![];
   let chunk_graph_artifact = &mut compilation.build_chunk_graph_artifact;
   let chunk_graph = &chunk_graph_artifact.chunk_graph;
   let chunk_by_ukey = &mut chunk_graph_artifact.chunk_by_ukey;
   for (identifier, module) in mg.modules() {
-    let assets = &module.build_info().assets;
+    let build_info = module.build_info();
+    let assets = build_info.assets.as_ref();
     if assets.is_empty() {
       continue;
     }
 
-    for (name, asset) in assets.as_ref() {
+    module_assets.reserve(assets.len());
+    for (name, asset) in assets {
       module_assets.push((name.clone(), asset.clone()));
     }
     // assets of executed modules are not in this compilation

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -23,9 +23,11 @@ pub async fn create_module_assets(
   compilation: &mut Compilation,
   _plugin_driver: SharedPluginDriver,
 ) {
-  let mut chunk_asset_map = vec![];
   let mut module_assets = vec![];
-  let mg = compilation.get_module_graph();
+  let mg = compilation.build_module_graph_artifact.get_module_graph();
+  let chunk_graph_artifact = &mut compilation.build_chunk_graph_artifact;
+  let chunk_graph = &chunk_graph_artifact.chunk_graph;
+  let chunk_by_ukey = &mut chunk_graph_artifact.chunk_by_ukey;
   for (identifier, module) in mg.modules() {
     let assets = &module.build_info().assets;
     if assets.is_empty() {
@@ -36,20 +38,11 @@ pub async fn create_module_assets(
       module_assets.push((name.clone(), asset.clone()));
     }
     // assets of executed modules are not in this compilation
-    if compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .chunk_graph_module_by_module_identifier
-      .contains_key(identifier)
-    {
-      for chunk in compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_module_chunks(*identifier)
-        .iter()
-      {
+    if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
+      for chunk in chunks {
+        let chunk = chunk_by_ukey.expect_get_mut(chunk);
         for name in assets.keys() {
-          chunk_asset_map.push((*chunk, name.clone()))
+          chunk.add_auxiliary_file(name.clone());
         }
       }
     }
@@ -57,13 +50,5 @@ pub async fn create_module_assets(
 
   for (name, asset) in module_assets {
     compilation.emit_asset(name, asset);
-  }
-
-  for (chunk, asset_name) in chunk_asset_map {
-    let chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .expect_get_mut(&chunk);
-    chunk.add_auxiliary_file(asset_name);
   }
 }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -35,17 +35,35 @@ pub async fn create_module_assets(
       continue;
     }
 
-    module_assets.reserve(assets.len());
-    for (name, asset) in assets {
-      module_assets.push((name.clone(), asset.clone()));
-    }
     // assets of executed modules are not in this compilation
     if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
-      for chunk in chunks {
+      module_assets.reserve(assets.len());
+      if chunks.len() == 1 {
+        let chunk = chunks
+          .iter()
+          .next()
+          .expect("chunk set should not be empty when len is 1");
         let chunk = chunk_by_ukey.expect_get_mut(chunk);
-        for name in assets.keys() {
-          chunk.add_auxiliary_file(name.clone());
+        for (name, asset) in assets {
+          let name = name.clone();
+          module_assets.push((name.clone(), asset.clone()));
+          chunk.add_auxiliary_file(name);
         }
+      } else {
+        for (name, asset) in assets {
+          module_assets.push((name.clone(), asset.clone()));
+        }
+        for chunk in chunks {
+          let chunk = chunk_by_ukey.expect_get_mut(chunk);
+          for name in assets.keys() {
+            chunk.add_auxiliary_file(name.clone());
+          }
+        }
+      }
+    } else {
+      module_assets.reserve(assets.len());
+      for (name, asset) in assets {
+        module_assets.push((name.clone(), asset.clone()));
       }
     }
   }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::Entry;
+
 use async_trait::async_trait;
 
 use super::*;
@@ -69,41 +71,59 @@ fn emit_module_asset(
   filename: String,
   asset: CompilationAsset,
 ) {
-  if let Some(mut original) = compilation_assets.remove(&filename)
-    && let Some(original_source) = &original.source
-    && let Some(asset_source) = asset.get_source()
-  {
-    let is_source_equal = is_source_equal(original_source, asset_source);
-    if !is_source_equal {
-      tracing::error!(
-        "Emit Duplicate Filename({}), is_source_equal: {:?}",
-        filename,
-        is_source_equal
-      );
-      diagnostics.push(
-        rspack_error::error!(
-          "Conflict: Multiple assets emit different content to the same filename {}{}",
-          filename,
-          // TODO: source file name
-          ""
-        )
-        .into(),
-      );
-      set_module_asset_info(assets_related_in, &filename, Some(asset.get_info()), None);
-      compilation_assets.insert(filename, asset);
-      return;
+  match compilation_assets.entry(filename) {
+    Entry::Occupied(mut entry) => {
+      let filename = entry.key().clone();
+      let original = entry.get_mut();
+      if let Some(original_source) = &original.source
+        && let Some(asset_source) = asset.get_source()
+      {
+        let is_source_equal = is_source_equal(original_source, asset_source);
+        if !is_source_equal {
+          tracing::error!(
+            "Emit Duplicate Filename({}), is_source_equal: {:?}",
+            filename,
+            is_source_equal
+          );
+          diagnostics.push(
+            rspack_error::error!(
+              "Conflict: Multiple assets emit different content to the same filename {}{}",
+              filename,
+              // TODO: source file name
+              ""
+            )
+            .into(),
+          );
+          if asset.get_info().related.source_map.is_some() {
+            set_module_asset_info(assets_related_in, &filename, Some(asset.get_info()), None);
+          }
+          entry.insert(asset);
+          return;
+        }
+        if asset.get_info().related.source_map.is_some()
+          || original.get_info().related.source_map.is_some()
+        {
+          set_module_asset_info(
+            assets_related_in,
+            &filename,
+            Some(asset.get_info()),
+            Some(original.get_info()),
+          );
+        }
+        original.info = asset.info;
+        return;
+      }
+      if asset.get_info().related.source_map.is_some() {
+        set_module_asset_info(assets_related_in, &filename, Some(asset.get_info()), None);
+      }
+      entry.insert(asset);
     }
-    set_module_asset_info(
-      assets_related_in,
-      &filename,
-      Some(asset.get_info()),
-      Some(original.get_info()),
-    );
-    original.info = asset.info;
-    compilation_assets.insert(filename, original);
-  } else {
-    set_module_asset_info(assets_related_in, &filename, Some(asset.get_info()), None);
-    compilation_assets.insert(filename, asset);
+    Entry::Vacant(entry) => {
+      if asset.get_info().related.source_map.is_some() {
+        set_module_asset_info(assets_related_in, entry.key(), Some(asset.get_info()), None);
+      }
+      entry.insert(asset);
+    }
   }
 }
 

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -35,7 +35,9 @@ pub async fn create_module_assets(
       continue;
     }
 
-    module_assets.reserve(assets.len());
+    if assets.len() > 1 {
+      module_assets.reserve(assets.len());
+    }
     for (name, asset) in assets {
       module_assets.push((name.clone(), asset.clone()));
     }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -35,35 +35,17 @@ pub async fn create_module_assets(
       continue;
     }
 
+    module_assets.reserve(assets.len());
+    for (name, asset) in assets {
+      module_assets.push((name.clone(), asset.clone()));
+    }
     // assets of executed modules are not in this compilation
     if let Some(chunks) = chunk_graph.try_get_module_chunks(identifier) {
-      module_assets.reserve(assets.len());
-      if chunks.len() == 1 {
-        let chunk = chunks
-          .iter()
-          .next()
-          .expect("chunk set should not be empty when len is 1");
+      for chunk in chunks {
         let chunk = chunk_by_ukey.expect_get_mut(chunk);
-        for (name, asset) in assets {
-          let name = name.clone();
-          module_assets.push((name.clone(), asset.clone()));
-          chunk.add_auxiliary_file(name);
+        for name in assets.keys() {
+          chunk.add_auxiliary_file(name.clone());
         }
-      } else {
-        for (name, asset) in assets {
-          module_assets.push((name.clone(), asset.clone()));
-        }
-        for chunk in chunks {
-          let chunk = chunk_by_ukey.expect_get_mut(chunk);
-          for name in assets.keys() {
-            chunk.add_auxiliary_file(name.clone());
-          }
-        }
-      }
-    } else {
-      module_assets.reserve(assets.len());
-      for (name, asset) in assets {
-        module_assets.push((name.clone(), asset.clone()));
       }
     }
   }


### PR DESCRIPTION
## Summary

- reduce temporary buffering in `create_module_assets`
- add chunk auxiliary files while scanning module assets instead of collecting a separate chunk asset map
- keep module asset emission order and duplicate handling behavior unchanged

## Target

CodSpeed benchmark: `rust@create_module_assets`
Goal: at least `+10%`

## Validation

- `cargo check -p rspack_core`
- `cargo fmt --all --check`

This PR was recreated from the latest `origin/main` after closing the outdated PR #14578.