### PR TITLE
chore(release): stream per-package publish output

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -9,7 +9,7 @@ const __filename = path.resolve(fileURLToPath(import.meta.url));
 const __dirname = path.dirname(__filename);
 
 export async function publish_handler(mode, options) {
-  $.verbose = true; // zx is silent by default; stream per-package publish output
+  $.verbose = true;
   console.log('options:', options);
   const root = process.cwd();
   const version = await getLastVersion(root);

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -9,6 +9,7 @@ const __filename = path.resolve(fileURLToPath(import.meta.url));
 const __dirname = path.dirname(__filename);
 
 export async function publish_handler(mode, options) {
+  $.verbose = true; // zx is silent by default; stream per-package publish output
   console.log('options:', options);
   const root = process.cwd();
   const version = await getLastVersion(root);


### PR DESCRIPTION
## Why

\`./x publish\` runs \`pnpm publish -r\` through zx. zx v8 is silent by default (\`$.verbose === false\`): it captures child stdout/stderr but never streams it, so the per-package publish flow is invisible in the release logs.

## Fix

Set \`$.verbose = true\` in \`publish_handler\` so each command and its output (per-package publish progress, git tag/push) is streamed.

## Before / After

Verified on the canary channel with a **debug-profile** dispatch of `Release Canary` built from this branch — [Release job log](https://github.com/web-infra-dev/rspack/actions/runs/28223098621/job/83611808631#step:10:224).

**Before** (main, prior canary run) — `Release` step printed **0** per-package lines.

**After** (this branch) — `Release` step now streams every package:

```
$ pnpm publish -r --tag latest --no-git-checks --provenance
📦 @rspack-canary/binding@2.1.0-canary-489147ec-… → https://registry.npmjs.org/
📦 @rspack-canary/binding-darwin-arm64@… → https://registry.npmjs.org/
…
📦 @rspack-canary/core@… → https://registry.npmjs.org/
📦 @rspack-canary/cli@… → https://registry.npmjs.org/
```