### PR TITLE
perf: erase js tap storage types to reduce binary size

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1,6 +1,7 @@
 use std::{
   ffi::c_void,
   hash::Hash,
+  marker::PhantomData,
   ptr::NonNull,
   sync::{Arc, RwLock},
 };
@@ -9,7 +10,7 @@ use async_trait::async_trait;
 use cow_utils::CowUtils;
 use napi::{
   Either, Env, JsValue,
-  bindgen_prelude::{Buffer, FromNapiValue, Function, JsValuesTupleIntoVec, Promise, ToNapiValue},
+  bindgen_prelude::{Buffer, FromNapiValue, Function, JsValuesTupleIntoVec, Promise},
 };
 use rspack_collections::{Identifier, IdentifierMap, IdentifierSet};
 use rspack_core::{
@@ -49,7 +50,7 @@ use rspack_core::{
 use rspack_error::Diagnostic;
 use rspack_hash::RspackHash;
 use rspack_hook::{Hook, Interceptor};
-use rspack_napi::threadsafe_function::ThreadsafeFunction;
+use rspack_napi::threadsafe_function::DynThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
 use rspack_plugin_html::{
   AfterEmitData, AfterTemplateExecutionData, AlterAssetTagGroupsData, AlterAssetTagsData,
@@ -143,26 +144,16 @@ pub struct JsTap<'f> {
   pub stage: i32,
 }
 
-pub struct ThreadsafeJsTap<T: 'static + JsValuesTupleIntoVec, R> {
-  pub function: ThreadsafeFunction<T, R>,
+#[derive(Clone)]
+pub struct ThreadsafeJsTap {
+  pub function: DynThreadsafeFunction,
   pub stage: i32,
 }
 
-impl<T: 'static + JsValuesTupleIntoVec, R> Clone for ThreadsafeJsTap<T, R> {
-  fn clone(&self) -> Self {
-    Self {
-      function: self.function.clone(),
-      stage: self.stage,
-    }
-  }
-}
-
-impl<T: 'static + ToNapiValue + JsValuesTupleIntoVec, R: 'static + FromNapiValue>
-  ThreadsafeJsTap<T, R>
-{
+impl ThreadsafeJsTap {
   pub fn from_js_tap(js_tap: JsTap, env: Env) -> napi::Result<Self> {
     let function =
-      unsafe { ThreadsafeFunction::from_napi_value(env.raw(), js_tap.function.raw()) }?;
+      unsafe { DynThreadsafeFunction::from_napi_value(env.raw(), js_tap.function.raw()) }?;
     Ok(Self {
       function,
       stage: js_tap.stage,
@@ -170,9 +161,7 @@ impl<T: 'static + ToNapiValue + JsValuesTupleIntoVec, R: 'static + FromNapiValue
   }
 }
 
-impl<T: 'static + ToNapiValue + JsValuesTupleIntoVec, R: 'static + FromNapiValue> FromNapiValue
-  for ThreadsafeJsTap<T, R>
-{
+impl FromNapiValue for ThreadsafeJsTap {
   unsafe fn from_napi_value(
     env: napi::sys::napi_env,
     napi_val: napi::sys::napi_value,
@@ -184,20 +173,63 @@ impl<T: 'static + ToNapiValue + JsValuesTupleIntoVec, R: 'static + FromNapiValue
   }
 }
 
-type RegisterFunctionOutput<T, R> = Vec<ThreadsafeJsTap<T, R>>;
+struct ThreadsafeJsTapFunction<T, R> {
+  inner: DynThreadsafeFunction,
+  _marker: PhantomData<fn(T) -> R>,
+}
+
+impl<T, R> Clone for ThreadsafeJsTapFunction<T, R> {
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+      _marker: PhantomData,
+    }
+  }
+}
+
+impl<T, R> ThreadsafeJsTapFunction<T, R> {
+  fn new(inner: DynThreadsafeFunction) -> Self {
+    Self {
+      inner,
+      _marker: PhantomData,
+    }
+  }
+}
+
+impl<T, R> ThreadsafeJsTapFunction<T, R>
+where
+  T: 'static + JsValuesTupleIntoVec,
+  R: 'static + FromNapiValue,
+{
+  async fn call_with_sync(&self, value: T) -> rspack_error::Result<R> {
+    self.inner.call_with_sync::<T, R>(value).await
+  }
+}
+
+impl<T, R> ThreadsafeJsTapFunction<T, Promise<R>>
+where
+  T: 'static + JsValuesTupleIntoVec,
+  R: 'static + FromNapiValue,
+{
+  async fn call_with_promise(&self, value: T) -> rspack_error::Result<R> {
+    self.inner.call_with_promise::<T, R>(value).await
+  }
+}
+
+type RegisterFunctionOutput = Vec<ThreadsafeJsTap>;
 // The register callback itself is compiler-scoped because it can capture compiler or
 // compilation JS objects across builds. The taps returned by that callback stay as ordinary
 // TSFNs: uncached taps die with the returned vector, while cached taps are explicitly
 // released by `clear_cache()`.
-type RegisterFunction<T, R> = CompilerScopedTsFnHandle<Vec<i32>, RegisterFunctionOutput<T, R>>;
+type RegisterFunction = CompilerScopedTsFnHandle<Vec<i32>, RegisterFunctionOutput>;
 
-struct RegisterJsTapsInner<T: 'static + JsValuesTupleIntoVec, R> {
-  register: RegisterFunction<T, R>,
-  cache: RegisterJsTapsCache<T, R>,
+struct RegisterJsTapsInner {
+  register: RegisterFunction,
+  cache: RegisterJsTapsCache,
   non_skippable_registers: Option<NonSkippableRegisters>,
 }
 
-impl<T: 'static + JsValuesTupleIntoVec, R> Clone for RegisterJsTapsInner<T, R> {
+impl Clone for RegisterJsTapsInner {
   fn clone(&self) -> Self {
     Self {
       register: self.register.clone(),
@@ -207,12 +239,12 @@ impl<T: 'static + JsValuesTupleIntoVec, R> Clone for RegisterJsTapsInner<T, R> {
   }
 }
 
-enum RegisterJsTapsCache<T: 'static + JsValuesTupleIntoVec, R> {
+enum RegisterJsTapsCache {
   NoCache,
-  Cache(Arc<RwLock<Option<RegisterFunctionOutput<T, R>>>>),
+  Cache(Arc<RwLock<Option<RegisterFunctionOutput>>>),
 }
 
-impl<T: 'static + JsValuesTupleIntoVec, R> Clone for RegisterJsTapsCache<T, R> {
+impl Clone for RegisterJsTapsCache {
   fn clone(&self) -> Self {
     match self {
       Self::NoCache => Self::NoCache,
@@ -221,7 +253,7 @@ impl<T: 'static + JsValuesTupleIntoVec, R> Clone for RegisterJsTapsCache<T, R> {
   }
 }
 
-impl<T: 'static + JsValuesTupleIntoVec, R> RegisterJsTapsCache<T, R> {
+impl RegisterJsTapsCache {
   pub fn new(cache: bool) -> Self {
     if cache {
       Self::Cache(Default::default())
@@ -231,9 +263,9 @@ impl<T: 'static + JsValuesTupleIntoVec, R> RegisterJsTapsCache<T, R> {
   }
 }
 
-impl<T: 'static + ToNapiValue, R: 'static + FromNapiValue> RegisterJsTapsInner<T, R> {
+impl RegisterJsTapsInner {
   pub fn new(
-    register: RegisterFunction<T, R>,
+    register: RegisterFunction,
     non_skippable_registers: Option<NonSkippableRegisters>,
     cache: bool,
   ) -> Self {
@@ -247,7 +279,7 @@ impl<T: 'static + ToNapiValue, R: 'static + FromNapiValue> RegisterJsTapsInner<T
   pub async fn call_register(
     &self,
     hook: &impl Hook,
-  ) -> rspack_error::Result<RegisterFunctionOutput<T, R>> {
+  ) -> rspack_error::Result<RegisterFunctionOutput> {
     if let RegisterJsTapsCache::Cache(rw) = &self.cache {
       let cache = {
         #[allow(clippy::unwrap_used)]
@@ -274,7 +306,7 @@ impl<T: 'static + ToNapiValue, R: 'static + FromNapiValue> RegisterJsTapsInner<T
   async fn call_register_impl(
     &self,
     hook: &impl Hook,
-  ) -> rspack_error::Result<RegisterFunctionOutput<T, R>> {
+  ) -> rspack_error::Result<RegisterFunctionOutput> {
     let mut used_stages = Vec::from_iter(hook.used_stages());
     used_stages.sort_unstable();
     self.register.call_with_sync(used_stages).await
@@ -300,6 +332,11 @@ impl<T: 'static + ToNapiValue, R: 'static + FromNapiValue> RegisterJsTapsInner<T
 ///       be sync since calling a ThreadsafeFunction is async, for now it's only used by
 ///       execute_module, which strongly required sync call.
 macro_rules! define_register {
+  ($name:ident, tap = $tap_name:ident<$arg:ty, Promise<$promise_ret:ty>> @ $tap_hook:ty, cache = $cache:literal, kind = $kind:expr, skip = $skip:tt,) => {
+    define_register!(@BASE_PROMISE $name, $tap_name<$arg, $promise_ret>, $cache);
+    define_register!(@SKIP $name, $arg, Promise<$promise_ret>, $cache, $skip);
+    define_register!(@INTERCEPTOR $name, $tap_name, $tap_hook, $cache, $kind);
+  };
   ($name:ident, tap = $tap_name:ident<$arg:ty, $ret:ty> @ $tap_hook:ty, cache = $cache:literal, kind = $kind:expr, skip = $skip:tt,) => {
     define_register!(@BASE $name, $tap_name<$arg, $ret>, $cache);
     define_register!(@SKIP $name, $arg, $ret, $cache, $skip);
@@ -308,7 +345,7 @@ macro_rules! define_register {
   (@BASE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      inner: RegisterJsTapsInner<$arg, $ret>,
+      inner: RegisterJsTapsInner,
     }
 
     impl $name {
@@ -319,14 +356,41 @@ macro_rules! define_register {
 
     #[derive(Clone)]
     struct $tap_name {
-      function: ThreadsafeFunction<$arg, $ret>,
+      function: ThreadsafeJsTapFunction<$arg, $ret>,
       stage: i32,
     }
 
     impl $tap_name {
-      pub fn new(tap: ThreadsafeJsTap<$arg, $ret>) -> Self {
+      pub fn new(tap: ThreadsafeJsTap) -> Self {
         Self {
-          function: tap.function,
+          function: ThreadsafeJsTapFunction::new(tap.function),
+          stage: tap.stage,
+        }
+      }
+    }
+  };
+  (@BASE_PROMISE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
+    #[derive(Clone)]
+    pub struct $name {
+      inner: RegisterJsTapsInner,
+    }
+
+    impl $name {
+      pub fn clear_cache(&self) {
+        self.inner.clear_cache();
+      }
+    }
+
+    #[derive(Clone)]
+    struct $tap_name {
+      function: ThreadsafeJsTapFunction<$arg, Promise<$ret>>,
+      stage: i32,
+    }
+
+    impl $tap_name {
+      pub fn new(tap: ThreadsafeJsTap) -> Self {
+        Self {
+          function: ThreadsafeJsTapFunction::new(tap.function),
           stage: tap.stage,
         }
       }
@@ -334,7 +398,7 @@ macro_rules! define_register {
   };
   (@SKIP $name:ident, $arg:ty, $ret:ty, $cache:literal, $skip:literal) => {
     impl $name {
-      pub fn new(register: RegisterFunction<$arg, $ret>, non_skippable_registers: NonSkippableRegisters) -> Self {
+      pub fn new(register: RegisterFunction, non_skippable_registers: NonSkippableRegisters) -> Self {
         Self {
           inner: RegisterJsTapsInner::new(register, $skip.then_some(non_skippable_registers), $cache),
         }
@@ -438,239 +502,207 @@ pub struct RegisterJsTaps {
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => void); stage: number; }>"
   )]
-  pub register_compiler_this_compilation_taps: RegisterFunction<JsCompilationWrapper, ()>,
+  pub register_compiler_this_compilation_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => void); stage: number; }>"
   )]
-  pub register_compiler_compilation_taps: RegisterFunction<JsCompilationWrapper, ()>,
+  pub register_compiler_compilation_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => Promise<void>); stage: number; }>"
   )]
-  pub register_compiler_make_taps: RegisterFunction<JsCompilationWrapper, Promise<()>>,
+  pub register_compiler_make_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => void); stage: number; }>"
   )]
-  pub register_compiler_finish_make_taps: RegisterFunction<JsCompilationWrapper, Promise<()>>,
+  pub register_compiler_finish_make_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => boolean | undefined); stage: number; }>"
   )]
-  pub register_compiler_should_emit_taps: RegisterFunction<JsCompilationWrapper, Option<bool>>,
+  pub register_compiler_should_emit_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: (() => Promise<void>); stage: number; }>"
   )]
-  pub register_compiler_emit_taps: RegisterFunction<(), Promise<()>>,
+  pub register_compiler_emit_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: (() => Promise<void>); stage: number; }>"
   )]
