### PR TITLE
refactor: use rspack scheme for source map defaults

### DIFF
--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -18,7 +18,8 @@ use rspack_plugin_javascript::{
 use rspack_util::{fx_hash::FxDashMap, json_stringify_str};
 
 use crate::{
-  ModuleFilenameTemplate, SourceReference, module_filename_helpers::ModuleFilenameHelpers,
+  ModuleFilenameTemplate, SourceReference, default_eval_module_filename_template,
+  module_filename_helpers::ModuleFilenameHelpers,
 };
 
 #[derive(Clone, Debug)]
@@ -37,7 +38,7 @@ pub struct EvalDevToolModulePlugin {
   namespace: String,
   source_url_comment: String,
   #[debug(skip)]
-  module_filename_template: ModuleFilenameTemplate,
+  module_filename_template: Option<ModuleFilenameTemplate>,
   cache: FxDashMap<BoxSource, BoxSource>,
 }
 
@@ -49,17 +50,10 @@ impl EvalDevToolModulePlugin {
       .source_url_comment
       .unwrap_or("\n//# sourceURL=[url]".to_string());
 
-    let module_filename_template =
-      options
-        .module_filename_template
-        .unwrap_or(ModuleFilenameTemplate::String(
-          "webpack://[namespace]/[resource-path]?[hash]".to_string(),
-        ));
-
     Self::new_inner(
       namespace,
       source_url_comment,
-      module_filename_template,
+      options.module_filename_template,
       Default::default(),
     )
   }
@@ -121,7 +115,13 @@ async fn render_module_content(
   let namespace = compilation.get_path(&filename, path_data).await?;
 
   let output_options = &compilation.options.output;
-  let str = match &self.module_filename_template {
+  let default_module_filename_template =
+    default_eval_module_filename_template(compilation.options.experiments.runtime_mode);
+  let module_filename_template = self
+    .module_filename_template
+    .as_ref()
+    .unwrap_or(default_module_filename_template);
+  let str = match module_filename_template {
     ModuleFilenameTemplate::String(s) => ModuleFilenameHelpers::create_filename_of_string_template(
       &SourceReference::Module(module.identifier()),
       compilation,

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -25,7 +25,8 @@ use rspack_util::{
 
 use crate::{
   ModuleFilenameTemplate, SourceMapDevToolPluginOptions, SourceReference,
-  generate_debug_id::generate_debug_id, module_filename_helpers::ModuleFilenameHelpers,
+  default_eval_module_filename_template, generate_debug_id::generate_debug_id,
+  module_filename_helpers::ModuleFilenameHelpers,
 };
 
 const EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME: &str = "rspack.EvalSourceMapDevToolPlugin";
@@ -36,7 +37,7 @@ pub struct EvalSourceMapDevToolPlugin {
   columns: bool,
   no_sources: bool,
   #[debug(skip)]
-  module_filename_template: ModuleFilenameTemplate,
+  module_filename_template: Option<ModuleFilenameTemplate>,
   namespace: String,
   source_root: Option<String>,
   debug_ids: bool,
@@ -51,19 +52,12 @@ pub struct EvalSourceMapDevToolPlugin {
 
 impl EvalSourceMapDevToolPlugin {
   pub fn new(options: SourceMapDevToolPluginOptions) -> Self {
-    let module_filename_template =
-      options
-        .module_filename_template
-        .unwrap_or(ModuleFilenameTemplate::String(
-          "webpack://[namespace]/[resource-path]?[hash]".to_string(),
-        ));
-
     let namespace = options.namespace.unwrap_or_default();
 
     Self::new_inner(
       options.columns,
       options.no_sources,
-      module_filename_template,
+      options.module_filename_template,
       namespace,
       options.source_root,
       options.debug_ids,
@@ -149,7 +143,10 @@ async fn render_module_content(
 
       {
         let modules = map.sources().iter().map(|source| {
-          if let Some(stripped) = source.strip_prefix("webpack://") {
+          if let Some(stripped) = source
+            .strip_prefix("webpack://")
+            .or_else(|| source.strip_prefix("rspack://"))
+          {
             let source = make_paths_absolute(compilation.options.context.as_str(), stripped);
             let identifier = ModuleIdentifier::from(source.as_str());
             match compilation
@@ -174,7 +171,13 @@ async fn render_module_content(
         let filename = Filename::from(self.namespace.as_str());
         let namespace = compilation.get_path(&filename, path_data).await?;
 
-        let module_filenames = match &self.module_filename_template {
+        let default_module_filename_template =
+          default_eval_module_filename_template(compilation.options.experiments.runtime_mode);
+        let module_filename_template = self
+          .module_filename_template
+          .as_ref()
+          .unwrap_or(default_module_filename_template);
+        let module_filenames = match module_filename_template {
           ModuleFilenameTemplate::String(s) => modules
             .map(|source_reference| {
               ModuleFilenameHelpers::create_filename_of_string_template(

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -5,15 +5,56 @@ mod module_filename_helpers;
 mod source_map_dev_tool_module_options_plugin;
 mod source_map_dev_tool_plugin;
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 pub use eval_dev_tool_module_plugin::*;
 pub use eval_source_map_dev_tool_plugin::*;
 use futures::future::BoxFuture;
-use rspack_core::ModuleIdentifier;
+use rspack_core::{ModuleIdentifier, runtime_mode::RuntimeMode};
 use rspack_error::Result;
 pub use source_map_dev_tool_module_options_plugin::*;
 pub use source_map_dev_tool_plugin::*;
+
+static WEBPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE: LazyLock<ModuleFilenameTemplate> =
+  LazyLock::new(|| {
+    ModuleFilenameTemplate::String("webpack://[namespace]/[resourcePath]".to_string())
+  });
+static RSPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE: LazyLock<ModuleFilenameTemplate> =
+  LazyLock::new(|| {
+    ModuleFilenameTemplate::String("rspack://[namespace]/[resourcePath]".to_string())
+  });
+static WEBPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE_WITH_HASH: LazyLock<ModuleFilenameTemplate> =
+  LazyLock::new(|| {
+    ModuleFilenameTemplate::String("webpack://[namespace]/[resourcePath]?[hash]".to_string())
+  });
+static RSPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE_WITH_HASH: LazyLock<ModuleFilenameTemplate> =
+  LazyLock::new(|| {
+    ModuleFilenameTemplate::String("rspack://[namespace]/[resourcePath]?[hash]".to_string())
+  });
+
+pub(crate) fn default_source_map_module_filename_template(
+  runtime_mode: RuntimeMode,
+) -> &'static ModuleFilenameTemplate {
+  match runtime_mode {
+    RuntimeMode::Webpack => &WEBPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE,
+    RuntimeMode::Rspack => &RSPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE,
+  }
+}
+
+pub(crate) fn default_source_map_fallback_module_filename_template(
+  runtime_mode: RuntimeMode,
+) -> &'static ModuleFilenameTemplate {
+  match runtime_mode {
+    RuntimeMode::Webpack => &WEBPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE_WITH_HASH,
+    RuntimeMode::Rspack => &RSPACK_SOURCE_MAP_MODULE_FILENAME_TEMPLATE_WITH_HASH,
+  }
+}
+
+pub(crate) fn default_eval_module_filename_template(
+  runtime_mode: RuntimeMode,
+) -> &'static ModuleFilenameTemplate {
+  default_source_map_fallback_module_filename_template(runtime_mode)
+}
 
 pub type ModuleFilenameTemplateFn =
   Arc<dyn Fn(ModuleFilenameTemplateFnCtx) -> BoxFuture<'static, Result<String>> + Sync + Send>;

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -1,7 +1,8 @@
-use std::{borrow::Cow, cell::OnceCell, path::Path};
+use std::{borrow::Cow, cell::OnceCell, path::Path, sync::LazyLock};
 
 use cow_utils::CowUtils;
-use rspack_core::{ChunkGraph, Compilation, OutputOptions, contextify};
+use regex::Regex;
+use rspack_core::{ChunkGraph, Compilation, OutputOptions, contextify, runtime_mode::RuntimeMode};
 use rspack_error::Result;
 use rspack_hash::{RspackHash, RspackHashable};
 use rspack_paths::Utf8Path;
@@ -36,16 +37,32 @@ fn get_hash(text: &str, output_options: &OutputOptions) -> String {
 
 pub struct ModuleFilenameHelpers;
 
+static DEFAULT_RESOURCE_PATH_TEMPLATE_REGEXP: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"^(webpack://|rspack://)\[namespace\]/\[resourcePath\]$")
+    .expect("failed to compile DEFAULT_RESOURCE_PATH_TEMPLATE_REGEXP regex")
+});
+
+fn default_resource_path_template_scheme(module_filename_template: &str) -> Option<&str> {
+  DEFAULT_RESOURCE_PATH_TEMPLATE_REGEXP
+    .captures(module_filename_template)
+    .and_then(|captures| captures.get(1).map(|scheme| scheme.as_str()))
+}
+
 // sources in a source map should be relative/URL-style (not absolute filesystem paths)
 fn resolve_relative_resource_path(
   absolute_resource_path: &str,
   source_map_path: Option<&Utf8Path>,
+  runtime_mode: RuntimeMode,
 ) -> Option<String> {
   if absolute_resource_path.starts_with("webpack/runtime")
     || absolute_resource_path.starts_with("rspack/runtime")
   {
     // Runtime modules are virtual
-    return Some(format!("webpack://{absolute_resource_path}"));
+    let scheme = match runtime_mode {
+      RuntimeMode::Webpack => "webpack",
+      RuntimeMode::Rspack => "rspack",
+    };
+    return Some(format!("{scheme}://{absolute_resource_path}"));
   }
 
   let Some(source_map_path) = source_map_path else {
@@ -165,8 +182,11 @@ impl ModuleFilenameHelpers {
         };
 
         let absolute_resource_path = source.split('!').next_back().unwrap_or("").to_string();
-        let relative_resource_path =
-          resolve_relative_resource_path(&absolute_resource_path, unresolved_source_map_path);
+        let relative_resource_path = resolve_relative_resource_path(
+          &absolute_resource_path,
+          unresolved_source_map_path,
+          options.experiments.runtime_mode,
+        );
 
         ModuleFilenameTemplateFnCtx {
           short_identifier,
@@ -213,8 +233,8 @@ impl ModuleFilenameHelpers {
     namespace: &str,
     unresolved_source_map_path: Option<&Utf8Path>,
   ) -> String {
-    if module_filename_template == "webpack://[namespace]/[resourcePath]" {
-      return create_default_module_filename(source_reference, compilation, namespace);
+    if let Some(scheme) = default_resource_path_template_scheme(module_filename_template) {
+      return create_default_module_filename(source_reference, compilation, namespace, scheme);
     }
 
     let ctx = ModuleFilenameHelpers::create_module_filename_template_string_ctx(
@@ -284,6 +304,7 @@ fn create_default_module_filename(
   source_reference: &SourceReference,
   compilation: &Compilation,
   namespace: &str,
+  scheme: &str,
 ) -> String {
   let Compilation { options, .. } = compilation;
   let context = &options.context;
@@ -304,9 +325,8 @@ fn create_default_module_filename(
   let resource = short_identifier.split('!').next_back().unwrap_or("");
   let resource_path = resource.split_once('?').map_or(resource, |(path, _)| path);
 
-  let mut result =
-    String::with_capacity("webpack://".len() + namespace.len() + 1 + resource_path.len());
-  result.push_str("webpack://");
+  let mut result = String::with_capacity(scheme.len() + namespace.len() + 1 + resource_path.len());
+  result.push_str(scheme);
   result.push_str(namespace);
   result.push('/');
   result.push_str(resource_path);
@@ -390,8 +410,12 @@ impl<'a> ModuleFilenameTemplateStringCtx<'a> {
       }
       SourceReference::Source(_) => {
         let absolute_resource_path = self.absolute_resource_path();
-        resolve_relative_resource_path(absolute_resource_path, self.unresolved_source_map_path)
-          .map(Cow::Owned)
+        resolve_relative_resource_path(
+          absolute_resource_path,
+          self.unresolved_source_map_path,
+          self.compilation.options.experiments.runtime_mode,
+        )
+        .map(Cow::Owned)
       }
     }
   }

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -38,7 +38,8 @@ use thread_local::ThreadLocal;
 use url::Url;
 
 use crate::{
-  ModuleFilenameTemplateFn, SourceReference, generate_debug_id::generate_debug_id,
+  ModuleFilenameTemplateFn, SourceReference, default_source_map_fallback_module_filename_template,
+  default_source_map_module_filename_template, generate_debug_id::generate_debug_id,
   module_filename_helpers::ModuleFilenameHelpers,
 };
 
@@ -123,7 +124,10 @@ fn compute_source_references(
     .sources()
     .iter()
     .map(|source_name| {
-      if let Some(stripped) = source_name.strip_prefix("webpack://") {
+      if let Some(stripped) = source_name
+        .strip_prefix("webpack://")
+        .or_else(|| source_name.strip_prefix("rspack://"))
+      {
         let source_name = make_paths_absolute(compilation.options.context.as_str(), stripped);
         let identifier = ModuleIdentifier::from(source_name.as_str());
         match compilation
@@ -297,9 +301,9 @@ pub struct SourceMapDevToolPlugin {
   source_mapping_url_comment: Option<SourceMappingUrlComment>,
   file_context: Option<String>,
   #[debug(skip)]
-  module_filename_template: ModuleFilenameTemplate,
+  module_filename_template: Option<ModuleFilenameTemplate>,
   #[debug(skip)]
-  fallback_module_filename_template: ModuleFilenameTemplate,
+  fallback_module_filename_template: Option<ModuleFilenameTemplate>,
   namespace: String,
   columns: bool,
   no_sources: bool,
@@ -344,14 +348,6 @@ impl SourceMapDevToolPlugin {
         "\n//# sourceMappingURL=[url]".to_string(),
       )),
     };
-
-    let fallback_module_filename_template = fallback_module_filename_template.unwrap_or(
-      ModuleFilenameTemplate::String("webpack://[namespace]/[resourcePath]?[hash]".to_string()),
-    );
-
-    let module_filename_template = module_filename_template.unwrap_or(
-      ModuleFilenameTemplate::String("webpack://[namespace]/[resourcePath]".to_string()),
-    );
 
     let source_map_filename = filename.map(Filename::from);
     let namespace = namespace.unwrap_or_default();
@@ -521,8 +517,14 @@ impl SourceMapDevToolPlugin {
       exclude: self.exclude.as_ref(),
     };
     let tls = ThreadLocal::new();
+    let default_module_filename_template =
+      default_source_map_module_filename_template(compilation.options.experiments.runtime_mode);
+    let module_filename_template = self
+      .module_filename_template
+      .as_ref()
+      .unwrap_or(default_module_filename_template);
 
-    let results: Vec<Result<Option<TaskAndSourceNames>>> = match &self.module_filename_template {
+    let results: Vec<Result<Option<TaskAndSourceNames>>> = match module_filename_template {
       ModuleFilenameTemplate::String(template) => rspack_parallel::scope::<
         _,
         Result<Option<TaskAndSourceNames>>,
@@ -753,6 +755,14 @@ impl SourceMapDevToolPlugin {
       reference_to_source_name_mapping.len(),
       Default::default(),
     );
+    let default_fallback_module_filename_template =
+      default_source_map_fallback_module_filename_template(
+        compilation.options.experiments.runtime_mode,
+      );
+    let fallback_module_filename_template = self
+      .fallback_module_filename_template
+      .as_ref()
+      .unwrap_or(default_fallback_module_filename_template);
 
     // Sort source references by identifier length so the shorter canonical resource wins first.
     // A CSS file can appear twice in the same source map: once as the extracted CSS module and
@@ -781,7 +791,7 @@ impl SourceMapDevToolPlugin {
       }
 
       let unresolved_source_map_path = &source_name_entry.unresolved_source_map_path;
-      let new_source_name = match &self.fallback_module_filename_template {
+      let new_source_name = match fallback_module_filename_template {
         ModuleFilenameTemplate::String(s) => {
           ModuleFilenameHelpers::create_filename_of_string_template(
             source_reference,

--- a/tests/rspack-test/configCases/asset-modules/keep-source-maps/index.js
+++ b/tests/rspack-test/configCases/asset-modules/keep-source-maps/index.js
@@ -10,7 +10,11 @@ it("should write sourcemap file relative to fileContext", function () {
 	const path = require("path");
 	expect(fs.existsSync(path.join(__dirname, "asset.css.map"))).toBe(true);
 	const source = JSON.parse(fs.readFileSync(path.join(__dirname, "asset.css.map"), "utf-8"));
-	expect(source.sources[0]).toBe("webpack:///asset.scss");
+	let assetSource = "webpack:///asset.scss";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		assetSource = "rspack:///asset.scss";
+	}
+	expect(source.sources[0]).toBe(assetSource);
 	expect(source.sources[1]).toBe("data:;charset=utf-8,@import%20%22base%22;%0A%0Aa%20%7B%0A%20%20color:%20red;%0A%7D%0A");
 	expect(source.sources[2]).toBe("http://example.com/index.js.map");
 	expect(source.sources[3]).toBe('https://example.com/index.js.map');

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/sass-previous-source-map/rspack.config.js
@@ -26,7 +26,10 @@ class Plugin {
         expect(fooSource).toBeTruthy();
         expect(barSource).toBeTruthy();
         expect(map.file).toEqual('bundle0.css');
-        const normalizedBarSource = `webpack:///${path.basename(barSource)}`;
+        let normalizedBarSource = `webpack:///${path.basename(barSource)}`;
+        if (compiler.options.experiments?.runtimeMode === 'rspack') {
+          normalizedBarSource = `rspack:///${path.basename(barSource)}`;
+        }
 
         const css = fs.readFileSync(
           path.resolve(outputPath, 'bundle0.css'),

--- a/tests/rspack-test/configCases/builtin-swc-loader/input-source-map-cheap-module/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/input-source-map-cheap-module/index.js
@@ -8,28 +8,29 @@ const source = fs.readFileSync(__filename + ".map", "utf-8");
 const map = JSON.parse(source);
 const output = fs.readFileSync(__filename, "utf-8");
 const input = fs.readFileSync(path.resolve(CONTEXT, "a.jsx"), "utf-8");
-const runtimePrefix = map.sources.some(source =>
-	source.startsWith("webpack:///rspack/runtime/")
-)
-	? "rspack"
-	: "webpack";
+let sourceUrl = source => `webpack:///${source}`;
+let runtimeSource = name => sourceUrl(`webpack/runtime/${name}`);
+if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+	sourceUrl = source => `rspack:///${source}`;
+	runtimeSource = name => sourceUrl(`rspack/runtime/${name}`);
+}
 
 it("should keep the original content with `devtool: \"cheap-module-source-map\"` enabled", () => {
 	expect(map.sources.sort()).toEqual([
-		"webpack:///./a.jsx",
-		"webpack:///./index.js",
-		`webpack:///${runtimePrefix}/runtime/define_property_getters`,
-		`webpack:///${runtimePrefix}/runtime/has_own_property`,
-		`webpack:///${runtimePrefix}/runtime/make_namespace_object`,
-	]);
+		sourceUrl("./a.jsx"),
+		sourceUrl("./index.js"),
+		runtimeSource("define_property_getters"),
+		runtimeSource("has_own_property"),
+		runtimeSource("make_namespace_object"),
+	].sort());
 	expect(map.sourcesContent[0]).toEqual(input)
 })
 it("should keep the mappings to the original content", async () => {
 	// does not checking columns for cheap source-map
 	const CHECK_COLUMN = false;
 	expect(await checkMap(output, source, {
-		"'*a0*'": "webpack:///a.jsx",
-		"'*a1*'": "webpack:///a.jsx",
-		"'*a2*'": "webpack:///a.jsx",
+		"'*a0*'": sourceUrl("a.jsx"),
+		"'*a1*'": sourceUrl("a.jsx"),
+		"'*a2*'": sourceUrl("a.jsx"),
 	}, CHECK_COLUMN)).toBe(true)
 })

--- a/tests/rspack-test/configCases/builtin-swc-loader/input-source-map-module/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/input-source-map-module/index.js
@@ -8,27 +8,28 @@ const source = fs.readFileSync(__filename + ".map", "utf-8");
 const map = JSON.parse(source);
 const output = fs.readFileSync(__filename, "utf-8");
 const input = fs.readFileSync(path.resolve(CONTEXT, "a.jsx"), "utf-8");
-const runtimePrefix = map.sources.some(source =>
-	source.startsWith("webpack:///rspack/runtime/")
-)
-	? "rspack"
-	: "webpack";
+let sourceUrl = source => `webpack:///${source}`;
+let runtimeSource = name => sourceUrl(`webpack/runtime/${name}`);
+if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+	sourceUrl = source => `rspack:///${source}`;
+	runtimeSource = name => sourceUrl(`rspack/runtime/${name}`);
+}
 
 it("should keep the original content with `devtool: \"source-map\"` enabled", () => {
 	expect(map.sources.sort()).toEqual([
-		"webpack:///./a.jsx",
-		"webpack:///./index.js",
-		`webpack:///${runtimePrefix}/runtime/define_property_getters`,
-		`webpack:///${runtimePrefix}/runtime/has_own_property`,
-		`webpack:///${runtimePrefix}/runtime/make_namespace_object`,
-	]);
+		sourceUrl("./a.jsx"),
+		sourceUrl("./index.js"),
+		runtimeSource("define_property_getters"),
+		runtimeSource("has_own_property"),
+		runtimeSource("make_namespace_object"),
+	].sort());
 	expect(map.sourcesContent[0]).toEqual(input)
 })
 
 it("should keep the mappings to the original content", async () => {
 	expect(await checkMap(output, source, {
-		"'*a0*'": "webpack:///a.jsx",
-		"'*a1*'": "webpack:///a.jsx",
-		"'*a2*'": "webpack:///a.jsx",
+		"'*a0*'": sourceUrl("a.jsx"),
+		"'*a1*'": sourceUrl("a.jsx"),
+		"'*a2*'": sourceUrl("a.jsx"),
 	})).toBe(true)
 })

--- a/tests/rspack-test/configCases/builtin-swc-loader/source-map/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/source-map/index.js
@@ -9,7 +9,11 @@ it("should generate correct sourceMap", async () => {
 		__dirname + "/" + require("!!./a.ts?resource"),
 		"utf-8"
 	);
-	const aSourceIndex = map.sources.indexOf("webpack:///./a.ts");
+	let aSource = "webpack:///./a.ts";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		aSource = "rspack:///./a.ts";
+	}
+	const aSourceIndex = map.sources.indexOf(aSource);
 	expect(aSourceIndex).toBeGreaterThanOrEqual(0);
 	expect(map.sourcesContent[aSourceIndex]).toEqual(sourceContent);
 

--- a/tests/rspack-test/configCases/less-loader/with-source-map/index.js
+++ b/tests/rspack-test/configCases/less-loader/with-source-map/index.js
@@ -6,7 +6,11 @@ it("basic", () => {
 	expect(css).toEqual(nsObj({}));
 	const sourceMap = fs.readFileSync(__dirname + "/bundle0.css.map", "utf-8");
 	const map = JSON.parse(sourceMap);
-	expect(map.sources).toContain("webpack:///./index.less");
+	let source = "webpack:///./index.less";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		source = "rspack:///./index.less";
+	}
+	expect(map.sources).toContain(source);
 	expect(map.file).toEqual("bundle0.css");
 	expect(map.sourcesContent).toEqual([
 		fs.readFileSync(

--- a/tests/rspack-test/configCases/postcss-loader/with-previous-source-map/index.js
+++ b/tests/rspack-test/configCases/postcss-loader/with-previous-source-map/index.js
@@ -6,7 +6,11 @@ it("basic", () => {
 	const sourceMap = fs.readFileSync(__dirname + "/bundle0.css.map", "utf-8");
 	const scss = fs.readFileSync(path.resolve(CONTEXT, "./index.scss"), "utf-8");
 	const map = JSON.parse(sourceMap);
-	expect(map.sources).toContain("webpack:///./index.scss");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./index.scss"));
 	expect(map.file).toEqual("bundle0.css");
 	expect(map.sourcesContent).toEqual([scss]);
 });

--- a/tests/rspack-test/configCases/postcss-loader/with-source-map/index.js
+++ b/tests/rspack-test/configCases/postcss-loader/with-source-map/index.js
@@ -6,7 +6,11 @@ it("basic", () => {
 	const sourceMap = fs.readFileSync(__dirname + "/bundle0.css.map", "utf-8");
 	const css = fs.readFileSync(path.resolve(CONTEXT, "./index.css"), "utf-8");
 	const map = JSON.parse(sourceMap);
-	expect(map.sources).toContain("webpack:///./index.css");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./index.css"));
 	expect(map.file).toEqual("bundle0.css");
 	expect(map.sourcesContent).toEqual([css]);
 });

--- a/tests/rspack-test/configCases/sass/with-source-map/index.js
+++ b/tests/rspack-test/configCases/sass/with-source-map/index.js
@@ -10,7 +10,11 @@ it("basic", () => {
 	);
 	const map = JSON.parse(source);
 	const scss = fs.readFileSync(path.resolve(CONTEXT, "./index.scss"), "utf-8");
-	expect(map.sources).toEqual(["webpack:///./index.scss"]);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toEqual([sourceUrl("./index.scss")]);
 	expect(map.sourcesContent).toEqual([scss]);
 	expect(map.file).toEqual("bundle0.css");
 });

--- a/tests/rspack-test/configCases/source-map/basic/index.js
+++ b/tests/rspack-test/configCases/source-map/basic/index.js
@@ -2,6 +2,10 @@ it("basic", () => {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./index.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./index.js"));
 	expect(map.file).toEqual("bundle0.js");
 });

--- a/tests/rspack-test/configCases/source-map/cheap-module/index.js
+++ b/tests/rspack-test/configCases/source-map/cheap-module/index.js
@@ -5,7 +5,11 @@ require("./index.scss");
 it("should only map original lines if cheap module options is used", async () => {
 	const source = fs.readFileSync(__dirname + "/bundle0.css.map", "utf-8");
 	const map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./index.scss");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./index.scss"));
 	expect(map.file).toEqual("bundle0.css");
 	expect(map.sourcesContent[0]).toContain("$backgroundColor");
 	const consumer = await new sourceMap.SourceMapConsumer(map);

--- a/tests/rspack-test/configCases/source-map/conflict/index.js
+++ b/tests/rspack-test/configCases/source-map/conflict/index.js
@@ -6,13 +6,17 @@ it("conflict", () => {
 	const source_a = fs.readFileSync(__dirname + "/a_js.bundle0.js.map", "utf-8");
 	const source_b = fs.readFileSync(__dirname + "/b_js.bundle0.js.map", "utf-8");
 	const map_a = JSON.parse(source_a);
-  const map_b = JSON.parse(source_b);
+	const map_b = JSON.parse(source_b);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
 	expect(map_a.sources).toStrictEqual([
-    "webpack:///./a.js",
-    "webpack:///./common.js",
-  ]);
+		sourceUrl("./a.js"),
+		sourceUrl("./common.js"),
+	]);
 	expect(map_b.sources).toStrictEqual([
-    "webpack:///./b.js",
-    "webpack:///./common.js",
-  ]);
+		sourceUrl("./b.js"),
+		sourceUrl("./common.js"),
+	]);
 });

--- a/tests/rspack-test/configCases/source-map/context-module-source-path/index.js
+++ b/tests/rspack-test/configCases/source-map/context-module-source-path/index.js
@@ -5,6 +5,10 @@ it("context module should use relative path in source map file", () => {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
 
-	expect(map.sources).toContain("webpack:///./foo|sync|/^\\.\\/.*\\.js$/");
+	expect(map.sources).toContain(sourceUrl("./foo|sync|/^\\.\\/.*\\.js$/"));
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-a.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-a.js
@@ -1,5 +1,20 @@
-it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", function() {
+it("should include the entry-a source in SourceMap", function() {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename, "utf-8");
-	expect(source).toContain("sourceURL=webpack://library-entry-a/./src/entry-a.js");
+	const match = source.match(
+		/sourceMappingURL=data:application\/json;charset=utf-8;base64,([A-Za-z0-9+/=]+)/
+	);
+	expect(match).toBeTruthy();
+	const map = JSON.parse(Buffer.from(match[1], "base64").toString());
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(
+		map.sources.some(source =>
+			new RegExp(
+				`${scheme}:\\/\\/library-entry-a\\/\\.\\/src\\/entry-a\\.js\\?[a-zA-Z0-9]+`
+			).test(source)
+		)
+	).toBe(true);
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-b.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval-source-map/src/entry-b.js
@@ -1,5 +1,20 @@
-it("should include webpack://library-entry-b/./src/entry-b.js in SourceMap", function() {
+it("should include the entry-b source in SourceMap", function() {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename, "utf-8");
-	expect(source).toContain("sourceURL=webpack://library-entry-b/./src/entry-b.js");
+	const match = source.match(
+		/sourceMappingURL=data:application\/json;charset=utf-8;base64,([A-Za-z0-9+/=]+)/
+	);
+	expect(match).toBeTruthy();
+	const map = JSON.parse(Buffer.from(match[1], "base64").toString());
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(
+		map.sources.some(source =>
+			new RegExp(
+				`${scheme}:\\/\\/library-entry-b\\/\\.\\/src\\/entry-b\\.js\\?[a-zA-Z0-9]+`
+			).test(source)
+		)
+	).toBe(true);
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval/rspack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     filename: '[name]-bundle.js',
     library: { type: 'commonjs', name: 'library-[name]' },
     devtoolNamespace: 'library-[name]',
+    devtoolFallbackModuleFilenameTemplate: 'fallback://[resource-path]?[hash]',
   },
   devtool: 'eval',
 };

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-a.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-a.js
@@ -1,5 +1,13 @@
-it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", function() {
+it("should include the entry-a sourceURL in SourceMap", function() {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename, "utf-8");
-	expect(source).toContain("sourceURL=webpack://library-entry-a/./src/entry-a.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(source).toMatch(
+		new RegExp(
+			`sourceURL=${scheme}:\\/\\/library-entry-a\\/\\.\\/src\\/entry-a\\.js\\?[a-zA-Z0-9]+`
+		)
+	);
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-b.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-eval/src/entry-b.js
@@ -1,5 +1,13 @@
-it("should include webpack://library-entry-b/./src/entry-b.js in SourceMap", function() {
+it("should include the entry-b sourceURL in SourceMap", function() {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename, "utf-8");
-	expect(source).toContain("sourceURL=webpack://library-entry-b/./src/entry-b.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(source).toMatch(
+		new RegExp(
+			`sourceURL=${scheme}:\\/\\/library-entry-b\\/\\.\\/src\\/entry-b\\.js\\?[a-zA-Z0-9]+`
+		)
+	);
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-source-map/index.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-source-map/index.js
@@ -2,5 +2,9 @@ it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", fun
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("sourceURL=webpack://library-entry-a/./src/entry-a.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(map.sources).toContain(`sourceURL=${scheme}://library-entry-a/./src/entry-a.js`);
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-a.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-a.js
@@ -2,5 +2,9 @@ it("should include webpack://library-entry-a/./src/entry-a.js in SourceMap", fun
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(source);
-	expect(map.sources).toContain("webpack://library-entry-a/./src/entry-a.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(map.sources).toContain(`${scheme}://library-entry-a/./src/entry-a.js`);
 });

--- a/tests/rspack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-b.js
+++ b/tests/rspack-test/configCases/source-map/devtool-namespace-with-source-map/src/entry-b.js
@@ -2,5 +2,9 @@ it("should include webpack://library-entry-b/./src/entry-b.js in SourceMap", fun
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(source);
-	expect(map.sources).toContain("webpack://library-entry-b/./src/entry-b.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(map.sources).toContain(`${scheme}://library-entry-b/./src/entry-b.js`);
 });

--- a/tests/rspack-test/configCases/source-map/eval-source-map-base/index.js
+++ b/tests/rspack-test/configCases/source-map/eval-source-map-base/index.js
@@ -8,7 +8,13 @@ it("basic", () => {
 			source
 		)[1];
 	const map = JSON.parse(Buffer.from(base64, "base64").toString("utf-8"));
-	expect(source.includes('//# sourceURL=webpack-internal:///./index.js'))
-	expect(map.sources[0]).toMatch(/webpack:\/\/\/\.\/index.js?[a-zA-Z0-9]+/);
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(source).toContain(`//# sourceURL=webpack-internal:///./index.js`);
+	expect(map.sources[0]).toMatch(
+		new RegExp(`${scheme}:\\/\\/\\/\\.\\/index\\.js\\?[a-zA-Z0-9]+`)
+	);
 	expect(map.file).toBe(path.join(CONTEXT, "index.js"));
 });

--- a/tests/rspack-test/configCases/source-map/eval-source-map-base/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/eval-source-map-base/rspack.config.js
@@ -9,6 +9,9 @@ module.exports = {
   devtool: 'eval-source-map',
   externals: ['source-map'],
   externalsType: 'commonjs',
+  output: {
+    devtoolFallbackModuleFilenameTemplate: 'fallback://[resource-path]?[hash]',
+  },
   optimization: {
     moduleIds: 'named',
   },

--- a/tests/rspack-test/configCases/source-map/exclude-chunks-source-map/index.js
+++ b/tests/rspack-test/configCases/source-map/exclude-chunks-source-map/index.js
@@ -2,7 +2,11 @@ it("should include test.js in SourceMap for bundle0 chunk", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./test.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./test.js"));
 });
 
 it("should not produce a SourceMap for vendors chunk", function() {

--- a/tests/rspack-test/configCases/source-map/extract-source-map-virtual-modules/index.js
+++ b/tests/rspack-test/configCases/source-map/extract-source-map-virtual-modules/index.js
@@ -7,15 +7,19 @@ require("./lib/components/virtual-component");
 it("should extract source map from virtual modules", () => {
 	const fileData = fs.readFileSync(__filename + ".map").toString("utf-8");
 	const { sources } = JSON.parse(fileData);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
 
 	// Should include main file and virtual modules without inline sourcemap
-	expect(sources).toContain("webpack:///./index.js");
-	expect(sources).toContain("webpack:///./virtual-module-without-sourcemap.js");
-	expect(sources).toContain("webpack:///./virtual-test.txt");
-	expect(sources).toContain("webpack:///./src/components/virtual-component.js");
+	expect(sources).toContain(sourceUrl("./index.js"));
+	expect(sources).toContain(sourceUrl("./virtual-module-without-sourcemap.js"));
+	expect(sources).toContain(sourceUrl("./virtual-test.txt"));
+	expect(sources).toContain(sourceUrl("./src/components/virtual-component.js"));
 
 	// Should not include virtual modules with inline sourcemap as they're filtered by extractSourceMap
-	expect(sources).not.toContain("webpack:///./virtual-module-with-sourcemap.js");
+	expect(sources).not.toContain(sourceUrl("./virtual-module-with-sourcemap.js"));
 });
 
 it("should handle virtual modules with extractSourceMap correctly", () => {

--- a/tests/rspack-test/configCases/source-map/extract-source-map/extract1.js
+++ b/tests/rspack-test/configCases/source-map/extract-source-map/extract1.js
@@ -8,7 +8,11 @@ require("./no-source-map");
 it("should extract source map - 1", () => {
 	const fileData = fs.readFileSync(__filename + ".map").toString("utf-8");
 	const { sources } = JSON.parse(fileData);
-	expect(sources).toContain("webpack:///./extract1.js");
-	expect(sources).toContain("webpack:///./charset-inline-source-map.txt");
-	expect(sources).toContain("webpack:///./no-source-map.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(sources).toContain(sourceUrl("./extract1.js"));
+	expect(sources).toContain(sourceUrl("./charset-inline-source-map.txt"));
+	expect(sources).toContain(sourceUrl("./no-source-map.js"));
 });

--- a/tests/rspack-test/configCases/source-map/extract-source-map/extract2.js
+++ b/tests/rspack-test/configCases/source-map/extract-source-map/extract2.js
@@ -10,6 +10,10 @@ it("should extract source map - 2", () => {
 		.readFileSync(path.resolve(__dirname, "bundle1.js.map"))
 		.toString("utf-8");
 	const { sources } = JSON.parse(fileData);
-	expect(sources).toContain("webpack:///./external-source-map.txt");
-	expect(sources).toContain("webpack:///./extract2.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(sources).toContain(sourceUrl("./external-source-map.txt"));
+	expect(sources).toContain(sourceUrl("./extract2.js"));
 });

--- a/tests/rspack-test/configCases/source-map/extract-source-map/extract3.js
+++ b/tests/rspack-test/configCases/source-map/extract-source-map/extract3.js
@@ -10,6 +10,10 @@ it("should extract source map - 3", () => {
 		.readFileSync(path.resolve(__dirname, "bundle2.js.map"))
 		.toString("utf-8");
 	const { sources } = JSON.parse(fileData);
-	expect(sources).toContain("webpack:///./external-source-map.txt");
-	expect(sources).toContain("webpack:///./extract3.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(sources).toContain(sourceUrl("./external-source-map.txt"));
+	expect(sources).toContain(sourceUrl("./extract3.js"));
 });

--- a/tests/rspack-test/configCases/source-map/extract-source-map/extract4.js
+++ b/tests/rspack-test/configCases/source-map/extract-source-map/extract4.js
@@ -6,7 +6,15 @@ const path = require("path");
 require("./test4");
 
 it("should extract source map - 4", () => {
-	const fileData = fs.readFileSync(path.resolve(__dirname, "bundle3.js.map")).toString("utf-8");
+	const fileData = fs
+		.readFileSync(path.resolve(__dirname, "bundle3.js.map"))
+		.toString("utf-8");
 	const { sources } = JSON.parse(fileData);
-	expect(sources.includes("webpack:///antd/./components/button/index.tsx")).toBe(true);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(sources.includes(sourceUrl("antd/./components/button/index.tsx"))).toBe(
+		true
+	);
 });

--- a/tests/rspack-test/configCases/source-map/extract-source-map2/index.js
+++ b/tests/rspack-test/configCases/source-map/extract-source-map2/index.js
@@ -4,8 +4,14 @@ const path = require("path");
 require("./a");
 
 it("should extract source map", () => {
-	const fileData = fs.readFileSync(path.resolve(__dirname, "bundle0.js.map")).toString("utf-8");
+	const fileData = fs
+		.readFileSync(path.resolve(__dirname, "bundle0.js.map"))
+		.toString("utf-8");
 	const { sources, sourcesContent } = JSON.parse(fileData);
-	expect(sources.includes("webpack:///./external-source-map.txt")).toBe(true);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(sources.includes(sourceUrl("./external-source-map.txt"))).toBe(true);
 	expect(sourcesContent.map(s => s.trim())).toContain("source");
 });

--- a/tests/rspack-test/configCases/source-map/hidden/index.js
+++ b/tests/rspack-test/configCases/source-map/hidden/index.js
@@ -4,6 +4,10 @@ it("should not have map from url comments if hidden options is used", function (
 	expect(/sourceMappingURL\s*=\s*(.*)/.test(source)).toBe(false);
 	const mapSource = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(mapSource);
-	expect(map.sources).toContain("webpack:///./index.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./index.js"));
 	expect(map.file).toEqual("bundle0.js");
 });

--- a/tests/rspack-test/configCases/source-map/inline/index.js
+++ b/tests/rspack-test/configCases/source-map/inline/index.js
@@ -6,6 +6,10 @@ it("should have map from url comments if inline options is used", function () {
 			source
 		)[1];
 	const map = JSON.parse(Buffer.from(base64, "base64").toString("utf-8"));
-	expect(map.sources).toContain("webpack:///./index.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./index.js"));
 	expect(map.file).toEqual("bundle0.js");
 });

--- a/tests/rspack-test/configCases/source-map/namespace-source-path-no-truncate/index.js
+++ b/tests/rspack-test/configCases/source-map/namespace-source-path-no-truncate/index.js
@@ -2,7 +2,11 @@ it("should include [id].js in SourceMap", function () {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./[id].js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./[id].js"));
 });
 
 if (Math.random() < 0) require("./[id].js");

--- a/tests/rspack-test/configCases/source-map/namespace-source-path.library/index.js
+++ b/tests/rspack-test/configCases/source-map/namespace-source-path.library/index.js
@@ -2,7 +2,11 @@ it("should include webpack://mylibrary/./test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack://mylibrary/./test.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(map.sources).toContain(`${scheme}://mylibrary/./test.js`);
 });
 
 if (Math.random() < 0) require("./test.js");

--- a/tests/rspack-test/configCases/source-map/namespace-source-path/index.js
+++ b/tests/rspack-test/configCases/source-map/namespace-source-path/index.js
@@ -2,7 +2,11 @@ it("should include webpack://mynamespace/./test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack://mynamespace/./test.js");
+	let scheme = "webpack";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		scheme = "rspack";
+	}
+	expect(map.sources).toContain(`${scheme}://mynamespace/./test.js`);
 });
 
 if (Math.random() < 0) require("./test.js");

--- a/tests/rspack-test/configCases/source-map/nosources/index.js
+++ b/tests/rspack-test/configCases/source-map/nosources/index.js
@@ -17,7 +17,11 @@ it("should preserve test call original positions when noSources option is used",
 	var testSource = fs.readFileSync(path.resolve(CONTEXT, "./list.test.ts"), "utf-8");
 	var map = JSON.parse(source);
 	var consumer = await new sourceMap.SourceMapConsumer(map);
-	var testSourceIndex = map.sources.indexOf("webpack:///./list.test.ts");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	var testSourceIndex = map.sources.indexOf(sourceUrl("./list.test.ts"));
 	expect(testSourceIndex).toBeGreaterThanOrEqual(0);
 	expect(map).not.toHaveProperty("sourcesContent");
 

--- a/tests/rspack-test/configCases/source-map/plugin-defaults/index.js
+++ b/tests/rspack-test/configCases/source-map/plugin-defaults/index.js
@@ -7,7 +7,11 @@ it("`module` should be enabled by default", async () => {
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const app = fs.readFileSync(path.resolve(CONTEXT, "./App.jsx"), "utf-8");
 	const map = JSON.parse(source);
-	const appSourceIndex = map.sources.indexOf("webpack:///./App.jsx")
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	const appSourceIndex = map.sources.indexOf(sourceUrl("./App.jsx"));
 	expect(appSourceIndex).toBeGreaterThanOrEqual(0);
 	expect(map.sourcesContent[appSourceIndex]).toEqual(app);
 });

--- a/tests/rspack-test/configCases/source-map/relative-resource-path-inline/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/relative-resource-path-inline/rspack.config.js
@@ -55,7 +55,10 @@ module.exports = {
             const assetPath = path.join(outputPath, assetFilename);
             const sourceMap = readInlineSourceMap(assetPath);
             const realSources = sourceMap.sources
-              .filter((s) => !s.startsWith('webpack://'))
+              .filter(
+                (s) =>
+                  !s.startsWith('webpack://') && !s.startsWith('rspack://'),
+              )
               .sort();
 
             realSources.forEach((s) => {

--- a/tests/rspack-test/configCases/source-map/relative-resource-path/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/relative-resource-path/rspack.config.js
@@ -45,7 +45,10 @@ module.exports = {
             const sourceMapJSON = fs.readFileSync(sourceMapPath, 'utf-8');
             const sourceMap = JSON.parse(sourceMapJSON);
             const realSources = sourceMap.sources
-              .filter((s) => !s.startsWith('webpack://'))
+              .filter(
+                (s) =>
+                  !s.startsWith('webpack://') && !s.startsWith('rspack://'),
+              )
               .sort();
 
             realSources.forEach((s) => {

--- a/tests/rspack-test/configCases/source-map/relative-source-maps-by-loader/index.js
+++ b/tests/rspack-test/configCases/source-map/relative-source-maps-by-loader/index.js
@@ -11,7 +11,11 @@ it("should run", () => {
 it("should generate the correct SourceMap", function () {
 	var fs = require("fs");
 	var source = JSON.parse(fs.readFileSync(__filename + ".map", "utf-8"));
-	expect(source.sources).toContain("webpack:///./folder/test1.txt");
+	let sourceUrl = sourceName => `webpack:///${sourceName}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = sourceName => `rspack:///${sourceName}`;
+	}
+	expect(source.sources).toContain(sourceUrl("./folder/test1.txt"));
 	// expect(source.sources).toContain("webpack:///./folder/test2.txt");
 	// expect(source.sources).toContain("webpack:///./folder/test3.txt");
 	// expect(source.sources).toContain("webpack:///./folder/test4.txt");

--- a/tests/rspack-test/configCases/source-map/source-map-loader/index.js
+++ b/tests/rspack-test/configCases/source-map/source-map-loader/index.js
@@ -2,7 +2,11 @@ it("should include a.ts in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./a.ts");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./a.ts"));
 });
 
 if (Math.random() < 0) require("./a.js");

--- a/tests/rspack-test/configCases/source-map/source-map-resolve-vendor-path/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/source-map-resolve-vendor-path/rspack.config.js
@@ -20,10 +20,14 @@ module.exports = {
           const sourceMap = JSON.parse(
             compilation.assets['bundle0.js.map'].source(),
           );
+          let sourceUrl = (source) => `webpack:///${source}`;
+          if (compiler.options.experiments?.runtimeMode === 'rspack') {
+            sourceUrl = (source) => `rspack:///${source}`;
+          }
           expect(sourceMap.sources).toEqual(
             expect.arrayContaining([
-              'webpack:///./node_modules/lib-with-source-map/main.js',
-              'webpack:///./index.js',
+              sourceUrl('./node_modules/lib-with-source-map/main.js'),
+              sourceUrl('./index.js'),
             ]),
           );
         });

--- a/tests/rspack-test/configCases/source-map/source-map/index.js
+++ b/tests/rspack-test/configCases/source-map/source-map/index.js
@@ -10,7 +10,11 @@ it("should map to the original content if `module` enabled", async () => {
 	const app = fs.readFileSync(path.resolve(CONTEXT, "./App.jsx"), "utf-8");
 	const map = JSON.parse(source);
 	const consumer = await new sourceMap.SourceMapConsumer(map);
-	const appSourceIndex = map.sources.indexOf("webpack:///./App.jsx")
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	const appSourceIndex = map.sources.indexOf(sourceUrl("./App.jsx"));
 	expect(appSourceIndex).toBeGreaterThanOrEqual(0);
 	expect(map.sourcesContent[appSourceIndex]).toEqual(app);
 	const STUB = "Hello Rspack!";

--- a/tests/rspack-test/configCases/source-map/sources-array-production/index.js
+++ b/tests/rspack-test/configCases/source-map/sources-array-production/index.js
@@ -2,7 +2,11 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./test.js");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
+	expect(map.sources).toContain(sourceUrl("./test.js"));
 });
 
 if (Math.random() < 0) require("./test.js");

--- a/tests/rspack-test/configCases/source-map/verify-bundle-css-minify-lightning/index.js
+++ b/tests/rspack-test/configCases/source-map/verify-bundle-css-minify-lightning/index.js
@@ -10,49 +10,53 @@ it("verify css bundle source map", async () => {
 		"utf-8"
 	);
 	const map = JSON.parse(source);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
 	expect(map.sources).toEqual([
-		"webpack:///./b-dir/c-dir/c.css",
-		"webpack:///./b-dir/b.css",
-		"webpack:///./a.css"
+		sourceUrl("./b-dir/c-dir/c.css"),
+		sourceUrl("./b-dir/b.css"),
+		sourceUrl("./a.css")
 	]);
 	expect(map.file).toEqual("bundle0.css");
 	const out = fs.readFileSync(path.resolve(__dirname, "bundle0.css"), "utf-8");
 	expect(
 		await checkMap(out, source, {
 			'a:nth-child(0):after { content: "a0"; }': {
-				inSource: "webpack:///a.css",
+				inSource: sourceUrl("a.css"),
 				outId: 'a:nth-child(0):after{content:"a0"}'
 			},
 			'a:nth-child(1):after { content: "a1"; }': {
-				inSource: "webpack:///a.css",
+				inSource: sourceUrl("a.css"),
 				outId: 'a:first-child:after{content:"a1"}'
 			},
 			'a:nth-child(2):after { content: "a2"; }': {
-				inSource: "webpack:///a.css",
+				inSource: sourceUrl("a.css"),
 				outId: 'a:nth-child(2):after{content:"a2"}'
 			},
 			'b:nth-child(0):after { content: "b0"; }': {
-				inSource: "webpack:///b-dir/b.css",
+				inSource: sourceUrl("b-dir/b.css"),
 				outId: 'b:nth-child(0):after{content:"b0"}'
 			},
 			'b:nth-child(1):after { content: "b1"; }': {
-				inSource: "webpack:///b-dir/b.css",
+				inSource: sourceUrl("b-dir/b.css"),
 				outId: 'b:first-child:after{content:"b1"}'
 			},
 			'b:nth-child(2):after { content: "b2"; }': {
-				inSource: "webpack:///b-dir/b.css",
+				inSource: sourceUrl("b-dir/b.css"),
 				outId: 'b:nth-child(2):after{content:"b2"}'
 			},
 			'c:nth-child(0):after { content: "c0"; }': {
-				inSource: "webpack:///b-dir/c-dir/c.css",
+				inSource: sourceUrl("b-dir/c-dir/c.css"),
 				outId: 'c:nth-child(0):after{content:"c0"}'
 			},
 			'c:nth-child(1):after { content: "c1"; }': {
-				inSource: "webpack:///b-dir/c-dir/c.css",
+				inSource: sourceUrl("b-dir/c-dir/c.css"),
 				outId: 'c:first-child:after{content:"c1"}'
 			},
 			'c:nth-child(2):after { content: "c2"; }': {
-				inSource: "webpack:///b-dir/c-dir/c.css",
+				inSource: sourceUrl("b-dir/c-dir/c.css"),
 				outId: 'c:nth-child(2):after{content:"c2"}'
 			},
 		})

--- a/tests/rspack-test/configCases/source-map/verify-bundle-css/index.js
+++ b/tests/rspack-test/configCases/source-map/verify-bundle-css/index.js
@@ -10,25 +10,29 @@ it("verify css bundle source map", async () => {
 		"utf-8"
 	);
 	const map = JSON.parse(source);
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
 	expect(map.sources).toEqual([
-		"webpack:///./b-dir/c-dir/c.css",
-		"webpack:///./b-dir/b.css",
-		"webpack:///./a.css",
-		"webpack:///./entry.css"
+		sourceUrl("./b-dir/c-dir/c.css"),
+		sourceUrl("./b-dir/b.css"),
+		sourceUrl("./a.css"),
+		sourceUrl("./entry.css")
 	]);
 	expect(map.file).toEqual("bundle0.css");
 	const out = fs.readFileSync(path.resolve(__dirname, "bundle0.css"), "utf-8");
 	expect(
 		await checkMap(out, source, {
-			'a:nth-child(0):after { content: "a0"; }': "webpack:///a.css",
-			'a:nth-child(1):after { content: "a1"; }': "webpack:///a.css",
-			'a:nth-child(2):after { content: "a2"; }': "webpack:///a.css",
-			'b:nth-child(0):after { content: "b0"; }': "webpack:///b-dir/b.css",
-			'b:nth-child(1):after { content: "b1"; }': "webpack:///b-dir/b.css",
-			'b:nth-child(2):after { content: "b2"; }': "webpack:///b-dir/b.css",
-			'c:nth-child(0):after { content: "c0"; }': "webpack:///b-dir/c-dir/c.css",
-			'c:nth-child(1):after { content: "c1"; }': "webpack:///b-dir/c-dir/c.css",
-			'c:nth-child(2):after { content: "c2"; }': "webpack:///b-dir/c-dir/c.css"
+			'a:nth-child(0):after { content: "a0"; }': sourceUrl("a.css"),
+			'a:nth-child(1):after { content: "a1"; }': sourceUrl("a.css"),
+			'a:nth-child(2):after { content: "a2"; }': sourceUrl("a.css"),
+			'b:nth-child(0):after { content: "b0"; }': sourceUrl("b-dir/b.css"),
+			'b:nth-child(1):after { content: "b1"; }': sourceUrl("b-dir/b.css"),
+			'b:nth-child(2):after { content: "b2"; }': sourceUrl("b-dir/b.css"),
+			'c:nth-child(0):after { content: "c0"; }': sourceUrl("b-dir/c-dir/c.css"),
+			'c:nth-child(1):after { content: "c1"; }': sourceUrl("b-dir/c-dir/c.css"),
+			'c:nth-child(2):after { content: "c2"; }': sourceUrl("b-dir/c-dir/c.css")
 		})
 	).toBe(true);
 });

--- a/tests/rspack-test/configCases/source-map/verify-css-js-mix/index.js
+++ b/tests/rspack-test/configCases/source-map/verify-css-js-mix/index.js
@@ -11,23 +11,24 @@ try {
 it("verify importing css js source map", async () => {
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(source);
-	const runtimePrefix = map.sources.some(source =>
-		source.startsWith("webpack:///rspack/runtime/")
-	)
-		? "rspack"
-		: "webpack";
+	let sourceUrl = source => `webpack:///${source}`;
+	let runtimeSource = name => sourceUrl(`webpack/runtime/${name}`);
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+		runtimeSource = name => sourceUrl(`rspack/runtime/${name}`);
+	}
 	expect(map.sources.sort()).toEqual([
-		"webpack:///./a.js",
-		"webpack:///./index.js",
-		`webpack:///${runtimePrefix}/runtime/make_namespace_object`,
-	]);
+		sourceUrl("./a.js"),
+		sourceUrl("./index.js"),
+		runtimeSource("make_namespace_object"),
+	].sort());
 	expect(map.file).toEqual("bundle0.js");
 	const out = fs.readFileSync(__filename, "utf-8");
 	expect(
 		await checkMap(out, source, {
 			// *${id}* as the search key to avoid conflict with `Object.defineProperty(exports, ${id}, ...)`
-			['"*a0*"']: "webpack:///a.js",
-			['"*a1*"']: "webpack:///a.js"
+			['"*a0*"']: sourceUrl("a.js"),
+			['"*a1*"']: sourceUrl("a.js")
 		}, false)
 	).toBe(true);
 });
@@ -38,7 +39,11 @@ it("verify css source map", async () => {
 		"utf-8"
 	);
 	const cssMap = JSON.parse(cssSource);
-	expect(cssMap.sources).toEqual(["webpack:///./a.css"]);
+	let cssSourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		cssSourceUrl = source => `rspack:///${source}`;
+	}
+	expect(cssMap.sources).toEqual([cssSourceUrl("./a.css")]);
 	expect(cssMap.file).toEqual("bundle0.css");
 	const cssOut = fs.readFileSync(
 		path.resolve(__dirname, "bundle0.css"),
@@ -46,9 +51,9 @@ it("verify css source map", async () => {
 	);
 	expect(
 		await checkMap(cssOut, cssSource, {
-			[`a:nth-child(0):after { content: "a0"; }`]: "webpack:///a.css",
-			[`a:nth-child(1):after { content: "a1"; }`]: "webpack:///a.css",
-			[`a:nth-child(2):after { content: "a2"; }`]: "webpack:///a.css"
+			[`a:nth-child(0):after { content: "a0"; }`]: cssSourceUrl("a.css"),
+			[`a:nth-child(1):after { content: "a1"; }`]: cssSourceUrl("a.css"),
+			[`a:nth-child(2):after { content: "a2"; }`]: cssSourceUrl("a.css")
 		})
 	).toBe(true);
 });

--- a/tests/rspack-test/configCases/source-map/verify-es6-minify/index.js
+++ b/tests/rspack-test/configCases/source-map/verify-es6-minify/index.js
@@ -10,33 +10,34 @@ it("verify es6 (esmodule) minify bundle source map", async () => {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(source);
-	const runtimePrefix = map.sources.some(source =>
-		source.startsWith("webpack:///rspack/runtime/")
-	)
-		? "rspack"
-		: "webpack";
+	let sourceUrl = source => `webpack:///${source}`;
+	let runtimeSource = name => sourceUrl(`webpack/runtime/${name}`);
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+		runtimeSource = name => sourceUrl(`rspack/runtime/${name}`);
+	}
 	expect(map.sources.sort()).toEqual([
-		`webpack:///../../../../../packages/rspack-test-tools/dist/helper/util/checkSourceMap.js`,
-		"webpack:///./a.js",
-		"webpack:///./b-dir/b.js",
-		"webpack:///./b-dir/c-dir/c.js",
-		"webpack:///./index.js",
-		`webpack:///${runtimePrefix}/runtime/define_property_getters`,
-		`webpack:///${runtimePrefix}/runtime/has_own_property`,
-		`webpack:///${runtimePrefix}/runtime/make_namespace_object`,
-	]);
+		sourceUrl(`../../../../../packages/rspack-test-tools/dist/helper/util/checkSourceMap.js`),
+		sourceUrl("./a.js"),
+		sourceUrl("./b-dir/b.js"),
+		sourceUrl("./b-dir/c-dir/c.js"),
+		sourceUrl("./index.js"),
+		runtimeSource("define_property_getters"),
+		runtimeSource("has_own_property"),
+		runtimeSource("make_namespace_object"),
+	].sort());
 	expect(map.file).toEqual("bundle0.js");
 	const out = fs.readFileSync(__filename, "utf-8");
 	expect(
 		await checkMap(out, source, {
 			// *${id}* as the search key to avoid conflict with `Object.defineProperty(exports, ${id}, ...)`
 			// "*a0*", "*a1*" is eliminate by minify
-			['"*a2*"']: checkColumn("webpack:///a.js"),
+			['"*a2*"']: checkColumn(sourceUrl("a.js")),
 			// "*b0*", "*b1*" is eliminate by minify
-			['"*b2*"']: checkColumn("webpack:///b-dir/b.js"),
+			['"*b2*"']: checkColumn(sourceUrl("b-dir/b.js")),
 			// "*c0*" is eliminate by minify
 			// "*c1*" is eliminate by minify
-			['"*c2*"']: "webpack:///b-dir/c-dir/c.js"
+			['"*c2*"']: sourceUrl("b-dir/c-dir/c.js")
 		})
 	).toBe(true);
 });

--- a/tests/rspack-test/configCases/source-map/verify-es6/index.js
+++ b/tests/rspack-test/configCases/source-map/verify-es6/index.js
@@ -11,43 +11,47 @@ it("verify es6 (esmodule) bundle source map", async () => {
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
 	const map = JSON.parse(source);
 	const out = fs.readFileSync(__filename, "utf-8");
+	let sourceUrl = source => `webpack:///${source}`;
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		sourceUrl = source => `rspack:///${source}`;
+	}
 	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
 		expect(map.sources.filter(source =>
 			!source.startsWith("webpack:///webpack/runtime/") &&
-			!source.startsWith("webpack:///rspack/runtime/")
+			!source.startsWith("rspack:///rspack/runtime/")
 		)).toEqual([
-			`webpack:///../../../../../packages/rspack-test-tools/dist/helper/util/checkSourceMap.js`,
-			"webpack:///./b-dir/c-dir/c.js",
-			"webpack:///./b-dir/b.js",
-			"webpack:///./a.js",
-			"webpack:///./index.js",
+			sourceUrl(`../../../../../packages/rspack-test-tools/dist/helper/util/checkSourceMap.js`),
+			sourceUrl("./b-dir/c-dir/c.js"),
+			sourceUrl("./b-dir/b.js"),
+			sourceUrl("./a.js"),
+			sourceUrl("./index.js"),
 		]);
 	} else {
 		expect(map.sources).toEqual([
-			`webpack:///../../../../../packages/rspack-test-tools/dist/helper/util/checkSourceMap.js`,
-			"webpack:///./b-dir/c-dir/c.js",
-			"webpack:///./b-dir/b.js",
-			"webpack:///./a.js",
-			"webpack:///./index.js",
+			sourceUrl(`../../../../../packages/rspack-test-tools/dist/helper/util/checkSourceMap.js`),
+			sourceUrl("./b-dir/c-dir/c.js"),
+			sourceUrl("./b-dir/b.js"),
+			sourceUrl("./a.js"),
+			sourceUrl("./index.js"),
 		]);
 	}
 	expect(map.file).toEqual("bundle0.js");
 	expect(
 		await checkMap(out, source, {
 			// *${id}* as the search key to avoid conflict with `Object.defineProperty(exports, ${id}, ...)`
-			['"*a0*"']: "webpack:///a.js",
-			['"*a1*"']: "webpack:///a.js",
+			['"*a0*"']: sourceUrl("a.js"),
+			['"*a1*"']: sourceUrl("a.js"),
 			// The result is generated upon `OriginalSource`
 			// and webpack generates sourcemap of`("xx")` as a block.
-			['("*a2*")']: checkColumn("webpack:///a.js"),
-			['"*b0*"']: "webpack:///b-dir/b.js",
-			['"*b1*"']: "webpack:///b-dir/b.js",
+			['("*a2*")']: checkColumn(sourceUrl("a.js")),
+			['"*b0*"']: sourceUrl("b-dir/b.js"),
+			['"*b1*"']: sourceUrl("b-dir/b.js"),
 			// The result is generated upon `OriginalSource`
 			// and webpack generates sourcemap of`("xx")` as a block.
-			['("*b2*")']: checkColumn("webpack:///b-dir/b.js"),
-			['"*c0*"']: "webpack:///b-dir/c-dir/c.js",
-			['"*c1*"']: "webpack:///b-dir/c-dir/c.js",
-			['"*c2*"']: "webpack:///b-dir/c-dir/c.js"
+			['("*b2*")']: checkColumn(sourceUrl("b-dir/b.js")),
+			['"*c0*"']: sourceUrl("b-dir/c-dir/c.js"),
+			['"*c1*"']: sourceUrl("b-dir/c-dir/c.js"),
+			['"*c2*"']: sourceUrl("b-dir/c-dir/c.js")
 		}, false)
 	).toBe(true);
 });


### PR DESCRIPTION
## Summary

Set the default source map module filename templates to `rspack://` when `experiments.runtimeMode` is `rspack`.

This PR also updates the Rust devtool source map handling so `rspack://` source URLs are accepted alongside `webpack://`, and keeps explicit template schemes intact when generating module filenames.

Note: explicit devtool plugin default options are left unchanged in this PR; this only changes the normalized config defaults path.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

