### PR TITLE
fix: update runtime context during hot updates

### DIFF
--- a/crates/rspack_plugin_javascript/src/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/runtime_context.rs
@@ -345,11 +345,15 @@ pub async fn render_hot_update_chunk_runtime_modules(
       ) else {
         continue;
       };
+      let json_key = rspack_util::json_stringify(key);
+      let context_property = property_access([key], 0);
       sources.add(RawStringSource::from(format!(
-        ";{}{} = {};\n",
-        runtime_context,
-        property_access([key], 0),
-        lexical_name
+        r#";(function() {{
+var oldSetter = Object.getOwnPropertyDescriptor({runtime_context}, {json_key}) && Object.getOwnPropertyDescriptor({runtime_context}, {json_key}).set;
+Object.defineProperty({runtime_context}, {json_key}, {{ configurable: true, get: function() {{ return {lexical_name}; }}, set: function(value) {{ {lexical_name} = value; if (oldSetter) oldSetter.call({runtime_context}, value); }} }});
+{runtime_context}{context_property} = {lexical_name};
+}})();
+"#
       )));
     }
   }

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -1,6 +1,7 @@
 # Case update-chunk-loading-runtime: Step 1
 
 ## Changed Files
+- chunk.js
 - index.js
 - node_modules/vendor.js
 
@@ -10,7 +11,7 @@
 - Bundle: runtime~main.js
 - Bundle: vendors-node_modules_vendor_js.js
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
-- Update: main.LAST_HASH.hot-update.js, size: 571
+- Update: main.LAST_HASH.hot-update.js, size: 660
 - Update: runtime~main.LAST_HASH.hot-update.js, size: 18983
 - Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
 
@@ -44,10 +45,12 @@ __webpack_require__.r(__webpack_exports__);
 
 module.hot.data.ok = true;
 module.hot.data.loadChunk = () => __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
+globalThis.__UPDATE_CHUNK_LOADING_RUNTIME_DATA__ = module.hot.data;
 module.hot.data.test = () => {
 	expect(vendor__rspack_import_0["default"]).toBe(2);
 };
 module.hot.data.hash = __webpack_require__.h();
+module.hot.accept();
 
 
 },

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/2.snap.txt
@@ -1,0 +1,157 @@
+# Case update-chunk-loading-runtime: Step 2
+
+## Changed Files
+- chunk.js
+- index.js
+- node_modules/vendor.js
+
+## Asset Files
+- Bundle: chunk_js.chunk.CURRENT_HASH.js
+- Bundle: main.js
+- Bundle: runtime~main.js
+- Bundle: vendors-node_modules_vendor_js.js
+- Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
+- Update: main.LAST_HASH.hot-update.js, size: 633
+- Update: runtime~main.LAST_HASH.hot-update.js, size: 189
+- Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
+
+## Manifest
+
+### runtime~main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main","runtime~main","vendors-node_modules_vendor_js"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./index.js
+
+#### Changed Runtime Modules
+
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("main", {
+"./index.js"(module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+/* import */ var vendor__rspack_import_0 = __webpack_require__("./node_modules/vendor.js");
+
+module.hot.data.loadChunk = () => __webpack_require__.e(/* import() */ "chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js"));
+globalThis.__UPDATE_CHUNK_LOADING_RUNTIME_DATA__ = module.hot.data;
+module.hot.data.test = () => {
+	expect(vendor__rspack_import_0["default"]).toBe(3);
+};
+module.hot.data.hash = __webpack_require__.h();
+module.hot.accept();
+
+
+},
+
+});
+```
+
+
+
+### runtime~main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("runtime~main", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### vendors-node_modules_vendor_js.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./node_modules/vendor.js
+
+#### Changed Runtime Modules
+
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("vendors-node_modules_vendor_js", {
+"./node_modules/vendor.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+/* export default */ const __rspack_default_export = (3);
+
+
+},
+
+});
+```
+
+
+
+
+## Runtime
+### Status
+
+```txt
+check => prepare => dispose => apply => idle
+```
+
+
+
+### JavaScript
+
+#### Outdated
+
+Outdated Modules:
+- ./index.js
+- ./node_modules/vendor.js
+
+
+Outdated Dependencies:
+```json
+{}
+```
+
+#### Updated
+
+Updated Modules:
+- ./index.js
+- ./node_modules/vendor.js
+
+Updated Runtime:
+- `__webpack_require__.e`
+- `__webpack_require__.f`
+- `__webpack_require__.h`
+- `__webpack_require__.hmrM`
+- `__webpack_require__.hmrS_jsonp`
+- `__webpack_require__.u`
+
+
+#### Callback
+
+Accepted Callback:
+
+
+Disposed Callback:
+- ./index.js

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/chunk.js
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/chunk.js
@@ -1,1 +1,3 @@
 export default 42;
+---
+export default 42;

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/index.js
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/index.js
@@ -9,18 +9,38 @@ it("should correctly self-accept an entrypoint when chunk loading runtime module
 	});
 
 	await NEXT_HMR();
+	hmrData = globalThis.__UPDATE_CHUNK_LOADING_RUNTIME_DATA__ || hmrData;
 	expect(hmrData).toHaveProperty("ok", true);
 	hmrData.test();
 	expect(hmrData.hash).not.toBe(hash);
 	const m = await hmrData.loadChunk();
 	expect(m.default).toBe(42);
+	const firstUpdateHash = hmrData.hash;
+
+	await NEXT_HMR();
+	hmrData = globalThis.__UPDATE_CHUNK_LOADING_RUNTIME_DATA__ || hmrData;
+	hmrData.test();
+	expect(hmrData.hash).not.toBe(firstUpdateHash);
+	const m2 = await hmrData.loadChunk();
+	expect(m2.default).toBe(42);
 });
 import.meta.webpackHot.accept();
 ---
 import value from "vendor";
 import.meta.webpackHot.data.ok = true;
 import.meta.webpackHot.data.loadChunk = () => import("./chunk");
+globalThis.__UPDATE_CHUNK_LOADING_RUNTIME_DATA__ = import.meta.webpackHot.data;
 import.meta.webpackHot.data.test = () => {
 	expect(value).toBe(2);
 };
 import.meta.webpackHot.data.hash = __webpack_hash__;
+import.meta.webpackHot.accept();
+---
+import value from "vendor";
+import.meta.webpackHot.data.loadChunk = () => import("./chunk");
+globalThis.__UPDATE_CHUNK_LOADING_RUNTIME_DATA__ = import.meta.webpackHot.data;
+import.meta.webpackHot.data.test = () => {
+	expect(value).toBe(3);
+};
+import.meta.webpackHot.data.hash = __webpack_hash__;
+import.meta.webpackHot.accept();

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/node_modules/vendor.js
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/node_modules/vendor.js
@@ -1,3 +1,5 @@
 export default 1;
 ---
 export default 2;
+---
+export default 3;


### PR DESCRIPTION
## Summary

- Preserve and forward existing `__rspack_context` property setters when rendering runtime modules in hot update chunks.
- Re-assign the updated context property after defining the new getter/setter so main runtime lexical variables receive the hot update value.
- Extend the `update-chunk-loading-runtime` hot case to cover multiple HMR updates in `runtimeMode: "rspack"`.

## Root Cause

In `runtimeMode: "rspack"`, hot update chunks can update runtime modules that write runtime globals back through `__rspack_context`. The hot update chunk previously replaced context fields with plain assignments, which did not reliably propagate the new runtime module value back to the main runtime chunk's lexical variables across later updates.
