### PR TITLE
chore(ci): run binary size limit on linux mini runner

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   size-limit:
     name: Binding Size Limit
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 


### PR DESCRIPTION
## Why

The `size-limit` job only downloads a prebuilt binding artifact, strips it, and compares the size. This is pure IO/script work that does not need a heavy self-hosted build runner.

Move it onto the lighter mini runner (the same one already used by `ci-lint` / `ci-rust`) so it no longer occupies the build runner pool.

## Before / After

```diff
- runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+ runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
```
