### PR TITLE
docs: document asset/resource emit generator option

### DIFF
--- a/website/docs/en/config/module-generator.mdx
+++ b/website/docs/en/config/module-generator.mdx
@@ -45,6 +45,7 @@ export default {
       },
       // Generator options for asset/resource modules
       'asset/resource': {
+        emit: true,
         filename: '[name]-[contenthash][ext]',
         publicPath: 'https://cdn.example.com/',
       },
@@ -524,6 +525,22 @@ export default {
     generator: {
       'asset/resource': {
         publicPath: 'https://cdn.example.com/',
+      },
+    },
+  },
+};
+```
+
+### ["asset/resource"].emit
+
+Same as [`module.generator["asset"].emit`](#assetemit).
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'asset/resource': {
+        emit: false,
       },
     },
   },

--- a/website/docs/zh/config/module-generator.mdx
+++ b/website/docs/zh/config/module-generator.mdx
@@ -45,6 +45,7 @@ export default {
       },
       // asset/resource 模块的生成器选项
       'asset/resource': {
+        emit: true,
         filename: '[name]-[contenthash][ext]',
         publicPath: 'https://cdn.example.com/',
       },
@@ -523,6 +524,22 @@ export default {
     generator: {
       'asset/resource': {
         publicPath: 'https://cdn.example.com/',
+      },
+    },
+  },
+};
+```
+
+### ["asset/resource"].emit
+
+和 [`module.generator["asset"].emit`](#assetemit) 一样。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    generator: {
+      'asset/resource': {
+        emit: false,
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR documents the `emit` generator option for `asset/resource` modules in both English and Chinese configuration docs, aligning it with the existing `asset.emit` documentation and example config. The commit hook ran the website spell check for the staged docs files.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).