### PR TITLE
refactor(lightningcss): replace parcel source map with rspack source map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
-source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
+source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
+source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
+source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
+source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
+source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,17 +29,6 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -289,20 +278,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
-dependencies = [
- "simd-abstraction",
-]
-
-[[package]]
-name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
- "outref 0.5.1",
+ "outref",
  "vsimd",
 ]
 
@@ -385,7 +365,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f42db7dd1800856ac32d4a08c2915de9a9a2a72ce1fdd86189daed368729fd4"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "chrono",
 ]
 
@@ -395,7 +375,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd48a6ca358df4f7000e3fb5f08738b1b91a0e5d5f862e2f77b2b14647547f5"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "browserslist-data",
  "chrono",
  "either",
@@ -427,36 +407,14 @@ dependencies = [
 
 [[package]]
 name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive 0.6.12",
- "ptr_meta 0.1.4",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f"
 dependencies = [
- "bytecheck_derive 0.8.0",
- "ptr_meta 0.3.0",
+ "bytecheck_derive",
+ "ptr_meta",
  "rancor",
  "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -489,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
 dependencies = [
  "bytes",
- "rkyv 0.8.16",
+ "rkyv",
  "serde",
 ]
 
@@ -864,23 +822,9 @@ dependencies = [
 
 [[package]]
 name = "const-str"
-version = "0.3.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
-dependencies = [
- "const-str-proc-macro",
-]
-
-[[package]]
-name = "const-str-proc-macro"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "constant_time_eq"
@@ -1136,32 +1080,32 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "serde",
  "smallvec",
 ]
 
 [[package]]
 name = "cssparser-color"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
+checksum = "bbaa233e1dcd9c13a5d3e3a8a2c0f5a727bac380398345dbcb31db4597edc86b"
 dependencies = [
  "cssparser",
 ]
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1238,15 +1182,6 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
-name = "data-url"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
-dependencies = [
- "matches",
-]
 
 [[package]]
 name = "debugid"
@@ -1963,20 +1898,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -2507,10 +2433,9 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6314c2f0590ac93c86099b98bb7ba8abcf759bfd89604ffca906472bb54937"
+source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bitflags 2.11.1",
  "const-str",
  "cssparser",
@@ -2522,7 +2447,6 @@ dependencies = [
  "lazy_static",
  "lightningcss-derive",
  "parcel_selectors",
- "parcel_sourcemap",
  "pastey",
  "pathdiff",
  "serde",
@@ -2534,8 +2458,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
+source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2621,12 +2544,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "maybe-owned"
@@ -3022,12 +2939,6 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "outref"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
-
-[[package]]
-name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
@@ -3074,33 +2985,18 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
+source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
  "log",
- "phf",
+ "phf 0.11.2",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
  "serde",
  "smallvec",
  "static-self",
-]
-
-[[package]]
-name = "parcel_sourcemap"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485b74d7218068b2b7c0e3ff12fbc61ae11d57cb5d8224f525bd304c6be05bbb"
-dependencies = [
- "base64-simd 0.7.0",
- "data-url",
- "rkyv 0.7.45",
- "serde",
- "serde_json",
- "vlq",
 ]
 
 [[package]]
@@ -3175,8 +3071,19 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.2",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3185,8 +3092,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -3195,8 +3102,18 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.2",
  "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3205,8 +3122,21 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3218,7 +3148,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -3372,31 +3311,11 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive 0.1.4",
-]
-
-[[package]]
-name = "ptr_meta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
 dependencies = [
- "ptr_meta_derive 0.3.0",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "ptr_meta_derive",
 ]
 
 [[package]]
@@ -3476,7 +3395,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
 dependencies = [
- "ptr_meta 0.3.0",
+ "ptr_meta",
 ]
 
 [[package]]
@@ -3619,38 +3538,11 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck 0.6.12",
-]
-
-[[package]]
-name = "rend"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 dependencies = [
- "bytecheck 0.8.0",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec",
- "bytecheck 0.6.12",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta 0.1.4",
- "rend 0.4.2",
- "rkyv_derive 0.7.45",
- "seahash",
- "tinyvec",
- "uuid",
+ "bytecheck",
 ]
 
 [[package]]
@@ -3659,29 +3551,18 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
- "bytecheck 0.8.0",
+ "bytecheck",
  "bytes",
  "hashbrown 0.17.1",
  "indexmap",
  "munge",
- "ptr_meta 0.3.0",
+ "ptr_meta",
  "rancor",
- "rend 0.5.2",
- "rkyv_derive 0.8.16",
+ "rend",
+ "rkyv_derive",
  "smallvec",
  "tinyvec",
  "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3976,7 +3857,7 @@ dependencies = [
  "lightningcss",
  "once_cell",
  "regex",
- "rkyv 0.8.16",
+ "rkyv",
  "rspack-allocative",
  "rspack_cacheable_macros",
  "rspack_resolver",
