### PR TITLE
fix(ci): build wasm in release debug so the wasm binding gets published

### DIFF
--- a/.github/workflows/reusable-build-all.yml
+++ b/.github/workflows/reusable-build-all.yml
@@ -47,10 +47,18 @@ jobs:
             runner: ${{ '"macos-latest"' }}
           - target: aarch64-apple-darwin
             runner: ${{ '"macos-latest"' }}
+          - target: wasm32-wasip1-threads
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            profile: release
+          - target: wasm32-wasip1-threads
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            binding_postfix: '-browser'
+            profile: release
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ inputs.ref }}
       target: ${{ matrix.array.target }}
       runner: ${{ matrix.array.runner }}
-      profile: ${{ inputs.profile }}
+      binding_postfix: ${{ matrix.array.binding_postfix }}
+      profile: ${{ matrix.array.profile || inputs.profile }}
       test: ${{ inputs.test }}


### PR DESCRIPTION
## Why

The **Release Debug** workflow never published the wasm binding under the debug scope (`@rspack-debug/binding-wasm32-wasi`).

Root cause: `reusable-build-all.yml` (used by Release Debug) has no wasm target in its build matrix, unlike Release Full / Release Canary. So:

1. No `bindings-wasm32-wasip1-threads` artifact is produced.
2. `scripts/build-npm.cjs` can't find `rspack.wasm32-wasi.wasm` → marks `@rspack/binding-wasm32-wasi` as `private: true`.
3. `x version debug` skips private packages, `x publish` skips them too → the package is never released.

## What

Mirror the Release Canary matrix: add the wasi and browser wasm variants as two `profile: release` jobs (and pass `binding_postfix` / per-entry `profile` through to `reusable-build.yml`).

Like canary, the published wasm always uses the optimized release build regardless of the surrounding profile — a debug-profile wasm build would be unoptimized and huge. The `-browser` artifact is already consumed by the browser package's `rslib.browser.config.ts`, so `@rspack-debug/browser` keeps its wasm with no further change.

## Before / After

| | Before | After |
|---|---|---|
| `@rspack-debug/binding-wasm32-wasi` | not published | published |
| `@rspack-debug/browser` wasm | missing | bundled |
