### PR TITLE
perf: upgrade napi and remove compat mode

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -28,7 +28,7 @@ ignored = ["napi-derive", "tracing"]
 [dependencies]
 rspack_binding_api = { workspace = true }
 
-napi-derive = { workspace = true, features = ["compat-mode", "type-def"] }
+napi-derive = { workspace = true, features = ["type-def"] }
 tracing     = { workspace = true }
 
 [build-dependencies]

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -53,8 +53,8 @@ tracing                 = { workspace = true }
 tracing-subscriber      = { workspace = true }
 tracy-client            = { workspace = true, optional = true }
 
-napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9", "compat-mode"] }
-napi-derive = { workspace = true, features = ["compat-mode"] }
+napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9"] }
+napi-derive = { workspace = true }
 
 derive_more                            = { workspace = true, features = ["debug"] }
 futures                                = { workspace = true }

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "256"]
-#![allow(deprecated)]
 #![allow(unused)]
 #![allow(trivial_numeric_casts)]
 
@@ -108,7 +107,7 @@ use std::{
   sync::{Arc, RwLock},
 };
 
-use napi::{CallContext, bindgen_prelude::*};
+use napi::bindgen_prelude::*;
 pub use raw_options::{CustomPluginBuilder, register_custom_plugin};
 use rspack_core::{
   BoxDependency, Compilation, CompilerId, CompilerPlatform, EntryOptions, ModuleIdentifier,
@@ -152,15 +151,6 @@ pub const EXPECTED_RSPACK_CORE_VERSION: &str = rspack_workspace::rspack_pkg_vers
 
 thread_local! {
   static COMPILER_REFERENCES: RefCell<FxHashMap<CompilerId, WeakReference<JsCompiler>>> = Default::default();
-}
-
-#[js_function(1)]
-fn cleanup_revoked_modules(ctx: CallContext) -> Result<()> {
-  let external = ctx.get::<&mut External<(CompilerId, Vec<ModuleIdentifier>)>>(0)?;
-  let compiler_id = external.0;
-  let revoked_modules = external.1.take();
-  ModuleObject::cleanup_by_module_identifiers(&compiler_id, &revoked_modules);
-  Ok(())
 }
 
 #[napi(custom_finalize)]
@@ -233,8 +223,15 @@ impl JsCompiler {
         rspack_loader_preact_refresh::PreactRefreshLoaderPlugin::new(),
       ));
 
-      let tsfn = env
-        .create_function("cleanup_revoked_modules", cleanup_revoked_modules)?
+      let cleanup_revoked_modules =
+        env.create_function_from_closure("cleanup_revoked_modules", |ctx| {
+          let external = ctx.get::<&mut External<(CompilerId, Vec<ModuleIdentifier>)>>(0)?;
+          let compiler_id = external.0;
+          let revoked_modules = external.1.take();
+          ModuleObject::cleanup_by_module_identifiers(&compiler_id, &revoked_modules);
+          Ok(())
+        })?;
+      let tsfn = cleanup_revoked_modules
         .build_threadsafe_function::<External<(CompilerId, Vec<ModuleIdentifier>)>>()
         .weak::<true>()
         .callee_handled::<false>()

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -1,7 +1,6 @@
-#![allow(deprecated)]
 use std::{any::TypeId, cell::RefCell, ptr::NonNull, sync::Arc};
 
-use napi::{CallContext, JsObject, JsString, JsSymbol, NapiRaw};
+use napi::{JsString, sys};
 use napi_derive::napi;
 use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
@@ -10,7 +9,7 @@ use rspack_core::{
   RuntimeModuleStage, SourceType, internal,
 };
 use rspack_napi::{
-  OneShotInstanceRef, WeakRef, napi::bindgen_prelude::*, string::JsStringExt,
+  OneShotInstanceRef, OneShotRef, napi::bindgen_prelude::*, string::JsStringExt,
   threadsafe_function::ThreadsafeFunction,
 };
 use rspack_plugin_runtime::RuntimeModuleFromJs;
@@ -55,211 +54,83 @@ impl From<JsFactoryMeta> for FactoryMeta {
 }
 
 thread_local! {
-  pub(crate) static MODULE_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::with_capacity(4));
+  static MODULE_PROPERTIES_BUFFER: RefCell<Vec<Property>> = RefCell::new(Vec::with_capacity(1));
 }
+
+const COMMON_MODULE_OWN_PROPERTIES: &[&str] = &[
+  "type",
+  "context",
+  "layer",
+  "useSourceMap",
+  "useSimpleSourceMap",
+  "factoryMeta",
+  "buildInfo",
+  "buildMeta",
+];
 
 pub(crate) trait DerivedModule {
   fn as_module(&mut self) -> &mut Module;
 }
 
