### PR TITLE
perf: deduplicate runtime module macro glue

### DIFF
--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -6,15 +6,14 @@ use napi_derive::napi;
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
   BindingCell, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilerId,
-  FactoryMeta, LibIdentOptions, Module as _, ModuleIdentifier, RuntimeModuleStage, SourceType,
-  internal,
+  FactoryMeta, LibIdentOptions, Module as _, ModuleIdentifier, RuntimeModuleCommon,
+  RuntimeModuleStage, SourceType, internal,
 };
 use rspack_napi::{
   OneShotInstanceRef, WeakRef, napi::bindgen_prelude::*, string::JsStringExt,
   threadsafe_function::ThreadsafeFunction,
 };
 use rspack_plugin_runtime::RuntimeModuleFromJs;
-use rspack_util::source_map::SourceMapKind;
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -790,8 +789,10 @@ pub struct JsAddingRuntimeModule {
 impl From<JsAddingRuntimeModule> for RuntimeModuleFromJs {
   fn from(value: JsAddingRuntimeModule) -> Self {
     Self {
-      chunk: None,
-      id: Identifier::from(value.name),
+      common: RuntimeModuleCommon {
+        id: Identifier::from(value.name),
+        ..Default::default()
+      },
       full_hash: value.full_hash,
       dependent_hash: value.dependent_hash,
       isolate: value.isolate,
@@ -800,9 +801,6 @@ impl From<JsAddingRuntimeModule> for RuntimeModuleFromJs {
         let generator = value.generator.clone();
         Box::pin(async move { generator.call_with_sync(()).await })
       }),
-      source_map_kind: SourceMapKind::empty(),
-      custom_source: None,
-      cached_generated_code: Default::default(),
     }
   }
 }

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -1,10 +1,18 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use rspack_cacheable::cacheable;
 use rspack_collections::Identifier;
+use rspack_error::Result;
+use rspack_hash::RspackHashDigest;
+use rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source, SourceExt};
+use rspack_util::{ext::DynHash, source_map::SourceMapKind};
+use tokio::sync::OnceCell;
 
-use crate::{ChunkUkey, Compilation, Module, RuntimeCodeTemplate, RuntimeGlobals};
+use crate::{
+  ChunkUkey, CodeGenerationResult, Compilation, Module, ModuleCodeGenerationContext,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeSpec, RuntimeTemplate, SourceType,
+};
 
 pub struct RuntimeModuleGenerateContext<'a> {
   pub compilation: &'a Compilation,
