### PR TITLE
perf: validate side effects artifact clone on Rome benchmark

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1227,13 +1227,11 @@ impl ModuleConcatenationPlugin {
       let mut candidates_visited = IdentifierSet::default();
       let mut candidates = VecDeque::new();
       let imports = {
-        let side_effects_state_artifact = compilation
-          .build_module_graph_artifact
-          .side_effects_state_artifact
-          .clone();
         let module_graph_artifacts = ModuleGraphArtifacts {
           mg_cache: module_graph_cache,
-          side_effects_state_artifact: &side_effects_state_artifact,
+          side_effects_state_artifact: &compilation
+            .build_module_graph_artifact
+            .side_effects_state_artifact,
           exports_info_artifact: &compilation.exports_info_artifact,
         };
 


### PR DESCRIPTION
Temporary validation PR for #14622 against the Rome benchmark base from #14624.

This keeps the Rome benchmark case in the base branch and applies only the perf commit from #14622 on top, so CodSpeed can report whether the optimization affects `rome-ts`.

Validation target:
- Base: `codex/rome-ts-benchmark-case` / #14624
- Head: `codex/verify-rome-side-effects-perf`
- Perf commit under test: `42801754c1f1dd2d2e28c5ee4264cd6145a6b328`

No code changes beyond cherry-picking the #14622 perf commit.