-#[js_function]
-fn module_context_getter(ctx: CallContext) -> napi::Result<Either<String, ()>> {
-  let this = ctx.this_unchecked::<JsObject>();
-  let wrapped_value = unsafe { Module::from_napi_mut_ref(ctx.env.raw(), this.raw())? };
-  let (_, module) = wrapped_value.as_ref()?;
-  Ok(match module.get_context() {
-    Some(ctx) => Either::A(ctx.to_string()),
-    None => Either::B(()),
-  })
-}
-
-#[js_function]
-fn module_layer_getter(ctx: CallContext<'_>) -> napi::Result<Either<&String, ()>> {
-  let this = ctx.this_unchecked::<JsObject>();
-  let wrapped_value = unsafe { Module::from_napi_mut_ref(ctx.env.raw(), this.raw())? };
-  let (_, module) = wrapped_value.as_ref()?;
-  Ok(match module.get_layer() {
-    Some(layer) => Either::A(layer),
-    None => Either::B(()),
-  })
-}
-
-#[js_function]
-fn module_use_source_map_getter(ctx: CallContext) -> napi::Result<bool> {
-  let this = ctx.this_unchecked::<JsObject>();
-  let wrapped_value = unsafe { Module::from_napi_mut_ref(ctx.env.raw(), this.raw())? };
-  let (_, module) = wrapped_value.as_ref()?;
-  Ok(module.get_source_map_kind().source_map())
-}
-
-#[js_function]
-fn module_use_simple_source_map_getter(ctx: CallContext) -> napi::Result<bool> {
-  let this = ctx.this_unchecked::<JsObject>();
-  let wrapped_value = unsafe { Module::from_napi_mut_ref(ctx.env.raw(), this.raw())? };
-  let (_, module) = wrapped_value.as_ref()?;
-  Ok(module.get_source_map_kind().simple_source_map())
-}
-
-#[js_function]
-fn module_factory_meta_getter(ctx: CallContext) -> napi::Result<JsFactoryMeta> {
-  let this = ctx.this_unchecked::<JsObject>();
-  let wrapped_value = unsafe { Module::from_napi_mut_ref(ctx.env.raw(), this.raw())? };
-  let (_, module) = wrapped_value.as_ref()?;
-  Ok(match module.as_normal_module() {
-    Some(normal_module) => match normal_module.factory_meta() {
-      Some(meta) => JsFactoryMeta {
-        side_effect_free: meta.side_effect_free,
-      },
-      None => JsFactoryMeta {
-        side_effect_free: None,
-      },
-    },
-    None => JsFactoryMeta {
-      side_effect_free: None,
-    },
-  })
-}
-
-#[js_function(1)]
-fn module_factory_meta_setter(ctx: CallContext) -> napi::Result<()> {
-  let this = ctx.this_unchecked::<JsObject>();
-  let wrapped_value = unsafe { Module::from_napi_mut_ref(ctx.env.raw(), this.raw())? };
-  let module = wrapped_value.as_mut()?;
-  let factory_meta = ctx.get::<JsFactoryMeta>(0)?;
-  module.set_factory_meta(factory_meta.into());
-  Ok(())
-}
-
-#[js_function]
-fn module_build_info_getter(ctx: CallContext) -> napi::Result<Object> {
-  let mut this = ctx.this_unchecked::<JsObject>();
-  let env = ctx.env;
-  let raw_env = env.raw();
-  let mut reference: Reference<Module> =
-    unsafe { Reference::from_napi_value(raw_env, this.raw())? };
-  if let Some(r) = &reference.build_info_ref {
-    return r.as_object(env);
+pub(crate) fn define_own_properties_from_prototype(
+  env: &Env,
+  object: &mut Object,
+  names: &[&str],
+) -> napi::Result<()> {
+  if names.is_empty() {
+    return Ok(());
   }
-  let mut build_info = BuildInfo::new(reference.downgrade()).get_jsobject(env)?;
-  MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
-    let sym = unsafe {
-      #[allow(clippy::unwrap_used)]
-      let napi_val = ToNapiValue::to_napi_value(env.raw(), once_cell.get().unwrap())?;
-      JsSymbol::from_napi_value(env.raw(), napi_val)
-    };
-    this.set_property(sym, build_info)
-  })?;
-  let r = WeakRef::new(raw_env, &mut build_info)?;
-  let result = r.as_object(env);
-  reference.build_info_ref = Some(r);
-  result
-}
 
