### PR TITLE
feat: support fine-grained import.meta parser options

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2494,7 +2494,7 @@ export interface RawJavascriptParserOptions {
   reexportExportsPresence?: string
   worker?: boolean | Array<string> | RawJavascriptParserWorkerOptions
   overrideStrict?: string
-  importMeta?: string
+  importMeta?: string | Record<string, boolean>
   commonjsMagicComments?: boolean
   createRequire?: boolean | string
 commonjs?: boolean | { exports?: boolean | 'skipInEsm' }

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -341,7 +341,7 @@ pub struct RawJavascriptParserOptions {
   pub pure_functions: Option<Vec<String>>,
 }
 
-pub type RawImportMetaOptions = rustc_hash::FxHashMap<String, bool>;
+pub type RawImportMetaOptions = Arc<HashMap<String, bool>>;
 
 #[napi(object)]
 #[derive(Debug)]

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -30,7 +30,7 @@ use rspack_core::{
 };
 use rspack_error::error;
 use rspack_regex::RspackRegex;
-use rustc_hash::{FxHashMap, FxHashMap as HashMap};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   compiler_scoped_tsfn::CompilerScopedTsFnHandle as ThreadsafeFunction, filename::JsFilename,
@@ -341,7 +341,7 @@ pub struct RawJavascriptParserOptions {
   pub pure_functions: Option<Vec<String>>,
 }
 
-pub type RawImportMetaOptions = FxHashMap<String, bool>;
+pub type RawImportMetaOptions = rustc_hash::FxHashMap<String, bool>;
 
 #[napi(object)]
 #[derive(Debug)]

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -19,17 +19,18 @@ use rspack_core::{
   CssAutoOrModuleParserOptions, CssGeneratorOptions, CssModuleGeneratorOptions,
   CssModuleParserOptions, CssParserImport, CssParserImportContext, CssParserOptions,
   DescriptionData, DynamicImportFetchPriority, DynamicImportMode, ExportPresenceMode, FuncUseCtx,
-  GeneratorOptions, GeneratorOptionsMap, ImportMeta, JavascriptParserCommonjsExportsOption,
-  JavascriptParserCommonjsOptions, JavascriptParserCreateRequire, JavascriptParserOptions,
-  JavascriptParserOrder, JavascriptParserUrl, JavascriptParserWorkerOptions,
-  JavascriptParserWorkerUrl, JsonGeneratorOptions, JsonParserOptions, ModuleNoParseRule,
-  ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions, ModuleRule, ModuleRuleEffect,
-  ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, OverrideStrict, ParseOption,
-  ParserOptions, ParserOptionsMap, TypeReexportPresenceMode,
+  GeneratorOptions, GeneratorOptionsMap, ImportMeta, ImportMetaOptions,
+  JavascriptParserCommonjsExportsOption, JavascriptParserCommonjsOptions,
+  JavascriptParserCreateRequire, JavascriptParserOptions, JavascriptParserOrder,
+  JavascriptParserUrl, JavascriptParserWorkerOptions, JavascriptParserWorkerUrl,
+  JsonGeneratorOptions, JsonParserOptions, ModuleNoParseRule, ModuleNoParseRules,
+  ModuleNoParseTestFn, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleEnforce,
+  ModuleRuleUse, ModuleRuleUseLoader, OverrideStrict, ParseOption, ParserOptions, ParserOptionsMap,
+  TypeReexportPresenceMode,
 };
 use rspack_error::error;
 use rspack_regex::RspackRegex;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap, FxHashMap as HashMap};
 
 use crate::{
   compiler_scoped_tsfn::CompilerScopedTsFnHandle as ThreadsafeFunction, filename::JsFilename,
@@ -299,7 +300,8 @@ pub struct RawJavascriptParserOptions {
   #[napi(ts_type = "boolean | Array<string> | RawJavascriptParserWorkerOptions")]
   pub worker: Option<Either3<bool, Vec<String>, RawJavascriptParserWorkerOptions>>,
   pub override_strict: Option<String>,
-  pub import_meta: Option<String>,
+  #[napi(ts_type = "string | Record<string, boolean>")]
+  pub import_meta: Option<Either<String, RawImportMetaOptions>>,
   pub commonjs_magic_comments: Option<bool>,
   #[napi(ts_type = "boolean | string")]
   pub create_require: Option<Either<bool, String>>,
@@ -338,6 +340,8 @@ pub struct RawJavascriptParserOptions {
   #[napi(js_name = "pureFunctions")]
   pub pure_functions: Option<Vec<String>>,
 }
+
+pub type RawImportMetaOptions = FxHashMap<String, bool>;
 
 #[napi(object)]
 #[derive(Debug)]
@@ -413,7 +417,10 @@ impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
       override_strict: value
         .override_strict
         .map(|e| OverrideStrict::from(e.as_str())),
-      import_meta: value.import_meta.map(|e| ImportMeta::from(e.as_str())),
+      import_meta: value.import_meta.map(|e| match e {
+        Either::A(value) => ImportMeta::from(value.as_str()),
+        Either::B(value) => ImportMeta::Granular(ImportMetaOptions::new(value)),
+      }),
       require_alias: value.require_alias,
       require_as_expression: value.require_as_expression,
       require_dynamic: value.require_dynamic,

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -341,7 +341,7 @@ pub struct RawJavascriptParserOptions {
   pub pure_functions: Option<Vec<String>>,
 }
 
-pub type RawImportMetaOptions = Arc<HashMap<String, bool>>;
+pub type RawImportMetaOptions = HashMap<String, bool>;
 
 #[napi(object)]
 #[derive(Debug)]

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -14,7 +14,7 @@ use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap, FxHashMap as HashMap};
 use smallvec::SmallVec;
 use tokio::sync::OnceCell;
 
@@ -298,11 +298,12 @@ impl From<&str> for OverrideStrict {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Copy, MergeFrom)]
+#[derive(Debug, Clone, MergeFrom)]
 pub enum ImportMeta {
   PreserveUnknown,
   Enabled,
   Disabled,
+  Granular(ImportMetaOptions),
 }
 
 impl From<&str> for ImportMeta {
@@ -340,6 +341,83 @@ impl RspackHash for JavascriptParserWorkerUrl {
 }
 
 #[cacheable]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash)]
+pub struct ImportMetaKnownProperties(u32);
+
+macro_rules! define_import_meta_known_properties {
+  (@step ($val:expr) ({$($flags:tt)*}) ({$($properties:tt)*}) ($(#[$($attr:tt)+])* const $name:ident = $property:literal; $($rest:tt)*)) => {
+    define_import_meta_known_properties! {
+      @step ($val << 1) ({
+        $($flags)*
+        $(#[$($attr)+])*
+        const $name = $val;
+      }) ({
+        $($properties)*
+        ($name, $property);
+      }) ($($rest)*)
+    }
+  };
+  (@step ($val:expr) ({$($flags:tt)*}) ({$($properties:tt)*}) ()) => {
+    bitflags! {
+      impl ImportMetaKnownProperties: u32 {
+        $($flags)*
+      }
+    }
+
+    impl ImportMetaKnownProperties {
+      pub fn enabled_from_properties(properties: &FxHashMap<String, bool>) -> Self {
+        let mut enabled_properties = Self::all();
+        define_import_meta_known_properties! {
+          @disable (enabled_properties) (properties) $($properties)*
+        }
+        enabled_properties
+      }
+    }
+  };
+  (@disable ($enabled_properties:ident) ($properties:ident) ($name:ident, $property:literal); $($rest:tt)*) => {
+    if matches!($properties.get($property), Some(false)) {
+      $enabled_properties.remove(Self::$name);
+    }
+    define_import_meta_known_properties! {
+      @disable ($enabled_properties) ($properties) $($rest)*
+    }
+  };
+  (@disable ($enabled_properties:ident) ($properties:ident)) => {};
+  ($($rest:tt)*) => {
+    define_import_meta_known_properties! {
+      @step (1u32) ({}) ({}) ($($rest)*)
+    }
+  };
+}
+
+define_import_meta_known_properties! {
+  const DIRNAME = "dirname";
+  const FILENAME = "filename";
+  const GLOB = "glob";
+  const MAIN = "main";
+  const RESOLVE = "resolve";
+  const RSPACK_BASE_URI = "rspackBaseUri";
+  const RSPACK_HASH = "rspackHash";
+  const RSPACK_INIT_SHARING = "rspackInitSharing";
+  const RSPACK_NONCE = "rspackNonce";
+  const RSPACK_PUBLIC_PATH = "rspackPublicPath";
+  const RSPACK_RSC = "rspackRsc";
+  const RSPACK_SHARE_SCOPES = "rspackShareScopes";
+  const RSPACK_UNIQUE_ID = "rspackUniqueId";
+  const RSPACK_VERSION = "rspackVersion";
+  const URL = "url";
+  const WEBPACK = "webpack";
+  const WEBPACK_CONTEXT = "webpackContext";
+  const WEBPACK_HOT = "webpackHot";
+}
+
+impl MergeFrom for ImportMetaKnownProperties {
+  fn merge_from(self, other: &Self) -> Self {
+    *other
+  }
+}
+
+#[cacheable]
 #[derive(Debug, Clone, MergeFrom, Default)]
 pub struct JavascriptParserWorkerOptions {
   pub alias: Option<Vec<String>>,
@@ -352,6 +430,77 @@ impl JavascriptParserWorkerOptions {
       alias: Some(alias),
       url,
     }
+  }
+}
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct ImportMetaOptions {
+  enabled_known_properties: ImportMetaKnownProperties,
+  properties: FxHashMap<String, bool>,
+}
+
+impl ImportMetaOptions {
+  pub fn new(properties: FxHashMap<String, bool>) -> Self {
+    Self {
+      enabled_known_properties: Self::enabled_known_properties(&properties),
+      properties,
+    }
+  }
+
+  fn enabled_known_properties(properties: &FxHashMap<String, bool>) -> ImportMetaKnownProperties {
+    ImportMetaKnownProperties::enabled_from_properties(properties)
+  }
+
+  pub fn is_known_property_enabled(&self, property: ImportMetaKnownProperties) -> bool {
+    self.enabled_known_properties.contains(property)
+  }
+}
+
+impl MergeFrom for ImportMetaOptions {
+  fn merge_from(mut self, other: &Self) -> Self {
+    self.properties.extend(other.properties.clone());
+    self.enabled_known_properties = Self::enabled_known_properties(&self.properties);
+    self
+  }
+}
+
+impl Default for ImportMetaOptions {
+  fn default() -> Self {
+    Self {
+      enabled_known_properties: ImportMetaKnownProperties::all(),
+      properties: Default::default(),
+    }
+  }
+}
+
+impl ImportMeta {
+  pub fn is_enabled(&self) -> bool {
+    !matches!(self, Self::Disabled)
+  }
+
+  pub fn preserve_unknown(&self) -> bool {
+    matches!(self, Self::PreserveUnknown | Self::Granular(_))
+  }
+
+  pub fn is_known_property_enabled(&self, property: ImportMetaKnownProperties) -> bool {
+    match self {
+      Self::Disabled => false,
+      Self::Enabled | Self::PreserveUnknown => true,
+      Self::Granular(options) => options.is_known_property_enabled(property),
+    }
+  }
+
+  pub fn is_webpack_context_enabled(&self) -> bool {
+    self.is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_CONTEXT)
+  }
+
+  pub fn is_glob_enabled(&self) -> bool {
+    self.is_known_property_enabled(ImportMetaKnownProperties::GLOB)
+  }
+
+  pub fn is_webpack_hot_enabled(&self) -> bool {
+    self.is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_HOT)
   }
 }
 

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -530,8 +530,11 @@ pub struct JavascriptParserOptions {
 }
 
 impl JavascriptParserOptions {
-  pub fn import_meta(&self) -> ImportMeta {
-    self.import_meta.clone().unwrap_or(ImportMeta::Enabled)
+  pub fn import_meta(&self) -> &ImportMeta {
+    self
+      .import_meta
+      .as_ref()
+      .expect("javascript parser import_meta should be normalized by defaults")
   }
 
   pub fn create_require_option(&self) -> Option<&str> {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -492,18 +492,6 @@ impl ImportMeta {
       Self::Granular(options) => options.is_known_property_enabled(property),
     }
   }
-
-  pub fn is_webpack_context_enabled(&self) -> bool {
-    self.is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_CONTEXT)
-  }
-
-  pub fn is_glob_enabled(&self) -> bool {
-    self.is_known_property_enabled(ImportMetaKnownProperties::GLOB)
-  }
-
-  pub fn is_webpack_hot_enabled(&self) -> bool {
-    self.is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_HOT)
-  }
 }
 
 #[cacheable]