-  pub register_compiler_after_emit_taps: RegisterFunction<(), Promise<()>>,
+  pub register_compiler_after_emit_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAssetEmittedArgs) => Promise<void>); stage: number; }>"
   )]
-  pub register_compiler_asset_emitted_taps: RegisterFunction<JsAssetEmittedArgs, Promise<()>>,
+  pub register_compiler_asset_emitted_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: Module) => void); stage: number; }>"
   )]
-  pub register_compilation_build_module_taps: RegisterFunction<ModuleObject, ()>,
+  pub register_compilation_build_module_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: Module) => void); stage: number; }>"
   )]
-  pub register_compilation_still_valid_module_taps: RegisterFunction<ModuleObject, ()>,
+  pub register_compilation_still_valid_module_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: Module) => void); stage: number; }>"
   )]
-  pub register_compilation_succeed_module_taps: RegisterFunction<ModuleObject, ()>,
+  pub register_compilation_succeed_module_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsExecuteModuleArg) => void); stage: number; }>"
   )]
-  pub register_compilation_execute_module_taps: RegisterFunction<JsExecuteModuleArg, ()>,
+  pub register_compilation_execute_module_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAdditionalTreeRuntimeRequirementsArg) => JsAdditionalTreeRuntimeRequirementsResult | undefined); stage: number; }>"
   )]