@@ -23,6 +31,146 @@ impl RuntimeModuleRuntimeRequirements {
   pub fn lexical_requirements(&self) -> RuntimeGlobals {
     self.dependencies | self.weak | self.write | self.force_context
   }
+}
+
+#[cacheable]
+#[derive(Debug, Default, Clone)]
+pub struct RuntimeModuleCommon {
+  pub id: Identifier,
+  pub chunk: Option<ChunkUkey>,
+  pub source_map_kind: SourceMapKind,
+  pub custom_source: Option<String>,
+  #[cacheable(with=rspack_cacheable::with::Skip)]
+  pub cached_generated_code: Arc<OnceCell<BoxSource>>,
+}
+
+impl RuntimeModuleCommon {
+  pub fn with_default(runtime_template: &RuntimeTemplate, type_name: &str) -> Self {
+    Self {
+      source_map_kind: SourceMapKind::empty(),
+      custom_source: None,
+      cached_generated_code: Default::default(),
+      chunk: None,
+      id: runtime_template.create_runtime_module_identifier(type_name),
+    }
+  }
+
+  pub fn with_name(runtime_template: &RuntimeTemplate, name: &str) -> Self {
+    Self {
+      source_map_kind: SourceMapKind::empty(),
+      custom_source: None,
+      cached_generated_code: Default::default(),
+      chunk: None,
+      id: runtime_template.create_custom_runtime_module_identifier(name),
+    }
+  }
+
+  pub fn attach(&mut self, chunk: ChunkUkey) {
+    self.chunk = Some(chunk);
+  }
+
+  pub fn name(&self) -> Identifier {
+    self.id
+  }
+
+  pub fn id(&self) -> &Identifier {
+    &self.id
+  }
+
+  pub fn chunk(&self) -> Option<ChunkUkey> {
+    self.chunk
+  }
+
+  pub fn set_custom_source(&mut self, source: String) {
+    self.custom_source = Some(source);
+  }
+
+  pub fn get_custom_source(&self) -> Option<String> {
+    self.custom_source.clone()
+  }
+
+  pub fn get_source_map_kind(&self) -> &SourceMapKind {
+    &self.source_map_kind
+  }
+
+  pub fn set_source_map_kind(&mut self, source_map_kind: SourceMapKind) {
+    self.source_map_kind = source_map_kind;
+  }
+
+  pub fn size(&self) -> f64 {
+    self
+      .cached_generated_code
+      .get()
+      .map_or(0f64, |cached_generated_code| {
+        cached_generated_code.size() as f64
+      })
+  }
+}
+
+pub async fn runtime_module_get_generated_code(
+  module: &dyn RuntimeModule,
+  common: &RuntimeModuleCommon,
+  compilation: &Compilation,
+) -> Result<Arc<dyn Source>> {
+  let result: Result<&BoxSource> = common
+    .cached_generated_code
+    .get_or_try_init(|| async {
+      let runtime_template = compilation.runtime_template.create_runtime_code_template();
+      let context = RuntimeModuleGenerateContext {
+        compilation,
+        runtime_template: &runtime_template,
+      };
+      let source_str = module.generate_with_custom(&context).await?;
+      let source_map_kind = module.get_source_map_kind();
+      Ok(if source_map_kind.enabled() {
+        OriginalSource::new(source_str, module.identifier().as_str()).boxed()
+      } else {
+        RawStringSource::from(source_str).boxed()
+      })
+    })
+    .await;
+  let source = result?.clone();
+  Ok(source)
+}
+
+pub async fn runtime_module_code_generation(
+  module: &dyn RuntimeModule,
+  common: &RuntimeModuleCommon,
+  ctx: &mut ModuleCodeGenerationContext<'_>,
+) -> Result<CodeGenerationResult> {
+  let mut result = CodeGenerationResult::default();
+  let source = runtime_module_get_generated_code(module, common, ctx.compilation).await?;
+  result.add(SourceType::Runtime, source);
+  Ok(result)
+}
+
+pub async fn runtime_module_get_runtime_hash(
+  module: &dyn RuntimeModule,
+  common: &RuntimeModuleCommon,
+  compilation: &Compilation,
+  _runtime: Option<&RuntimeSpec>,
+) -> Result<RspackHashDigest> {
+  let mut hasher = rspack_hash::RspackHash::from(&compilation.options.output);
+  module.name().dyn_hash(&mut hasher);
+  module.stage().dyn_hash(&mut hasher);
+  if module.full_hash() || module.dependent_hash() {
+    use std::hash::Hash;
+
+    let runtime_template = compilation.runtime_template.create_runtime_code_template();
+    let context = RuntimeModuleGenerateContext {
+      compilation,
+      runtime_template: &runtime_template,
+    };
+    module
+      .generate_with_custom(&context)
+      .await?
+      .hash(&mut hasher);
+  } else {
+    runtime_module_get_generated_code(module, common, compilation)
+      .await?
+      .dyn_hash(&mut hasher);
+  }
+  Ok(hasher.digest(&compilation.options.output.hash_digest))
 }
 
 #[async_trait]

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -14,33 +14,8 @@ pub fn impl_runtime_module(
   if let syn::Fields::Named(ref mut fields) = input.fields {
     fields.named.push(
       syn::Field::parse_named
-        .parse2(quote! { pub id: ::rspack_collections::Identifier })
-        .expect("Failed to parse new field for id"),
-    );
-    fields.named.push(
-      syn::Field::parse_named
-        .parse2(quote! { pub chunk: Option<::rspack_core::ChunkUkey> })
-        .expect("Failed to parse new field for chunk"),
-    );
-    fields.named.push(
-      syn::Field::parse_named
-        .parse2(quote! { pub source_map_kind: ::rspack_util::source_map::SourceMapKind })
-        .expect("Failed to parse new field for source_map_kind"),
-    );
-    fields.named.push(
-      syn::Field::parse_named
-        .parse2(quote! {
-            pub custom_source: Option<String>
-        })
-        .expect("Failed to parse new field for custom_source"),
-    );
-    fields.named.push(
-      syn::Field::parse_named
-            .parse2(quote! {
-                #[cacheable(with=rspack_cacheable::with::Skip)]
-                pub cached_generated_code: std::sync::Arc<::tokio::sync::OnceCell<::rspack_core::rspack_sources::BoxSource>>
-            })
-        .expect("Failed to parse new field for cached_generated_code"),
+        .parse2(quote! { pub common: ::rspack_core::RuntimeModuleCommon })
+        .expect("Failed to parse new field for common"),
     );
   }
 
@@ -53,11 +28,7 @@ pub fn impl_runtime_module(
     #[allow(clippy::too_many_arguments)]
     fn with_default(runtime_template: &::rspack_core::RuntimeTemplate, #(#field_names: #field_tys,)*) -> Self {
       Self {
-        source_map_kind: ::rspack_util::source_map::SourceMapKind::empty(),
-        custom_source: None,
-        cached_generated_code: Default::default(),
-        chunk: None,
-        id: runtime_template.create_runtime_module_identifier(stringify!(#name)),
+        common: ::rspack_core::RuntimeModuleCommon::with_default(runtime_template, stringify!(#name)),
         #(#field_names,)*
       }
     }
@@ -67,11 +38,7 @@ pub fn impl_runtime_module(
     #[allow(clippy::too_many_arguments)]
     fn with_name(runtime_template: &::rspack_core::RuntimeTemplate, name: &str, #(#field_names: #field_tys,)*) -> Self {
       Self {
-        source_map_kind: ::rspack_util::source_map::SourceMapKind::empty(),
-        custom_source: None,
-        cached_generated_code: Default::default(),
-        chunk: None,
-        id: runtime_template.create_custom_runtime_module_identifier(name),
+        common: ::rspack_core::RuntimeModuleCommon::with_name(runtime_template, name),
         #(#field_names,)*
       }
     }
@@ -85,43 +52,28 @@ pub fn impl_runtime_module(
 
       #with_name
 
+      pub fn id(&self) -> &::rspack_collections::Identifier {
+        self.common.id()
+      }
+
+      pub fn chunk(&self) -> Option<::rspack_core::ChunkUkey> {
+        self.common.chunk()
+      }
+
       async fn get_generated_code(
         &self,
         compilation: &::rspack_core::Compilation,
       ) -> ::rspack_error::Result<std::sync::Arc<dyn ::rspack_core::rspack_sources::Source>> {
-        let result: ::rspack_error::Result<&::rspack_core::rspack_sources::BoxSource> = self.cached_generated_code.get_or_try_init(|| async {
-          use ::rspack_util::source_map::ModuleSourceMapConfig;
-          use ::rspack_collections::Identifiable;
-          use ::rspack_core::rspack_sources::SourceExt;
-
-          let runtime_template = compilation.runtime_template.create_runtime_code_template();
-          let context = ::rspack_core::RuntimeModuleGenerateContext {
-            compilation,
-            runtime_template: &runtime_template,
-          };
-          let source_str = self.generate_with_custom(&context).await?;
-          let source_map_kind = self.get_source_map_kind();
-          Ok(if source_map_kind.enabled() {
-            ::rspack_core::rspack_sources::OriginalSource::new(
-              source_str,
-              self.identifier().as_str(),
-            )
-            .boxed()
-          } else {
-            ::rspack_core::rspack_sources::RawStringSource::from(source_str).boxed()
-          })
-        }).await;
-        let source = result?.clone();
-        Ok(source)
+        ::rspack_core::runtime_module_get_generated_code(self, &self.common, compilation).await
       }
     }
 
     impl #impl_generics ::rspack_core::CustomSourceRuntimeModule for #name #ty_generics #where_clause {
       fn set_custom_source(&mut self, source: String) -> () {
-        self.custom_source = Some(source);
+        self.common.set_custom_source(source);
       }
       fn get_custom_source(&self) -> Option<String> {
-        self.custom_source.clone()
+        self.common.get_custom_source()
       }
       fn get_constructor_name(&self) -> String {
         String::from(stringify!(#name))
@@ -130,13 +82,13 @@ pub fn impl_runtime_module(
 
     impl #impl_generics ::rspack_core::AttachableRuntimeModule for #name #ty_generics #where_clause {
       fn attach(&mut self, chunk: ::rspack_core::ChunkUkey) -> () {
-        self.chunk = Some(chunk);
+        self.common.attach(chunk);
       }
     }
 
     impl #impl_generics ::rspack_core::NamedRuntimeModule for #name #ty_generics #where_clause {
       fn name(&self) -> ::rspack_collections::Identifier {
-        self.id
+        *self.id()
       }
     }
 
@@ -185,10 +137,7 @@ pub fn impl_runtime_module(
         _source_type: Option<&::rspack_core::SourceType>,
         _compilation: Option<&::rspack_core::Compilation>,
       ) -> f64 {
-        self
-          .cached_generated_code
-          .get()
-          .map_or(0f64, |cached_generated_code| cached_generated_code.size() as f64)
+        self.common.size()
       }
 
       fn readable_identifier(&self, _context: &::rspack_core::Context) -> std::borrow::Cow<str> {
@@ -226,10 +175,7 @@ pub fn impl_runtime_module(
         &self,
         code_generation_context: &mut ::rspack_core::ModuleCodeGenerationContext,
       ) -> rspack_error::Result<::rspack_core::CodeGenerationResult> {
-        let mut result = ::rspack_core::CodeGenerationResult::default();
-        let source = self.get_generated_code(code_generation_context.compilation).await?;
-        result.add(::rspack_core::SourceType::Runtime, source);
-        Ok(result)
+        ::rspack_core::runtime_module_code_generation(self, &self.common, code_generation_context).await
       }
 
       async fn get_runtime_hash(
@@ -237,23 +183,7 @@ pub fn impl_runtime_module(
         compilation: &::rspack_core::Compilation,
         runtime: Option<&::rspack_core::RuntimeSpec>,
       ) -> rspack_error::Result<::rspack_hash::RspackHashDigest> {
-        use rspack_util::ext::DynHash;
-        use rspack_core::NamedRuntimeModule;
-        let mut hasher = rspack_hash::RspackHash::from(&compilation.options.output);
-        self.name().dyn_hash(&mut hasher);
-        self.stage().dyn_hash(&mut hasher);
-        if self.full_hash() || self.dependent_hash() {
-          use std::hash::Hash;
-          let runtime_template = compilation.runtime_template.create_runtime_code_template();
-          let context = ::rspack_core::RuntimeModuleGenerateContext {
-            compilation,
-            runtime_template: &runtime_template,
-          };
-          self.generate_with_custom(&context).await?.hash(&mut hasher);
-        } else {
-          self.get_generated_code(compilation).await?.dyn_hash(&mut hasher);
-        }
-        Ok(hasher.digest(&compilation.options.output.hash_digest))
+        ::rspack_core::runtime_module_get_runtime_hash(self, &self.common, compilation, runtime).await
       }
 
       async fn build(
@@ -284,11 +214,11 @@ pub fn impl_runtime_module(
 
     impl #impl_generics ::rspack_util::source_map::ModuleSourceMapConfig for #name #ty_generics #where_clause {
       fn get_source_map_kind(&self) -> &::rspack_util::source_map::SourceMapKind {
-        &self.source_map_kind
+        self.common.get_source_map_kind()
       }
 
       fn set_source_map_kind(&mut self, source_map_kind: ::rspack_util::source_map::SourceMapKind) {
-        self.source_map_kind = source_map_kind;
+        self.common.set_source_map_kind(source_map_kind);
       }
     }
   }

--- a/crates/rspack_macros_test/tests/runtime_module.rs
+++ b/crates/rspack_macros_test/tests/runtime_module.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use rspack_core::{RuntimeModule, RuntimeModuleGenerateContext, rspack_sources::Source};
+use rspack_core::{RuntimeModule, RuntimeModuleGenerateContext};
 use rspack_macros::impl_runtime_module;
 
 #[allow(dead_code)]

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -100,7 +100,7 @@ impl CssLoadingRuntimeModule {
   }
 
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.to_string();
+    let base_id = self.id().to_string();
 
     match id {
       TemplateId::Raw => base_id,
@@ -132,7 +132,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     &self,
     compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return rspack_core::RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -203,7 +203,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       let runtime_hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
       let chunk = compilation
         .build_chunk_graph_artifact

--- a/crates/rspack_plugin_esm_library/src/runtime.rs
+++ b/crates/rspack_plugin_esm_library/src/runtime.rs
@@ -120,7 +120,7 @@ impl RuntimeModule for EsmChunkLoadingRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
-    let chunk_ukey = self.chunk.expect("should have chunk");
+    let chunk_ukey = self.chunk().expect("should have chunk");
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -137,7 +137,7 @@ impl CssLoadingRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(self.chunk.as_ref().expect("should attached chunk"));
+      .expect_get(&self.chunk().expect("should attached chunk"));
 
     for chunk in
       chunk.get_all_async_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
@@ -176,7 +176,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     &self,
     compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return rspack_core::RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -248,16 +248,14 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
     let runtime_hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
-    let runtime_requirements = get_chunk_runtime_requirements(
-      compilation,
-      self.chunk.as_ref().expect("should attached chunk"),
-    );
+    let runtime_requirements =
+      get_chunk_runtime_requirements(compilation, &self.chunk().expect("should attached chunk"));
 
     let with_loading = runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) && {
       let chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey
-        .expect_get(self.chunk.as_ref().expect("should attached chunk"));
+        .expect_get(&self.chunk().expect("should attached chunk"));
 
       chunk
         .get_all_async_chunks(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey)
@@ -281,7 +279,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
       .build_chunk_graph_artifact
       .chunk_graph
       .get_chunk_condition_map(
-        self.chunk.as_ref().expect("should attached chunk"),
+        &self.chunk().expect("should attached chunk"),
         compilation,
         chunk_has_css,
       );
@@ -315,7 +313,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
       .call(CreateLinkData {
         code: create_link_raw,
         chunk: RuntimeModuleChunkWrapper {
-          chunk_ukey: self.chunk.expect("should attached chunk"),
+          chunk_ukey: self.chunk().expect("should attached chunk"),
           compilation_id: compilation.id(),
           compilation: NonNull::from(compilation),
         },
@@ -348,7 +346,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         let chunk = compilation
           .build_chunk_graph_artifact
           .chunk_by_ukey
-          .expect_get(self.chunk.as_ref().expect("should attached chunk"));
+          .expect_get(&self.chunk().expect("should attached chunk"));
         let loading = runtime_template.render(
           &self.template_id(TemplateId::WithLoading),
           Some(serde_json::json!({
@@ -403,7 +401,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         .call(LinkPrefetchData {
           code: link_prefetch_raw,
           chunk: RuntimeModuleChunkWrapper {
-            chunk_ukey: self.chunk.expect("should attached chunk"),
+            chunk_ukey: self.chunk().expect("should attached chunk"),
             compilation_id: compilation.id(),
             compilation: NonNull::from(compilation),
           },
@@ -437,7 +435,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         .call(LinkPreloadData {
           code: link_preload_raw,
           chunk: RuntimeModuleChunkWrapper {
-            chunk_ukey: self.chunk.expect("should attached chunk"),
+            chunk_ukey: self.chunk().expect("should attached chunk"),
             compilation_id: compilation.id(),
             compilation: NonNull::from(compilation),
           },
@@ -462,7 +460,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
 
 impl CssLoadingRuntimeModule {
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.to_string();
+    let base_id = self.id().to_string();
 
     match id {
       TemplateId::Raw => base_id,

--- a/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
+++ b/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
@@ -36,7 +36,7 @@ impl HotModuleReplacementRuntimeModule {
 impl RuntimeModule for HotModuleReplacementRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       HOT_MODULE_REPLACEMENT_TEMPLATE.to_string(),
     )]
   }
@@ -46,7 +46,7 @@ impl RuntimeModule for HotModuleReplacementRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let content = context.runtime_template.render(
-      self.id.as_str(),
+      self.id().as_str(),
       Some(serde_json::json!({
         "_is_hot_test": is_hot_test(),
         "_is_rspack_runtime_mode": context.compilation.options.experiments.runtime_mode == RuntimeMode::Rspack,

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_module.rs
@@ -43,8 +43,8 @@ enum TemplateId {
 impl EmbedFederationRuntimeModule {
   fn template_id(&self, template_id: TemplateId) -> String {
     match template_id {
-      TemplateId::Async => format!("{}_async", self.id),
-      TemplateId::Sync => format!("{}_sync", self.id),
+      TemplateId::Async => format!("{}_async", self.id()),
+      TemplateId::Sync => format!("{}_sync", self.id()),
     }
   }
 }
@@ -82,7 +82,7 @@ impl RuntimeModule for EmbedFederationRuntimeModule {
   async fn generate(&self, context: &RuntimeModuleGenerateContext<'_>) -> Result<String> {
     let compilation = context.compilation;
     let chunk_ukey = self
-      .chunk
+      .chunk()
       .expect("Chunk should be attached to RuntimeModule");
 
     let collected_deps = &self.options.collected_dependency_ids;

--- a/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
@@ -59,7 +59,7 @@ impl RuntimeModule for ExposeRuntimeModule {
     compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     let mut dependencies = runtime_require_scope_requirement(compilation);
-    if let Some(chunk_ukey) = self.chunk
+    if let Some(chunk_ukey) = self.chunk()
       && let Some(data) = self.find_expose_data(&chunk_ukey, compilation)
     {
       dependencies.insert(data.module_map_runtime_requirements);
@@ -80,7 +80,7 @@ impl RuntimeModule for ExposeRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let chunk_ukey = self
-      .chunk
+      .chunk()
       .expect("should have chunk in <ExposeRuntimeModule as RuntimeModule>::generate");
     let Some(data) = self.find_expose_data(&chunk_ukey, compilation) else {
       return Ok(String::new());

--- a/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
@@ -36,7 +36,7 @@ impl RuntimeModule for FederationDataRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(&self.chunk.expect("The chunk should be attached."));
+      .expect_get(&self.chunk().expect("The chunk should be attached."));
     Ok(federation_runtime_template(chunk, runtime_template, compilation).await)
   }
   fn runtime_requirements(

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -59,7 +59,7 @@ impl RuntimeModule for RemoteRuntimeModule {
   }
 
   fn template(&self) -> Vec<(String, String)> {
-    vec![(self.id.to_string(), REMOTES_LOADING_TEMPLATE.to_string())]
+    vec![(self.id().to_string(), REMOTES_LOADING_TEMPLATE.to_string())]
   }
 
   async fn generate(
@@ -69,7 +69,7 @@ impl RuntimeModule for RemoteRuntimeModule {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
     let chunk_ukey = self
-      .chunk
+      .chunk()
       .expect("should have chunk in <RemoteRuntimeModule as RuntimeModule>::generate");
     let chunk = compilation
       .build_chunk_graph_artifact
@@ -140,7 +140,7 @@ impl RuntimeModule for RemoteRuntimeModule {
           runtime_template.render_runtime_globals(&RuntimeGlobals::ENSURE_CHUNK_HANDLERS),
       )
     } else {
-      runtime_template.render(self.id.as_str(), None)?
+      runtime_template.render(self.id().as_str(), None)?
     };
     Ok(format!(
       r#"

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -55,9 +55,9 @@ impl ConsumeSharedRuntimeModule {
 
   fn get_template_id(&self, template_id: TemplateId) -> String {
     match template_id {
-      TemplateId::Common => format!("{}_consumesCommon", self.id),
-      TemplateId::Initial => format!("{}_consumesInitial", self.id),
-      TemplateId::Loading => format!("{}_consumesLoading", self.id),
+      TemplateId::Common => format!("{}_consumesCommon", self.id()),
+      TemplateId::Initial => format!("{}_consumesInitial", self.id()),
+      TemplateId::Loading => format!("{}_consumesLoading", self.id()),
     }
   }
 }
@@ -112,7 +112,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
     let chunk_ukey = self
-      .chunk
+      .chunk()
       .expect("should have chunk in <ConsumeSharedRuntimeModule as RuntimeModule>::generate");
     let chunk = compilation
       .build_chunk_graph_artifact

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -60,7 +60,10 @@ impl RuntimeModule for ShareRuntimeModule {
   }
 
   fn template(&self) -> Vec<(String, String)> {
-    vec![(self.id.to_string(), INITIALIZE_SHARING_TEMPLATE.to_string())]
+    vec![(
+      self.id().to_string(),
+      INITIALIZE_SHARING_TEMPLATE.to_string(),
+    )]
   }
 
   async fn generate(
@@ -70,7 +73,7 @@ impl RuntimeModule for ShareRuntimeModule {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
     let chunk_ukey = self
-      .chunk
+      .chunk()
       .expect("should have chunk in <ShareRuntimeModule as RuntimeModule>::generate");
     let chunk = compilation
       .build_chunk_graph_artifact
@@ -161,7 +164,7 @@ impl RuntimeModule for ShareRuntimeModule {
           runtime_template.render_runtime_globals(&RuntimeGlobals::INITIALIZE_SHARING)
       )
     } else {
-      runtime_template.render(self.id.as_str(), None)?
+      runtime_template.render(self.id().as_str(), None)?
     };
     Ok(format!(
       r#"

--- a/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
+++ b/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
@@ -46,7 +46,7 @@ impl RuntimeModule for RscManifestRuntimeModule {
     let server_compiler_id = compilation.compiler_id();
 
     let Some(entry_name) = self
-      .chunk
+      .chunk()
       .as_ref()
       .and_then(|chunk_ukey| {
         compilation

--- a/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
@@ -23,7 +23,7 @@ impl RuntimeModule for AsyncRuntimeModule {
   ) -> rspack_error::Result<String> {
     let runtime_template = context.runtime_template;
     runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_module_cache": runtime_template.render_runtime_variable(&RuntimeVariable::ModuleCache),
       })),
@@ -31,7 +31,7 @@ impl RuntimeModule for AsyncRuntimeModule {
   }
 
   fn template(&self) -> Vec<(String, String)> {
-    vec![(self.id.to_string(), ASYNC_MODULE_TEMPLATE.to_string())]
+    vec![(self.id().to_string(), ASYNC_MODULE_TEMPLATE.to_string())]
   }
   fn runtime_requirements(
     &self,

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -23,7 +23,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
   }
 
   fn template(&self) -> Vec<(String, String)> {
-    vec![(self.id.to_string(), AUTO_PUBLIC_PATH_TEMPLATE.to_string())]
+    vec![(self.id().to_string(), AUTO_PUBLIC_PATH_TEMPLATE.to_string())]
   }
 
   async fn generate(
@@ -32,7 +32,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    let chunk = self.chunk.expect("The chunk should be attached");
+    let chunk = self.chunk().expect("The chunk should be attached");
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
@@ -61,7 +61,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
       .await?;
     auto_public_path_template(
       runtime_template,
-      &self.id,
+      self.id(),
       &filename,
       &compilation.options.output,
     )

--- a/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
@@ -33,7 +33,7 @@ impl RuntimeModule for BaseUriRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let base_uri = self
-      .chunk
+      .chunk()
       .and_then(|ukey| {
         compilation
           .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
@@ -30,7 +30,7 @@ impl RuntimeModule for ChunkNameRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       let chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
@@ -30,7 +30,7 @@ impl ChunkPrefetchPreloadFunctionRuntimeModule {
 impl RuntimeModule for ChunkPrefetchPreloadFunctionRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/chunk_prefetch_preload_function.ejs").to_string(),
     )]
   }
@@ -41,7 +41,7 @@ impl RuntimeModule for ChunkPrefetchPreloadFunctionRuntimeModule {
   ) -> rspack_error::Result<String> {
     let runtime_template = context.runtime_template;
     let source = runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_runtime_handlers":  runtime_template.render_runtime_globals(&self.runtime_handlers),
         "_runtime_function": runtime_template.render_runtime_globals(&self.runtime_function),

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
@@ -37,7 +37,7 @@ impl ChunkPrefetchStartupRuntimeModule {
 impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       CHUNK_PREFETCH_STARTUP_TEMPLATE.to_string(),
     )]
   }
@@ -47,7 +47,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
-    let chunk_ukey = self.chunk.expect("chunk do not attached");
+    let chunk_ukey = self.chunk().expect("chunk do not attached");
 
     let source = self
       .startup_chunks
@@ -80,7 +80,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
           .collect_vec();
 
         let source = context.runtime_template.render(
-          &self.id,
+          self.id(),
           Some(serde_json::json!({
             "_chunk_ids": simd_json::to_string(&group_chunk_ids).expect("invalid json to_string"),
             "_child_chunk_ids": simd_json::to_string(&child_chunk_ids).expect("invalid json to_string"),

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
@@ -36,7 +36,7 @@ impl ChunkPrefetchTriggerRuntimeModule {
 impl RuntimeModule for ChunkPrefetchTriggerRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       CHUNK_PREFETCH_TRIGGER_TEMPLATE.to_string(),
     )]
   }
@@ -46,7 +46,7 @@ impl RuntimeModule for ChunkPrefetchTriggerRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_chunk_map": &self.chunk_map,
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
@@ -36,7 +36,7 @@ impl ChunkPreloadTriggerRuntimeModule {
 impl RuntimeModule for ChunkPreloadTriggerRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       CHUNK_PRELOAD_TRIGGER_TEMPLATE.to_string(),
     )]
   }
@@ -46,7 +46,7 @@ impl RuntimeModule for ChunkPreloadTriggerRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_chunk_map": &self.chunk_map,
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
@@ -31,7 +31,7 @@ impl RuntimeModule for CompatGetDefaultExportRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       COMPAT_GET_DEFAULT_EXPORT_TEMPLATE.to_string(),
     )]
   }
@@ -40,7 +40,7 @@ impl RuntimeModule for CompatGetDefaultExportRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
@@ -31,7 +31,7 @@ impl RuntimeModule for CreateFakeNamespaceObjectRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       CREATE_FAKE_NAMESPACE_OBJECT_TEMPLATE.to_string(),
     )]
   }
@@ -51,7 +51,7 @@ impl RuntimeModule for CreateFakeNamespaceObjectRuntimeModule {
         })
       },
     );
-    let source = context.runtime_template.render(&self.id, params)?;
+    let source = context.runtime_template.render(self.id(), params)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
@@ -34,7 +34,7 @@ impl RuntimeModule for CreateScriptRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/create_script.ejs").to_string(),
     )]
   }
@@ -45,7 +45,7 @@ impl RuntimeModule for CreateScriptRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_trusted_types": compilation.options.output.trusted_types.is_some(),
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
@@ -34,7 +34,7 @@ impl RuntimeModule for CreateScriptUrlRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/create_script_url.ejs").to_string(),
     )]
   }
@@ -45,7 +45,7 @@ impl RuntimeModule for CreateScriptUrlRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_trusted_types": compilation.options.output.trusted_types.is_some(),
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
@@ -30,7 +30,7 @@ impl RuntimeModule for DefinePropertyGettersRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       DEFINE_PROPERTY_GETTERS_TEMPLATE.to_string(),
     )]
   }
@@ -51,7 +51,7 @@ impl RuntimeModule for DefinePropertyGettersRuntimeModule {
       "var descriptor = { enumerable: true };\n\t\t\t\tdescriptor[kind] = defs[key];\n\t\t\t\tObject.defineProperty(exports, key, descriptor);"
     };
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_define_property_code": define_property_code,
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
@@ -25,8 +25,8 @@ enum TemplateId {
 impl EnsureChunkRuntimeModule {
   fn template_id(&self, id: TemplateId) -> String {
     match id {
-      TemplateId::Raw => self.id.to_string(),
-      TemplateId::WithInline => format!("{}_inline", &self.id),
+      TemplateId::Raw => self.id().to_string(),
+      TemplateId::WithInline => format!("{}_inline", self.id()),
     }
   }
 }
@@ -52,7 +52,7 @@ impl RuntimeModule for EnsureChunkRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    let chunk_ukey = self.chunk.expect("should have chunk");
+    let chunk_ukey = self.chunk().expect("should have chunk");
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     let source = if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) {
       let fetch_priority = if runtime_requirements.contains(RuntimeGlobals::HAS_FETCH_PRIORITY) {
@@ -79,7 +79,7 @@ impl RuntimeModule for EnsureChunkRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     let mut dependencies = RuntimeGlobals::default();
     let mut write = RuntimeGlobals::ENSURE_CHUNK;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       if self.has_async_chunks
         || get_chunk_runtime_requirements(compilation, &chunk_ukey)
           .contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS)

--- a/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for ESMModuleDecoratorRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/esm_module_decorator.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for ESMModuleDecoratorRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -34,8 +34,8 @@ pub struct GetChunkFilenameRuntimeModule {
 impl fmt::Debug for GetChunkFilenameRuntimeModule {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("GetChunkFilenameRuntimeModule")
-      .field("id", &self.id)
-      .field("chunk", &self.chunk)
+      .field("id", self.id())
+      .field("chunk", &self.chunk())
       .field("content_type", &self.content_type)
       .field("source_type", &self.source_type)
       .field("global", &self.global)
@@ -102,7 +102,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/get_chunk_filename.ejs").to_string(),
     )]
   }
@@ -118,7 +118,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
     let chunks = self
-      .chunk
+      .chunk()
       .and_then(|chunk_ukey| {
         compilation
           .build_chunk_graph_artifact
@@ -412,7 +412,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
       }
     }
 
-    let source = runtime_template.render(&self.id, Some(serde_json::json!({
+    let source = runtime_template.render(self.id(), Some(serde_json::json!({
       "_global": self.global,
       "_static_urls": static_urls
                         .iter()

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -41,7 +41,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/get_chunk_update_filename.ejs").to_string(),
     )]
   }
@@ -52,7 +52,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       let chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey
@@ -84,7 +84,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
         .await?;
 
       let source = runtime_template.render(
-        &self.id,
+        self.id(),
         Some(serde_json::json!({
           "_filename": format!("'{}'", filename),
         })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for GetFullHashRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/get_full_hash.ejs").to_string(),
     )]
   }
@@ -38,7 +38,7 @@ impl RuntimeModule for GetFullHashRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_hash": format!("\"{}\"", compilation.get_hash().unwrap_or("XXXX"))
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -51,7 +51,7 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       let chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -29,7 +29,7 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/get_trusted_types_policy.ejs").to_string(),
     )]
   }
@@ -46,14 +46,14 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
       .as_ref()
       .expect("should have trusted_types");
     let runtime_requirements =
-      get_chunk_runtime_requirements(compilation, &self.chunk.expect("should have chunk"));
+      get_chunk_runtime_requirements(compilation, &self.chunk().expect("should have chunk"));
     let wrap_policy_creation_in_try_catch = matches!(
       trusted_types.on_policy_creation_failure,
       OnPolicyCreationFailure::Continue
     );
 
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_create_script": runtime_requirements.contains(RuntimeGlobals::CREATE_SCRIPT),
         "_create_script_url": runtime_requirements.contains(RuntimeGlobals::CREATE_SCRIPT_URL),

--- a/crates/rspack_plugin_runtime/src/runtime_module/global.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/global.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for GlobalRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/global.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for GlobalRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for HasOwnPropertyRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/has_own_property.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for HasOwnPropertyRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -118,7 +118,7 @@ impl ImportScriptsChunkLoadingRuntimeModule {
   }
 
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.as_str();
+    let base_id = self.id().as_str();
 
     match id {
       TemplateId::Raw => base_id.to_string(),
@@ -159,7 +159,7 @@ enum TemplateId {
 #[async_trait::async_trait]
 impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -221,10 +221,10 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(&self.chunk.expect("The chunk should be attached."));
+      .expect_get(&self.chunk().expect("The chunk should be attached."));
 
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey());
-    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+    let initial_chunks = get_initial_chunk_ids(self.chunk(), compilation, chunk_has_js);
 
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);
     let with_hmr = runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS);

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -174,7 +174,7 @@ impl JsonpChunkLoadingRuntimeModule {
   }
 
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.as_str();
+    let base_id = self.id().as_str();
 
     match id {
       TemplateId::Raw => base_id.to_string(),
@@ -208,7 +208,7 @@ enum TemplateId {
 #[async_trait::async_trait]
 impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -305,7 +305,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(&self.chunk.expect("The chunk should be attached"));
+      .expect_get(&self.chunk().expect("The chunk should be attached"));
 
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey());
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);
@@ -341,7 +341,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       .chunk_graph
       .get_chunk_condition_map(&chunk.ukey(), compilation, chunk_has_js);
     let has_js_matcher = compile_boolean_matcher(&condition_map);
-    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+    let initial_chunks = get_initial_chunk_ids(self.chunk(), compilation, chunk_has_js);
 
     let js_matcher = has_js_matcher.render("chunkId");
 
@@ -408,7 +408,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
         })),
       )?;
 
-      let chunk_ukey = self.chunk.expect("The chunk should be attached");
+      let chunk_ukey = self.chunk().expect("The chunk should be attached");
       let res = hooks
         .borrow()
         .link_prefetch
@@ -442,7 +442,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
         })),
       )?;
 
-      let chunk_ukey = self.chunk.expect("The chunk should be attached");
+      let chunk_ukey = self.chunk().expect("The chunk should be attached");
       let res = hooks
         .borrow()
         .link_preload

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -132,7 +132,7 @@ impl RuntimeModule for LoadScriptRuntimeModule {
 
 impl LoadScriptRuntimeModule {
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.to_string();
+    let base_id = self.id().to_string();
 
     match id {
       TemplateId::Raw => base_id,

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_deferred_namespace_object_runtime.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_deferred_namespace_object_runtime.rs
@@ -24,7 +24,7 @@ impl MakeDeferredNamespaceObjectRuntimeModule {
 impl RuntimeModule for MakeDeferredNamespaceObjectRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       MAKE_DEFERRED_NAMESPACE_OBJECT_TEMPLATE.to_string(),
     )]
   }
@@ -38,7 +38,7 @@ impl RuntimeModule for MakeDeferredNamespaceObjectRuntimeModule {
     let has_async = get_chunk_runtime_requirements(compilation, &self.chunk_ukey)
       .contains(RuntimeGlobals::ASYNC_MODULE);
     let source = runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_module_cache": runtime_template.render_runtime_variable(&RuntimeVariable::ModuleCache),
         "_has_async": has_async,

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for MakeNamespaceObjectRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/make_namespace_object.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for MakeNamespaceObjectRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_optimized_deferred_namespace_object_runtime.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_optimized_deferred_namespace_object_runtime.rs
@@ -24,7 +24,7 @@ impl MakeOptimizedDeferredNamespaceObjectRuntimeModule {
 impl RuntimeModule for MakeOptimizedDeferredNamespaceObjectRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       MAKE_OPTIMIZED_DEFERRED_NAMESPACE_OBJECT_TEMPLATE.to_string(),
     )]
   }
@@ -38,7 +38,7 @@ impl RuntimeModule for MakeOptimizedDeferredNamespaceObjectRuntimeModule {
     let has_async = get_chunk_runtime_requirements(compilation, &self.chunk_ukey)
       .contains(RuntimeGlobals::ASYNC_MODULE);
     let source = runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_module_cache": runtime_template.render_runtime_variable(&RuntimeVariable::ModuleCache),
         "_has_async": has_async,

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -176,15 +176,15 @@ impl ModuleChunkLoadingRuntimeModule {
 
   fn template(&self, template_id: TemplateId) -> String {
     match template_id {
-      TemplateId::Raw => self.id.to_string(),
-      TemplateId::WithLoading => format!("{}_with_loading", self.id),
-      TemplateId::WithPrefetch => format!("{}_with_prefetch", self.id),
-      TemplateId::WithPrefetchLink => format!("{}_with_prefetch_link", self.id),
-      TemplateId::WithPreload => format!("{}_with_preload", self.id),
-      TemplateId::WithPreloadLink => format!("{}_with_preload_link", self.id),
-      TemplateId::WithHMR => format!("{}_with_hmr", self.id),
-      TemplateId::WithHMRManifest => format!("{}_with_hmr_manifest", self.id),
-      TemplateId::HmrRuntime => format!("{}_hmr_runtime", self.id),
+      TemplateId::Raw => self.id().to_string(),
+      TemplateId::WithLoading => format!("{}_with_loading", self.id()),
+      TemplateId::WithPrefetch => format!("{}_with_prefetch", self.id()),
+      TemplateId::WithPrefetchLink => format!("{}_with_prefetch_link", self.id()),
+      TemplateId::WithPreload => format!("{}_with_preload", self.id()),
+      TemplateId::WithPreloadLink => format!("{}_with_preload_link", self.id()),
+      TemplateId::WithHMR => format!("{}_with_hmr", self.id()),
+      TemplateId::WithHMRManifest => format!("{}_with_hmr_manifest", self.id()),
+      TemplateId::HmrRuntime => format!("{}_hmr_runtime", self.id()),
     }
   }
 }
@@ -204,7 +204,7 @@ enum TemplateId {
 #[async_trait::async_trait]
 impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -292,7 +292,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(&self.chunk.expect("The chunk should be attached."));
+      .expect_get(&self.chunk().expect("The chunk should be attached."));
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey());
 
     let hooks = RuntimePlugin::get_compilation_hooks(compilation.id());
@@ -330,7 +330,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
       .chunk_graph
       .get_chunk_condition_map(&chunk.ukey(), compilation, chunk_has_js);
     let has_js_matcher = compile_boolean_matcher(&condition_map);
-    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+    let initial_chunks = get_initial_chunk_ids(self.chunk(), compilation, chunk_has_js);
 
     let root_output_dir = get_output_dir(chunk, compilation, true).await?;
     let import_function_name = &compilation.options.output.import_function_name;
@@ -421,7 +421,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
           })),
         )?;
 
-        let chunk_ukey = self.chunk.expect("The chunk should be attached");
+        let chunk_ukey = self.chunk().expect("The chunk should be attached");
         let res = hooks
           .borrow()
           .link_prefetch
@@ -454,7 +454,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
           })),
         )?;
 
-        let chunk_ukey = self.chunk.expect("The chunk should be attached");
+        let chunk_ukey = self.chunk().expect("The chunk should be attached");
         let res = hooks
           .borrow()
           .link_preload

--- a/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for NodeModuleDecoratorRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/node_module_decorator.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for NodeModuleDecoratorRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for OnChunkLoadedRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/on_chunk_loaded.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for OnChunkLoadedRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -140,7 +140,7 @@ impl ReadFileChunkLoadingRuntimeModule {
   }
 
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.to_string();
+    let base_id = self.id().to_string();
 
     match id {
       TemplateId::Raw => base_id,
@@ -194,7 +194,7 @@ enum TemplateId {
 #[async_trait::async_trait]
 impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -272,7 +272,7 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(&self.chunk.expect("The chunk should be attached."));
+      .expect_get(&self.chunk().expect("The chunk should be attached."));
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey());
 
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);
@@ -289,7 +289,7 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
       .get_chunk_condition_map(&chunk.ukey(), compilation, chunk_has_js);
     let has_js_matcher = compile_boolean_matcher(&condition_map);
 
-    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+    let initial_chunks = get_initial_chunk_ids(self.chunk(), compilation, chunk_has_js);
     let root_output_dir = get_output_dir(chunk, compilation, false).await?;
     let mut source = String::default();
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for RelativeUrlRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/relative_url.ejs").to_string(),
     )]
   }
@@ -36,7 +36,7 @@ impl RuntimeModule for RelativeUrlRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    let source = context.runtime_template.render(&self.id, None)?;
+    let source = context.runtime_template.render(self.id(), None)?;
 
     Ok(source)
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -148,7 +148,7 @@ impl RequireChunkLoadingRuntimeModule {
   }
 
   fn template_id(&self, id: TemplateId) -> String {
-    let base_id = self.id.to_string();
+    let base_id = self.id().to_string();
 
     match id {
       TemplateId::WithLoading => format!("{}_with_loading", &base_id),
@@ -205,7 +205,7 @@ enum TemplateId {
 #[async_trait::async_trait]
 impl RuntimeModule for RequireChunkLoadingRuntimeModule {
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
-    let Some(chunk_ukey) = self.chunk else {
+    let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
@@ -287,7 +287,7 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
     let chunk = compilation
       .build_chunk_graph_artifact
       .chunk_by_ukey
-      .expect_get(&self.chunk.expect("The chunk should be attached."));
+      .expect_get(&self.chunk().expect("The chunk should be attached."));
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey());
 
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);
@@ -303,7 +303,7 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
       .chunk_graph
       .get_chunk_condition_map(&chunk.ukey(), compilation, chunk_has_js);
     let has_js_matcher = compile_boolean_matcher(&condition_map);
-    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+    let initial_chunks = get_initial_chunk_ids(self.chunk(), compilation, chunk_has_js);
     let root_output_dir = get_output_dir(chunk, compilation, true).await?;
 
     let mut source = String::default();

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
@@ -38,7 +38,7 @@ impl RuntimeModule for RspackUniqueIdRuntimeModule {
   }
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/get_unique_id.ejs").to_string(),
     )]
   }
@@ -48,7 +48,7 @@ impl RuntimeModule for RspackUniqueIdRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_bundler_name": &self.bundler_name,
         "_bundler_version": &self.bundler_version,

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
@@ -30,7 +30,7 @@ impl RuntimeModule for RspackVersionRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/get_version.ejs").to_string(),
     )]
   }
