### PR TITLE
fix(css): skip re-applying unchanged CSS during HMR

### DIFF
--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_hmr.ejs
@@ -1,25 +1,31 @@
 var oldTags = [];
 var newTags = [];
+var cssTextKey = function (link) {
+	return Array.from(link.sheet.cssRules, function (r) { return r.cssText; }).join();
+}
 var applyHandler = function (options) {
 	return {
-		dispose: function () {
+		dispose: function () {},
+		apply: function () {
+			for (var i = 0; i < newTags.length; i++) newTags[i].sheet.disabled = false;
 			for (var i = 0; i < oldTags.length; i++) {
 				var oldTag = oldTags[i];
 				if (oldTag.parentNode) oldTag.parentNode.removeChild(oldTag);
 			}
 			oldTags.length = 0;
-		},
-		apply: function () {
-			for (var i = 0; i < newTags.length; i++) newTags[i].rel = "stylesheet";
 			newTags.length = 0;
 		}
 	}
 }
 <%- HMR_DOWNLOAD_UPDATE_HANDLERS %>.miniCss = function (chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList) {
 	applyHandlers.push(applyHandler);
+	var seen = {};
 	chunkIds.forEach(function (chunkId) {
 		var href = <%- REQUIRE_SCOPE %>.miniCssF(chunkId);
+		if (!href) return;
 		var fullhref = <%- PUBLIC_PATH %> + href;
+		if (seen[fullhref]) return;
+		seen[fullhref] = true;
 		var oldTag = findStylesheet(href, fullhref);
 		if (!oldTag) return;
 		promises.push(new Promise(function (resolve, reject) {
@@ -33,14 +39,19 @@ var applyHandler = function (options) {
 				`${fullhref}?${Date.now()}`,
 				oldTag,
 				function () {
-					tag.as = "style";
-					tag.rel = "preload";
+					try {
+						if (cssTextKey(oldTag) === cssTextKey(tag)) {
+							if (tag.parentNode) tag.parentNode.removeChild(tag);
+							return resolve();
+						}
+					} catch (e) {}
+					tag.sheet.disabled = true;
+					oldTags.push(oldTag);
+					newTags.push(tag);
 					resolve();
 				},
 				reject
 			);
-			oldTags.push(oldTag);
-			newTags.push(tag);
 		}))
 	});
 }

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/index.test.ts
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/index.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@/fixtures';
+
+const COLOR_BLUE = 'rgb(10, 20, 30)';
+const COLOR_RED = 'rgb(120, 0, 0)';
+const COLOR_GREEN = 'rgb(0, 90, 0)';
+
+// The hot-update lists both the `style` and `main` chunks while the fixed
+// `filename` maps them to one stylesheet. Without de-duplication the handler
+// re-fetched it once per chunk and leaked one <link> per update.
+test('should keep a single stylesheet link when several updated chunks share it', async ({
+  page,
+  fileAction,
+}) => {
+  const links = page.locator('link[rel="stylesheet"]');
+  await expect(page.locator('body')).toHaveCSS('background-color', COLOR_BLUE);
+  await expect(links).toHaveCount(1);
+
+  fileAction.updateFile('src/index.css', (content) =>
+    content.replace(COLOR_BLUE, COLOR_RED),
+  );
+  await expect(page.locator('body')).toHaveCSS('background-color', COLOR_RED);
+  await expect(links).toHaveCount(1);
+
+  fileAction.updateFile('src/index.css', (content) =>
+    content.replace(COLOR_RED, COLOR_GREEN),
+  );
+  await expect(page.locator('body')).toHaveCSS('background-color', COLOR_GREEN);
+  await expect(links).toHaveCount(1);
+});

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/rspack.config.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/rspack.config.js
@@ -1,0 +1,51 @@
+const { rspack } = require('@rspack/core');
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+  context: __dirname,
+  mode: 'development',
+  entry: {
+    main: ['./src/index.css', './src/index.js'],
+  },
+  devServer: {
+    hot: true,
+  },
+  plugins: [
+    new rspack.HtmlRspackPlugin({
+      template: './src/index.html',
+      inject: 'body',
+    }),
+    // A fixed filename (no [name]) makes miniCssF resolve every chunk id to the
+    // same stylesheet, so one update lists several chunks for one file.
+    new rspack.CssExtractRspackPlugin({
+      filename: 'static/style.css',
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'javascript/auto',
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        style: {
+          name: 'style',
+          test: /\.css$/,
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+  watchOptions: {
+    poll: 1000,
+  },
+  experiments: {
+    css: false,
+  },
+};

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/rspack.config.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/rspack.config.js
@@ -42,10 +42,4 @@ module.exports = {
       },
     },
   },
-  watchOptions: {
-    poll: 1000,
-  },
-  experiments: {
-    css: false,
-  },
 };

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.css
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: rgb(10, 20, 30);
+}

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.html
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.html
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body></body>
+</html>

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+module.hot.accept();


### PR DESCRIPTION
## Why

The CSS HMR handler (`CssExtractRspackPlugin`) re-applies the stylesheet of **every** chunk in the hot-update `c` list. The runtime chunk is always in `c` (its full hash changes on every rebuild), so the entry stylesheet is removed and re-inserted on **every** update — even when its content never changed.

The old swap order makes this visible: `dispose` removes the old `<link>` **before** `apply` enables the new one, so there is a window where the page has **zero** active stylesheets. The most visible case is the first lazy-compiled dynamic `import()` (delivered as an HMR update): the import resolves right inside that window, and anything that forces a paint there (e.g. a synchronous `alert()`) freezes a fully unstyled page on screen — reported in web-infra-dev/rsbuild#7951, related to #11377.

Additionally, several updated chunks can map to one extracted stylesheet (e.g. a fixed `filename` without `[name]` plus a `splitChunks` style chunk). The handler processed the file once per chunk: it double-fetched the CSS and, since `findStylesheet` only ever returns the first match, leaked one duplicated `<link>` per update.

### Before / After (first dynamic import, CSS unchanged)

| | Before | After |
|---|---|---|
| entry `<link>` | removed + re-inserted (flash) | untouched |
| active stylesheets during swap | 1 → **0** → 1 | 1 → 2 → 1 (no unstyled gap) |
| `<link>` count over repeated edits | grows 1→2→3 | stays 1 |

## What

Runtime-only change in `css_loading_with_hmr.ejs`, aligning the extract_css HMR runtime with the built-in CSS runtime (`rspack_plugin_css`) and webpack's native CSS loading runtime:

- Compare the reloaded stylesheet's content (`cssRules` text) with the existing one after it loads; if identical, drop the probe `<link>` and keep the existing one untouched.
- When content did change, swap in a safe order: enable the new sheet (`sheet.disabled = false`) first, then remove the old one.
- De-duplicate stylesheets by href so each extracted file is processed once per update.

Added an e2e case (`cases/css/shared-stylesheet-dedup`) where one update lists several chunks for one stylesheet; it asserts updates still apply and the `<link>` count stays at 1 (fails on the previous runtime with `Expected: 1, Received: 2`).

## Issues

- resolve #11377
- resolve web-infra-dev/rsbuild#7951