-  pub register_compilation_additional_tree_runtime_requirements_taps: RegisterFunction<
-    JsAdditionalTreeRuntimeRequirementsArg,
-    Option<JsAdditionalTreeRuntimeRequirementsResult>,
-  >,
+  pub register_compilation_additional_tree_runtime_requirements_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRuntimeRequirementInTreeArg) => JsRuntimeRequirementInTreeResult | undefined); stage: number; }>"
   )]
-  pub register_compilation_runtime_requirement_in_tree_taps:
-    RegisterFunction<JsRuntimeRequirementInTreeArg, Option<JsRuntimeRequirementInTreeResult>>,
+  pub register_compilation_runtime_requirement_in_tree_taps: RegisterFunction,
 
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRuntimeModuleArg) => JsRuntimeModule | undefined); stage: number; }>"
   )]
-  pub register_compilation_runtime_module_taps:
-    RegisterFunction<JsRuntimeModuleArg, Option<JsRuntimeModule>>,
+  pub register_compilation_runtime_module_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => Promise<void>); stage: number; }>"
   )]
-  pub register_compilation_finish_modules_taps: RegisterFunction<JsCompilationWrapper, Promise<()>>,
+  pub register_compilation_finish_modules_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: (() => boolean | undefined); stage: number; }>"
   )]
