### PR TITLE
refactor: rename hash objects for clearer semantics

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -58,7 +58,7 @@ use rspack_core::{
 };
 use rspack_error::{Error, Result};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
-use rspack_hash::{HashDigest, HashFunction, HashSalt};
+use rspack_hash::{HashAlgorithm, HashDigest, HashSalt};
 use rspack_paths::{AssertUtf8, Utf8PathBuf};
 use rspack_regex::RspackRegex;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -2177,7 +2177,7 @@ pub struct OutputOptionsBuilder {
   /// Set the source map filename.
   source_map_filename: Option<Filename>,
   /// Set the hash function.
-  hash_function: Option<HashFunction>,
+  hash_function: Option<HashAlgorithm>,
   /// Set the hash digest.
   hash_digest: Option<HashDigest>,
   /// Set the hash digest length.
@@ -2535,7 +2535,7 @@ impl OutputOptionsBuilder {
   }
 
   /// Set the hash function.
-  pub fn hash_function(&mut self, function: HashFunction) -> &mut Self {
+  pub fn hash_function(&mut self, function: HashAlgorithm) -> &mut Self {
     self.hash_function = Some(function);
     self
   }
@@ -2901,7 +2901,7 @@ impl OutputOptionsBuilder {
     let module = d!(self.module.take(), output_module);
     let source_map_filename = f!(self.source_map_filename.take(), || "[file].map[query]"
       .into());
-    let hash_function = d!(self.hash_function.take(), HashFunction::Xxhash64);
+    let hash_function = d!(self.hash_function.take(), HashAlgorithm::Xxhash64);
     let hash_digest = d!(self.hash_digest.take(), HashDigest::Hex);
     let hash_digest_length = d!(self.hash_digest_length.take(), 16);
     let hash_salt = d!(self.hash_salt.take(), HashSalt::None);

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -58,7 +58,7 @@ use rspack_core::{
 };
 use rspack_error::{Error, Result};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
-use rspack_hash::{HashAlgorithm, HashDigest, HashSalt};
+use rspack_hash::{HashDigest, HashFunction, HashSalt};
 use rspack_paths::{AssertUtf8, Utf8PathBuf};
 use rspack_regex::RspackRegex;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -2177,7 +2177,7 @@ pub struct OutputOptionsBuilder {
   /// Set the source map filename.
   source_map_filename: Option<Filename>,
   /// Set the hash function.
-  hash_function: Option<HashAlgorithm>,
+  hash_function: Option<HashFunction>,
   /// Set the hash digest.
   hash_digest: Option<HashDigest>,
   /// Set the hash digest length.
@@ -2535,7 +2535,7 @@ impl OutputOptionsBuilder {
   }
 
   /// Set the hash function.
-  pub fn hash_function(&mut self, function: HashAlgorithm) -> &mut Self {
+  pub fn hash_function(&mut self, function: HashFunction) -> &mut Self {
     self.hash_function = Some(function);
     self
   }
@@ -2901,7 +2901,7 @@ impl OutputOptionsBuilder {
     let module = d!(self.module.take(), output_module);
     let source_map_filename = f!(self.source_map_filename.take(), || "[file].map[query]"
       .into());
-    let hash_function = d!(self.hash_function.take(), HashAlgorithm::Xxhash64);
+    let hash_function = d!(self.hash_function.take(), HashFunction::Xxhash64);
     let hash_digest = d!(self.hash_digest.take(), HashDigest::Hex);
     let hash_digest_length = d!(self.hash_digest_length.take(), 16);
     let hash_salt = d!(self.hash_salt.take(), HashSalt::None);

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -47,7 +47,7 @@ use rspack_core::{
   build_module_graph::BuildModuleGraphArtifact, parse_resource, rspack_sources::RawStringSource,
 };
 use rspack_error::Diagnostic;
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_hook::{Hook, Interceptor};
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
@@ -1497,7 +1497,7 @@ impl CompilationChunkHash for CompilationChunkHashTap {
     &self,
     compilation: &Compilation,
     chunk_ukey: &ChunkUkey,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
   ) -> rspack_error::Result<()> {
     let result = self
       .function
@@ -1783,7 +1783,7 @@ impl JavascriptModulesChunkHash for JavascriptModulesChunkHashTap {
     &self,
     compilation: &Compilation,
     chunk_ukey: &ChunkUkey,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
   ) -> rspack_error::Result<()> {
     let result = self
       .function

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -47,7 +47,7 @@ use rspack_core::{
   build_module_graph::BuildModuleGraphArtifact, parse_resource, rspack_sources::RawStringSource,
 };
 use rspack_error::Diagnostic;
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_hook::{Hook, Interceptor};
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
@@ -1497,7 +1497,7 @@ impl CompilationChunkHash for CompilationChunkHashTap {
     &self,
     compilation: &Compilation,
     chunk_ukey: &ChunkUkey,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
   ) -> rspack_error::Result<()> {
     let result = self
       .function
@@ -1783,7 +1783,7 @@ impl JavascriptModulesChunkHash for JavascriptModulesChunkHashTap {
     &self,
     compilation: &Compilation,
     chunk_ukey: &ChunkUkey,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
   ) -> rspack_error::Result<()> {
     let result = self
       .function

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
@@ -3,7 +3,7 @@ use std::{ptr::NonNull, sync::Arc};
 use futures::future::BoxFuture;
 use napi_derive::napi;
 use rspack_core::{CompilerId, Module};
-use rspack_hash::{HashAlgorithm, HashDigest};
+use rspack_hash::{HashDigest, HashFunction};
 use rspack_ids::{
   DeterministicModuleIdsPluginOptions, HashedModuleIdsPluginOptions, ModuleFilterFn,
   OccurrenceChunkIdsPluginOptions, SyncModuleIdsPluginMode, SyncModuleIdsPluginOptions,
@@ -43,7 +43,7 @@ impl From<RawHashedModuleIdsPluginOptions> for HashedModuleIdsPluginOptions {
       context: value.context,
       hash_function: value
         .hash_function
-        .map_or(defaults.hash_function, |s| HashAlgorithm::from(s.as_str())),
+        .map_or(defaults.hash_function, |s| HashFunction::from(s.as_str())),
       hash_digest: value
         .hash_digest
         .map_or(defaults.hash_digest, |s| HashDigest::from(s.as_str())),

--- a/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_builtins/raw_ids.rs
@@ -3,7 +3,7 @@ use std::{ptr::NonNull, sync::Arc};
 use futures::future::BoxFuture;
 use napi_derive::napi;
 use rspack_core::{CompilerId, Module};
-use rspack_hash::{HashDigest, HashFunction};
+use rspack_hash::{HashAlgorithm, HashDigest};
 use rspack_ids::{
   DeterministicModuleIdsPluginOptions, HashedModuleIdsPluginOptions, ModuleFilterFn,
   OccurrenceChunkIdsPluginOptions, SyncModuleIdsPluginMode, SyncModuleIdsPluginOptions,
@@ -43,7 +43,7 @@ impl From<RawHashedModuleIdsPluginOptions> for HashedModuleIdsPluginOptions {
       context: value.context,
       hash_function: value
         .hash_function
-        .map_or(defaults.hash_function, |s| HashFunction::from(s.as_str())),
+        .map_or(defaults.hash_function, |s| HashAlgorithm::from(s.as_str())),
       hash_digest: value
         .hash_digest
         .map_or(defaults.hash_digest, |s| HashDigest::from(s.as_str())),

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -6,7 +6,9 @@ use std::{
 
 use anymap::CloneAny;
 use rspack_collections::IdentifierMap;
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher};
+use rspack_hash::{
+  HashAlgorithm, HashDigest, HashSalt, RspackHash, RspackHashDigest, RspackHasher,
+};
 use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -159,7 +161,7 @@ impl CodeGenerationResult {
 
   pub fn set_hash(
     &mut self,
-    hash_function: &HashFunction,
+    hash_function: &HashAlgorithm,
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {
@@ -180,7 +182,7 @@ impl CodeGenerationResult {
   pub fn set_hash_for_concatenated_module(
     &mut self,
     runtime_hash: &RspackHashDigest,
-    hash_function: &HashFunction,
+    hash_function: &HashAlgorithm,
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -6,9 +6,7 @@ use std::{
 
 use anymap::CloneAny;
 use rspack_collections::IdentifierMap;
-use rspack_hash::{
-  HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest,
-};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher};
 use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -165,7 +163,7 @@ impl CodeGenerationResult {
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {
-    let mut hasher = HashAlgorithm::with_salt(hash_function, hash_salt);
+    let mut hasher = RspackHasher::with_salt(hash_function, hash_salt);
     for (source_type, source) in self.inner.as_ref() {
       source_type.hash(&mut hasher);
       std::hash::Hash::hash(source, &mut hasher);
@@ -186,7 +184,7 @@ impl CodeGenerationResult {
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {
-    let mut hasher = HashAlgorithm::with_salt(hash_function, hash_salt);
+    let mut hasher = RspackHasher::with_salt(hash_function, hash_salt);
     runtime_hash.hash(&mut hasher);
     for source_type in self.inner.as_ref().keys() {
       source_type.hash(&mut hasher);

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -7,7 +7,7 @@ use std::{
 use anymap::CloneAny;
 use rspack_collections::IdentifierMap;
 use rspack_hash::{
-  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHashable,
+  HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest,
 };
 use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
@@ -165,7 +165,7 @@ impl CodeGenerationResult {
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {
-    let mut hasher = RspackHash::with_salt(hash_function, hash_salt);
+    let mut hasher = HashAlgorithm::with_salt(hash_function, hash_salt);
     for (source_type, source) in self.inner.as_ref() {
       source_type.hash(&mut hasher);
       std::hash::Hash::hash(source, &mut hasher);
@@ -186,7 +186,7 @@ impl CodeGenerationResult {
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {
-    let mut hasher = RspackHash::with_salt(hash_function, hash_salt);
+    let mut hasher = HashAlgorithm::with_salt(hash_function, hash_salt);
     runtime_hash.hash(&mut hasher);
     for source_type in self.inner.as_ref().keys() {
       source_type.hash(&mut hasher);

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -6,9 +6,7 @@ use std::{
 
 use anymap::CloneAny;
 use rspack_collections::IdentifierMap;
-use rspack_hash::{
-  HashAlgorithm, HashDigest, HashSalt, RspackHash, RspackHashDigest, RspackHasher,
-};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher};
 use rspack_sources::BoxSource;
 use rspack_util::atom::Atom;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -161,7 +159,7 @@ impl CodeGenerationResult {
 
   pub fn set_hash(
     &mut self,
-    hash_function: &HashAlgorithm,
+    hash_function: &HashFunction,
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {
@@ -182,7 +180,7 @@ impl CodeGenerationResult {
   pub fn set_hash_for_concatenated_module(
     &mut self,
     runtime_hash: &RspackHashDigest,
-    hash_function: &HashAlgorithm,
+    hash_function: &HashFunction,
     hash_digest: &HashDigest,
     hash_salt: &HashSalt,
   ) {

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use rspack_collections::IdentifierSet;
 use rspack_error::Diagnostic;
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use ustr::Ustr;
@@ -734,7 +734,7 @@ impl Chunk {
     self.groups.clear();
   }
 
-  pub fn update_hash(&self, hasher: &mut RspackHash, compilation: &Compilation) {
+  pub fn update_hash(&self, hasher: &mut HashAlgorithm, compilation: &Compilation) {
     self.id().hash(hasher);
     let runtime_modules = compilation
       .build_chunk_graph_artifact

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use rspack_collections::IdentifierSet;
 use rspack_error::Diagnostic;
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_util::fx_hash::{FxIndexMap, FxIndexSet};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use ustr::Ustr;
@@ -734,7 +734,7 @@ impl Chunk {
     self.groups.clear();
   }
 
-  pub fn update_hash(&self, hasher: &mut HashAlgorithm, compilation: &Compilation) {
+  pub fn update_hash(&self, hasher: &mut RspackHasher, compilation: &Compilation) {
     self.id().hash(hasher);
     let runtime_modules = compilation
       .build_chunk_graph_artifact

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_collections::{IdentifierHasher, IdentifierLinkedMap, IdentifierMap, IdentifierSet};
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Serialize, Serializer};
@@ -78,8 +78,8 @@ impl ChunkId {
   }
 }
 
-impl rspack_hash::RspackHashable for ChunkId {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for ChunkId {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.0.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_collections::{IdentifierHasher, IdentifierLinkedMap, IdentifierMap, IdentifierSet};
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Serialize, Serializer};
@@ -79,7 +79,7 @@ impl ChunkId {
 }
 
 impl rspack_hash::RspackHash for ChunkId {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.0.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_collections::{IdentifierHasher, IdentifierSet};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_util::ext::DynHash;
 use rustc_hash::{FxHashSet, FxHasher};
 use serde::{Serialize, Serializer};
@@ -74,8 +74,8 @@ impl ModuleId {
   }
 }
 
-impl rspack_hash::RspackHashable for ModuleId {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for ModuleId {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_collections::{IdentifierHasher, IdentifierSet};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::ext::DynHash;
 use rustc_hash::{FxHashSet, FxHasher};
 use serde::{Serialize, Serializer};
@@ -75,7 +75,7 @@ impl ModuleId {
 }
 
 impl rspack_hash::RspackHash for ModuleId {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use rspack_cacheable::cacheable;
 use rspack_collections::IdentifierMap;
 use rspack_error::{Result, error};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 
@@ -443,7 +443,7 @@ impl EntryRuntime {
 }
 
 impl RspackHash for EntryRuntime {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       EntryRuntime::String(s) => s.hash(state),
       EntryRuntime::False => "false".hash(state),
@@ -571,7 +571,7 @@ pub enum GroupOptions {
 }
 
 impl RspackHash for GroupOptions {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       GroupOptions::Entrypoint(options) => {
         "entrypoint".hash(state);

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use rspack_cacheable::cacheable;
 use rspack_collections::IdentifierMap;
 use rspack_error::{Result, error};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 
@@ -442,8 +442,8 @@ impl EntryRuntime {
   }
 }
 
-impl RspackHashable for EntryRuntime {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for EntryRuntime {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       EntryRuntime::String(s) => s.hash(state),
       EntryRuntime::False => "false".hash(state),
@@ -462,7 +462,7 @@ impl Display for EntryRuntime {
 
 // pub type EntryRuntime = String;
 #[cacheable]
-#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, rspack_hash::RspackHashable)]
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, rspack_hash::RspackHash)]
 pub struct EntryOptions {
   pub name: Option<String>,
   pub runtime: Option<EntryRuntime>,
@@ -535,7 +535,7 @@ impl Display for ChunkGroupOrderKey {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHash)]
 pub struct ChunkGroupOptions {
   pub name: Option<String>,
   pub preload_order: Option<i32>,
@@ -570,8 +570,8 @@ pub enum GroupOptions {
   ChunkGroup(ChunkGroupOptions),
 }
 
-impl RspackHashable for GroupOptions {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for GroupOptions {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       GroupOptions::Entrypoint(options) => {
         "entrypoint".hash(state);

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rustc_hash::FxHashSet;
 
 use super::*;
@@ -129,7 +129,7 @@ pub async fn create_hash(
       .collect()
   };
 
-  let mut compilation_hasher = RspackHash::from(&compilation.options.output);
+  let mut compilation_hasher = HashAlgorithm::from(&compilation.options.output);
 
   fn try_process_chunk_hash_results(
     compilation: &mut Compilation,
@@ -433,7 +433,7 @@ pub async fn create_hash(
       let chunk_hash = chunk
         .hash(&compilation.chunk_hashes_artifact)
         .expect("should have chunk hash");
-      let mut hasher = RspackHash::from(&compilation.options.output);
+      let mut hasher = HashAlgorithm::from(&compilation.options.output);
       hasher.update(chunk_hash);
       hasher.update(
         compilation
@@ -450,7 +450,7 @@ pub async fn create_hash(
       content_hash
         .iter()
         .map(|(source_type, content_hash)| {
-          let mut hasher = RspackHash::from(&compilation.options.output);
+          let mut hasher = HashAlgorithm::from(&compilation.options.output);
           hasher.update(content_hash);
           hasher.update(
             compilation
@@ -530,7 +530,7 @@ async fn process_chunk_hash(
   chunk_ukey: ChunkUkey,
   plugin_driver: &SharedPluginDriver,
 ) -> Result<ChunkHashResult> {
-  let mut hasher = RspackHash::from(&compilation.options.output);
+  let mut hasher = HashAlgorithm::from(&compilation.options.output);
   if let Some(chunk) = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey
@@ -545,7 +545,7 @@ async fn process_chunk_hash(
     .await?;
   let chunk_hash = hasher.digest(&compilation.options.output.hash_digest);
 
-  let mut content_hashes: HashMap<SourceType, RspackHash> = HashMap::default();
+  let mut content_hashes: HashMap<SourceType, HashAlgorithm> = HashMap::default();
   plugin_driver
     .compilation_hooks
     .content_hash

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rustc_hash::FxHashSet;
 
 use super::*;
@@ -129,7 +129,7 @@ pub async fn create_hash(
       .collect()
   };
 
-  let mut compilation_hasher = HashAlgorithm::from(&compilation.options.output);
+  let mut compilation_hasher = RspackHasher::from(&compilation.options.output);
 
   fn try_process_chunk_hash_results(
     compilation: &mut Compilation,
@@ -433,7 +433,7 @@ pub async fn create_hash(
       let chunk_hash = chunk
         .hash(&compilation.chunk_hashes_artifact)
         .expect("should have chunk hash");
-      let mut hasher = HashAlgorithm::from(&compilation.options.output);
+      let mut hasher = RspackHasher::from(&compilation.options.output);
       hasher.update(chunk_hash);
       hasher.update(
         compilation
@@ -450,7 +450,7 @@ pub async fn create_hash(
       content_hash
         .iter()
         .map(|(source_type, content_hash)| {
-          let mut hasher = HashAlgorithm::from(&compilation.options.output);
+          let mut hasher = RspackHasher::from(&compilation.options.output);
           hasher.update(content_hash);
           hasher.update(
             compilation
@@ -530,7 +530,7 @@ async fn process_chunk_hash(
   chunk_ukey: ChunkUkey,
   plugin_driver: &SharedPluginDriver,
 ) -> Result<ChunkHashResult> {
-  let mut hasher = HashAlgorithm::from(&compilation.options.output);
+  let mut hasher = RspackHasher::from(&compilation.options.output);
   if let Some(chunk) = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey
@@ -545,7 +545,7 @@ async fn process_chunk_hash(
     .await?;
   let chunk_hash = hasher.digest(&compilation.options.output.hash_digest);
 
-  let mut content_hashes: HashMap<SourceType, HashAlgorithm> = HashMap::default();
+  let mut content_hashes: HashMap<SourceType, RspackHasher> = HashMap::default();
   plugin_driver
     .compilation_hooks
     .content_hash

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -48,7 +48,7 @@ use rspack_cacheable::{
 use rspack_collections::{Identifier, IdentifierDashMap, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
 use rspack_paths::{ArcPath, ArcPathIndexSet, ArcPathSet};
 use rspack_sources::BoxSource;
@@ -136,8 +136,8 @@ define_hook!(CompilationAdditionalTreeRuntimeRequirements: Series(compilation: &
 define_hook!(CompilationRuntimeRequirementInTree: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals, runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>));
 define_hook!(CompilationOptimizeCodeGeneration: Series(compilation: &Compilation, build_module_graph_artifact: &mut BuildModuleGraphArtifact, exports_info_artifact: &mut ExportsInfoArtifact, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationAfterCodeGeneration: Series(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>));
-define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut HashAlgorithm),tracing=false);
-define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, HashAlgorithm>));
+define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHasher),tracing=false);
+define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, RspackHasher>));
 define_hook!(CompilationDependentFullHash: Sync(compilation: &Compilation, chunk_ukey: &ChunkUkey, dependent_full_hash: &mut bool));
 define_hook!(CompilationRenderManifest: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, manifest: &mut Vec<RenderManifestEntry>, diagnostics: &mut Vec<Diagnostic>),tracing=false);
 define_hook!(CompilationChunkAsset: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, filename: &str));

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -48,7 +48,7 @@ use rspack_cacheable::{
 use rspack_collections::{Identifier, IdentifierDashMap, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_hook::define_hook;
 use rspack_paths::{ArcPath, ArcPathIndexSet, ArcPathSet};
 use rspack_sources::BoxSource;
@@ -136,8 +136,8 @@ define_hook!(CompilationAdditionalTreeRuntimeRequirements: Series(compilation: &
 define_hook!(CompilationRuntimeRequirementInTree: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, all_runtime_requirements: &RuntimeGlobals, runtime_requirements: &RuntimeGlobals, runtime_requirements_mut: &mut RuntimeGlobals, runtime_modules_to_add: &mut Vec<(ChunkUkey, Box<dyn RuntimeModule>)>));
 define_hook!(CompilationOptimizeCodeGeneration: Series(compilation: &Compilation, build_module_graph_artifact: &mut BuildModuleGraphArtifact, exports_info_artifact: &mut ExportsInfoArtifact, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationAfterCodeGeneration: Series(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>));
-define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash),tracing=false);
-define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, RspackHash>));
+define_hook!(CompilationChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut HashAlgorithm),tracing=false);
+define_hook!(CompilationContentHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hashes: &mut HashMap<SourceType, HashAlgorithm>));
 define_hook!(CompilationDependentFullHash: Sync(compilation: &Compilation, chunk_ukey: &ChunkUkey, dependent_full_hash: &mut bool));
 define_hook!(CompilationRenderManifest: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, manifest: &mut Vec<RenderManifestEntry>, diagnostics: &mut Vec<Diagnostic>),tracing=false);
 define_hook!(CompilationChunkAsset: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, filename: &str));

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -13,7 +13,7 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashAlgorithm, HashDigest, RspackHash, RspackHashDigest, RspackHasher};
+use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
@@ -656,7 +656,7 @@ impl ConcatenatedModule {
   pub fn create(
     mut root_module_ctxt: RootModuleContext,
     mut modules: Vec<ConcatenatedInnerModule>,
-    hash_function: Option<HashAlgorithm>,
+    hash_function: Option<HashFunction>,
     runtime: Option<RuntimeSpec>,
     compilation: &Compilation,
   ) -> Self {
@@ -694,13 +694,13 @@ impl ConcatenatedModule {
   fn create_identifier(
     root_module_ctxt: &RootModuleContext,
     modules: &Vec<ConcatenatedInnerModule>,
-    hash_function: Option<HashAlgorithm>,
+    hash_function: Option<HashFunction>,
   ) -> String {
     let mut identifiers = vec![];
     for m in modules {
       identifiers.push(m.shorten_id.as_str());
     }
-    let mut hash = RspackHasher::new(&hash_function.unwrap_or(HashAlgorithm::MD4));
+    let mut hash = RspackHasher::new(&hash_function.unwrap_or(HashFunction::MD4));
     if let Some(id) = identifiers.first() {
       hash.write(id.as_bytes());
     }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -13,7 +13,7 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest, RspackHasher};
+use rspack_hash::{HashAlgorithm, HashDigest, RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
@@ -656,7 +656,7 @@ impl ConcatenatedModule {
   pub fn create(
     mut root_module_ctxt: RootModuleContext,
     mut modules: Vec<ConcatenatedInnerModule>,
-    hash_function: Option<HashFunction>,
+    hash_function: Option<HashAlgorithm>,
     runtime: Option<RuntimeSpec>,
     compilation: &Compilation,
   ) -> Self {
@@ -694,13 +694,13 @@ impl ConcatenatedModule {
   fn create_identifier(
     root_module_ctxt: &RootModuleContext,
     modules: &Vec<ConcatenatedInnerModule>,
-    hash_function: Option<HashFunction>,
+    hash_function: Option<HashAlgorithm>,
   ) -> String {
     let mut identifiers = vec![];
     for m in modules {
       identifiers.push(m.shorten_id.as_str());
     }
-    let mut hash = RspackHasher::new(&hash_function.unwrap_or(HashFunction::MD4));
+    let mut hash = RspackHasher::new(&hash_function.unwrap_or(HashAlgorithm::MD4));
     if let Some(id) = identifiers.first() {
       hash.write(id.as_bytes());
     }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -13,7 +13,7 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, RspackHash, RspackHashDigest};
+use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
@@ -700,7 +700,7 @@ impl ConcatenatedModule {
     for m in modules {
       identifiers.push(m.shorten_id.as_str());
     }
-    let mut hash = HashAlgorithm::new(&hash_function.unwrap_or(HashFunction::MD4));
+    let mut hash = RspackHasher::new(&hash_function.unwrap_or(HashFunction::MD4));
     if let Some(id) = identifiers.first() {
       hash.write(id.as_bytes());
     }
@@ -2039,7 +2039,7 @@ impl Module for ConcatenatedModule {
     compilation: &Compilation,
     generation_runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     let runtime = if let Some(self_runtime) = &self.runtime
       && let Some(generation_runtime) = generation_runtime
     {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -13,7 +13,7 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
 use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt,
@@ -700,7 +700,7 @@ impl ConcatenatedModule {
     for m in modules {
       identifiers.push(m.shorten_id.as_str());
     }
-    let mut hash = RspackHash::new(&hash_function.unwrap_or(HashFunction::MD4));
+    let mut hash = HashAlgorithm::new(&hash_function.unwrap_or(HashFunction::MD4));
     if let Some(id) = identifiers.first() {
       hash.write(id.as_bytes());
     }
@@ -2039,7 +2039,7 @@ impl Module for ConcatenatedModule {
     compilation: &Compilation,
     generation_runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     let runtime = if let Some(self_runtime) = &self.runtime
       && let Some(generation_runtime) = generation_runtime
     {

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -12,7 +12,7 @@ use rspack_cacheable::{
 };
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_macros::impl_source_map_config;
 use rspack_paths::{ArcPathSet, Utf8PathBuf};
 use rspack_regex::RspackRegex;
@@ -1538,7 +1538,7 @@ impl Module for ContextModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -12,7 +12,7 @@ use rspack_cacheable::{
 };
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
 use rspack_paths::{ArcPathSet, Utf8PathBuf};
 use rspack_regex::RspackRegex;
@@ -1538,7 +1538,7 @@ impl Module for ContextModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write as _, hash::BuildHasherDefault};
 
 use rspack_cacheable::cacheable;
 use rspack_collections::{Identifier, IdentifierHasher};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 use crate::{
   BoxDependency, Compilation, DependencyId, DependencyLocation, GroupOptions, ModuleIdentifier,
@@ -32,7 +32,7 @@ pub type AsyncDependenciesBlockIdentifierSet =
 pub fn dependencies_block_update_hash(
   deps: &[DependencyId],
   blocks: &[AsyncDependenciesBlockIdentifier],
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {
@@ -54,7 +54,7 @@ pub fn dependencies_block_update_hash(
 pub struct AsyncDependenciesBlockIdentifier(Identifier);
 
 impl rspack_hash::RspackHash for AsyncDependenciesBlockIdentifier {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.0.as_str().hash(state);
   }
 }
@@ -187,7 +187,7 @@ impl AsyncDependenciesBlock {
 
   pub fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write as _, hash::BuildHasherDefault};
 
 use rspack_cacheable::cacheable;
 use rspack_collections::{Identifier, IdentifierHasher};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 use crate::{
   BoxDependency, Compilation, DependencyId, DependencyLocation, GroupOptions, ModuleIdentifier,
@@ -32,7 +32,7 @@ pub type AsyncDependenciesBlockIdentifierSet =
 pub fn dependencies_block_update_hash(
   deps: &[DependencyId],
   blocks: &[AsyncDependenciesBlockIdentifier],
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {
@@ -53,8 +53,8 @@ pub fn dependencies_block_update_hash(
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AsyncDependenciesBlockIdentifier(Identifier);
 
-impl rspack_hash::RspackHashable for AsyncDependenciesBlockIdentifier {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for AsyncDependenciesBlockIdentifier {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.0.as_str().hash(state);
   }
 }
@@ -187,7 +187,7 @@ impl AsyncDependenciesBlock {
 
   pub fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 use super::DependencyRange;
 use crate::{
@@ -23,7 +23,7 @@ impl CachedConstDependencyPlace {
 }
 
 impl RspackHash for CachedConstDependencyPlace {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.order().hash(state);
   }
 }
@@ -76,7 +76,7 @@ impl CachedConstDependency {
 }
 
 impl RspackHash for CachedConstDependency {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.place.hash(state);
     self.identifier.hash(state);
     match self.range {
@@ -95,7 +95,7 @@ impl DependencyCodeGeneration for CachedConstDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 use super::DependencyRange;
 use crate::{
@@ -22,8 +22,8 @@ impl CachedConstDependencyPlace {
   }
 }
 
-impl RspackHashable for CachedConstDependencyPlace {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for CachedConstDependencyPlace {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.order().hash(state);
   }
 }
@@ -75,8 +75,8 @@ impl CachedConstDependency {
   }
 }
 
-impl RspackHashable for CachedConstDependency {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for CachedConstDependency {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.place.hash(state);
     self.identifier.hash(state);
     match self.range {
@@ -95,11 +95,11 @@ impl DependencyCodeGeneration for CachedConstDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsRefStr};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 use super::DependencyRange;
 use crate::{
@@ -22,7 +22,7 @@ impl ConstDependency {
 }
 
 impl RspackHash for ConstDependency {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.range.hash(state);
     state.write(b"|");
     self.content.hash(state);
@@ -37,7 +37,7 @@ impl DependencyCodeGeneration for ConstDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsRefStr};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 use super::DependencyRange;
 use crate::{
@@ -21,8 +21,8 @@ impl ConstDependency {
   }
 }
 
-impl RspackHashable for ConstDependency {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ConstDependency {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.range.hash(state);
     state.write(b"|");
     self.content.hash(state);
@@ -37,11 +37,11 @@ impl DependencyCodeGeneration for ConstDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_core/src/dependency/dependency_location.rs
+++ b/crates/rspack_core/src/dependency/dependency_location.rs
@@ -6,7 +6,7 @@ use rspack_util::SpanExt;
 /// Represents a range in a dependency, typically used for tracking the span of code in a source file.
 /// It stores the start and end positions (as offsets) of the range, typically using base-0 indexing.
 #[cacheable]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Default, rspack_hash::RspackHash)]
 pub struct DependencyRange {
   pub start: u32,
   pub end: u32,

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use dyn_clone::{DynClone, clone_trait_object};
 use rspack_cacheable::cacheable_dyn;
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_sources::ReplaceSource;
 use rspack_util::ext::AsAny;
 
@@ -48,7 +48,7 @@ clone_trait_object!(DependencyCodeGeneration);
 pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
   fn update_hash(
     &self,
-    _hasher: &mut HashAlgorithm,
+    _hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use dyn_clone::{DynClone, clone_trait_object};
 use rspack_cacheable::cacheable_dyn;
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_sources::ReplaceSource;
 use rspack_util::ext::AsAny;
 
@@ -48,7 +48,7 @@ clone_trait_object!(DependencyCodeGeneration);
 pub trait DependencyCodeGeneration: Debug + DynClone + Sync + Send + AsAny {
   fn update_hash(
     &self,
-    _hasher: &mut RspackHash,
+    _hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 use crate::{
   Compilation, DependencyCodeGeneration, DependencyRange, DependencyTemplate,
@@ -21,7 +21,7 @@ pub enum RuntimeRequirementsDependencyMode {
 }
 
 impl RspackHash for RuntimeRequirementsDependencyMode {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -56,7 +56,7 @@ pub struct RuntimeRequirementsDependency {
 }
 
 impl RspackHash for RuntimeRequirementsDependency {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     "runtime_requirements".hash(state);
     self.runtime_requirements.hash(state);
     match self.mode {
@@ -94,7 +94,7 @@ impl DependencyCodeGeneration for RuntimeRequirementsDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 use crate::{
   Compilation, DependencyCodeGeneration, DependencyRange, DependencyTemplate,
@@ -20,8 +20,8 @@ pub enum RuntimeRequirementsDependencyMode {
   UnsupportedRequireProperty,
 }
 
-impl RspackHashable for RuntimeRequirementsDependencyMode {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for RuntimeRequirementsDependencyMode {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -55,8 +55,8 @@ pub struct RuntimeRequirementsDependency {
   pub mode: RuntimeRequirementsDependencyMode,
 }
 
-impl RspackHashable for RuntimeRequirementsDependency {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for RuntimeRequirementsDependency {
+  fn hash(&self, state: &mut HashAlgorithm) {
     "runtime_requirements".hash(state);
     self.runtime_requirements.hash(state);
     match self.mode {
@@ -94,11 +94,11 @@ impl DependencyCodeGeneration for RuntimeRequirementsDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -9,7 +9,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsPreset, AsVec},
 };
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_util::{atom::Atom, json_stringify, ryu_js};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -65,8 +65,8 @@ impl std::hash::Hash for EvaluatedInlinableValue {
   }
 }
 
-impl rspack_hash::RspackHashable for EvaluatedInlinableValue {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for EvaluatedInlinableValue {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.render("").hash(state);
   }
 }
@@ -126,8 +126,8 @@ pub enum UsedNameItem {
   Inlined(EvaluatedInlinableValue),
 }
 
-impl rspack_hash::RspackHashable for UsedNameItem {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for UsedNameItem {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       UsedNameItem::Str(value) => value.hash(state),
       UsedNameItem::Inlined(value) => value.hash(state),
@@ -135,7 +135,7 @@ impl rspack_hash::RspackHashable for UsedNameItem {
   }
 }
 
-#[derive(Debug, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, rspack_hash::RspackHash)]
 pub struct InlinedUsedName {
   value: EvaluatedInlinableValue,
   suffix: Vec<Atom>,
@@ -189,8 +189,8 @@ pub enum ExportProvided {
   Unknown,
 }
 
-impl rspack_hash::RspackHashable for ExportProvided {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for ExportProvided {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -230,8 +230,8 @@ pub enum UsageState {
   Used = 4,
 }
 
-impl rspack_hash::RspackHashable for UsageState {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for UsageState {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/exports/utils.rs
+++ b/crates/rspack_core/src/exports/utils.rs
@@ -9,7 +9,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsPreset, AsVec},
 };
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_util::{atom::Atom, json_stringify, ryu_js};
 use rustc_hash::FxHashSet as HashSet;
 
@@ -66,7 +66,7 @@ impl std::hash::Hash for EvaluatedInlinableValue {
 }
 
 impl rspack_hash::RspackHash for EvaluatedInlinableValue {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.render("").hash(state);
   }
 }
@@ -127,7 +127,7 @@ pub enum UsedNameItem {
 }
 
 impl rspack_hash::RspackHash for UsedNameItem {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       UsedNameItem::Str(value) => value.hash(state),
       UsedNameItem::Inlined(value) => value.hash(state),
@@ -190,7 +190,7 @@ pub enum ExportProvided {
 }
 
 impl rspack_hash::RspackHash for ExportProvided {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -231,7 +231,7 @@ pub enum UsageState {
 }
 
 impl rspack_hash::RspackHash for UsageState {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, iter};
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
 use rspack_util::{json_stringify_str, source_map::SourceMapKind};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -719,8 +719,8 @@ impl ExternalModule {
           let id: Cow<'_, str> = if to_identifier(&request.primary) != request.primary
             || self.dependency_meta.attributes.is_some()
           {
-            let mut hasher = RspackHash::from(&compilation.options.output);
-            use rspack_hash::RspackHashable as _;
+            let mut hasher = HashAlgorithm::from(&compilation.options.output);
+            use rspack_hash::RspackHash as _;
             request.primary.hash(&mut hasher);
             if let Some(attributes) = &self.dependency_meta.attributes {
               simd_json::to_string(attributes)
@@ -1247,8 +1247,8 @@ impl Module for ExternalModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
-    use rspack_hash::RspackHashable as _;
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    use rspack_hash::RspackHash as _;
     self.id.as_str().hash(&mut hasher);
     let side_effects_state_artifact = &compilation
       .build_module_graph_artifact

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, iter};
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_macros::impl_source_map_config;
 use rspack_util::{json_stringify_str, source_map::SourceMapKind};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet};
@@ -719,7 +719,7 @@ impl ExternalModule {
           let id: Cow<'_, str> = if to_identifier(&request.primary) != request.primary
             || self.dependency_meta.attributes.is_some()
           {
-            let mut hasher = HashAlgorithm::from(&compilation.options.output);
+            let mut hasher = RspackHasher::from(&compilation.options.output);
             use rspack_hash::RspackHash as _;
             request.primary.hash(&mut hasher);
             if let Some(attributes) = &self.dependency_meta.attributes {
@@ -1247,7 +1247,7 @@ impl Module for ExternalModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     use rspack_hash::RspackHash as _;
     self.id.as_str().hash(&mut hasher);
     let side_effects_state_artifact = &compilation

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -9,7 +9,7 @@ use dyn_clone::{DynClone, clone_trait_object};
 use hashlink::LinkedHashSet;
 use indexmap::IndexMap;
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt};
 use rspack_util::ext::IntoAny;
 use rustc_hash::FxHasher;
@@ -53,7 +53,7 @@ impl InitFragmentKey {
 }
 
 impl RspackHash for InitFragmentKey {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       InitFragmentKey::Unique(id) => {
         "unique".hash(state);
@@ -255,7 +255,7 @@ pub enum InitFragmentStage {
 }
 
 impl RspackHash for InitFragmentStage {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -428,7 +428,7 @@ pub enum ESMExportBinding {
 }
 
 impl RspackHash for ESMExportBinding {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       ESMExportBinding::Getter(value) => {
         "getter".hash(state);
@@ -571,7 +571,7 @@ impl AwaitDependenciesInitFragment {
 }
 
 impl RspackHash for AwaitDependenciesInitFragment {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     for promise in &self.promises {
       promise.hash(state);
     }

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -9,7 +9,7 @@ use dyn_clone::{DynClone, clone_trait_object};
 use hashlink::LinkedHashSet;
 use indexmap::IndexMap;
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_sources::{BoxSource, ConcatSource, RawStringSource, SourceExt};
 use rspack_util::ext::IntoAny;
 use rustc_hash::FxHasher;
@@ -52,8 +52,8 @@ impl InitFragmentKey {
   }
 }
 
-impl RspackHashable for InitFragmentKey {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for InitFragmentKey {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       InitFragmentKey::Unique(id) => {
         "unique".hash(state);
@@ -215,7 +215,7 @@ pub trait InitFragmentRenderContext {
   fn runtime_template(&mut self) -> &mut ModuleCodeTemplate;
 }
 
-pub trait InitFragment<C>: IntoAny + RspackHashable + DynClone + Debug + Sync + Send {
+pub trait InitFragment<C>: IntoAny + RspackHash + DynClone + Debug + Sync + Send {
   /// getContent + getEndContent
   fn contents(self: Box<Self>, context: &mut C) -> Result<InitFragmentContents>;
 
@@ -254,8 +254,8 @@ pub enum InitFragmentStage {
   StageAsyncESMImports,
 }
 
-impl RspackHashable for InitFragmentStage {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for InitFragmentStage {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -362,7 +362,7 @@ impl InitFragmentRenderContext for ChunkRenderContext {
   }
 }
 
-#[derive(Debug, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, rspack_hash::RspackHash)]
 pub struct NormalInitFragment {
   content: String,
   stage: InitFragmentStage,
@@ -427,8 +427,8 @@ pub enum ESMExportBinding {
   Value(Atom),
 }
 
-impl RspackHashable for ESMExportBinding {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ESMExportBinding {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       ESMExportBinding::Getter(value) => {
         "getter".hash(state);
@@ -442,7 +442,7 @@ impl RspackHashable for ESMExportBinding {
   }
 }
 
-#[derive(Debug, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, rspack_hash::RspackHash)]
 pub struct ESMExportInitFragment {
   exports_argument: ExportsArgument,
   // TODO: should be a map
@@ -570,8 +570,8 @@ impl AwaitDependenciesInitFragment {
   }
 }
 
-impl RspackHashable for AwaitDependenciesInitFragment {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for AwaitDependenciesInitFragment {
+  fn hash(&self, state: &mut HashAlgorithm) {
     for promise in &self.promises {
       promise.hash(state);
     }
@@ -617,7 +617,7 @@ impl<C: InitFragmentRenderContext> InitFragment<C> for AwaitDependenciesInitFrag
   }
 }
 
-#[derive(Debug, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, rspack_hash::RspackHash)]
 pub struct ConditionalInitFragment {
   content: String,
   stage: InitFragmentStage,
@@ -733,7 +733,7 @@ fn wrap_in_condition(condition: &str, source: &str) -> String {
   )
 }
 
-#[derive(Debug, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, rspack_hash::RspackHash)]
 pub struct ExternalModuleInitFragment {
   imported_module: String,
   // webpack also supports `ImportSpecifiers` but not ever used.

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -107,7 +107,7 @@ pub use rspack_location::{
 pub mod concatenated_module;
 pub mod reserved_names;
 use rspack_cacheable::{cacheable, with::AsPreset};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 pub use rspack_loader_runner::{
   AdditionalData, BUILTIN_LOADER_PREFIX, ParseMeta, ResourceData, ResourceParsedData, Scheme,
   get_scheme, parse_resource,
@@ -145,7 +145,7 @@ impl std::fmt::Display for SourceType {
 }
 
 impl RspackHash for SourceType {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -107,7 +107,7 @@ pub use rspack_location::{
 pub mod concatenated_module;
 pub mod reserved_names;
 use rspack_cacheable::{cacheable, with::AsPreset};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 pub use rspack_loader_runner::{
   AdditionalData, BUILTIN_LOADER_PREFIX, ParseMeta, ResourceData, ResourceParsedData, Scheme,
   get_scheme, parse_resource,
@@ -144,8 +144,8 @@ impl std::fmt::Display for SourceType {
   }
 }
 
-impl RspackHashable for SourceType {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for SourceType {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -14,7 +14,7 @@ use rspack_cacheable::{
 use rspack_collections::{Identifiable, Identifier, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Result};
 use rspack_fs::ReadableFileSystem;
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest, write_u64_hex};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher, write_u64_hex};
 use rspack_paths::ArcPathSet;
 use rspack_sources::BoxSource;
 use rspack_util::{
@@ -600,7 +600,7 @@ impl BuildMeta {
 }
 
 impl RspackHash for BuildMetaExportsType {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     if matches!(self, BuildMetaExportsType::Unset) {
       return;
     }
@@ -609,25 +609,25 @@ impl RspackHash for BuildMetaExportsType {
 }
 
 impl RspackHash for ExportsType {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for BuildMetaDefaultObject {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for ModuleArgument {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for ExportsArgument {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -945,7 +945,7 @@ fn get_exports_type_impl(
 
 pub fn module_update_hash(
   module: &dyn Module,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -14,7 +14,7 @@ use rspack_cacheable::{
 use rspack_collections::{Identifiable, Identifier, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Result};
 use rspack_fs::ReadableFileSystem;
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable, write_u64_hex};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest, write_u64_hex};
 use rspack_paths::ArcPathSet;
 use rspack_sources::BoxSource;
 use rspack_util::{
@@ -498,7 +498,7 @@ impl ExportsArgument {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone, Serialize, rspack_hash::RspackHashable)]
+#[derive(Debug, Default, Clone, Serialize, rspack_hash::RspackHash)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildMeta {
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -599,8 +599,8 @@ impl BuildMeta {
   }
 }
 
-impl RspackHashable for BuildMetaExportsType {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for BuildMetaExportsType {
+  fn hash(&self, state: &mut HashAlgorithm) {
     if matches!(self, BuildMetaExportsType::Unset) {
       return;
     }
@@ -608,26 +608,26 @@ impl RspackHashable for BuildMetaExportsType {
   }
 }
 
-impl RspackHashable for ExportsType {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ExportsType {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for BuildMetaDefaultObject {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for BuildMetaDefaultObject {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for ModuleArgument {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ModuleArgument {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for ExportsArgument {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ExportsArgument {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -945,7 +945,7 @@ fn get_exports_type_impl(
 
 pub fn module_update_hash(
   module: &dyn Module,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::cacheable;
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 
 use crate::{
   DependencyId, ExportsInfoArtifact, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
@@ -141,7 +141,7 @@ pub enum ConnectionState {
 }
 
 impl rspack_hash::RspackHash for ConnectionState {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       ConnectionState::Active(value) => {
         "active".hash(state);

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -1,5 +1,5 @@
 use rspack_cacheable::cacheable;
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 
 use crate::{
   DependencyId, ExportsInfoArtifact, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
@@ -140,8 +140,8 @@ pub enum ConnectionState {
   TransitiveOnly,
 }
 
-impl rspack_hash::RspackHashable for ConnectionState {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for ConnectionState {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       ConnectionState::Active(value) => {
         "active".hash(state);

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -14,7 +14,7 @@ use rspack_cacheable::{
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{AdditionalData, Content, LoaderContext, ResourceData, run_loaders};
 use rspack_sources::{
@@ -291,7 +291,7 @@ impl NormalModule {
     output_options: &OutputOptions,
     build_meta: &BuildMeta,
   ) -> RspackHashDigest {
-    let mut hasher = RspackHash::from(output_options);
+    let mut hasher = HashAlgorithm::from(output_options);
     "source".hash(&mut hasher);
     if let Some(error) = self.first_error() {
       error.message.hash(&mut hasher);
@@ -692,7 +692,7 @@ impl Module for NormalModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     self.build_info.hash.hash(&mut hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
     if self.source.is_some() {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -14,7 +14,7 @@ use rspack_cacheable::{
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{AdditionalData, Content, LoaderContext, ResourceData, run_loaders};
 use rspack_sources::{
@@ -291,7 +291,7 @@ impl NormalModule {
     output_options: &OutputOptions,
     build_meta: &BuildMeta,
   ) -> RspackHashDigest {
-    let mut hasher = HashAlgorithm::from(output_options);
+    let mut hasher = RspackHasher::from(output_options);
     "source".hash(&mut hasher);
     if let Some(error) = self.first_error() {
       error.message.hash(&mut hasher);
@@ -692,7 +692,7 @@ impl Module for NormalModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     self.build_info.hash.hash(&mut hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
     if self.source.is_some() {

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{
   with::{AsPreset, Unsupported},
 };
 use rspack_error::ToStringResultToRspackResultExt;
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_paths::Utf8PathBuf;
 use rspack_util::{MergeFrom, atom::Atom, base64, ext::CowExt};
 
@@ -82,8 +82,8 @@ impl Filename {
   }
 }
 
-impl rspack_hash::RspackHashable for Filename {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for Filename {
+  fn hash(&self, state: &mut HashAlgorithm) {
     if let FilenameKind::Template(template) = &self.0 {
       template.hash(state);
     }

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{
   with::{AsPreset, Unsupported},
 };
 use rspack_error::ToStringResultToRspackResultExt;
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_paths::Utf8PathBuf;
 use rspack_util::{MergeFrom, atom::Atom, base64, ext::CowExt};
 
@@ -83,7 +83,7 @@ impl Filename {
 }
 
 impl rspack_hash::RspackHash for Filename {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     if let FilenameKind::Template(template) = &self.0 {
       template.hash(state);
     }

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -10,7 +10,7 @@ use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_cacheable::{cacheable, with::Unsupported};
 use rspack_error::{Result, error};
-use rspack_hash::{HashAlgorithm, HashDigest, HashSalt, RspackHash, RspackHasher};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
@@ -950,7 +950,7 @@ pub struct CssModuleGeneratorOptions {
   pub exports_only: Option<bool>,
   pub local_ident_hash_digest: Option<HashDigest>,
   pub local_ident_hash_digest_length: Option<u32>,
-  pub local_ident_hash_function: Option<HashAlgorithm>,
+  pub local_ident_hash_function: Option<HashFunction>,
   pub local_ident_hash_salt: HashSalt,
   pub local_ident_name: Option<LocalIdentName>,
   pub es_module: Option<bool>,
@@ -962,7 +962,7 @@ impl CssModuleGeneratorOptions {
       exports_convention: Some(CssExportsConvention::default()),
       local_ident_hash_digest: Some(HashDigest::Base64Url),
       local_ident_hash_digest_length: Some(6),
-      local_ident_hash_function: Some(HashAlgorithm::Xxhash64),
+      local_ident_hash_function: Some(HashFunction::Xxhash64),
       local_ident_name: Some("[uniqueName]-[id]-[local]".into()),
       es_module: Some(true),
       ..Default::default()

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -10,7 +10,7 @@ use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_cacheable::{cacheable, with::Unsupported};
 use rspack_error::{Result, error};
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHash};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
@@ -142,8 +142,8 @@ impl fmt::Display for DynamicImportFetchPriority {
   }
 }
 
-impl RspackHashable for DynamicImportFetchPriority {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for DynamicImportFetchPriority {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -585,8 +585,8 @@ impl fmt::Display for CssExportType {
   }
 }
 
-impl RspackHashable for CssExportType {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for CssExportType {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -883,8 +883,8 @@ pub struct AssetGeneratorDataUrlOptions {
   pub mimetype: Option<String>,
 }
 
-impl RspackHashable for AssetGeneratorDataUrlOptions {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for AssetGeneratorDataUrlOptions {
+  fn hash(&self, state: &mut HashAlgorithm) {
     if let Some(encoding) = &self.encoding
       && !matches!(encoding, DataUrlEncoding::Base64)
     {
@@ -911,8 +911,8 @@ impl fmt::Display for DataUrlEncoding {
   }
 }
 
-impl RspackHashable for DataUrlEncoding {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for DataUrlEncoding {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -10,7 +10,7 @@ use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_cacheable::{cacheable, with::Unsupported};
 use rspack_error::{Result, error};
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHasher};
+use rspack_hash::{HashAlgorithm, HashDigest, HashSalt, RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
@@ -950,7 +950,7 @@ pub struct CssModuleGeneratorOptions {
   pub exports_only: Option<bool>,
   pub local_ident_hash_digest: Option<HashDigest>,
   pub local_ident_hash_digest_length: Option<u32>,
-  pub local_ident_hash_function: Option<HashFunction>,
+  pub local_ident_hash_function: Option<HashAlgorithm>,
   pub local_ident_hash_salt: HashSalt,
   pub local_ident_name: Option<LocalIdentName>,
   pub es_module: Option<bool>,
@@ -962,7 +962,7 @@ impl CssModuleGeneratorOptions {
       exports_convention: Some(CssExportsConvention::default()),
       local_ident_hash_digest: Some(HashDigest::Base64Url),
       local_ident_hash_digest_length: Some(6),
-      local_ident_hash_function: Some(HashFunction::Xxhash64),
+      local_ident_hash_function: Some(HashAlgorithm::Xxhash64),
       local_ident_name: Some("[uniqueName]-[id]-[local]".into()),
       es_module: Some(true),
       ..Default::default()

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -10,7 +10,7 @@ use derive_more::Debug;
 use futures::future::BoxFuture;
 use rspack_cacheable::{cacheable, with::Unsupported};
 use rspack_error::{Result, error};
-use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHash};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_regex::RspackRegex;
 use rspack_util::{MergeFrom, try_all, try_any};
@@ -143,7 +143,7 @@ impl fmt::Display for DynamicImportFetchPriority {
 }
 
 impl RspackHash for DynamicImportFetchPriority {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -586,7 +586,7 @@ impl fmt::Display for CssExportType {
 }
 
 impl RspackHash for CssExportType {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -884,7 +884,7 @@ pub struct AssetGeneratorDataUrlOptions {
 }
 
 impl RspackHash for AssetGeneratorDataUrlOptions {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     if let Some(encoding) = &self.encoding
       && !matches!(encoding, DataUrlEncoding::Base64)
     {
@@ -912,7 +912,7 @@ impl fmt::Display for DataUrlEncoding {
 }
 
 impl RspackHash for DataUrlEncoding {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -8,8 +8,8 @@ use std::{
 
 use regex::Regex;
 use rspack_cacheable::cacheable;
-use rspack_hash::{HashAlgorithm, RspackHash};
 pub use rspack_hash::{HashDigest, HashFunction, HashSalt};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
 #[cfg(allocative)]
@@ -71,7 +71,7 @@ pub struct OutputOptions {
   pub compare_before_emit: bool,
 }
 
-impl From<&OutputOptions> for HashAlgorithm {
+impl From<&OutputOptions> for RspackHasher {
   fn from(value: &OutputOptions) -> Self {
     Self::with_salt(&value.hash_function, &value.hash_salt)
   }
@@ -125,7 +125,7 @@ impl ChunkLoading {
 }
 
 impl RspackHash for ChunkLoading {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -174,7 +174,7 @@ impl ChunkLoadingType {
 }
 
 impl RspackHash for ChunkLoadingType {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -187,7 +187,7 @@ pub enum WasmLoading {
 }
 
 impl RspackHash for WasmLoading {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -225,7 +225,7 @@ pub enum WasmLoadingType {
 }
 
 impl RspackHash for WasmLoadingType {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
@@ -390,7 +390,7 @@ pub enum PublicPath {
 }
 
 impl RspackHash for PublicPath {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       PublicPath::Filename(filename) => filename.hash(state),
       PublicPath::Auto => "auto".hash(state),
@@ -570,7 +570,7 @@ pub enum LibraryName {
 }
 
 impl RspackHash for LibraryName {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       LibraryName::NonUmdObject(value) => value.hash(state),
       LibraryName::UmdObject(value) => value.hash(state),
@@ -586,7 +586,7 @@ pub enum LibraryNonUmdObject {
 }
 
 impl RspackHash for LibraryNonUmdObject {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       LibraryNonUmdObject::Array(value) => value.hash(state),
       LibraryNonUmdObject::String(value) => value.hash(state),

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -8,7 +8,7 @@ use std::{
 
 use regex::Regex;
 use rspack_cacheable::cacheable;
-pub use rspack_hash::{HashAlgorithm, HashDigest, HashSalt};
+pub use rspack_hash::{HashDigest, HashFunction, HashSalt};
 use rspack_hash::{RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
@@ -58,7 +58,7 @@ pub struct OutputOptions {
   pub module: bool,
   pub trusted_types: Option<TrustedTypes>,
   pub source_map_filename: Filename,
-  pub hash_function: HashAlgorithm,
+  pub hash_function: HashFunction,
   pub hash_digest: HashDigest,
   pub hash_digest_length: usize,
   pub hash_salt: HashSalt,

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -8,7 +8,7 @@ use std::{
 
 use regex::Regex;
 use rspack_cacheable::cacheable;
-pub use rspack_hash::{HashDigest, HashFunction, HashSalt};
+pub use rspack_hash::{HashAlgorithm, HashDigest, HashSalt};
 use rspack_hash::{RspackHash, RspackHasher};
 use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
@@ -58,7 +58,7 @@ pub struct OutputOptions {
   pub module: bool,
   pub trusted_types: Option<TrustedTypes>,
   pub source_map_filename: Filename,
-  pub hash_function: HashFunction,
+  pub hash_function: HashAlgorithm,
   pub hash_digest: HashDigest,
   pub hash_digest_length: usize,
   pub hash_salt: HashSalt,

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -8,8 +8,8 @@ use std::{
 
 use regex::Regex;
 use rspack_cacheable::cacheable;
+use rspack_hash::{HashAlgorithm, RspackHash};
 pub use rspack_hash::{HashDigest, HashFunction, HashSalt};
-use rspack_hash::{RspackHash, RspackHashable};
 use rspack_macros::MergeFrom;
 use rspack_paths::Utf8PathBuf;
 #[cfg(allocative)]
@@ -71,7 +71,7 @@ pub struct OutputOptions {
   pub compare_before_emit: bool,
 }
 
-impl From<&OutputOptions> for RspackHash {
+impl From<&OutputOptions> for HashAlgorithm {
   fn from(value: &OutputOptions) -> Self {
     Self::with_salt(&value.hash_function, &value.hash_salt)
   }
@@ -124,8 +124,8 @@ impl ChunkLoading {
   }
 }
 
-impl RspackHashable for ChunkLoading {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ChunkLoading {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -173,8 +173,8 @@ impl ChunkLoadingType {
   }
 }
 
-impl RspackHashable for ChunkLoadingType {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ChunkLoadingType {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -186,8 +186,8 @@ pub enum WasmLoading {
   Disable,
 }
 
-impl RspackHashable for WasmLoading {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for WasmLoading {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -224,8 +224,8 @@ pub enum WasmLoadingType {
   Universal,
 }
 
-impl RspackHashable for WasmLoadingType {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for WasmLoadingType {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
@@ -389,8 +389,8 @@ pub enum PublicPath {
   Auto,
 }
 
-impl RspackHashable for PublicPath {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for PublicPath {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       PublicPath::Filename(filename) => filename.hash(state),
       PublicPath::Auto => "auto".hash(state),
@@ -538,7 +538,7 @@ pub fn get_js_chunk_filename_template(
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHash)]
 pub struct LibraryOptions {
   pub name: Option<LibraryName>,
   pub export: Option<LibraryExport>,
@@ -554,7 +554,7 @@ pub type LibraryType = String;
 pub type LibraryExport = Vec<String>;
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHash)]
 pub struct LibraryAuxiliaryComment {
   pub root: Option<String>,
   pub commonjs: Option<String>,
@@ -569,8 +569,8 @@ pub enum LibraryName {
   UmdObject(LibraryCustomUmdObject),
 }
 
-impl RspackHashable for LibraryName {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for LibraryName {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       LibraryName::NonUmdObject(value) => value.hash(state),
       LibraryName::UmdObject(value) => value.hash(state),
@@ -585,8 +585,8 @@ pub enum LibraryNonUmdObject {
   String(String),
 }
 
-impl RspackHashable for LibraryNonUmdObject {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for LibraryNonUmdObject {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       LibraryNonUmdObject::Array(value) => value.hash(state),
       LibraryNonUmdObject::String(value) => value.hash(state),
@@ -595,7 +595,7 @@ impl RspackHashable for LibraryNonUmdObject {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, rspack_hash::RspackHash)]
 pub struct LibraryCustomUmdObject {
   pub amd: Option<String>,
   pub commonjs: Option<String>,

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -6,7 +6,7 @@ use rspack_cacheable::{
 };
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_macros::impl_source_map_config;
 use rspack_sources::{BoxSource, OriginalSource, RawStringSource, SourceExt};
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
@@ -148,7 +148,7 @@ impl Module for RawModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     self.source_str.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -6,7 +6,7 @@ use rspack_cacheable::{
 };
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_macros::impl_source_map_config;
 use rspack_sources::{BoxSource, OriginalSource, RawStringSource, SourceExt};
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
@@ -148,7 +148,7 @@ impl Module for RawModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     self.source_str.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsRefStr, AsVec},
 };
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 #[cfg(allocative)]
 use rspack_util::allocative;
 use rustc_hash::FxHashMap;
@@ -13,7 +13,7 @@ use ustr::{Ustr, UstrSet};
 use crate::{EntryOptions, EntryRuntime};
 
 #[cacheable]
-#[derive(Debug, Default, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Default, Clone, rspack_hash::RspackHash)]
 #[cfg_attr(allocative, derive(allocative::Allocative))]
 pub struct RuntimeSpec {
   #[cacheable(with=AsVec<AsRefStr>)]
@@ -199,8 +199,8 @@ pub enum RuntimeCondition {
   Spec(RuntimeSpec),
 }
 
-impl rspack_hash::RspackHashable for RuntimeCondition {
-  fn hash(&self, state: &mut RspackHash) {
+impl rspack_hash::RspackHash for RuntimeCondition {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       RuntimeCondition::Boolean(value) => value.hash(state),
       RuntimeCondition::Spec(spec) => spec.hash(state),

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::{
   cacheable,
   with::{AsRefStr, AsVec},
 };
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 #[cfg(allocative)]
 use rspack_util::allocative;
 use rustc_hash::FxHashMap;
@@ -200,7 +200,7 @@ pub enum RuntimeCondition {
 }
 
 impl rspack_hash::RspackHash for RuntimeCondition {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       RuntimeCondition::Boolean(value) => value.hash(state),
       RuntimeCondition::Spec(spec) => spec.hash(state),

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use bitflags::bitflags;
 use heck::ToLowerCamelCase;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rustc_hash::FxHashMap;
 
 use crate::{CompilerOptions, runtime_mode::RuntimeMode};
@@ -643,8 +643,8 @@ impl RuntimeGlobals {
   }
 }
 
-impl RspackHashable for RuntimeGlobals {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for RuntimeGlobals {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.bits().hash(state);
   }
 }

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use bitflags::bitflags;
 use heck::ToLowerCamelCase;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rustc_hash::FxHashMap;
 
 use crate::{CompilerOptions, runtime_mode::RuntimeMode};
@@ -644,7 +644,7 @@ impl RuntimeGlobals {
 }
 
 impl RspackHash for RuntimeGlobals {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.bits().hash(state);
   }
 }

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use rspack_cacheable::cacheable;
 use rspack_collections::Identifier;
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source, SourceExt};
 use rspack_util::source_map::SourceMapKind;
 use tokio::sync::OnceCell;
@@ -150,7 +150,7 @@ pub async fn runtime_module_get_runtime_hash(
   compilation: &Compilation,
   _runtime: Option<&RuntimeSpec>,
 ) -> Result<RspackHashDigest> {
-  let mut hasher = HashAlgorithm::from(&compilation.options.output);
+  let mut hasher = RspackHasher::from(&compilation.options.output);
   module.name().hash(&mut hasher);
   module.stage().hash(&mut hasher);
   if module.full_hash() || module.dependent_hash() {
@@ -259,7 +259,7 @@ impl From<RuntimeModuleStage> for u32 {
 }
 
 impl RspackHash for RuntimeModuleStage {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     let stage: u32 = self.clone().into();
     stage.hash(state);
   }

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use rspack_cacheable::cacheable;
 use rspack_collections::Identifier;
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source, SourceExt};
 use rspack_util::source_map::SourceMapKind;
 use tokio::sync::OnceCell;
@@ -150,7 +150,7 @@ pub async fn runtime_module_get_runtime_hash(
   compilation: &Compilation,
   _runtime: Option<&RuntimeSpec>,
 ) -> Result<RspackHashDigest> {
-  let mut hasher = RspackHash::from(&compilation.options.output);
+  let mut hasher = HashAlgorithm::from(&compilation.options.output);
   module.name().hash(&mut hasher);
   module.stage().hash(&mut hasher);
   if module.full_hash() || module.dependent_hash() {
@@ -159,7 +159,7 @@ pub async fn runtime_module_get_runtime_hash(
       compilation,
       runtime_template: &runtime_template,
     };
-    RspackHashable::hash(&module.generate_with_custom(&context).await?, &mut hasher);
+    RspackHash::hash(&module.generate_with_custom(&context).await?, &mut hasher);
   } else {
     use std::hash::Hash;
 
@@ -258,8 +258,8 @@ impl From<RuntimeModuleStage> for u32 {
   }
 }
 
-impl RspackHashable for RuntimeModuleStage {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for RuntimeModuleStage {
+  fn hash(&self, state: &mut HashAlgorithm) {
     let stage: u32 = self.clone().into();
     stage.hash(state);
   }

--- a/crates/rspack_hash/src/hashable/containers.rs
+++ b/crates/rspack_hash/src/hashable/containers.rs
@@ -3,35 +3,35 @@ use std::{
   sync::Arc,
 };
 
-use crate::{RspackHash, RspackHashable};
+use crate::{HashAlgorithm, RspackHash};
 
-impl<T: RspackHashable + ?Sized> RspackHashable for &T {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash + ?Sized> RspackHash for &T {
+  fn hash(&self, state: &mut HashAlgorithm) {
     (*self).hash(state);
   }
 }
 
-impl<T: RspackHashable + ?Sized> RspackHashable for Box<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash + ?Sized> RspackHash for Box<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     (**self).hash(state);
   }
 }
 
-impl<T: RspackHashable + ?Sized> RspackHashable for Arc<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash + ?Sized> RspackHash for Arc<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     (**self).hash(state);
   }
 }
 
-impl<T: RspackHashable> RspackHashable for Option<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash> RspackHash for Option<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     if let Some(value) = self {
       value.hash(state);
     }
   }
 }
 
-fn hash_iter<T: RspackHashable>(mut iter: impl Iterator<Item = T>, state: &mut RspackHash) {
+fn hash_iter<T: RspackHash>(mut iter: impl Iterator<Item = T>, state: &mut HashAlgorithm) {
   state.write(b"[");
   if let Some(item) = iter.next() {
     item.hash(state);
@@ -44,38 +44,38 @@ fn hash_iter<T: RspackHashable>(mut iter: impl Iterator<Item = T>, state: &mut R
   state.write(b"]");
 }
 
-impl<T: RspackHashable> RspackHashable for [T] {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash> RspackHash for [T] {
+  fn hash(&self, state: &mut HashAlgorithm) {
     hash_iter(self.iter(), state);
   }
 }
 
-impl<T: RspackHashable> RspackHashable for Vec<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash> RspackHash for Vec<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     hash_iter(self.iter(), state);
   }
 }
 
-impl<T: RspackHashable + Ord> RspackHashable for BTreeSet<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash + Ord> RspackHash for BTreeSet<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     hash_iter(self.iter(), state);
   }
 }
 
-impl<K: RspackHashable + Ord, V: RspackHashable> RspackHashable for BTreeMap<K, V> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<K: RspackHash + Ord, V: RspackHash> RspackHash for BTreeMap<K, V> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     hash_iter(self.iter(), state);
   }
 }
 
-impl<T: RspackHashable, const N: usize> RspackHashable for [T; N] {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash, const N: usize> RspackHash for [T; N] {
+  fn hash(&self, state: &mut HashAlgorithm) {
     hash_iter(self.iter(), state);
   }
 }
 
-impl<A: RspackHashable, B: RspackHashable> RspackHashable for (A, B) {
-  fn hash(&self, state: &mut RspackHash) {
+impl<A: RspackHash, B: RspackHash> RspackHash for (A, B) {
+  fn hash(&self, state: &mut HashAlgorithm) {
     state.write(b"(");
     self.0.hash(state);
     state.write(b",");

--- a/crates/rspack_hash/src/hashable/containers.rs
+++ b/crates/rspack_hash/src/hashable/containers.rs
@@ -3,35 +3,35 @@ use std::{
   sync::Arc,
 };
 
-use crate::{HashAlgorithm, RspackHash};
+use crate::{RspackHash, RspackHasher};
 
 impl<T: RspackHash + ?Sized> RspackHash for &T {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     (*self).hash(state);
   }
 }
 
 impl<T: RspackHash + ?Sized> RspackHash for Box<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     (**self).hash(state);
   }
 }
 
 impl<T: RspackHash + ?Sized> RspackHash for Arc<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     (**self).hash(state);
   }
 }
 
 impl<T: RspackHash> RspackHash for Option<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     if let Some(value) = self {
       value.hash(state);
     }
   }
 }
 
-fn hash_iter<T: RspackHash>(mut iter: impl Iterator<Item = T>, state: &mut HashAlgorithm) {
+fn hash_iter<T: RspackHash>(mut iter: impl Iterator<Item = T>, state: &mut RspackHasher) {
   state.write(b"[");
   if let Some(item) = iter.next() {
     item.hash(state);
@@ -45,37 +45,37 @@ fn hash_iter<T: RspackHash>(mut iter: impl Iterator<Item = T>, state: &mut HashA
 }
 
 impl<T: RspackHash> RspackHash for [T] {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     hash_iter(self.iter(), state);
   }
 }
 
 impl<T: RspackHash> RspackHash for Vec<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     hash_iter(self.iter(), state);
   }
 }
 
 impl<T: RspackHash + Ord> RspackHash for BTreeSet<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     hash_iter(self.iter(), state);
   }
 }
 
 impl<K: RspackHash + Ord, V: RspackHash> RspackHash for BTreeMap<K, V> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     hash_iter(self.iter(), state);
   }
 }
 
 impl<T: RspackHash, const N: usize> RspackHash for [T; N] {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     hash_iter(self.iter(), state);
   }
 }
 
 impl<A: RspackHash, B: RspackHash> RspackHash for (A, B) {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     state.write(b"(");
     self.0.hash(state);
     state.write(b",");

--- a/crates/rspack_hash/src/hashable/external.rs
+++ b/crates/rspack_hash/src/hashable/external.rs
@@ -1,10 +1,10 @@
 use lightningcss::targets::Browsers;
 use swc_config::types::{BoolOr, BoolOrDataConfig};
 
-use crate::{HashAlgorithm, RspackHash, hash_by_json};
+use crate::{RspackHash, RspackHasher, hash_by_json};
 
 impl<T: RspackHash> RspackHash for BoolOr<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       BoolOr::Bool(value) => {
         "bool".hash(state);
@@ -19,7 +19,7 @@ impl<T: RspackHash> RspackHash for BoolOr<T> {
 }
 
 impl<T: RspackHash> RspackHash for BoolOrDataConfig<T> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     if let Some(value) = self.inner() {
       value.hash(state);
     }
@@ -27,7 +27,7 @@ impl<T: RspackHash> RspackHash for BoolOrDataConfig<T> {
 }
 
 impl RspackHash for Browsers {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     hash_by_json(self, state);
   }
 }

--- a/crates/rspack_hash/src/hashable/external.rs
+++ b/crates/rspack_hash/src/hashable/external.rs
@@ -1,10 +1,10 @@
 use lightningcss::targets::Browsers;
 use swc_config::types::{BoolOr, BoolOrDataConfig};
 
-use crate::{RspackHash, RspackHashable, hash_by_json};
+use crate::{HashAlgorithm, RspackHash, hash_by_json};
 
-impl<T: RspackHashable> RspackHashable for BoolOr<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash> RspackHash for BoolOr<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       BoolOr::Bool(value) => {
         "bool".hash(state);
@@ -18,16 +18,16 @@ impl<T: RspackHashable> RspackHashable for BoolOr<T> {
   }
 }
 
-impl<T: RspackHashable> RspackHashable for BoolOrDataConfig<T> {
-  fn hash(&self, state: &mut RspackHash) {
+impl<T: RspackHash> RspackHash for BoolOrDataConfig<T> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     if let Some(value) = self.inner() {
       value.hash(state);
     }
   }
 }
 
-impl RspackHashable for Browsers {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for Browsers {
+  fn hash(&self, state: &mut HashAlgorithm) {
     hash_by_json(self, state);
   }
 }

--- a/crates/rspack_hash/src/hashable/primitives.rs
+++ b/crates/rspack_hash/src/hashable/primitives.rs
@@ -5,34 +5,34 @@ use std::{
 
 use smol_str::SmolStr;
 
-use crate::{RspackHash, RspackHashable};
+use crate::{HashAlgorithm, RspackHash};
 
-impl RspackHashable for str {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for str {
+  fn hash(&self, state: &mut HashAlgorithm) {
     state.write(self.as_bytes());
   }
 }
 
-impl RspackHashable for String {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for String {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for SmolStr {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for SmolStr {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for Cow<'_, str> {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for Cow<'_, str> {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_ref().hash(state);
   }
 }
 
-impl RspackHashable for bool {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for bool {
+  fn hash(&self, state: &mut HashAlgorithm) {
     state.write(if *self { b"true" } else { b"false" });
   }
 }
@@ -40,8 +40,8 @@ impl RspackHashable for bool {
 macro_rules! impl_content_hash_for_integer {
   ($($ty:ty),+ $(,)?) => {
     $(
-      impl RspackHashable for $ty {
-        fn hash(&self, state: &mut RspackHash) {
+      impl RspackHash for $ty {
+        fn hash(&self, state: &mut HashAlgorithm) {
           let mut buffer = itoa::Buffer::new();
           state.write(buffer.format(*self).as_bytes());
         }
@@ -54,14 +54,14 @@ impl_content_hash_for_integer!(
   u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
 );
 
-impl RspackHashable for Path {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for Path {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.to_string_lossy().hash(state);
   }
 }
 
-impl RspackHashable for PathBuf {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for PathBuf {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_path().hash(state);
   }
 }

--- a/crates/rspack_hash/src/hashable/primitives.rs
+++ b/crates/rspack_hash/src/hashable/primitives.rs
@@ -5,34 +5,34 @@ use std::{
 
 use smol_str::SmolStr;
 
-use crate::{HashAlgorithm, RspackHash};
+use crate::{RspackHash, RspackHasher};
 
 impl RspackHash for str {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     state.write(self.as_bytes());
   }
 }
 
 impl RspackHash for String {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for SmolStr {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for Cow<'_, str> {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_ref().hash(state);
   }
 }
 
 impl RspackHash for bool {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     state.write(if *self { b"true" } else { b"false" });
   }
 }
@@ -41,7 +41,7 @@ macro_rules! impl_content_hash_for_integer {
   ($($ty:ty),+ $(,)?) => {
     $(
       impl RspackHash for $ty {
-        fn hash(&self, state: &mut HashAlgorithm) {
+        fn hash(&self, state: &mut RspackHasher) {
           let mut buffer = itoa::Buffer::new();
           state.write(buffer.format(*self).as_bytes());
         }
@@ -55,13 +55,13 @@ impl_content_hash_for_integer!(
 );
 
 impl RspackHash for Path {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.to_string_lossy().hash(state);
   }
 }
 
 impl RspackHash for PathBuf {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_path().hash(state);
   }
 }

--- a/crates/rspack_hash/src/hashable/rspack.rs
+++ b/crates/rspack_hash/src/hashable/rspack.rs
@@ -4,22 +4,22 @@ use rspack_util::{
   atom::Atom,
 };
 
-use crate::{RspackHash, RspackHashable};
+use crate::{HashAlgorithm, RspackHash};
 
-impl RspackHashable for Atom {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for Atom {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for Identifier {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for Identifier {
+  fn hash(&self, state: &mut HashAlgorithm) {
     self.as_str().hash(state);
   }
 }
 
-impl RspackHashable for AssetCondition {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for AssetCondition {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       AssetCondition::String(value) => {
         "string".hash(state);
@@ -34,8 +34,8 @@ impl RspackHashable for AssetCondition {
   }
 }
 
-impl RspackHashable for AssetConditions {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for AssetConditions {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       AssetConditions::Single(value) => {
         "single".hash(state);

--- a/crates/rspack_hash/src/hashable/rspack.rs
+++ b/crates/rspack_hash/src/hashable/rspack.rs
@@ -4,22 +4,22 @@ use rspack_util::{
   atom::Atom,
 };
 
-use crate::{HashAlgorithm, RspackHash};
+use crate::{RspackHash, RspackHasher};
 
 impl RspackHash for Atom {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for Identifier {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
   }
 }
 
 impl RspackHash for AssetCondition {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       AssetCondition::String(value) => {
         "string".hash(state);
@@ -35,7 +35,7 @@ impl RspackHash for AssetCondition {
 }
 
 impl RspackHash for AssetConditions {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       AssetConditions::Single(value) => {
         "single".hash(state);

--- a/crates/rspack_hash/src/lib.rs
+++ b/crates/rspack_hash/src/lib.rs
@@ -201,9 +201,9 @@ macro_rules! rspack_hash_update {
 impl fmt::Debug for RspackHasher {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Self::Xxhash64(_) => write!(f, "RspackHash(Xxhash64)"),
-      Self::MD4(_) => write!(f, "RspackHash(MD4)"),
-      Self::SHA256(_) => write!(f, "RspackHash(SHA256"),
+      Self::Xxhash64(_) => write!(f, "RspackHasher(Xxhash64)"),
+      Self::MD4(_) => write!(f, "RspackHasher(MD4)"),
+      Self::SHA256(_) => write!(f, "RspackHasher(SHA256)"),
     }
   }
 }

--- a/crates/rspack_hash/src/lib.rs
+++ b/crates/rspack_hash/src/lib.rs
@@ -16,24 +16,24 @@ mod hashable;
 
 #[cacheable]
 #[derive(Debug, Clone, Copy)]
-pub enum HashFunction {
+pub enum HashAlgorithm {
   Xxhash64,
   MD4,
   SHA256,
 }
 
-impl From<&str> for HashFunction {
+impl From<&str> for HashAlgorithm {
   fn from(value: &str) -> Self {
     match value {
-      "xxhash64" => HashFunction::Xxhash64,
-      "md4" => HashFunction::MD4,
-      "sha256" => HashFunction::SHA256,
-      _ => panic!("Unsupported hash function: '{value}'. Expected one of: xxhash64, md4, sha256"),
+      "xxhash64" => HashAlgorithm::Xxhash64,
+      "md4" => HashAlgorithm::MD4,
+      "sha256" => HashAlgorithm::SHA256,
+      _ => panic!("Unsupported hash algorithm: '{value}'. Expected one of: xxhash64, md4, sha256"),
     }
   }
 }
 
-impl MergeFrom for HashFunction {
+impl MergeFrom for HashAlgorithm {
   fn merge_from(self, other: &Self) -> Self {
     *other
   }
@@ -209,15 +209,15 @@ impl fmt::Debug for RspackHasher {
 }
 
 impl RspackHasher {
-  pub fn new(function: &HashFunction) -> Self {
+  pub fn new(function: &HashAlgorithm) -> Self {
     match function {
-      HashFunction::Xxhash64 => Self::Xxhash64(Box::new(Xxh64::new(0))),
-      HashFunction::MD4 => Self::MD4(Box::new(md4::Md4::new())),
-      HashFunction::SHA256 => Self::SHA256(Box::new(sha2::Sha256::new())),
+      HashAlgorithm::Xxhash64 => Self::Xxhash64(Box::new(Xxh64::new(0))),
+      HashAlgorithm::MD4 => Self::MD4(Box::new(md4::Md4::new())),
+      HashAlgorithm::SHA256 => Self::SHA256(Box::new(sha2::Sha256::new())),
     }
   }
 
-  pub fn with_salt(function: &HashFunction, salt: &HashSalt) -> Self {
+  pub fn with_salt(function: &HashAlgorithm, salt: &HashSalt) -> Self {
     let mut this = Self::new(function);
     if let HashSalt::Salt(salt) = salt {
       this.write(salt.as_bytes());

--- a/crates/rspack_hash/src/lib.rs
+++ b/crates/rspack_hash/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use base64_simd::{AsOut, STANDARD, URL_SAFE_NO_PAD};
 use md4::Digest;
 use rspack_cacheable::{cacheable, with::AsPreset};
-pub use rspack_macros::RspackHashable;
+pub use rspack_macros::RspackHash;
 use rspack_util::MergeFrom;
 use smol_str::SmolStr;
 use xxhash_rust::xxh64::Xxh64;
@@ -112,24 +112,24 @@ impl MergeFrom for HashSalt {
 
 /// Hasher used for webpack-compatible content hashes.
 ///
-/// `RspackHash` is the stateful writer behind output hashes such as full hash,
+/// `HashAlgorithm` is the stateful writer behind output hashes such as full hash,
 /// chunk hash, content hash and module/runtime hashes that affect generated
 /// assets or persistent cache correctness. Inputs should be written through
-/// [`RspackHashable`] so the serialized form can follow webpack content-hash
+/// [`RspackHash`] so the serialized form can follow webpack content-hash
 /// semantics instead of Rust collection-key hashing semantics.
 #[derive(Clone)]
-pub enum RspackHash {
+pub enum HashAlgorithm {
   Xxhash64(Box<Xxh64>),
   MD4(Box<md4::Md4>),
   SHA256(Box<sha2::Sha256>),
 }
 
-/// Content-hash input contract for values that participate in `RspackHash`.
+/// Content-hash input contract for values that participate in `HashAlgorithm`.
 ///
 /// This trait is intentionally separate from [`std::hash::Hash`]. `Hash` is for
 /// hash-map/set keys and is free to optimize around Rust data-structure needs,
 /// including implementation details that may change with the standard library
-/// or with local keying requirements. `RspackHashable` is for stable,
+/// or with local keying requirements. `RspackHash` is for stable,
 /// webpack-aligned content hashing: implement it only for data that should
 /// affect emitted asset hashes, runtime/module hashes, or persistent cache
 /// content keys.
@@ -138,18 +138,18 @@ pub enum RspackHash {
 /// without changing content hash behavior, and lets content hashing encode the
 /// same logical inputs webpack uses rather than the shape of Rust data
 /// structures.
-pub trait RspackHashable {
-  fn hash(&self, state: &mut RspackHash);
+pub trait RspackHash {
+  fn hash(&self, state: &mut HashAlgorithm);
 }
 
 #[inline]
-pub fn hash_by_json<T: serde::Serialize>(value: &T, state: &mut RspackHash) {
+pub fn hash_by_json<T: serde::Serialize>(value: &T, state: &mut HashAlgorithm) {
   let json = simd_json::to_string(value).expect("should be able to serialize value for hash");
   state.write(json.as_bytes());
 }
 
 #[inline]
-pub fn write_u64_hex(value: u64, state: &mut RspackHash) {
+pub fn write_u64_hex(value: u64, state: &mut HashAlgorithm) {
   if value == 0 {
     state.write(b"0");
     return;
@@ -180,9 +180,9 @@ macro_rules! rspack_hash_object {
         $state.write(b",");
       }
       is_first_rspack_hash_field = false;
-      $crate::RspackHashable::hash($key, $state);
+      $crate::RspackHash::hash($key, $state);
       $state.write(b":");
-      $crate::RspackHashable::hash(&$value, $state);
+      $crate::RspackHash::hash(&$value, $state);
     )*
     let _ = is_first_rspack_hash_field;
     $state.write(b"}");
@@ -198,7 +198,7 @@ macro_rules! rspack_hash_update {
   };
 }
 
-impl fmt::Debug for RspackHash {
+impl fmt::Debug for HashAlgorithm {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Self::Xxhash64(_) => write!(f, "RspackHash(Xxhash64)"),
@@ -208,7 +208,7 @@ impl fmt::Debug for RspackHash {
   }
 }
 
-impl RspackHash {
+impl HashAlgorithm {
   pub fn new(function: &HashFunction) -> Self {
     match function {
       HashFunction::Xxhash64 => Self::Xxhash64(Box::new(Xxh64::new(0))),
@@ -227,37 +227,37 @@ impl RspackHash {
 
   pub fn digest(self, digest: &HashDigest) -> RspackHashDigest {
     match self {
-      RspackHash::Xxhash64(hasher) => {
+      HashAlgorithm::Xxhash64(hasher) => {
         let buf = hasher.finish().to_be_bytes();
         RspackHashDigest::new(&buf, digest)
       }
-      RspackHash::MD4(hash) => {
+      HashAlgorithm::MD4(hash) => {
         let buf = hash.finalize();
         RspackHashDigest::new(&buf, digest)
       }
-      RspackHash::SHA256(hash) => {
+      HashAlgorithm::SHA256(hash) => {
         let buf = hash.finalize();
         RspackHashDigest::new(&buf, digest)
       }
     }
   }
 
-  pub fn update<T: RspackHashable + ?Sized>(&mut self, value: &T) {
+  pub fn update<T: RspackHash + ?Sized>(&mut self, value: &T) {
     value.hash(self);
   }
 
   pub fn write(&mut self, bytes: &[u8]) {
     match self {
-      RspackHash::Xxhash64(hasher) => hasher.write(bytes),
-      RspackHash::MD4(hasher) => hasher.update(bytes),
-      RspackHash::SHA256(hasher) => hasher.update(bytes),
+      HashAlgorithm::Xxhash64(hasher) => hasher.write(bytes),
+      HashAlgorithm::MD4(hasher) => hasher.update(bytes),
+      HashAlgorithm::SHA256(hasher) => hasher.update(bytes),
     }
   }
 
   pub fn finish(&self) -> u64 {
     match self {
-      RspackHash::Xxhash64(hasher) => hasher.finish(),
-      RspackHash::MD4(hasher) => {
+      HashAlgorithm::Xxhash64(hasher) => hasher.finish(),
+      HashAlgorithm::MD4(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -265,7 +265,7 @@ impl RspackHash {
             .expect("md4 digest length is at least 8"),
         )
       }
-      RspackHash::SHA256(hasher) => {
+      HashAlgorithm::SHA256(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -277,11 +277,11 @@ impl RspackHash {
   }
 }
 
-impl Hasher for RspackHash {
+impl Hasher for HashAlgorithm {
   fn finish(&self) -> u64 {
     match self {
-      RspackHash::Xxhash64(hasher) => hasher.finish(),
-      RspackHash::MD4(hasher) => {
+      HashAlgorithm::Xxhash64(hasher) => hasher.finish(),
+      HashAlgorithm::MD4(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -289,7 +289,7 @@ impl Hasher for RspackHash {
             .expect("md4 digest length is at least 8"),
         )
       }
-      RspackHash::SHA256(hasher) => {
+      HashAlgorithm::SHA256(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -302,9 +302,9 @@ impl Hasher for RspackHash {
 
   fn write(&mut self, bytes: &[u8]) {
     match self {
-      RspackHash::Xxhash64(hasher) => hasher.write(bytes),
-      RspackHash::MD4(hasher) => hasher.update(bytes),
-      RspackHash::SHA256(hasher) => hasher.update(bytes),
+      HashAlgorithm::Xxhash64(hasher) => hasher.write(bytes),
+      HashAlgorithm::MD4(hasher) => hasher.update(bytes),
+      HashAlgorithm::SHA256(hasher) => hasher.update(bytes),
     }
   }
 }
@@ -366,9 +366,9 @@ impl RspackHashDigest {
   }
 }
 
-impl RspackHashable for RspackHashDigest {
-  fn hash(&self, state: &mut RspackHash) {
-    RspackHashable::hash(self.encoded.as_str(), state);
+impl RspackHash for RspackHashDigest {
+  fn hash(&self, state: &mut HashAlgorithm) {
+    RspackHash::hash(self.encoded.as_str(), state);
   }
 }
 

--- a/crates/rspack_hash/src/lib.rs
+++ b/crates/rspack_hash/src/lib.rs
@@ -112,19 +112,19 @@ impl MergeFrom for HashSalt {
 
 /// Hasher used for webpack-compatible content hashes.
 ///
-/// `HashAlgorithm` is the stateful writer behind output hashes such as full hash,
+/// `RspackHasher` is the stateful writer behind output hashes such as full hash,
 /// chunk hash, content hash and module/runtime hashes that affect generated
 /// assets or persistent cache correctness. Inputs should be written through
 /// [`RspackHash`] so the serialized form can follow webpack content-hash
 /// semantics instead of Rust collection-key hashing semantics.
 #[derive(Clone)]
-pub enum HashAlgorithm {
+pub enum RspackHasher {
   Xxhash64(Box<Xxh64>),
   MD4(Box<md4::Md4>),
   SHA256(Box<sha2::Sha256>),
 }
 
-/// Content-hash input contract for values that participate in `HashAlgorithm`.
+/// Content-hash input contract for values that participate in `RspackHasher`.
 ///
 /// This trait is intentionally separate from [`std::hash::Hash`]. `Hash` is for
 /// hash-map/set keys and is free to optimize around Rust data-structure needs,
@@ -139,17 +139,17 @@ pub enum HashAlgorithm {
 /// same logical inputs webpack uses rather than the shape of Rust data
 /// structures.
 pub trait RspackHash {
-  fn hash(&self, state: &mut HashAlgorithm);
+  fn hash(&self, state: &mut RspackHasher);
 }
 
 #[inline]
-pub fn hash_by_json<T: serde::Serialize>(value: &T, state: &mut HashAlgorithm) {
+pub fn hash_by_json<T: serde::Serialize>(value: &T, state: &mut RspackHasher) {
   let json = simd_json::to_string(value).expect("should be able to serialize value for hash");
   state.write(json.as_bytes());
 }
 
 #[inline]
-pub fn write_u64_hex(value: u64, state: &mut HashAlgorithm) {
+pub fn write_u64_hex(value: u64, state: &mut RspackHasher) {
   if value == 0 {
     state.write(b"0");
     return;
@@ -198,7 +198,7 @@ macro_rules! rspack_hash_update {
   };
 }
 
-impl fmt::Debug for HashAlgorithm {
+impl fmt::Debug for RspackHasher {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Self::Xxhash64(_) => write!(f, "RspackHash(Xxhash64)"),
@@ -208,7 +208,7 @@ impl fmt::Debug for HashAlgorithm {
   }
 }
 
-impl HashAlgorithm {
+impl RspackHasher {
   pub fn new(function: &HashFunction) -> Self {
     match function {
       HashFunction::Xxhash64 => Self::Xxhash64(Box::new(Xxh64::new(0))),
@@ -227,15 +227,15 @@ impl HashAlgorithm {
 
   pub fn digest(self, digest: &HashDigest) -> RspackHashDigest {
     match self {
-      HashAlgorithm::Xxhash64(hasher) => {
+      RspackHasher::Xxhash64(hasher) => {
         let buf = hasher.finish().to_be_bytes();
         RspackHashDigest::new(&buf, digest)
       }
-      HashAlgorithm::MD4(hash) => {
+      RspackHasher::MD4(hash) => {
         let buf = hash.finalize();
         RspackHashDigest::new(&buf, digest)
       }
-      HashAlgorithm::SHA256(hash) => {
+      RspackHasher::SHA256(hash) => {
         let buf = hash.finalize();
         RspackHashDigest::new(&buf, digest)
       }
@@ -248,16 +248,16 @@ impl HashAlgorithm {
 
   pub fn write(&mut self, bytes: &[u8]) {
     match self {
-      HashAlgorithm::Xxhash64(hasher) => hasher.write(bytes),
-      HashAlgorithm::MD4(hasher) => hasher.update(bytes),
-      HashAlgorithm::SHA256(hasher) => hasher.update(bytes),
+      RspackHasher::Xxhash64(hasher) => hasher.write(bytes),
+      RspackHasher::MD4(hasher) => hasher.update(bytes),
+      RspackHasher::SHA256(hasher) => hasher.update(bytes),
     }
   }
 
   pub fn finish(&self) -> u64 {
     match self {
-      HashAlgorithm::Xxhash64(hasher) => hasher.finish(),
-      HashAlgorithm::MD4(hasher) => {
+      RspackHasher::Xxhash64(hasher) => hasher.finish(),
+      RspackHasher::MD4(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -265,7 +265,7 @@ impl HashAlgorithm {
             .expect("md4 digest length is at least 8"),
         )
       }
-      HashAlgorithm::SHA256(hasher) => {
+      RspackHasher::SHA256(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -277,11 +277,11 @@ impl HashAlgorithm {
   }
 }
 
-impl Hasher for HashAlgorithm {
+impl Hasher for RspackHasher {
   fn finish(&self) -> u64 {
     match self {
-      HashAlgorithm::Xxhash64(hasher) => hasher.finish(),
-      HashAlgorithm::MD4(hasher) => {
+      RspackHasher::Xxhash64(hasher) => hasher.finish(),
+      RspackHasher::MD4(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -289,7 +289,7 @@ impl Hasher for HashAlgorithm {
             .expect("md4 digest length is at least 8"),
         )
       }
-      HashAlgorithm::SHA256(hasher) => {
+      RspackHasher::SHA256(hasher) => {
         let hash = (**hasher).clone().finalize();
         u64::from_be_bytes(
           hash[..8]
@@ -302,9 +302,9 @@ impl Hasher for HashAlgorithm {
 
   fn write(&mut self, bytes: &[u8]) {
     match self {
-      HashAlgorithm::Xxhash64(hasher) => hasher.write(bytes),
-      HashAlgorithm::MD4(hasher) => hasher.update(bytes),
-      HashAlgorithm::SHA256(hasher) => hasher.update(bytes),
+      RspackHasher::Xxhash64(hasher) => hasher.write(bytes),
+      RspackHasher::MD4(hasher) => hasher.update(bytes),
+      RspackHasher::SHA256(hasher) => hasher.update(bytes),
     }
   }
 }
@@ -367,7 +367,7 @@ impl RspackHashDigest {
 }
 
 impl RspackHash for RspackHashDigest {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     RspackHash::hash(self.encoded.as_str(), state);
   }
 }

--- a/crates/rspack_hash/src/lib.rs
+++ b/crates/rspack_hash/src/lib.rs
@@ -16,24 +16,24 @@ mod hashable;
 
 #[cacheable]
 #[derive(Debug, Clone, Copy)]
-pub enum HashAlgorithm {
+pub enum HashFunction {
   Xxhash64,
   MD4,
   SHA256,
 }
 
-impl From<&str> for HashAlgorithm {
+impl From<&str> for HashFunction {
   fn from(value: &str) -> Self {
     match value {
-      "xxhash64" => HashAlgorithm::Xxhash64,
-      "md4" => HashAlgorithm::MD4,
-      "sha256" => HashAlgorithm::SHA256,
-      _ => panic!("Unsupported hash algorithm: '{value}'. Expected one of: xxhash64, md4, sha256"),
+      "xxhash64" => HashFunction::Xxhash64,
+      "md4" => HashFunction::MD4,
+      "sha256" => HashFunction::SHA256,
+      _ => panic!("Unsupported hash function: '{value}'. Expected one of: xxhash64, md4, sha256"),
     }
   }
 }
 
-impl MergeFrom for HashAlgorithm {
+impl MergeFrom for HashFunction {
   fn merge_from(self, other: &Self) -> Self {
     *other
   }
@@ -209,15 +209,15 @@ impl fmt::Debug for RspackHasher {
 }
 
 impl RspackHasher {
-  pub fn new(function: &HashAlgorithm) -> Self {
+  pub fn new(function: &HashFunction) -> Self {
     match function {
-      HashAlgorithm::Xxhash64 => Self::Xxhash64(Box::new(Xxh64::new(0))),
-      HashAlgorithm::MD4 => Self::MD4(Box::new(md4::Md4::new())),
-      HashAlgorithm::SHA256 => Self::SHA256(Box::new(sha2::Sha256::new())),
+      HashFunction::Xxhash64 => Self::Xxhash64(Box::new(Xxh64::new(0))),
+      HashFunction::MD4 => Self::MD4(Box::new(md4::Md4::new())),
+      HashFunction::SHA256 => Self::SHA256(Box::new(sha2::Sha256::new())),
     }
   }
 
-  pub fn with_salt(function: &HashAlgorithm, salt: &HashSalt) -> Self {
+  pub fn with_salt(function: &HashFunction, salt: &HashSalt) -> Self {
     let mut this = Self::new(function);
     if let HashSalt::Salt(salt) = salt {
       this.write(salt.as_bytes());

--- a/crates/rspack_hash/tests/hash.rs
+++ b/crates/rspack_hash/tests/hash.rs
@@ -1,5 +1,5 @@
 use rspack_hash::{
-  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher, write_u64_hex,
+  HashAlgorithm, HashDigest, HashSalt, RspackHash, RspackHashDigest, RspackHasher, write_u64_hex,
 };
 
 #[test]
@@ -27,12 +27,12 @@ fn encodes_base64url_without_padding() {
 #[test]
 fn hash_salt_is_written_as_raw_bytes() {
   let salt = HashSalt::Salt("salt".into());
-  let salted = RspackHasher::with_salt(&HashFunction::Xxhash64, &salt)
+  let salted = RspackHasher::with_salt(&HashAlgorithm::Xxhash64, &salt)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(b"salt");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -48,11 +48,11 @@ fn writes_u64_hex_without_leading_zeroes() {
     (0x0abc, "abc"),
     (u64::MAX, "ffffffffffffffff"),
   ] {
-    let mut actual = RspackHasher::new(&HashFunction::Xxhash64);
+    let mut actual = RspackHasher::new(&HashAlgorithm::Xxhash64);
     write_u64_hex(value, &mut actual);
     let actual = actual.digest(&HashDigest::Hex).encoded().to_string();
 
-    let mut expected_hash = RspackHasher::new(&HashFunction::Xxhash64);
+    let mut expected_hash = RspackHasher::new(&HashAlgorithm::Xxhash64);
     expected_hash.write(expected.as_bytes());
     let expected = expected_hash.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -69,14 +69,14 @@ fn derive_rspack_hash_skips_marked_fields() {
     _cached: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
   derived.update(&Value {
     content: "payload",
     _cached: "cache",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -97,14 +97,14 @@ fn derive_rspack_hash_respects_explicit_field_order() {
     first: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
   derived.update(&Value {
     first: "a",
     second: "b",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(b"{");
   expected.write(b"first");
   expected.write(b":");
@@ -121,22 +121,22 @@ fn derive_rspack_hash_respects_explicit_field_order() {
 
 #[test]
 fn option_rspack_hash_skips_none() {
-  let mut none = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut none = RspackHasher::new(&HashAlgorithm::Xxhash64);
   none.update(&Option::<&str>::None);
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let empty = RspackHasher::new(&HashFunction::Xxhash64)
+  let empty = RspackHasher::new(&HashAlgorithm::Xxhash64)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
   assert_eq!(none, empty);
 
-  let mut some = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut some = RspackHasher::new(&HashAlgorithm::Xxhash64);
   some.update(&Some("value"));
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(b"value");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -151,11 +151,11 @@ fn derive_rspack_hash_can_hash_none_as_null() {
     value: Option<&'static str>,
   }
 
-  let mut none = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut none = RspackHasher::new(&HashAlgorithm::Xxhash64);
   none.update(&Value { value: None });
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_none = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected_none = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected_none.write(b"{");
   expected_none.write(b"value");
   expected_none.write(b":");
@@ -165,13 +165,13 @@ fn derive_rspack_hash_can_hash_none_as_null() {
 
   assert_eq!(none, expected_none);
 
-  let mut some = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut some = RspackHasher::new(&HashAlgorithm::Xxhash64);
   some.update(&Value {
     value: Some("present"),
   });
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_some = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected_some = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected_some.write(b"{");
   expected_some.write(b"value");
   expected_some.write(b":");
@@ -190,14 +190,14 @@ fn derive_rspack_hash_hashes_option_field_names() {
     commonjs: Option<&'static str>,
   }
 
-  let mut root = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut root = RspackHasher::new(&HashAlgorithm::Xxhash64);
   root.update(&Value {
     root: Some("x"),
     commonjs: None,
   });
   let root = root.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut commonjs = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut commonjs = RspackHasher::new(&HashAlgorithm::Xxhash64);
   commonjs.update(&Value {
     root: None,
     commonjs: Some("x"),
@@ -206,7 +206,7 @@ fn derive_rspack_hash_hashes_option_field_names() {
 
   assert_ne!(root, commonjs);
 
-  let mut expected_root = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected_root = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected_root.write(b"{");
   expected_root.write(b"root");
   expected_root.write(b":");
@@ -224,11 +224,11 @@ fn derive_rspack_hash_does_not_use_json_by_default() {
     content: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -247,11 +247,11 @@ fn derive_rspack_hash_can_use_explicit_json() {
     content: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(br#"{"content":"payload"}"#);
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -260,13 +260,13 @@ fn derive_rspack_hash_can_use_explicit_json() {
 
 #[test]
 fn rspack_hash_object_hashes_object_fields() {
-  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
   rspack_hash::rspack_hash_object!(&mut derived, {
     "content" => "payload",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");

--- a/crates/rspack_hash/tests/hash.rs
+++ b/crates/rspack_hash/tests/hash.rs
@@ -1,5 +1,5 @@
 use rspack_hash::{
-  HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, write_u64_hex,
+  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher, write_u64_hex,
 };
 
 #[test]
@@ -27,12 +27,12 @@ fn encodes_base64url_without_padding() {
 #[test]
 fn hash_salt_is_written_as_raw_bytes() {
   let salt = HashSalt::Salt("salt".into());
-  let salted = HashAlgorithm::with_salt(&HashFunction::Xxhash64, &salt)
+  let salted = RspackHasher::with_salt(&HashFunction::Xxhash64, &salt)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"salt");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -48,11 +48,11 @@ fn writes_u64_hex_without_leading_zeroes() {
     (0x0abc, "abc"),
     (u64::MAX, "ffffffffffffffff"),
   ] {
-    let mut actual = HashAlgorithm::new(&HashFunction::Xxhash64);
+    let mut actual = RspackHasher::new(&HashFunction::Xxhash64);
     write_u64_hex(value, &mut actual);
     let actual = actual.digest(&HashDigest::Hex).encoded().to_string();
 
-    let mut expected_hash = HashAlgorithm::new(&HashFunction::Xxhash64);
+    let mut expected_hash = RspackHasher::new(&HashFunction::Xxhash64);
     expected_hash.write(expected.as_bytes());
     let expected = expected_hash.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -69,14 +69,14 @@ fn derive_rspack_hash_skips_marked_fields() {
     _cached: &'static str,
   }
 
-  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value {
     content: "payload",
     _cached: "cache",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -97,14 +97,14 @@ fn derive_rspack_hash_respects_explicit_field_order() {
     first: &'static str,
   }
 
-  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value {
     first: "a",
     second: "b",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"first");
   expected.write(b":");
@@ -121,22 +121,22 @@ fn derive_rspack_hash_respects_explicit_field_order() {
 
 #[test]
 fn option_rspack_hash_skips_none() {
-  let mut none = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut none = RspackHasher::new(&HashFunction::Xxhash64);
   none.update(&Option::<&str>::None);
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let empty = HashAlgorithm::new(&HashFunction::Xxhash64)
+  let empty = RspackHasher::new(&HashFunction::Xxhash64)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
   assert_eq!(none, empty);
 
-  let mut some = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut some = RspackHasher::new(&HashFunction::Xxhash64);
   some.update(&Some("value"));
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"value");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -151,11 +151,11 @@ fn derive_rspack_hash_can_hash_none_as_null() {
     value: Option<&'static str>,
   }
 
-  let mut none = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut none = RspackHasher::new(&HashFunction::Xxhash64);
   none.update(&Value { value: None });
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_none = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected_none = RspackHasher::new(&HashFunction::Xxhash64);
   expected_none.write(b"{");
   expected_none.write(b"value");
   expected_none.write(b":");
@@ -165,13 +165,13 @@ fn derive_rspack_hash_can_hash_none_as_null() {
 
   assert_eq!(none, expected_none);
 
-  let mut some = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut some = RspackHasher::new(&HashFunction::Xxhash64);
   some.update(&Value {
     value: Some("present"),
   });
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_some = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected_some = RspackHasher::new(&HashFunction::Xxhash64);
   expected_some.write(b"{");
   expected_some.write(b"value");
   expected_some.write(b":");
@@ -190,14 +190,14 @@ fn derive_rspack_hash_hashes_option_field_names() {
     commonjs: Option<&'static str>,
   }
 
-  let mut root = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut root = RspackHasher::new(&HashFunction::Xxhash64);
   root.update(&Value {
     root: Some("x"),
     commonjs: None,
   });
   let root = root.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut commonjs = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut commonjs = RspackHasher::new(&HashFunction::Xxhash64);
   commonjs.update(&Value {
     root: None,
     commonjs: Some("x"),
@@ -206,7 +206,7 @@ fn derive_rspack_hash_hashes_option_field_names() {
 
   assert_ne!(root, commonjs);
 
-  let mut expected_root = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected_root = RspackHasher::new(&HashFunction::Xxhash64);
   expected_root.write(b"{");
   expected_root.write(b"root");
   expected_root.write(b":");
@@ -224,11 +224,11 @@ fn derive_rspack_hash_does_not_use_json_by_default() {
     content: &'static str,
   }
 
-  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -247,11 +247,11 @@ fn derive_rspack_hash_can_use_explicit_json() {
     content: &'static str,
   }
 
-  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(br#"{"content":"payload"}"#);
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -260,13 +260,13 @@ fn derive_rspack_hash_can_use_explicit_json() {
 
 #[test]
 fn rspack_hash_object_hashes_object_fields() {
-  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   rspack_hash::rspack_hash_object!(&mut derived, {
     "content" => "payload",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");

--- a/crates/rspack_hash/tests/hash.rs
+++ b/crates/rspack_hash/tests/hash.rs
@@ -1,5 +1,5 @@
 use rspack_hash::{
-  HashAlgorithm, HashDigest, HashSalt, RspackHash, RspackHashDigest, RspackHasher, write_u64_hex,
+  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher, write_u64_hex,
 };
 
 #[test]
@@ -27,12 +27,12 @@ fn encodes_base64url_without_padding() {
 #[test]
 fn hash_salt_is_written_as_raw_bytes() {
   let salt = HashSalt::Salt("salt".into());
-  let salted = RspackHasher::with_salt(&HashAlgorithm::Xxhash64, &salt)
+  let salted = RspackHasher::with_salt(&HashFunction::Xxhash64, &salt)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"salt");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -48,11 +48,11 @@ fn writes_u64_hex_without_leading_zeroes() {
     (0x0abc, "abc"),
     (u64::MAX, "ffffffffffffffff"),
   ] {
-    let mut actual = RspackHasher::new(&HashAlgorithm::Xxhash64);
+    let mut actual = RspackHasher::new(&HashFunction::Xxhash64);
     write_u64_hex(value, &mut actual);
     let actual = actual.digest(&HashDigest::Hex).encoded().to_string();
 
-    let mut expected_hash = RspackHasher::new(&HashAlgorithm::Xxhash64);
+    let mut expected_hash = RspackHasher::new(&HashFunction::Xxhash64);
     expected_hash.write(expected.as_bytes());
     let expected = expected_hash.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -69,14 +69,14 @@ fn derive_rspack_hash_skips_marked_fields() {
     _cached: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value {
     content: "payload",
     _cached: "cache",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -97,14 +97,14 @@ fn derive_rspack_hash_respects_explicit_field_order() {
     first: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value {
     first: "a",
     second: "b",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"first");
   expected.write(b":");
@@ -121,22 +121,22 @@ fn derive_rspack_hash_respects_explicit_field_order() {
 
 #[test]
 fn option_rspack_hash_skips_none() {
-  let mut none = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut none = RspackHasher::new(&HashFunction::Xxhash64);
   none.update(&Option::<&str>::None);
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let empty = RspackHasher::new(&HashAlgorithm::Xxhash64)
+  let empty = RspackHasher::new(&HashFunction::Xxhash64)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
   assert_eq!(none, empty);
 
-  let mut some = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut some = RspackHasher::new(&HashFunction::Xxhash64);
   some.update(&Some("value"));
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"value");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -151,11 +151,11 @@ fn derive_rspack_hash_can_hash_none_as_null() {
     value: Option<&'static str>,
   }
 
-  let mut none = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut none = RspackHasher::new(&HashFunction::Xxhash64);
   none.update(&Value { value: None });
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_none = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected_none = RspackHasher::new(&HashFunction::Xxhash64);
   expected_none.write(b"{");
   expected_none.write(b"value");
   expected_none.write(b":");
@@ -165,13 +165,13 @@ fn derive_rspack_hash_can_hash_none_as_null() {
 
   assert_eq!(none, expected_none);
 
-  let mut some = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut some = RspackHasher::new(&HashFunction::Xxhash64);
   some.update(&Value {
     value: Some("present"),
   });
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_some = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected_some = RspackHasher::new(&HashFunction::Xxhash64);
   expected_some.write(b"{");
   expected_some.write(b"value");
   expected_some.write(b":");
@@ -190,14 +190,14 @@ fn derive_rspack_hash_hashes_option_field_names() {
     commonjs: Option<&'static str>,
   }
 
-  let mut root = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut root = RspackHasher::new(&HashFunction::Xxhash64);
   root.update(&Value {
     root: Some("x"),
     commonjs: None,
   });
   let root = root.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut commonjs = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut commonjs = RspackHasher::new(&HashFunction::Xxhash64);
   commonjs.update(&Value {
     root: None,
     commonjs: Some("x"),
@@ -206,7 +206,7 @@ fn derive_rspack_hash_hashes_option_field_names() {
 
   assert_ne!(root, commonjs);
 
-  let mut expected_root = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected_root = RspackHasher::new(&HashFunction::Xxhash64);
   expected_root.write(b"{");
   expected_root.write(b"root");
   expected_root.write(b":");
@@ -224,11 +224,11 @@ fn derive_rspack_hash_does_not_use_json_by_default() {
     content: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -247,11 +247,11 @@ fn derive_rspack_hash_can_use_explicit_json() {
     content: &'static str,
   }
 
-  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(br#"{"content":"payload"}"#);
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -260,13 +260,13 @@ fn derive_rspack_hash_can_use_explicit_json() {
 
 #[test]
 fn rspack_hash_object_hashes_object_fields() {
-  let mut derived = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut derived = RspackHasher::new(&HashFunction::Xxhash64);
   rspack_hash::rspack_hash_object!(&mut derived, {
     "content" => "payload",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut expected = RspackHasher::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");

--- a/crates/rspack_hash/tests/hash.rs
+++ b/crates/rspack_hash/tests/hash.rs
@@ -1,5 +1,5 @@
 use rspack_hash::{
-  HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHashable, write_u64_hex,
+  HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, write_u64_hex,
 };
 
 #[test]
@@ -27,12 +27,12 @@ fn encodes_base64url_without_padding() {
 #[test]
 fn hash_salt_is_written_as_raw_bytes() {
   let salt = HashSalt::Salt("salt".into());
-  let salted = RspackHash::with_salt(&HashFunction::Xxhash64, &salt)
+  let salted = HashAlgorithm::with_salt(&HashFunction::Xxhash64, &salt)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(b"salt");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -48,11 +48,11 @@ fn writes_u64_hex_without_leading_zeroes() {
     (0x0abc, "abc"),
     (u64::MAX, "ffffffffffffffff"),
   ] {
-    let mut actual = RspackHash::new(&HashFunction::Xxhash64);
+    let mut actual = HashAlgorithm::new(&HashFunction::Xxhash64);
     write_u64_hex(value, &mut actual);
     let actual = actual.digest(&HashDigest::Hex).encoded().to_string();
 
-    let mut expected_hash = RspackHash::new(&HashFunction::Xxhash64);
+    let mut expected_hash = HashAlgorithm::new(&HashFunction::Xxhash64);
     expected_hash.write(expected.as_bytes());
     let expected = expected_hash.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -61,22 +61,22 @@ fn writes_u64_hex_without_leading_zeroes() {
 }
 
 #[test]
-fn derive_rspack_hashable_skips_marked_fields() {
-  #[derive(RspackHashable)]
+fn derive_rspack_hash_skips_marked_fields() {
+  #[derive(RspackHash)]
   struct Value {
     content: &'static str,
     #[rspack_hash(skip)]
     _cached: &'static str,
   }
 
-  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
   derived.update(&Value {
     content: "payload",
     _cached: "cache",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -88,8 +88,8 @@ fn derive_rspack_hashable_skips_marked_fields() {
 }
 
 #[test]
-fn derive_rspack_hashable_respects_explicit_field_order() {
-  #[derive(RspackHashable)]
+fn derive_rspack_hash_respects_explicit_field_order() {
+  #[derive(RspackHash)]
   struct Value {
     #[rspack_hash(order = 1)]
     second: &'static str,
@@ -97,14 +97,14 @@ fn derive_rspack_hashable_respects_explicit_field_order() {
     first: &'static str,
   }
 
-  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
   derived.update(&Value {
     first: "a",
     second: "b",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"first");
   expected.write(b":");
@@ -120,23 +120,23 @@ fn derive_rspack_hashable_respects_explicit_field_order() {
 }
 
 #[test]
-fn option_rspack_hashable_skips_none() {
-  let mut none = RspackHash::new(&HashFunction::Xxhash64);
+fn option_rspack_hash_skips_none() {
+  let mut none = HashAlgorithm::new(&HashFunction::Xxhash64);
   none.update(&Option::<&str>::None);
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let empty = RspackHash::new(&HashFunction::Xxhash64)
+  let empty = HashAlgorithm::new(&HashFunction::Xxhash64)
     .digest(&HashDigest::Hex)
     .encoded()
     .to_string();
 
   assert_eq!(none, empty);
 
-  let mut some = RspackHash::new(&HashFunction::Xxhash64);
+  let mut some = HashAlgorithm::new(&HashFunction::Xxhash64);
   some.update(&Some("value"));
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(b"value");
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -144,18 +144,18 @@ fn option_rspack_hashable_skips_none() {
 }
 
 #[test]
-fn derive_rspack_hashable_can_hash_none_as_null() {
-  #[derive(RspackHashable)]
+fn derive_rspack_hash_can_hash_none_as_null() {
+  #[derive(RspackHash)]
   struct Value {
     #[rspack_hash(null_if_none)]
     value: Option<&'static str>,
   }
 
-  let mut none = RspackHash::new(&HashFunction::Xxhash64);
+  let mut none = HashAlgorithm::new(&HashFunction::Xxhash64);
   none.update(&Value { value: None });
   let none = none.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_none = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected_none = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected_none.write(b"{");
   expected_none.write(b"value");
   expected_none.write(b":");
@@ -165,13 +165,13 @@ fn derive_rspack_hashable_can_hash_none_as_null() {
 
   assert_eq!(none, expected_none);
 
-  let mut some = RspackHash::new(&HashFunction::Xxhash64);
+  let mut some = HashAlgorithm::new(&HashFunction::Xxhash64);
   some.update(&Value {
     value: Some("present"),
   });
   let some = some.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected_some = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected_some = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected_some.write(b"{");
   expected_some.write(b"value");
   expected_some.write(b":");
@@ -183,21 +183,21 @@ fn derive_rspack_hashable_can_hash_none_as_null() {
 }
 
 #[test]
-fn derive_rspack_hashable_hashes_option_field_names() {
-  #[derive(RspackHashable)]
+fn derive_rspack_hash_hashes_option_field_names() {
+  #[derive(RspackHash)]
   struct Value {
     root: Option<&'static str>,
     commonjs: Option<&'static str>,
   }
 
-  let mut root = RspackHash::new(&HashFunction::Xxhash64);
+  let mut root = HashAlgorithm::new(&HashFunction::Xxhash64);
   root.update(&Value {
     root: Some("x"),
     commonjs: None,
   });
   let root = root.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut commonjs = RspackHash::new(&HashFunction::Xxhash64);
+  let mut commonjs = HashAlgorithm::new(&HashFunction::Xxhash64);
   commonjs.update(&Value {
     root: None,
     commonjs: Some("x"),
@@ -206,7 +206,7 @@ fn derive_rspack_hashable_hashes_option_field_names() {
 
   assert_ne!(root, commonjs);
 
-  let mut expected_root = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected_root = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected_root.write(b"{");
   expected_root.write(b"root");
   expected_root.write(b":");
@@ -218,17 +218,17 @@ fn derive_rspack_hashable_hashes_option_field_names() {
 }
 
 #[test]
-fn derive_rspack_hashable_does_not_use_json_by_default() {
-  #[derive(serde::Serialize, RspackHashable)]
+fn derive_rspack_hash_does_not_use_json_by_default() {
+  #[derive(serde::Serialize, RspackHash)]
   struct Value {
     content: &'static str,
   }
 
-  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");
@@ -240,18 +240,18 @@ fn derive_rspack_hashable_does_not_use_json_by_default() {
 }
 
 #[test]
-fn derive_rspack_hashable_can_use_explicit_json() {
-  #[derive(serde::Serialize, RspackHashable)]
+fn derive_rspack_hash_can_use_explicit_json() {
+  #[derive(serde::Serialize, RspackHash)]
   #[rspack_hash(json)]
   struct Value {
     content: &'static str,
   }
 
-  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
   derived.update(&Value { content: "payload" });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(br#"{"content":"payload"}"#);
   let expected = expected.digest(&HashDigest::Hex).encoded().to_string();
 
@@ -260,13 +260,13 @@ fn derive_rspack_hashable_can_use_explicit_json() {
 
 #[test]
 fn rspack_hash_object_hashes_object_fields() {
-  let mut derived = RspackHash::new(&HashFunction::Xxhash64);
+  let mut derived = HashAlgorithm::new(&HashFunction::Xxhash64);
   rspack_hash::rspack_hash_object!(&mut derived, {
     "content" => "payload",
   });
   let derived = derived.digest(&HashDigest::Hex).encoded().to_string();
 
-  let mut expected = RspackHash::new(&HashFunction::Xxhash64);
+  let mut expected = HashAlgorithm::new(&HashFunction::Xxhash64);
   expected.write(b"{");
   expected.write(b"content");
   expected.write(b":");

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{HashDigest, HashFunction, RspackHasher};
+use rspack_hash::{HashAlgorithm, HashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet;
 
@@ -15,7 +15,7 @@ use crate::id_helpers::{
 #[derive(Debug, Clone)]
 pub struct HashedModuleIdsPluginOptions {
   pub context: Option<String>,
-  pub hash_function: HashFunction,
+  pub hash_function: HashAlgorithm,
   pub hash_digest: HashDigest,
   pub hash_digest_length: usize,
 }
@@ -24,7 +24,7 @@ impl Default for HashedModuleIdsPluginOptions {
   fn default() -> Self {
     Self {
       context: None,
-      hash_function: HashFunction::MD4,
+      hash_function: HashAlgorithm::MD4,
       hash_digest: HashDigest::Base64,
       hash_digest_length: 4,
     }
@@ -35,7 +35,7 @@ impl Default for HashedModuleIdsPluginOptions {
 #[derive(Debug)]
 pub struct HashedModuleIdsPlugin {
   context: Option<String>,
-  hash_function: HashFunction,
+  hash_function: HashAlgorithm,
   hash_digest: HashDigest,
   hash_digest_length: usize,
 }

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{HashAlgorithm, HashDigest, RspackHasher};
+use rspack_hash::{HashDigest, HashFunction, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet;
 
@@ -15,7 +15,7 @@ use crate::id_helpers::{
 #[derive(Debug, Clone)]
 pub struct HashedModuleIdsPluginOptions {
   pub context: Option<String>,
-  pub hash_function: HashAlgorithm,
+  pub hash_function: HashFunction,
   pub hash_digest: HashDigest,
   pub hash_digest_length: usize,
 }
@@ -24,7 +24,7 @@ impl Default for HashedModuleIdsPluginOptions {
   fn default() -> Self {
     Self {
       context: None,
-      hash_function: HashAlgorithm::MD4,
+      hash_function: HashFunction::MD4,
       hash_digest: HashDigest::Base64,
       hash_digest_length: 4,
     }
@@ -35,7 +35,7 @@ impl Default for HashedModuleIdsPluginOptions {
 #[derive(Debug)]
 pub struct HashedModuleIdsPlugin {
   context: Option<String>,
-  hash_function: HashAlgorithm,
+  hash_function: HashFunction,
   hash_digest: HashDigest,
   hash_digest_length: usize,
 }

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{HashAlgorithm, HashDigest, HashFunction};
+use rspack_hash::{HashDigest, HashFunction, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet;
 
@@ -90,7 +90,7 @@ async fn module_ids(
     };
     let ident = get_full_module_name(module, context);
 
-    let mut hasher = HashAlgorithm::new(&self.hash_function);
+    let mut hasher = RspackHasher::new(&self.hash_function);
     hasher.write(ident.as_bytes());
     let hash_digest = hasher.digest(&self.hash_digest);
     let hash_id = hash_digest.encoded();

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{HashDigest, HashFunction, RspackHash};
+use rspack_hash::{HashAlgorithm, HashDigest, HashFunction};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashSet;
 
@@ -90,7 +90,7 @@ async fn module_ids(
     };
     let ident = get_full_module_name(module, context);
 
-    let mut hasher = RspackHash::new(&self.hash_function);
+    let mut hasher = HashAlgorithm::new(&self.hash_function);
     hasher.write(ident.as_bytes());
     let hash_digest = hasher.digest(&self.hash_digest);
     let hash_id = hash_digest.encoded();

--- a/crates/rspack_macros/src/lib.rs
+++ b/crates/rspack_macros/src/lib.rs
@@ -2,7 +2,7 @@ mod hook;
 mod javascript_parser_plugin_hooks;
 mod merge;
 mod plugin;
-mod rspack_hashable;
+mod rspack_hash;
 mod runtime_module;
 mod source_map_config;
 
@@ -70,10 +70,10 @@ pub fn merge_from_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
   .into()
 }
 
-#[proc_macro_derive(RspackHashable, attributes(rspack_hash))]
-pub fn rspack_hashable_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+#[proc_macro_derive(RspackHash, attributes(rspack_hash))]
+pub fn rspack_hash_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   let input = syn::parse_macro_input!(input as syn::DeriveInput);
-  let output = rspack_hashable::expand_rspack_hashable_derive(input);
+  let output = rspack_hash::expand_rspack_hash_derive(input);
   match output {
     syn::Result::Ok(tt) => tt,
     syn::Result::Err(err) => err.to_compile_error(),

--- a/crates/rspack_macros/src/rspack_hash.rs
+++ b/crates/rspack_macros/src/rspack_hash.rs
@@ -67,7 +67,7 @@ pub fn expand_rspack_hash_derive(input: DeriveInput) -> Result<TokenStream> {
 
   Ok(quote! {
     impl #impl_generics #hash_crate::RspackHash for #ident #ty_generics #where_clause {
-      fn hash(&self, state: &mut #hash_crate::HashAlgorithm) {
+      fn hash(&self, state: &mut #hash_crate::RspackHasher) {
         #body
       }
     }

--- a/crates/rspack_macros/src/rspack_hash.rs
+++ b/crates/rspack_macros/src/rspack_hash.rs
@@ -26,7 +26,7 @@ struct FieldHash {
   options: FieldOptions,
 }
 
-pub fn expand_rspack_hashable_derive(input: DeriveInput) -> Result<TokenStream> {
+pub fn expand_rspack_hash_derive(input: DeriveInput) -> Result<TokenStream> {
   let options = type_options(&input.attrs)?;
   let hash_crate = options
     .hash_crate
@@ -54,7 +54,7 @@ pub fn expand_rspack_hashable_derive(input: DeriveInput) -> Result<TokenStream> 
       Data::Union(data) => {
         return Err(Error::new_spanned(
           data.union_token,
-          "RspackHashable cannot be derived for unions",
+          "RspackHash cannot be derived for unions",
         ));
       }
     }
@@ -62,12 +62,12 @@ pub fn expand_rspack_hashable_derive(input: DeriveInput) -> Result<TokenStream> 
 
   let ident = &input.ident;
   let mut generics = input.generics.clone();
-  add_rspack_hashable_bounds(&mut generics, &hash_crate, use_json);
+  add_rspack_hash_bounds(&mut generics, &hash_crate, use_json);
   let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
   Ok(quote! {
-    impl #impl_generics #hash_crate::RspackHashable for #ident #ty_generics #where_clause {
-      fn hash(&self, state: &mut #hash_crate::RspackHash) {
+    impl #impl_generics #hash_crate::RspackHash for #ident #ty_generics #where_clause {
+      fn hash(&self, state: &mut #hash_crate::HashAlgorithm) {
         #body
       }
     }
@@ -328,7 +328,7 @@ fn hash_field_static(hash_crate: &Path, field: &FieldHash, prefix: &str) -> Toke
       match #target {
         Some(value) => {
           state.write(#prefix);
-          #hash_crate::RspackHashable::hash(value, state);
+          #hash_crate::RspackHash::hash(value, state);
         }
         None => {
           state.write(#null);
@@ -339,7 +339,7 @@ fn hash_field_static(hash_crate: &Path, field: &FieldHash, prefix: &str) -> Toke
     let prefix = Literal::byte_string(prefix.as_bytes());
     quote! {
       state.write(#prefix);
-      #hash_crate::RspackHashable::hash(#target, state);
+      #hash_crate::RspackHash::hash(#target, state);
     }
   }
 }
@@ -364,7 +364,7 @@ fn hash_field_dynamic(hash_crate: &Path, field: &FieldHash, start: &str) -> Toke
       match #target {
         Some(value) => {
           #hash_key
-          #hash_crate::RspackHashable::hash(value, state);
+          #hash_crate::RspackHash::hash(value, state);
         }
         None => {
           #hash_key
@@ -376,13 +376,13 @@ fn hash_field_dynamic(hash_crate: &Path, field: &FieldHash, start: &str) -> Toke
     quote! {
       if let Some(value) = #target {
         #hash_key
-        #hash_crate::RspackHashable::hash(value, state);
+        #hash_crate::RspackHash::hash(value, state);
       }
     }
   } else {
     quote! {
       #hash_key
-      #hash_crate::RspackHashable::hash(#target, state);
+      #hash_crate::RspackHash::hash(#target, state);
     }
   }
 }
@@ -417,9 +417,9 @@ fn sort_fields(fields: &mut [FieldHash]) -> Result<()> {
   Ok(())
 }
 
-fn add_rspack_hashable_bounds(generics: &mut Generics, hash_crate: &Path, json_hash: bool) {
+fn add_rspack_hash_bounds(generics: &mut Generics, hash_crate: &Path, json_hash: bool) {
   for param in generics.type_params_mut() {
-    let bound: TypeParamBound = parse_quote!(#hash_crate::RspackHashable);
+    let bound: TypeParamBound = parse_quote!(#hash_crate::RspackHash);
     param.bounds.push(bound);
     if json_hash {
       let serde_bound: TypeParamBound = parse_quote!(::serde::Serialize);

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, error};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{base64, fx_hash::FxHashSet, identifier::make_paths_relative};
 
@@ -115,7 +115,7 @@ impl AssetParserAndGenerator {
     source: &BoxSource,
     compiler_options: &CompilerOptions,
   ) -> RspackHashDigest {
-    let mut hasher = HashAlgorithm::from(&compiler_options.output);
+    let mut hasher = RspackHasher::from(&compiler_options.output);
     hasher.write(&source.buffer());
     hasher.digest(&compiler_options.output.hash_digest)
   }
@@ -760,7 +760,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     let asset_build_info = module
       .build_info()
       .asset

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, error};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{base64, fx_hash::FxHashSet, identifier::make_paths_relative};
 
@@ -115,7 +115,7 @@ impl AssetParserAndGenerator {
     source: &BoxSource,
     compiler_options: &CompilerOptions,
   ) -> RspackHashDigest {
-    let mut hasher = RspackHash::from(&compiler_options.output);
+    let mut hasher = HashAlgorithm::from(&compiler_options.output);
     hasher.write(&source.buffer());
     hasher.digest(&compiler_options.output.hash_digest)
   }
@@ -760,7 +760,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     let asset_build_info = module
       .build_info()
       .asset

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
-use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHashDigest};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
@@ -151,7 +151,7 @@ impl CopyRspackPlugin {
     digest: &HashDigest,
     salt: &HashSalt,
   ) -> RspackHashDigest {
-    let mut hasher = HashAlgorithm::with_salt(function, salt);
+    let mut hasher = RspackHasher::with_salt(function, salt);
     source.buffer().hash(&mut hasher);
     hasher.digest(digest)
   }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, HashSalt, RspackHashDigest};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
@@ -151,7 +151,7 @@ impl CopyRspackPlugin {
     digest: &HashDigest,
     salt: &HashSalt,
   ) -> RspackHashDigest {
-    let mut hasher = RspackHash::with_salt(function, salt);
+    let mut hasher = HashAlgorithm::with_salt(function, salt);
     source.buffer().hash(&mut hasher);
     hasher.digest(digest)
   }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
-use rspack_hash::{HashAlgorithm, HashDigest, HashSalt, RspackHashDigest, RspackHasher};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
@@ -147,7 +147,7 @@ impl CopyRspackPlugin {
 
   fn get_content_hash(
     source: &BoxSource,
-    function: &HashAlgorithm,
+    function: &HashFunction,
     digest: &HashDigest,
     salt: &HashSalt,
   ) -> RspackHashDigest {

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Error, Result};
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHashDigest, RspackHasher};
+use rspack_hash::{HashAlgorithm, HashDigest, HashSalt, RspackHashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
@@ -147,7 +147,7 @@ impl CopyRspackPlugin {
 
   fn get_content_hash(
     source: &BoxSource,
-    function: &HashFunction,
+    function: &HashAlgorithm,
     digest: &HashDigest,
     salt: &HashSalt,
   ) -> RspackHashDigest {

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   DependencyType, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec,
   ExportsSpec, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 use crate::utils::{escape_css, replace_css_module_id_placeholder};
 
@@ -82,7 +82,7 @@ impl DependencyCodeGeneration for CssLocalIdentDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   DependencyType, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec,
   ExportsSpec, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 use crate::utils::{escape_css, replace_css_module_id_placeholder};
 
@@ -82,7 +82,7 @@ impl DependencyCodeGeneration for CssLocalIdentDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -18,7 +18,7 @@ use rspack_core::{
 };
 pub use rspack_core::{CssExport, CssExports};
 use rspack_error::{Result, TWithDiagnosticArray};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_util::{
   atom::Atom,
   fx_hash::{FxIndexMap, FxIndexSet},
@@ -342,7 +342,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     self.es_module.hash(&mut hasher);
     self.exports_only.hash(&mut hasher);
     self.effective_export_type(module).hash(&mut hasher);

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -18,7 +18,7 @@ use rspack_core::{
 };
 pub use rspack_core::{CssExport, CssExports};
 use rspack_error::{Result, TWithDiagnosticArray};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_util::{
   atom::Atom,
   fx_hash::{FxIndexMap, FxIndexSet},
@@ -342,7 +342,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
     compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     self.es_module.hash(&mut hasher);
     self.exports_only.hash(&mut hasher);
     self.effective_export_type(module).hash(&mut hasher);

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::plugin_hook;
 use rspack_plugin_runtime::is_enabled_for_chunk;
 use rspack_util::fx_hash::FxDashMap;
@@ -464,7 +464,7 @@ async fn content_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hashes: &mut HashMap<SourceType, HashAlgorithm>,
+  hashes: &mut HashMap<SourceType, RspackHasher>,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact
@@ -483,7 +483,7 @@ async fn content_hash(
     Self::get_ordered_chunk_css_modules(chunk, compilation, css_import_modules, css_modules);
   let hasher = hashes
     .entry(SourceType::Css)
-    .or_insert_with(|| HashAlgorithm::from(&compilation.options.output));
+    .or_insert_with(|| RspackHasher::from(&compilation.options.output));
 
   ordered_modules
     .iter()

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::plugin_hook;
 use rspack_plugin_runtime::is_enabled_for_chunk;
 use rspack_util::fx_hash::FxDashMap;
@@ -464,7 +464,7 @@ async fn content_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hashes: &mut HashMap<SourceType, RspackHash>,
+  hashes: &mut HashMap<SourceType, HashAlgorithm>,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact
@@ -483,7 +483,7 @@ async fn content_hash(
     Self::get_ordered_chunk_css_modules(chunk, compilation, css_import_modules, css_modules);
   let hasher = hashes
     .entry(SourceType::Css)
-    .or_insert_with(|| RspackHash::from(&compilation.options.output));
+    .or_insert_with(|| HashAlgorithm::from(&compilation.options.output));
 
   ordered_modules
     .iter()

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   ResourceData,
 };
 use rspack_error::{Diagnostic, Error, Result, Severity};
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash};
+use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, HashSalt};
 use rspack_util::{base64, identifier::make_paths_relative, itoa, json_stringify_str};
 use rustc_hash::{FxHashSet, FxHasher};
 
@@ -227,7 +227,7 @@ impl<'a> LocalIdentOptions<'a> {
   fn get_module_hash(&self, module_hash_options: &LocalIdentModuleHashOptions<'_>) -> String {
     let local_ident_name = self.local_ident_name.template.as_str();
     let build_hash = {
-      let mut hasher = RspackHash::new(&self.local_ident_hash_function);
+      let mut hasher = HashAlgorithm::new(&self.local_ident_hash_function);
       hasher.write(b"source");
       hasher.write(b"OriginalSource");
       hasher.write(self.source.as_bytes());
@@ -250,7 +250,7 @@ impl<'a> LocalIdentOptions<'a> {
         .collect::<Vec<_>>();
       graph_exports.sort();
 
-      let mut hasher = RspackHash::new(&self.local_ident_hash_function);
+      let mut hasher = HashAlgorithm::new(&self.local_ident_hash_function);
       hasher.write(self.relative_resource.as_bytes());
       hasher.write(b"false");
       for name in graph_exports {
@@ -263,7 +263,7 @@ impl<'a> LocalIdentOptions<'a> {
     };
 
     let mut hasher =
-      RspackHash::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
+      HashAlgorithm::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
     hasher.write(build_hash.as_bytes());
     if module_hash_options.exports_only {
       hasher.write(b"javascript");
@@ -322,7 +322,7 @@ impl<'a> LocalIdentOptions<'a> {
     let output = &self.compiler_options.output;
     let local_ident_hash = {
       let mut hasher =
-        RspackHash::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
+        HashAlgorithm::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
       if !output.unique_name.is_empty() {
         hasher.write(output.unique_name.as_bytes());
       }
@@ -340,7 +340,7 @@ impl<'a> LocalIdentOptions<'a> {
       .as_str()
       .contains("[contenthash")
     {
-      let mut hasher = RspackHash::new(&output.hash_function);
+      let mut hasher = HashAlgorithm::new(&output.hash_function);
       hasher.write(self.source.as_bytes());
       let hash = hasher.digest(&output.hash_digest);
       content_hash = non_numeric_only_hash(hash.encoded(), output.hash_digest_length);

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   ResourceData,
 };
 use rspack_error::{Diagnostic, Error, Result, Severity};
-use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHasher};
+use rspack_hash::{HashAlgorithm, HashDigest, HashSalt, RspackHasher};
 use rspack_util::{base64, identifier::make_paths_relative, itoa, json_stringify_str};
 use rustc_hash::{FxHashSet, FxHasher};
 
@@ -170,7 +170,7 @@ pub struct LocalIdentOptions<'a> {
   local_ident_name: &'a LocalIdentName,
   local_ident_hash_digest: HashDigest,
   local_ident_hash_digest_length: usize,
-  local_ident_hash_function: HashFunction,
+  local_ident_hash_function: HashAlgorithm,
   local_ident_hash_salt: &'a HashSalt,
 }
 

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   ResourceData,
 };
 use rspack_error::{Diagnostic, Error, Result, Severity};
-use rspack_hash::{HashAlgorithm, HashDigest, HashSalt, RspackHasher};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHasher};
 use rspack_util::{base64, identifier::make_paths_relative, itoa, json_stringify_str};
 use rustc_hash::{FxHashSet, FxHasher};
 
@@ -170,7 +170,7 @@ pub struct LocalIdentOptions<'a> {
   local_ident_name: &'a LocalIdentName,
   local_ident_hash_digest: HashDigest,
   local_ident_hash_digest_length: usize,
-  local_ident_hash_function: HashAlgorithm,
+  local_ident_hash_function: HashFunction,
   local_ident_hash_salt: &'a HashSalt,
 }
 

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   ResourceData,
 };
 use rspack_error::{Diagnostic, Error, Result, Severity};
-use rspack_hash::{HashAlgorithm, HashDigest, HashFunction, HashSalt};
+use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHasher};
 use rspack_util::{base64, identifier::make_paths_relative, itoa, json_stringify_str};
 use rustc_hash::{FxHashSet, FxHasher};
 
@@ -227,7 +227,7 @@ impl<'a> LocalIdentOptions<'a> {
   fn get_module_hash(&self, module_hash_options: &LocalIdentModuleHashOptions<'_>) -> String {
     let local_ident_name = self.local_ident_name.template.as_str();
     let build_hash = {
-      let mut hasher = HashAlgorithm::new(&self.local_ident_hash_function);
+      let mut hasher = RspackHasher::new(&self.local_ident_hash_function);
       hasher.write(b"source");
       hasher.write(b"OriginalSource");
       hasher.write(self.source.as_bytes());
@@ -250,7 +250,7 @@ impl<'a> LocalIdentOptions<'a> {
         .collect::<Vec<_>>();
       graph_exports.sort();
 
-      let mut hasher = HashAlgorithm::new(&self.local_ident_hash_function);
+      let mut hasher = RspackHasher::new(&self.local_ident_hash_function);
       hasher.write(self.relative_resource.as_bytes());
       hasher.write(b"false");
       for name in graph_exports {
@@ -263,7 +263,7 @@ impl<'a> LocalIdentOptions<'a> {
     };
 
     let mut hasher =
-      HashAlgorithm::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
+      RspackHasher::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
     hasher.write(build_hash.as_bytes());
     if module_hash_options.exports_only {
       hasher.write(b"javascript");
@@ -322,7 +322,7 @@ impl<'a> LocalIdentOptions<'a> {
     let output = &self.compiler_options.output;
     let local_ident_hash = {
       let mut hasher =
-        HashAlgorithm::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
+        RspackHasher::with_salt(&self.local_ident_hash_function, self.local_ident_hash_salt);
       if !output.unique_name.is_empty() {
         hasher.write(output.unique_name.as_bytes());
       }
@@ -340,7 +340,7 @@ impl<'a> LocalIdentOptions<'a> {
       .as_str()
       .contains("[contenthash")
     {
-      let mut hasher = HashAlgorithm::new(&output.hash_function);
+      let mut hasher = RspackHasher::new(&output.hash_function);
       hasher.write(self.source.as_bytes());
       let hash = hasher.digest(&output.hash_digest);
       content_hash = non_numeric_only_hash(hash.encoded(), output.hash_digest_length);

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
@@ -183,7 +183,7 @@ async fn js_chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   EVAL_DEV_TOOL_MODULE_PLUGIN_NAME.hash(hasher);
   Ok(())

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
@@ -183,7 +183,7 @@ async fn js_chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   EVAL_DEV_TOOL_MODULE_PLUGIN_NAME.hash(hasher);
   Ok(())

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
@@ -286,7 +286,7 @@ async fn js_chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   RspackHash::hash(&EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME, hasher);
   Ok(())

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
@@ -286,9 +286,9 @@ async fn js_chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
-  RspackHashable::hash(&EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME, hasher);
+  RspackHash::hash(&EVAL_SOURCE_MAP_DEV_TOOL_PLUGIN_NAME, hasher);
   Ok(())
 }
 

--- a/crates/rspack_plugin_devtool/src/generate_debug_id.rs
+++ b/crates/rspack_plugin_devtool/src/generate_debug_id.rs
@@ -1,11 +1,11 @@
-use rspack_hash::{HashDigest, HashFunction, RspackHasher};
+use rspack_hash::{HashAlgorithm, HashDigest, RspackHasher};
 
 pub fn generate_debug_id(filename: &str, source: &[u8]) -> String {
-  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut hasher = RspackHasher::new(&HashAlgorithm::Xxhash64);
   hasher.write(source);
   let source_hash = hasher.digest(&HashDigest::Hex);
 
-  let mut file_hasher = RspackHasher::new(&HashFunction::Xxhash64);
+  let mut file_hasher = RspackHasher::new(&HashAlgorithm::Xxhash64);
   file_hasher.write(filename.as_bytes());
   file_hasher.write(source_hash.encoded().as_bytes());
   let file_hash = file_hasher.digest(&HashDigest::Hex);

--- a/crates/rspack_plugin_devtool/src/generate_debug_id.rs
+++ b/crates/rspack_plugin_devtool/src/generate_debug_id.rs
@@ -1,11 +1,11 @@
-use rspack_hash::{HashAlgorithm, HashDigest, RspackHasher};
+use rspack_hash::{HashDigest, HashFunction, RspackHasher};
 
 pub fn generate_debug_id(filename: &str, source: &[u8]) -> String {
-  let mut hasher = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
   hasher.write(source);
   let source_hash = hasher.digest(&HashDigest::Hex);
 
-  let mut file_hasher = RspackHasher::new(&HashAlgorithm::Xxhash64);
+  let mut file_hasher = RspackHasher::new(&HashFunction::Xxhash64);
   file_hasher.write(filename.as_bytes());
   file_hasher.write(source_hash.encoded().as_bytes());
   let file_hash = file_hasher.digest(&HashDigest::Hex);

--- a/crates/rspack_plugin_devtool/src/generate_debug_id.rs
+++ b/crates/rspack_plugin_devtool/src/generate_debug_id.rs
@@ -1,11 +1,11 @@
-use rspack_hash::{HashAlgorithm, HashDigest, HashFunction};
+use rspack_hash::{HashDigest, HashFunction, RspackHasher};
 
 pub fn generate_debug_id(filename: &str, source: &[u8]) -> String {
-  let mut hasher = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
   hasher.write(source);
   let source_hash = hasher.digest(&HashDigest::Hex);
 
-  let mut file_hasher = HashAlgorithm::new(&HashFunction::Xxhash64);
+  let mut file_hasher = RspackHasher::new(&HashFunction::Xxhash64);
   file_hasher.write(filename.as_bytes());
   file_hasher.write(source_hash.encoded().as_bytes());
   let file_hash = file_hasher.digest(&HashDigest::Hex);

--- a/crates/rspack_plugin_devtool/src/generate_debug_id.rs
+++ b/crates/rspack_plugin_devtool/src/generate_debug_id.rs
@@ -1,11 +1,11 @@
-use rspack_hash::{HashDigest, HashFunction, RspackHash};
+use rspack_hash::{HashAlgorithm, HashDigest, HashFunction};
 
 pub fn generate_debug_id(filename: &str, source: &[u8]) -> String {
-  let mut hasher = RspackHash::new(&HashFunction::Xxhash64);
+  let mut hasher = HashAlgorithm::new(&HashFunction::Xxhash64);
   hasher.write(source);
   let source_hash = hasher.digest(&HashDigest::Hex);
 
-  let mut file_hasher = RspackHash::new(&HashFunction::Xxhash64);
+  let mut file_hasher = HashAlgorithm::new(&HashFunction::Xxhash64);
   file_hasher.write(filename.as_bytes());
   file_hasher.write(source_hash.encoded().as_bytes());
   let file_hash = file_hasher.digest(&HashDigest::Hex);

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cell::OnceCell, path::Path};
 use cow_utils::CowUtils;
 use rspack_core::{ChunkGraph, Compilation, OutputOptions, contextify};
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_paths::Utf8Path;
 use rustc_hash::FxHashMap as HashMap;
 use sugar_path::SugarPath;
@@ -27,7 +27,7 @@ fn get_hash(text: &str, output_options: &OutputOptions) -> String {
     hash_salt,
     ..
   } = output_options;
-  let mut hasher = HashAlgorithm::with_salt(hash_function, hash_salt);
+  let mut hasher = RspackHasher::with_salt(hash_function, hash_salt);
   text.hash(&mut hasher);
   let mut buf = format!("{:x}", hasher.finish());
   buf.truncate(4);

--- a/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
+++ b/crates/rspack_plugin_devtool/src/module_filename_helpers.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cell::OnceCell, path::Path};
 use cow_utils::CowUtils;
 use rspack_core::{ChunkGraph, Compilation, OutputOptions, contextify};
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_paths::Utf8Path;
 use rustc_hash::FxHashMap as HashMap;
 use sugar_path::SugarPath;
@@ -27,7 +27,7 @@ fn get_hash(text: &str, output_options: &OutputOptions) -> String {
     hash_salt,
     ..
   } = output_options;
-  let mut hasher = RspackHash::with_salt(hash_function, hash_salt);
+  let mut hasher = HashAlgorithm::with_salt(hash_function, hash_salt);
   text.hash(&mut hasher);
   let mut buf = format!("{:x}", hasher.finish());
   buf.truncate(4);

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -21,7 +21,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::{
@@ -1012,7 +1012,7 @@ impl SourceMapDevToolPlugin {
 
       let content_hash_digest =
         if chunk.is_some() && has_content_hash_placeholder(source_map_filename_config.as_str()) {
-          let mut hasher = HashAlgorithm::from(&compilation.options.output);
+          let mut hasher = RspackHasher::from(&compilation.options.output);
           source_map_json.hash(&mut hasher);
           let digest = hasher.digest(&compilation.options.output.hash_digest);
           Some(digest)

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -21,7 +21,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::{
@@ -1012,7 +1012,7 @@ impl SourceMapDevToolPlugin {
 
       let content_hash_digest =
         if chunk.is_some() && has_content_hash_placeholder(source_map_filename_config.as_str()) {
-          let mut hasher = RspackHash::from(&compilation.options.output);
+          let mut hasher = HashAlgorithm::from(&compilation.options.output);
           source_map_json.hash(&mut hasher);
           let digest = hasher.digest(&compilation.options.output.hash_digest);
           Some(digest)

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 
 use super::dll_entry_dependency::DllEntryDependency;
 
@@ -131,7 +131,7 @@ impl Module for DllModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     format!("dll module {}", self.name).hash(&mut hasher);
 
     module_update_hash(self, &mut hasher, compilation, runtime);

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 
 use super::dll_entry_dependency::DllEntryDependency;
 
@@ -131,7 +131,7 @@ impl Module for DllModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     format!("dll module {}", self.name).hash(&mut hasher);
 
     module_update_hash(self, &mut hasher, compilation, runtime);

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_util::{json_stringify, source_map::ModuleSourceMapConfig};
 
 use super::delegated_source_dependency::DelegatedSourceDependency;
@@ -193,7 +193,7 @@ impl Module for DelegatedModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     self.delegation_type.hash(&mut hasher);
     self.request.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_util::{json_stringify, source_map::ModuleSourceMapConfig};
 
 use super::delegated_source_dependency::DelegatedSourceDependency;
@@ -193,7 +193,7 @@ impl Module for DelegatedModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     self.delegation_type.hash(&mut hasher);
     self.request.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -8,7 +8,7 @@ use rspack_core::{
   impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_util::itoa;
 
 use crate::{
@@ -83,7 +83,7 @@ impl CssModule {
   }
 
   fn compute_hash(&self, options: &CompilerOptions) -> RspackHashDigest {
-    let mut hasher = HashAlgorithm::from(&options.output);
+    let mut hasher = RspackHasher::from(&options.output);
 
     self.content.hash(&mut hasher);
     if let Some(layer) = &self.css_layer {
@@ -191,7 +191,7 @@ impl Module for CssModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     self.build_info.hash.hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -8,7 +8,7 @@ use rspack_core::{
   impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_util::itoa;
 
 use crate::{
@@ -83,7 +83,7 @@ impl CssModule {
   }
 
   fn compute_hash(&self, options: &CompilerOptions) -> RspackHashDigest {
-    let mut hasher = RspackHash::from(&options.output);
+    let mut hasher = HashAlgorithm::from(&options.output);
 
     self.content.hash(&mut hasher);
     if let Some(layer) = &self.css_layer {
@@ -191,7 +191,7 @@ impl Module for CssModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     self.build_info.hash.hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -20,7 +20,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin, parser_and_generator::JavaScriptParserAndGenerator,
@@ -600,7 +600,7 @@ async fn content_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hashes: &mut FxHashMap<SourceType, HashAlgorithm>,
+  hashes: &mut FxHashMap<SourceType, RspackHasher>,
 ) -> Result<()> {
   let module_graph = compilation.get_module_graph();
 
@@ -622,7 +622,7 @@ async fn content_hash(
 
   let hasher = hashes
     .entry(SOURCE_TYPE[0])
-    .or_insert_with(|| HashAlgorithm::from(&compilation.options.output));
+    .or_insert_with(|| RspackHasher::from(&compilation.options.output));
 
   used_modules
     .iter()

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -20,7 +20,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   BoxJavascriptParserPlugin, parser_and_generator::JavaScriptParserAndGenerator,
@@ -600,7 +600,7 @@ async fn content_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hashes: &mut FxHashMap<SourceType, RspackHash>,
+  hashes: &mut FxHashMap<SourceType, HashAlgorithm>,
 ) -> Result<()> {
   let module_graph = compilation.get_module_graph();
 
@@ -622,7 +622,7 @@ async fn content_hash(
 
   let hasher = hashes
     .entry(SOURCE_TYPE[0])
-    .or_insert_with(|| RspackHash::from(&compilation.options.output));
+    .or_insert_with(|| HashAlgorithm::from(&compilation.options.output));
 
   used_modules
     .iter()

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   rspack_sources::{RawBufferSource, RawStringSource, SourceExt},
 };
 use rspack_error::{AnyhowResultToRspackResultExt, Result};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_paths::Utf8PathBuf;
 use rspack_util::fx_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -337,7 +337,7 @@ pub async fn create_html_asset(
   template_file_name: &str,
   compilation: &Compilation,
 ) -> Result<(String, CompilationAsset)> {
-  let mut hasher = RspackHash::from(&compilation.options.output);
+  let mut hasher = HashAlgorithm::from(&compilation.options.output);
   html.hash(&mut hasher);
   let hash_digest = hasher.digest(&compilation.options.output.hash_digest);
   let content_hash = hash_digest.encoded();

--- a/crates/rspack_plugin_html/src/asset.rs
+++ b/crates/rspack_plugin_html/src/asset.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   rspack_sources::{RawBufferSource, RawStringSource, SourceExt},
 };
 use rspack_error::{AnyhowResultToRspackResultExt, Result};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_paths::Utf8PathBuf;
 use rspack_util::fx_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -337,7 +337,7 @@ pub async fn create_html_asset(
   template_file_name: &str,
   compilation: &Compilation,
 ) -> Result<(String, CompilationAsset)> {
-  let mut hasher = HashAlgorithm::from(&compilation.options.output);
+  let mut hasher = RspackHasher::from(&compilation.options.output);
   html.hash(&mut hasher);
   let hash_digest = hasher.digest(&compilation.options.output.hash_digest);
   let content_hash = hash_digest.encoded();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
   create_exports_object_referenced, create_no_exports_referenced,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 #[cacheable]
 #[derive(Debug, Clone, RspackHash)]
@@ -53,7 +53,7 @@ impl DependencyCodeGeneration for ModuleDecoratorDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -6,10 +6,10 @@ use rspack_core::{
   NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
   create_exports_object_referenced, create_no_exports_referenced,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 #[cacheable]
-#[derive(Debug, Clone, RspackHashable)]
+#[derive(Debug, Clone, RspackHash)]
 pub struct ModuleDecoratorDependency {
   decorator: RuntimeGlobals,
   allow_exports_access: bool,
@@ -53,11 +53,11 @@ impl DependencyCodeGeneration for ModuleDecoratorDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   Compilation, DependencyCodeGeneration, DependencyRange, DependencyTemplate,
   DependencyTemplateType, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 #[cacheable]
 #[derive(Debug, Clone, RspackHash)]
@@ -25,7 +25,7 @@ impl DependencyCodeGeneration for RequireMainDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_main_dependency.rs
@@ -3,10 +3,10 @@ use rspack_core::{
   Compilation, DependencyCodeGeneration, DependencyRange, DependencyTemplate,
   DependencyTemplateType, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 #[cacheable]
-#[derive(Debug, Clone, RspackHashable)]
+#[derive(Debug, Clone, RspackHash)]
 pub struct RequireMainDependency {
   pub range: DependencyRange,
 }
@@ -25,11 +25,11 @@ impl DependencyCodeGeneration for RequireMainDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -26,7 +26,7 @@ use rspack_core::{
   property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_util::json_stringify;
 use rustc_hash::{FxHashSet as HashSet, FxHasher};
 use swc_atoms::Atom;
@@ -1138,7 +1138,7 @@ pub struct DiscoverActiveExportsFromOtherStarExportsRet {
 impl DependencyCodeGeneration for ESMExportImportedSpecifierDependency {
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     compilation: &rspack_core::Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -26,7 +26,7 @@ use rspack_core::{
   property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_util::json_stringify;
 use rustc_hash::{FxHashSet as HashSet, FxHasher};
 use swc_atoms::Atom;
@@ -1138,7 +1138,7 @@ pub struct DiscoverActiveExportsFromOtherStarExportsRet {
 impl DependencyCodeGeneration for ESMExportImportedSpecifierDependency {
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     compilation: &rspack_core::Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
 
@@ -387,7 +387,7 @@ impl AsContextDependency for ESMImportSpecifierDependency {}
 impl DependencyCodeGeneration for ESMImportSpecifierDependency {
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     compilation: &rspack_core::Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
 
@@ -387,7 +387,7 @@ impl AsContextDependency for ESMImportSpecifierDependency {}
 impl DependencyCodeGeneration for ESMImportSpecifierDependency {
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     compilation: &rspack_core::Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -4,10 +4,10 @@ use rspack_core::{
   ExternalModuleInitFragment, InitFragmentExt, InitFragmentStage, RuntimeSpec, TemplateContext,
   TemplateReplaceSource,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 #[cacheable]
-#[derive(Debug, Clone, RspackHashable)]
+#[derive(Debug, Clone, RspackHash)]
 pub struct ExternalModuleDependency {
   module: String,
   import_specifier: Vec<(String, String)>,
@@ -37,11 +37,11 @@ impl DependencyCodeGeneration for ExternalModuleDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -4,7 +4,7 @@ use rspack_core::{
   ExternalModuleInitFragment, InitFragmentExt, InitFragmentStage, RuntimeSpec, TemplateContext,
   TemplateReplaceSource,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 #[cacheable]
 #[derive(Debug, Clone, RspackHash)]
@@ -37,7 +37,7 @@ impl DependencyCodeGeneration for ExternalModuleDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   ModuleGraphCacheArtifact, NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext,
   TemplateReplaceSource, create_exports_object_referenced,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
 
@@ -112,7 +112,7 @@ impl DependencyCodeGeneration for ImportMetaRscDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &rspack_core::Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   ModuleGraphCacheArtifact, NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext,
   TemplateReplaceSource, create_exports_object_referenced,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_util::json_stringify_str;
 use swc_atoms::Atom;
 
@@ -112,7 +112,7 @@ impl DependencyCodeGeneration for ImportMetaRscDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &rspack_core::Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, create_exports_object_referenced,
   property_access, to_normal_comment,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use swc_atoms::Atom;
 
 #[cacheable]
@@ -111,7 +111,7 @@ impl DependencyCodeGeneration for ProvideDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, create_exports_object_referenced,
   property_access, to_normal_comment,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use swc_atoms::Atom;
 
 #[cacheable]
@@ -111,7 +111,7 @@ impl DependencyCodeGeneration for ProvideDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   Compilation, DependencyCodeGeneration, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -23,8 +23,8 @@ impl ModuleArgumentDependency {
   }
 }
 
-impl RspackHashable for ModuleArgumentDependency {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ModuleArgumentDependency {
+  fn hash(&self, state: &mut HashAlgorithm) {
     "range".hash(state);
     self.range.hash(state);
     if let Some(id) = &self.id {
@@ -58,11 +58,11 @@ impl DependencyCodeGeneration for ModuleArgumentDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -3,7 +3,7 @@ use rspack_core::{
   Compilation, DependencyCodeGeneration, DependencyLocation, DependencyRange, DependencyTemplate,
   DependencyTemplateType, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ impl ModuleArgumentDependency {
 }
 
 impl RspackHash for ModuleArgumentDependency {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     "range".hash(state);
     self.range.hash(state);
     if let Some(id) = &self.id {
@@ -58,7 +58,7 @@ impl DependencyCodeGeneration for ModuleArgumentDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource,
   UsedByExports,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 use crate::runtime_condition_used_by_exports;
 
@@ -84,7 +84,7 @@ impl DependencyCodeGeneration for PureExpressionDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource,
   UsedByExports,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 use crate::runtime_condition_used_by_exports;
 
@@ -84,7 +84,7 @@ impl DependencyCodeGeneration for PureExpressionDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
   ModuleGraphCacheArtifact, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -43,8 +43,8 @@ impl WorkerDependency {
   }
 }
 
-impl RspackHashable for WorkerDependency {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for WorkerDependency {
+  fn hash(&self, state: &mut HashAlgorithm) {
     rspack_hash::rspack_hash_object!(state, {
       "publicPath" => self.public_path.as_str(),
       "needNewUrl" => self.need_new_url,
@@ -112,11 +112,11 @@ impl DependencyCodeGeneration for WorkerDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {
-    RspackHashable::hash(self, hasher);
+    RspackHash::hash(self, hasher);
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
   ModuleGraphCacheArtifact, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -44,7 +44,7 @@ impl WorkerDependency {
 }
 
 impl RspackHash for WorkerDependency {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     rspack_hash::rspack_hash_object!(state, {
       "publicPath" => self.public_path.as_str(),
       "needNewUrl" => self.need_new_url,
@@ -112,7 +112,7 @@ impl DependencyCodeGeneration for WorkerDependency {
 
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, EntryOptions, GroupOptions,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;
@@ -81,7 +81,7 @@ fn add_dependencies(
   need_new_url: bool,
 ) {
   let output_options = &parser.compiler_options.output;
-  let mut hasher = RspackHash::from(output_options);
+  let mut hasher = HashAlgorithm::from(output_options);
   parser.module_identifier.hash(&mut hasher);
   parser.worker_index.hash(&mut hasher);
   parser.worker_index += 1;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rspack_core::{
   AsyncDependenciesBlock, ConstDependency, DependencyRange, EntryOptions, GroupOptions,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;
@@ -81,7 +81,7 @@ fn add_dependencies(
   need_new_url: bool,
 ) {
   let output_options = &parser.compiler_options.output;
-  let mut hasher = HashAlgorithm::from(output_options);
+  let mut hasher = RspackHasher::from(output_options);
   parser.module_identifier.hash(&mut hasher);
   parser.worker_index.hash(&mut hasher);
   parser.worker_index += 1;

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -2,7 +2,7 @@ use rspack_core::{
   AssetInfo, BoxModule, Chunk, ChunkCodeTemplate, ChunkInitFragments, ChunkUkey, Compilation,
   Module, ModuleIdentifier, rspack_sources::BoxSource,
 };
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_hook::define_hook;
 #[cfg(allocative)]
 use rspack_util::allocative;
@@ -14,7 +14,7 @@ define_hook!(JavascriptModulesRenderStartup: Series(compilation: &Compilation, c
 define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &ChunkCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesRenderModuleContainer: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &ChunkCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &ChunkCodeTemplate),tracing=false);
-define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut HashAlgorithm));
+define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHasher));
 define_hook!(JavascriptModulesInlineInRuntimeBailout: SeriesBail(compilation: &Compilation) -> String);
 define_hook!(JavascriptModulesEmbedInRuntimeBailout: SeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
 define_hook!(JavascriptModulesStrictRuntimeBailout: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -2,7 +2,7 @@ use rspack_core::{
   AssetInfo, BoxModule, Chunk, ChunkCodeTemplate, ChunkInitFragments, ChunkUkey, Compilation,
   Module, ModuleIdentifier, rspack_sources::BoxSource,
 };
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_hook::define_hook;
 #[cfg(allocative)]
 use rspack_util::allocative;
@@ -14,7 +14,7 @@ define_hook!(JavascriptModulesRenderStartup: Series(compilation: &Compilation, c
 define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &ChunkCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesRenderModuleContainer: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &ChunkCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &ChunkCodeTemplate),tracing=false);
-define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHash));
+define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut HashAlgorithm));
 define_hook!(JavascriptModulesInlineInRuntimeBailout: SeriesBail(compilation: &Compilation) -> String);
 define_hook!(JavascriptModulesEmbedInRuntimeBailout: SeriesBail(compilation: &Compilation, module: &BoxModule, chunk: &Chunk) -> String);
 define_hook!(JavascriptModulesStrictRuntimeBailout: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey) -> String);

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::plugin_hook;
 use rustc_hash::FxHashMap;
 
@@ -469,7 +469,7 @@ async fn chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   self.get_chunk_hash(chunk_ukey, compilation, hasher).await?;
   if compilation
@@ -490,7 +490,7 @@ async fn content_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hashes: &mut FxHashMap<SourceType, RspackHash>,
+  hashes: &mut FxHashMap<SourceType, HashAlgorithm>,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact
@@ -498,7 +498,7 @@ async fn content_hash(
     .expect_get(chunk_ukey);
   let hasher = hashes
     .entry(SourceType::JavaScript)
-    .or_insert_with(|| RspackHash::from(&compilation.options.output));
+    .or_insert_with(|| HashAlgorithm::from(&compilation.options.output));
 
   if !chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
     chunk.id().hash(hasher);

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, CachedSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::plugin_hook;
 use rustc_hash::FxHashMap;
 
@@ -469,7 +469,7 @@ async fn chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   self.get_chunk_hash(chunk_ukey, compilation, hasher).await?;
   if compilation
@@ -490,7 +490,7 @@ async fn content_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hashes: &mut FxHashMap<SourceType, HashAlgorithm>,
+  hashes: &mut FxHashMap<SourceType, RspackHasher>,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact
@@ -498,7 +498,7 @@ async fn content_hash(
     .expect_get(chunk_ukey);
   let hasher = hashes
     .entry(SourceType::JavaScript)
-    .or_insert_with(|| HashAlgorithm::from(&compilation.options.output));
+    .or_insert_with(|| RspackHasher::from(&compilation.options.output));
 
   if !chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
     chunk.id().hash(hasher);

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -38,7 +38,7 @@ use rspack_core::{
   split_readable_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_hook::plugin;
 use rspack_util::SpanExt;
 #[cfg(allocative)]
@@ -1492,7 +1492,7 @@ var {} = {{}};
     &self,
     chunk_ukey: &ChunkUkey,
     compilation: &Compilation,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
   ) -> Result<()> {
     let hooks = Self::get_compilation_hooks(compilation.id());
     hooks
@@ -1509,7 +1509,7 @@ var {} = {{}};
     &self,
     chunk_ukey: &ChunkUkey,
     compilation: &Compilation,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
   ) -> Result<()> {
     let runtime_template = compilation.runtime_template.create_chunk_code_template();
     // sample hash use content
@@ -1526,7 +1526,7 @@ pub struct ExtractedCommentsInfo {
   pub comments_file_name: String,
 }
 
-#[derive(Debug, RspackHashable)]
+#[derive(Debug, RspackHash)]
 pub struct RenderBootstrapResult<'a> {
   pub header: Vec<Cow<'a, str>>,
   pub startup: Vec<Cow<'a, str>>,

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -38,7 +38,7 @@ use rspack_core::{
   split_readable_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::plugin;
 use rspack_util::SpanExt;
 #[cfg(allocative)]
@@ -1492,7 +1492,7 @@ var {} = {{}};
     &self,
     chunk_ukey: &ChunkUkey,
     compilation: &Compilation,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
   ) -> Result<()> {
     let hooks = Self::get_compilation_hooks(compilation.id());
     hooks
@@ -1509,7 +1509,7 @@ var {} = {{}};
     &self,
     chunk_ukey: &ChunkUkey,
     compilation: &Compilation,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
   ) -> Result<()> {
     let runtime_template = compilation.runtime_template.create_chunk_code_template();
     // sample hash use content

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1664,7 +1664,7 @@ async fn create_concatenated_module(
   let mut new_module = BoxModule::new(Box::from(ConcatenatedModule::create(
     root_module_ctxt,
     modules,
-    Some(rspack_hash::HashFunction::Xxhash64),
+    Some(rspack_hash::HashAlgorithm::Xxhash64),
     config.runtime.clone(),
     compilation,
   )));

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1664,7 +1664,7 @@ async fn create_concatenated_module(
   let mut new_module = BoxModule::new(Box::from(ConcatenatedModule::create(
     root_module_ctxt,
     modules,
-    Some(rspack_hash::HashAlgorithm::Xxhash64),
+    Some(rspack_hash::HashFunction::Xxhash64),
     config.runtime.clone(),
     compilation,
   )));

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   DependencyId, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec,
   ExportsSpec, ModuleGraph, ModuleGraphCacheArtifact, RuntimeSpec,
 };
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_util::itoa;
 
 #[cacheable]
@@ -58,7 +58,7 @@ impl AsContextDependency for JsonExportsDependency {}
 impl DependencyCodeGeneration for JsonExportsDependency {
   fn update_hash(
     &self,
-    hasher: &mut RspackHash,
+    hasher: &mut HashAlgorithm,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   DependencyId, ExportNameOrSpec, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec,
   ExportsSpec, ModuleGraph, ModuleGraphCacheArtifact, RuntimeSpec,
 };
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_util::itoa;
 
 #[cacheable]
@@ -58,7 +58,7 @@ impl AsContextDependency for JsonExportsDependency {}
 impl DependencyCodeGeneration for JsonExportsDependency {
   fn update_hash(
     &self,
-    hasher: &mut HashAlgorithm,
+    hasher: &mut RspackHasher,
     _compilation: &Compilation,
     _runtime: Option<&RuntimeSpec>,
   ) {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_plugin_javascript::dependency::CommonJsRequireDependency;
 use rspack_util::{
   json_stringify,
@@ -330,7 +330,7 @@ impl Module for LazyCompilationProxyModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     self.active.hash(&mut hasher);
     self.identifier.hash(&mut hasher);

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_plugin_javascript::dependency::CommonJsRequireDependency;
 use rspack_util::{
   json_stringify,
@@ -330,7 +330,7 @@ impl Module for LazyCompilationProxyModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     self.active.hash(&mut hasher);
     self.identifier.hash(&mut hasher);

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -174,7 +174,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -174,7 +174,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   to_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error, error_bail};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesEmbedInRuntimeBailout, JavascriptModulesRender,
@@ -356,7 +356,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   to_identifier,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error, error_bail};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesEmbedInRuntimeBailout, JavascriptModulesRender,
@@ -356,7 +356,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,
@@ -99,7 +99,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey) else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,
@@ -99,7 +99,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey) else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -112,7 +112,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -112,7 +112,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   to_identifier, to_module_export_name,
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,
@@ -147,7 +147,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(_) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   to_identifier, to_module_export_name,
 };
 use rspack_error::{Result, error_bail};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderStartup, JsPlugin, RenderSource,
@@ -147,7 +147,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(_) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error_bail};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -185,7 +185,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error_bail};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -185,7 +185,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(options) = self.get_options_for_chunk(compilation, chunk_ukey)? else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -329,7 +329,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let Some(_) = self.get_options_for_chunk(compilation, chunk_ukey) else {
     return Ok(());

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRender, JsPlugin, RenderSource,
@@ -329,7 +329,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let Some(_) = self.get_options_for_chunk(compilation, chunk_ukey) else {
     return Ok(());

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -20,7 +20,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::asset_condition::{AssetConditions, AssetConditionsObject, match_object};
 use thread_local::ThreadLocal;
@@ -28,7 +28,7 @@ use thread_local::ThreadLocal;
 static CSS_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.css(\?.*)?$").expect("Invalid RegExp"));
 
-#[derive(Debug, rspack_hash::RspackHashable)]
+#[derive(Debug, rspack_hash::RspackHash)]
 pub struct PluginOptions {
   pub test: Option<AssetConditions>,
   pub include: Option<AssetConditions>,
@@ -37,17 +37,17 @@ pub struct PluginOptions {
   pub minimizer_options: MinimizerOptions,
 }
 
-#[derive(Debug, rspack_hash::RspackHashable)]
+#[derive(Debug, rspack_hash::RspackHash)]
 pub struct Draft {
   pub custom_media: bool,
 }
 
-#[derive(Debug, rspack_hash::RspackHashable)]
+#[derive(Debug, rspack_hash::RspackHash)]
 pub struct NonStandard {
   pub deep_selector_combinator: bool,
 }
 
-#[derive(Debug, rspack_hash::RspackHashable)]
+#[derive(Debug, rspack_hash::RspackHash)]
 pub struct PseudoClasses {
   pub hover: Option<String>,
   pub active: Option<String>,
@@ -56,7 +56,7 @@ pub struct PseudoClasses {
   pub focus_within: Option<String>,
 }
 
-#[derive(Debug, rspack_hash::RspackHashable)]
+#[derive(Debug, rspack_hash::RspackHash)]
 pub struct MinimizerOptions {
   pub error_recovery: bool,
   pub include: Option<u32>,
@@ -85,9 +85,9 @@ async fn chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
-  rspack_hash::RspackHashable::hash(&self.options, hasher);
+  rspack_hash::RspackHash::hash(&self.options, hasher);
   Ok(())
 }
 

--- a/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_lightning_css_minimizer/src/lib.rs
@@ -20,7 +20,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::asset_condition::{AssetConditions, AssetConditionsObject, match_object};
 use thread_local::ThreadLocal;
@@ -85,7 +85,7 @@ async fn chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   rspack_hash::RspackHash::hash(&self.options, hasher);
   Ok(())

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_util::{json_stringify_str, source_map::SourceMapKind};
 use rustc_hash::FxHashSet;
 
@@ -433,7 +433,7 @@ var init = function(shareScope, initScope) {{
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::{json_stringify_str, source_map::SourceMapKind};
 use rustc_hash::FxHashSet;
 
@@ -274,7 +274,7 @@ impl Module for ContainerEntryModule {
 
       // Generate installInitialConsumes function using returning_function
       let install_initial_consumes_call = format!(
-        r#"localBundlerRuntime.installInitialConsumes({{ 
+        r#"localBundlerRuntime.installInitialConsumes({{
             installedModules: localInstalledModules, 
             initialConsumes: {require_name}.consumesLoadingData.initialConsumes, 
             moduleToHandlerMapping: {require_name}.federation.consumesLoadingModuleToHandlerMapping || {{}}, 
@@ -433,7 +433,7 @@ var init = function(shareScope, initScope) {{
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_util::{itoa, source_map::SourceMapKind};
 
 use super::fallback_item_dependency::FallbackItemDependency;
@@ -202,7 +202,7 @@ var handleError = function(e) {{
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::{itoa, source_map::SourceMapKind};
 
 use super::fallback_item_dependency::FallbackItemDependency;
@@ -202,7 +202,7 @@ var handleError = function(e) {{
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
@@ -226,7 +226,7 @@ impl Module for RemoteModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -12,7 +12,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
@@ -226,7 +226,7 @@ impl Module for RemoteModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -2,7 +2,7 @@ mod container;
 mod manifest;
 mod sharing;
 
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 
 #[rspack_cacheable::cacheable]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
@@ -35,8 +35,8 @@ impl ShareScope {
   }
 }
 
-impl RspackHashable for ShareScope {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ShareScope {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       ShareScope::Single(scope) => scope.hash(state),
       ShareScope::Multiple(scopes) => scopes.hash(state),

--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -2,7 +2,7 @@ mod container;
 mod manifest;
 mod sharing;
 
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 
 #[rspack_cacheable::cacheable]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
@@ -36,7 +36,7 @@ impl ShareScope {
 }
 
 impl RspackHash for ShareScope {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       ShareScope::Single(scope) => scope.hash(state),
       ShareScope::Multiple(scopes) => scopes.hash(state),

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_util::{json_stringify, json_stringify_str, source_map::SourceMapKind};
 
 use super::{
@@ -256,7 +256,7 @@ impl Module for ConsumeSharedModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     self.options.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash, RspackHashDigest};
 use rspack_util::{json_stringify, json_stringify_str, source_map::SourceMapKind};
 
 use super::{
@@ -256,7 +256,7 @@ impl Module for ConsumeSharedModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     self.options.hash(&mut hasher);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   RuntimeGlobals, RuntimeModule,
 };
 use rspack_error::{Diagnostic, Result, error};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashMap;
 
@@ -24,7 +24,7 @@ use super::{
 use crate::ShareScope;
 
 #[cacheable]
-#[derive(Debug, Clone, rspack_hash::RspackHashable)]
+#[derive(Debug, Clone, rspack_hash::RspackHash)]
 pub struct ConsumeOptions {
   pub import: Option<String>,
   pub import_resolved: Option<String>,
@@ -45,8 +45,8 @@ pub enum ConsumeVersion {
   False,
 }
 
-impl RspackHashable for ConsumeVersion {
-  fn hash(&self, state: &mut RspackHash) {
+impl RspackHash for ConsumeVersion {
+  fn hash(&self, state: &mut HashAlgorithm) {
     match self {
       ConsumeVersion::Version(version) => version.hash(state),
       ConsumeVersion::False => "false".hash(state),

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   RuntimeGlobals, RuntimeModule,
 };
 use rspack_error::{Diagnostic, Result, error};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rustc_hash::FxHashMap;
 
@@ -46,7 +46,7 @@ pub enum ConsumeVersion {
 }
 
 impl RspackHash for ConsumeVersion {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     match self {
       ConsumeVersion::Version(version) => version.hash(state),
       ConsumeVersion::False => "false".hash(state),

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
@@ -231,7 +231,7 @@ impl Module for ProvideSharedModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
@@ -231,7 +231,7 @@ impl Module for ProvideSharedModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   to_comment_with_nl,
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_css::{
   CssPlugin,
@@ -202,7 +202,7 @@ async fn chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   "ModuleInfoHeaderPlugin".hash(hasher);
   "1".hash(hasher);

--- a/crates/rspack_plugin_module_info_header/src/lib.rs
+++ b/crates/rspack_plugin_module_info_header/src/lib.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   to_comment_with_nl,
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_css::{
   CssPlugin,
@@ -202,7 +202,7 @@ async fn chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   "ModuleInfoHeaderPlugin".hash(hasher);
   "1".hash(hasher);

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt, SourceValue},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::fx_hash::FxDashMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
@@ -215,7 +215,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
               let new_hash = if let Some(new_hash) = updated_hash {
                 new_hash
               } else {
-                let mut hasher = HashAlgorithm::from(&compilation.options.output);
+                let mut hasher = RspackHasher::from(&compilation.options.output);
                 for asset_content in asset_contents {
                   hasher.write(&asset_content.buffer());
                 }

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt, SourceValue},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::fx_hash::FxDashMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
@@ -215,7 +215,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
               let new_hash = if let Some(new_hash) = updated_hash {
                 new_hash
               } else {
-                let mut hasher = RspackHash::from(&compilation.options.output);
+                let mut hasher = HashAlgorithm::from(&compilation.options.output);
                 for asset_content in asset_contents {
                   hasher.write(&asset_content.buffer());
                 }

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_plugin_javascript::dependency::ImportEagerDependency;
 use rspack_util::{fx_hash::FxIndexSet, source_map::SourceMapKind};
 use rustc_hash::FxHashSet;
@@ -402,7 +402,7 @@ impl Module for RscEntryModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = RspackHash::from(&compilation.options.output);
+    let mut hasher = HashAlgorithm::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_plugin_javascript::dependency::ImportEagerDependency;
 use rspack_util::{fx_hash::FxIndexSet, source_map::SourceMapKind};
 use rustc_hash::FxHashSet;
@@ -402,7 +402,7 @@ impl Module for RscEntryModule {
     compilation: &Compilation,
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
-    let mut hasher = HashAlgorithm::from(&compilation.options.output);
+    let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,
@@ -70,7 +70,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,
@@ -70,7 +70,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,
@@ -73,7 +73,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JsPlugin, RenderSource,
@@ -73,7 +73,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_plugin_javascript::runtime::stringify_chunks_to_array;
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::FxHashSet as HashSet;
@@ -34,7 +34,7 @@ pub fn should_export_webpack_require_for_module_chunk_loading(
 }
 
 pub fn update_hash_for_entry_startup(
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
   compilation: &Compilation,
   entries: &IdentifierLinkedMap<ChunkGroupUkey>,
   chunk: &ChunkUkey,

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, error};
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_plugin_javascript::runtime::stringify_chunks_to_array;
 use rspack_util::fx_hash::FxIndexSet;
 use rustc_hash::FxHashSet as HashSet;
@@ -34,7 +34,7 @@ pub fn should_export_webpack_require_for_module_chunk_loading(
 }
 
 pub fn update_hash_for_entry_startup(
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
   compilation: &Compilation,
   entries: &IdentifierLinkedMap<ChunkGroupUkey>,
   chunk: &ChunkUkey,

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JavascriptModulesRenderStartup,
@@ -77,7 +77,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   rspack_sources::{ConcatSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesRenderChunk, JavascriptModulesRenderStartup,
@@ -77,7 +77,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   get_js_chunk_filename_template,
 };
 use rspack_error::Result;
-use rspack_hash::{HashAlgorithm, RspackHash};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JsPlugin, impl_plugin_for_js_plugin::chunk_has_js,
@@ -119,7 +119,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   for identifier in compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
   get_js_chunk_filename_template,
 };
 use rspack_error::Result;
-use rspack_hash::{RspackHash, RspackHashable};
+use rspack_hash::{HashAlgorithm, RspackHash};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JsPlugin, impl_plugin_for_js_plugin::chunk_has_js,
@@ -119,7 +119,7 @@ async fn js_chunk_hash(
   &self,
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
   for identifier in compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   incremental::Mutation,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::{RspackHash, RspackHashDigest};
+use rspack_hash::{HashAlgorithm, RspackHashDigest};
 use rspack_util::identifier::make_paths_relative;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -120,7 +120,7 @@ fn get_size(module: &dyn Module, compilation: &Compilation) -> SplitChunkSizes {
 }
 
 fn hash_filename(filename: &str, options: &CompilerOptions) -> String {
-  let mut filename_hash = RspackHash::new(&options.output.hash_function);
+  let mut filename_hash = HashAlgorithm::new(&options.output.hash_function);
   filename_hash.write(filename.as_bytes());
   let hash_digest: RspackHashDigest = filename_hash.digest(&options.output.hash_digest);
   hash_digest.rendered(8).to_string()

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   incremental::Mutation,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
-use rspack_hash::{HashAlgorithm, RspackHashDigest};
+use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::identifier::make_paths_relative;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -120,7 +120,7 @@ fn get_size(module: &dyn Module, compilation: &Compilation) -> SplitChunkSizes {
 }
 
 fn hash_filename(filename: &str, options: &CompilerOptions) -> String {
-  let mut filename_hash = HashAlgorithm::new(&options.output.hash_function);
+  let mut filename_hash = RspackHasher::new(&options.output.hash_function);
   filename_hash.write(filename.as_bytes());
   let hash_digest: RspackHashDigest = filename_hash.digest(&options.output.hash_digest);
   hash_digest.rendered(8).to_string()

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -22,7 +22,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_plugin_javascript::{ExtractedCommentsInfo, JavascriptModulesChunkHash, JsPlugin};
@@ -74,7 +74,7 @@ pub struct MinimizerOptions {
 }
 
 impl rspack_hash::RspackHash for MinimizerOptions {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     rspack_hash::RspackHash::hash(
       self
         .__format_cache
@@ -149,7 +149,7 @@ impl<T: std::fmt::Debug + std::hash::Hash> Display for OptionWrapper<T> {
 impl<T: std::fmt::Debug + std::hash::Hash + rspack_hash::RspackHash> rspack_hash::RspackHash
   for OptionWrapper<T>
 {
-  fn hash(&self, state: &mut HashAlgorithm) {
+  fn hash(&self, state: &mut RspackHasher) {
     rspack_hash::RspackHash::hash(&self.to_string(), state);
     if let OptionWrapper::Custom(value) = self {
       rspack_hash::RspackHash::hash(value, state);
@@ -215,7 +215,7 @@ async fn js_chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut HashAlgorithm,
+  hasher: &mut RspackHasher,
 ) -> Result<()> {
   rspack_hash::RspackHash::hash(&self.options, hasher);
   Ok(())

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -22,7 +22,7 @@ use rspack_core::{
   },
 };
 use rspack_error::{Diagnostic, Result};
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_javascript_compiler::JavaScriptCompiler;
 use rspack_plugin_javascript::{ExtractedCommentsInfo, JavascriptModulesChunkHash, JsPlugin};
@@ -47,7 +47,7 @@ const PLUGIN_NAME: &str = "rspack.SwcJsMinimizerRspackPlugin";
 static JAVASCRIPT_ASSET_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.[cm]?js(\?.*)?$").expect("Invalid RegExp"));
 
-#[derive(Debug, Hash, rspack_hash::RspackHashable)]
+#[derive(Debug, Hash, rspack_hash::RspackHash)]
 pub struct PluginOptions {
   pub test: Option<AssetConditions>,
   pub include: Option<AssetConditions>,
@@ -73,15 +73,15 @@ pub struct MinimizerOptions {
   pub __format_cache: OnceCell<String>,
 }
 
-impl rspack_hash::RspackHashable for MinimizerOptions {
-  fn hash(&self, state: &mut RspackHash) {
-    rspack_hash::RspackHashable::hash(
+impl rspack_hash::RspackHash for MinimizerOptions {
+  fn hash(&self, state: &mut HashAlgorithm) {
+    rspack_hash::RspackHash::hash(
       self
         .__format_cache
         .get_or_init(|| simd_json::to_string(&self.format).expect("Should be able to serialize")),
       state,
     );
-    rspack_hash::RspackHashable::hash(
+    rspack_hash::RspackHash::hash(
       self.__compress_cache.get_or_init(|| {
         self
           .compress
@@ -90,7 +90,7 @@ impl rspack_hash::RspackHashable for MinimizerOptions {
       }),
       state,
     );
-    rspack_hash::RspackHashable::hash(
+    rspack_hash::RspackHash::hash(
       self.__mangle_cache.get_or_init(|| {
         self
           .mangle
@@ -146,18 +146,18 @@ impl<T: std::fmt::Debug + std::hash::Hash> Display for OptionWrapper<T> {
   }
 }
 
-impl<T: std::fmt::Debug + std::hash::Hash + rspack_hash::RspackHashable> rspack_hash::RspackHashable
+impl<T: std::fmt::Debug + std::hash::Hash + rspack_hash::RspackHash> rspack_hash::RspackHash
   for OptionWrapper<T>
 {
-  fn hash(&self, state: &mut RspackHash) {
-    rspack_hash::RspackHashable::hash(&self.to_string(), state);
+  fn hash(&self, state: &mut HashAlgorithm) {
+    rspack_hash::RspackHash::hash(&self.to_string(), state);
     if let OptionWrapper::Custom(value) = self {
-      rspack_hash::RspackHashable::hash(value, state);
+      rspack_hash::RspackHash::hash(value, state);
     }
   }
 }
 
-#[derive(Debug, rspack_hash::RspackHashable)]
+#[derive(Debug, rspack_hash::RspackHash)]
 pub struct ExtractComments {
   pub condition: String,
   pub condition_flags: String,
@@ -215,9 +215,9 @@ async fn js_chunk_hash(
   &self,
   _compilation: &Compilation,
   _chunk_ukey: &ChunkUkey,
-  hasher: &mut RspackHash,
+  hasher: &mut HashAlgorithm,
 ) -> Result<()> {
-  rspack_hash::RspackHashable::hash(&self.options, hasher);
+  rspack_hash::RspackHash::hash(&self.options, hasher);
   Ok(())
 }
 

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -27,7 +27,7 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
-use rspack_hash::HashAlgorithm;
+use rspack_hash::RspackHasher;
 use rspack_plugin_split_chunks::{
   CacheGroup, CacheGroupTest, ChunkNameGetter, FallbackCacheGroup, PluginOptions, SplitChunkSizes,
   SplitChunksPlugin, create_all_chunk_filter, create_default_module_layer_filter,
@@ -1668,7 +1668,7 @@ async fn process_chunk_hash(
   compilation: &Compilation,
   chunk_ukey: ChunkUkey,
 ) -> Result<(rspack_hash::RspackHashDigest, ChunkContentHash)> {
-  let mut hasher = HashAlgorithm::from(&compilation.options.output);
+  let mut hasher = RspackHasher::from(&compilation.options.output);
   if let Some(chunk) = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -27,7 +27,7 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_fs::{MemoryFileSystem, WritableFileSystem};
-use rspack_hash::RspackHash;
+use rspack_hash::HashAlgorithm;
 use rspack_plugin_split_chunks::{
   CacheGroup, CacheGroupTest, ChunkNameGetter, FallbackCacheGroup, PluginOptions, SplitChunkSizes,
   SplitChunksPlugin, create_all_chunk_filter, create_default_module_layer_filter,
@@ -1668,7 +1668,7 @@ async fn process_chunk_hash(
   compilation: &Compilation,
   chunk_ukey: ChunkUkey,
 ) -> Result<(rspack_hash::RspackHashDigest, ChunkContentHash)> {
-  let mut hasher = RspackHash::from(&compilation.options.output);
+  let mut hasher = HashAlgorithm::from(&compilation.options.output);
   if let Some(chunk) = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey


### PR DESCRIPTION
## Summary

This PR renames several hash-related objects so their names better match their roles:

- `RspackHash` now represents the content-hash input trait
- `HashAlgorithm` now represents the mutable hash algorithm/state
- the derive macro and generated code are aligned with the new names
- downstream call sites and hash tests are updated accordingly

## Validation

- `cargo check -p rspack_hash -p rspack_macros`
- `cargo check --workspace --exclude rspack_node --exclude rspack_binding_builder --exclude rspack_binding_builder_macros --exclude rspack_binding_builder_testing --exclude rspack_binding_build --exclude rspack_napi --exclude rspack_watcher`
- `cargo test -p rspack_hash`
- `git diff --check`
- `cargo fmt -p rspack_macros -p rspack_hash --check`

---
_by OpenAI Codex_