### PR TITLE
perf: avoid cloning side effects artifact in module concatenation

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1227,13 +1227,11 @@ impl ModuleConcatenationPlugin {
       let mut candidates_visited = IdentifierSet::default();
       let mut candidates = VecDeque::new();
       let imports = {
-        let side_effects_state_artifact = compilation
-          .build_module_graph_artifact
-          .side_effects_state_artifact
-          .clone();
         let module_graph_artifacts = ModuleGraphArtifacts {
           mg_cache: module_graph_cache,
-          side_effects_state_artifact: &side_effects_state_artifact,
+          side_effects_state_artifact: &compilation
+            .build_module_graph_artifact
+            .side_effects_state_artifact,
           exports_info_artifact: &compilation.exports_info_artifact,
         };
 


### PR DESCRIPTION
## What changed

Avoid cloning `side_effects_state_artifact` inside each module concatenation root attempt. `ModuleGraphArtifacts` now borrows the compilation-owned side effects artifact directly while collecting imports.

## Why this improves performance

The cloned artifact is an `IdentifierMap<SideEffectsState>`, and each `SideEffectsState` can own optimization bailout vectors. With `pureFunctions` enabled, `SideEffectsFlagPlugin` populates this artifact for many modules. In the `cases/all` investigation, module concatenation attempted 492 root configurations, so cloning the whole artifact once per root amplified both CPU and allocation work.

Debug Callgrind evidence from the investigation showed the hot edge was not final stats bailout output growth: final `optimizationBailout` item count was effectively unchanged with pure on/off. The extra cost came from repeated `SideEffectsStateArtifact` cloning, including `Vec<OptimizationBailoutItem>::clone`, while `ModuleGraph::batch_add_connections` did not show a matching clone delta.

## Hot path and cardinality risk

This sits in module concatenation's per-root candidate loop. The risk scales with `concat root attempts * side effects state map size * bailout vector payload`, which becomes high-cardinality when tree-shaking side effects analysis has populated the artifact.

## Expected impact

This removes repeated deep clones of a compilation-level side effects state map from the module concatenation hot path. It should reduce CPU instructions and allocation pressure for pureFunctions/tree-shaking workloads without changing observable output.

## Checks

- `cargo fmt --all --check`
- `cargo check -p rspack_plugin_javascript`