-  pub register_compilation_optimize_modules_taps: RegisterFunction<(), Option<bool>>,
+  pub register_compilation_optimize_modules_taps: RegisterFunction,
   #[napi(ts_type = "(stages: Array<number>) => Array<{ function: (() => void); stage: number; }>")]
-  pub register_compilation_after_optimize_modules_taps: RegisterFunction<(), ()>,
+  pub register_compilation_after_optimize_modules_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: (() => Promise<void>); stage: number; }>"
   )]
-  pub register_compilation_optimize_tree_taps: RegisterFunction<(), Promise<()>>,
+  pub register_compilation_optimize_tree_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: (() => Promise<boolean | undefined>); stage: number; }>"
   )]
-  pub register_compilation_optimize_chunk_modules_taps: RegisterFunction<(), Promise<Option<bool>>>,
+  pub register_compilation_optimize_chunk_modules_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsBeforeModuleIdsArg) => JsBeforeModuleIdsResult); stage: number; }>"
   )]
-  pub register_compilation_before_module_ids_taps:
-    RegisterFunction<JsBeforeModuleIdsArg, JsBeforeModuleIdsResult>,
+  pub register_compilation_before_module_ids_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: Chunk) => Buffer); stage: number; }>"
   )]
-  pub register_compilation_chunk_hash_taps: RegisterFunction<ChunkWrapper, Buffer>,
+  pub register_compilation_chunk_hash_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsChunkAssetArgs) => void); stage: number; }>"
   )]