-#[js_function(1)]
-fn module_build_info_setter(ctx: CallContext) -> napi::Result<()> {
-  let mut this = ctx.this_unchecked::<JsObject>();
-  let input_object = ctx.get::<Object>(0)?;
-  let env = ctx.env;
-  let raw_env = env.raw();
-  let mut reference: Reference<Module> =
-    unsafe { Reference::from_napi_value(raw_env, this.raw())? };
-  let new_build_info = BuildInfo::new(reference.downgrade());
-  let mut new_instance = new_build_info.get_jsobject(env)?;
+  let global = env.get_global()?;
+  let object_constructor: Function = global.get_named_property("Object")?;
+  let get_own_property_descriptor: Function<FnArgs<(Object, String)>, Either<Object, ()>> =
+    object_constructor.get_named_property("getOwnPropertyDescriptor")?;
+  let define_property: Function<FnArgs<(Object, String, Object)>, Object> =
+    object_constructor.get_named_property("defineProperty")?;
+  let prototype = object.get_prototype_unchecked::<Object>()?;
 
-  let names = input_object.get_all_property_names(
-    napi::KeyCollectionMode::OwnOnly,
-    napi::KeyFilter::AllProperties,
-    napi::KeyConversion::KeepNumbers,
-  )?;
-  let names = Array::from_unknown(names.to_unknown())?;
-  for index in 0..names.len() {
-    if let Some(name) = names.get::<Unknown>(index)? {
-      let name_clone = Object::from_raw(env.raw(), name.raw());
-      let name_str = name_clone.coerce_to_string()?.into_string();
-      // known build info properties
-      if name_str != "assets" {
-        let value = input_object.get_property::<Unknown, Unknown>(name)?;
-        new_instance.set_property::<Unknown, Unknown>(name, value)?;
-      }
+  for name in names {
+    if let Either::A(descriptor) =
+      get_own_property_descriptor.call(FnArgs::from((prototype, (*name).to_string())))?
+    {
+      define_property.call(FnArgs::from((*object, (*name).to_string(), descriptor)))?;
     }
   }
 
-  MODULE_BUILD_INFO_SYMBOL.with(|once_cell| {
-    let sym = unsafe {
-      #[allow(clippy::unwrap_used)]
-      let napi_val = ToNapiValue::to_napi_value(env.raw(), once_cell.get().unwrap())?;
-      JsSymbol::from_napi_value(env.raw(), napi_val)
-    };
-    this.set_property(sym, new_instance)
-  })?;
-  reference.build_info_ref = Some(WeakRef::new(raw_env, &mut new_instance)?);
   Ok(())
 }
 
-pub(crate) fn define_module_properties(
+pub(crate) fn define_module_instance_properties(
   env: &Env,
   instance: &mut impl DerivedModule,
   object: &mut Object,
-  properties: &mut Vec<Property>,
 ) -> napi::Result<()> {
+  define_own_properties_from_prototype(env, object, COMMON_MODULE_OWN_PROPERTIES)?;
+
   let (_, module) = instance.as_module().as_ref()?;
 
-  properties.push(
-    Property::new()
-      .with_utf8_name("type")?
-      .with_value(&env.create_string(module.module_type().as_str())?),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("context")?
-      .with_getter(module_context_getter),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("layer")?
-      .with_getter(module_layer_getter),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("useSourceMap")?
-      .with_getter(module_use_source_map_getter),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("useSimpleSourceMap")?
-      .with_getter(module_use_simple_source_map_getter),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("factoryMeta")?
-      .with_getter(module_factory_meta_getter)
-      .with_setter(module_factory_meta_setter),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("buildInfo")?
-      .with_getter(module_build_info_getter)
-      .with_setter(module_build_info_setter),
-  );
-  properties.push(
-    Property::new()
-      .with_utf8_name("buildMeta")?
-      .with_value(&Object::new(env)?),
-  );
   MODULE_IDENTIFIER_SYMBOL.with(|once_cell| {
     let identifier = env.create_string(module.identifier().as_str())?;
     #[allow(clippy::unwrap_used)]
     let symbol = once_cell.get().unwrap();
-    properties.push(
-      Property::new()
-        .with_name(env, symbol)?
-        .with_value(&identifier)
-        .with_property_attributes(PropertyAttributes::Configurable),
-    );
+    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
+      let mut properties = ref_cell.borrow_mut();
+      properties.clear();
+      properties.push(
+        Property::new()
+          .with_name(env, symbol)?
+          .with_value(&identifier)
+          .with_property_attributes(PropertyAttributes::Configurable),
+      );
+      object.define_properties(&properties)
+    })?;
     Ok::<(), napi::Error>(())
-  })?;
+  })
+}
 
-  object.define_properties(properties)
+fn object_from_ref<'a>(env: &'a Env, object_ref: &OneShotRef) -> napi::Result<Object<'a>> {
+  let raw = unsafe { ToNapiValue::to_napi_value(env.raw(), object_ref)? };
+  Ok(Object::from_raw(env.raw(), raw))
 }
 
 // ## Clarify Access Methods for napi Module to Rust Module
@@ -281,7 +152,8 @@ pub struct Module {
   ptr: Option<NonNull<dyn rspack_core::Module>>,
   compiler_id: CompilerId,
   compiler_reference: WeakReference<JsCompiler>,
-  pub(crate) build_info_ref: Option<WeakRef>,
+  build_info_ref: Option<OneShotRef>,
+  build_meta_ref: Option<OneShotRef>,
 }
 
 impl DerivedModule for Module {
@@ -294,12 +166,7 @@ impl Module {
   pub(crate) fn into_module_instance(self, env: &Env) -> napi::Result<ClassInstance<'_, Self>> {
     let mut instance = self.into_instance(env)?;
     let mut object = instance.as_object(env);
-
-    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
-      let mut properties = ref_cell.borrow_mut();
-      properties.clear();
-      define_module_properties(env, &mut *instance, &mut object, &mut properties)
-    })?;
+    define_module_instance_properties(env, &mut *instance, &mut object)?;
 
     Ok(instance)
   }
@@ -343,10 +210,186 @@ impl Module {
       ))),
     }
   }
