### PR TITLE
perf(hook): reduce hook macro expansion size and optimize performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4053,7 +4053,6 @@ dependencies = [
  "async-trait",
  "rspack_error",
  "rspack_macros",
- "rustc-hash",
  "tracing",
 ]
 

--- a/crates/rspack_hook/Cargo.toml
+++ b/crates/rspack_hook/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 async-trait   = { workspace = true }
 rspack_error  = { workspace = true }
 rspack_macros = { workspace = true }
-rustc-hash    = { workspace = true }
 tracing       = { workspace = true }
 
 [lints]

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use rspack_error::Result;
-use rustc_hash::FxHashSet;
 
 pub struct HookMetadata {
   pub name: &'static str,
@@ -49,8 +48,11 @@ impl HookCommon {
     self.interceptor_count
   }
 
-  pub fn used_stages(&self) -> FxHashSet<i32> {
-    FxHashSet::from_iter(self.tap_stages.iter().copied())
+  pub fn used_stages(&self) -> Vec<i32> {
+    let mut used_stages = self.tap_stages.clone();
+    // tap_stages is kept sorted by stage, so duplicate stages are adjacent.
+    used_stages.dedup();
+    used_stages
   }
 
   pub fn is_empty(&self) -> bool {
@@ -160,7 +162,7 @@ pub trait Interceptor<H: Hook> {
 pub trait Hook {
   type Tap;
 
-  fn used_stages(&self) -> FxHashSet<i32>;
+  fn used_stages(&self) -> Vec<i32>;
 
   fn intercept(&mut self, interceptor: impl Interceptor<Self> + Send + Sync + 'static)
   where
@@ -175,7 +177,6 @@ pub trait Hook {
 pub mod __macro_helper {
   pub use async_trait::async_trait;
   pub use rspack_error::Result;
-  pub use rustc_hash::FxHashSet;
   pub use tracing;
 }
 

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -2,6 +2,68 @@ use async_trait::async_trait;
 use rspack_error::Result;
 use rustc_hash::FxHashSet;
 
+pub struct HookMetadata {
+  pub name: &'static str,
+}
+
+pub struct HookCommon {
+  metadata: HookMetadata,
+  tap_stages: Vec<i32>,
+  interceptor_count: usize,
+}
+
+impl HookCommon {
+  pub fn new(name: &'static str) -> Self {
+    Self {
+      metadata: HookMetadata { name },
+      tap_stages: Vec::new(),
+      interceptor_count: 0,
+    }
+  }
+
+  pub fn name(&self) -> &'static str {
+    self.metadata.name
+  }
+
+  pub fn tap_stages(&self) -> &[i32] {
+    &self.tap_stages
+  }
+
+  pub fn push_tap_stage(&mut self, stage: i32) {
+    self.tap_stages.push(stage);
+  }
+
+  pub fn insert_tap_stage(&mut self, index: usize, stage: i32) {
+    self.tap_stages.insert(index, stage);
+  }
+
+  pub fn tap_insert_position(&self, stage: i32) -> usize {
+    self.tap_stages.partition_point(|&current| current <= stage)
+  }
+
+  pub fn increment_interceptor_count(&mut self) {
+    self.interceptor_count += 1;
+  }
+
+  pub fn interceptor_count(&self) -> usize {
+    self.interceptor_count
+  }
+
+  pub fn used_stages(&self) -> FxHashSet<i32> {
+    FxHashSet::from_iter(self.tap_stages.iter().copied())
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.tap_stages.is_empty() && self.interceptor_count == 0
+  }
+}
+
+pub fn sort_indices_by_stage(stages: &[i32]) -> Vec<usize> {
+  let mut indices: Vec<_> = (0..stages.len()).collect();
+  indices.sort_by_key(|&index| (stages[index], index));
+  indices
+}
+
 #[async_trait]
 pub trait Interceptor<H: Hook> {
   async fn call(&self, _hook: &H) -> Result<Vec<<H as Hook>::Tap>> {

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -60,90 +60,115 @@ impl HookCommon {
   }
 }
 
-pub fn sort_indices_by_stage(stages: &[i32]) -> Vec<usize> {
-  let mut indices: Vec<_> = (0..stages.len()).collect();
-  indices.sort_by_key(|&index| (stages[index], index));
+pub fn sort_indices_by_stage(stages: &[i32]) -> Vec<u16> {
+  debug_assert!(stages.len() <= HookTapIndex::INDEX_LIMIT);
+  let mut indices: Vec<_> = (0..stages.len()).map(|index| index as u16).collect();
+  indices.sort_by_key(|&index| {
+    let index = index as usize;
+    (stages[index], index)
+  });
+  debug_assert!(indices.windows(2).all(|indices| {
+    let prev = indices[0] as usize;
+    let next = indices[1] as usize;
+    (stages[prev], prev) <= (stages[next], next)
+  }));
   indices
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HookTapIndex(i32);
+pub struct HookTapIndex(u16);
 
 impl HookTapIndex {
-  pub fn base(index: usize) -> Self {
-    debug_assert!(index < i32::MAX as usize);
-    Self(index as i32 + 1)
+  const INTERCEPT_FLAG: u16 = 1 << 15;
+  const INDEX_MASK: u16 = !Self::INTERCEPT_FLAG;
+  const INDEX_LIMIT: usize = Self::INDEX_MASK as usize + 1;
+
+  pub fn tap(index: u16) -> Self {
+    debug_assert!(index <= Self::INDEX_MASK);
+    Self(index)
   }
 
-  pub fn additional(index: usize) -> Self {
-    debug_assert!(index < i32::MAX as usize);
-    Self(-((index as i32) + 1))
+  pub fn intercept(index: u16) -> Self {
+    debug_assert!(index <= Self::INDEX_MASK);
+    Self(Self::INTERCEPT_FLAG | index)
   }
 
-  pub fn is_base(self) -> bool {
-    self.0 > 0
+  pub fn is_tap(self) -> bool {
+    self.0 & Self::INTERCEPT_FLAG == 0
   }
 
   pub fn index(self) -> usize {
-    if self.is_base() {
-      (self.0 - 1) as usize
-    } else {
-      (-self.0 - 1) as usize
-    }
+    (self.0 & Self::INDEX_MASK) as usize
   }
 }
 
-pub struct MergedStageIndices<'a> {
+pub struct MergedTapIndicesByStage<'a> {
   base_stages: &'a [i32],
   additional_stages: &'a [i32],
-  additional_order: Vec<usize>,
-  base_index: usize,
-  additional_cursor: usize,
+  additional_order: Vec<u16>,
+  base_index: u16,
+  additional_cursor: u16,
 }
 
-pub fn merged_stage_indices<'a>(
+pub fn merged_tap_indices_by_stage<'a>(
   base_stages: &'a [i32],
   additional_stages: &'a [i32],
-) -> MergedStageIndices<'a> {
-  MergedStageIndices {
+) -> MergedTapIndicesByStage<'a> {
+  debug_assert!(base_stages.len() <= HookTapIndex::INDEX_LIMIT);
+  debug_assert!(additional_stages.len() <= HookTapIndex::INDEX_LIMIT);
+  debug_assert!(base_stages.windows(2).all(|stages| stages[0] <= stages[1]));
+  let additional_order = sort_indices_by_stage(additional_stages);
+  debug_assert_eq!(additional_order.len(), additional_stages.len());
+  debug_assert!(
+    additional_order
+      .iter()
+      .all(|&index| (index as usize) < additional_stages.len())
+  );
+  MergedTapIndicesByStage {
     base_stages,
     additional_stages,
-    additional_order: sort_indices_by_stage(additional_stages),
+    additional_order,
     base_index: 0,
     additional_cursor: 0,
   }
 }
 
-impl Iterator for MergedStageIndices<'_> {
+impl Iterator for MergedTapIndicesByStage<'_> {
   type Item = HookTapIndex;
 
   fn next(&mut self) -> Option<Self::Item> {
-    if self.base_index == self.base_stages.len()
-      && self.additional_cursor == self.additional_order.len()
-    {
+    let base_index = self.base_index as usize;
+    let additional_cursor = self.additional_cursor as usize;
+    debug_assert!(base_index <= self.base_stages.len());
+    debug_assert!(additional_cursor <= self.additional_order.len());
+    if base_index == self.base_stages.len() && additional_cursor == self.additional_order.len() {
       return None;
     }
 
-    if self.additional_cursor == self.additional_order.len() {
+    if additional_cursor == self.additional_order.len() {
       let index = self.base_index;
+      debug_assert!(index <= HookTapIndex::INDEX_MASK);
       self.base_index += 1;
-      return Some(HookTapIndex::base(index));
+      return Some(HookTapIndex::tap(index));
     }
 
-    if self.base_index == self.base_stages.len() {
-      let index = self.additional_order[self.additional_cursor];
+    if base_index == self.base_stages.len() {
+      let index = self.additional_order[additional_cursor];
+      debug_assert!(self.additional_cursor <= HookTapIndex::INDEX_MASK);
       self.additional_cursor += 1;
-      return Some(HookTapIndex::additional(index));
+      return Some(HookTapIndex::intercept(index));
     }
 
-    let additional_index = self.additional_order[self.additional_cursor];
-    if self.base_stages[self.base_index] <= self.additional_stages[additional_index] {
+    let additional_index = self.additional_order[additional_cursor];
+    if self.base_stages[base_index] <= self.additional_stages[additional_index as usize] {
       let index = self.base_index;
+      debug_assert!(index <= HookTapIndex::INDEX_MASK);
       self.base_index += 1;
-      Some(HookTapIndex::base(index))
+      Some(HookTapIndex::tap(index))
     } else {
+      debug_assert!(self.additional_cursor <= HookTapIndex::INDEX_MASK);
       self.additional_cursor += 1;
-      Some(HookTapIndex::additional(additional_index))
+      Some(HookTapIndex::intercept(additional_index))
     }
   }
 }

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -64,6 +64,88 @@ pub fn sort_indices_by_stage(stages: &[i32]) -> Vec<usize> {
   indices
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HookTapIndex(i32);
+
+impl HookTapIndex {
+  pub fn base(index: usize) -> Self {
+    debug_assert!(index < i32::MAX as usize);
+    Self(index as i32 + 1)
+  }
+
+  pub fn additional(index: usize) -> Self {
+    debug_assert!(index < i32::MAX as usize);
+    Self(-((index as i32) + 1))
+  }
+
+  pub fn is_base(self) -> bool {
+    self.0 > 0
+  }
+
+  pub fn index(self) -> usize {
+    if self.is_base() {
+      (self.0 - 1) as usize
+    } else {
+      (-self.0 - 1) as usize
+    }
+  }
+}
+
+pub struct MergedStageIndices<'a> {
+  base_stages: &'a [i32],
+  additional_stages: &'a [i32],
+  additional_order: Vec<usize>,
+  base_index: usize,
+  additional_cursor: usize,
+}
+
+pub fn merged_stage_indices<'a>(
+  base_stages: &'a [i32],
+  additional_stages: &'a [i32],
+) -> MergedStageIndices<'a> {
+  MergedStageIndices {
+    base_stages,
+    additional_stages,
+    additional_order: sort_indices_by_stage(additional_stages),
+    base_index: 0,
+    additional_cursor: 0,
+  }
+}
+
+impl Iterator for MergedStageIndices<'_> {
+  type Item = HookTapIndex;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.base_index == self.base_stages.len()
+      && self.additional_cursor == self.additional_order.len()
+    {
+      return None;
+    }
+
+    if self.additional_cursor == self.additional_order.len() {
+      let index = self.base_index;
+      self.base_index += 1;
+      return Some(HookTapIndex::base(index));
+    }
+
+    if self.base_index == self.base_stages.len() {
+      let index = self.additional_order[self.additional_cursor];
+      self.additional_cursor += 1;
+      return Some(HookTapIndex::additional(index));
+    }
+
+    let additional_index = self.additional_order[self.additional_cursor];
+    if self.base_stages[self.base_index] <= self.additional_stages[additional_index] {
+      let index = self.base_index;
+      self.base_index += 1;
+      Some(HookTapIndex::base(index))
+    } else {
+      self.additional_cursor += 1;
+      Some(HookTapIndex::additional(additional_index))
+    }
+  }
+}
+
 #[async_trait]
 pub trait Interceptor<H: Hook> {
   async fn call(&self, _hook: &H) -> Result<Vec<<H as Hook>::Tap>> {

--- a/crates/rspack_macros/Cargo.toml
+++ b/crates/rspack_macros/Cargo.toml
@@ -14,7 +14,7 @@ test       = false
 [dependencies]
 proc-macro2 = { workspace = true }
 quote       = { workspace = true }
-syn         = { workspace = true, features = ["full", "visit-mut", "derive", "parsing", "printing", "clone-impls", "proc-macro"] }
+syn         = { workspace = true, features = ["full", "visit", "visit-mut", "derive", "parsing", "printing", "clone-impls", "proc-macro"] }
 
 [lints]
 workspace = true

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -142,6 +142,7 @@ impl DefineHookInput {
       }
 
       pub struct #hook_name {
+        common: ::rspack_hook::HookCommon,
         taps: Vec<Box<dyn #trait_name + Send + Sync>>,
         interceptors: Vec<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>,
       }
@@ -150,23 +151,25 @@ impl DefineHookInput {
         type Tap = Box<dyn #trait_name + Send + Sync>;
 
         fn used_stages(&self) -> ::rspack_hook::__macro_helper::FxHashSet<i32> {
-          ::rspack_hook::__macro_helper::FxHashSet::from_iter(self.taps.iter().map(|h| h.stage()))
+          self.common.used_stages()
         }
 
         fn intercept(&mut self, interceptor: impl ::rspack_hook::Interceptor<Self> + Send + Sync + 'static) {
+          self.common.increment_interceptor_count();
           self.interceptors.push(Box::new(interceptor));
         }
       }
 
       impl std::fmt::Debug for #hook_name {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-          write!(f, #hook_name_lit_str)
+          f.write_str(self.common.name())
         }
       }
 
       impl Default for #hook_name {
         fn default() -> Self {
           Self {
+            common: ::rspack_hook::HookCommon::new(#hook_name_lit_str),
             taps: Default::default(),
             interceptors: Default::default(),
           }
@@ -177,11 +180,14 @@ impl DefineHookInput {
         pub #call_fn
 
         pub fn tap(&mut self, tap: impl #trait_name + Send + Sync + 'static) {
-          self.taps.push(Box::new(tap));
+          let stage = tap.stage();
+          let index = self.common.tap_insert_position(stage);
+          self.common.insert_tap_stage(index, stage);
+          self.taps.insert(index, Box::new(tap));
         }
 
         pub fn is_empty(&self) -> bool {
-          self.taps.is_empty() && self.interceptors.is_empty()
+          self.common.is_empty()
         }
       }
     })
@@ -238,10 +244,8 @@ impl ExecKind {
       for interceptor in self.interceptors.iter() {
         #call
       }
-      let mut all_taps = std::vec::Vec::with_capacity(self.taps.len() + additional_taps.len());
-      all_taps.extend(&self.taps);
-      all_taps.extend(&additional_taps);
-      all_taps.sort_by_key(|hook| hook.stage());
+      let mut all_stages = self.common.tap_stages().to_vec();
+      all_stages.extend(additional_taps.iter().map(|tap| tap.stage()));
     }
   }
 
@@ -250,27 +254,62 @@ impl ExecKind {
     match self {
       Self::Series => {
         quote! {
+          if self.common.interceptor_count() == 0 {
+            for tap in &self.taps {
+              tap.run(#args).await?;
+            }
+            return Ok(());
+          }
+
           #additional_taps
-          for tap in all_taps {
-            tap.run(#args).await?;
+          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
+            if index < self.taps.len() {
+              self.taps[index].run(#args).await?;
+            } else {
+              additional_taps[index - self.taps.len()].run(#args).await?;
+            }
           }
           Ok(())
         }
       }
       Self::Sync => {
         quote! {
+          if self.common.interceptor_count() == 0 {
+            for tap in &self.taps {
+              tap.run(#args)?;
+            }
+            return Ok(());
+          }
+
           #additional_taps
-          for tap in all_taps {
-            tap.run(#args)?;
+          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
+            if index < self.taps.len() {
+              self.taps[index].run(#args)?;
+            } else {
+              additional_taps[index - self.taps.len()].run(#args)?;
+            }
           }
           Ok(())
         }
       }
       Self::SeriesBail { .. } => {
         quote! {
+          if self.common.interceptor_count() == 0 {
+            for tap in &self.taps {
+              if let Some(res) = tap.run(#args).await? {
+                return Ok(Some(res));
+              }
+            }
+            return Ok(None);
+          }
+
           #additional_taps
-          for tap in all_taps {
-            if let Some(res) = tap.run(#args).await? {
+          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
+            if index < self.taps.len() {
+              if let Some(res) = self.taps[index].run(#args).await? {
+                return Ok(Some(res));
+              }
+            } else if let Some(res) = additional_taps[index - self.taps.len()].run(#args).await? {
               return Ok(Some(res));
             }
           }
@@ -279,18 +318,42 @@ impl ExecKind {
       }
       Self::SeriesWaterfall { .. } => {
         quote! {
-          #additional_taps
           let mut data = #args;
-          for tap in all_taps {
-            data = tap.run(data).await?
+          if self.common.interceptor_count() == 0 {
+            for tap in &self.taps {
+              data = tap.run(data).await?
+            }
+            return Ok(data);
+          }
+
+          #additional_taps
+          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
+            if index < self.taps.len() {
+              data = self.taps[index].run(data).await?
+            } else {
+              data = additional_taps[index - self.taps.len()].run(data).await?
+            }
           }
           Ok(data)
         }
       }
       Self::Parallel => {
         quote! {
+          if self.common.interceptor_count() == 0 {
+            let futs: std::vec::Vec<_> = self.taps.iter().map(|t| t.run(#args)).collect();
+            futures_concurrency::vec::TryJoin(futs).await?;
+            return Ok(());
+          }
+
           #additional_taps
-          let futs: std::vec::Vec<_> = all_taps.iter().map(|t| t.run(#args)).collect();
+          let mut futs = std::vec::Vec::with_capacity(all_stages.len());
+          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
+            if index < self.taps.len() {
+              futs.push(self.taps[index].run(#args));
+            } else {
+              futs.push(additional_taps[index - self.taps.len()].run(#args));
+            }
+          }
           futures_concurrency::vec::TryJoin(futs).await?;
           Ok(())
         }

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -261,8 +261,8 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
-            if index.is_base() {
+          for index in ::rspack_hook::merged_tap_indices_by_stage(self.common.tap_stages(), &additional_stages) {
+            if index.is_tap() {
               self.taps[index.index()].run(#args).await?;
             } else {
               additional_taps[index.index()].run(#args).await?;
@@ -281,8 +281,8 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
-            if index.is_base() {
+          for index in ::rspack_hook::merged_tap_indices_by_stage(self.common.tap_stages(), &additional_stages) {
+            if index.is_tap() {
               self.taps[index.index()].run(#args)?;
             } else {
               additional_taps[index.index()].run(#args)?;
@@ -303,8 +303,8 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
-            if index.is_base() {
+          for index in ::rspack_hook::merged_tap_indices_by_stage(self.common.tap_stages(), &additional_stages) {
+            if index.is_tap() {
               if let Some(res) = self.taps[index.index()].run(#args).await? {
                 return Ok(Some(res));
               }
@@ -326,8 +326,8 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
-            if index.is_base() {
+          for index in ::rspack_hook::merged_tap_indices_by_stage(self.common.tap_stages(), &additional_stages) {
+            if index.is_tap() {
               data = self.taps[index.index()].run(data).await?
             } else {
               data = additional_taps[index.index()].run(data).await?
@@ -346,8 +346,8 @@ impl ExecKind {
 
           #additional_taps
           let mut futs = std::vec::Vec::with_capacity(self.taps.len() + additional_taps.len());
-          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
-            if index.is_base() {
+          for index in ::rspack_hook::merged_tap_indices_by_stage(self.common.tap_stages(), &additional_stages) {
+            if index.is_tap() {
               futs.push(self.taps[index.index()].run(#args));
             } else {
               futs.push(additional_taps[index.index()].run(#args));

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -244,8 +244,7 @@ impl ExecKind {
       for interceptor in self.interceptors.iter() {
         #call
       }
-      let mut all_stages = self.common.tap_stages().to_vec();
-      all_stages.extend(additional_taps.iter().map(|tap| tap.stage()));
+      let additional_stages: std::vec::Vec<_> = additional_taps.iter().map(|tap| tap.stage()).collect();
     }
   }
 
@@ -262,11 +261,11 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
-            if index < self.taps.len() {
-              self.taps[index].run(#args).await?;
+          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
+            if index.is_base() {
+              self.taps[index.index()].run(#args).await?;
             } else {
-              additional_taps[index - self.taps.len()].run(#args).await?;
+              additional_taps[index.index()].run(#args).await?;
             }
           }
           Ok(())
@@ -282,11 +281,11 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
-            if index < self.taps.len() {
-              self.taps[index].run(#args)?;
+          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
+            if index.is_base() {
+              self.taps[index.index()].run(#args)?;
             } else {
-              additional_taps[index - self.taps.len()].run(#args)?;
+              additional_taps[index.index()].run(#args)?;
             }
           }
           Ok(())
@@ -304,12 +303,12 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
-            if index < self.taps.len() {
-              if let Some(res) = self.taps[index].run(#args).await? {
+          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
+            if index.is_base() {
+              if let Some(res) = self.taps[index.index()].run(#args).await? {
                 return Ok(Some(res));
               }
-            } else if let Some(res) = additional_taps[index - self.taps.len()].run(#args).await? {
+            } else if let Some(res) = additional_taps[index.index()].run(#args).await? {
               return Ok(Some(res));
             }
           }
@@ -327,11 +326,11 @@ impl ExecKind {
           }
 
           #additional_taps
-          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
-            if index < self.taps.len() {
-              data = self.taps[index].run(data).await?
+          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
+            if index.is_base() {
+              data = self.taps[index.index()].run(data).await?
             } else {
-              data = additional_taps[index - self.taps.len()].run(data).await?
+              data = additional_taps[index.index()].run(data).await?
             }
           }
           Ok(data)
@@ -346,12 +345,12 @@ impl ExecKind {
           }
 
           #additional_taps
-          let mut futs = std::vec::Vec::with_capacity(all_stages.len());
-          for index in ::rspack_hook::sort_indices_by_stage(&all_stages) {
-            if index < self.taps.len() {
-              futs.push(self.taps[index].run(#args));
+          let mut futs = std::vec::Vec::with_capacity(self.taps.len() + additional_taps.len());
+          for index in ::rspack_hook::merged_stage_indices(self.common.tap_stages(), &additional_stages) {
+            if index.is_base() {
+              futs.push(self.taps[index.index()].run(#args));
             } else {
-              futs.push(additional_taps[index - self.taps.len()].run(#args));
+              futs.push(additional_taps[index.index()].run(#args));
             }
           }
           futures_concurrency::vec::TryJoin(futs).await?;

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -150,7 +150,7 @@ impl DefineHookInput {
       impl ::rspack_hook::Hook for #hook_name {
         type Tap = Box<dyn #trait_name + Send + Sync>;
 
-        fn used_stages(&self) -> ::rspack_hook::__macro_helper::FxHashSet<i32> {
+        fn used_stages(&self) -> Vec<i32> {
           self.common.used_stages()
         }
 

--- a/crates/rspack_macros/src/plugin.rs
+++ b/crates/rspack_macros/src/plugin.rs
@@ -2,6 +2,7 @@ use quote::quote;
 use syn::{
   Pat, PatIdent, Result, Token,
   parse::{Parse, ParseStream, Parser},
+  visit::{self, Visit},
 };
 
 pub fn expand_struct(mut input: syn::ItemStruct) -> proc_macro::TokenStream {
@@ -93,6 +94,25 @@ pub fn expand_struct(mut input: syn::ItemStruct) -> proc_macro::TokenStream {
 fn plugin_inner_ident(ident: &syn::Ident) -> syn::Ident {
   let inner_name = format!("{ident}Inner");
   syn::Ident::new(&inner_name, ident.span())
+}
+
+struct SelfExprVisitor {
+  found: bool,
+}
+
+impl<'ast> Visit<'ast> for SelfExprVisitor {
+  fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+    if node.path.is_ident("self") {
+      self.found = true;
+    }
+    visit::visit_expr_path(self, node);
+  }
+}
+
+fn expr_uses_self(expr: &syn::Expr) -> bool {
+  let mut visitor = SelfExprVisitor { found: false };
+  visitor.visit_expr(expr);
+  visitor.found
 }
 
 pub struct HookArgs {
@@ -192,6 +212,7 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
     }
   });
 
+  let stage_uses_self = stage.as_ref().is_some_and(expr_uses_self);
   let stage_fn = stage.map(|stage| {
     quote! {
       fn stage(&self) -> i32 {
@@ -212,6 +233,17 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
     quote! { #name::#fn_ident(&#name::from_inner(&self.inner), #(#rest_args,)*) }
   };
 
+  let hook_deref = stage_uses_self.then(|| {
+    quote! {
+      impl #impl_generics ::std::ops::Deref for #fn_ident #ty_generics #where_clause {
+        type Target = #inner_ident #ty_generics;
+        fn deref(&self) -> &Self::Target {
+          &self.inner
+        }
+      }
+    }
+  });
+
   let expanded = quote! {
     #[allow(non_camel_case_types)]
     #vis struct #fn_ident #impl_generics #where_clause {
@@ -231,12 +263,7 @@ pub fn expand_fn(args: HookArgs, input: syn::ItemFn) -> proc_macro::TokenStream 
       #real_sig #block
     }
 
-    impl #impl_generics ::std::ops::Deref for #fn_ident #ty_generics #where_clause {
-      type Target = #inner_ident #ty_generics;
-      fn deref(&self) -> &Self::Target {
-        &self.inner
-      }
-    }
+    #hook_deref
 
     #attr
     impl #impl_generics #trait_ for #fn_ident #ty_generics #where_clause {

--- a/crates/rspack_macros_test/tests/hook.rs
+++ b/crates/rspack_macros_test/tests/hook.rs
@@ -88,3 +88,92 @@ mod sync_series {
     Ok(())
   }
 }
+
+mod stage_order {
+  use rspack_hook::Hook as _;
+
+  use super::*;
+
+  define_hook!(Render: Sync(source: &mut String));
+
+  struct Tap {
+    label: &'static str,
+    stage: i32,
+  }
+
+  impl Render for Tap {
+    fn run(&self, source: &mut String) -> Result<()> {
+      source.push_str(self.label);
+      Ok(())
+    }
+
+    fn stage(&self) -> i32 {
+      self.stage
+    }
+  }
+
+  struct AdditionalTaps;
+
+  impl rspack_hook::Interceptor<RenderHook> for AdditionalTaps {
+    fn call_blocking(
+      &self,
+      _hook: &RenderHook,
+    ) -> Result<Vec<<RenderHook as rspack_hook::Hook>::Tap>> {
+      Ok(vec![
+        Box::new(Tap {
+          label: "D",
+          stage: 5,
+        }),
+        Box::new(Tap {
+          label: "E",
+          stage: 10,
+        }),
+      ])
+    }
+  }
+
+  #[test]
+  fn sorts_base_taps_at_registration() -> Result<()> {
+    let mut hook = RenderHook::default();
+    hook.tap(Tap {
+      label: "A",
+      stage: 10,
+    });
+    hook.tap(Tap {
+      label: "B",
+      stage: 0,
+    });
+    hook.tap(Tap {
+      label: "C",
+      stage: 10,
+    });
+
+    let mut source = String::new();
+    hook.call(&mut source)?;
+    assert_eq!(source, "BAC");
+    Ok(())
+  }
+
+  #[test]
+  fn sorts_additional_taps_by_stage_indices() -> Result<()> {
+    let mut hook = RenderHook::default();
+    hook.tap(Tap {
+      label: "A",
+      stage: 10,
+    });
+    hook.tap(Tap {
+      label: "B",
+      stage: 0,
+    });
+    hook.tap(Tap {
+      label: "C",
+      stage: 10,
+    });
+    hook.intercept(AdditionalTaps);
+
+    let mut source = String::new();
+    hook.call(&mut source)?;
+    assert_eq!(source, "BDACE");
+    Ok(())
+  }
+}

--- a/crates/rspack_macros_test/tests/plugin.rs
+++ b/crates/rspack_macros_test/tests/plugin.rs
@@ -41,24 +41,34 @@ mod named_struct {
     format!("compilation {} {}", self.options, self.state)
   }
 
+  #[plugin_hook(mock_hook::Series<mock_core::Compilation, String> for Plugin, stage = self.state as i32)]
+  fn dynamic_stage(&self, _a: mock_core::Compilation) -> String {
+    format!("dynamic_stage {} {}", self.options, self.state)
+  }
+
   #[test]
   fn test() {
-    let plugin = Plugin::new_inner("aa".to_string(), 0);
+    let plugin = Plugin::new_inner("aa".to_string(), 7);
     let hook1 = &compilation::new(&plugin);
     let hook2 = &make::new(&plugin);
     let hook3 = &process_assets::new(&plugin);
+    let hook4 = &dynamic_stage::new(&plugin);
     let r = mock_hook::Series::run(hook1, mock_core::Compilation);
-    assert_eq!(r, "compilation aa 0");
+    assert_eq!(r, "compilation aa 7");
     let s = mock_hook::Series::stage(hook1);
     assert_eq!(s, 20);
     let r = mock_hook::Series::run(hook2, mock_core::Compilation);
-    assert_eq!(r, "make aa 0");
+    assert_eq!(r, "make aa 7");
     let s = mock_hook::Series::stage(hook2);
     assert_eq!(s, 100);
     let r = mock_hook::Series::run(hook3, mock_core::Compilation);
-    assert_eq!(r, "process_assets aa 0");
+    assert_eq!(r, "process_assets aa 7");
     let s = mock_hook::Series::stage(hook3);
     assert_eq!(s, 0);
+    let r = mock_hook::Series::run(hook4, mock_core::Compilation);
+    assert_eq!(r, "dynamic_stage aa 7");
+    let s = mock_hook::Series::stage(hook4);
+    assert_eq!(s, 7);
   }
 }
 


### PR DESCRIPTION
## What changed

- Add shared `HookCommon` metadata/stage storage in `rspack_hook` so generated hooks share name, base tap stages, and interceptor count handling.
- Cache base tap stages at `tap()` registration time and keep base taps sorted by stage, preserving original insertion order for equal stages.
- Add primitive stage helpers, including sorted stage-index iteration and `HookTapIndex`, so interceptor slow paths sort and merge `i32`/`usize` data instead of boxed tap trait objects.
- Keep no-interceptor hook calls on a simple fast path that directly iterates registered taps without stage collection or sorting.
- Update `plugin_hook` so wrapper `Deref` is only generated for `stage = self...` expressions; constant/static stage expressions no longer need dynamic wrapper access.
- Change `used_stages()` to return a sorted, deduped `Vec<i32>` by using the already sorted base stage list, avoiding the old `Vec -> HashSet -> Vec -> sort` path in the binding interceptor register flow.
- Add macro tests for base tap stage ordering, interceptor additional tap ordering, and dynamic `self` stage behavior.

## Applied optimizations

- Reduces repeated generic macro expansion by moving common hook state and metadata into non-generic `HookCommon`.
- Avoids repeatedly calling `stage()` on base tap trait objects during hook calls; base stages are captured once when taps are registered.
- Avoids sorting base taps at call time when there are no interceptors, which is the common hot path.
- For interceptor-created additional taps, sorts only lightweight stage indices and merges them with the already sorted base tap queue.
- Removes unnecessary `Deref` generation for plugin hook wrappers whose stage expression does not reference `self`.
- Removes the `rustc-hash` dependency from `rspack_hook` after `used_stages()` no longer needs `FxHashSet`.

## Why

This reduces emitted hook-related code size and lowers per-hook-call overhead while preserving dynamic stage behavior for interceptor-created taps and `stage = self...` plugin hooks.

## Scope note

The tracing release-off experiment is not included in this branch. It was only used locally for size comparison.

## Checks

- `cargo test -p rspack_macros_test`
- `cargo check -p rspack_hook -p rspack_macros -p rspack_core`
- `cargo check -p rspack_hook -p rspack_macros -p rspack_binding_api`
- `cargo shear`
- `cargo fmt --all --check`
- `git diff --check`

Release `rspack_core` rlib size comparison:

- baseline: `63,032,150` bytes
- this branch: `58,476,106` bytes
- this branch plus local-only tracing release off experiment: `58,353,084` bytes

---
_by OpenAI Codex_