### PR TITLE
docs: update module variable docs for import.meta

### DIFF
--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -452,17 +452,15 @@ componentsContext.keys().forEach((fileName) => {
 
 The ESM equivalent of [`module.hot`](#modulehot). `import.meta.webpackHot` can be used in strict ESM modules (module type `javascript/esm`), while `module.hot` cannot.
 
-## Runtime
+### import.meta.rspackHash
 
-### \_\_webpack_hash\_\_
-
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
 
 It provides access to the hash of the compilation.
 
 <Columns>
 ```js title=Source
-__webpack_hash__
+import.meta.rspackHash;
 ```
 
 ```js title=Compiled
@@ -475,6 +473,157 @@ __webpack_require__.h = function () {
 ```
 
 </Columns>
+
+### import.meta.rspackPublicPath
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+Equals the configuration option's [`output.publicPath`](/config/output#outputpublicpath).
+
+<Columns>
+```js title=Source
+import.meta.rspackPublicPath;
+```
+
+```js title=Compiled
+__webpack_require__.p;
+
+// output.publicPath !== "auto"
+__webpack_require__.p = 'output.publicPath';
+// output.publicPath === "auto"
+__webpack_require__.p = 'calculated from document/location';
+```
+
+</Columns>
+
+> See [Dynamically set publicPath](/guide/features/asset-base-path#dynamically-set-publicpath) for more information about the usage of `import.meta.rspackPublicPath`.
+
+### import.meta.rspackBaseUri
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+Get or change base URI at runtime.
+
+<Columns>
+```js title=Source
+import.meta.rspackBaseUri;
+```
+
+```js title=Compiled
+__webpack_require__.b;
+
+// chunk loading
+__webpack_require__.b = document.baseURI || self.location.href;
+```
+
+</Columns>
+
+### import.meta.rspackNonce
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+Rspack is capable of adding a nonce to all scripts that it loads. To activate this feature, set `import.meta.rspackNonce` in your entry script.
+
+<Columns>
+```js title=Source
+import.meta.rspackNonce = 'your_nonce_code';
+```
+
+```js title=Compiled
+__webpack_require__.nc = '2312312';
+
+// webpack/runtime/load_script
+if (__webpack_require__.nc) {
+  script.setAttribute('nonce', __webpack_require__.nc);
+}
+```
+
+</Columns>
+
+### import.meta.rspackShareScopes
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+This object is used as a shared scope in the remote container and is filled with the provided modules from a host.
+
+<Columns>
+```js title=Source
+import.meta.rspackShareScopes;
+```
+
+```js title=Compiled
+__webpack_require__.S;
+```
+
+</Columns>
+
+### import.meta.rspackInitSharing
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+This method is used to initialize modules of a shared scope in the host container.
+
+<Columns>
+```js title=Source
+import.meta.rspackInitSharing('default');
+```
+
+```js title=Compiled
+__webpack_require__.I('default');
+```
+
+</Columns>
+
+### import.meta.rspackVersion
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+Current Rspack version, default to version in `@rspack/core/package.json`, can be modified through `output.bundlerInfo.version`.
+
+<Columns>
+```js title=Source
+import.meta.rspackVersion;
+```
+
+```js title=Compiled
+__webpack_require__.rv();
+
+// webpack/runtime/rspack_version
+__webpack_require__.rv = () => '0.7.4';
+```
+
+</Columns>
+
+### import.meta.rspackUniqueId
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+The ID of the current bundler, the value is `bundler={bundler}@{version}`:
+
+- `bundler`: Default to `"rspack"` and can be modified through [output.bundlerInfo.bundler](/config/output#outputbundlerinfo).
+- `version`: Default to version in `@rspack/core/package.json` and can be modified through [output.bundlerInfo.version](/config/output#outputbundlerinfo).
+
+<Columns>
+```js title=Source
+import.meta.rspackUniqueId;
+```
+
+```js title=Compiled
+__webpack_require__.ruid;
+
+// webpack/runtime/rspack_unique_id
+__webpack_require__.ruid = 'bundler=rspack@0.7.4';
+```
+
+</Columns>
+
+## Runtime
+
+### \_\_webpack_hash\_\_
+
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
+
+The CommonJS equivalent of [`import.meta.rspackHash`](#importmetarspackhash).
 
 ### \_\_webpack_runtime_id\_\_
 
@@ -498,70 +647,21 @@ __webpack_require__.j = '909';
 
 ### \_\_webpack_public_path\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-Equals the configuration option's [`output.publicPath`](/config/output#outputpublicpath).
-
-<Columns>
-```js title=Source
-__webpack_public_path__
-```
-
-```js title=Compiled
-__webpack_require__.p;
-
-// output.publicPath !== "auto"
-__webpack_require__.p = 'output.publicPath';
-// output.publicPath === "auto"
-__webpack_require__.p = 'calculated from document/location';
-```
-
-</Columns>
-
-> See [Dynamically set publicPath](/guide/features/asset-base-path#dynamically-set-publicpath) for more information about the usage of `__webpack_public_path__`.
+The CommonJS equivalent of [`import.meta.rspackPublicPath`](#importmetarspackpublicpath).
 
 ### \_\_webpack_base_uri\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-Get or change base URI at runtime.
-
-<Columns>
-```js title=Source
-__webpack_base_uri__
-```
-
-```js title=Compiled
-__webpack_require__.b;
-
-// chunk loading
-__webpack_require__.b = document.baseURI || self.location.href;
-```
-
-</Columns>
+The CommonJS equivalent of [`import.meta.rspackBaseUri`](#importmetarspackbaseuri).
 
 ### \_\_webpack_nonce\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-Rspack is capable of adding a nonce to all scripts that it loads.
-To activate this feature, set a `__webpack_nonce__` variable and include it in your entry script.
-
-<Columns>
-```js title=Source
-__webpack_nonce__ = 'your_nonce_code';
-```
-
-```js title=Compiled
-__webpack_require__.nc = '2312312';
-
-// webpack/runtime/load_script
-if (__webpack_require__.nc) {
-  script.setAttribute('nonce', __webpack_require__.nc);
-}
-```
-
-</Columns>
+The CommonJS equivalent of [`import.meta.rspackNonce`](#importmetarspacknonce).
 
 ## Modules
 
@@ -798,7 +898,7 @@ const publicPaths = ['a', 'b', 'c'];
 __webpack_chunk_load__ = async (id) => {
   let error;
   for (const path of publicPaths) {
-    __webpack_public_path__ = path;
+    import.meta.rspackPublicPath = path;
     try {
       return await originalLoad(id);
     } catch (e) {
@@ -849,15 +949,15 @@ __webpack_get_script_filename__ = (chunkId) => {
 
 ### \_\_webpack_share_scopes\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-This object is used as a shared scope in the remote container and is filled with the provided modules from a host
+The CommonJS equivalent of [`import.meta.rspackShareScopes`](#importmetarspacksharescopes).
 
 ### \_\_webpack_init_sharing\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-This method is used to initialize modules of a shared scope in the host container.
+The CommonJS equivalent of [`import.meta.rspackInitSharing`](#importmetarspackinitsharing).
 
 ## System.js
 
@@ -871,43 +971,16 @@ Context from System.js when `output.library.type="system"`
 
 ### \_\_rspack_version\_\_
 
-<ApiMeta specific={['Rspack']} />
-Current Rspack version, default to version in `@rspack/core/package.json`, can
-be modified through output.bundlerInfo.version.
+<ApiMeta specific={['Rspack']} stability={Stability.Deprecated} />
 
-<Columns>
-```js title=Source
-__rspack_version__
-```
-
-```js title=Compiled
-__webpack_require__.rv;
-
-// webpack/runtime/rspack_version
-__webpack_require__.rv = '0.7.4';
-```
-
-</Columns>
+The CommonJS equivalent of [`import.meta.rspackVersion`](#importmetarspackversion).
 
 ### \_\_rspack_unique_id\_\_
 
-<ApiMeta addedVersion="1.0.0" specific={['Rspack']} />
+<ApiMeta
+  addedVersion="1.0.0"
+  specific={['Rspack']}
+  stability={Stability.Deprecated}
+/>
 
-The ID of the current bundler, the value is `bundler={bundler}@{version}`:
-
-- `bundler`: Default to `"rspack"` and can be modified through [output.bundlerInfo.bundler](/config/output#outputbundlerinfo).
-- `version`: Default to version in `@rspack/core/package.json` and can be modified through [output.bundlerInfo.version](/config/output#outputbundlerinfo).
-
-<Columns>
-```js title=Source
-__rspack_unique_id__
-```
-
-```js title=Compiled
-__webpack_require__.ruid;
-
-// webpack/runtime/rspack_unique_id
-__webpack_require__.ruid = 'bundler=rspack@0.7.4';
-```
-
-</Columns>
+The CommonJS equivalent of [`import.meta.rspackUniqueId`](#importmetarspackuniqueid).

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -72,10 +72,10 @@ Used to inject the currently used Rspack information into the generated asset:
 - `bundler`: Used to specify the name of the packaging tool, defaults to `rspack`.
 - `force`: Whether to force the injection of Rspack information, which will be added to chunk as a runtime module, and defaults to `false`. An array can be used to select the items to be forced injected.
 
-By default, injection occurs when either `__rspack_version__` or `__rspack_unique_id__` is detected in the code, and only the corresponding runtime module is injected. Set `force` to `true` to always inject both:
+By default, injection occurs when either `import.meta.rspackVersion` or `import.meta.rspackUniqueId` is detected in the code, and only the corresponding runtime module is injected. Set `force` to `true` to always inject both:
 
-- [`__rspack_version__`](/api/runtime-api/module-variables#__rspack_version__): Inject version information.
-- [`__rspack_unique_id__`](/api/runtime-api/module-variables#__rspack_unique_id__): Inject the unique ID of the bundler.
+- [`import.meta.rspackVersion`](/api/runtime-api/module-variables#importmetarspackversion): Inject version information.
+- [`import.meta.rspackUniqueId`](/api/runtime-api/module-variables#importmetarspackuniqueid): Inject the unique ID of the bundler.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/features/asset-base-path.mdx
+++ b/website/docs/en/guide/features/asset-base-path.mdx
@@ -73,14 +73,14 @@ With this configuration:
 
 ## Dynamically set publicPath
 
-You can set `publicPath` dynamically using `__webpack_public_path__` in your JavaScript code.
+You can set `publicPath` dynamically using [`import.meta.rspackPublicPath`](/api/runtime-api/module-variables#importmetarspackpublicpath) in your JavaScript code.
 
-The `__webpack_public_path__` will override the `output.publicPath` in the Rspack config, but it will only take effect for dynamically loaded assets, not for assets loaded via `<script src="...">`.
+The `import.meta.rspackPublicPath` will override the `output.publicPath` in the Rspack config, but it will only take effect for dynamically loaded assets, not for assets loaded via `<script src="...">`.
 
 First create a `publicPath.js`:
 
 ```js title="publicPath.js"
-__webpack_public_path__ =
+import.meta.rspackPublicPath =
   location.hostname === 'foo.com'
     ? 'https://cdn1.com/assets/'
     : 'https://cdn2.com/assets/';

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -452,17 +452,15 @@ componentsContext.keys().forEach((fileName) => {
 
 是 [`module.hot`](#modulehot) 的 ESM 等价写法，`import.meta.webpackHot` 可以在严格 ESM 模块（模块类型为 `javascript/esm`）中使用，而 `module.hot` 不能。
 
-## Runtime
+### import.meta.rspackHash
 
-### \_\_webpack_hash\_\_
-
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
 
 提供对编译过程中（compilation）的 hash 信息的访问。
 
 <Columns>
 ```js title=源码
-__webpack_hash__
+import.meta.rspackHash;
 ```
 
 ```js title=产物
@@ -475,6 +473,158 @@ __webpack_require__.h = function () {
 ```
 
 </Columns>
+
+### import.meta.rspackPublicPath
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+等于配置选项的 [output.publicPath](/config/output#outputpublicpath)。
+
+<Columns>
+```js title=源码
+import.meta.rspackPublicPath;
+```
+
+```js title=产物
+__webpack_require__.p;
+
+// output.publicPath !== "auto"
+__webpack_require__.p = 'output.publicPath';
+// output.publicPath === "auto"，
+__webpack_require__.p = '由 document/location 计算得来';
+```
+
+</Columns>
+
+> 查看 [动态设置 publicPath](/guide/features/asset-base-path#动态设置-publicpath) 了解更多关于 `import.meta.rspackPublicPath` 的用法。
+
+### import.meta.rspackBaseUri
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+运行时获取或修改 Base URI。
+
+<Columns>
+```js title=源码
+import.meta.rspackBaseUri;
+```
+
+```js title=产物
+__webpack_require__.b;
+
+// chunk loading
+__webpack_require__.b = document.baseURI || self.location.href;
+```
+
+</Columns>
+
+### import.meta.rspackNonce
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+Rspack 能够为其加载的所有脚本添加 nonce，即一次性随机数。在入口文件中设置 `import.meta.rspackNonce` 变量以激活此功能。
+
+<Columns>
+```js title=源码
+import.meta.rspackNonce = 'your_nonce_code';
+```
+
+```js title=产物
+__webpack_require__.nc = '2312312';
+
+// webpack/runtime/load_script
+if (__webpack_require__.nc) {
+  script.setAttribute('nonce', __webpack_require__.nc);
+}
+```
+
+</Columns>
+
+### import.meta.rspackShareScopes
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+用于存储 module federation 中的一个远程容器共享作用域 (shared scope) 相关信息。
+
+<Columns>
+```js title=源码
+import.meta.rspackShareScopes;
+```
+
+```js title=产物
+__webpack_require__.S;
+```
+
+</Columns>
+
+### import.meta.rspackInitSharing
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+用于初始化 module federation 中的一个远程容器共享作用域 (shared scope) 并加载相关模块。
+
+<Columns>
+```js title=源码
+import.meta.rspackInitSharing('default');
+```
+
+```js title=产物
+__webpack_require__.I('default');
+```
+
+</Columns>
+
+### import.meta.rspackVersion
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+当前使用的 Rspack 版本，默认从 `@rspack/core/package.json` 读取。可以通过
+`output.bundlerInfo.version` 修改。
+
+<Columns>
+```js title=源码
+import.meta.rspackVersion;
+```
+
+```js title=产物
+__webpack_require__.rv();
+
+// webpack/runtime/rspack_version
+__webpack_require__.rv = () => '0.7.4';
+```
+
+</Columns>
+
+### import.meta.rspackUniqueId
+
+<ApiMeta specific={['Rspack']} addedVersion="2.1.2" />
+
+当前打包工具的 ID，值为 `bundler={bundler}@{version}`。其中：
+
+- `bundler`：默认为 `"rspack"` 可以通过 [output.bundlerInfo.bundler](/config/output#outputbundlerinfo) 修改。
+- `version`：默认从 `@rspack/core/package.json` 读取，可以通过 [output.bundlerInfo.version](/config/output#outputbundlerinfo) 修改。
+
+<Columns>
+```js title=源码
+import.meta.rspackUniqueId;
+```
+
+```js title=产物
+__webpack_require__.ruid;
+
+// webpack/runtime/rspack_unique_id
+__webpack_require__.ruid = 'bundler=rspack@0.7.4';
+```
+
+</Columns>
+
+## Runtime
+
+### \_\_webpack_hash\_\_
+
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
+
+是 [`import.meta.rspackHash`](#importmetarspackhash) 在 CommonJS 下的等价写法。
 
 ### \_\_webpack_runtime_id\_\_
 
@@ -498,67 +648,21 @@ __webpack_require__.j = '909';
 
 ### \_\_webpack_public_path\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
-等于配置选项的 [output.publicPath](/config/output#outputpublicpath)。
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-<Columns>
-```js title=源码
-__webpack_public_path__
-```
-
-```js title=产物
-__webpack_require__.p;
-
-// output.publicPath !== "auto"
-__webpack_require__.p = 'output.publicPath';
-// output.publicPath === "auto"，
-__webpack_require__.p = '由 document/location 计算得来';
-```
-
-</Columns>
-
-> 查看 [动态设置 publicPath](/guide/features/asset-base-path#动态设置-publicpath) 了解更多关于 `__webpack_public_path__` 的用法。
+是 [`import.meta.rspackPublicPath`](#importmetarspackpublicpath) 在 CommonJS 下的等价写法。
 
 ### \_\_webpack_base_uri\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
-运行时获取或修改 Base URI。
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-<Columns>
-```js title=源码
-__webpack_base_uri__
-```
-
-```js title=产物
-__webpack_require__.b;
-
-// chunk loading
-__webpack_require__.b = document.baseURI || self.location.href;
-```
-
-</Columns>
+是 [`import.meta.rspackBaseUri`](#importmetarspackbaseuri) 在 CommonJS 下的等价写法。
 
 ### \_\_webpack_nonce\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-Rspack 能够为其加载的所有脚本添加 nonce，即一次性随机数。在入口文件中设置 `__webpack_nonce__` 变量以激活此功能。
-
-<Columns>
-```js title=源码
-__webpack_nonce__ = 'your_nonce_code';
-```
-
-```js title=产物
-__webpack_require__.nc = '2312312';
-
-// webpack/runtime/load_script
-if (__webpack_require__.nc) {
-  script.setAttribute('nonce', __webpack_require__.nc);
-}
-```
-
-</Columns>
+是 [`import.meta.rspackNonce`](#importmetarspacknonce) 在 CommonJS 下的等价写法。
 
 ## Modules
 
@@ -762,6 +866,8 @@ __webpack_require__.cn = 'main';
 
 ### \_\_webpack_chunk_load\_\_
 
+<ApiMeta specific={['Rspack', 'Webpack']} />
+
 内部 chunk 载入函数，有一个输入参数：
 
 - `chunkId`: 需要载入的 chunk id
@@ -790,7 +896,7 @@ const publicPaths = ['a', 'b', 'c'];
 __webpack_chunk_load__ = async (id) => {
   let error;
   for (const path of publicPaths) {
-    __webpack_public_path__ = path;
+    import.meta.rspackPublicPath = path;
     try {
       return await originalLoad(id);
     } catch (e) {
@@ -841,15 +947,15 @@ __webpack_get_script_filename__ = (chunkId) => {
 
 ### \_\_webpack_share_scopes\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-用于存储 module federation 中的一个远程容器共享作用域 (shared scope) 相关信息。
+是 [`import.meta.rspackShareScopes`](#importmetarspacksharescopes) 在 CommonJS 下的等价写法。
 
 ### \_\_webpack_init_sharing\_\_
 
-<ApiMeta specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} stability={Stability.Deprecated} />
 
-用于初始化 module federation 中的一个远程容器共享作用域 (shared scope) 并加载相关模块。
+是 [`import.meta.rspackInitSharing`](#importmetarspackinitsharing) 在 CommonJS 下的等价写法。
 
 ## System.js
 
@@ -863,43 +969,16 @@ __webpack_get_script_filename__ = (chunkId) => {
 
 ### \_\_rspack_version\_\_
 
-<ApiMeta specific={['Rspack']} />
-当前使用的 Rspack 版本，默认从 `@rspack/core/package.json` 读取。可以通过
-`output.bundlerInfo.version` 修改。
+<ApiMeta specific={['Rspack']} stability={Stability.Deprecated} />
 
-<Columns>
-```js title=源码
-__rspack_version__
-```
-
-```js title=产物
-__webpack_require__.rv;
-
-// webpack/runtime/rspack_version
-__webpack_require__.rv = '0.7.4';
-```
-
-</Columns>
+是 [`import.meta.rspackVersion`](#importmetarspackversion) 在 CommonJS 下的等价写法。
 
 ### \_\_rspack_unique_id\_\_
 
-<ApiMeta addedVersion="1.0.0" specific={['Rspack']} />
+<ApiMeta
+  addedVersion="1.0.0"
+  specific={['Rspack']}
+  stability={Stability.Deprecated}
+/>
 
-当前打包工具的 ID，值为 `{bundler}@{version}`。其中：
-
-- `bundler`：默认为 `"rspack"` 可以通过 [output.bundlerInfo.bundler](/config/output#outputbundlerinfo) 修改。
-- `version`：默认从 `@rspack/core/package.json` 读取，可以通过 [output.bundlerInfo.version](/config/output#outputbundlerinfo) 修改。
-
-<Columns>
-```js title=源码
-__rspack_unique_id__
-```
-
-```js title=产物
-__webpack_require__.ruid;
-
-// webpack/runtime/rspack_unique_id
-__webpack_require__.ruid = 'bundler=rspack@0.7.4';
-```
-
-</Columns>
+是 [`import.meta.rspackUniqueId`](#importmetarspackuniqueid) 在 CommonJS 下的等价写法。

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -72,10 +72,10 @@ export default {
 - `bundler`：用于指定打包工具名称，默认为 `rspack`
 - `force`：是否强制注入 Rspack 信息，会以运行时模块的形式加入到产物中，默认为 `false`，可通过数组选择强制注入的项目。
 
-默认情况下，在检测到代码中使用了 `__rspack_version__` 或 `__rspack_unique_id__` 时，会按需注入对应信息。可将 `force` 设定为 `true` 始终注入：
+默认情况下，在检测到代码中使用了 `import.meta.rspackVersion` 或 `import.meta.rspackUniqueId` 时，会按需注入对应信息。可将 `force` 设定为 `true` 始终注入：
 
-- [`__rspack_version__`](/api/runtime-api/module-variables#__rspack_version__)：注入版本信息
-- [`__rspack_unique_id__`](/api/runtime-api/module-variables#__rspack_unique_id__)：注入打包工具唯一ID
+- [`import.meta.rspackVersion`](/api/runtime-api/module-variables#importmetarspackversion)：注入版本信息
+- [`import.meta.rspackUniqueId`](/api/runtime-api/module-variables#importmetarspackuniqueid)：注入打包工具唯一 ID
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/features/asset-base-path.mdx
+++ b/website/docs/zh/guide/features/asset-base-path.mdx
@@ -73,14 +73,14 @@ export default {
 
 ## 动态设置 publicPath
 
-在 JavaScript 代码中，你可以通过 Rspack 的 [`__webpack_public_path__`](/api/runtime-api/module-variables#__webpack_public_path__) 来动态设置 `publicPath`。
+在 JavaScript 代码中，你可以通过 Rspack 的 [`import.meta.rspackPublicPath`](/api/runtime-api/module-variables#importmetarspackpublicpath) 来动态设置 `publicPath`。
 
-`__webpack_public_path__` 会覆盖 Rspack 配置中的 `output.publicPath`，但它只能对异步加载的资源生效，不会对 HTML 中通过 `<script src="...">` 加载的资源生效。
+`import.meta.rspackPublicPath` 会覆盖 Rspack 配置中的 `output.publicPath`，但它只能对异步加载的资源生效，不会对 HTML 中通过 `<script src="...">` 加载的资源生效。
 
 首先创建一个 `publicPath.js`：
 
 ```js title="publicPath.js"
-__webpack_public_path__ =
+import.meta.rspackPublicPath =
   location.hostname === 'foo.com'
     ? 'https://cdn1.com/assets/'
     : 'https://cdn2.com/assets/';


### PR DESCRIPTION
## Summary

Update the runtime module variables docs in both English and Chinese to document the new `import.meta.rspack*` APIs under the `import.meta (ESM)` section, and keep the existing CommonJS-style module variable entries as compatibility references.

## Added `import.meta` APIs

| `import.meta` API | Existing equivalent |
| --- | --- |
| `import.meta.rspackHash` | `__webpack_hash__` |
| `import.meta.rspackPublicPath` | `__webpack_public_path__` |
| `import.meta.rspackBaseUri` | `__webpack_base_uri__` |
| `import.meta.rspackNonce` | `__webpack_nonce__` |
| `import.meta.rspackShareScopes` | `__webpack_share_scopes__` |
| `import.meta.rspackInitSharing` | `__webpack_init_sharing__` |
| `import.meta.rspackVersion` | `__rspack_version__` |
| `import.meta.rspackUniqueId` | `__rspack_unique_id__` |

## Details

- Add the new `import.meta.rspack*` entries with `addedVersion="2.1.2"`.
- Update examples to prefer the `import.meta.rspack*` forms.
- Keep the existing runtime variable headings, and mark only the legacy variables listed above as deprecated CommonJS equivalents.
- Update related docs links and examples in `output.bundlerInfo` and asset base path docs.