+
+  fn create_reference(&mut self, env: &Env) -> napi::Result<Reference<Module>> {
+    // SAFETY: Module is the first field of every derived module wrapper with #[repr(C)].
+    // The native pointer registered by napi-rs therefore has the same address as this field.
+    unsafe { Reference::from_value_ptr((self as *mut Self).cast(), env.raw()) }
+  }
+
+  pub(crate) fn get_module_type(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.module_type().as_str().to_string())
+  }
+
+  pub(crate) fn get_context(&mut self) -> napi::Result<Either<String, ()>> {
+    let (_, module) = self.as_ref()?;
+    Ok(match module.get_context() {
+      Some(ctx) => Either::A(ctx.to_string()),
+      None => Either::B(()),
+    })
+  }
+
+  pub(crate) fn get_layer(&mut self) -> napi::Result<Either<String, ()>> {
+    let (_, module) = self.as_ref()?;
+    Ok(match module.get_layer() {
+      Some(layer) => Either::A(layer.clone()),
+      None => Either::B(()),
+    })
+  }
+
+  pub(crate) fn get_use_source_map(&mut self) -> napi::Result<bool> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.get_source_map_kind().source_map())
+  }
+
+  pub(crate) fn get_use_simple_source_map(&mut self) -> napi::Result<bool> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.get_source_map_kind().simple_source_map())
+  }
+
+  pub(crate) fn get_factory_meta(&mut self) -> napi::Result<JsFactoryMeta> {
+    let (_, module) = self.as_ref()?;
+    Ok(match module.as_normal_module() {
+      Some(normal_module) => match normal_module.factory_meta() {
+        Some(meta) => JsFactoryMeta {
+          side_effect_free: meta.side_effect_free,
+        },
+        None => JsFactoryMeta {
+          side_effect_free: None,
+        },
+      },
+      None => JsFactoryMeta {
+        side_effect_free: None,
+      },
+    })
+  }
+
+  pub(crate) fn set_factory_meta_value(&mut self, factory_meta: JsFactoryMeta) -> napi::Result<()> {
+    let module = self.as_mut()?;
+    module.set_factory_meta(factory_meta.into());
+    Ok(())
+  }
+
+  pub(crate) fn get_build_info<'a>(&mut self, env: &'a Env) -> napi::Result<Object<'a>> {
+    if let Some(object_ref) = &self.build_info_ref {
+      return object_from_ref(env, object_ref);
+    }
+
+    let reference = self.create_reference(env)?;
+    let build_info = BuildInfo::new(reference.downgrade()).get_jsobject(env)?;
+    self.build_info_ref = Some(OneShotRef::new(env.raw(), build_info)?);
+    Ok(build_info)
+  }
+
+  pub(crate) fn set_build_info_object(
+    &mut self,
+    env: &Env,
+    input_object: Object,
+  ) -> napi::Result<()> {
+    let reference = self.create_reference(env)?;
+    let new_build_info = BuildInfo::new(reference.downgrade());
+    let mut new_instance = new_build_info.get_jsobject(env)?;
+
+    let names = input_object.get_all_property_names(
+      napi::KeyCollectionMode::OwnOnly,
+      napi::KeyFilter::AllProperties,
+      napi::KeyConversion::KeepNumbers,
+    )?;
+    let names = Array::from_unknown(names.to_unknown())?;
+    for index in 0..names.len() {
+      if let Some(name) = names.get::<Unknown>(index)? {
+        let name_clone = Object::from_raw(env.raw(), name.raw());
+        let name_str = name_clone.coerce_to_string()?.into_string();
+        // known build info properties
+        if name_str != "assets" {
+          let value = input_object.get_property::<Unknown, Unknown>(name)?;
+          new_instance.set_property::<Unknown, Unknown>(name, value)?;
+        }
+      }
+    }
+
+    self.build_info_ref = Some(OneShotRef::new(env.raw(), new_instance)?);
+    Ok(())
+  }
+
+  pub(crate) fn get_build_meta<'a>(&mut self, env: &'a Env) -> napi::Result<Object<'a>> {
+    if let Some(object_ref) = &self.build_meta_ref {
+      return object_from_ref(env, object_ref);
+    }
+
+    let build_meta = Object::new(env)?;
+    self.build_meta_ref = Some(OneShotRef::new(env.raw(), build_meta)?);
+    Ok(build_meta)
+  }
+
+  pub(crate) fn set_build_meta_object(
+    &mut self,
+    env: &Env,
+    build_meta: Object,
+  ) -> napi::Result<()> {
+    self.build_meta_ref = Some(OneShotRef::new(env.raw(), build_meta)?);
+    Ok(())
+  }
 }
 
 #[napi]
 impl Module {
+  #[napi(skip_typescript, getter, js_name = "type")]
+  pub fn module_type(&mut self) -> napi::Result<String> {
+    self.get_module_type()
+  }
+
+  #[napi(skip_typescript, getter)]
+  pub fn context(&mut self) -> napi::Result<Either<String, ()>> {
+    self.get_context()
+  }
+
+  #[napi(skip_typescript, getter)]
+  pub fn layer(&mut self) -> napi::Result<Either<String, ()>> {
+    self.get_layer()
+  }
+
+  #[napi(skip_typescript, getter, js_name = "useSourceMap")]
+  pub fn use_source_map(&mut self) -> napi::Result<bool> {
+    self.get_use_source_map()
+  }
+
+  #[napi(skip_typescript, getter, js_name = "useSimpleSourceMap")]
+  pub fn use_simple_source_map(&mut self) -> napi::Result<bool> {
+    self.get_use_simple_source_map()
+  }
+
+  #[napi(skip_typescript, getter, js_name = "factoryMeta")]
+  pub fn factory_meta(&mut self) -> napi::Result<JsFactoryMeta> {
+    self.get_factory_meta()
+  }
+
+  #[napi(skip_typescript, setter)]
+  pub fn set_factory_meta(&mut self, factory_meta: JsFactoryMeta) -> napi::Result<()> {
+    self.set_factory_meta_value(factory_meta)
+  }
+
+  #[napi(skip_typescript, getter, js_name = "buildInfo")]
+  pub fn build_info<'a>(&mut self, env: &'a Env) -> napi::Result<Object<'a>> {
+    self.get_build_info(env)
+  }
+
+  #[napi(skip_typescript, setter)]
+  pub fn set_build_info(&mut self, env: &Env, build_info: Object) -> napi::Result<()> {
+    self.set_build_info_object(env, build_info)
+  }
+
+  #[napi(skip_typescript, getter, js_name = "buildMeta")]
+  pub fn build_meta<'a>(&mut self, env: &'a Env) -> napi::Result<Object<'a>> {
+    self.get_build_meta(env)
+  }
+
+  #[napi(skip_typescript, setter)]
+  pub fn set_build_meta(&mut self, env: &Env, build_meta: Object) -> napi::Result<()> {
+    self.set_build_meta_object(env, build_meta)
+  }
+
   #[napi]
   pub fn readable_identifier(&mut self) -> napi::Result<String> {
     let (compilation, module) = self.as_ref()?;
@@ -634,6 +677,7 @@ impl ToNapiValue for ModuleObject {
                 ptr: val.ptr,
                 compiler_reference,
                 build_info_ref: Default::default(),
+                build_meta_ref: Default::default(),
               };
               let env_wrapper = Env::from_raw(env);
 

--- a/crates/rspack_binding_api/src/modules/concatenated_module.rs
+++ b/crates/rspack_binding_api/src/modules/concatenated_module.rs
@@ -1,6 +1,6 @@
 use crate::{
   impl_module_methods,
-  module::{MODULE_PROPERTIES_BUFFER, Module, ModuleObject},
+  module::{Module, ModuleObject},
 };
 
 #[napi]
@@ -14,12 +14,7 @@ impl ConcatenatedModule {
     self,
     env: &napi::Env,
   ) -> napi::Result<napi::bindgen_prelude::ClassInstance<'_, Self>> {
-    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
-      let mut properties = ref_cell.borrow_mut();
-      properties.clear();
-
-      Self::new_inherited(self, env, &mut properties)
-    })
+    Self::new_inherited(self, env, &[])
   }
 
   fn as_ref(

--- a/crates/rspack_binding_api/src/modules/context_module.rs
+++ b/crates/rspack_binding_api/src/modules/context_module.rs
@@ -1,7 +1,4 @@
-use crate::{
-  impl_module_methods,
-  module::{MODULE_PROPERTIES_BUFFER, Module},
-};
+use crate::{impl_module_methods, module::Module};
 
 #[napi]
 #[repr(C)]
@@ -14,12 +11,7 @@ impl ContextModule {
     self,
     env: &napi::Env,
   ) -> napi::Result<napi::bindgen_prelude::ClassInstance<'_, Self>> {
-    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
-      let mut properties = ref_cell.borrow_mut();
-      properties.clear();
-
-      Self::new_inherited(self, env, &mut properties)
-    })
+    Self::new_inherited(self, env, &[])
   }
 }
 