@@ -4062,7 +3943,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "regex",
- "rkyv 0.8.16",
+ "rkyv",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_dojang",
@@ -4151,7 +4032,7 @@ dependencies = [
 name = "rspack_hash"
 version = "0.101.0-rc.0"
 dependencies = [
- "base64-simd 0.8.0",
+ "base64-simd",
  "md4",
  "rspack_cacheable",
  "rspack_util",
@@ -4222,7 +4103,6 @@ dependencies = [
  "cow-utils",
  "derive_more",
  "lightningcss",
- "parcel_sourcemap",
  "rspack_browserslist",
  "rspack_cacheable",
  "rspack_core",
@@ -4875,7 +4755,6 @@ name = "rspack_plugin_lightning_css_minimizer"
 version = "0.101.0-rc.0"
 dependencies = [
  "lightningcss",
- "parcel_sourcemap",
  "rayon",
  "regex",
  "rspack_core",
@@ -5366,7 +5245,7 @@ version = "0.101.0-rc.0"
 dependencies = [
  "memchr",
  "regex",
- "rkyv 0.8.16",
+ "rkyv",
  "rustc-hash",
  "serde",
  "simd-json",
@@ -5465,7 +5344,7 @@ name = "rspack_util"
 version = "0.101.0-rc.0"
 dependencies = [
  "anyhow",
- "base64-simd 0.8.0",
+ "base64-simd",
  "bitflags 2.11.1",
  "concat-string",
  "cow-utils",
@@ -5604,12 +5483,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -5760,15 +5633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-abstraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
-dependencies = [
- "outref 0.1.0",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5811,6 +5675,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5899,8 +5769,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6635404b73efc136af3a7956e53c53d4f34b2f16c95a15c438929add0f69412"
+source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5910,8 +5779,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5268c96d4b907c558a9a52d8492522d6c7b559651a5e1d8f2d551e461b9425d5"
+source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6062,12 +5930,12 @@ version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "845f31910b5236db42dba106e8277681098d183b9b65b8dfa88ca8abe464aeff"
 dependencies = [
- "bytecheck 0.8.0",
+ "bytecheck",
  "cbor4ii",
  "hstr",
  "once_cell",
  "rancor",
- "rkyv 0.8.16",
+ "rkyv",
  "serde",
 ]
 
@@ -6080,7 +5948,7 @@ dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
- "bytecheck 0.8.0",
+ "bytecheck",
  "bytes-str",
  "cbor4ii",
  "either",
@@ -6089,10 +5957,10 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rancor",
- "rkyv 0.8.16",
+ "rkyv",
  "rustc-hash",
  "serde",
- "siphasher",
+ "siphasher 0.3.11",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_sourcemap",
@@ -6202,7 +6070,7 @@ dependencies = [
  "is-macro",
  "num-bigint",
  "once_cell",
- "phf",
+ "phf 0.11.2",
  "rustc-hash",
  "serde",
  "string_enum",
@@ -6424,7 +6292,7 @@ version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd2ef55e6c17a5bcae3967ec8b6ef26e2b6e10c5437bc23bfc5eb97d0efcdc94"
 dependencies = [
- "phf",
+ "phf 0.11.2",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_utils",
@@ -6480,7 +6348,7 @@ dependencies = [
  "par-core",
  "par-iter",
  "parking_lot",
- "phf",
+ "phf 0.11.2",
  "radix_fmt",
  "rustc-hash",
  "ryu-js",
@@ -6509,7 +6377,7 @@ dependencies = [
  "bitflags 2.11.1",
  "either",
  "num-bigint",
- "phf",
+ "phf 0.11.2",
  "rustc-hash",
  "seq-macro",
  "serde",
@@ -6591,7 +6459,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e66cd49fcb866106ea9ef2a1eb7a5f6b8df040d72608843f53c0ffc49fc0078"
 dependencies = [
- "phf",
+ "phf 0.11.2",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
@@ -6695,7 +6563,7 @@ dependencies = [
  "once_cell",
  "par-core",
  "par-iter",
- "phf",
+ "phf 0.11.2",
  "rustc-hash",
  "serde",
  "swc_atoms",
@@ -7234,7 +7102,7 @@ version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c421e5e39e43a4b1b70c07922d7bffd5c22e8eff1340c0b15d0bfd0328822ee"
 dependencies = [
- "base64-simd 0.8.0",
+ "base64-simd",
  "bitvec",
  "bytes-str",
  "data-encoding",
@@ -7926,12 +7794,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vlq"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,6 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -2458,7 +2457,6 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2985,7 +2983,6 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -5769,7 +5766,6 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5779,7 +5775,6 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4754,13 +4754,13 @@ dependencies = [
 name = "rspack_plugin_lightning_css_minimizer"
 version = "0.101.0-rc.0"
 dependencies = [
- "lightningcss",
  "rayon",
  "regex",
  "rspack_core",
  "rspack_error",
  "rspack_hash",
  "rspack_hook",
+ "rspack_loader_lightningcss",
  "rspack_util",
  "thread_local",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,6 +2433,7 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
+source = "git+https://github.com/intellild/lightningcss.git?rev=0bac61168acfba545e0378731ebce05809c57c64#0bac61168acfba545e0378731ebce05809c57c64"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -2457,6 +2458,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
+source = "git+https://github.com/intellild/lightningcss.git?rev=0bac61168acfba545e0378731ebce05809c57c64#0bac61168acfba545e0378731ebce05809c57c64"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2983,6 +2985,7 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
+source = "git+https://github.com/intellild/lightningcss.git?rev=0bac61168acfba545e0378731ebce05809c57c64#0bac61168acfba545e0378731ebce05809c57c64"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -5766,6 +5769,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
+source = "git+https://github.com/intellild/lightningcss.git?rev=0bac61168acfba545e0378731ebce05809c57c64#0bac61168acfba545e0378731ebce05809c57c64"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5775,6 +5779,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
+source = "git+https://github.com/intellild/lightningcss.git?rev=0bac61168acfba545e0378731ebce05809c57c64#0bac61168acfba545e0378731ebce05809c57c64"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
-source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "git+https://github.com/intellild/lightningcss.git?rev=8e0cd43eb7c8aff6ff88a4e376161221ba037337#8e0cd43eb7c8aff6ff88a4e376161221ba037337"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ae071b316c5d3527bce9f9e6dd67082650812f64#ae071b316c5d3527bce9f9e6dd67082650812f64"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
+source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
+source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
+source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
+source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
+source = "git+https://github.com/intellild/lightningcss.git?rev=7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3#7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.71"
-source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "lightningcss-derive"
 version = "1.0.0-alpha.43"
-source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "parcel_selectors"
 version = "0.28.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "static-self"
 version = "0.1.2"
-source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "static-self-derive"
 version = "0.1.1"
-source = "git+https://github.com/intellild/lightningcss.git?rev=61aee3776df2563e7c0d2982fcf1e7d3ec51571b#61aee3776df2563e7c0d2982fcf1e7d3ec51571b"
+source = "git+https://github.com/intellild/lightningcss.git?rev=ac21884329bd182b37b03713ab0d5f0597d430f1#ac21884329bd182b37b03713ab0d5f0597d430f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "8e0cd43eb7c8aff6ff88a4e376161221ba037337", default-features = false, features = ["serde", "custom_sourcemap"] }
+lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "ae071b316c5d3527bce9f9e6dd67082650812f64", default-features = false, features = ["serde", "custom_sourcemap"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde", "custom_sourcemap"] }
+lightningcss        = { git = "https://github.com/intellild/lightningcss.git", rev = "0bac61168acfba545e0378731ebce05809c57c64", default-features = false, features = ["serde", "custom_sourcemap"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
@@ -318,9 +318,6 @@ opt-level = "s"
 
 [profile.release.package.fancy-regex]
 opt-level = "s"
-
-[patch.crates-io]
-lightningcss = { git = "https://github.com/intellild/lightningcss.git", rev = "0bac61168acfba545e0378731ebce05809c57c64" }
 
 [profile.release.package.swc_ecma_loader]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3", default-features = false, features = ["serde", "custom_sourcemap"] }
+lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "8e0cd43eb7c8aff6ff88a4e376161221ba037337", default-features = false, features = ["serde", "custom_sourcemap"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "ae071b316c5d3527bce9f9e6dd67082650812f64", default-features = false, features = ["serde", "custom_sourcemap"] }
+lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde", "custom_sourcemap"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
@@ -318,6 +318,9 @@ opt-level = "s"
 
 [profile.release.package.fancy-regex]
 opt-level = "s"
+
+[patch.crates-io]
+lightningcss = { path = "../lightningcss" }
 
 [profile.release.package.swc_ecma_loader]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "ac21884329bd182b37b03713ab0d5f0597d430f1", default-features = false, features = ["serde", "custom_sourcemap"] }
+lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "7bb4e0364b0c28b056a6841ec16ca1dfa9bad9d3", default-features = false, features = ["serde", "custom_sourcemap"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
+lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "61aee3776df2563e7c0d2982fcf1e7d3ec51571b", default-features = false, features = ["serde"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }
@@ -70,7 +70,6 @@ num-bigint          = { version = "0.4.6", default-features = false }
 once_cell           = { version = "1.21.4", default-features = false }
 oneshot             = { version = "0.2.1", default-features = false, features = ["std", "async"] }
 owo-colors          = { version = "4.0.0", default-features = false, features = ["supports-colors"] }
-parcel_sourcemap    = { version = "2.1.1", default-features = false }
 paste               = { version = "1.0.15", default-features = false }
 path-clean          = { version = "1.0.1", default-features = false }
 pathdiff            = { version = "0.2.3", default-features = false }
@@ -430,9 +429,6 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package.notify]
-opt-level = "s"
-
-[profile.release.package.parcel_sourcemap]
 opt-level = "s"
 
 [profile.release.package.rspack_plugin_esm_library]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,7 +320,7 @@ opt-level = "s"
 opt-level = "s"
 
 [patch.crates-io]
-lightningcss = { path = "../lightningcss" }
+lightningcss = { git = "https://github.com/intellild/lightningcss.git", rev = "0bac61168acfba545e0378731ebce05809c57c64" }
 
 [profile.release.package.swc_ecma_loader]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "61aee3776df2563e7c0d2982fcf1e7d3ec51571b", default-features = false, features = ["serde"] }
+lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "ac21884329bd182b37b03713ab0d5f0597d430f1", default-features = false, features = ["serde"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools           = { version = "0.14.0", default-features = false, features =
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.0.2", default-features = false }
-lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "ac21884329bd182b37b03713ab0d5f0597d430f1", default-features = false, features = ["serde"] }
+lightningcss        = { version = "1.0.0-alpha.71", git = "https://github.com/intellild/lightningcss.git", rev = "ac21884329bd182b37b03713ab0d5f0597d430f1", default-features = false, features = ["serde", "custom_sourcemap"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -11,8 +11,7 @@ version.workspace = true
 async-trait          = { workspace = true }
 cow-utils            = { workspace = true }
 derive_more          = { workspace = true, features = ["debug"] }
-lightningcss         = { workspace = true, features = ["sourcemap", "into_owned"] }
-parcel_sourcemap     = { workspace = true }
+lightningcss         = { workspace = true, features = ["into_owned"] }
 rspack_browserslist  = { workspace = true }
 rspack_cacheable     = { workspace = true }
 rspack_core          = { workspace = true }

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -8,10 +8,7 @@ use cow_utils::CowUtils;
 use derive_more::Debug;
 pub use lightningcss;
 use lightningcss::{
-  printer::{
-    OriginalLocation as LightningOriginalLocation, PrinterOptions, PseudoClasses,
-    SourceMap as LightningSourceMap,
-  },
+  printer::{PrinterOptions, PseudoClasses, SourceMap as LightningSourceMap},
   stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
   targets::{Features, Targets},
   traits::IntoOwned,
@@ -19,10 +16,7 @@ use lightningcss::{
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   Loader, LoaderContext, RunnerContext,
-  rspack_sources::{
-    MapOptions, Mapping, ObjectPool, OriginalLocation as RspackOriginalLocation, SourceExt,
-    SourceMap, SourceMapSource, SourceMapSourceOptions, encode_mappings,
-  },
+  rspack_sources::{MapOptions, ObjectPool, SourceExt, SourceMapSource, SourceMapSourceOptions},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_loader_runner::Identifier;
@@ -30,112 +24,14 @@ use tokio::sync::Mutex;
 
 pub mod config;
 mod plugin;
+pub mod source_map;
 
 pub use plugin::LightningcssLoaderPlugin;
+pub use source_map::RspackSourceMap;
 
 pub const LIGHTNINGCSS_LOADER_IDENTIFIER: &str = "builtin:lightningcss-loader";
 
 pub type LightningcssLoaderVisitor = Box<dyn Send + Fn(&mut StyleSheet<'static>)>;
-
-#[derive(Default)]
-struct RspackSourceMap {
-  sources: Vec<Cow<'static, str>>,
-  sources_content: Vec<Cow<'static, str>>,
-  names: Vec<Cow<'static, str>>,
-  mappings: Vec<Mapping>,
-}
-
-impl RspackSourceMap {
-  fn finish(self) -> SourceMap<'static> {
-    SourceMap::new(
-      encode_mappings(self.mappings.into_iter()),
-      self.sources,
-      self.sources_content,
-      self.names,
-    )
-  }
-}
-
-impl LightningSourceMap for RspackSourceMap {
-  fn add_source(&mut self, source: &str) -> u32 {
-    if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
-      index as u32
-    } else {
-      self.sources.push(Cow::Owned(source.to_string()));
-      (self.sources.len() - 1) as u32
-    }
-  }
-
-  fn add_name(&mut self, name: &str) -> u32 {
-    if let Some(index) = self.names.iter().position(|n| n.as_ref() == name) {
-      index as u32
-    } else {
-      self.names.push(Cow::Owned(name.to_string()));
-      (self.names.len() - 1) as u32
-    }
-  }
-
-  fn set_source_content(&mut self, source_index: u32, source_content: &str) {
-    let source_index = source_index as usize;
-    if self.sources_content.len() <= source_index {
-      self
-        .sources_content
-        .resize_with(source_index + 1, || Cow::Borrowed(""));
-    }
-    self.sources_content[source_index] = Cow::Owned(source_content.to_string());
-  }
-
-  fn add_mapping(
-    &mut self,
-    generated_line: u32,
-    generated_column: u32,
-    original: Option<LightningOriginalLocation>,
-  ) {
-    self.mappings.push(Mapping {
-      generated_line: generated_line + 1,
-      generated_column,
-      original: original.map(|original| RspackOriginalLocation {
-        source_index: original.source,
-        original_line: original.original_line + 1,
-        original_column: original.original_column,
-        name_index: original.name,
-      }),
-    });
-  }
-
-  fn from_data_url(_source_root: &str, _data_url: &str) -> Option<Self> {
-    None
-  }
-
-  fn find_closest_mapping(
-    &mut self,
-    _line: u32,
-    _column: u32,
-  ) -> Option<LightningOriginalLocation> {
-    None
-  }
-
-  fn get_source(&self, source_index: u32) -> Option<&str> {
-    self
-      .sources
-      .get(source_index as usize)
-      .map(|source| source.as_ref())
-  }
-
-  fn get_name(&self, name_index: u32) -> Option<&str> {
-    self
-      .names
-      .get(name_index as usize)
-      .map(|name| name.as_ref())
-  }
-
-  fn get_source_content(&self, source_index: u32) -> Option<&str> {
-    self
-      .sources_content
-      .get(source_index as usize)
-      .map(|source_content| source_content.as_ref())
-  }
-}
 
 #[cacheable]
 #[derive(Debug)]

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -9,7 +9,8 @@ use derive_more::Debug;
 pub use lightningcss;
 use lightningcss::{
   printer::{
-    OriginalLocation as LightningOriginalLocation, PrinterOptions, PseudoClasses, SourceMapWriter,
+    OriginalLocation as LightningOriginalLocation, PrinterOptions, PseudoClasses,
+    SourceMap as LightningSourceMap,
   },
   stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
   targets::{Features, Targets},
@@ -37,14 +38,14 @@ pub const LIGHTNINGCSS_LOADER_IDENTIFIER: &str = "builtin:lightningcss-loader";
 pub type LightningcssLoaderVisitor = Box<dyn Send + Fn(&mut StyleSheet<'static>)>;
 
 #[derive(Default)]
-struct RspackSourceMapWriter {
+struct RspackSourceMap {
   sources: Vec<Cow<'static, str>>,
   sources_content: Vec<Cow<'static, str>>,
   names: Vec<Cow<'static, str>>,
   mappings: Vec<Mapping>,
 }
 
-impl RspackSourceMapWriter {
+impl RspackSourceMap {
   fn finish(self) -> SourceMap<'static> {
     SourceMap::new(
       encode_mappings(self.mappings.into_iter()),
@@ -55,7 +56,7 @@ impl RspackSourceMapWriter {
   }
 }
 
-impl SourceMapWriter for RspackSourceMapWriter {
+impl LightningSourceMap for RspackSourceMap {
   fn add_source(&mut self, source: &str) -> u32 {
     if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
       index as u32
@@ -100,6 +101,39 @@ impl SourceMapWriter for RspackSourceMapWriter {
         name_index: original.name,
       }),
     });
+  }
+
+  fn from_data_url(_source_root: &str, _data_url: &str) -> Option<Self> {
+    None
+  }
+
+  fn find_closest_mapping(
+    &mut self,
+    _line: u32,
+    _column: u32,
+  ) -> Option<LightningOriginalLocation> {
+    None
+  }
+
+  fn get_source(&self, source_index: u32) -> Option<&str> {
+    self
+      .sources
+      .get(source_index as usize)
+      .map(|source| source.as_ref())
+  }
+
+  fn get_name(&self, name_index: u32) -> Option<&str> {
+    self
+      .names
+      .get(name_index as usize)
+      .map(|name| name.as_ref())
+  }
+
+  fn get_source_content(&self, source_index: u32) -> Option<&str> {
+    self
+      .sources_content
+      .get(source_index as usize)
+      .map(|source_content| source_content.as_ref())
   }
 }
 
@@ -246,7 +280,7 @@ impl LightningCssLoader {
       .to_rspack_result()?;
 
     let mut source_map = if loader_context.context.source_map_kind.enabled() {
-      let mut sm = RspackSourceMapWriter::default();
+      let mut sm = RspackSourceMap::default();
       let source_index = sm.add_source(&filename);
       sm.set_source_content(source_index, &content_str);
       Some(sm)
@@ -254,28 +288,27 @@ impl LightningCssLoader {
       None
     };
 
-    let content = stylesheet
-      .to_css(PrinterOptions {
-        minify: self.config.minify.unwrap_or(false),
-        source_map: source_map
-          .as_mut()
-          .map(|source_map| source_map as &mut dyn SourceMapWriter),
-        project_root: None,
-        targets,
-        analyze_dependencies: None,
-        pseudo_classes: self
-          .config
-          .pseudo_classes
-          .as_ref()
-          .map(|pseudo_classes| PseudoClasses {
-            hover: pseudo_classes.hover.as_deref(),
-            active: pseudo_classes.active.as_deref(),
-            focus: pseudo_classes.focus.as_deref(),
-            focus_visible: pseudo_classes.focus_visible.as_deref(),
-            focus_within: pseudo_classes.focus_within.as_deref(),
-          }),
-      })
-      .to_rspack_result_with_message(|e| format!("failed to generate css: {e}"))?;
+    let content =
+      stylesheet
+        .to_css(
+          PrinterOptions {
+            minify: self.config.minify.unwrap_or(false),
+            project_root: None,
+            targets,
+            analyze_dependencies: None,
+            pseudo_classes: self.config.pseudo_classes.as_ref().map(|pseudo_classes| {
+              PseudoClasses {
+                hover: pseudo_classes.hover.as_deref(),
+                active: pseudo_classes.active.as_deref(),
+                focus: pseudo_classes.focus.as_deref(),
+                focus_visible: pseudo_classes.focus_visible.as_deref(),
+                focus_within: pseudo_classes.focus_within.as_deref(),
+              }
+            }),
+          },
+          source_map.as_mut(),
+        )
+        .to_rspack_result_with_message(|e| format!("failed to generate css: {e}"))?;
 
     if let Some(source_map) = source_map {
       let rspack_source_map = source_map.finish();

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -8,7 +8,9 @@ use cow_utils::CowUtils;
 use derive_more::Debug;
 pub use lightningcss;
 use lightningcss::{
-  printer::{PrinterOptions, PseudoClasses},
+  printer::{
+    OriginalLocation as LightningOriginalLocation, PrinterOptions, PseudoClasses, SourceMapWriter,
+  },
   stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
   targets::{Features, Targets},
   traits::IntoOwned,
@@ -17,8 +19,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
 use rspack_core::{
   Loader, LoaderContext, RunnerContext,
   rspack_sources::{
-    MapOptions, Mapping, ObjectPool, OriginalLocation, SourceExt, SourceMap, SourceMapSource,
-    SourceMapSourceOptions, encode_mappings,
+    MapOptions, Mapping, ObjectPool, OriginalLocation as RspackOriginalLocation, SourceExt,
+    SourceMap, SourceMapSource, SourceMapSourceOptions, encode_mappings,
   },
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
@@ -32,7 +34,74 @@ pub use plugin::LightningcssLoaderPlugin;
 
 pub const LIGHTNINGCSS_LOADER_IDENTIFIER: &str = "builtin:lightningcss-loader";
 
-pub type LightningcssLoaderVisitor = Box<dyn Send + Fn(&mut StyleSheet<'static, 'static>)>;
+pub type LightningcssLoaderVisitor = Box<dyn Send + Fn(&mut StyleSheet<'static>)>;
+
+#[derive(Default)]
+struct RspackSourceMapWriter {
+  sources: Vec<Cow<'static, str>>,
+  sources_content: Vec<Cow<'static, str>>,
+  names: Vec<Cow<'static, str>>,
+  mappings: Vec<Mapping>,
+}
+
+impl RspackSourceMapWriter {
+  fn finish(self) -> SourceMap<'static> {
+    SourceMap::new(
+      encode_mappings(self.mappings.into_iter()),
+      self.sources,
+      self.sources_content,
+      self.names,
+    )
+  }
+}
+
+impl SourceMapWriter for RspackSourceMapWriter {
+  fn add_source(&mut self, source: &str) -> u32 {
+    if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
+      index as u32
+    } else {
+      self.sources.push(Cow::Owned(source.to_string()));
+      (self.sources.len() - 1) as u32
+    }
+  }
+
+  fn add_name(&mut self, name: &str) -> u32 {
+    if let Some(index) = self.names.iter().position(|n| n.as_ref() == name) {
+      index as u32
+    } else {
+      self.names.push(Cow::Owned(name.to_string()));
+      (self.names.len() - 1) as u32
+    }
+  }
+
+  fn set_source_content(&mut self, source_index: u32, source_content: &str) {
+    let source_index = source_index as usize;
+    if self.sources_content.len() <= source_index {
+      self
+        .sources_content
+        .resize_with(source_index + 1, || Cow::Borrowed(""));
+    }
+    self.sources_content[source_index] = Cow::Owned(source_content.to_string());
+  }
+
+  fn add_mapping(
+    &mut self,
+    generated_line: u32,
+    generated_column: u32,
+    original: Option<LightningOriginalLocation>,
+  ) {
+    self.mappings.push(Mapping {
+      generated_line: generated_line + 1,
+      generated_column,
+      original: original.map(|original| RspackOriginalLocation {
+        source_index: original.source,
+        original_line: original.original_line + 1,
+        original_column: original.original_column,
+        name_index: original.name,
+      }),
+    });
+  }
+}
 
 #[cacheable]
 #[derive(Debug)]
@@ -176,10 +245,10 @@ impl LightningCssLoader {
       })
       .to_rspack_result()?;
 
-    let mut parcel_source_map = if loader_context.context.source_map_kind.enabled() {
-      let mut sm = parcel_sourcemap::SourceMap::new(&loader_context.context.options.context);
-      sm.add_source(&filename);
-      sm.set_source_content(0, &content_str).to_rspack_result()?;
+    let mut source_map = if loader_context.context.source_map_kind.enabled() {
+      let mut sm = RspackSourceMapWriter::default();
+      let source_index = sm.add_source(&filename);
+      sm.set_source_content(source_index, &content_str);
       Some(sm)
     } else {
       None
@@ -188,7 +257,7 @@ impl LightningCssLoader {
     let content = stylesheet
       .to_css(PrinterOptions {
         minify: self.config.minify.unwrap_or(false),
-        source_map: parcel_source_map.as_mut(),
+        source_map: source_map.as_mut(),
         project_root: None,
         targets,
         analyze_dependencies: None,
@@ -206,60 +275,8 @@ impl LightningCssLoader {
       })
       .to_rspack_result_with_message(|e| format!("failed to generate css: {e}"))?;
 
-    if let Some(parcel_source_map) = parcel_source_map {
-      let mappings = encode_mappings(parcel_source_map.get_mappings().iter().map(|mapping| {
-        // Parcel source map uses 0-based line numbers, while Rspack source map uses 1-based
-        Mapping {
-          generated_line: mapping.generated_line + 1,
-          generated_column: mapping.generated_column,
-          original: mapping.original.map(|original| OriginalLocation {
-            source_index: original.source,
-            original_line: original.original_line + 1,
-            original_column: original.original_column,
-            name_index: original.name,
-          }),
-        }
-      }));
-
-      let mut posix_context = loader_context
-        .context
-        .options
-        .context
-        .cow_replace("\\", "/");
-      if !posix_context.ends_with('/') {
-        posix_context.to_mut().push('/');
-      }
-      let posix_context = posix_context.into_owned();
-
-      let rspack_source_map = SourceMap::new(
-        mappings,
-        // Parcel stores sources relative to project_root, while Rspack source maps
-        // use absolute module paths for downstream loader/plugin handling.
-        parcel_source_map
-          .get_sources()
-          .iter()
-          .map(|source| {
-            Cow::Owned(if source.starts_with('/') || source.contains(':') {
-              source.clone()
-            } else {
-              let mut absolute_source = String::with_capacity(posix_context.len() + source.len());
-              absolute_source.push_str(&posix_context);
-              absolute_source.push_str(source);
-              absolute_source
-            })
-          })
-          .collect::<Vec<_>>(),
-        parcel_source_map
-          .get_sources_content()
-          .iter()
-          .map(|source_content| Cow::Owned(source_content.clone()))
-          .collect::<Vec<_>>(),
-        parcel_source_map
-          .get_names()
-          .iter()
-          .map(|name| Cow::Owned(name.clone()))
-          .collect::<Vec<_>>(),
-      );
+    if let Some(source_map) = source_map {
+      let rspack_source_map = source_map.finish();
 
       let posix_name = filename.cow_replace("\\", "/");
       let source_map_source = SourceMapSource::new(SourceMapSourceOptions {
@@ -299,10 +316,7 @@ impl Loader<RunnerContext> for LightningCssLoader {
   }
 }
 
-pub fn to_static(
-  stylesheet: StyleSheet,
-  options: ParserOptions<'static, 'static>,
-) -> StyleSheet<'static, 'static> {
+pub fn to_static(stylesheet: StyleSheet, options: ParserOptions<'static>) -> StyleSheet<'static> {
   let sources = stylesheet.sources.clone();
   let rules = stylesheet.rules.clone().into_owned();
 

--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -257,7 +257,9 @@ impl LightningCssLoader {
     let content = stylesheet
       .to_css(PrinterOptions {
         minify: self.config.minify.unwrap_or(false),
-        source_map: source_map.as_mut(),
+        source_map: source_map
+          .as_mut()
+          .map(|source_map| source_map as &mut dyn SourceMapWriter),
         project_root: None,
         targets,
         analyze_dependencies: None,

--- a/crates/rspack_loader_lightningcss/src/source_map.rs
+++ b/crates/rspack_loader_lightningcss/src/source_map.rs
@@ -1,0 +1,118 @@
+use std::borrow::Cow;
+
+use lightningcss::printer::{
+  OriginalLocation as LightningOriginalLocation, SourceMap as LightningSourceMap,
+};
+use rspack_core::rspack_sources::{
+  Mapping, OriginalLocation as RspackOriginalLocation, SourceMap, encode_mappings,
+};
+
+#[derive(Default)]
+pub struct RspackSourceMap {
+  sources: Vec<Cow<'static, str>>,
+  sources_content: Vec<Cow<'static, str>>,
+  names: Vec<Cow<'static, str>>,
+  mappings: Vec<Mapping>,
+  source_root: Option<Cow<'static, str>>,
+}
+
+impl RspackSourceMap {
+  pub fn with_source_root(source_root: Option<&str>) -> Self {
+    Self {
+      source_root: source_root.map(|source_root| Cow::Owned(source_root.to_string())),
+      ..Default::default()
+    }
+  }
+
+  pub fn finish(self) -> SourceMap<'static> {
+    let mut source_map = SourceMap::new(
+      encode_mappings(self.mappings.into_iter()),
+      self.sources,
+      self.sources_content,
+      self.names,
+    );
+    source_map.set_source_root(self.source_root);
+    source_map
+  }
+}
+
+impl LightningSourceMap for RspackSourceMap {
+  fn add_source(&mut self, source: &str) -> u32 {
+    if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
+      index as u32
+    } else {
+      self.sources.push(Cow::Owned(source.to_string()));
+      (self.sources.len() - 1) as u32
+    }
+  }
+
+  fn add_name(&mut self, name: &str) -> u32 {
+    if let Some(index) = self.names.iter().position(|n| n.as_ref() == name) {
+      index as u32
+    } else {
+      self.names.push(Cow::Owned(name.to_string()));
+      (self.names.len() - 1) as u32
+    }
+  }
+
+  fn set_source_content(&mut self, source_index: u32, source_content: &str) {
+    let source_index = source_index as usize;
+    if self.sources_content.len() <= source_index {
+      self
+        .sources_content
+        .resize_with(source_index + 1, || Cow::Borrowed(""));
+    }
+    self.sources_content[source_index] = Cow::Owned(source_content.to_string());
+  }
+
+  fn add_mapping(
+    &mut self,
+    generated_line: u32,
+    generated_column: u32,
+    original: Option<LightningOriginalLocation>,
+  ) {
+    self.mappings.push(Mapping {
+      generated_line: generated_line + 1,
+      generated_column,
+      original: original.map(|original| RspackOriginalLocation {
+        source_index: original.source,
+        original_line: original.original_line + 1,
+        original_column: original.original_column,
+        name_index: original.name,
+      }),
+    });
+  }
+
+  fn from_data_url(_source_root: &str, _data_url: &str) -> Option<Self> {
+    None
+  }
+
+  fn find_closest_mapping(
+    &mut self,
+    _line: u32,
+    _column: u32,
+  ) -> Option<LightningOriginalLocation> {
+    None
+  }
+
+  fn get_source(&self, source_index: u32) -> Option<&str> {
+    self
+      .sources
+      .get(source_index as usize)
+      .map(|source| source.as_ref())
+  }
+
+  fn get_name(&self, name_index: u32) -> Option<&str> {
+    self
+      .names
+      .get(name_index as usize)
+      .map(|name| name.as_ref())
+  }
+
+  fn get_source_content(&self, source_index: u32) -> Option<&str> {
+    self
+      .sources_content
+      .get(source_index as usize)
+      .map(|source_content| source_content.as_ref())
+  }
+}

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -8,17 +8,17 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightningcss = { workspace = true }
 rayon        = { workspace = true }
 regex        = { workspace = true }
 thread_local = { workspace = true }
 tracing      = { workspace = true }
 
-rspack_core  = { workspace = true }
-rspack_error = { workspace = true }
-rspack_hash  = { workspace = true }
-rspack_hook  = { workspace = true }
-rspack_util  = { workspace = true }
+rspack_core                = { workspace = true }
+rspack_error               = { workspace = true }
+rspack_hash                = { workspace = true }
+rspack_hook                = { workspace = true }
+rspack_loader_lightningcss = { workspace = true }
+rspack_util                = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -8,12 +8,11 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightningcss     = { workspace = true, features = ["sourcemap"] }
-parcel_sourcemap = { workspace = true }
-rayon            = { workspace = true }
-regex            = { workspace = true }
-thread_local     = { workspace = true }
-tracing          = { workspace = true }
+lightningcss = { workspace = true }
+rayon        = { workspace = true }
+regex        = { workspace = true }
+thread_local = { workspace = true }
+tracing      = { workspace = true }
 
 rspack_core  = { workspace = true }
 rspack_error = { workspace = true }

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -316,7 +316,9 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           stylesheet
             .to_css(PrinterOptions {
               minify: true,
-              source_map: source_map.as_mut(),
+              source_map: source_map
+                .as_mut()
+                .map(|source_map| source_map as &mut dyn SourceMapWriter),
               project_root: None,
               targets,
               analyze_dependencies: None,

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -7,7 +7,9 @@ use std::{
 
 pub use lightningcss::targets::Browsers;
 use lightningcss::{
-  printer::{OriginalLocation as LightningOriginalLocation, PrinterOptions, SourceMapWriter},
+  printer::{
+    OriginalLocation as LightningOriginalLocation, PrinterOptions, SourceMap as LightningSourceMap,
+  },
   stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
   targets::{Features, Targets},
 };
@@ -31,7 +33,7 @@ static CSS_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.css(\?.*)?$").expect("Invalid RegExp"));
 
 #[derive(Default)]
-struct RspackSourceMapWriter {
+struct RspackSourceMap {
   sources: Vec<Cow<'static, str>>,
   sources_content: Vec<Cow<'static, str>>,
   names: Vec<Cow<'static, str>>,
@@ -39,7 +41,7 @@ struct RspackSourceMapWriter {
   source_root: Option<Cow<'static, str>>,
 }
 
-impl RspackSourceMapWriter {
+impl RspackSourceMap {
   fn with_source_root(source_root: Option<&str>) -> Self {
     Self {
       source_root: source_root.map(|source_root| Cow::Owned(source_root.to_string())),
@@ -59,7 +61,7 @@ impl RspackSourceMapWriter {
   }
 }
 
-impl SourceMapWriter for RspackSourceMapWriter {
+impl LightningSourceMap for RspackSourceMap {
   fn add_source(&mut self, source: &str) -> u32 {
     if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
       index as u32
@@ -104,6 +106,39 @@ impl SourceMapWriter for RspackSourceMapWriter {
         name_index: original.name,
       }),
     });
+  }
+
+  fn from_data_url(_source_root: &str, _data_url: &str) -> Option<Self> {
+    None
+  }
+
+  fn find_closest_mapping(
+    &mut self,
+    _line: u32,
+    _column: u32,
+  ) -> Option<LightningOriginalLocation> {
+    None
+  }
+
+  fn get_source(&self, source_index: u32) -> Option<&str> {
+    self
+      .sources
+      .get(source_index as usize)
+      .map(|source| source.as_ref())
+  }
+
+  fn get_name(&self, name_index: u32) -> Option<&str> {
+    self
+      .names
+      .get(name_index as usize)
+      .map(|name| name.as_ref())
+  }
+
+  fn get_source_content(&self, source_index: u32) -> Option<&str> {
+    self
+      .sources_content
+      .get(source_index as usize)
+      .map(|source_content| source_content.as_ref())
   }
 }
 
@@ -249,7 +284,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         );
 
         let mut source_map = input_source_map.as_ref().map(|input_source_map| {
-          let mut sm = RspackSourceMapWriter::with_source_root(input_source_map.source_root());
+          let mut sm = RspackSourceMap::with_source_root(input_source_map.source_root());
           let source_index = sm.add_source(filename);
           sm.set_source_content(source_index, &input);
           sm
@@ -316,9 +351,6 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           stylesheet
             .to_css(PrinterOptions {
               minify: true,
-              source_map: source_map
-                .as_mut()
-                .map(|source_map| source_map as &mut dyn SourceMapWriter),
               project_root: None,
               targets,
               analyze_dependencies: None,
@@ -331,7 +363,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
                 focus_visible: pseudo_classes.focus_visible.as_deref(),
                 focus_within: pseudo_classes.focus_within.as_deref(),
               }),
-            })
+            }, source_map.as_mut())
             .to_rspack_result()?
         };
 

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+  borrow::Cow,
   collections::HashSet,
   hash::Hash,
   sync::{Arc, LazyLock, RwLock},
@@ -6,7 +7,7 @@ use std::{
 
 pub use lightningcss::targets::Browsers;
 use lightningcss::{
-  printer::PrinterOptions,
+  printer::{OriginalLocation as LightningOriginalLocation, PrinterOptions, SourceMapWriter},
   stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
   targets::{Features, Targets},
 };
@@ -16,8 +17,8 @@ use rspack_core::{
   ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets, Plugin,
   diagnostics::MinifyError,
   rspack_sources::{
-    MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMap, SourceMapSource,
-    SourceMapSourceOptions,
+    MapOptions, Mapping, ObjectPool, OriginalLocation as RspackOriginalLocation, RawStringSource,
+    Source, SourceExt, SourceMap, SourceMapSource, SourceMapSourceOptions, encode_mappings,
   },
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
@@ -28,6 +29,83 @@ use thread_local::ThreadLocal;
 
 static CSS_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.css(\?.*)?$").expect("Invalid RegExp"));
+
+#[derive(Default)]
+struct RspackSourceMapWriter {
+  sources: Vec<Cow<'static, str>>,
+  sources_content: Vec<Cow<'static, str>>,
+  names: Vec<Cow<'static, str>>,
+  mappings: Vec<Mapping>,
+  source_root: Option<Cow<'static, str>>,
+}
+
+impl RspackSourceMapWriter {
+  fn with_source_root(source_root: Option<&str>) -> Self {
+    Self {
+      source_root: source_root.map(|source_root| Cow::Owned(source_root.to_string())),
+      ..Default::default()
+    }
+  }
+
+  fn finish(self) -> SourceMap<'static> {
+    let mut source_map = SourceMap::new(
+      encode_mappings(self.mappings.into_iter()),
+      self.sources,
+      self.sources_content,
+      self.names,
+    );
+    source_map.set_source_root(self.source_root);
+    source_map
+  }
+}
+
+impl SourceMapWriter for RspackSourceMapWriter {
+  fn add_source(&mut self, source: &str) -> u32 {
+    if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
+      index as u32
+    } else {
+      self.sources.push(Cow::Owned(source.to_string()));
+      (self.sources.len() - 1) as u32
+    }
+  }
+
+  fn add_name(&mut self, name: &str) -> u32 {
+    if let Some(index) = self.names.iter().position(|n| n.as_ref() == name) {
+      index as u32
+    } else {
+      self.names.push(Cow::Owned(name.to_string()));
+      (self.names.len() - 1) as u32
+    }
+  }
+
+  fn set_source_content(&mut self, source_index: u32, source_content: &str) {
+    let source_index = source_index as usize;
+    if self.sources_content.len() <= source_index {
+      self
+        .sources_content
+        .resize_with(source_index + 1, || Cow::Borrowed(""));
+    }
+    self.sources_content[source_index] = Cow::Owned(source_content.to_string());
+  }
+
+  fn add_mapping(
+    &mut self,
+    generated_line: u32,
+    generated_column: u32,
+    original: Option<LightningOriginalLocation>,
+  ) {
+    self.mappings.push(Mapping {
+      generated_line: generated_line + 1,
+      generated_column,
+      original: original.map(|original| RspackOriginalLocation {
+        source_index: original.source,
+        original_line: original.original_line + 1,
+        original_column: original.original_column,
+        name_index: original.name,
+      }),
+    });
+  }
+}
 
 #[derive(Debug, Hash)]
 pub struct PluginOptions {
@@ -170,16 +248,12 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
           matches!(&minimizer_options.non_standard, Some(non_standard) if non_standard.deep_selector_combinator),
         );
 
-        let mut source_map = input_source_map
-          .as_ref()
-          .map(|input_source_map| -> Result<_> {
-            let mut sm =
-              parcel_sourcemap::SourceMap::new(input_source_map.source_root().unwrap_or("/"));
-            sm.add_source(filename);
-            sm.set_source_content(0, &input).to_rspack_result()?;
-            Ok(sm)
-          })
-          .transpose()?;
+        let mut source_map = input_source_map.as_ref().map(|input_source_map| {
+          let mut sm = RspackSourceMapWriter::with_source_root(input_source_map.source_root());
+          let source_index = sm.add_source(filename);
+          sm.set_source_content(source_index, &input);
+          sm
+        });
         let result = {
           let warnings: Arc<RwLock<Vec<_>>> = Default::default();
           let mut stylesheet = StyleSheet::parse(
@@ -259,16 +333,11 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             .to_rspack_result()?
         };
 
-        let minimized_source = if let Some(mut source_map) = source_map {
+        let minimized_source = if let Some(source_map) = source_map {
           SourceMapSource::new(SourceMapSourceOptions {
             value: result.code,
             name: filename,
-            source_map: SourceMap::from_json(
-              source_map
-                .to_json(None)
-                .to_rspack_result()?,
-            )
-            .expect("should be able to generate source-map"),
+            source_map: source_map.finish(),
             original_source: Some(Box::from(input)),
             inner_source_map: input_source_map,
             remove_original_source: true,

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -1,146 +1,36 @@
 use std::{
-  borrow::Cow,
   collections::HashSet,
   hash::Hash,
   sync::{Arc, LazyLock, RwLock},
 };
 
-pub use lightningcss::targets::Browsers;
-use lightningcss::{
-  printer::{
-    OriginalLocation as LightningOriginalLocation, PrinterOptions, SourceMap as LightningSourceMap,
-  },
-  stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
-  targets::{Features, Targets},
-};
 use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   ChunkUkey, Compilation, CompilationChunkHash, CompilationProcessAssets, Plugin,
   diagnostics::MinifyError,
   rspack_sources::{
-    MapOptions, Mapping, ObjectPool, OriginalLocation as RspackOriginalLocation, RawStringSource,
-    Source, SourceExt, SourceMap, SourceMapSource, SourceMapSourceOptions, encode_mappings,
+    MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMapSource,
+    SourceMapSourceOptions,
   },
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHash;
 use rspack_hook::{plugin, plugin_hook};
+pub use rspack_loader_lightningcss::lightningcss::targets::Browsers;
+use rspack_loader_lightningcss::{
+  RspackSourceMap,
+  lightningcss::{
+    printer::{PrinterOptions, SourceMap as LightningSourceMap},
+    stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet},
+    targets::{Features, Targets},
+  },
+};
 use rspack_util::asset_condition::{AssetConditions, AssetConditionsObject, match_object};
 use thread_local::ThreadLocal;
 
 static CSS_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.css(\?.*)?$").expect("Invalid RegExp"));
-
-#[derive(Default)]
-struct RspackSourceMap {
-  sources: Vec<Cow<'static, str>>,
-  sources_content: Vec<Cow<'static, str>>,
-  names: Vec<Cow<'static, str>>,
-  mappings: Vec<Mapping>,
-  source_root: Option<Cow<'static, str>>,
-}
-
-impl RspackSourceMap {
-  fn with_source_root(source_root: Option<&str>) -> Self {
-    Self {
-      source_root: source_root.map(|source_root| Cow::Owned(source_root.to_string())),
-      ..Default::default()
-    }
-  }
-
-  fn finish(self) -> SourceMap<'static> {
-    let mut source_map = SourceMap::new(
-      encode_mappings(self.mappings.into_iter()),
-      self.sources,
-      self.sources_content,
-      self.names,
-    );
-    source_map.set_source_root(self.source_root);
-    source_map
-  }
-}
-
-impl LightningSourceMap for RspackSourceMap {
-  fn add_source(&mut self, source: &str) -> u32 {
-    if let Some(index) = self.sources.iter().position(|s| s.as_ref() == source) {
-      index as u32
-    } else {
-      self.sources.push(Cow::Owned(source.to_string()));
-      (self.sources.len() - 1) as u32
-    }
-  }
-
-  fn add_name(&mut self, name: &str) -> u32 {
-    if let Some(index) = self.names.iter().position(|n| n.as_ref() == name) {
-      index as u32
-    } else {
-      self.names.push(Cow::Owned(name.to_string()));
-      (self.names.len() - 1) as u32
-    }
-  }
-
-  fn set_source_content(&mut self, source_index: u32, source_content: &str) {
-    let source_index = source_index as usize;
-    if self.sources_content.len() <= source_index {
-      self
-        .sources_content
-        .resize_with(source_index + 1, || Cow::Borrowed(""));
-    }
-    self.sources_content[source_index] = Cow::Owned(source_content.to_string());
-  }
-
-  fn add_mapping(
-    &mut self,
-    generated_line: u32,
-    generated_column: u32,
-    original: Option<LightningOriginalLocation>,
-  ) {
-    self.mappings.push(Mapping {
-      generated_line: generated_line + 1,
-      generated_column,
-      original: original.map(|original| RspackOriginalLocation {
-        source_index: original.source,
-        original_line: original.original_line + 1,
-        original_column: original.original_column,
-        name_index: original.name,
-      }),
-    });
-  }
-
-  fn from_data_url(_source_root: &str, _data_url: &str) -> Option<Self> {
-    None
-  }
-
-  fn find_closest_mapping(
-    &mut self,
-    _line: u32,
-    _column: u32,
-  ) -> Option<LightningOriginalLocation> {
-    None
-  }
-
-  fn get_source(&self, source_index: u32) -> Option<&str> {
-    self
-      .sources
-      .get(source_index as usize)
-      .map(|source| source.as_ref())
-  }
-
-  fn get_name(&self, name_index: u32) -> Option<&str> {
-    self
-      .names
-      .get(name_index as usize)
-      .map(|name| name.as_ref())
-  }
-
-  fn get_source_content(&self, source_index: u32) -> Option<&str> {
-    self
-      .sources_content
-      .get(source_index as usize)
-      .map(|source_content| source_content.as_ref())
-  }
-}
 
 #[derive(Debug, Hash)]
 pub struct PluginOptions {
@@ -356,7 +246,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
               analyze_dependencies: None,
               pseudo_classes: minimizer_options.pseudo_classes
               .as_ref()
-              .map(|pseudo_classes| lightningcss::stylesheet::PseudoClasses {
+              .map(|pseudo_classes| rspack_loader_lightningcss::lightningcss::stylesheet::PseudoClasses {
                 hover: pseudo_classes.hover.as_deref(),
                 active: pseudo_classes.active.as_deref(),
                 focus: pseudo_classes.focus.as_deref(),


### PR DESCRIPTION
## Summary

Use the new generic Lightning CSS source map writer API so Rspack can generate `rspack_sources::SourceMap` directly instead of going through `parcel_sourcemap`.

This updates the workspace `lightningcss` dependency to the git revision `61aee3776df2563e7c0d2982fcf1e7d3ec51571b` from `intellild/lightningcss`, removes direct `parcel_sourcemap` usage from the loader and minimizer, and keeps source map output wired through local `RspackSourceMapWriter` adapters.

## Validation

- `cargo check -p rspack_loader_lightningcss -p rspack_plugin_lightning_css_minimizer`
- `cargo tree -i parcel_sourcemap` returns package not found
- `cargo fmt --check -p rspack_loader_lightningcss -p rspack_plugin_lightning_css_minimizer`
- `pnpm exec rstest Config.part1.test.js -t source-map-absolute-sources`
- `pnpm exec rstest Config.part3.test.js -t verify-bundle-css-minify-lightning`

---
_by OpenAI Codex_