### PR TITLE
docs: enable Rspress anchor checks

### DIFF
--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -328,7 +328,7 @@ export default {
 - **Type:** `string`
 - **Default:** `node_modules/.cache/rspack/<mode>` or `node_modules/.cache/rspack/<name>-<mode>`
 
-Use `directory` to configure the cache directory. The default directory is resolved from [`config.context`](/config/#context), [`config.name`](/config/other-options#name), [`config.mode`](/config/mode#mode), and the multi-compiler index. In multi-compiler mode, later compilers append `-<index>` to avoid sharing the same directory.
+Use `directory` to configure the cache directory. The default directory is resolved from [`config.context`](/config/context), [`config.name`](/config/other-options#name), [`config.mode`](/config/mode#mode), and the multi-compiler index. In multi-compiler mode, later compilers append `-<index>` to avoid sharing the same directory.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -330,7 +330,7 @@ export default {
 - **类型：** `string`
 - **默认值：** `node_modules/.cache/rspack/<mode>` 或 `node_modules/.cache/rspack/<name>-<mode>`
 
-通过 `directory` 设置缓存目录。默认目录会基于 [`config.context`](/config/#context)、[`config.name`](/config/other-options#name)、[`config.mode`](/config/mode#mode) 和 multi compiler 的 index 生成。在 multi compiler 模式下，后续 compiler 会追加 `-<index>` 以避免共享同一个目录。
+通过 `directory` 设置缓存目录。默认目录会基于 [`config.context`](/config/context)、[`config.name`](/config/other-options#name)、[`config.mode`](/config/mode#mode) 和 multi compiler 的 index 生成。在 multi compiler 模式下，后续 compiler 会追加 `-<index>` 以避免共享同一个目录。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
   lang: 'en',
   globalStyles: path.join(__dirname, 'theme', 'index.css'),
   markdown: {
+    link: {
+      checkAnchors: true,
+    },
     shiki: {
       transformers: [transformerNotationHighlight(), transformerNotationDiff()],
       langAlias: {


### PR DESCRIPTION
## Summary

This PR enables Rspress markdown anchor checking for the docs site and fixes the existing dead cache docs links that pointed to `/config/#context` after `context` became its own config page.

## Related links

https://github.com/web-infra-dev/rspress/releases/tag/v2.0.15

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).