--- a/crates/rspack_binding_api/src/modules/external_module.rs
+++ b/crates/rspack_binding_api/src/modules/external_module.rs
@@ -1,7 +1,4 @@
-use crate::{
-  impl_module_methods,
-  module::{MODULE_PROPERTIES_BUFFER, Module},
-};
+use crate::{impl_module_methods, module::Module};
 
 #[napi]
 #[repr(C)]
@@ -14,20 +11,7 @@ impl ExternalModule {
     mut self,
     env: &napi::Env,
   ) -> napi::Result<napi::bindgen_prelude::ClassInstance<'_, Self>> {
-    let (_, module) = self.as_ref()?;
-    let user_request = env.create_string(module.user_request())?;
-
-    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
-      let mut properties = ref_cell.borrow_mut();
-      properties.clear();
-
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("userRequest")?
-          .with_value(&user_request),
-      );
-      Self::new_inherited(self, env, &mut properties)
-    })
+    Self::new_inherited(self, env, &["userRequest"])
   }
 
   fn as_ref(&mut self) -> napi::Result<(&rspack_core::Compilation, &rspack_core::ExternalModule)> {
@@ -39,6 +23,15 @@ impl ExternalModule {
         "Module is not a ExternalModule",
       )),
     }
+  }
+}
+
+#[napi]
+impl ExternalModule {
+  #[napi(skip_typescript, getter, js_name = "userRequest")]
+  pub fn user_request(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.user_request().to_string())
   }
 }
 

--- a/crates/rspack_binding_api/src/modules/macros.rs
+++ b/crates/rspack_binding_api/src/modules/macros.rs
@@ -11,18 +11,14 @@ macro_rules! impl_module_methods {
       fn new_inherited<'a>(
         self,
         env: &'a napi::Env,
-        properties: &mut Vec<napi::Property>,
+        own_property_names: &[&str],
       ) -> napi::Result<napi::bindgen_prelude::ClassInstance<'a, Self>> {
         use napi::bindgen_prelude::{JavaScriptClassExt, JsObjectValue};
 
         let mut instance = self.into_instance(env)?;
         let mut object = instance.as_object(env);
-        $crate::module::define_module_properties(
-          env,
-          &mut *instance,
-          &mut object,
-          properties,
-        )?;
+        $crate::module::define_module_instance_properties(env, &mut *instance, &mut object)?;
+        $crate::module::define_own_properties_from_prototype(env, &mut object, own_property_names)?;
 
         Ok(instance)
       }
