### PR TITLE
perf(hook): share define hook tap storage

### DIFF
--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -16,6 +16,8 @@ pub trait Interceptor<H: Hook> {
 pub trait Hook {
   type Tap;
 
+  fn tap_stage(tap: &Self::Tap) -> i32;
+
   fn used_stages(&self) -> FxHashSet<i32>;
 
   fn intercept(&mut self, interceptor: impl Interceptor<Self> + Send + Sync + 'static)
@@ -33,6 +35,64 @@ pub mod __macro_helper {
   pub use rspack_error::Result;
   pub use rustc_hash::FxHashSet;
   pub use tracing;
+
+  use crate::{Hook, Interceptor};
+
+  pub struct HookTaps<H: Hook> {
+    taps: Vec<H::Tap>,
+    interceptors: Vec<Box<dyn Interceptor<H> + Send + Sync>>,
+  }
+
+  impl<H: Hook> Default for HookTaps<H> {
+    fn default() -> Self {
+      Self {
+        taps: Default::default(),
+        interceptors: Default::default(),
+      }
+    }
+  }
+
+  impl<H: Hook> HookTaps<H> {
+    pub fn used_stages(&self) -> FxHashSet<i32> {
+      FxHashSet::from_iter(self.taps.iter().map(H::tap_stage))
+    }
+
+    pub fn intercept(&mut self, interceptor: impl Interceptor<H> + Send + Sync + 'static) {
+      self.interceptors.push(Box::new(interceptor));
+    }
+
+    pub fn tap(&mut self, tap: H::Tap) {
+      self.taps.push(tap);
+    }
+
+    pub fn is_empty(&self) -> bool {
+      self.taps.is_empty() && self.interceptors.is_empty()
+    }
+
+    pub async fn call_interceptors(&self, hook: &H) -> Result<Vec<H::Tap>> {
+      let mut additional_taps = Vec::new();
+      for interceptor in self.interceptors.iter() {
+        additional_taps.extend(interceptor.call(hook).await?);
+      }
+      Ok(additional_taps)
+    }
+
+    pub fn call_interceptors_blocking(&self, hook: &H) -> Result<Vec<H::Tap>> {
+      let mut additional_taps = Vec::new();
+      for interceptor in self.interceptors.iter() {
+        additional_taps.extend(interceptor.call_blocking(hook)?);
+      }
+      Ok(additional_taps)
+    }
+
+    pub fn sorted_taps<'a>(&'a self, additional_taps: &'a [H::Tap]) -> Vec<&'a H::Tap> {
+      let mut all_taps = Vec::with_capacity(self.taps.len() + additional_taps.len());
+      all_taps.extend(&self.taps);
+      all_taps.extend(additional_taps);
+      all_taps.sort_by_key(|hook| H::tap_stage(hook));
+      all_taps
+    }
+  }
 }
 
 pub use rspack_macros::{define_hook, plugin, plugin_hook};

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -142,19 +142,22 @@ impl DefineHookInput {
       }
 
       pub struct #hook_name {
-        taps: Vec<Box<dyn #trait_name + Send + Sync>>,
-        interceptors: Vec<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>,
+        taps: ::rspack_hook::__macro_helper::HookTaps<Self>,
       }
 
       impl ::rspack_hook::Hook for #hook_name {
         type Tap = Box<dyn #trait_name + Send + Sync>;
 
+        fn tap_stage(tap: &Self::Tap) -> i32 {
+          tap.stage()
+        }
+
         fn used_stages(&self) -> ::rspack_hook::__macro_helper::FxHashSet<i32> {
-          ::rspack_hook::__macro_helper::FxHashSet::from_iter(self.taps.iter().map(|h| h.stage()))
+          self.taps.used_stages()
         }
 
         fn intercept(&mut self, interceptor: impl ::rspack_hook::Interceptor<Self> + Send + Sync + 'static) {
-          self.interceptors.push(Box::new(interceptor));
+          self.taps.intercept(interceptor);
         }
       }
 
@@ -168,7 +171,6 @@ impl DefineHookInput {
         fn default() -> Self {
           Self {
             taps: Default::default(),
-            interceptors: Default::default(),
           }
         }
       }
@@ -177,11 +179,11 @@ impl DefineHookInput {
         pub #call_fn
 
         pub fn tap(&mut self, tap: impl #trait_name + Send + Sync + 'static) {
-          self.taps.push(Box::new(tap));
+          self.taps.tap(Box::new(tap));
         }
 
         pub fn is_empty(&self) -> bool {
-          self.taps.is_empty() && self.interceptors.is_empty()
+          self.taps.is_empty()
         }
       }
     })
@@ -229,19 +231,13 @@ impl ExecKind {
 
   fn additional_taps(&self) -> TokenStream {
     let call = if self.is_async() {
-      quote! { additional_taps.extend(interceptor.call(self).await?); }
+      quote! { self.taps.call_interceptors(self).await? }
     } else {
-      quote! { additional_taps.extend(interceptor.call_blocking(self)?); }
+      quote! { self.taps.call_interceptors_blocking(self)? }
     };
     quote! {
-      let mut additional_taps = std::vec::Vec::new();
-      for interceptor in self.interceptors.iter() {
-        #call
-      }
-      let mut all_taps = std::vec::Vec::with_capacity(self.taps.len() + additional_taps.len());
-      all_taps.extend(&self.taps);
-      all_taps.extend(&additional_taps);
-      all_taps.sort_by_key(|hook| hook.stage());
+      let additional_taps = #call;
+      let all_taps = self.taps.sorted_taps(&additional_taps);
     }
   }
 


### PR DESCRIPTION
## Summary

- Add a shared `HookTaps` helper for generated hook tap/interceptor storage.
- Update `define_hook!` output to delegate stage collection, interceptor calls, tap registration, and tap sorting to the shared helper.
- Keep hook call signatures unchanged so generated hook behavior remains the same while reducing repeated generated boilerplate.

## Validation

- `cargo check -p rspack_hook -p rspack_macros`
- `cargo check -p rspack_core`
- `cargo check -p rspack_binding_api`
- `cargo test -p rspack_macros_test`
- `cargo fmt --all`

---
_by OpenAI Codex_