### PR TITLE
docs: document more rule use options

### DIFF
--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -857,6 +857,10 @@ export type RuleSetLoader = string;
 export type RuleSetLoaderOptions = string | Record<string, any>;
 
 export type RuleSetLoaderWithOptions = {
+  /**
+   * Stable identifier used to reference object-form loader options.
+   * When provided, Rspack passes object options to the loader request as `??${ident}`.
+   */
   ident?: string;
 
   loader: RuleSetLoader;
@@ -1311,7 +1315,8 @@ export type JsonParserOptions = {
    */
   exportsDepth?: number;
   /**
-   * If Rule.type is set to 'json' then Rules.parser.parse option may be a function that implements custom logic to parse module's source and convert it to a json-compatible data.
+   * Custom synchronous parser for json modules. It receives the module source and should return JSON-serializable data.
+   * Can be configured through module.parser.json or through Rule.parser when Rule.type is 'json'.
    */
   parse?: (source: string) => any;
 };

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -808,6 +808,36 @@ export default {
 };
 ```
 
+## rules[].use.ident
+
+- **Type:** `string`
+- **Default:** `undefined`
+
+Provides a stable name for object-form loader options. Rspack uses it when building the loader request, so generated rules or reused options can keep the same `??<ident>` reference.
+
+Most configurations do not need to set it manually. If omitted, Rspack uses `options.ident` when present, otherwise it generates an internal identifier.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.svg$/,
+        use: [
+          {
+            loader: 'svgo-loader',
+            ident: 'svgo-inline',
+            options: {
+              multipass: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ## rules[].use.parallel
 
 <ApiMeta addedVersion="1.3.1" />
@@ -852,6 +882,36 @@ When multiple loaders within the same rule have `parallel` enabled, Rspack execu
 - In worker mode, most methods on `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module` are not supported.
 
 :::
+
+## rules[].use.parallel.maxWorkers
+
+- **Type:** `number`
+- **Default:** `undefined`
+
+Limits the maximum number of worker threads used by the shared loader worker pool when `parallel` is configured as an object. Use a positive integer.
+
+When `maxWorkers` is omitted, Rspack automatically chooses the worker count. The loader worker pool is shared within the current process, so use a consistent `maxWorkers` value if multiple loaders configure `parallel`.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        use: [
+          {
+            loader: 'less-loader',
+            parallel: {
+              maxWorkers: 4,
+            },
+            options: {},
+          },
+        ],
+      },
+    ],
+  },
+};
+```
 
 ## rules[].resolve
 

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -806,6 +806,36 @@ export default {
 };
 ```
 
+## rules[].use.ident
+
+- **类型：** `string`
+- **默认值：** `undefined`
+
+为对象形式的 loader options 提供一个稳定名称。Rspack 构造 loader request 时会使用它，因此在生成规则或复用同一组选项时，可以保持稳定的 `??<ident>` 引用。
+
+大多数配置不需要手动设置它。如果省略，Rspack 会优先使用 `options.ident`，否则生成内部标识符。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.svg$/,
+        use: [
+          {
+            loader: 'svgo-loader',
+            ident: 'svgo-inline',
+            options: {
+              multipass: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ## rules[].use.parallel
 
 <ApiMeta addedVersion="1.3.1" />
@@ -850,6 +880,36 @@ export default {
 - 目前 loader 在 worker 中不支持 `LoaderContext._compilation`, `LoaderContext._compiler`, `LoaderContext._module` 上的大多数方法。
 
 :::
+
+## rules[].use.parallel.maxWorkers
+
+- **类型：** `number`
+- **默认值：** `undefined`
+
+当 `parallel` 配置为对象时，限制共享 loader worker pool 使用的最大 worker 线程数。请使用正整数。
+
+如果省略 `maxWorkers`，Rspack 会自动选择 worker 数量。loader worker pool 在当前进程内共享；如果多个 loader 都配置 `parallel`，建议使用一致的 `maxWorkers` 值。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        use: [
+          {
+            loader: 'less-loader',
+            parallel: {
+              maxWorkers: 4,
+            },
+            options: {},
+          },
+        ],
+      },
+    ],
+  },
+};
+```
 
 ## rules[].resolve
 


### PR DESCRIPTION
## Summary

Document `rules[].use[].ident` and `rules[].use.parallel.maxWorkers` in the English and Chinese module rules docs, and align the TypeScript option comments with the public behavior. The docs describe stable loader option identifiers, parallel loader worker limits, and avoid exposing internal environment variables.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).