@@ -30,6 +26,78 @@ macro_rules! impl_module_methods {
 
     #[napi]
     impl $module {
+      #[napi(skip_typescript, getter, js_name = "type")]
+      pub fn module_type(&mut self) -> napi::Result<String> {
+        self.module.get_module_type()
+      }
+
+      #[napi(skip_typescript, getter)]
+      pub fn context(&mut self) -> napi::Result<napi::Either<String, ()>> {
+        self.module.get_context()
+      }
+
+      #[napi(skip_typescript, getter)]
+      pub fn layer(&mut self) -> napi::Result<napi::Either<String, ()>> {
+        self.module.get_layer()
+      }
+
+      #[napi(skip_typescript, getter, js_name = "useSourceMap")]
+      pub fn use_source_map(&mut self) -> napi::Result<bool> {
+        self.module.get_use_source_map()
+      }
+
+      #[napi(skip_typescript, getter, js_name = "useSimpleSourceMap")]
+      pub fn use_simple_source_map(&mut self) -> napi::Result<bool> {
+        self.module.get_use_simple_source_map()
+      }
+
+      #[napi(skip_typescript, getter, js_name = "factoryMeta")]
+      pub fn factory_meta(&mut self) -> napi::Result<$crate::module::JsFactoryMeta> {
+        self.module.get_factory_meta()
+      }
+
+      #[napi(skip_typescript, setter)]
+      pub fn set_factory_meta(
+        &mut self,
+        factory_meta: $crate::module::JsFactoryMeta,
+      ) -> napi::Result<()> {
+        self.module.set_factory_meta_value(factory_meta)
+      }
+
+      #[napi(skip_typescript, getter, js_name = "buildInfo")]
+      pub fn build_info<'a>(
+        &mut self,
+        env: &'a napi::Env,
+      ) -> napi::Result<napi::bindgen_prelude::Object<'a>> {
+        self.module.get_build_info(env)
+      }
+
+      #[napi(skip_typescript, setter)]
+      pub fn set_build_info(
+        &mut self,
+        env: &napi::Env,
+        build_info: napi::bindgen_prelude::Object,
+      ) -> napi::Result<()> {
+        self.module.set_build_info_object(env, build_info)
+      }
+
+      #[napi(skip_typescript, getter, js_name = "buildMeta")]
+      pub fn build_meta<'a>(
+        &mut self,
+        env: &'a napi::Env,
+      ) -> napi::Result<napi::bindgen_prelude::Object<'a>> {
+        self.module.get_build_meta(env)
+      }
+
+      #[napi(skip_typescript, setter)]
+      pub fn set_build_meta(
+        &mut self,
+        env: &napi::Env,
+        build_meta: napi::bindgen_prelude::Object,
+      ) -> napi::Result<()> {
+        self.module.set_build_meta_object(env, build_meta)
+      }
+
       #[napi]
       pub fn readable_identifier(&mut self) -> napi::Result<String> {
         self.module.readable_identifier()

--- a/crates/rspack_binding_api/src/modules/normal_module.rs
+++ b/crates/rspack_binding_api/src/modules/normal_module.rs
@@ -1,18 +1,25 @@
 use napi::{
-  CallContext, Either, JsObject, NapiRaw,
-  bindgen_prelude::{FromNapiMutRef, Object, ToNapiValue},
+  Either,
+  bindgen_prelude::{Object, ToNapiValue},
 };
 use rspack_core::{ResourceData, ResourceParsedData, parse_resource};
 use rspack_error::Diagnosable;
 
 use crate::{
-  diagnostic,
-  error::RspackError,
-  impl_module_methods,
-  module::{MODULE_PROPERTIES_BUFFER, Module},
-  plugins::JsLoaderItem,
+  diagnostic, error::RspackError, impl_module_methods, module::Module, plugins::JsLoaderItem,
   resource_data::ReadonlyResourceDataWrapper,
 };
+
+const NORMAL_MODULE_OWN_PROPERTIES: &[&str] = &[
+  "resource",
+  "request",
+  "userRequest",
+  "rawRequest",
+  "resourceResolveData",
+  "loaders",
+  "matchResource",
+  "error",
+];
 
 #[napi]
 #[repr(C)]
@@ -26,133 +33,10 @@ impl NormalModule {
   }
 
   pub(crate) fn into_module_instance(
-    mut self,
+    self,
     env: &napi::Env,
   ) -> napi::Result<napi::bindgen_prelude::ClassInstance<'_, Self>> {
-    let (_, module) = self.as_ref()?;
-
-    let resource_resolved_data = module.resource_resolved_data();
-    let resource = env.create_string(resource_resolved_data.resource())?;
-    let request = env.create_string(module.request())?;
-    let user_request = env.create_string(module.user_request())?;
-    let raw_request = env.create_string(module.raw_request())?;
-    let resource_resolve_data = Object::from_raw(env.raw(), unsafe {
-      ToNapiValue::to_napi_value(
-        env.raw(),
-        ReadonlyResourceDataWrapper::from(resource_resolved_data.clone()),
-      )?
-    });
-    let loaders = Object::from_raw(env.raw(), unsafe {
-      ToNapiValue::to_napi_value(
-        env.raw(),
-        module
-          .loaders()
-          .iter()
-          .map(JsLoaderItem::from)
-          .collect::<Vec<_>>(),
-      )?
-    });
-
-    #[js_function]
-    pub fn match_resource_getter(ctx: CallContext<'_>) -> napi::Result<Either<&str, ()>> {
-      let this = ctx.this_unchecked::<JsObject>();
-      let env = ctx.env.raw();
-      let wrapped_value = unsafe { NormalModule::from_napi_mut_ref(env, this.raw())? };
-
-      let (_, module) = wrapped_value.as_ref()?;
-      Ok(match module.match_resource() {
-        Some(match_resource) => Either::A(match_resource.resource()),
-        None => Either::B(()),
-      })
-    }
-
-    #[js_function(1)]
-    pub fn match_resource_setter(ctx: CallContext) -> napi::Result<()> {
-      let this = ctx.this_unchecked::<JsObject>();
-      let env = ctx.env.raw();
-      let wrapped_value = unsafe { NormalModule::from_napi_mut_ref(env, this.raw())? };
-
-      let val = ctx.get::<Either<String, ()>>(0)?;
-      match val {
-        Either::A(val) => {
-          let module = wrapped_value.as_mut()?;
-          let ResourceParsedData {
-            path,
-            query,
-            fragment,
-          } = parse_resource(&val).expect("Should parse resource");
-          *module.match_resource_mut() =
-            Some(ResourceData::new_with_path(val, path, query, fragment));
-        }
-        Either::B(_) => {}
-      }
-      Ok(())
-    }
-
-    #[js_function]
-    fn error_getter(ctx: CallContext<'_>) -> napi::Result<Either<RspackError, ()>> {
-      let this = ctx.this_unchecked::<JsObject>();
-      let env = ctx.env.raw();
-      let wrapped_value = unsafe { NormalModule::from_napi_mut_ref(env, this.raw())? };
-
-      let (compilation, module) = wrapped_value.as_ref()?;
-      Ok(match module.first_error() {
-        Some(diagnostic) => Either::A(RspackError::try_from_diagnostic(
-          compilation,
-          diagnostic.as_ref(),
-        )?),
-        None => Either::B(()),
-      })
-    }
-
-    MODULE_PROPERTIES_BUFFER.with(|ref_cell| {
-      let mut properties = ref_cell.borrow_mut();
-      properties.clear();
-
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("resource")?
-          .with_value(&resource),
-      );
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("request")?
-          .with_value(&request),
-      );
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("userRequest")?
-          .with_value(&user_request),
-      );
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("rawRequest")?
-          .with_value(&raw_request),
-      );
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("resourceResolveData")?
-          .with_value(&resource_resolve_data),
-      );
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("loaders")?
-          .with_value(&loaders),
-      );
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("matchResource")?
-          .with_getter(match_resource_getter)
-          .with_setter(match_resource_setter),
-      );
-      // Info from Build
-      properties.push(
-        napi::Property::new()
-          .with_utf8_name("error")?
-          .with_getter(error_getter),
-      );
-      Self::new_inherited(self, env, &mut properties)
-    })
+    Self::new_inherited(self, env, NORMAL_MODULE_OWN_PROPERTIES)
   }
 
   fn as_ref(&mut self) -> napi::Result<(&rspack_core::Compilation, &rspack_core::NormalModule)> {
@@ -175,6 +59,91 @@ impl NormalModule {
         "Module is not a NormalModule",
       )),
     }