-  pub register_compilation_chunk_asset_taps: RegisterFunction<JsChunkAssetArgs, ()>,
+  pub register_compilation_chunk_asset_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => Promise<void>); stage: number; }>"
   )]
-  pub register_compilation_process_assets_taps: RegisterFunction<JsCompilationWrapper, Promise<()>>,
+  pub register_compilation_process_assets_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCompilation) => void); stage: number; }>"
   )]
-  pub register_compilation_after_process_assets_taps: RegisterFunction<JsCompilationWrapper, ()>,
+  pub register_compilation_after_process_assets_taps: RegisterFunction,
   #[napi(ts_type = "(stages: Array<number>) => Array<{ function: (() => void); stage: number; }>")]
-  pub register_compilation_seal_taps: RegisterFunction<(), ()>,
+  pub register_compilation_seal_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: (() => Promise<void>); stage: number; }>"
   )]
-  pub register_compilation_after_seal_taps: RegisterFunction<(), Promise<()>>,
+  pub register_compilation_after_seal_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsResolveData) => Promise<[boolean | undefined, JsResolveData]>); stage: number; }>"
   )]
-  pub register_normal_module_factory_before_resolve_taps:
-    RegisterFunction<JsResolveData, Promise<(Option<bool>, JsResolveData)>>,
+  pub register_normal_module_factory_before_resolve_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsResolveData) => Promise<JsResolveData>); stage: number; }>"
   )]
-  pub register_normal_module_factory_factorize_taps:
-    RegisterFunction<JsResolveData, Promise<JsResolveData>>,
+  pub register_normal_module_factory_factorize_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsResolveData) => Promise<JsResolveData>); stage: number; }>"
   )]
-  pub register_normal_module_factory_resolve_taps:
-    RegisterFunction<JsResolveData, Promise<JsResolveData>>,
+  pub register_normal_module_factory_resolve_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsResolveForSchemeArgs) => Promise<[boolean | undefined, JsResolveForSchemeArgs]>); stage: number; }>"
   )]
-  pub register_normal_module_factory_resolve_for_scheme_taps:
-    RegisterFunction<JsResolveForSchemeArgs, Promise<JsResolveForSchemeOutput>>,
+  pub register_normal_module_factory_resolve_for_scheme_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsResolveData) => Promise<[boolean | undefined, JsResolveData]>); stage: number; }>"
   )]
-  pub register_normal_module_factory_after_resolve_taps:
-    RegisterFunction<JsResolveData, Promise<(Option<bool>, JsResolveData)>>,
+  pub register_normal_module_factory_after_resolve_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsNormalModuleFactoryCreateModuleArgs) => Promise<void>); stage: number; }>"
   )]
-  pub register_normal_module_factory_create_module_taps:
-    RegisterFunction<JsNormalModuleFactoryCreateModuleArgs, Promise<()>>,
+  pub register_normal_module_factory_create_module_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryBeforeResolveData) => Promise<false | JsContextModuleFactoryBeforeResolveData>); stage: number; }>"
   )]
-  pub register_context_module_factory_before_resolve_taps: RegisterFunction<
-    JsContextModuleFactoryBeforeResolveResult,
-    Promise<JsContextModuleFactoryBeforeResolveResult>,
-  >,
+  pub register_context_module_factory_before_resolve_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryAfterResolveData) => Promise<false | JsContextModuleFactoryAfterResolveData>); stage: number; }>"
   )]
-  pub register_context_module_factory_after_resolve_taps: RegisterFunction<
-    JsContextModuleFactoryAfterResolveResult,
-    Promise<JsContextModuleFactoryAfterResolveResult>,
-  >,
+  pub register_context_module_factory_after_resolve_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: Chunk) => Buffer); stage: number; }>"
   )]
