### PR TITLE
fix(browser): inject runtime require into browser MF runtime

### DIFF
--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -365,9 +365,11 @@ function getDefaultEntryRuntimeSource(
     );
   }
 
-  const defaultRuntimeSource = compiler.rspack.Template.getFunctionContent(
-    require('./moduleFederationDefaultRuntime.js').default,
-  );
+  const defaultRuntimeSource = IS_BROWSER
+    ? MF_RUNTIME_CODE
+    : compiler.rspack.Template.getFunctionContent(
+        require('./moduleFederationDefaultRuntime.js').default,
+      );
   const compilerRuntimeGlobals = createCompilerRuntimeGlobals(compiler.options);
   const runtimeSource = getDefaultRuntimeSource(
     defaultRuntimeSource,
@@ -407,7 +409,7 @@ function getDefaultEntryRuntimeSource(
       treeShakingShareFallbacks,
     )}`,
     `const __module_federation_library_type__ = ${JSON.stringify(libraryType)}`,
-    IS_BROWSER ? MF_RUNTIME_CODE : runtimeSource,
+    runtimeSource,
   ].join(';');
   return content;
 }


### PR DESCRIPTION
## Summary

Introduced by https://github.com/web-infra-dev/rspack/pull/14254

Fixes Module Federation runtime source generation for the browser build.

- Uses the bundled browser MF runtime code as the default runtime source in browser environments.
- Applies `getDefaultRuntimeSource` consistently so `__module_federation_runtime_require__` is replaced with the compiler-specific runtime require/proxy.
- Keeps the non-browser runtime loading path unchanged.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).