+  }
+}
+
+#[napi]
+impl NormalModule {
+  #[napi(skip_typescript, getter)]
+  pub fn resource(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.resource_resolved_data().resource().to_string())
+  }
+
+  #[napi(skip_typescript, getter)]
+  pub fn request(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.request().to_string())
+  }
+
+  #[napi(skip_typescript, getter, js_name = "userRequest")]
+  pub fn user_request(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.user_request().to_string())
+  }
+
+  #[napi(skip_typescript, getter, js_name = "rawRequest")]
+  pub fn raw_request(&mut self) -> napi::Result<String> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.raw_request().to_string())
+  }
+
+  #[napi(skip_typescript, getter, js_name = "resourceResolveData")]
+  pub fn resource_resolve_data<'a>(&mut self, env: &'a napi::Env) -> napi::Result<Object<'a>> {
+    let (_, module) = self.as_ref()?;
+    let resource_resolved_data = module.resource_resolved_data().clone();
+    let napi_value = unsafe {
+      ToNapiValue::to_napi_value(
+        env.raw(),
+        ReadonlyResourceDataWrapper::from(resource_resolved_data),
+      )?
+    };
+    Ok(Object::from_raw(env.raw(), napi_value))
+  }
+
+  #[napi(skip_typescript, getter)]
+  pub fn loaders(&mut self) -> napi::Result<Vec<JsLoaderItem>> {
+    let (_, module) = self.as_ref()?;
+    Ok(module.loaders().iter().map(JsLoaderItem::from).collect())
+  }
+
+  #[napi(skip_typescript, getter, js_name = "matchResource")]
+  pub fn match_resource(&mut self) -> napi::Result<Either<String, ()>> {
+    let (_, module) = self.as_ref()?;
+    Ok(match module.match_resource() {
+      Some(match_resource) => Either::A(match_resource.resource().to_string()),
+      None => Either::B(()),
+    })
+  }
+
+  #[napi(skip_typescript, setter)]
+  pub fn set_match_resource(&mut self, val: Either<String, ()>) -> napi::Result<()> {
+    match val {
+      Either::A(val) => {
+        let module = self.as_mut()?;
+        let ResourceParsedData {
+          path,
+          query,
+          fragment,
+        } = parse_resource(&val).expect("Should parse resource");
+        *module.match_resource_mut() =
+          Some(ResourceData::new_with_path(val, path, query, fragment));
+      }
+      Either::B(_) => {}
+    }
+    Ok(())
+  }
+
+  #[napi(skip_typescript, getter)]
+  pub fn error(&mut self) -> napi::Result<Either<RspackError, ()>> {
+    let (compilation, module) = self.as_ref()?;
+    Ok(match module.first_error() {
+      Some(diagnostic) => Either::A(RspackError::try_from_diagnostic(
+        compilation,
+        diagnostic.as_ref(),
+      )?),
+      None => Either::B(()),
+    })
   }
 }
 

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -198,7 +198,7 @@ impl JsEventHandler {
       .max_queue_size::<1>()
       .weak::<true>()
       .build_callback(
-        move |ctx: napi::threadsafe_function::ThreadSafeCallContext<_>| Ok(ctx.value),
+        move |ctx: napi::threadsafe_function::ThreadsafeCallContext<_>| Ok(ctx.value),
       )?;
 
     Ok(Self { inner: callback })
@@ -252,7 +252,7 @@ impl JsEventHandlerUndelayed {
       .weak::<false>()
       .max_queue_size::<1>()
       .build_callback(
-        move |ctx: napi::threadsafe_function::ThreadSafeCallContext<_>| Ok(ctx.value),
+        move |ctx: napi::threadsafe_function::ThreadsafeCallContext<_>| Ok(ctx.value),
       )?;
 
     Ok(Self { inner: callback })

--- a/crates/rspack_binding_builder_testing/Cargo.toml
+++ b/crates/rspack_binding_builder_testing/Cargo.toml
@@ -31,8 +31,8 @@ rspack_core  = { workspace = true }
 rspack_error = { workspace = true }
 rspack_napi  = { workspace = true }
 
-napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9", "compat-mode"] }
-napi-derive = { workspace = true, features = ["compat-mode"] }
+napi        = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9"] }
+napi-derive = { workspace = true }
 
 [build-dependencies]
 rspack_binding_build = { workspace = true }

--- a/crates/rspack_napi/Cargo.toml
+++ b/crates/rspack_napi/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9", "compat-mode"] }
+napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow", "napi9"] }
 oneshot      = { workspace = true }
 rspack_error = { workspace = true }
 serde_json   = { workspace = true }

--- a/crates/rspack_napi/src/threadsafe_js_value_ref.rs
+++ b/crates/rspack_napi/src/threadsafe_js_value_ref.rs
@@ -1,19 +1,24 @@
-use std::sync::{Arc, Mutex};
+use std::{
+  marker::PhantomData,
+  sync::{Arc, Mutex},
+};
 
-use napi::{Ref, bindgen_prelude::*};
+use napi::bindgen_prelude::*;
 
-use crate::JsCallback;
+use crate::{JsCallback, Ref};
 
 struct ThreadsafeJsValueRefHandle<T: JsValue<'static>> {
-  value_ref: Arc<Mutex<Ref<T>>>,
+  value_ref: Arc<Mutex<Ref>>,
   drop_handle: JsCallback<Box<dyn FnOnce(Env)>>,
+  _marker: PhantomData<T>,
 }
 
 impl<T: JsValue<'static>> ThreadsafeJsValueRefHandle<T> {
-  fn new(env: Env, js_ref: Ref<T>) -> Result<Self> {
+  fn new(env: Env, js_ref: Ref) -> Result<Self> {
     Ok(Self {
       value_ref: Arc::new(Mutex::new(js_ref)),
       drop_handle: unsafe { JsCallback::new(env.raw()) }?,
+      _marker: PhantomData,
     })
   }
 }
@@ -25,7 +30,7 @@ impl<T: JsValue<'static>> Drop for ThreadsafeJsValueRefHandle<T> {
       let _ = value_ref
         .lock()
         .expect("should lock `value_ref`")
-        .unref(&env);
+        .unref(env.raw());
     }))
   }
 }
