### PR TITLE
perf: reduce plugin hook macro expansion

### DIFF
--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -29,10 +29,34 @@ pub trait Hook {
 
 #[doc(hidden)]
 pub mod __macro_helper {
+  use std::marker::PhantomData;
+
   pub use async_trait::async_trait;
   pub use rspack_error::Result;
   pub use rustc_hash::FxHashSet;
   pub use tracing;
+
+  pub trait PluginHookTapPlugin: Sized {
+    fn clone_for_plugin_hook_tap(&self) -> Self;
+  }
+
+  #[allow(non_camel_case_types)]
+  pub struct PluginHookTap<M, P> {
+    pub plugin: P,
+    marker: PhantomData<fn() -> M>,
+  }
+
+  impl<M, P> PluginHookTap<M, P>
+  where
+    P: PluginHookTapPlugin,
+  {
+    pub fn new(plugin: &P) -> Self {
+      Self {
+        plugin: plugin.clone_for_plugin_hook_tap(),
+        marker: PhantomData,
+      }
+    }
+  }
 }
 
 pub use rspack_macros::{define_hook, plugin, plugin_hook};

--- a/crates/rspack_macros/src/plugin.rs
+++ b/crates/rspack_macros/src/plugin.rs
@@ -1,7 +1,9 @@
 use quote::quote;
 use syn::{
-  Pat, PatIdent, Result, Token,
+  Expr, Pat, PatIdent, Result, Token,
   parse::{Parse, ParseStream, Parser},
+  parse_quote,
+  visit_mut::{self, VisitMut},
 };
 
 pub fn expand_struct(mut input: syn::ItemStruct) -> proc_macro::TokenStream {
@@ -83,6 +85,13 @@ pub fn expand_struct(mut input: syn::ItemStruct) -> proc_macro::TokenStream {
       }
     }
 
+    impl #impl_generics ::rspack_hook::__macro_helper::PluginHookTapPlugin for #ident #ty_generics #where_clause {
+      #[inline(never)]
+      fn clone_for_plugin_hook_tap(&self) -> Self {
+        Self::from_inner(self.inner())
+      }
+    }
+
     #[doc(hidden)]
     #(#attrs)*
     #inner_struct