-  pub register_javascript_modules_chunk_hash_taps: RegisterFunction<ChunkWrapper, Buffer>,
+  pub register_javascript_modules_chunk_hash_taps: RegisterFunction,
   // html plugin
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsBeforeAssetTagGenerationData) => JsBeforeAssetTagGenerationData); stage: number; }>"
   )]
-  pub register_html_plugin_before_asset_tag_generation_taps:
-    RegisterFunction<JsBeforeAssetTagGenerationData, Promise<JsBeforeAssetTagGenerationData>>,
+  pub register_html_plugin_before_asset_tag_generation_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAlterAssetTagsData) => JsAlterAssetTagsData); stage: number; }>"
   )]
-  pub register_html_plugin_alter_asset_tags_taps:
-    RegisterFunction<JsAlterAssetTagsData, Promise<JsAlterAssetTagsData>>,
+  pub register_html_plugin_alter_asset_tags_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAlterAssetTagGroupsData) => JsAlterAssetTagGroupsData); stage: number; }>"
   )]
-  pub register_html_plugin_alter_asset_tag_groups_taps:
-    RegisterFunction<JsAlterAssetTagGroupsData, Promise<JsAlterAssetTagGroupsData>>,
+  pub register_html_plugin_alter_asset_tag_groups_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAfterTemplateExecutionData) => JsAfterTemplateExecutionData); stage: number; }>"
   )]
-  pub register_html_plugin_after_template_execution_taps:
-    RegisterFunction<JsAfterTemplateExecutionData, Promise<JsAfterTemplateExecutionData>>,
+  pub register_html_plugin_after_template_execution_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsBeforeEmitData) => JsBeforeEmitData); stage: number; }>"
   )]
-  pub register_html_plugin_before_emit_taps:
-    RegisterFunction<JsBeforeEmitData, Promise<JsBeforeEmitData>>,
+  pub register_html_plugin_before_emit_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsAfterEmitData) => JsAfterEmitData); stage: number; }>"
   )]
-  pub register_html_plugin_after_emit_taps:
-    RegisterFunction<JsAfterEmitData, Promise<JsAfterEmitData>>,
+  pub register_html_plugin_after_emit_taps: RegisterFunction,
   // runtime plugin
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCreateScriptData) => String); stage: number; }>"
   )]
-  pub register_runtime_plugin_create_script_taps:
-    RegisterFunction<JsCreateScriptData, Option<String>>,
+  pub register_runtime_plugin_create_script_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsLinkPreloadData) => String); stage: number; }>"
   )]
-  pub register_runtime_plugin_create_link_taps: RegisterFunction<JsCreateLinkData, Option<String>>,
+  pub register_runtime_plugin_create_link_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsCreateLinkData) => String); stage: number; }>"
   )]
-  pub register_runtime_plugin_link_preload_taps:
-    RegisterFunction<JsLinkPreloadData, Option<String>>,
+  pub register_runtime_plugin_link_preload_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsLinkPrefetchData) => String); stage: number; }>"
   )]
-  pub register_runtime_plugin_link_prefetch_taps:
-    RegisterFunction<JsLinkPrefetchData, Option<String>>,
+  pub register_runtime_plugin_link_prefetch_taps: RegisterFunction,
   // rsdoctor plugin
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorModuleGraph) => Promise<boolean | undefined>); stage: number; }>"
   )]
-  pub register_rsdoctor_plugin_module_graph_taps:
-    RegisterFunction<JsRsdoctorModuleGraph, Promise<Option<bool>>>,
+  pub register_rsdoctor_plugin_module_graph_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorChunkGraph) => Promise<boolean | undefined>); stage: number; }>"
   )]
-  pub register_rsdoctor_plugin_chunk_graph_taps:
-    RegisterFunction<JsRsdoctorChunkGraph, Promise<Option<bool>>>,
+  pub register_rsdoctor_plugin_chunk_graph_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorModuleIdsPatch) => Promise<boolean | undefined>); stage: number; }>"
   )]
-  pub register_rsdoctor_plugin_module_ids_taps:
-    RegisterFunction<JsRsdoctorModuleIdsPatch, Promise<Option<bool>>>,
+  pub register_rsdoctor_plugin_module_ids_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorModuleSourcesPatch) => Promise<boolean | undefined>); stage: number; }>"
   )]
