### PR TITLE
docs: document json parser parse option

### DIFF
--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -1017,6 +1017,49 @@ export default {
 };
 ```
 
+### json.parse
+
+- **Type:** `(source: string) => any`
+- **Default:** `undefined`
+
+Customize how Rspack parses the source of `json` modules. The function receives the module source as a string. It is called synchronously and must return JSON-serializable data, such as an object, array, string, number, boolean, or `null`.
+
+Rspack serializes the returned value with `JSON.stringify` and then parses that serialized JSON as the module data, so values that cannot be represented as valid JSON should not be returned. For normal JSON files you do not need to configure this option; it is mainly useful when modules are treated as `type: 'json'` but need custom source-to-data conversion.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      json: {
+        parse: (source) => {
+          return JSON.parse(source);
+        },
+      },
+    },
+  },
+};
+```
+
+You can also use this option through `module.rules[].parser` when the matched rule sets `type: 'json'`. For example, parse `.json5` files as JSON modules:
+
+```js title="rspack.config.mjs"
+import JSON5 from 'json5';
+
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.json5$/,
+        type: 'json',
+        parser: {
+          parse: JSON5.parse,
+        },
+      },
+    ],
+  },
+};
+```
+
 ### ["css/auto"]
 
 Parser options for `css/auto` modules.

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -1017,6 +1017,49 @@ export default {
 };
 ```
 
+### json.parse
+
+- **类型：** `(source: string) => any`
+- **默认值：** `undefined`
+
+自定义 Rspack 如何解析 `json` 模块的源码。该函数会收到模块源码字符串，函数必须返回可 JSON 序列化的数据。
+
+Rspack 会先通过 `JSON.stringify` 序列化该函数的返回值，再将序列化后的 JSON 作为模块数据继续解析。普通 JSON 文件通常不需要配置这个选项；它主要用于将某些模块按 `type: 'json'` 处理，但又需要自定义源码到数据的转换逻辑。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      json: {
+        parse: (source) => {
+          return JSON.parse(source);
+        },
+      },
+    },
+  },
+};
+```
+
+当命中的规则设置了 `type: 'json'` 时，也可以通过 `module.rules[].parser` 使用这个选项。例如，将 `.json5` 文件作为 JSON 模块解析：
+
+```js title="rspack.config.mjs"
+import JSON5 from 'json5';
+
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.json5$/,
+        type: 'json',
+        parser: {
+          parse: JSON5.parse,
+        },
+      },
+    ],
+  },
+};
+```
+
 ### ["css/auto"]
 
 `css/auto` 模块的解析器选项。


### PR DESCRIPTION
## Summary

Document `module.parser.json.parse` in the English and Chinese module parser docs, including its synchronous parser contract, JSON-serializable return value, and a `module.rules[].parser` example for parsing `.json5` files as JSON modules.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).