@@ -40,7 +40,7 @@ impl RuntimeModule for RspackVersionRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_version": format!("\"{}\"", &self.version),
       })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
@@ -31,7 +31,7 @@ impl RuntimeModule for RuntimeIdRuntimeModule {
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       let chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -39,7 +39,7 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/startup_chunk_dependencies.ejs").to_string(),
     )]
   }
@@ -50,7 +50,7 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    if let Some(chunk_ukey) = self.chunk {
+    if let Some(chunk_ukey) = self.chunk() {
       let chunk_ids = compilation
         .build_chunk_graph_artifact
         .chunk_graph
@@ -109,7 +109,7 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
       };
 
       let source = runtime_template.render(
-        &self.id,
+        self.id(),
         Some(serde_json::json!({
           "_body": body,
         })),

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_entrypoint.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_entrypoint.rs
@@ -19,7 +19,7 @@ impl StartupEntrypointRuntimeModule {
 impl RuntimeModule for StartupEntrypointRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       if self.async_chunk_loading {
         include_str!("runtime/startup_entrypoint_with_async.ejs").to_string()
       } else {
@@ -32,7 +32,7 @@ impl RuntimeModule for StartupEntrypointRuntimeModule {
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
-    context.runtime_template.render(&self.id, None)
+    context.runtime_template.render(self.id(), None)
   }
   fn runtime_requirements(
     &self,

--- a/crates/rspack_plugin_runtime/src/runtime_module/to_binary.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/to_binary.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for ToBinaryRuntimeModule {
 
   fn template(&self) -> Vec<(String, String)> {
     vec![(
-      self.id.to_string(),
+      self.id().to_string(),
       include_str!("runtime/to_binary.ejs").to_string(),
     )]
   }
@@ -42,7 +42,7 @@ impl RuntimeModule for ToBinaryRuntimeModule {
     let is_neutral_platform = compilation.platform.is_neutral();
 
     let source = context.runtime_template.render(
-      &self.id,
+      self.id(),
       Some(serde_json::json!({
         "_is_node_platform": is_node_platform,
         "_is_web_platform": is_web_platform,

--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -49,7 +49,7 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
   async fn generate(&self, context: &RuntimeModuleGenerateContext<'_>) -> Result<String> {
     let compilation = context.compilation;
     let Some(chunk) = self
-      .chunk
+      .chunk()
       .as_ref()
       .and_then(|c| compilation.build_chunk_graph_artifact.chunk_by_ukey.get(c))
     else {
@@ -96,23 +96,20 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
       ),
     ];
 
-    let all_chunks = find_chunks(
-      self.chunk.as_ref().expect("should attached chunk"),
-      compilation,
-    )
-    .into_iter()
-    .filter(|c| {
-      compilation
-        .build_chunk_graph_artifact
-        .chunk_graph
-        .get_chunk_modules(c, module_graph)
-        .iter()
-        .any(|m| {
-          let result = compilation.code_generation_results.get_one(&m.identifier());
-          result.inner.values().any(|v| v.size() != 0)
-        })
-    })
-    .collect::<Vec<_>>();
+    let all_chunks = find_chunks(&self.chunk().expect("should attached chunk"), compilation)
+      .into_iter()
+      .filter(|c| {
+        compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .get_chunk_modules(c, module_graph)
+          .iter()
+          .any(|m| {
+            let result = compilation.code_generation_results.get_one(&m.identifier());
+            result.inner.values().any(|v| v.size() != 0)
+          })
+      })
+      .collect::<Vec<_>>();
 
     let mut code = vec![];
 

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -106,11 +106,8 @@ impl RuntimeModule for AsyncWasmCompileRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    let path = render_wasm_module_path(
-      compilation,
-      self.chunk.as_ref().expect("should attached chunk"),
-    )
-    .await?;
+    let path =
+      render_wasm_module_path(compilation, &self.chunk().expect("should attached chunk")).await?;
 
     Ok(get_async_wasm_compile(
       &self
@@ -153,11 +150,8 @@ impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
   ) -> rspack_error::Result<String> {
     let compilation = context.compilation;
     let runtime_template = context.runtime_template;
-    let path = render_wasm_module_path(
-      compilation,
-      self.chunk.as_ref().expect("should attached chunk"),
-    )
-    .await?;
+    let path =
+      render_wasm_module_path(compilation, &self.chunk().expect("should attached chunk")).await?;
 
     Ok(get_async_wasm_loading(
       &self


### PR DESCRIPTION
## Summary

- Introduce `RuntimeModuleCommon` to hold shared runtime module state and helpers.
- Thin out `#[impl_runtime_module]` so generated impls mostly forward to shared core functions.
- Move generated-code, code-generation, and runtime-hash bodies into non-generic `&dyn RuntimeModule` helpers to avoid repeating the large async body per concrete runtime module.
- Update runtime modules and JS runtime-module construction to access shared state through `common`.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test:rs`
- `pnpm run build:js`
- `pnpm run test:unit`
- `cargo test -p rspack_macros_test --test runtime_module`
- `cargo fmt --check --package rspack_core --package rspack_macros --package rspack_binding_api --package rspack_macros_test`

---
_by OpenAI Codex_