-  pub register_rsdoctor_plugin_module_sources_taps:
-    RegisterFunction<JsRsdoctorModuleSourcesPatch, Promise<Option<bool>>>,
+  pub register_rsdoctor_plugin_module_sources_taps: RegisterFunction,
   #[napi(
     ts_type = "(stages: Array<number>) => Array<{ function: ((arg: JsRsdoctorAssetPatch) => Promise<boolean | undefined>); stage: number; }>"
   )]
-  pub register_rsdoctor_plugin_assets_taps:
-    RegisterFunction<JsRsdoctorAssetPatch, Promise<Option<bool>>>,
+  pub register_rsdoctor_plugin_assets_taps: RegisterFunction,
 }
 
 /* Compiler Hooks */

--- a/crates/rspack_napi/src/threadsafe_function.rs
+++ b/crates/rspack_napi/src/threadsafe_function.rs
@@ -7,7 +7,7 @@ use std::{
 use napi::{
   Env, JsValue, Status, Unknown, ValueType,
   bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName, ValidateNapiValue},
-  sys::{self, napi_env},
+  sys::{self, napi_env, napi_value},
   threadsafe_function::{ThreadsafeFunction as RawThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use oneshot::{Receiver, channel};
@@ -23,6 +23,29 @@ pub struct ThreadsafeFunction<T: 'static + JsValuesTupleIntoVec, R> {
   inner: Arc<RawThreadsafeFunction<T, Unknown<'static>, T, Status, false, true>>,
   env: napi_env,
   _data: PhantomData<R>,
+}
+
+pub struct DynThreadsafeFunction {
+  inner: Arc<RawThreadsafeFunction<DynJsArgs, Unknown<'static>, DynJsArgs, Status, false, true>>,
+  env: napi_env,
+}
+
+struct DynJsArgs(Box<dyn DynJsArgsToVec>);
+
+trait DynJsArgsToVec {
+  fn into_vec(self: Box<Self>, env: napi_env) -> napi::Result<Vec<napi_value>>;
+}
+
+impl<T: JsValuesTupleIntoVec> DynJsArgsToVec for T {
+  fn into_vec(self: Box<Self>, env: napi_env) -> napi::Result<Vec<napi_value>> {
+    (*self).into_vec(env)
+  }
+}
+
+impl JsValuesTupleIntoVec for DynJsArgs {
+  fn into_vec(self, env: napi_env) -> napi::Result<Vec<napi_value>> {
+    self.0.into_vec(env)
+  }
 }
 
 impl<T: 'static + JsValuesTupleIntoVec, R> Debug for ThreadsafeFunction<T, R> {
@@ -41,8 +64,26 @@ impl<T: 'static + JsValuesTupleIntoVec, R> Clone for ThreadsafeFunction<T, R> {
   }
 }
 
+impl Debug for DynThreadsafeFunction {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("DynThreadsafeFunction")
+      .finish_non_exhaustive()
+  }
+}
+
+impl Clone for DynThreadsafeFunction {
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+      env: self.env,
+    }
+  }
+}
+
 unsafe impl<T: 'static + JsValuesTupleIntoVec, R> Sync for ThreadsafeFunction<T, R> {}
 unsafe impl<T: 'static + JsValuesTupleIntoVec, R> Send for ThreadsafeFunction<T, R> {}
+unsafe impl Sync for DynThreadsafeFunction {}
+unsafe impl Send for DynThreadsafeFunction {}
 
 impl<T: 'static + JsValuesTupleIntoVec, R> FromNapiValue for ThreadsafeFunction<T, R> {
   unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
@@ -57,6 +98,22 @@ impl<T: 'static + JsValuesTupleIntoVec, R> FromNapiValue for ThreadsafeFunction<
       inner: Arc::new(inner),
       env,
       _data: PhantomData,
+    })
+  }
+}
+
+impl FromNapiValue for DynThreadsafeFunction {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    let inner = unsafe {
+      <RawThreadsafeFunction<DynJsArgs, Unknown, DynJsArgs, Status, false, true> as FromNapiValue>::from_napi_value(
+        env, napi_val,
+      )
+    }?;
+    let _ = ERROR_RESOLVER
+      .get_or_init(|| unsafe { JsCallback::new(env).expect("should initialize error resolver") });
+    Ok(Self {
+      inner: Arc::new(inner),
+      env,
     })
   }
 }