@@ -63,7 +68,7 @@ impl<T: ToNapiValue + JsValue<'static>> ToNapiValue for ThreadsafeJsValueRef<T> 
 
 impl<T: JsValue<'static>> ThreadsafeJsValueRef<T> {
   pub fn new(env: Env, value: T) -> Result<Self> {
-    let js_ref = Ref::new(&env, &value)?;
+    let js_ref = Ref::new(env.raw(), value.raw(), 1)?;
 
     Ok(Self {
       inner: Arc::new(ThreadsafeJsValueRefHandle::new(env, js_ref)?),
@@ -71,11 +76,12 @@ impl<T: JsValue<'static>> ThreadsafeJsValueRef<T> {
   }
 
   pub fn get(&self, env: Env) -> Result<T> {
-    self
+    let value_ref = self
       .inner
       .value_ref
       .lock()
-      .expect("should lock `value_ref`")
-      .get_value(&env)
+      .expect("should lock `value_ref`");
+    let raw_value = unsafe { ToNapiValue::to_napi_value(env.raw(), &*value_ref) }?;
+    unsafe { T::from_napi_value(env.raw(), raw_value) }
   }
 }


### PR DESCRIPTION
## What Changed

- Removed `compat-mode` from the napi-related Rust dependencies.
- Moved module-facing JS accessors from handwritten raw N-API callbacks to `#[napi]` getters/setters for `Module`, `NormalModule`, `ExternalModule`, and derived module wrappers.
- Preserved existing JS object shape by copying prototype accessor descriptors onto module instances, so `Object.hasOwn(...)` behavior remains unchanged.
- Marked the new macro accessors as `skip_typescript`, keeping the public TypeScript API owned by `banner.d.ts` and avoiding generated duplicate declarations.
- Replaced the revoked-module cleanup raw callback with `create_function_from_closure`.
- Moved `ThreadsafeJsValueRef` off the compat-only `napi::Ref` path.

## Why This Should Help

The previous module binding path generated a lot of repeated raw callback glue and per-module property setup. Module instances can be high-cardinality objects in loader/plugin hooks, so repeated accessor definitions and generic callback adapters are a poor place to spend binary size.

This keeps the JS-facing API stable while shifting the runtime accessors to napi-rs macro-generated registration and shared Rust helper methods. The remaining per-instance work is mainly descriptor copying for compatibility and the module identifier symbol.

## Expected Benefit

- Less handwritten N-API callback glue in `rspack_binding_api`.
- Fewer duplicated accessor implementations across module wrapper types.
- Smaller node binding surface from removing compat-mode support paths, while preserving the generated `napi-binding.d.ts` shape.

---
_by OpenAI Codex_