### PR TITLE
feat: add name/value accessors to ESMExportSpecifierDependency

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_specifier_dependency.rs
@@ -46,6 +46,14 @@ impl ESMExportSpecifierDependency {
       id: DependencyId::new(),
     }
   }
+
+  pub fn name(&self) -> &Atom {
+    &self.name
+  }
+
+  pub fn value(&self) -> &Atom {
+    &self.value
+  }
 }
 
 #[cacheable_dyn]


### PR DESCRIPTION
## Summary

ESMExportSpecifierDependency is a public struct, but its name and value fields are private with no accessors, so code outside rspack_plugin_javascript cannot read them:

- name: the public export name (for example, Checkbox in export { CheckboxShim as Checkbox })
- value: the local binding, equivalent to dependency.id in webpack (for example, CheckboxShim)

This PR adds two borrowing accessors, name() and value(), exposing those fields.

**Why:** Consumers that reconstruct a module's export map, for example to emit a library manifest, need both the public export name and the local binding to correctly resolve aliased exports. Without accessors, external code cannot distinguish the two and may end up dropping or mislabeling aliased exports. This follows the same accessor pattern already used by sibling types such as *ESMImportSpecifierDependency::name()


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