@@ -104,6 +161,85 @@ impl<T: 'static + JsValuesTupleIntoVec, R> ThreadsafeFunction<T, R> {
   }
 }
 
+impl DynThreadsafeFunction {
+  async fn resolve_error(&self, err: napi::Error) -> Error {
+    let (tx, rx) = tokio::sync::oneshot::channel::<rspack_error::Error>();
+    ERROR_RESOLVER
+      .get()
+      // SAFETY: The error resolver is initialized in `FromNapiValue::from_napi_value` and it's the only way to create a tsfn.
+      .expect("should have error resolver initialized")
+      .call(Box::new(move |env| {
+        let err = err.to_rspack_error(&env);
+        tx.send(err).expect("failed to resolve js error");
+      }));
+    rx.await.expect("failed to resolve js error")
+  }
+
+  fn call_with_return<T, D>(&self, value: T) -> Receiver<Result<D>>
+  where
+    T: 'static + JsValuesTupleIntoVec,
+    D: 'static + FromNapiValue,
+  {
+    let (tx, rx) = channel::<Result<D>>();
+    self.inner.call_with_return_value(
+      DynJsArgs(Box::new(value)),
+      ThreadsafeFunctionCallMode::NonBlocking,
+      {
+        move |r: napi::Result<Unknown>, env| {
+          let r = match r {
+            Err(err) => Err(err.to_rspack_error(&env)),
+            Ok(o) => {
+              let raw_env = env.raw();
+              let return_value = o.raw();
+              unsafe { D::from_napi_value(raw_env, return_value) }
+                .map_err(|e| pretty_type_error(o, e))
+            }
+          };
+          tx.send(r)
+            .unwrap_or_else(|_| panic!("failed to send tsfn value"));
+          Ok(())
+        }
+      },
+    );
+    rx
+  }
+
+  async fn call_async<T, D>(&self, value: T) -> Result<D>
+  where
+    T: 'static + JsValuesTupleIntoVec,
+    D: 'static + FromNapiValue,
+  {
+    let rx = self.call_with_return(value);
+    rx.await.expect("failed to receive tsfn value")
+  }
+
+  /// Call the JS function.
+  pub async fn call_with_sync<T, R>(&self, value: T) -> Result<R>
+  where
+    T: 'static + JsValuesTupleIntoVec,
+    R: 'static + FromNapiValue,
+  {
+    self.call_async::<T, R>(value).await
+  }
+
+  /// Call the JS function.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, an [napi::Error] is returned.
+  pub async fn call_with_promise<T, R>(&self, value: T) -> Result<R>
+  where
+    T: 'static + JsValuesTupleIntoVec,
+    R: 'static + FromNapiValue,
+  {
+    match self.call_async::<T, Promise<R>>(value).await {
+      Ok(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Err(err) => Err(err),
+    }
+  }
+}
+
 impl<T: 'static + JsValuesTupleIntoVec, R: 'static + FromNapiValue> ThreadsafeFunction<T, R> {
   /// Call the JS function.
   pub async fn call_with_sync(&self, value: T) -> Result<R> {
@@ -133,7 +269,19 @@ impl<T: 'static + JsValuesTupleIntoVec + JsValuesTupleIntoVec, R> ValidateNapiVa
 {
 }
 
+impl ValidateNapiValue for DynThreadsafeFunction {}
+
 impl<T: 'static + JsValuesTupleIntoVec, R> TypeName for ThreadsafeFunction<T, R> {
+  fn type_name() -> &'static str {
+    "ThreadsafeFunction"
+  }
+
+  fn value_type() -> napi::ValueType {
+    ValueType::Function
+  }
+}
+
+impl TypeName for DynThreadsafeFunction {
   fn type_name() -> &'static str {
     "ThreadsafeFunction"
   }


### PR DESCRIPTION
## Summary

Refactors JS plugin tap registration storage so the register/cache layer stores dyn threadsafe functions instead of monomorphized hook argument and return types.

The concrete hook argument and return types are restored at each generated tap call boundary, keeping hook execution typed while reducing repeated generic expansion across register storage types.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_napi -p rspack_binding_api`

---
_by OpenAI Codex_