@@ -93,6 +102,21 @@ pub fn expand_struct(mut input: syn::ItemStruct) -> proc_macro::TokenStream {
 fn plugin_inner_ident(ident: &syn::Ident) -> syn::Ident {
   let inner_name = format!("{ident}Inner");
   syn::Ident::new(&inner_name, ident.span())
+}
+
+struct StageExprSelfRewriter;
+
+impl VisitMut for StageExprSelfRewriter {
+  fn visit_expr_mut(&mut self, expr: &mut Expr) {
+    if let Expr::Path(path) = expr
+      && path.path.is_ident("self")
+    {
+      *expr = parse_quote!(plugin);
+      return;
+    }
+
+    visit_mut::visit_expr_mut(self, expr);
+  }
 }
 
 pub struct HookArgs {
@@ -179,8 +203,6 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
   let fn_ident = sig.ident.clone();
   sig.ident = syn::Ident::new("run", fn_ident.span());
 
-  let inner_ident = plugin_inner_ident(&name);
-
   let tracing_name = syn::LitStr::new(&format!("{}:{}", &name, &fn_ident), name.span());
   let plugin_name = syn::LitStr::new(&format!("{}", &name), name.span());
   let tracing_annotation = tracing.is_none_or(|bool_lit| bool_lit.value).then(|| {
@@ -192,9 +214,11 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
     }
   });
 
-  let stage_fn = stage.map(|stage| {
+  let stage_fn = stage.map(|mut stage| {
+    StageExprSelfRewriter.visit_expr_mut(&mut stage);
     quote! {
       fn stage(&self) -> i32 {
+        let plugin = &self.tap.plugin;
         #stage
       }
     }
@@ -207,21 +231,24 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
   };
 
   let call_real_fn = if is_async {
-    quote! { #name::#fn_ident(&#name::from_inner(&self.inner), #(#rest_args,)*).await }
+    quote! { #name::#fn_ident(&self.tap.plugin, #(#rest_args,)*).await }
   } else {
-    quote! { #name::#fn_ident(&#name::from_inner(&self.inner), #(#rest_args,)*) }
+    quote! { #name::#fn_ident(&self.tap.plugin, #(#rest_args,)*) }
   };
 
   let expanded = quote! {
     #[allow(non_camel_case_types)]
     #vis struct #fn_ident #impl_generics #where_clause {
-      #vis inner: ::std::sync::Arc<#inner_ident #ty_generics>,
+      tap: ::rspack_hook::__macro_helper::PluginHookTap<
+        #fn_ident #ty_generics,
+        #name #ty_generics,
+      >,
     }
 
     impl #impl_generics #fn_ident #ty_generics #where_clause {
       #vis fn new(plugin: &#name #ty_generics) -> Self {
-        #fn_ident {
-          inner: ::std::sync::Arc::clone(plugin.inner()),
+        Self {
+          tap: ::rspack_hook::__macro_helper::PluginHookTap::new(plugin),
         }
       }
     }
@@ -229,13 +256,6 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
     impl #impl_generics #name #ty_generics #where_clause {
       #[allow(clippy::ptr_arg)]
       #real_sig #block
-    }
-
-    impl #impl_generics ::std::ops::Deref for #fn_ident #ty_generics #where_clause {
-      type Target = #inner_ident #ty_generics;
-      fn deref(&self) -> &Self::Target {
-        &self.inner
-      }
     }
 
     #attr

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -16,7 +16,7 @@ use rspack_hook::plugin_hook;
 use rustc_hash::FxHashMap;
 
 use crate::{
-  JsPlugin, JsPluginInner,
+  JsPlugin,
   dependency::{
     AMDRequireContextDependencyTemplate, CommonJsExportRequireDependencyTemplate,
     CommonJsExportsDependencyTemplate, CommonJsFullRequireDependencyTemplate,

--- a/crates/rspack_plugin_sri/src/asset.rs
+++ b/crates/rspack_plugin_sri/src/asset.rs
@@ -14,7 +14,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tokio::sync::RwLock;
 
 use crate::{
-  IntegrityCallbackData, SubresourceIntegrityPlugin, SubresourceIntegrityPluginInner,
+  IntegrityCallbackData, SubresourceIntegrityPlugin,
   config::IntegrityHtmlPlugin,
   integrity::{SubresourceIntegrityHashFunction, compute_integrity},
   util::{PLACEHOLDER_PREFIX, PLACEHOLDER_REGEX, make_placeholder, use_any_hash},

--- a/crates/rspack_plugin_sri/src/html.rs
+++ b/crates/rspack_plugin_sri/src/html.rs
@@ -20,8 +20,7 @@ static HTTP_PROTOCOL_REGEX: Lazy<Regex> =
 
 use crate::{
   SRICompilationContext, SubresourceIntegrityHashFunction, SubresourceIntegrityPlugin,
-  SubresourceIntegrityPluginInner, config::ArcFs, integrity::compute_integrity,
-  util::normalize_path,
+  config::ArcFs, integrity::compute_integrity, util::normalize_path,
 };
 
 async fn handle_html_plugin_assets(

--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -12,7 +12,7 @@ use rspack_plugin_runtime::{
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  SubresourceIntegrityHashFunction, SubresourceIntegrityPlugin, SubresourceIntegrityPluginInner,
+  SubresourceIntegrityHashFunction, SubresourceIntegrityPlugin,
   util::{find_chunks, get_hash_variable, make_placeholder},
 };
 


### PR DESCRIPTION
## Summary

- Add a shared hidden `PluginHookTap` helper for plugin hook tap storage and cloning.
- Update `#[plugin]` / `#[plugin_hook]` expansion to reuse that helper, avoid per-run plugin handle reconstruction, and remove the generated tap `Deref` impl.
- Remove now-unused `*Inner` imports surfaced by the slimmer macro expansion.

## Why

`plugin_hook` is used broadly across built-in plugins. Keeping common tap storage and clone behavior in one helper reduces repeated macro-generated code while preserving the existing `foo::new(self)` registration shape.

## Validation

- `cargo test -p rspack_macros_test --test hook`
- `cargo test -p rspack_macros_test --test plugin`
- `cargo check -p rspack_plugin_banner -p rspack_plugin_sri -p rspack_plugin_lazy_compilation`

---
_by OpenAI Codex_