@@ -542,6 +530,10 @@ pub struct JavascriptParserOptions {
 }
 
 impl JavascriptParserOptions {
+  pub fn import_meta(&self) -> ImportMeta {
+    self.import_meta.clone().unwrap_or(ImportMeta::Enabled)
+  }
+
   pub fn create_require_option(&self) -> Option<&str> {
     match self.create_require.as_ref()? {
       JavascriptParserCreateRequire::Disabled => None,

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -365,7 +365,7 @@ macro_rules! define_import_meta_known_properties {
     }
 
     impl ImportMetaKnownProperties {
-      pub fn enabled_from_properties(properties: &rustc_hash::FxHashMap<String, bool>) -> Self {
+      pub fn enabled_from_properties(properties: &HashMap<String, bool>) -> Self {
         let mut enabled_properties = Self::all();
         define_import_meta_known_properties! {
           @disable (enabled_properties) (properties) $($properties)*

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -437,20 +437,20 @@ impl JavascriptParserWorkerOptions {
 #[derive(Debug, Clone)]
 pub struct ImportMetaOptions {
   enabled_known_properties: ImportMetaKnownProperties,
-  properties: rustc_hash::FxHashMap<String, bool>,
+  properties: Arc<HashMap<String, bool>>,
 }
 
 impl ImportMetaOptions {
-  pub fn new(properties: rustc_hash::FxHashMap<String, bool>) -> Self {
+  pub fn new(properties: Arc<HashMap<String, bool>>) -> Self {
+    let enabled_known_properties = ImportMetaKnownProperties::enabled_from_properties(&properties);
+
     Self {
-      enabled_known_properties: Self::enabled_known_properties(&properties),
+      enabled_known_properties,
       properties,
     }
   }
 
-  fn enabled_known_properties(
-    properties: &rustc_hash::FxHashMap<String, bool>,
-  ) -> ImportMetaKnownProperties {
+  fn enabled_known_properties(properties: &HashMap<String, bool>) -> ImportMetaKnownProperties {
     ImportMetaKnownProperties::enabled_from_properties(properties)
   }
 

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -14,7 +14,7 @@ use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
-use rustc_hash::{FxHashMap, FxHashMap as HashMap};
+use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 use tokio::sync::OnceCell;
 
@@ -365,7 +365,7 @@ macro_rules! define_import_meta_known_properties {
     }
 
     impl ImportMetaKnownProperties {
-      pub fn enabled_from_properties(properties: &FxHashMap<String, bool>) -> Self {
+      pub fn enabled_from_properties(properties: &rustc_hash::FxHashMap<String, bool>) -> Self {
         let mut enabled_properties = Self::all();
         define_import_meta_known_properties! {
           @disable (enabled_properties) (properties) $($properties)*
@@ -437,18 +437,20 @@ impl JavascriptParserWorkerOptions {
 #[derive(Debug, Clone)]
 pub struct ImportMetaOptions {
   enabled_known_properties: ImportMetaKnownProperties,
-  properties: FxHashMap<String, bool>,
+  properties: rustc_hash::FxHashMap<String, bool>,
 }
 
 impl ImportMetaOptions {
-  pub fn new(properties: FxHashMap<String, bool>) -> Self {
+  pub fn new(properties: rustc_hash::FxHashMap<String, bool>) -> Self {
     Self {
       enabled_known_properties: Self::enabled_known_properties(&properties),
       properties,
     }
   }
 
-  fn enabled_known_properties(properties: &FxHashMap<String, bool>) -> ImportMetaKnownProperties {
+  fn enabled_known_properties(
+    properties: &rustc_hash::FxHashMap<String, bool>,
+  ) -> ImportMetaKnownProperties {
     ImportMetaKnownProperties::enabled_from_properties(properties)
   }
 

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -437,11 +437,11 @@ impl JavascriptParserWorkerOptions {
 #[derive(Debug, Clone)]
 pub struct ImportMetaOptions {
   enabled_known_properties: ImportMetaKnownProperties,
-  properties: Arc<HashMap<String, bool>>,
+  properties: HashMap<String, bool>,
 }
 
 impl ImportMetaOptions {
-  pub fn new(properties: Arc<HashMap<String, bool>>) -> Self {
+  pub fn new(properties: HashMap<String, bool>) -> Self {
     let enabled_known_properties = ImportMetaKnownProperties::enabled_from_properties(&properties);
 
     Self {

--- a/crates/rspack_core/src/plugin/context.rs
+++ b/crates/rspack_core/src/plugin/context.rs
@@ -6,16 +6,17 @@ use rspack_util::fx_hash::FxDashMap;
 use crate::{
   AssetGeneratorOptions, AssetParserOptions, AssetResourceGeneratorOptions, CompilationHooks,
   CompilerHooks, CompilerOptions, ConcatenatedModuleHooks, ContextModuleFactoryHooks,
-  CssAutoOrModuleParserOptions, CssModuleGeneratorOptions, GeneratorOptions, JsonGeneratorOptions,
-  JsonParserOptions, MODULE_RULE_ID_UNASSIGNED, ModuleRuleEffect, ModuleRuleIds, ModuleType,
-  NormalModuleFactoryHooks, NormalModuleHooks, ParserAndGenerator, ParserOptions,
+  CssAutoOrModuleParserOptions, CssModuleGeneratorOptions, GeneratorOptions, ImportMeta,
+  JavascriptParserOptions, JsonGeneratorOptions, JsonParserOptions, MODULE_RULE_ID_UNASSIGNED,
+  ModuleRuleEffect, ModuleRuleIds, ModuleType, NormalModuleFactoryHooks, NormalModuleHooks,
+  ParserAndGenerator, ParserOptions,
 };
 
 pub type BoxedParserAndGenerator = Box<dyn ParserAndGenerator>;
 pub type BoxedParserAndGeneratorBuilder =
   Box<dyn 'static + Send + Sync + Fn(Arc<ResolvedModuleOptions>) -> BoxedParserAndGenerator>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ArcComputed<T, U> {
   owner: Arc<T>,
   computed: *const U,
@@ -34,6 +35,15 @@ impl<T, U> ArcComputed<T, U> {
 
   pub fn owner(&self) -> &Arc<T> {
     &self.owner
+  }
+}
+
+impl<T, U> Clone for ArcComputed<T, U> {
+  fn clone(&self) -> Self {
+    Self {
+      owner: Arc::clone(&self.owner),
+      computed: self.computed,
+    }
   }
 }
 
@@ -106,6 +116,22 @@ impl<'a> From<&'a ResolvedModuleOptions> for &'a JsonParserOptions {
       .parser_options()
       .and_then(ParserOptions::get_json)
       .expect("should have JsonParserOptions")
+  }
+}
+
+impl<'a> From<&'a ResolvedModuleOptions> for &'a JavascriptParserOptions {
+  fn from(owner: &'a ResolvedModuleOptions) -> Self {
+    owner
+      .parser_options()
+      .and_then(ParserOptions::get_javascript)
+      .expect("should have JavascriptParserOptions")
+  }
+}
+
+impl<'a> From<&'a ResolvedModuleOptions> for &'a ImportMeta {
+  fn from(owner: &'a ResolvedModuleOptions) -> Self {
+    let javascript_options: &JavascriptParserOptions = owner.into();
+    javascript_options.import_meta()
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -5,13 +5,17 @@ use std::{
 };
 
 use regex::Regex;
-use rspack_cacheable::{cacheable, cacheable_dyn, with::Skip};
+use rspack_cacheable::{
+  cacheable, cacheable_dyn,
+  with::{AsInner, Skip},
+};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BuildMetaExportsType, COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY,
-  ChunkGraph, CollectedTypeScriptInfo, Compilation, DependenciesBlock, DependencyId,
-  GenerateContext, Module, ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  ParseContext, ParseResult, ParserAndGenerator, RuntimeGlobals, RuntimeVariable,
-  SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
+  ArcComputed, AsyncDependenciesBlockIdentifier, BuildMetaExportsType,
+  COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, ChunkGraph, CollectedTypeScriptInfo, Compilation,
+  DependenciesBlock, DependencyId, GenerateContext, ImportMeta, Module, ModuleArgument,
+  ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult, ParserAndGenerator,
+  ResolvedModuleOptions, RuntimeGlobals, RuntimeVariable, SideEffectsBailoutItem, SourceType,
+  TemplateContext, TemplateReplaceSource,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   remove_bom, render_init_fragments,
   rspack_sources::{BoxSource, ReplaceSource, Source, SourceExt},
@@ -107,8 +111,9 @@ impl ParserRuntimeRequirementsData {
 }
 
 #[cacheable]
-#[derive(Default)]
 pub struct JavaScriptParserAndGenerator {
+  #[cacheable(with=AsInner)]
+  import_meta: ArcComputed<ResolvedModuleOptions, ImportMeta>,
   #[cacheable(with=Skip)]
   parser_plugins: Vec<BoxJavascriptParserPlugin>,
 }
@@ -122,6 +127,13 @@ impl std::fmt::Debug for JavaScriptParserAndGenerator {
 }
 
 impl JavaScriptParserAndGenerator {
+  pub fn new(module_options: Arc<ResolvedModuleOptions>) -> Self {
+    Self {
+      import_meta: ArcComputed::new(module_options, |options| options.into()),
+      parser_plugins: Vec::default(),
+    }
+  }
+
   pub fn add_parser_plugin(&mut self, parser_plugin: BoxJavascriptParserPlugin) {
     self.parser_plugins.push(parser_plugin);
   }
@@ -326,6 +338,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       build_info,
       module_identifier,
       module_parser_options,
+      ArcComputed::clone(&self.import_meta),
       &mut semicolons,
       &mut self.parser_plugins,
       parse_meta,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -1,5 +1,6 @@
 use rspack_core::{
-  ConstDependency, ModuleArgument, RuntimeGlobals, RuntimeRequirementsDependency, property_access,
+  ConstDependency, ImportMetaKnownProperties, ModuleArgument, RuntimeGlobals,
+  RuntimeRequirementsDependency, property_access,
   runtime_mode::RuntimeMode as ExperimentRuntimeMode,
 };
 use rspack_error::{Error, Severity};
@@ -15,7 +16,7 @@ use crate::{
   },
   parser_plugin::JavascriptParserPlugin,
   utils::eval::{self, BasicEvaluatedExpression},
-  visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error},
+  visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error, expr_name},
 };
 
 fn expression_not_supported(
@@ -177,65 +178,72 @@ static RUNTIME_APIS: &[RuntimeApi] = &[
 #[derive(Clone, Copy)]
 pub(crate) struct ImportMetaRuntimeApi {
   pub(crate) name: &'static str,
-  pub(crate) property: &'static str,
+  pub(crate) property: ImportMetaKnownProperties,
   pub(crate) type_of: &'static str,
   runtime_global: RuntimeGlobals,
   runtime_call: bool,
 }
 
+impl ImportMetaRuntimeApi {
+  fn property_name(&self) -> &'static str {
+    debug_assert!(self.name.starts_with(expr_name::IMPORT_META_PREFIX));
+    &self.name[expr_name::IMPORT_META_PREFIX.len()..]
+  }
+}
+
 static IMPORT_META_RUNTIME_APIS: &[ImportMetaRuntimeApi] = &[
   ImportMetaRuntimeApi {
     name: "import.meta.rspackPublicPath",
-    property: "rspackPublicPath",
+    property: ImportMetaKnownProperties::RSPACK_PUBLIC_PATH,
     type_of: "string",
     runtime_global: RuntimeGlobals::PUBLIC_PATH,
     runtime_call: false,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackBaseUri",
-    property: "rspackBaseUri",
+    property: ImportMetaKnownProperties::RSPACK_BASE_URI,
     type_of: "string",
     runtime_global: RuntimeGlobals::BASE_URI,
     runtime_call: false,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackShareScopes",
-    property: "rspackShareScopes",
+    property: ImportMetaKnownProperties::RSPACK_SHARE_SCOPES,
     type_of: "object",
     runtime_global: RuntimeGlobals::SHARE_SCOPE_MAP,
     runtime_call: false,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackInitSharing",
-    property: "rspackInitSharing",
+    property: ImportMetaKnownProperties::RSPACK_INIT_SHARING,
     type_of: "function",
     runtime_global: RuntimeGlobals::INITIALIZE_SHARING,
     runtime_call: false,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackNonce",
-    property: "rspackNonce",
+    property: ImportMetaKnownProperties::RSPACK_NONCE,
     type_of: "string",
     runtime_global: RuntimeGlobals::SCRIPT_NONCE,
     runtime_call: false,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackUniqueId",
-    property: "rspackUniqueId",
+    property: ImportMetaKnownProperties::RSPACK_UNIQUE_ID,
     type_of: "string",
     runtime_global: RuntimeGlobals::RSPACK_UNIQUE_ID,
     runtime_call: false,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackVersion",
-    property: "rspackVersion",
+    property: ImportMetaKnownProperties::RSPACK_VERSION,
     type_of: "string",
     runtime_global: RuntimeGlobals::RSPACK_VERSION,
     runtime_call: true,
   },
   ImportMetaRuntimeApi {
     name: "import.meta.rspackHash",
-    property: "rspackHash",
+    property: ImportMetaKnownProperties::RSPACK_HASH,
     type_of: "string",
     runtime_global: RuntimeGlobals::GET_FULL_HASH,
     runtime_call: true,
@@ -276,7 +284,7 @@ pub(crate) fn import_meta_runtime_api_from_property(
 ) -> Option<&'static ImportMetaRuntimeApi> {
   IMPORT_META_RUNTIME_APIS
     .iter()
-    .find(|api| api.property == property)
+    .find(|api| api.property_name() == property)
 }
 
 pub(crate) fn render_import_meta_runtime_api(
@@ -313,7 +321,7 @@ pub(crate) fn render_import_meta_runtime_api_destructuring(
   )));
   Some(format!(
     "{}: {}",
-    api.property,
+    api.property_name(),
     render_import_meta_runtime_api(parser, api)?
   ))
 }
@@ -356,18 +364,17 @@ pub(crate) fn import_meta_runtime_api_assign(
   simple_assignment: bool,
 ) -> Option<bool> {
   if api.runtime_call {
+    let property = api.property_name();
     let content = if full_assignment {
       if simple_assignment {
-        format!("({{}}).{}", api.property)
+        format!("({{}}).{property}")
       } else {
         parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::add_only(
           api.runtime_global,
         )));
         format!(
-          "({{ {}: {} }}).{}",
-          api.property,
+          "({{ {property}: {} }}).{property}",
           render_import_meta_runtime_api(parser, api)?,
-          api.property
         )
       }
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -1,3 +1,4 @@
+use concat_string::concat_string;
 use rspack_core::{
   ConstDependency, ImportMetaKnownProperties, ModuleArgument, RuntimeGlobals,
   RuntimeRequirementsDependency, property_access,
@@ -367,14 +368,18 @@ pub(crate) fn import_meta_runtime_api_assign(
     let property = api.property_name();
     let content = if full_assignment {
       if simple_assignment {
-        format!("({{}}).{property}")
+        concat_string!("({}).", property)
       } else {
         parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::add_only(
           api.runtime_global,
         )));
-        format!(
-          "({{ {property}: {} }}).{property}",
+        concat_string!(
+          "({ ",
+          property,
+          ": ",
           render_import_meta_runtime_api(parser, api)?,
+          " }).",
+          property
         )
       }
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -1,4 +1,4 @@
-use rspack_core::{BoxDependency, DependencyRange};
+use rspack_core::{BoxDependency, DependencyRange, ImportMetaKnownProperties};
 use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{CallExpr, GetSpan, MemberExpr, Span};
@@ -15,14 +15,6 @@ use crate::{
 };
 
 type CreateDependency = fn(Atom, DependencyRange) -> BoxDependency;
-
-fn import_meta_webpack_hot_enabled(parser: &JavascriptParser) -> bool {
-  parser
-    .javascript_options
-    .import_meta
-    .as_ref()
-    .is_none_or(|import_meta| import_meta.is_webpack_hot_enabled())
-}
 
 fn extract_deps(
   parser: &mut JavascriptParser,
@@ -219,7 +211,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPl
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {
-    if for_name == expr_name::IMPORT_META_HOT && import_meta_webpack_hot_enabled(parser) {
+    if for_name == expr_name::IMPORT_META_HOT
+      && parser
+        .javascript_options
+        .import_meta()
+        .is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_HOT)
+    {
       Some(eval::evaluate_to_identifier(
         expr_name::IMPORT_META_HOT.into(),
         expr_name::IMPORT_META.into(),
@@ -238,7 +235,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPl
     expr: &MemberExpr,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == expr_name::IMPORT_META_HOT && import_meta_webpack_hot_enabled(parser) {
+    if for_name == expr_name::IMPORT_META_HOT
+      && parser
+        .javascript_options
+        .import_meta()
+        .is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_HOT)
+    {
       parser.create_hmr_expression_handler(expr.span());
       Some(true)
     } else {
@@ -252,7 +254,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPl
     call_expr: &CallExpr,
     for_name: &str,
   ) -> Option<bool> {
-    if !import_meta_webpack_hot_enabled(parser) {
+    if !parser
+      .javascript_options
+      .import_meta()
+      .is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_HOT)
+    {
       return None;
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -16,6 +16,14 @@ use crate::{
 
 type CreateDependency = fn(Atom, DependencyRange) -> BoxDependency;
 
+fn import_meta_webpack_hot_enabled(parser: &JavascriptParser) -> bool {
+  parser
+    .javascript_options
+    .import_meta
+    .as_ref()
+    .is_none_or(|import_meta| import_meta.is_webpack_hot_enabled())
+}
+
 fn extract_deps(
   parser: &mut JavascriptParser,
   call_expr: &CallExpr,
@@ -205,13 +213,13 @@ impl ImportMetaHotReplacementParserPlugin {
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPlugin {
   fn evaluate_identifier(
     &self,
-    _parser: &mut JavascriptParser<'p>,
+    parser: &mut JavascriptParser<'p>,
     for_name: &str,
     _member_expr_info: Option<&crate::visitors::ExpressionExpressionInfo>,
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {
-    if for_name == expr_name::IMPORT_META_HOT {
+    if for_name == expr_name::IMPORT_META_HOT && import_meta_webpack_hot_enabled(parser) {
       Some(eval::evaluate_to_identifier(
         expr_name::IMPORT_META_HOT.into(),
         expr_name::IMPORT_META.into(),
@@ -230,7 +238,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPl
     expr: &MemberExpr,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == expr_name::IMPORT_META_HOT {
+    if for_name == expr_name::IMPORT_META_HOT && import_meta_webpack_hot_enabled(parser) {
       parser.create_hmr_expression_handler(expr.span());
       Some(true)
     } else {
@@ -244,6 +252,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaHotReplacementParserPl
     call_expr: &CallExpr,
     for_name: &str,
   ) -> Option<bool> {
+    if !import_meta_webpack_hot_enabled(parser) {
+      return None;
+    }
+
     if for_name == expr_name::IMPORT_META_HOT_ACCEPT {
       parser.create_accept_handler(call_expr, |request, range| {
         Box::new(ImportMetaHotAcceptDependency::new(request, range))

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -424,7 +424,10 @@ fn create_import_meta_glob_dependency(
   ))
 }
 
-pub struct ImportMetaContextDependencyParserPlugin;
+pub struct ImportMetaContextDependencyParserPlugin {
+  pub webpack_context: bool,
+  pub glob: bool,
+}
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaContextDependencyParserPlugin {
@@ -437,8 +440,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaContextDependencyParse
     end: u32,
   ) -> Option<BasicEvaluatedExpression<'p>> {
     let name = match for_name {
-      expr_name::IMPORT_META_CONTEXT => expr_name::IMPORT_META_CONTEXT,
-      expr_name::IMPORT_META_GLOB => expr_name::IMPORT_META_GLOB,
+      expr_name::IMPORT_META_CONTEXT if self.webpack_context => expr_name::IMPORT_META_CONTEXT,
+      expr_name::IMPORT_META_GLOB if self.glob => expr_name::IMPORT_META_GLOB,
       _ => return None,
     };
 
@@ -462,8 +465,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaContextDependencyParse
     }
 
     let dep = match for_name {
-      expr_name::IMPORT_META_CONTEXT => create_import_meta_context_dependency(expr, parser),
-      expr_name::IMPORT_META_GLOB => create_import_meta_glob_dependency(expr, parser),
+      expr_name::IMPORT_META_CONTEXT if self.webpack_context => {
+        create_import_meta_context_dependency(expr, parser)
+      }
+      expr_name::IMPORT_META_GLOB if self.glob => create_import_meta_glob_dependency(expr, parser),
       _ => None,
     };
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_path.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_path.rs
@@ -1,3 +1,4 @@
+use concat_string::concat_string;
 use rspack_core::{
   CachedConstDependency, CachedConstDependencyPlace, DependencyRange, ImportMetaKnownProperties,
   NodeDirnameOption, NodeFilenameOption, NodeOption, parse_resource,
@@ -45,15 +46,21 @@ fn warning_code(property: ImportMetaKnownProperties) -> &'static str {
 
 fn warning_message(property: ImportMetaKnownProperties) -> String {
   match property {
-    ImportMetaKnownProperties::FILENAME => format!(
-      "\"{}\" is used and has been mocked. Remove it from your code, or set `{}` to disable this warning.",
-      yellow(&"import.meta.filename"),
-      cyan(&"node.__filename")
+    ImportMetaKnownProperties::FILENAME => concat_string!(
+      "\"",
+      yellow(&"import.meta.filename").to_string(),
+      "\" is used and has been mocked. ",
+      "Remove it from your code, or set `",
+      cyan(&"node.__filename").to_string(),
+      "` to disable this warning."
     ),
-    ImportMetaKnownProperties::DIRNAME => format!(
-      "\"{}\" is used and has been mocked. Remove it from your code, or set `{}` to disable this warning.",
-      yellow(&"import.meta.dirname"),
-      cyan(&"node.__dirname")
+    ImportMetaKnownProperties::DIRNAME => concat_string!(
+      "\"",
+      yellow(&"import.meta.dirname").to_string(),
+      "\" is used and has been mocked. ",
+      "Remove it from your code, or set `",
+      cyan(&"node.__dirname").to_string(),
+      "` to disable this warning."
     ),
     _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_path.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_path.rs
@@ -1,0 +1,357 @@
+use rspack_core::{
+  CachedConstDependency, CachedConstDependencyPlace, DependencyRange, ImportMetaKnownProperties,
+  NodeDirnameOption, NodeFilenameOption, NodeOption, parse_resource,
+};
+use rspack_error::{Diagnostic, cyan, yellow};
+use sugar_path::SugarPath;
+use url::Url;
+
+use crate::{dependency::ExternalModuleDependency, visitors::JavascriptParser};
+
+const MOCK_DIRNAME: &str = "/";
+const MOCK_FILENAME: &str = "/index.js";
+
+fn mock_value(property: ImportMetaKnownProperties) -> &'static str {
+  match property {
+    ImportMetaKnownProperties::FILENAME => MOCK_FILENAME,
+    ImportMetaKnownProperties::DIRNAME => MOCK_DIRNAME,
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn import_meta_name(property: ImportMetaKnownProperties) -> &'static str {
+  match property {
+    ImportMetaKnownProperties::FILENAME => "import.meta.filename",
+    ImportMetaKnownProperties::DIRNAME => "import.meta.dirname",
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn cjs_name(property: ImportMetaKnownProperties) -> &'static str {
+  match property {
+    ImportMetaKnownProperties::FILENAME => "__filename",
+    ImportMetaKnownProperties::DIRNAME => "__dirname",
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn warning_code(property: ImportMetaKnownProperties) -> &'static str {
+  match property {
+    ImportMetaKnownProperties::FILENAME => "NODE_IMPORT_META_FILENAME",
+    ImportMetaKnownProperties::DIRNAME => "NODE_IMPORT_META_DIRNAME",
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn warning_message(property: ImportMetaKnownProperties) -> String {
+  match property {
+    ImportMetaKnownProperties::FILENAME => format!(
+      "\"{}\" is used and has been mocked. Remove it from your code, or set `{}` to disable this warning.",
+      yellow(&"import.meta.filename"),
+      cyan(&"node.__filename")
+    ),
+    ImportMetaKnownProperties::DIRNAME => format!(
+      "\"{}\" is used and has been mocked. Remove it from your code, or set `{}` to disable this warning.",
+      yellow(&"import.meta.dirname"),
+      cyan(&"node.__dirname")
+    ),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn node_module_runtime_expr(property: ImportMetaKnownProperties) -> &'static str {
+  match property {
+    ImportMetaKnownProperties::FILENAME => "__rspack_fileURLToPath(import.meta.url)",
+    ImportMetaKnownProperties::DIRNAME => {
+      "__rspack_dirname(__rspack_fileURLToPath(import.meta.url))"
+    }
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn import_meta_cached_identifier(property: ImportMetaKnownProperties) -> &'static str {
+  match property {
+    ImportMetaKnownProperties::FILENAME => "__rspack_import_meta_filename__",
+    ImportMetaKnownProperties::DIRNAME => "__rspack_import_meta_dirname__",
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn is_disabled(property: ImportMetaKnownProperties, node_option: &NodeOption) -> bool {
+  match property {
+    ImportMetaKnownProperties::FILENAME => {
+      matches!(node_option.filename, NodeFilenameOption::False)
+    }
+    ImportMetaKnownProperties::DIRNAME => matches!(node_option.dirname, NodeDirnameOption::False),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn is_mock(property: ImportMetaKnownProperties, node_option: &NodeOption) -> bool {
+  match property {
+    ImportMetaKnownProperties::FILENAME => matches!(node_option.filename, NodeFilenameOption::Mock),
+    ImportMetaKnownProperties::DIRNAME => matches!(node_option.dirname, NodeDirnameOption::Mock),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn is_warn_mock(property: ImportMetaKnownProperties, node_option: &NodeOption) -> bool {
+  match property {
+    ImportMetaKnownProperties::FILENAME => {
+      matches!(node_option.filename, NodeFilenameOption::WarnMock)
+    }
+    ImportMetaKnownProperties::DIRNAME => {
+      matches!(node_option.dirname, NodeDirnameOption::WarnMock)
+    }
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn is_true(property: ImportMetaKnownProperties, node_option: &NodeOption) -> bool {
+  match property {
+    ImportMetaKnownProperties::FILENAME => matches!(node_option.filename, NodeFilenameOption::True),
+    ImportMetaKnownProperties::DIRNAME => matches!(node_option.dirname, NodeDirnameOption::True),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn is_eval_only(property: ImportMetaKnownProperties, node_option: &NodeOption) -> bool {
+  match property {
+    ImportMetaKnownProperties::FILENAME => {
+      matches!(node_option.filename, NodeFilenameOption::EvalOnly)
+    }
+    ImportMetaKnownProperties::DIRNAME => {
+      matches!(node_option.dirname, NodeDirnameOption::EvalOnly)
+    }
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn is_node_module(property: ImportMetaKnownProperties, node_option: &NodeOption) -> bool {
+  match property {
+    ImportMetaKnownProperties::FILENAME => {
+      matches!(node_option.filename, NodeFilenameOption::NodeModule)
+    }
+    ImportMetaKnownProperties::DIRNAME => {
+      matches!(node_option.dirname, NodeDirnameOption::NodeModule)
+    }
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+pub(crate) fn should_handle_import_meta_path(
+  parser: &JavascriptParser,
+  property: ImportMetaKnownProperties,
+) -> bool {
+  parser
+    .compiler_options
+    .node
+    .as_ref()
+    .is_some_and(|node_option| !is_disabled(property, node_option))
+}
+
+fn get_relative_path(
+  parser: &JavascriptParser,
+  property: ImportMetaKnownProperties,
+) -> Option<String> {
+  match property {
+    ImportMetaKnownProperties::FILENAME => Some(
+      parser
+        .resource_data
+        .path()?
+        .as_std_path()
+        .relative(&parser.compiler_options.context)
+        .to_string_lossy()
+        .to_string(),
+    ),
+    ImportMetaKnownProperties::DIRNAME => Some(
+      parser
+        .resource_data
+        .path()?
+        .parent()?
+        .as_std_path()
+        .relative(&parser.compiler_options.context)
+        .to_string_lossy()
+        .to_string(),
+    ),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn get_absolute_path(
+  parser: &JavascriptParser,
+  property: ImportMetaKnownProperties,
+) -> Option<String> {
+  let path = Url::from_file_path(parser.resource_data.resource())
+    .expect("should be a path")
+    .to_file_path()
+    .expect("should be a path");
+
+  match property {
+    ImportMetaKnownProperties::FILENAME => Some(path.to_string_lossy().into_owned()),
+    ImportMetaKnownProperties::DIRNAME => Some(
+      path
+        .parent()
+        .expect("should have a parent")
+        .to_string_lossy()
+        .into_owned(),
+    ),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn get_eval_only_path(
+  parser: &JavascriptParser,
+  property: ImportMetaKnownProperties,
+) -> Option<String> {
+  match property {
+    ImportMetaKnownProperties::FILENAME => {
+      let resource = parse_resource(parser.resource_data.path()?.as_str())?;
+      Some(resource.path.to_string())
+    }
+    ImportMetaKnownProperties::DIRNAME => Some(parser.resource_data.path()?.parent()?.to_string()),
+    _ => unreachable!("only import.meta.dirname and import.meta.filename are supported"),
+  }
+}
+
+fn add_node_module_dependencies(
+  parser: &mut JavascriptParser,
+  property: ImportMetaKnownProperties,
+) {
+  let external_url_dep = ExternalModuleDependency::new(
+    "url".to_string(),
+    vec![(
+      "fileURLToPath".to_string(),
+      "__rspack_fileURLToPath".to_string(),
+    )],
+    None,
+  );
+  parser.add_presentational_dependency(Box::new(external_url_dep));
+
+  if property == ImportMetaKnownProperties::DIRNAME {
+    let external_path_dep = ExternalModuleDependency::new(
+      "path".to_string(),
+      vec![("dirname".to_string(), "__rspack_dirname".to_string())],
+      None,
+    );
+    parser.add_presentational_dependency(Box::new(external_path_dep));
+  }
+}
+
+fn add_import_meta_cached_dependency(
+  parser: &mut JavascriptParser,
+  range: Option<DependencyRange>,
+  property: ImportMetaKnownProperties,
+  content: impl Into<Box<str>>,
+) -> String {
+  let identifier = import_meta_cached_identifier(property);
+  let const_dep = match range {
+    Some(range) => CachedConstDependency::new_with_place(
+      range,
+      identifier.into(),
+      content.into(),
+      CachedConstDependencyPlace::Chunk,
+    ),
+    None => CachedConstDependency::new_without_replacement(
+      identifier.into(),
+      content.into(),
+      CachedConstDependencyPlace::Chunk,
+    ),
+  };
+  parser.add_presentational_dependency(Box::new(const_dep));
+  identifier.to_string()
+}
+
+pub(crate) fn get_import_meta_eval_value(
+  parser: &JavascriptParser,
+  property: ImportMetaKnownProperties,
+) -> Option<String> {
+  let node_option = parser.compiler_options.node.as_ref()?;
+
+  if is_disabled(property, node_option) {
+    return None;
+  }
+
+  if is_mock(property, node_option) || is_warn_mock(property, node_option) {
+    return Some(mock_value(property).to_string());
+  }
+
+  if is_true(property, node_option) {
+    return get_relative_path(parser, property);
+  }
+
+  if is_eval_only(property, node_option) {
+    return get_eval_only_path(parser, property);
+  }
+
+  if is_node_module(property, node_option) {
+    return get_absolute_path(parser, property);
+  }
+
+  None
+}
+
+pub(crate) fn get_import_meta_member_replacement(
+  parser: &mut JavascriptParser,
+  property: ImportMetaKnownProperties,
+) -> Option<String> {
+  let node_option = match parser.compiler_options.node.as_ref() {
+    None => return Some(import_meta_name(property).to_string()),
+    Some(opt) => opt,
+  };
+
+  if is_disabled(property, node_option) {
+    return Some(import_meta_name(property).to_string());
+  }
+
+  if is_mock(property, node_option) {
+    return Some(rspack_util::json_stringify_str(mock_value(property)));
+  }
+
+  if is_warn_mock(property, node_option) {
+    parser.add_warning(Diagnostic::warn(
+      warning_code(property).to_string(),
+      warning_message(property),
+    ));
+    return Some(rspack_util::json_stringify_str(mock_value(property)));
+  }
+
+  if is_true(property, node_option) {
+    let path = get_relative_path(parser, property)?;
+    return Some(rspack_util::json_stringify_str(&path));
+  }
+
+  if is_eval_only(property, node_option) {
+    return Some(if parser.compiler_options.output.module {
+      add_import_meta_cached_dependency(parser, None, property, import_meta_name(property))
+    } else {
+      cjs_name(property).to_string()
+    });
+  }
+
+  if is_node_module(property, node_option) {
+    if parser.compiler_options.output.module
+      && parser
+        .compiler_options
+        .output
+        .environment
+        .supports_import_meta_dirname_and_filename()
+    {
+      return Some(add_import_meta_cached_dependency(
+        parser,
+        None,
+        property,
+        import_meta_name(property),
+      ));
+    }
+    add_node_module_dependencies(parser, property);
+    return Some(add_import_meta_cached_dependency(
+      parser,
+      None,
+      property,
+      node_module_runtime_expr(property),
+    ));
+  }
+
+  None
+}

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -1,9 +1,9 @@
 use concat_string::concat_string;
 use itertools::Itertools;
 use rspack_core::{
-  ConstDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
-  DependencyRange, ImportMeta, ImportMetaKnownProperties, RscMeta, RscModuleType, RuntimeGlobals,
-  RuntimeRequirementsDependency, property_access,
+  ArcComputed, ConstDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
+  DependencyRange, ImportMeta, ImportMetaKnownProperties, ResolvedModuleOptions, RscMeta,
+  RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access,
 };
 use rspack_error::{Error, Severity};
 use rspack_util::SpanExt;
@@ -287,7 +287,7 @@ impl ImportMetaBuiltinProperty {
   }
 }
 
-pub struct ImportMetaPlugin(pub(crate) ImportMeta);
+pub struct ImportMetaPlugin(pub(crate) ArcComputed<ResolvedModuleOptions, ImportMeta>);
 
 impl ImportMetaPlugin {
   fn known_property_from_name(name: &str) -> Option<ImportMetaKnownProperties> {
@@ -301,7 +301,7 @@ impl ImportMetaPlugin {
   }
 
   fn preserve_property(&self, property: Option<&str>) -> bool {
-    match &self.0 {
+    match self.0.as_ref() {
       ImportMeta::PreserveUnknown => true,
       ImportMeta::Granular(_) => property.is_none_or(|property| {
         let name = concat_string!(expr_name::IMPORT_META, ".", property);
@@ -796,7 +796,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     match root_info {
       ExportedVariableInfo::Name(root) => {
         if root == expr_name::IMPORT_META {
-          if matches!(self.0, ImportMeta::PreserveUnknown) {
+          if matches!(self.0.as_ref(), ImportMeta::PreserveUnknown) {
             return Some(true);
           }
           let members = parser

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -631,53 +631,51 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         .cloned();
 
       if let Some(referenced_properties_in_destructuring) = destructuring_assignment_properties {
-        let mut content = vec![];
-        for prop in referenced_properties_in_destructuring.iter() {
+        let mut content = String::from("({");
+        for (index, prop) in referenced_properties_in_destructuring.iter().enumerate() {
+          if index > 0 {
+            content.push(',');
+          }
           let res = parser
             .plugin_drive
             .clone()
             .import_meta_property_in_destructuring(parser, prop);
 
           if let Some(property) = res {
-            content.push(property);
+            content.push_str(&property);
             continue;
           }
           if let Some(property) = ImportMetaBuiltinProperty::from_property(prop.id.as_ref()) {
             if let Some(rendered) = property.render_destructuring(self, parser, span) {
-              content.push(rendered);
+              content.push_str(&rendered);
             } else {
-              content.push(concat_string!(
-                "[",
-                rspack_util::json_stringify_str(&prop.id),
-                "]: ",
-                self.import_meta_unknown_property(&vec![prop.id.to_string()])
-              ));
+              content.push('[');
+              content.push_str(&rspack_util::json_stringify_str(&prop.id));
+              content.push_str("]: ");
+              content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
             }
           } else if let Some(api) = import_meta_runtime_api_from_property(prop.id.as_ref()) {
             if self.runtime_api_enabled(api)
               && let Some(property) = render_import_meta_runtime_api_destructuring(parser, api)
             {
-              content.push(property);
+              content.push_str(&property);
             } else {
-              content.push(concat_string!(
-                "[",
-                rspack_util::json_stringify_str(&prop.id),
-                "]: ",
-                self.import_meta_unknown_property(&vec![prop.id.to_string()])
-              ));
+              content.push('[');
+              content.push_str(&rspack_util::json_stringify_str(&prop.id));
+              content.push_str("]: ");
+              content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
             }
           } else {
-            content.push(concat_string!(
-              "[",
-              rspack_util::json_stringify_str(&prop.id),
-              "]: ",
-              self.import_meta_unknown_property(&vec![prop.id.to_string()])
-            ));
+            content.push('[');
+            content.push_str(&rspack_util::json_stringify_str(&prop.id));
+            content.push_str("]: ");
+            content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
           }
         }
+        content.push_str("})");
         parser.add_presentational_dependency(Box::new(ConstDependency::new(
           span.into(),
-          concat_string!("({", content.join(","), "})").into(),
+          content.into(),
         )));
         Some(true)
       } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -808,15 +808,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
 
           let dep = if let Some(members) = members {
             if self.preserve_property(members.members.first().map(|property| property.as_str())) {
-              ConstDependency::new(
-                expr.span().into(),
-                self
-                  .import_meta_unknown_property(
-                    &members.members.iter().map(|x| x.to_string()).collect_vec(),
-                  )
-                  .into(),
-              )
-            } else if members.members.get(1).is_some()
+              return Some(true);
+            }
+            if members.members.get(1).is_some()
               && members
                 .members_optionals
                 .get(1)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -1,3 +1,4 @@
+use concat_string::concat_string;
 use itertools::Itertools;
 use rspack_core::{
   ConstDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
@@ -193,7 +194,7 @@ impl ImportMetaBuiltinProperty {
     let type_of = self.evaluate_typeof(plugin, parser)?;
     parser.add_presentational_dependency(Box::new(ConstDependency::new(
       unary_expr.span().into(),
-      format!("'{type_of}'").into(),
+      concat_string!("'", type_of, "'").into(),
     )));
     Some(true)
   }
@@ -210,22 +211,27 @@ impl ImportMetaBuiltinProperty {
 
     let property = self.property_name();
     match self.property {
-      ImportMetaKnownProperties::URL => Some(format!(
-        r#"{property}: "{}""#,
-        plugin.import_meta_url(parser)
+      ImportMetaKnownProperties::URL => Some(concat_string!(
+        property,
+        ": \"",
+        plugin.import_meta_url(parser),
+        "\""
       )),
       ImportMetaKnownProperties::WEBPACK => {
-        Some(format!("{property}: {}", plugin.import_meta_version()))
+        Some(concat_string!(property, ": ", plugin.import_meta_version()))
       }
-      ImportMetaKnownProperties::MAIN => {
-        Some(format!("{property}: {}", plugin.import_meta_main(parser)))
-      }
+      ImportMetaKnownProperties::MAIN => Some(concat_string!(
+        property,
+        ": ",
+        plugin.import_meta_main(parser)
+      )),
       ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME => {
         get_import_meta_member_replacement(parser, self.property)
-          .map(|value| format!("{property}: {value}"))
+          .map(|value| concat_string!(property, ": ", value))
       }
-      ImportMetaKnownProperties::RSPACK_RSC => Some(format!(
-        "{property}: {}",
+      ImportMetaKnownProperties::RSPACK_RSC => Some(concat_string!(
+        property,
+        ": ",
         plugin.process_rspack_rsc_destructuring(parser, span)
       )),
       ImportMetaKnownProperties::RESOLVE => None,
@@ -244,7 +250,7 @@ impl ImportMetaBuiltinProperty {
     }
 
     let replacement = match self.property {
-      ImportMetaKnownProperties::URL => format!("'{}'", plugin.import_meta_url(parser)),
+      ImportMetaKnownProperties::URL => concat_string!("'", plugin.import_meta_url(parser), "'"),
       ImportMetaKnownProperties::WEBPACK => plugin.import_meta_version(),
       ImportMetaKnownProperties::MAIN => plugin.import_meta_main(parser),
       ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME => {
@@ -298,7 +304,7 @@ impl ImportMetaPlugin {
     match &self.0 {
       ImportMeta::PreserveUnknown => true,
       ImportMeta::Granular(_) => property.is_none_or(|property| {
-        let name = format!("{}.{property}", expr_name::IMPORT_META);
+        let name = concat_string!(expr_name::IMPORT_META, ".", property);
         Self::known_property_from_name(&name)
           .is_none_or(|property| !self.known_property_enabled(property))
       }),
@@ -329,23 +335,27 @@ impl ImportMetaPlugin {
     parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::add_only(
       RuntimeGlobals::MODULE_CACHE | RuntimeGlobals::ENTRY_MODULE_ID | RuntimeGlobals::MODULE,
     )));
-    format!(
-      "({}[{}] === {})",
+    concat_string!(
+      "(",
       parser.parser_runtime_requirements.module_cache,
+      "[",
       parser.parser_runtime_requirements.entry_module_id,
+      "] === ",
       parser
         .parser_runtime_requirements
-        .module_argument(&parser.build_info.module_argument)
+        .module_argument(&parser.build_info.module_argument),
+      ")"
     )
   }
 
   fn import_meta_unknown_property(&self, members: &Vec<String>) -> String {
     if self.preserve_property(members.first().map(|property| property.as_str())) {
-      format!("import.meta{}", property_access(members, 0))
+      concat_string!("import.meta", property_access(members, 0))
     } else {
-      format!(
-        r#"/* unsupported import.meta.{} */ undefined{}"#,
+      concat_string!(
+        "/* unsupported import.meta.",
         members.join("."),
+        " */ undefined",
         property_access(members, 1)
       )
     }
@@ -636,9 +646,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             if let Some(rendered) = property.render_destructuring(self, parser, span) {
               content.push(rendered);
             } else {
-              content.push(format!(
-                r#"[{}]: {}"#,
+              content.push(concat_string!(
+                "[",
                 rspack_util::json_stringify_str(&prop.id),
+                "]: ",
                 self.import_meta_unknown_property(&vec![prop.id.to_string()])
               ));
             }
@@ -648,23 +659,25 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             {
               content.push(property);
             } else {
-              content.push(format!(
-                r#"[{}]: {}"#,
+              content.push(concat_string!(
+                "[",
                 rspack_util::json_stringify_str(&prop.id),
+                "]: ",
                 self.import_meta_unknown_property(&vec![prop.id.to_string()])
               ));
             }
           } else {
-            content.push(format!(
-              r#"[{}]: {}"#,
+            content.push(concat_string!(
+              "[",
               rspack_util::json_stringify_str(&prop.id),
+              "]: ",
               self.import_meta_unknown_property(&vec![prop.id.to_string()])
             ));
           }
         }
         parser.add_presentational_dependency(Box::new(ConstDependency::new(
           span.into(),
-          format!("({{{}}})", content.join(",")).into(),
+          concat_string!("({", content.join(","), "})").into(),
         )));
         Some(true)
       } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -794,7 +794,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             });
 
           let dep = if let Some(members) = members {
-            if members.members.get(1).is_some()
+            if self.preserve_property(members.members.first().map(|property| property.as_str())) {
+              ConstDependency::new(
+                expr.span().into(),
+                self
+                  .import_meta_unknown_property(
+                    &members.members.iter().map(|x| x.to_string()).collect_vec(),
+                  )
+                  .into(),
+              )
+            } else if members.members.get(1).is_some()
               && members
                 .members_optionals
                 .get(1)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rspack_core::{
   ConstDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
-  DependencyRange, ImportMeta, RscMeta, RscModuleType, RuntimeGlobals,
+  DependencyRange, ImportMeta, ImportMetaKnownProperties, RscMeta, RscModuleType, RuntimeGlobals,
   RuntimeRequirementsDependency, property_access,
 };
 use rspack_error::{Error, Severity};
@@ -15,10 +15,13 @@ use url::Url;
 use super::{
   JavascriptParserPlugin,
   api_plugin::{
-    import_meta_runtime_api_assign, import_meta_runtime_api_call,
+    ImportMetaRuntimeApi, import_meta_runtime_api_assign, import_meta_runtime_api_call,
     import_meta_runtime_api_from_name, import_meta_runtime_api_from_property,
     import_meta_runtime_api_member, is_simple_assign_op,
     render_import_meta_runtime_api_destructuring,
+  },
+  import_meta_path::{
+    get_import_meta_eval_value, get_import_meta_member_replacement, should_handle_import_meta_path,
   },
 };
 use crate::{
@@ -59,9 +62,258 @@ fn create_import_meta_resolve_context_dependency(
   dep
 }
 
+#[derive(Clone, Copy)]
+struct ImportMetaBuiltinProperty {
+  name: &'static str,
+  property: ImportMetaKnownProperties,
+  type_of: &'static str,
+}
+
+static IMPORT_META_BUILTIN_PROPERTIES: &[ImportMetaBuiltinProperty] = &[
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_URL,
+    property: ImportMetaKnownProperties::URL,
+    type_of: "string",
+  },
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_RESOLVE,
+    property: ImportMetaKnownProperties::RESOLVE,
+    type_of: "function",
+  },
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_VERSION,
+    property: ImportMetaKnownProperties::WEBPACK,
+    type_of: "number",
+  },
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_MAIN,
+    property: ImportMetaKnownProperties::MAIN,
+    type_of: "boolean",
+  },
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_FILENAME,
+    property: ImportMetaKnownProperties::FILENAME,
+    type_of: "string",
+  },
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_DIRNAME,
+    property: ImportMetaKnownProperties::DIRNAME,
+    type_of: "string",
+  },
+  ImportMetaBuiltinProperty {
+    name: expr_name::IMPORT_META_RSPACK_RSC,
+    property: ImportMetaKnownProperties::RSPACK_RSC,
+    type_of: "object",
+  },
+];
+
+impl ImportMetaBuiltinProperty {
+  fn from_name(name: &str) -> Option<&'static Self> {
+    IMPORT_META_BUILTIN_PROPERTIES
+      .iter()
+      .find(|property| property.name == name)
+  }
+
+  fn from_property(property: &str) -> Option<&'static Self> {
+    IMPORT_META_BUILTIN_PROPERTIES
+      .iter()
+      .find(|builtin| builtin.property_name() == property)
+  }
+
+  fn property_name(&self) -> &'static str {
+    debug_assert!(self.name.starts_with(expr_name::IMPORT_META_PREFIX));
+    &self.name[expr_name::IMPORT_META_PREFIX.len()..]
+  }
+
+  fn enabled(&self, plugin: &ImportMetaPlugin, parser: &JavascriptParser) -> bool {
+    if !plugin.known_property_enabled(self.property) {
+      return false;
+    }
+
+    match self.property {
+      ImportMetaKnownProperties::RESOLVE => {
+        parser.javascript_options.import_meta_resolve == Some(true)
+      }
+      ImportMetaKnownProperties::RSPACK_RSC => is_rsc_layer(parser),
+      _ => true,
+    }
+  }
+
+  fn evaluate_typeof(&self, plugin: &ImportMetaPlugin, parser: &JavascriptParser) -> Option<&str> {
+    if matches!(
+      self.property,
+      ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME
+    ) && !should_handle_import_meta_path(parser, self.property)
+    {
+      return None;
+    }
+    self.enabled(plugin, parser).then_some(self.type_of)
+  }
+
+  fn evaluate_identifier<'p>(
+    &self,
+    plugin: &ImportMetaPlugin,
+    parser: &mut JavascriptParser<'p>,
+    start: u32,
+    end: u32,
+  ) -> Option<eval::BasicEvaluatedExpression<'p>> {
+    if !self.enabled(plugin, parser) {
+      return None;
+    }
+
+    match self.property {
+      ImportMetaKnownProperties::URL => Some(eval::evaluate_to_string(
+        plugin.import_meta_url(parser),
+        start,
+        end,
+      )),
+      ImportMetaKnownProperties::RESOLVE => Some(eval::evaluate_to_identifier(
+        expr_name::IMPORT_META_RESOLVE.into(),
+        expr_name::IMPORT_META_RESOLVE.into(),
+        Some(true),
+        start,
+        end,
+      )),
+      ImportMetaKnownProperties::WEBPACK => Some(eval::evaluate_to_number(5_f64, start, end)),
+      ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME => {
+        get_import_meta_eval_value(parser, self.property)
+          .map(|value| eval::evaluate_to_string(value, start, end))
+      }
+      ImportMetaKnownProperties::MAIN | ImportMetaKnownProperties::RSPACK_RSC => None,
+      _ => unreachable!("unexpected import.meta builtin property"),
+    }
+  }
+
+  fn add_typeof_dependency(
+    &self,
+    plugin: &ImportMetaPlugin,
+    parser: &mut JavascriptParser,
+    unary_expr: &UnaryExpr,
+  ) -> Option<bool> {
+    let type_of = self.evaluate_typeof(plugin, parser)?;
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      unary_expr.span().into(),
+      format!("'{type_of}'").into(),
+    )));
+    Some(true)
+  }
+
+  fn render_destructuring(
+    &self,
+    plugin: &ImportMetaPlugin,
+    parser: &mut JavascriptParser,
+    span: Span,
+  ) -> Option<String> {
+    if !self.enabled(plugin, parser) {
+      return None;
+    }
+
+    let property = self.property_name();
+    match self.property {
+      ImportMetaKnownProperties::URL => Some(format!(
+        r#"{property}: "{}""#,
+        plugin.import_meta_url(parser)
+      )),
+      ImportMetaKnownProperties::WEBPACK => {
+        Some(format!("{property}: {}", plugin.import_meta_version()))
+      }
+      ImportMetaKnownProperties::MAIN => {
+        Some(format!("{property}: {}", plugin.import_meta_main(parser)))
+      }
+      ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME => {
+        get_import_meta_member_replacement(parser, self.property)
+          .map(|value| format!("{property}: {value}"))
+      }
+      ImportMetaKnownProperties::RSPACK_RSC => Some(format!(
+        "{property}: {}",
+        plugin.process_rspack_rsc_destructuring(parser, span)
+      )),
+      ImportMetaKnownProperties::RESOLVE => None,
+      _ => unreachable!("unexpected import.meta builtin property"),
+    }
+  }
+
+  fn member(
+    &self,
+    plugin: &ImportMetaPlugin,
+    parser: &mut JavascriptParser,
+    member_expr: &MemberExpr,
+  ) -> Option<bool> {
+    if !self.enabled(plugin, parser) {
+      return None;
+    }
+
+    let replacement = match self.property {
+      ImportMetaKnownProperties::URL => format!("'{}'", plugin.import_meta_url(parser)),
+      ImportMetaKnownProperties::WEBPACK => plugin.import_meta_version(),
+      ImportMetaKnownProperties::MAIN => plugin.import_meta_main(parser),
+      ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME => {
+        get_import_meta_member_replacement(parser, self.property)?
+      }
+      ImportMetaKnownProperties::RSPACK_RSC => {
+        plugin.process_rspack_rsc(parser, member_expr);
+        return Some(true);
+      }
+      ImportMetaKnownProperties::RESOLVE => return None,
+      _ => unreachable!("unexpected import.meta builtin property"),
+    };
+
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      member_expr.span().into(),
+      replacement.into(),
+    )));
+    Some(true)
+  }
+
+  fn skip_undefined_evaluation(
+    &self,
+    plugin: &ImportMetaPlugin,
+    parser: &JavascriptParser,
+  ) -> bool {
+    match self.property {
+      // dirname/filename may be preserved at runtime based on node options, so don't fold them to undefined.
+      ImportMetaKnownProperties::FILENAME | ImportMetaKnownProperties::DIRNAME => true,
+      ImportMetaKnownProperties::MAIN | ImportMetaKnownProperties::RSPACK_RSC => {
+        self.enabled(plugin, parser)
+      }
+      _ => false,
+    }
+  }
+}
+
 pub struct ImportMetaPlugin(pub(crate) ImportMeta);
 
 impl ImportMetaPlugin {
+  fn known_property_from_name(name: &str) -> Option<ImportMetaKnownProperties> {
+    if let Some(property) = ImportMetaBuiltinProperty::from_name(name) {
+      return Some(property.property);
+    }
+    if let Some(api) = import_meta_runtime_api_from_name(name) {
+      return Some(api.property);
+    }
+    None
+  }
+
+  fn preserve_property(&self, property: Option<&str>) -> bool {
+    match &self.0 {
+      ImportMeta::PreserveUnknown => true,
+      ImportMeta::Granular(_) => property.is_none_or(|property| {
+        let name = format!("{}.{property}", expr_name::IMPORT_META);
+        Self::known_property_from_name(&name)
+          .is_none_or(|property| !self.known_property_enabled(property))
+      }),
+      ImportMeta::Enabled | ImportMeta::Disabled => false,
+    }
+  }
+
+  fn known_property_enabled(&self, property: ImportMetaKnownProperties) -> bool {
+    self.0.is_known_property_enabled(property)
+  }
+
+  fn runtime_api_enabled(&self, api: &ImportMetaRuntimeApi) -> bool {
+    self.known_property_enabled(api.property)
+  }
+
   fn import_meta_url(&self, parser: &JavascriptParser) -> String {
     Url::from_file_path(parser.resource_data.resource())
       .expect("should be a path")
@@ -88,7 +340,7 @@ impl ImportMetaPlugin {
   }
 
   fn import_meta_unknown_property(&self, members: &Vec<String>) -> String {
-    if matches!(self.0, ImportMeta::PreserveUnknown) {
+    if self.preserve_property(members.first().map(|property| property.as_str())) {
       format!("import.meta{}", property_access(members, 0))
     } else {
       format!(
@@ -218,19 +470,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     let mut evaluated = None;
     if for_name == expr_name::IMPORT_META {
       evaluated = Some("object".to_string());
-    } else if for_name == expr_name::IMPORT_META_URL {
-      evaluated = Some("string".to_string());
-    } else if parser.javascript_options.import_meta_resolve == Some(true)
-      && for_name == expr_name::IMPORT_META_RESOLVE
+    } else if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name)
+      && let Some(type_of) = property.evaluate_typeof(self, parser)
     {
-      evaluated = Some("function".to_string());
-    } else if for_name == expr_name::IMPORT_META_VERSION {
-      evaluated = Some("number".to_string())
-    } else if for_name == expr_name::IMPORT_META_MAIN {
-      evaluated = Some("boolean".to_string())
-    } else if for_name == expr_name::IMPORT_META_RSPACK_RSC && is_rsc_layer(parser) {
-      evaluated = Some("object".to_string())
-    } else if let Some(api) = import_meta_runtime_api_from_name(for_name) {
+      evaluated = Some(type_of.to_string())
+    } else if let Some(api) = import_meta_runtime_api_from_name(for_name)
+      && self.runtime_api_enabled(api)
+    {
       evaluated = Some(api.type_of.to_string())
     } else if let Some(member_expr) = expr.arg.as_member()
       && let Some(meta_expr) = member_expr.obj.as_meta_prop()
@@ -242,6 +488,20 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         MemberProp::Computed(computed) => computed.expr.is_lit(),
         _ => false,
       })
+      && member_expr
+        .prop
+        .as_ident()
+        .map(|ident| !self.preserve_property(Some(ident.sym.as_ref())))
+        .or_else(|| {
+          member_expr
+            .prop
+            .as_computed()
+            .and_then(|computed| computed.expr.as_lit())
+            .and_then(|lit| lit.as_str())
+            .and_then(|str_lit| str_lit.value.as_str())
+            .map(|value| !self.preserve_property(Some(value)))
+        })
+        .unwrap_or(false)
     {
       evaluated = Some("undefined".to_string())
     }
@@ -256,27 +516,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     start: u32,
     end: u32,
   ) -> Option<eval::BasicEvaluatedExpression<'p>> {
-    if for_name == expr_name::IMPORT_META_VERSION {
-      Some(eval::evaluate_to_number(5_f64, start, end))
-    } else if for_name == expr_name::IMPORT_META_URL {
-      Some(eval::evaluate_to_string(
-        self.import_meta_url(parser),
-        start,
-        end,
-      ))
-    } else if parser.javascript_options.import_meta_resolve == Some(true)
-      && for_name == expr_name::IMPORT_META_RESOLVE
-    {
-      Some(eval::evaluate_to_identifier(
-        expr_name::IMPORT_META_RESOLVE.into(),
-        expr_name::IMPORT_META_RESOLVE.into(),
-        Some(true),
-        start,
-        end,
-      ))
-    } else {
-      None
-    }
+    let property = ImportMetaBuiltinProperty::from_name(for_name)?;
+    property.evaluate_identifier(self, parser, start, end)
   }
 
   fn evaluate(
@@ -289,14 +530,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
       && meta_prop.kind == MetaPropKind::ImportMeta
     {
       if let Some(ident) = member.prop.as_ident() {
-        // - Skip `dirname` and `filename` - they are handled by NodeStuffPlugin
+        // - Skip `dirname` and `filename` - they are handled by `member`
         //   and may have runtime values when node.__dirname/node.__filename is false
         // - Skip `main` - it will generate dynamic code: `moduleCache[entryModuleId] === module`
-        if ident.sym == "dirname"
-          || ident.sym == "filename"
-          || ident.sym == "main"
-          || (ident.sym == "rspackRsc" && is_rsc_layer(parser))
-          || import_meta_runtime_api_from_property(ident.sym.as_ref()).is_some()
+        if ImportMetaBuiltinProperty::from_property(ident.sym.as_ref())
+          .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
+          || import_meta_runtime_api_from_property(ident.sym.as_ref())
+            .is_some_and(|api| self.runtime_api_enabled(api))
+          || self.preserve_property(Some(ident.sym.as_ref()))
         {
           return None;
         }
@@ -309,11 +550,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         // Check for computed properties like import.meta["dirname"]
         if let Some(str_lit) = computed.expr.as_lit().and_then(|lit| lit.as_str())
           && str_lit.value.as_str().is_some_and(|value| {
-            value == "dirname"
-              || value == "filename"
-              || value == "main"
-              || (value == "rspackRsc" && is_rsc_layer(parser))
-              || import_meta_runtime_api_from_property(value).is_some()
+            ImportMetaBuiltinProperty::from_property(value)
+              .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
+              || import_meta_runtime_api_from_property(value)
+                .is_some_and(|api| self.runtime_api_enabled(api))
+              || self.preserve_property(Some(value))
           })
         {
           return None;
@@ -339,38 +580,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         )));
         Some(true)
       }
-      expr_name::IMPORT_META_URL => {
-        parser.add_presentational_dependency(Box::new(ConstDependency::new(
-          unary_expr.span().into(),
-          "'string'".into(),
-        )));
-        Some(true)
-      }
-      expr_name::IMPORT_META_RESOLVE
-        if parser.javascript_options.import_meta_resolve == Some(true) =>
-      {
-        parser.add_presentational_dependency(Box::new(ConstDependency::new(
-          unary_expr.span().into(),
-          "'function'".into(),
-        )));
-        Some(true)
-      }
-      expr_name::IMPORT_META_VERSION => {
-        parser.add_presentational_dependency(Box::new(ConstDependency::new(
-          unary_expr.span().into(),
-          "'number'".into(),
-        )));
-        Some(true)
-      }
-      expr_name::IMPORT_META_MAIN => {
-        parser.add_presentational_dependency(Box::new(ConstDependency::new(
-          unary_expr.span().into(),
-          "'boolean'".into(),
-        )));
-        Some(true)
-      }
       _ => {
+        if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name) {
+          return property.add_typeof_dependency(self, parser, unary_expr);
+        }
         let api = import_meta_runtime_api_from_name(for_name)?;
+        if !self.runtime_api_enabled(api) {
+          return None;
+        }
         parser.add_presentational_dependency(Box::new(ConstDependency::new(
           unary_expr.span().into(),
           format!("'{}'", api.type_of).into(),
@@ -415,19 +632,20 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             content.push(property);
             continue;
           }
-          if prop.id == "url" {
-            content.push(format!(r#"url: "{}""#, self.import_meta_url(parser)))
-          } else if prop.id == "webpack" {
-            content.push(format!(r#"webpack: {}"#, self.import_meta_version()));
-          } else if prop.id == "main" {
-            content.push(format!("main: {}", self.import_meta_main(parser)));
-          } else if prop.id == "rspackRsc" && is_rsc_layer(parser) {
-            content.push(format!(
-              "rspackRsc: {}",
-              self.process_rspack_rsc_destructuring(parser, span)
-            ));
+          if let Some(property) = ImportMetaBuiltinProperty::from_property(prop.id.as_ref()) {
+            if let Some(rendered) = property.render_destructuring(self, parser, span) {
+              content.push(rendered);
+            } else {
+              content.push(format!(
+                r#"[{}]: {}"#,
+                rspack_util::json_stringify_str(&prop.id),
+                self.import_meta_unknown_property(&vec![prop.id.to_string()])
+              ));
+            }
           } else if let Some(api) = import_meta_runtime_api_from_property(prop.id.as_ref()) {
-            if let Some(property) = render_import_meta_runtime_api_destructuring(parser, api) {
+            if self.runtime_api_enabled(api)
+              && let Some(property) = render_import_meta_runtime_api_destructuring(parser, api)
+            {
               content.push(property);
             } else {
               content.push(format!(
@@ -483,32 +701,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     member_expr: &MemberExpr,
     for_name: &str,
   ) -> Option<bool> {
-    if for_name == expr_name::IMPORT_META_URL {
-      // import.meta.url
-      parser.add_presentational_dependency(Box::new(ConstDependency::new(
-        member_expr.span().into(),
-        format!("'{}'", self.import_meta_url(parser)).into(),
-      )));
-      Some(true)
-    } else if for_name == expr_name::IMPORT_META_VERSION {
-      // import.meta.webpack
-      parser.add_presentational_dependency(Box::new(ConstDependency::new(
-        member_expr.span().into(),
-        self.import_meta_version().into(),
-      )));
-      Some(true)
-    } else if for_name == expr_name::IMPORT_META_MAIN {
-      // import.meta.main
-      let content = self.import_meta_main(parser);
-      parser.add_presentational_dependency(Box::new(ConstDependency::new(
-        member_expr.span().into(),
-        content.into(),
-      )));
-      Some(true)
-    } else if for_name == expr_name::IMPORT_META_RSPACK_RSC && is_rsc_layer(parser) {
-      self.process_rspack_rsc(parser, member_expr);
-      Some(true)
-    } else if let Some(api) = import_meta_runtime_api_from_name(for_name) {
+    if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name)
+      && let Some(handled) = property.member(self, parser, member_expr)
+    {
+      Some(handled)
+    } else if let Some(api) = import_meta_runtime_api_from_name(for_name)
+      && self.runtime_api_enabled(api)
+    {
       import_meta_runtime_api_member(parser, member_expr.span(), api)
     } else {
       None
@@ -523,11 +722,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
   ) -> Option<bool> {
     if parser.javascript_options.import_meta_resolve == Some(true)
       && for_name == expr_name::IMPORT_META_RESOLVE
+      && self.known_property_enabled(ImportMetaKnownProperties::RESOLVE)
     {
       self.process_import_meta_resolve(parser, call_expr);
       return Some(true);
     }
     if let Some(api) = import_meta_runtime_api_from_name(for_name) {
+      if !self.runtime_api_enabled(api) {
+        return None;
+      }
       return import_meta_runtime_api_call(parser, call_expr, api);
     }
     None
@@ -546,6 +749,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     }
     let property = members.first()?;
     let api = import_meta_runtime_api_from_property(property.as_ref())?;
+    if !self.runtime_api_enabled(api) {
+      return None;
+    }
     let full_assignment = members.len() == 1;
     let span = if full_assignment {
       expr.left.span()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -11,6 +11,7 @@ mod esm_export_dependency_parser_plugin;
 mod esm_import_dependency_parser_plugin;
 mod esm_top_level_this_plugin;
 mod import_meta_context_dependency_parser_plugin;
+mod import_meta_path;
 mod import_meta_plugin;
 mod import_parser_plugin;
 mod import_phase;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -1,30 +1,23 @@
 use rspack_core::{
-  CachedConstDependency, CachedConstDependencyPlace, ConstDependency, ImportMeta,
-  NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, RuntimeGlobals,
-  RuntimeRequirementsDependency, get_context, parse_resource,
+  CachedConstDependency, CachedConstDependencyPlace, ConstDependency, NodeDirnameOption,
+  NodeFilenameOption, NodeGlobalOption, RuntimeGlobals, RuntimeRequirementsDependency, get_context,
+  parse_resource,
 };
 use rspack_error::{Diagnostic, cyan, yellow};
-use rspack_util::SpanExt;
 use sugar_path::SugarPath;
-use swc_experimental_ecma_ast::{Expr, GetSpan, Ident, MemberExpr, Span, UnaryExpr};
-use url::Url;
+use swc_experimental_ecma_ast::{Expr, GetSpan, Ident, UnaryExpr};
 
 use crate::{
-  JavascriptParserPlugin,
-  dependency::ExternalModuleDependency,
-  utils::eval,
-  visitors::{DestructuringAssignmentProperty, JavascriptParser},
+  JavascriptParserPlugin, dependency::ExternalModuleDependency, utils::eval,
+  visitors::JavascriptParser,
 };
 
 const DIRNAME: &str = "__dirname";
 const FILENAME: &str = "__filename";
-const IMPORT_META_DIRNAME: &str = "import.meta.dirname";
-const IMPORT_META_FILENAME: &str = "import.meta.filename";
 const GLOBAL: &str = "global";
 const MOCK_DIRNAME: &str = "/";
 const MOCK_FILENAME: &str = "/index.js";
 
-/// Represents the type of import.meta property being handled (filename or dirname)
 #[derive(Clone, Copy)]
 enum NodeMetaProperty {
   Filename,
@@ -32,62 +25,6 @@ enum NodeMetaProperty {
 }
 
 impl NodeMetaProperty {
-  /// Returns the mock value for this property
-  fn mock_value(&self) -> &'static str {
-    match self {
-      NodeMetaProperty::Filename => MOCK_FILENAME,
-      NodeMetaProperty::Dirname => MOCK_DIRNAME,
-    }
-  }
-
-  /// Returns the import.meta property name
-  fn import_meta_name(&self) -> &'static str {
-    match self {
-      NodeMetaProperty::Filename => "import.meta.filename",
-      NodeMetaProperty::Dirname => "import.meta.dirname",
-    }
-  }
-
-  /// Returns the CJS equivalent variable name
-  fn cjs_name(&self) -> &'static str {
-    match self {
-      NodeMetaProperty::Filename => "__filename",
-      NodeMetaProperty::Dirname => "__dirname",
-    }
-  }
-
-  /// Returns the warning code for this property
-  fn warning_code(&self) -> &'static str {
-    match self {
-      NodeMetaProperty::Filename => "NODE_IMPORT_META_FILENAME",
-      NodeMetaProperty::Dirname => "NODE_IMPORT_META_DIRNAME",
-    }
-  }
-
-  /// Returns the warning message for this property
-  fn warning_message(&self) -> String {
-    match self {
-      NodeMetaProperty::Filename => format!(
-        "\"{}\" is used and has been mocked. Remove it from your code, or set `{}` to disable this warning.",
-        yellow(&IMPORT_META_FILENAME),
-        cyan(&"node.__filename")
-      ),
-      NodeMetaProperty::Dirname => format!(
-        "\"{}\" is used and has been mocked. Remove it from your code, or set `{}` to disable this warning.",
-        yellow(&IMPORT_META_DIRNAME),
-        cyan(&"node.__dirname")
-      ),
-    }
-  }
-
-  /// Returns the runtime expression for NodeModule mode
-  fn node_module_runtime_expr(&self) -> &'static str {
-    match self {
-      NodeMetaProperty::Filename => "__rspack_fileURLToPath(import.meta.url)",
-      NodeMetaProperty::Dirname => "__rspack_dirname(__rspack_fileURLToPath(import.meta.url))",
-    }
-  }
-
   fn import_meta_cached_identifier(&self) -> &'static str {
     match self {
       NodeMetaProperty::Filename => "__rspack_import_meta_filename__",
@@ -95,78 +32,28 @@ impl NodeMetaProperty {
     }
   }
 
-  /// Returns whether dirname is disabled based on node options
-  fn is_disabled(&self, node_option: &rspack_core::NodeOption) -> bool {
+  fn node_module_runtime_expr(&self) -> &'static str {
     match self {
-      NodeMetaProperty::Filename => matches!(node_option.filename, NodeFilenameOption::False),
-      NodeMetaProperty::Dirname => matches!(node_option.dirname, NodeDirnameOption::False),
-    }
-  }
-
-  /// Check if the option is Mock
-  fn is_mock(&self, node_option: &rspack_core::NodeOption) -> bool {
-    match self {
-      NodeMetaProperty::Filename => matches!(node_option.filename, NodeFilenameOption::Mock),
-      NodeMetaProperty::Dirname => matches!(node_option.dirname, NodeDirnameOption::Mock),
-    }
-  }
-
-  /// Check if the option is WarnMock
-  fn is_warn_mock(&self, node_option: &rspack_core::NodeOption) -> bool {
-    match self {
-      NodeMetaProperty::Filename => matches!(node_option.filename, NodeFilenameOption::WarnMock),
-      NodeMetaProperty::Dirname => matches!(node_option.dirname, NodeDirnameOption::WarnMock),
-    }
-  }
-
-  /// Check if the option is True
-  fn is_true(&self, node_option: &rspack_core::NodeOption) -> bool {
-    match self {
-      NodeMetaProperty::Filename => matches!(node_option.filename, NodeFilenameOption::True),
-      NodeMetaProperty::Dirname => matches!(node_option.dirname, NodeDirnameOption::True),
-    }
-  }
-
-  /// Check if the option is EvalOnly
-  fn is_eval_only(&self, node_option: &rspack_core::NodeOption) -> bool {
-    match self {
-      NodeMetaProperty::Filename => matches!(node_option.filename, NodeFilenameOption::EvalOnly),
-      NodeMetaProperty::Dirname => matches!(node_option.dirname, NodeDirnameOption::EvalOnly),
-    }
-  }
-
-  /// Check if the option is NodeModule
-  fn is_node_module(&self, node_option: &rspack_core::NodeOption) -> bool {
-    match self {
-      NodeMetaProperty::Filename => matches!(node_option.filename, NodeFilenameOption::NodeModule),
-      NodeMetaProperty::Dirname => matches!(node_option.dirname, NodeDirnameOption::NodeModule),
+      NodeMetaProperty::Filename => "__rspack_fileURLToPath(import.meta.url)",
+      NodeMetaProperty::Dirname => "__rspack_dirname(__rspack_fileURLToPath(import.meta.url))",
     }
   }
 }
 
-/// Plugin for handling Node.js-specific variables like `__dirname`, `__filename`, `global`,
-/// and their ESM equivalents `import.meta.dirname` and `import.meta.filename`.
+/// Plugin for handling Node.js-specific variables like `__dirname`, `__filename`, and `global`.
 ///
 /// This mirrors webpack's approach where NodeStuffPlugin is registered once per module type
-/// with boolean flags controlling which features to handle:
-/// - `handle_cjs`: handle `__dirname`, `__filename`, `global`
-/// - `handle_esm`: handle `import.meta.dirname`, `import.meta.filename`
+/// with boolean flags controlling which features to handle.
 pub struct NodeStuffPlugin {
   /// When true, handle __dirname/__filename/global (CJS features)
   handle_cjs: bool,
-  /// When true, handle import.meta.dirname/filename (ESM features)
-  handle_esm: bool,
 }
 
 impl NodeStuffPlugin {
-  pub fn new(handle_cjs: bool, handle_esm: bool) -> Self {
-    Self {
-      handle_cjs,
-      handle_esm,
-    }
+  pub fn new(handle_cjs: bool) -> Self {
+    Self { handle_cjs }
   }
 
-  /// Get the relative path value for the given property (filename or dirname)
   fn get_relative_path(parser: &JavascriptParser, property: NodeMetaProperty) -> Option<String> {
     match property {
       NodeMetaProperty::Filename => Some(
@@ -191,37 +78,6 @@ impl NodeStuffPlugin {
     }
   }
 
-  /// Get the absolute path value for node-module mode
-  fn get_absolute_path(parser: &JavascriptParser, property: NodeMetaProperty) -> Option<String> {
-    let path = Url::from_file_path(parser.resource_data.resource())
-      .expect("should be a path")
-      .to_file_path()
-      .expect("should be a path");
-
-    match property {
-      NodeMetaProperty::Filename => Some(path.to_string_lossy().into_owned()),
-      NodeMetaProperty::Dirname => Some(
-        path
-          .parent()
-          .expect("should have a parent")
-          .to_string_lossy()
-          .into_owned(),
-      ),
-    }
-  }
-
-  /// Get the eval-only path value
-  fn get_eval_only_path(parser: &JavascriptParser, property: NodeMetaProperty) -> Option<String> {
-    match property {
-      NodeMetaProperty::Filename => {
-        let resource = parse_resource(parser.resource_data.path()?.as_str())?;
-        Some(resource.path.to_string())
-      }
-      NodeMetaProperty::Dirname => Some(parser.resource_data.path()?.parent()?.to_string()),
-    }
-  }
-
-  /// Add external dependencies for NodeModule mode
   fn add_node_module_dependencies(parser: &mut JavascriptParser, property: NodeMetaProperty) {
     let external_url_dep = ExternalModuleDependency::new(
       "url".to_string(),
@@ -245,7 +101,7 @@ impl NodeStuffPlugin {
 
   fn add_cjs_node_module_dependency(
     parser: &mut JavascriptParser,
-    ident_span: Span,
+    ident_span: swc_experimental_ecma_ast::Span,
     name: &str,
     property: NodeMetaProperty,
   ) {
@@ -267,194 +123,6 @@ impl NodeStuffPlugin {
       place,
     );
     parser.add_presentational_dependency(Box::new(const_dep));
-  }
-
-  fn add_import_meta_cached_dependency(
-    parser: &mut JavascriptParser,
-    range: Option<rspack_core::DependencyRange>,
-    property: NodeMetaProperty,
-    content: impl Into<Box<str>>,
-  ) -> String {
-    let identifier = property.import_meta_cached_identifier();
-    let const_dep = match range {
-      Some(range) => CachedConstDependency::new_with_place(
-        range,
-        identifier.into(),
-        content.into(),
-        CachedConstDependencyPlace::Chunk,
-      ),
-      None => CachedConstDependency::new_without_replacement(
-        identifier.into(),
-        content.into(),
-        CachedConstDependencyPlace::Chunk,
-      ),
-    };
-    parser.add_presentational_dependency(Box::new(const_dep));
-    identifier.to_string()
-  }
-
-  /// Get the evaluated value for import.meta.filename/dirname
-  fn get_import_meta_eval_value(
-    parser: &JavascriptParser,
-    property: NodeMetaProperty,
-  ) -> Option<String> {
-    let node_option = parser.compiler_options.node.as_ref()?;
-
-    if property.is_disabled(node_option) {
-      return None;
-    }
-
-    if property.is_mock(node_option) || property.is_warn_mock(node_option) {
-      return Some(property.mock_value().to_string());
-    }
-
-    if property.is_true(node_option) {
-      return Self::get_relative_path(parser, property);
-    }
-
-    if property.is_eval_only(node_option) {
-      return Self::get_eval_only_path(parser, property);
-    }
-
-    if property.is_node_module(node_option) {
-      return Self::get_absolute_path(parser, property);
-    }
-
-    None
-  }
-
-  /// Get the member replacement value for import.meta.filename/dirname
-  fn get_import_meta_member_replacement(
-    parser: &mut JavascriptParser,
-    property: NodeMetaProperty,
-  ) -> Option<String> {
-    let node_option = match parser.compiler_options.node.as_ref() {
-      None => return Some(property.import_meta_name().to_string()),
-      Some(opt) => opt,
-    };
-
-    if property.is_disabled(node_option) {
-      return Some(property.import_meta_name().to_string());
-    }
-
-    if property.is_mock(node_option) {
-      return Some(rspack_util::json_stringify_str(property.mock_value()));
-    }
-
-    if property.is_warn_mock(node_option) {
-      parser.add_warning(Diagnostic::warn(
-        property.warning_code().to_string(),
-        property.warning_message(),
-      ));
-      return Some(rspack_util::json_stringify_str(property.mock_value()));
-    }
-
-    if property.is_true(node_option) {
-      let path = Self::get_relative_path(parser, property)?;
-      return Some(rspack_util::json_stringify_str(&path));
-    }
-
-    if property.is_eval_only(node_option) {
-      return Some(if parser.compiler_options.output.module {
-        Self::add_import_meta_cached_dependency(parser, None, property, property.import_meta_name())
-      } else {
-        property.cjs_name().to_string()
-      });
-    }
-
-    if property.is_node_module(node_option) {
-      // Check if native import.meta.dirname/filename is supported
-      if parser.compiler_options.output.module
-        && parser
-          .compiler_options
-          .output
-          .environment
-          .supports_import_meta_dirname_and_filename()
-      {
-        return Some(Self::add_import_meta_cached_dependency(
-          parser,
-          None,
-          property,
-          property.import_meta_name(),
-        ));
-      }
-      Self::add_node_module_dependencies(parser, property);
-      return Some(Self::add_import_meta_cached_dependency(
-        parser,
-        None,
-        property,
-        property.node_module_runtime_expr(),
-      ));
-    }
-
-    None
-  }
-
-  /// Get the destructuring replacement value for import.meta.filename/dirname
-  fn get_import_meta_destructuring_value(
-    parser: &mut JavascriptParser,
-    property: NodeMetaProperty,
-  ) -> Option<String> {
-    let node_option = match parser.compiler_options.node.as_ref() {
-      None => return Some(property.import_meta_name().to_string()),
-      Some(opt) => opt,
-    };
-
-    if property.is_disabled(node_option) {
-      return Some(property.import_meta_name().to_string());
-    }
-
-    if property.is_mock(node_option) {
-      return Some(rspack_util::json_stringify_str(property.mock_value()));
-    }
-
-    if property.is_warn_mock(node_option) {
-      parser.add_warning(Diagnostic::warn(
-        property.warning_code().to_string(),
-        property.warning_message(),
-      ));
-      return Some(rspack_util::json_stringify_str(property.mock_value()));
-    }
-
-    if property.is_true(node_option) {
-      let path = Self::get_relative_path(parser, property)?;
-      return Some(rspack_util::json_stringify_str(&path));
-    }
-
-    if property.is_eval_only(node_option) {
-      return Some(if parser.compiler_options.output.module {
-        Self::add_import_meta_cached_dependency(parser, None, property, property.import_meta_name())
-      } else {
-        property.cjs_name().to_string()
-      });
-    }
-
-    if property.is_node_module(node_option) {
-      // Check if native import.meta.dirname/filename is supported
-      if parser.compiler_options.output.module
-        && parser
-          .compiler_options
-          .output
-          .environment
-          .supports_import_meta_dirname_and_filename()
-      {
-        return Some(Self::add_import_meta_cached_dependency(
-          parser,
-          None,
-          property,
-          property.import_meta_name(),
-        ));
-      }
-      Self::add_node_module_dependencies(parser, property);
-      return Some(Self::add_import_meta_cached_dependency(
-        parser,
-        None,
-        property,
-        property.node_module_runtime_expr(),
-      ));
-    }
-
-    None
   }
 }
 
@@ -509,16 +177,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
           );
           return Some(true);
         }
-        NodeDirnameOption::True => Some(
-          parser
-            .resource_data
-            .path()?
-            .parent()?
-            .as_std_path()
-            .relative(&parser.compiler_options.context)
-            .to_string_lossy()
-            .to_string(),
-        ),
+        NodeDirnameOption::True => Self::get_relative_path(parser, NodeMetaProperty::Dirname),
         NodeDirnameOption::False => None,
       };
       if let Some(dirname) = dirname {
@@ -562,15 +221,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
           );
           return Some(true);
         }
-        NodeFilenameOption::True => Some(
-          parser
-            .resource_data
-            .path()?
-            .as_std_path()
-            .relative(&parser.compiler_options.context)
-            .to_string_lossy()
-            .to_string(),
-        ),
+        NodeFilenameOption::True => Self::get_relative_path(parser, NodeMetaProperty::Filename),
         NodeFilenameOption::False => None,
       };
       if let Some(filename) = filename {
@@ -623,35 +274,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
     unary_expr: &UnaryExpr,
     for_name: &str,
   ) -> Option<bool> {
-    use crate::visitors::expr_name;
-
     match for_name {
       FILENAME => {
         // Skip CJS __filename if not handling CJS
         if !self.handle_cjs {
-          return None;
-        }
-        // Skip if node: false or node.filename is disabled
-        if parser.compiler_options.node.is_none()
-          || parser
-            .compiler_options
-            .node
-            .as_ref()
-            .is_some_and(|node_option| matches!(node_option.filename, NodeFilenameOption::False))
-        {
-          return None;
-        }
-      }
-      expr_name::IMPORT_META_FILENAME => {
-        // Skip ESM import.meta.filename if not handling ESM
-        if !self.handle_esm {
-          return None;
-        }
-        // Skip if importMeta is disabled
-        if matches!(
-          parser.javascript_options.import_meta,
-          Some(ImportMeta::Disabled)
-        ) {
           return None;
         }
         // Skip if node: false or node.filename is disabled
@@ -681,29 +307,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
           return None;
         }
       }
-      expr_name::IMPORT_META_DIRNAME => {
-        // Skip ESM import.meta.dirname if not handling ESM
-        if !self.handle_esm {
-          return None;
-        }
-        // Skip if importMeta is disabled
-        if matches!(
-          parser.javascript_options.import_meta,
-          Some(ImportMeta::Disabled)
-        ) {
-          return None;
-        }
-        // Skip if node: false or node.dirname is disabled
-        if parser.compiler_options.node.is_none()
-          || parser
-            .compiler_options
-            .node
-            .as_ref()
-            .is_some_and(|node_option| matches!(node_option.dirname, NodeDirnameOption::False))
-        {
-          return None;
-        }
-      }
       _ => return None,
     }
 
@@ -714,67 +317,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
     Some(true)
   }
 
-  fn evaluate_typeof(
-    &self,
-    parser: &mut JavascriptParser<'p>,
-    expr: &'a UnaryExpr<'a>,
-    for_name: &str,
-  ) -> Option<eval::BasicEvaluatedExpression<'a>> {
-    use crate::visitors::expr_name;
-
-    match for_name {
-      expr_name::IMPORT_META_FILENAME => {
-        // Skip processing if importMeta is disabled
-        if matches!(
-          parser.javascript_options.import_meta,
-          Some(ImportMeta::Disabled)
-        ) {
-          return None;
-        }
-        // Skip processing if node: false or node.filename is disabled
-        if parser.compiler_options.node.is_none()
-          || parser
-            .compiler_options
-            .node
-            .as_ref()
-            .is_some_and(|node_option| matches!(node_option.filename, NodeFilenameOption::False))
-        {
-          return None;
-        }
-        Some(eval::evaluate_to_string(
-          "string".to_string(),
-          expr.span.real_lo(),
-          expr.span.real_hi(),
-        ))
-      }
-      expr_name::IMPORT_META_DIRNAME => {
-        // Skip processing if importMeta is disabled
-        if matches!(
-          parser.javascript_options.import_meta,
-          Some(ImportMeta::Disabled)
-        ) {
-          return None;
-        }
-        // Skip processing if node: false or node.dirname is disabled
-        if parser.compiler_options.node.is_none()
-          || parser
-            .compiler_options
-            .node
-            .as_ref()
-            .is_some_and(|node_option| matches!(node_option.dirname, NodeDirnameOption::False))
-        {
-          return None;
-        }
-        Some(eval::evaluate_to_string(
-          "string".to_string(),
-          expr.span.real_lo(),
-          expr.span.real_hi(),
-        ))
-      }
-      _ => None,
-    }
-  }
-
   fn evaluate_identifier(
     &self,
     parser: &mut JavascriptParser<'p>,
@@ -783,8 +325,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression<'p>> {
-    use crate::visitors::expr_name;
-
     if for_name == DIRNAME {
       // Skip CJS handling if not enabled
       if !self.handle_cjs {
@@ -826,92 +366,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
         start,
         end,
       ))
-    } else if for_name == expr_name::IMPORT_META_FILENAME
-      || for_name == expr_name::IMPORT_META_DIRNAME
-    {
-      // Skip ESM handling if not enabled
-      if !self.handle_esm {
-        return None;
-      }
-      // Skip processing if importMeta is disabled
-      if matches!(
-        parser.javascript_options.import_meta,
-        Some(ImportMeta::Disabled)
-      ) {
-        return None;
-      }
-      let property = if for_name == expr_name::IMPORT_META_FILENAME {
-        NodeMetaProperty::Filename
-      } else {
-        NodeMetaProperty::Dirname
-      };
-      let value = Self::get_import_meta_eval_value(parser, property)?;
-      Some(eval::evaluate_to_string(value, start, end))
     } else {
       None
     }
-  }
-
-  fn member(
-    &self,
-    parser: &mut JavascriptParser<'p>,
-    member_expr: &MemberExpr,
-    for_name: &str,
-  ) -> Option<bool> {
-    use crate::visitors::expr_name;
-
-    // Skip ESM handling if not enabled
-    if !self.handle_esm {
-      return None;
-    }
-
-    let property = match for_name {
-      expr_name::IMPORT_META_FILENAME => NodeMetaProperty::Filename,
-      expr_name::IMPORT_META_DIRNAME => NodeMetaProperty::Dirname,
-      _ => return None,
-    };
-
-    // Skip processing if importMeta is disabled
-    if matches!(
-      parser.javascript_options.import_meta,
-      Some(ImportMeta::Disabled)
-    ) {
-      return None;
-    }
-
-    let replacement = Self::get_import_meta_member_replacement(parser, property)?;
-    parser.add_presentational_dependency(Box::new(ConstDependency::new(
-      member_expr.span().into(),
-      replacement.into(),
-    )));
-    Some(true)
-  }
-
-  fn import_meta_property_in_destructuring(
-    &self,
-    parser: &mut JavascriptParser<'p>,
-    property: &DestructuringAssignmentProperty,
-  ) -> Option<String> {
-    // Skip ESM handling if not enabled
-    if !self.handle_esm {
-      return None;
-    }
-
-    // Skip processing if importMeta is disabled
-    if matches!(
-      parser.javascript_options.import_meta,
-      Some(ImportMeta::Disabled)
-    ) {
-      return None;
-    }
-
-    let meta_property = match property.id.as_str() {
-      "filename" => NodeMetaProperty::Filename,
-      "dirname" => NodeMetaProperty::Dirname,
-      _ => return None,
-    };
-
-    let value = Self::get_import_meta_destructuring_value(parser, meta_property)?;
-    Some(format!("{}: {value}", property.id))
   }
 }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -672,18 +672,18 @@ impl Plugin for JsPlugin {
       .tap(render_manifest::new(self));
 
     ctx.register_parser_and_generator_builder(ModuleType::JsAuto, {
-      Box::new(move |_| {
-        Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>
+      Box::new(move |options| {
+        Box::new(JavaScriptParserAndGenerator::new(options)) as Box<dyn ParserAndGenerator>
       })
     });
     ctx.register_parser_and_generator_builder(ModuleType::JsEsm, {
-      Box::new(move |_| {
-        Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>
+      Box::new(move |options| {
+        Box::new(JavaScriptParserAndGenerator::new(options)) as Box<dyn ParserAndGenerator>
       })
     });
     ctx.register_parser_and_generator_builder(ModuleType::JsDynamic, {
-      Box::new(move |_| {
-        Box::<JavaScriptParserAndGenerator>::default() as Box<dyn ParserAndGenerator>
+      Box::new(move |options| {
+        Box::new(JavaScriptParserAndGenerator::new(options)) as Box<dyn ParserAndGenerator>
       })
     });
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -3,9 +3,9 @@ mod parser;
 mod util;
 
 use rspack_core::{
-  AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, FactoryMeta, ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta,
-  ParserOptions, ResourceData, SideEffectsBailoutItemWithSpan,
+  ArcComputed, AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
+  CompilerOptions, FactoryMeta, ImportMeta, ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta,
+  ParserOptions, ResolvedModuleOptions, ResourceData, SideEffectsBailoutItemWithSpan,
 };
 use rspack_error::Diagnostic;
 use rustc_hash::FxHashSet;
@@ -54,6 +54,7 @@ pub fn scan_dependencies(
   build_info: &mut BuildInfo,
   module_identifier: ModuleIdentifier,
   module_parser_options: Option<&ParserOptions>,
+  import_meta: ArcComputed<ResolvedModuleOptions, ImportMeta>,
   semicolons: &mut FxHashSet<u32>,
   parser_plugins: &mut Vec<BoxJavascriptParserPlugin>,
   parse_meta: ParseMeta,
@@ -66,6 +67,7 @@ pub fn scan_dependencies(
     module_parser_options
       .and_then(|p| p.get_javascript())
       .expect("should at least have a global javascript parser options"),
+    import_meta,
     &module_identifier,
     module_type,
     module_layer,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -22,9 +22,10 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, DependencyId, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
-  JavascriptParserCommonjsExportsOption, JavascriptParserOptions, ModuleIdentifier, ModuleLayer,
-  ModuleType, ParseMeta, ResourceData, SideEffectsBailoutItemWithSpan,
+  CompilerOptions, DependencyId, DependencyLocation, DependencyRange, FactoryMeta,
+  ImportMetaKnownProperties, JavascriptParserCommonjsExportsOption, JavascriptParserOptions,
+  ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResourceData,
+  SideEffectsBailoutItemWithSpan,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_util::fx_hash::FxIndexSet;
@@ -476,14 +477,12 @@ impl<'parser> JavascriptParser<'parser> {
     if module_type.is_js_auto() || module_type.is_js_esm() {
       plugins.push(Box::new(parser_plugin::ESMTopLevelThisParserPlugin));
       plugins.push(Box::<parser_plugin::ESMDetectionParserPlugin>::default());
-      let import_meta = javascript_options
-        .import_meta
-        .clone()
-        .unwrap_or(ImportMeta::Enabled);
+      let import_meta = javascript_options.import_meta();
       plugins.push(Box::new(
         parser_plugin::ImportMetaContextDependencyParserPlugin {
-          webpack_context: import_meta.is_webpack_context_enabled(),
-          glob: import_meta.is_glob_enabled(),
+          webpack_context: import_meta
+            .is_known_property_enabled(ImportMetaKnownProperties::WEBPACK_CONTEXT),
+          glob: import_meta.is_known_property_enabled(ImportMetaKnownProperties::GLOB),
         },
       ));
       if import_meta.is_enabled() {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -476,16 +476,18 @@ impl<'parser> JavascriptParser<'parser> {
     if module_type.is_js_auto() || module_type.is_js_esm() {
       plugins.push(Box::new(parser_plugin::ESMTopLevelThisParserPlugin));
       plugins.push(Box::<parser_plugin::ESMDetectionParserPlugin>::default());
+      let import_meta = javascript_options
+        .import_meta
+        .clone()
+        .unwrap_or(ImportMeta::Enabled);
       plugins.push(Box::new(
-        parser_plugin::ImportMetaContextDependencyParserPlugin,
+        parser_plugin::ImportMetaContextDependencyParserPlugin {
+          webpack_context: import_meta.is_webpack_context_enabled(),
+          glob: import_meta.is_glob_enabled(),
+        },
       ));
-      if matches!(
-        javascript_options.import_meta,
-        Some(ImportMeta::Enabled | ImportMeta::PreserveUnknown)
-      ) {
-        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
-          javascript_options.import_meta.expect("should have value"),
-        )));
+      if import_meta.is_enabled() {
+        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(import_meta)));
       } else {
         plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
       }
@@ -521,15 +523,11 @@ impl<'parser> JavascriptParser<'parser> {
       }
     }
 
-    // NodeStuffPlugin: handle __dirname/__filename/global (CJS) and import.meta.dirname/filename (ESM)
-    // CJS features require node options; ESM features are always available for ESM-capable modules
+    // NodeStuffPlugin handles __dirname/__filename/global (CJS).
     let handle_cjs =
       (module_type.is_js_auto() || module_type.is_js_dynamic()) && compiler_options.node.is_some();
-    let handle_esm = module_type.is_js_auto() || module_type.is_js_esm();
-    if handle_cjs || handle_esm {
-      plugins.push(Box::new(parser_plugin::NodeStuffPlugin::new(
-        handle_cjs, handle_esm,
-      )));
+    if handle_cjs {
+      plugins.push(Box::new(parser_plugin::NodeStuffPlugin::new(handle_cjs)));
     }
 
     if module_type.is_js_auto() || module_type.is_js_dynamic() || module_type.is_js_esm() {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -486,7 +486,9 @@ impl<'parser> JavascriptParser<'parser> {
         },
       ));
       if import_meta.is_enabled() {
-        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(import_meta)));
+        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
+          import_meta.clone(),
+        )));
       } else {
         plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -21,10 +21,10 @@ use rspack_cacheable::{
   with::{AsCacheable, AsOption, AsPreset, AsVec},
 };
 use rspack_core::{
-  AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
-  CompilerOptions, DependencyId, DependencyLocation, DependencyRange, FactoryMeta,
+  ArcComputed, AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
+  CompilerOptions, DependencyId, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
   ImportMetaKnownProperties, JavascriptParserCommonjsExportsOption, JavascriptParserOptions,
-  ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResourceData,
+  ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResolvedModuleOptions, ResourceData,
   SideEffectsBailoutItemWithSpan,
 };
 use rspack_error::{Diagnostic, Result};
@@ -436,6 +436,7 @@ impl<'parser> JavascriptParser<'parser> {
     ast: &'parser ParsedJavaScriptAst<'parser>,
     compiler_options: &'parser CompilerOptions,
     javascript_options: &'parser JavascriptParserOptions,
+    import_meta: ArcComputed<ResolvedModuleOptions, ImportMeta>,
     module_identifier: &'parser ModuleIdentifier,
     module_type: &'parser ModuleType,
     module_layer: Option<&'parser ModuleLayer>,
@@ -477,7 +478,6 @@ impl<'parser> JavascriptParser<'parser> {
     if module_type.is_js_auto() || module_type.is_js_esm() {
       plugins.push(Box::new(parser_plugin::ESMTopLevelThisParserPlugin));
       plugins.push(Box::<parser_plugin::ESMDetectionParserPlugin>::default());
-      let import_meta = javascript_options.import_meta();
       plugins.push(Box::new(
         parser_plugin::ImportMetaContextDependencyParserPlugin {
           webpack_context: import_meta
@@ -486,9 +486,7 @@ impl<'parser> JavascriptParser<'parser> {
         },
       ));
       if import_meta.is_enabled() {
-        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(
-          import_meta.clone(),
-        )));
+        plugins.push(Box::new(parser_plugin::ImportMetaPlugin(import_meta)));
       } else {
         plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -20,6 +20,7 @@ pub mod expr_name {
   pub const REQUIRE: &str = "require";
   pub const REQUIRE_RESOLVE: &str = "require.resolve";
   pub const REQUIRE_RESOLVE_WEAK: &str = "require.resolveWeak";
+  pub const IMPORT_META_PREFIX: &str = "import.meta.";
   pub const IMPORT_META: &str = "import.meta";
   pub const IMPORT_META_FILENAME: &str = "import.meta.filename";
   pub const IMPORT_META_DIRNAME: &str = "import.meta.dirname";

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -192,7 +192,7 @@ async fn nmf_parser(
       // force_node_shims means we want to handle CJS shims (__dirname/__filename) in ESM modules
       // So we use handle_cjs=true to enable __dirname/__filename handling
       parser.add_parser_plugin(Box::new(
-        rspack_plugin_javascript::node_stuff_plugin::NodeStuffPlugin::new(true, false),
+        rspack_plugin_javascript::node_stuff_plugin::NodeStuffPlugin::new(true),
       ) as BoxJavascriptParserPlugin);
     }
   } else if parser.is::<AssetParserAndGenerator>() {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -603,10 +603,7 @@ function getRawJavascriptParserOptions(
     dynamicImportPreload: parser.dynamicImportPreload?.toString(),
     dynamicImportPrefetch: parser.dynamicImportPrefetch?.toString(),
     dynamicImportFetchPriority: parser.dynamicImportFetchPriority,
-    importMeta:
-      typeof parser.importMeta === 'boolean'
-        ? String(parser.importMeta)
-        : parser.importMeta,
+    importMeta: getRawImportMeta(parser.importMeta),
     url: parser.url?.toString(),
     exprContextCritical: parser.exprContextCritical,
     unknownContextCritical: parser.unknownContextCritical,
@@ -652,6 +649,24 @@ function getRawJavascriptParserWorkerOptions(
     return { alias: worker };
   }
   return worker;
+}
+
+function getRawImportMeta(
+  importMeta: JavascriptParserOptions['importMeta'],
+): RawJavascriptParserOptions['importMeta'] {
+  if (typeof importMeta === 'boolean') {
+    return String(importMeta);
+  }
+  if (typeof importMeta === 'object' && importMeta !== null) {
+    const rawImportMeta: Record<string, boolean> = {};
+    for (const [property, value] of Object.entries(importMeta)) {
+      if (typeof value === 'boolean') {
+        rawImportMeta[property] = value;
+      }
+    }
+    return rawImportMeta;
+  }
+  return importMeta;
 }
 
 function getRawAssetParserOptions(

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1190,11 +1190,6 @@ export type ImportMetaParserOptions = {
   dirname?: boolean;
 
   /**
-   * Enable/disable evaluating import.meta.env.
-   */
-  env?: boolean;
-
-  /**
    * Enable/disable evaluating import.meta.filename.
    */
   filename?: boolean;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1181,6 +1181,105 @@ export type JavascriptParserWorkerOptions =
       url?: 'new-url-relative';
     };
 
+export type ImportMetaParserOptions = {
+  [property: string]: boolean | undefined;
+
+  /**
+   * Enable/disable evaluating import.meta.dirname.
+   */
+  dirname?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.env.
+   */
+  env?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.filename.
+   */
+  filename?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.glob.
+   */
+  glob?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.main.
+   */
+  main?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.resolve.
+   */
+  resolve?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackBaseUri.
+   */
+  rspackBaseUri?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackHash.
+   */
+  rspackHash?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackInitSharing.
+   */
+  rspackInitSharing?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackNonce.
+   */
+  rspackNonce?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackPublicPath.
+   */
+  rspackPublicPath?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackRsc.
+   */
+  rspackRsc?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackShareScopes.
+   */
+  rspackShareScopes?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackUniqueId.
+   */
+  rspackUniqueId?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.rspackVersion.
+   */
+  rspackVersion?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.url.
+   */
+  url?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.webpack.
+   */
+  webpack?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.webpackContext.
+   */
+  webpackContext?: boolean;
+
+  /**
+   * Enable/disable evaluating import.meta.webpackHot.
+   */
+  webpackHot?: boolean;
+};
+
 export type JavascriptParserOptions = {
   /**
    * Specifies global mode for dynamic import.
@@ -1207,9 +1306,9 @@ export type JavascriptParserOptions = {
   dynamicImportFetchPriority?: 'low' | 'high' | 'auto';
 
   /**
-   * Enable or disable evaluating import.meta. Set to 'preserve-unknown' to preserve unknown properties for runtime evaluation.
+   * Enable or disable evaluating import.meta. Set to 'preserve-unknown' or use an object to preserve unknown properties for runtime evaluation.
    */
-  importMeta?: boolean | 'preserve-unknown';
+  importMeta?: boolean | 'preserve-unknown' | ImportMetaParserOptions;
 
   /**
    * Enable parsing of new URL() syntax.

--- a/tests/rspack-test/configCases/module/import-meta-context-priority/context-field-disabled.js
+++ b/tests/rspack-test/configCases/module/import-meta-context-priority/context-field-disabled.js
@@ -1,0 +1,1 @@
+export default typeof import.meta.webpackContext;

--- a/tests/rspack-test/configCases/module/import-meta-context-priority/context-field-enabled.js
+++ b/tests/rspack-test/configCases/module/import-meta-context-priority/context-field-enabled.js
@@ -1,0 +1,5 @@
+const context = import.meta.webpackContext("./context", {
+	regExp: /value/
+});
+
+export default context("./value").default;

--- a/tests/rspack-test/configCases/module/import-meta-context-priority/context/value.js
+++ b/tests/rspack-test/configCases/module/import-meta-context-priority/context/value.js
@@ -1,0 +1,1 @@
+export default "context-value";

--- a/tests/rspack-test/configCases/module/import-meta-context-priority/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-context-priority/index.js
@@ -1,0 +1,7 @@
+import fieldDisabledContext from "./context-field-disabled";
+import fieldEnabledContext from "./context-field-enabled";
+
+it("should control import.meta.webpackContext with importMeta.webpackContext", () => {
+	expect(fieldEnabledContext).toBe("context-value");
+	expect(fieldDisabledContext).toBe("undefined");
+});

--- a/tests/rspack-test/configCases/module/import-meta-context-priority/rspack.config.js
+++ b/tests/rspack-test/configCases/module/import-meta-context-priority/rspack.config.js
@@ -1,0 +1,33 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  target: 'node',
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    module: true,
+    chunkFormat: 'module',
+  },
+  module: {
+    rules: [
+      {
+        test: /context-field-enabled\.js$/,
+        parser: {
+          importMeta: {
+            webpackContext: true,
+          },
+        },
+      },
+      {
+        test: /context-field-disabled\.js$/,
+        parser: {
+          importMeta: {
+            webpackContext: false,
+          },
+        },
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
@@ -6,18 +6,11 @@ const sourceFilename = path.resolve(
 );
 const sourceDirname = path.dirname(sourceFilename);
 const sourceUrl = pathToFileURL(sourceFilename).toString();
-const { env, url, webpack } = import.meta;
-const envType = typeof import.meta.env;
-
-if (!import.meta.env) {
-	import.meta.env = { RSPACK_TEST: "runtime" };
-}
+const { url, webpack } = import.meta;
 
 export default {
 	contextType: typeof import.meta.webpackContext,
 	dirname: import.meta.dirname,
-	envOptional: import.meta.env?.RSPACK_TEST,
-	envType,
 	filename: import.meta.filename,
 	globType: typeof import.meta.glob,
 	hotType: typeof import.meta.webpackHot,
@@ -26,7 +19,7 @@ export default {
 	sourceFilename,
 	sourceUrl,
 	url,
-	destructuredEnvType: typeof env,
+	urlOptional: import.meta.url?.length,
 	destructuredUrl: url,
 	destructuredWebpack: webpack,
 	webpack

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
@@ -7,11 +7,17 @@ const sourceFilename = path.resolve(
 const sourceDirname = path.dirname(sourceFilename);
 const sourceUrl = pathToFileURL(sourceFilename).toString();
 const { env, url, webpack } = import.meta;
+const envType = typeof import.meta.env;
+
+if (!import.meta.env) {
+	import.meta.env = { RSPACK_TEST: "runtime" };
+}
 
 export default {
 	contextType: typeof import.meta.webpackContext,
 	dirname: import.meta.dirname,
-	envType: typeof import.meta.env,
+	envOptional: import.meta.env?.RSPACK_TEST,
+	envType,
 	filename: import.meta.filename,
 	globType: typeof import.meta.glob,
 	hotType: typeof import.meta.webpackHot,

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
@@ -1,0 +1,27 @@
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const sourceFilename = path.resolve(
+	"./configCases/module/import-meta-parser-options/disabled-fields.js"
+);
+const sourceDirname = path.dirname(sourceFilename);
+const sourceUrl = pathToFileURL(sourceFilename).toString();
+const { env, url, webpack } = import.meta;
+
+export default {
+	contextType: typeof import.meta.webpackContext,
+	dirname: import.meta.dirname,
+	envType: typeof import.meta.env,
+	filename: import.meta.filename,
+	globType: typeof import.meta.glob,
+	hotType: typeof import.meta.webpackHot,
+	main: import.meta.main,
+	sourceDirname,
+	sourceFilename,
+	sourceUrl,
+	url,
+	destructuredEnvType: typeof env,
+	destructuredUrl: url,
+	destructuredWebpack: webpack,
+	webpack
+};

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
@@ -20,6 +20,7 @@ export default {
 	sourceUrl,
 	url,
 	urlOptional: import.meta.url?.length,
+	webpackOptional: import.meta.webpack?.x,
 	destructuredUrl: url,
 	destructuredWebpack: webpack,
 	webpack

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
@@ -1,0 +1,19 @@
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const sourceUrl = pathToFileURL(
+	path.resolve("./configCases/module/import-meta-parser-options/empty-options.js")
+).toString();
+
+if (!import.meta.UNKNOWN_PROPERTY) {
+	import.meta.UNKNOWN_PROPERTY = "runtime";
+}
+
+const { UNKNOWN_PROPERTY, url, webpack } = import.meta;
+
+export default {
+	sourceUrl,
+	unknown: UNKNOWN_PROPERTY,
+	url,
+	webpack
+};

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
@@ -15,6 +15,7 @@ export default {
 	sourceUrl,
 	unknown: UNKNOWN_PROPERTY,
 	unknownOptional: import.meta.UNKNOWN_PROPERTY?.length,
+	missingOptional: import.meta.MISSING_PROPERTY?.length,
 	url,
 	webpack
 };

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
@@ -14,6 +14,7 @@ const { UNKNOWN_PROPERTY, url, webpack } = import.meta;
 export default {
 	sourceUrl,
 	unknown: UNKNOWN_PROPERTY,
+	unknownOptional: import.meta.UNKNOWN_PROPERTY?.length,
 	url,
 	webpack
 };

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -6,6 +6,7 @@ it("should treat an empty importMeta object like preserve-unknown", () => {
 	expect(emptyOptions.url).toBe(emptyOptions.sourceUrl);
 	expect(emptyOptions.webpack).toBe(5);
 	expect(emptyOptions.unknown).toBe("runtime");
+	expect(emptyOptions.unknownOptional).toBe("runtime".length);
 });
 
 it("should preserve disabled import.meta fields for runtime evaluation", () => {
@@ -13,6 +14,7 @@ it("should preserve disabled import.meta fields for runtime evaluation", () => {
 	expect(disabledFields.webpack).toBeUndefined();
 	expect(disabledFields.main).toBeUndefined();
 	expect(disabledFields.envType).toBe("undefined");
+	expect(disabledFields.envOptional).toBe("runtime");
 	expect(disabledFields.contextType).toBe("undefined");
 	expect(disabledFields.globType).toBe("undefined");
 	expect(disabledFields.hotType).toBe("undefined");
@@ -22,6 +24,7 @@ it("should preserve disabled import.meta fields for runtime evaluation", () => {
 
 	const source = fs.readFileSync(__filename, "utf-8");
 	const importMeta = ["import", "meta"].join(".");
+	expect(source).toContain(`${importMeta}.env`);
 	expect(source).toContain(`${importMeta}.webpackContext`);
 	expect(source).toContain(`${importMeta}.glob`);
 	expect(source).toContain(`${importMeta}.webpackHot`);

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -7,11 +7,13 @@ it("should treat an empty importMeta object like preserve-unknown", () => {
 	expect(emptyOptions.webpack).toBe(5);
 	expect(emptyOptions.unknown).toBe("runtime");
 	expect(emptyOptions.unknownOptional).toBe("runtime".length);
+	expect(emptyOptions.missingOptional).toBeUndefined();
 });
 
 it("should preserve disabled import.meta fields for runtime evaluation", () => {
 	expect(disabledFields.url).not.toBe(disabledFields.sourceUrl);
 	expect(disabledFields.urlOptional).toBe(disabledFields.url.length);
+	expect(disabledFields.webpackOptional).toBeUndefined();
 	expect(disabledFields.webpack).toBeUndefined();
 	expect(disabledFields.main).toBeUndefined();
 	expect(disabledFields.contextType).toBe("undefined");

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -11,20 +11,18 @@ it("should treat an empty importMeta object like preserve-unknown", () => {
 
 it("should preserve disabled import.meta fields for runtime evaluation", () => {
 	expect(disabledFields.url).not.toBe(disabledFields.sourceUrl);
+	expect(disabledFields.urlOptional).toBe(disabledFields.url.length);
 	expect(disabledFields.webpack).toBeUndefined();
 	expect(disabledFields.main).toBeUndefined();
-	expect(disabledFields.envType).toBe("undefined");
-	expect(disabledFields.envOptional).toBe("runtime");
 	expect(disabledFields.contextType).toBe("undefined");
 	expect(disabledFields.globType).toBe("undefined");
 	expect(disabledFields.hotType).toBe("undefined");
 	expect(disabledFields.destructuredUrl).toBe(disabledFields.url);
 	expect(disabledFields.destructuredWebpack).toBeUndefined();
-	expect(disabledFields.destructuredEnvType).toBe("undefined");
 
 	const source = fs.readFileSync(__filename, "utf-8");
 	const importMeta = ["import", "meta"].join(".");
-	expect(source).toContain(`${importMeta}.env`);
+	expect(source).toContain(`${importMeta}.url`);
 	expect(source).toContain(`${importMeta}.webpackContext`);
 	expect(source).toContain(`${importMeta}.glob`);
 	expect(source).toContain(`${importMeta}.webpackHot`);

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -1,0 +1,40 @@
+import disabledFields from "./disabled-fields";
+import emptyOptions from "./empty-options";
+const fs = require("fs");
+
+it("should treat an empty importMeta object like preserve-unknown", () => {
+	expect(emptyOptions.url).toBe(emptyOptions.sourceUrl);
+	expect(emptyOptions.webpack).toBe(5);
+	expect(emptyOptions.unknown).toBe("runtime");
+});
+
+it("should preserve disabled import.meta fields for runtime evaluation", () => {
+	expect(disabledFields.url).not.toBe(disabledFields.sourceUrl);
+	expect(disabledFields.webpack).toBeUndefined();
+	expect(disabledFields.main).toBeUndefined();
+	expect(disabledFields.envType).toBe("undefined");
+	expect(disabledFields.contextType).toBe("undefined");
+	expect(disabledFields.globType).toBe("undefined");
+	expect(disabledFields.hotType).toBe("undefined");
+	expect(disabledFields.destructuredUrl).toBe(disabledFields.url);
+	expect(disabledFields.destructuredWebpack).toBeUndefined();
+	expect(disabledFields.destructuredEnvType).toBe("undefined");
+
+	const source = fs.readFileSync(__filename, "utf-8");
+	const importMeta = ["import", "meta"].join(".");
+	expect(source).toContain(`${importMeta}.webpackContext`);
+	expect(source).toContain(`${importMeta}.glob`);
+	expect(source).toContain(`${importMeta}.webpackHot`);
+
+	if (typeof disabledFields.filename === "string") {
+		expect(disabledFields.filename).not.toBe(disabledFields.sourceFilename);
+	} else {
+		expect(disabledFields.filename).toBeUndefined();
+	}
+
+	if (typeof disabledFields.dirname === "string") {
+		expect(disabledFields.dirname).not.toBe(disabledFields.sourceDirname);
+	} else {
+		expect(disabledFields.dirname).toBeUndefined();
+	}
+});

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/rspack.config.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/rspack.config.js
@@ -23,7 +23,6 @@ module.exports = {
         parser: {
           importMeta: {
             dirname: false,
-            env: false,
             filename: false,
             main: false,
             url: false,

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/rspack.config.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/rspack.config.js
@@ -1,0 +1,39 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  target: 'node',
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    module: true,
+    chunkFormat: 'module',
+  },
+  module: {
+    rules: [
+      {
+        test: /empty-options\.js$/,
+        parser: {
+          importMeta: {},
+        },
+      },
+      {
+        test: /disabled-fields\.js$/,
+        parser: {
+          importMeta: {
+            dirname: false,
+            env: false,
+            filename: false,
+            main: false,
+            url: false,
+            webpack: false,
+            webpackContext: false,
+            glob: false,
+            webpackHot: false,
+          },
+        },
+      },
+    ],
+  },
+};

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -98,7 +98,7 @@ __dirname
 
 The `import.meta` exposes context-specific metadata to a JavaScript module, such as the URL of the module. It is only available in modules that support ESM ([module type](/misc/glossary#module-type) is `javascript/auto` or `javascript/esm`).
 
-Normally, unknown `import.meta` metadata is replaced with `undefined` by default. When using [ESM output](/guide/features/esm), [`module.parser.javascript.importMeta`](/config/module-parser#javascriptimportmeta) defaults to `'preserve-unknown'`, so unknown metadata is preserved for runtime evaluation.
+Normally, unknown `import.meta` metadata is replaced with `undefined` by default. When using [ESM output](/guide/features/esm), [`module.parser.javascript.importMeta`](/config/module-parser#javascriptimportmeta) defaults to `'preserve-unknown'`, so unknown metadata is preserved for runtime evaluation. You can also use the object form of `module.parser.javascript.importMeta` to control known `import.meta` properties individually.
 
 Rspack statically analyzes `import.meta` properties and replaces them with concrete values at compile time, so dynamic access to `import.meta` (e.g., `Object.keys(import.meta)`) is not supported and will emit a warning. You should access metadata on `import.meta` via property access or destructuring assignment.
 

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -375,7 +375,7 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-alpha.6" />
 
-- **Type:** `boolean | 'preserve-unknown'`
+- **Type:** `boolean | 'preserve-unknown' | ImportMetaParserOptions`
 - **Default:** When using [ESM output](/guide/features/esm), the default value is `'preserve-unknown'`; otherwise, it is `true`
 
 Control whether Rspack parses and replaces `import.meta` in source code. Available values:
@@ -383,6 +383,7 @@ Control whether Rspack parses and replaces `import.meta` in source code. Availab
 - `"preserve-unknown"`: [Known `import.meta` properties](/api/runtime-api/module-variables#import-meta) are statically analyzed at compile-time, other properties are preserved and evaluated at runtime.
 - `true`: All `import.meta` properties are statically analyzed at compile-time.
 - `false`: All `import.meta` properties are evaluated at runtime.
+- `ImportMetaParserOptions`: Configure each known `import.meta` property independently. Properties set to `false` are preserved for runtime evaluation, while omitted properties keep the default enabled behavior. Unknown `import.meta` properties are preserved.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -395,6 +396,30 @@ export default {
   },
 };
 ```
+
+The object form supports the following keys:
+
+- Webpack-compatible keys: `dirname`, `env`, `filename`, `main`, `url`, `webpack`, and `webpackContext`.
+- Rspack-specific keys: `glob`, `resolve`, `rspackBaseUri`, `rspackHash`, `rspackInitSharing`, `rspackNonce`, `rspackPublicPath`, `rspackRsc`, `rspackShareScopes`, `rspackUniqueId`, and `rspackVersion`.
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        importMeta: {
+          url: false,
+          webpack: true,
+          webpackContext: true,
+          rspackHash: false,
+        },
+      },
+    },
+  },
+};
+```
+
+`resolve` only controls whether an already enabled [`import.meta.resolve()`](#javascriptimportmetaresolve) expression is handled at compile time. To use `import.meta.resolve()`, you still need to enable `javascript.importMetaResolve`.
 
 ### javascript.exportsPresence
 

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -399,7 +399,7 @@ export default {
 
 The object form supports the following keys:
 
-- Webpack-compatible keys: `dirname`, `env`, `filename`, `main`, `url`, `webpack`, and `webpackContext`.
+- Webpack-compatible keys: `dirname`, `filename`, `main`, `url`, `webpack`, and `webpackContext`.
 - Rspack-specific keys: `glob`, `resolve`, `rspackBaseUri`, `rspackHash`, `rspackInitSharing`, `rspackNonce`, `rspackPublicPath`, `rspackRsc`, `rspackShareScopes`, `rspackUniqueId`, and `rspackVersion`.
 
 ```js title="rspack.config.mjs"

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -98,7 +98,7 @@ __dirname
 
 `import.meta` 将特定上下文的元数据暴露给 JavaScript 模块，例如模块的 URL。它仅在支持 ESM（[模块类型](/misc/glossary#module-type模块类型)为 `javascript/auto` 或 `javascript/esm`）的模块中可用。
 
-通常情况下，未知的 `import.meta` 元数据默认会被替换为 `undefined`。当使用 [ESM 格式](/guide/features/esm)输出时，[`module.parser.javascript.importMeta`](/config/module-parser#javascriptimportmeta) 的默认值为 `'preserve-unknown'`，因此未知的元数据会被保留并在运行时被计算。
+通常情况下，未知的 `import.meta` 元数据默认会被替换为 `undefined`。当使用 [ESM 格式](/guide/features/esm)输出时，[`module.parser.javascript.importMeta`](/config/module-parser#javascriptimportmeta) 的默认值为 `'preserve-unknown'`，因此未知的元数据会被保留并在运行时被计算。你也可以使用 `module.parser.javascript.importMeta` 的对象形式，分别控制已知的 `import.meta` 字段。
 
 Rspack 在编译时会静态分析将 `import.meta` 的属性替换为具体值，因此不支持动态访问 `import.meta`（如 `Object.keys(import.meta)`），否则会抛出警告。你应该通过属性访问或解构赋值的方式来访问 `import.meta` 上的元数据。
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -399,7 +399,7 @@ export default {
 
 对象形式支持以下字段：
 
-- 兼容 webpack 的字段：`dirname`、`env`、`filename`、`main`、`url`、`webpack` 和 `webpackContext`。
+- 兼容 webpack 的字段：`dirname`、`filename`、`main`、`url`、`webpack` 和 `webpackContext`。
 - Rspack 特有字段：`glob`、`resolve`、`rspackBaseUri`、`rspackHash`、`rspackInitSharing`、`rspackNonce`、`rspackPublicPath`、`rspackRsc`、`rspackShareScopes`、`rspackUniqueId` 和 `rspackVersion`。
 
 ```js title="rspack.config.mjs"

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -375,7 +375,7 @@ export default {
 
 <ApiMeta addedVersion="1.0.0-alpha.6" />
 
-- **类型：** `boolean | 'preserve-unknown'`
+- **类型：** `boolean | 'preserve-unknown' | ImportMetaParserOptions`
 - **默认值：** 当输出为 [ESM 格式](/guide/features/esm) 时，默认值为 `'preserve-unknown'`，其他情况默认值为 `true`
 
 用于控制是否要解析和替换源代码中的 `import.meta`，可选值有：
@@ -383,6 +383,7 @@ export default {
 - `"preserve-unknown"`: [已知的 `import.meta` 字段](/api/runtime-api/module-variables#import-meta) 会在编译期被替换，其他字段会被保留并在运行时被计算。
 - `true`: 所有 `import.meta` 字段在编译期被替换。
 - `false`: 所有 `import.meta` 字段都在运行时被计算。
+- `ImportMetaParserOptions`: 对每个已知的 `import.meta` 字段分别配置。设置为 `false` 的字段会被保留并在运行时计算，未设置的字段会保持默认启用行为。未知的 `import.meta` 字段会被保留。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -395,6 +396,30 @@ export default {
   },
 };
 ```
+
+对象形式支持以下字段：
+
+- 兼容 webpack 的字段：`dirname`、`env`、`filename`、`main`、`url`、`webpack` 和 `webpackContext`。
+- Rspack 特有字段：`glob`、`resolve`、`rspackBaseUri`、`rspackHash`、`rspackInitSharing`、`rspackNonce`、`rspackPublicPath`、`rspackRsc`、`rspackShareScopes`、`rspackUniqueId` 和 `rspackVersion`。
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    parser: {
+      javascript: {
+        importMeta: {
+          url: false,
+          webpack: true,
+          webpackContext: true,
+          rspackHash: false,
+        },
+      },
+    },
+  },
+};
+```
+
+`resolve` 只控制已经启用的 [`import.meta.resolve()`](#javascriptimportmetaresolve) 表达式是否在编译期处理。要使用 `import.meta.resolve()`，仍然需要启用 `javascript.importMetaResolve`。
 
 ### javascript.exportsPresence
 

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -12,7 +12,8 @@ use rspack::builder::{Builder as _, NodeOptionBuilder};
 use rspack_benchmark::Criterion;
 use rspack_core::{
   BuildInfo, BuildMeta, Compiler, CompilerOptions, Mode, ModuleIdentifier, ModuleType,
-  Optimization, ParseMeta, ParserOptions, ResourceData, RuntimeTemplate, SideEffectOption,
+  Optimization, ParseMeta, ResolvedModuleOptions, ResolvedModuleOptionsCacheKey, ResourceData,
+  RuntimeTemplate, SideEffectOption,
 };
 use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin,
@@ -49,7 +50,7 @@ struct PreparedScanDependenciesBenchmarkCase {
   source_text: String,
   compiler_options: Arc<CompilerOptions>,
   initial_semicolons: FxHashSet<u32>,
-  parser_options: ParserOptions,
+  module_options: Arc<ResolvedModuleOptions>,
   parsed_ast: ParsedJavaScriptAst<'static>,
   module_identifier: ModuleIdentifier,
   module_type: ModuleType,
@@ -154,6 +155,11 @@ fn prepare_scan_dependencies_benchmark_case(
     .and_then(|parser_map| parser_map.get("javascript"))
     .cloned()
     .expect("scan_dependencies benchmark compiler should include javascript parser options");
+  let module_options = Arc::new(ResolvedModuleOptions::new(
+    ResolvedModuleOptionsCacheKey::new(&[], module_type),
+    Some(parser_options),
+    None,
+  ));
 
   let runtime_template =
     RuntimeTemplate::new(compiler_options.clone()).create_module_code_template();
@@ -163,7 +169,7 @@ fn prepare_scan_dependencies_benchmark_case(
     source_text,
     compiler_options,
     initial_semicolons: semicolons,
-    parser_options,
+    module_options,
     parsed_ast,
     module_identifier: resource_path.into(),
     module_type,
@@ -256,7 +262,15 @@ impl PreparedScanDependenciesBenchmarkCase {
       &mut iteration_state.build_meta,
       &mut iteration_state.build_info,
       self.module_identifier,
-      Some(&self.parser_options),
+      self.module_options.parser_options(),
+      self
+        .module_options
+        .parser_options_computed(|options| {
+          options
+            .get_javascript()
+            .map(|javascript_options| javascript_options.import_meta())
+        })
+        .expect("scan_dependencies benchmark compiler should include import_meta parser options"),
       &mut iteration_state.semicolons,
       &mut iteration_state.parser_plugins,
       std::mem::take(&mut iteration_state.parse_meta),


### PR DESCRIPTION
## Summary

- Support object form `module.parser.javascript.importMeta` for fine-grained `import.meta.*` handling.
- Include Rspack-specific import.meta fields such as `rspackPublicPath`, `rspackHash`, `rspackRsc`, and `glob` in the granular option shape.
- Add a config case covering preserved fields, enabled known fields, Rspack-specific fields, unknown fields, and `webpackContext` priority.

## Example

A project may want Rspack to keep runtime-provided `import.meta.url` and Rspack-specific runtime fields untouched, while still folding webpack-compatible fields that are safe to compile:

```js
// rspack.config.js
module.exports = {
  module: {
    parser: {
      javascript: {
        importMeta: {
          url: false,
          webpack: true,
          env: true,
          rspackHash: false,
          webpackContext: true,
        },
      },
    },
  },
};
```

With source like this:

```js
const preservedUrl = import.meta.url;
const webpackVersion = import.meta.webpack;
const knownEnv = import.meta.env;
const preservedRspackHash = import.meta.rspackHash;
const preservedCustomValue = import.meta.customRuntimeValue;
const context = import.meta.webpackContext("./dir", {
  recursive: false,
});

export const values = [
  preservedUrl,
  webpackVersion,
  knownEnv,
  preservedRspackHash,
  preservedCustomValue,
  context.keys(),
];
```

The object form makes each field explicit:

- `url: false` preserves `import.meta.url` for runtime evaluation instead of replacing it with the source file URL.
- `webpack: true` keeps the existing compile-time replacement, so `import.meta.webpack` becomes `5`.
- `env: true` keeps the existing enabled behavior for `import.meta.env`; since this branch does not implement `import.meta.env` itself, it still follows the existing unsupported fallback.
- `rspackHash: false` preserves `import.meta.rspackHash`, which is useful when a runtime wants to provide its own value.
- Unknown fields such as `import.meta.customRuntimeValue` are preserved by the object form, matching the `preserve-unknown` behavior for custom runtime metadata.
- `webpackContext: true` takes priority over `importMetaContext: false`, so `import.meta.webpackContext("./dir", { recursive: false })` is still parsed into a context dependency and includes `./a.js` from the test fixture.

This gives users a migration path between Rspack's compile-time replacements and runtimes that expose selected `import.meta` properties themselves.

## Related links

- Mentioned context: web-infra-dev/rspack#12266

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

After rebasing this branch onto the latest `origin/main`:

- `cargo check -p rspack_plugin_javascript -p rspack_binding_api`

Previously validated on this branch:

- `corepack pnpm --filter @rspack/binding run build:dev`
- `corepack pnpm --filter @rspack/core build`
- `corepack pnpm --filter @rspack/test-tools build`
- `corepack pnpm --filter @rspack/cli build`
- `cargo fmt --all --check`
- `corepack pnpm --filter @rspack/tests test -- -t "configCases/parsing/import-meta-object"`

---
_by OpenAI Codex_