### PR TITLE
fix: empty references export for cjs and dynamic import tree shaking

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -39,7 +39,6 @@ impl CommonJsRequireDependency {
     range_expr: Option<DependencyRange>,
     optional: bool,
     loc: Option<DependencyLocation>,
-    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
   ) -> Self {
     Self {
       id: DependencyId::new(),
@@ -48,7 +47,7 @@ impl CommonJsRequireDependency {
       range,
       range_expr,
       loc,
-      referenced_specifiers,
+      referenced_specifiers: None,
       branch_guard: None,
       context: None,
       resource_identifier: Default::default(),
@@ -63,7 +62,6 @@ impl CommonJsRequireDependency {
     optional: bool,
     context: Context,
     loc: Option<DependencyLocation>,
-    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
   ) -> Self {
     let resource_identifier = create_resource_identifier_for_contextual_commonjs_dependency(
       "cjs require",
@@ -74,18 +72,17 @@ impl CommonJsRequireDependency {
     Self {
       context: Some(context),
       resource_identifier,
-      ..Self::new(
-        request,
-        range,
-        range_expr,
-        optional,
-        loc,
-        referenced_specifiers,
-      )
+      ..Self::new(request, range, range_expr, optional, loc)
     }
   }
 
   pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+    if referenced_specifiers.is_empty() {
+      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
+      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
+      // see test case `tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free`
+      return;
+    }
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -55,6 +55,12 @@ impl CommonJsRequireContextDependency {
   }
 
   pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+    if referenced_specifiers.is_empty() {
+      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
+      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
+      // see test case `tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free`
+      return;
+    }
     self.options.referenced_specifiers = Some(referenced_specifiers);
     self.resource_identifier = create_resource_identifier_for_context_dependency(
       self.context.as_ref().map(|c| c.as_str()),

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -55,7 +55,17 @@ impl ImportContextDependency {
     }
   }
 
-  pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+  pub fn set_referenced_specifiers(
+    &mut self,
+    referenced_specifiers: Vec<ReferencedSpecifier>,
+    from_magic_comment: bool,
+  ) {
+    if !from_magic_comment && referenced_specifiers.is_empty() {
+      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
+      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
+      // see test case `tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import`
+      return;
+    }
     self.options.referenced_specifiers = Some(referenced_specifiers);
     self.resource_identifier = create_resource_identifier(&self.options);
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -38,7 +38,6 @@ impl ImportDependency {
   pub fn new(
     request: Atom,
     range: DependencyRange,
-    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
     attributes: Option<ImportAttributes>,
     phase: ImportPhase,
     optional: bool,
@@ -50,7 +49,7 @@ impl ImportDependency {
       request,
       range,
       id: DependencyId::new(),
-      referenced_specifiers,
+      referenced_specifiers: None,
       attributes,
       phase,
       resource_identifier,
@@ -61,7 +60,17 @@ impl ImportDependency {
     }
   }
 
-  pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+  pub fn set_referenced_specifiers(
+    &mut self,
+    referenced_specifiers: Vec<ReferencedSpecifier>,
+    from_magic_comment: bool,
+  ) {
+    if !from_magic_comment && referenced_specifiers.is_empty() {
+      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
+      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
+      // see test case `tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import`
+      return;
+    }
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -32,7 +32,6 @@ impl ImportEagerDependency {
   pub fn new(
     request: Atom,
     range: DependencyRange,
-    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
     attributes: Option<ImportAttributes>,
     phase: ImportPhase,
   ) -> Self {
@@ -42,7 +41,7 @@ impl ImportEagerDependency {
       request,
       range,
       id: DependencyId::new(),
-      referenced_specifiers,
+      referenced_specifiers: None,
       attributes,
       phase,
       resource_identifier,
@@ -50,7 +49,17 @@ impl ImportEagerDependency {
     }
   }
 
-  pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+  pub fn set_referenced_specifiers(
+    &mut self,
+    referenced_specifiers: Vec<ReferencedSpecifier>,
+    from_magic_comment: bool,
+  ) {
+    if !from_magic_comment && referenced_specifiers.is_empty() {
+      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
+      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
+      // see test case `tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import`
+      return;
+    }
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
@@ -35,7 +35,6 @@ impl ImportWeakDependency {
   pub fn new(
     request: Atom,
     range: DependencyRange,
-    referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
     attributes: Option<ImportAttributes>,
     phase: ImportPhase,
     optional: bool,
@@ -46,7 +45,7 @@ impl ImportWeakDependency {
       request,
       range,
       id: DependencyId::new(),
-      referenced_specifiers,
+      referenced_specifiers: None,
       attributes,
       phase,
       resource_identifier,
@@ -55,7 +54,17 @@ impl ImportWeakDependency {
     }
   }
 
-  pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
+  pub fn set_referenced_specifiers(
+    &mut self,
+    referenced_specifiers: Vec<ReferencedSpecifier>,
+    from_magic_comment: bool,
+  ) {
+    if !from_magic_comment && referenced_specifiers.is_empty() {
+      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
+      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
+      // see test case `tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import`
+      return;
+    }
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -1098,7 +1098,6 @@ fn create_commonjs_require_context_dependency(
     replaces: result.replaces,
     start: span.real_lo(),
     end: span.real_hi(),
-    referenced_specifiers,
     ..Default::default()
   };
   let range = call_expr.span.into();
@@ -1113,6 +1112,9 @@ fn create_commonjs_require_context_dependency(
     parser.in_try,
     request_context,
   );
+  if let Some(referenced_specifiers) = referenced_specifiers {
+    dep.set_referenced_specifiers(referenced_specifiers);
+  }
   *dep.critical_mut() = result.critical;
   dep
 }
@@ -1427,26 +1429,27 @@ impl CommonJsImportsParserPlugin {
             });
             refs
           });
-      let dep: Box<dyn rspack_core::Dependency> = if let Some(context) = request_context {
-        Box::new(CommonJsRequireDependency::new_contextual(
+      let mut dep = if let Some(context) = request_context {
+        CommonJsRequireDependency::new_contextual(
           param.string().clone(),
           range_expr,
           Some(span.into()),
           parser.in_try,
           context,
           loc,
-          referenced_specifiers,
-        ))
+        )
       } else {
-        Box::new(CommonJsRequireDependency::new(
+        CommonJsRequireDependency::new(
           param.string().clone(),
           range_expr,
           Some(span.into()),
           parser.in_try,
           loc,
-          referenced_specifiers,
-        ))
+        )
       };
+      if let Some(referenced_specifiers) = referenced_specifiers {
+        dep.set_referenced_specifiers(referenced_specifiers);
+      }
       let dep_idx = parser.next_dependency_idx();
       if let Some(require_references) = parser.common_js_require_references.get_require_mut(&span) {
         require_references.dep_locator = Some(RequireDependencyLocator {
@@ -1455,7 +1458,7 @@ impl CommonJsImportsParserPlugin {
           dep_type: DependencyType::CjsRequire,
         });
       }
-      parser.add_dependency(dep);
+      parser.add_dependency(Box::new(dep));
       true
     })
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -383,13 +383,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
 
     let dep_locator = if param.is_string() {
       if matches!(mode, DynamicImportMode::Eager) {
-        let dep = ImportEagerDependency::new(
+        let mut dep = ImportEagerDependency::new(
           param.string().as_str().into(),
           import_call_span.into(),
-          exports,
           attributes,
           phase,
         );
+        if let Some(exports) = exports {
+          dep.set_referenced_specifiers(exports, !is_statical && has_exports_magic_comment);
+        }
         let dep_idx = parser.next_dependency_idx();
         parser.add_dependency(Box::new(dep));
         ImportDependencyLocator {
@@ -398,14 +400,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           dep_type: DependencyType::DynamicImportEager,
         }
       } else if matches!(mode, DynamicImportMode::Weak) {
-        let dep = ImportWeakDependency::new(
+        let mut dep = ImportWeakDependency::new(
           param.string().as_str().into(),
           import_call_span.into(),
-          exports,
           attributes,
           phase,
           parser.in_try,
         );
+        if let Some(exports) = exports {
+          dep.set_referenced_specifiers(exports, !is_statical && has_exports_magic_comment);
+        }
         let dep_idx = parser.next_dependency_idx();
         parser.add_dependency(Box::new(dep));
         ImportDependencyLocator {
@@ -414,10 +418,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           dep_type: DependencyType::DynamicImportWeak,
         }
       } else {
-        let dep = Box::new(ImportDependency::new(
+        let mut dep = ImportDependency::new(
           param.string().as_str().into(),
           import_call_span.into(),
-          exports,
           attributes,
           phase,
           parser.in_try,
@@ -429,14 +432,17 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
               dyn_imported_span.end,
             )
           },
-        ));
+        );
+        if let Some(export) = exports {
+          dep.set_referenced_specifiers(export, !is_statical && has_exports_magic_comment);
+        }
         let range = DependencyRange::from(import_call_span);
         let loc = parser.to_dependency_location(range);
         let mut block = AsyncDependenciesBlock::new(
           *parser.module_identifier,
           loc,
           None,
-          vec![dep],
+          vec![Box::new(dep)],
           Some(param.string().clone()),
         );
         block.set_group_options(GroupOptions::ChunkGroup(ChunkGroupOptions::new(
@@ -493,7 +499,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           replaces,
           start: import_call_span.real_lo(),
           end: import_call_span.real_hi(),
-          referenced_specifiers: exports,
+          referenced_specifiers: None,
           glob_import: None,
           glob_exhaustive: false,
           attributes,
@@ -503,6 +509,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         dyn_imported_span.into(),
         parser.in_try,
       );
+      if let Some(export) = exports {
+        dep.set_referenced_specifiers(export, !is_statical && has_exports_magic_comment);
+      }
       *dep.critical_mut() = critical;
       let dep_idx = parser.next_dependency_idx();
       parser.add_dependency(Box::new(dep));
@@ -560,25 +569,25 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           let dep = dep
             .downcast_mut::<ImportDependency>()
             .expect("Failed to downcast to ImportDependency");
-          dep.set_referenced_specifiers(references);
+          dep.set_referenced_specifiers(references, false);
         }
         DependencyType::DynamicImportEager => {
           let dep = dep
             .downcast_mut::<ImportEagerDependency>()
             .expect("Failed to downcast to ImportEagerDependency");
-          dep.set_referenced_specifiers(references);
+          dep.set_referenced_specifiers(references, false);
         }
         DependencyType::DynamicImportWeak => {
           let dep = dep
             .downcast_mut::<ImportWeakDependency>()
             .expect("Failed to downcast to ImportWeakDependency");
-          dep.set_referenced_specifiers(references);
+          dep.set_referenced_specifiers(references, false);
         }
         DependencyType::ImportContext => {
           let dep = dep
             .downcast_mut::<ImportContextDependency>()
             .expect("Failed to downcast to ImportContextDependency");
-          dep.set_referenced_specifiers(references);
+          dep.set_referenced_specifiers(references, false);
         }
         _ => unreachable!(),
       };

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -197,7 +197,6 @@ impl Module for LazyCompilationProxyModule {
       None,
       false,
       None,
-      None,
     );
     let mut dependencies = vec![];
     let mut blocks = vec![];
@@ -225,7 +224,6 @@ impl Module for LazyCompilationProxyModule {
           DependencyRange::new(0, 0),
           None,
           false,
-          None,
           None,
         )) as BoxDependency);
       }

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -261,13 +261,15 @@ impl Module for RscEntryModule {
       let mut dependencies: Vec<BoxDependency> = Vec::with_capacity(all_client_modules.len());
       for client_module in all_client_modules {
         let referenced_specifiers = create_referenced_specifiers(&client_module.ids);
-        let dep = ImportEagerDependency::new(
+        let mut dep = ImportEagerDependency::new(
           Atom::from(client_module.request.as_str()),
           DependencyRange { start: 0, end: 0 },
-          referenced_specifiers,
           None,
           ImportPhase::Evaluation,
         );
+        if let Some(referenced_specifiers) = referenced_specifiers {
+          dep.set_referenced_specifiers(referenced_specifiers, true);
+        }
         dependencies.push(Box::new(dep));
       }
       Ok(BuildResult {

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -172,7 +172,6 @@ impl RstestParserPlugin {
             Some(call_expr.span.into()),
             parser.in_try,
             loc,
-            None,
           );
           parser.add_dependency(Box::new(dep));
 
@@ -227,7 +226,6 @@ impl RstestParserPlugin {
           let dep = Box::new(ImportDependency::new(
             Atom::from(lit.value.to_string_lossy().as_ref()),
             range,
-            None,
             Some(attrs),
             ImportPhase::Evaluation,
             parser.in_try,
@@ -562,7 +560,6 @@ impl RstestParserPlugin {
                 let dep = Box::new(ImportDependency::new(
                   Atom::from(mocked_target),
                   range,
-                  None,
                   Some(attrs),
                   ImportPhase::Evaluation,
                   parser.in_try,
@@ -594,7 +591,6 @@ impl RstestParserPlugin {
                   Some(call_expr.span.into()),
                   parser.in_try,
                   loc,
-                  None,
                 );
 
                 let callee_range = call_expr.callee.span().into();

--- a/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/index.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/index.js
@@ -1,0 +1,19 @@
+it("should work with cjs tree shaking and side effects free", () => {
+	const sideEffects =
+		(globalThis.__rspack_cjs_tree_shaking_side_effects_free_executions__ =
+			[]);
+
+	const lib = require("lib");
+	const {} = require("lib");
+	const unusedNewRequire = new require("lib");
+	const {} = new require("lib");
+	let b;
+	if (FALSY) {
+		b = lib.b;
+		b = unusedNewRequire.b;
+	}
+	expect(b).toBeUndefined();
+	expect(sideEffects).toEqual(["node_modules/lib/index.js", "node_modules/lib/m.js"]);
+
+	delete globalThis.__rspack_cjs_tree_shaking_side_effects_free_executions__;
+});

--- a/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/node_modules/lib/index.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/node_modules/lib/index.js
@@ -1,0 +1,9 @@
+globalThis.__rspack_cjs_tree_shaking_side_effects_free_executions__.push(
+	"node_modules/lib/index.js"
+);
+
+const b = require("./m.js");
+
+exports.a = { a: 1 };
+
+exports.b = b.f(exports.a)

--- a/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/node_modules/lib/m.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/node_modules/lib/m.js
@@ -1,0 +1,5 @@
+globalThis.__rspack_cjs_tree_shaking_side_effects_free_executions__.push(
+	"node_modules/lib/m.js"
+);
+
+exports.f = (obj) => obj.a + 1;

--- a/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/node_modules/lib/package.json
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/node_modules/lib/package.json
@@ -1,0 +1,3 @@
+{
+    "sideEffects": false
+}

--- a/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/rspack.config.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free/rspack.config.js
@@ -1,0 +1,10 @@
+const rspack = require('@rspack/core');
+
+module.exports = {
+  mode: 'production',
+  plugins: [
+    new rspack.DefinePlugin({
+      FALSY: JSON.stringify(false),
+    }),
+  ],
+};

--- a/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/index.js
@@ -1,0 +1,22 @@
+it("should work with dynamic import tree shaking and side effects free", async () => {
+	const sideEffects =
+		(globalThis.__rspack_dynamic_import_tree_shaking_side_effects_free_executions__ =
+			[]);
+
+	const lib = await import("lib");
+	const {} = await import("lib");
+	let thenCalled = false;
+	const libThen = await import("lib").then((m) => {
+		thenCalled = true;
+	});
+	expect(thenCalled).toBe(true);
+	let b;
+	if (FALSY) {
+		b = lib.b;
+		b = libThen;
+	}
+	expect(b).toBeUndefined();
+	expect(sideEffects).toEqual(["node_modules/lib/index.js", "node_modules/lib/m.js"]);
+
+	delete globalThis.__rspack_dynamic_import_tree_shaking_side_effects_free_executions__;
+});

--- a/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/node_modules/lib/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/node_modules/lib/index.js
@@ -1,0 +1,9 @@
+globalThis.__rspack_dynamic_import_tree_shaking_side_effects_free_executions__.push(
+	"node_modules/lib/index.js"
+);
+
+const b = require("./m.js");
+
+exports.a = { a: 1 };
+
+exports.b = b.f(exports.a)

--- a/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/node_modules/lib/m.js
+++ b/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/node_modules/lib/m.js
@@ -1,0 +1,5 @@
+globalThis.__rspack_dynamic_import_tree_shaking_side_effects_free_executions__.push(
+	"node_modules/lib/m.js"
+);
+
+exports.f = (obj) => obj.a + 1;

--- a/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/node_modules/lib/package.json
+++ b/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/node_modules/lib/package.json
@@ -1,0 +1,3 @@
+{
+    "sideEffects": false
+}

--- a/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/side-effects-free-dynamic-import/rspack.config.js
@@ -1,0 +1,10 @@
+const rspack = require('@rspack/core');
+
+module.exports = {
+  mode: 'production',
+  plugins: [
+    new rspack.DefinePlugin({
+      FALSY: JSON.stringify(false),
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

Fix #13865.

Fix incorrect tree shaking for CommonJS `require` and dynamic `import()` when static analysis infers empty referenced exports.

```js
// index.js
const lib = await import("lib");
const {} = await import("lib");

if (false) {
  console.log(lib.b);
}

// node_modules/lib/index.js (sideEffects: false)
const m = require("./m");

exports.a = { a: 1 };
exports.b = m.f(exports.a);

// node_modules/lib/m.js (sideEffects: false)
exports.f = (a) => a + 1
```

With `sideEffects: false` and production tree shaking, the empty referenced exports could cause incorrect output:

```js
// output of node_modules/lib/index.js
var __rspack_unused_export;
const m = __webpack_require__("./m");

__rspack_unused_export = { a: 1 };
__rspack_unused_export = m.f(exports.a);

// output of node_modules/lib/m.js
var __rspack_unused_export;
__rspack_unused_export = (obj) => obj.a + 1;
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
