### PR TITLE
chore: use forked napi-rs git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.11.1"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 
 [[package]]
 name = "darling"
@@ -2774,13 +2774,12 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+version = "3.9.4"
+source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "ctor 0.11.1",
+ "ctor 1.0.7",
  "futures",
  "napi-build",
  "napi-sys",
@@ -2793,18 +2792,16 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+version = "2.3.2"
+source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+version = "3.5.7"
+source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "convert_case 0.11.0",
- "ctor 0.11.1",
+ "ctor 1.0.7",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -2813,9 +2810,8 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+version = "5.0.5"
+source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -2826,9 +2822,8 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+version = "3.2.2"
+source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "napi"
 version = "3.9.4"
-source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2793,12 +2793,12 @@ dependencies = [
 [[package]]
 name = "napi-build"
 version = "2.3.2"
-source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
 
 [[package]]
 name = "napi-derive"
 version = "3.5.7"
-source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
 dependencies = [
  "convert_case 0.11.0",
  "ctor 1.0.7",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "5.0.5"
-source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "3.2.2"
-source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "napi"
 version = "3.9.4"
-source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2793,12 +2793,12 @@ dependencies = [
 [[package]]
 name = "napi-build"
 version = "2.3.2"
-source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 
 [[package]]
 name = "napi-derive"
 version = "3.5.7"
-source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "convert_case 0.11.0",
  "ctor 1.0.7",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "5.0.5"
-source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "3.2.2"
-source = "git+https://github.com/intellild/napi-rs.git?branch=codex%2Fraw-named-property-object-codegen#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
+source = "git+https://github.com/intellild/napi-rs.git?rev=b3c15a226c23e4c7bce6a07eb07c5445c3f3e443#b3c15a226c23e4c7bce6a07eb07c5445c3f3e443"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "napi"
 version = "3.9.4"
-source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
+source = "git+https://github.com/intellild/napi-rs.git?rev=e86ab8c3c4c601d42ba168ccbd977ea36d8f4305#e86ab8c3c4c601d42ba168ccbd977ea36d8f4305"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2793,12 +2793,12 @@ dependencies = [
 [[package]]
 name = "napi-build"
 version = "2.3.2"
-source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
+source = "git+https://github.com/intellild/napi-rs.git?rev=e86ab8c3c4c601d42ba168ccbd977ea36d8f4305#e86ab8c3c4c601d42ba168ccbd977ea36d8f4305"
 
 [[package]]
 name = "napi-derive"
 version = "3.5.7"
-source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
+source = "git+https://github.com/intellild/napi-rs.git?rev=e86ab8c3c4c601d42ba168ccbd977ea36d8f4305#e86ab8c3c4c601d42ba168ccbd977ea36d8f4305"
 dependencies = [
  "convert_case 0.11.0",
  "ctor 1.0.7",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "5.0.5"
-source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
+source = "git+https://github.com/intellild/napi-rs.git?rev=e86ab8c3c4c601d42ba168ccbd977ea36d8f4305#e86ab8c3c4c601d42ba168ccbd977ea36d8f4305"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "3.2.2"
-source = "git+https://github.com/intellild/napi-rs.git?rev=d2fa3b605c96f7dd7abf67a0fabad4f20b160a84#d2fa3b605c96f7dd7abf67a0fabad4f20b160a84"
+source = "git+https://github.com/intellild/napi-rs.git?rev=e86ab8c3c4c601d42ba168ccbd977ea36d8f4305#e86ab8c3c4c601d42ba168ccbd977ea36d8f4305"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,9 @@ xxhash-rust         = { version = "0.8.15", default-features = false }
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = ["camino", "dashmap", "hashbrown", "indexmap", "tokio", "once_cell", "ustr", "atomic_refcell"] }
 
 # Pinned
-napi        = { git = "https://github.com/intellild/napi-rs.git", rev = "d2fa3b605c96f7dd7abf67a0fabad4f20b160a84", default-features = false }
-napi-build  = { git = "https://github.com/intellild/napi-rs.git", rev = "d2fa3b605c96f7dd7abf67a0fabad4f20b160a84", default-features = false }
-napi-derive = { git = "https://github.com/intellild/napi-rs.git", rev = "d2fa3b605c96f7dd7abf67a0fabad4f20b160a84", default-features = false }
+napi        = { git = "https://github.com/intellild/napi-rs.git", rev = "e86ab8c3c4c601d42ba168ccbd977ea36d8f4305", default-features = false }
+napi-build  = { git = "https://github.com/intellild/napi-rs.git", rev = "e86ab8c3c4c601d42ba168ccbd977ea36d8f4305", default-features = false }
+napi-derive = { git = "https://github.com/intellild/napi-rs.git", rev = "e86ab8c3c4c601d42ba168ccbd977ea36d8f4305", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,9 @@ xxhash-rust         = { version = "0.8.15", default-features = false }
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = ["camino", "dashmap", "hashbrown", "indexmap", "tokio", "once_cell", "ustr", "atomic_refcell"] }
 
 # Pinned
-napi        = { version = "3.8.6", default-features = false }
-napi-build  = { version = "2.3.1", default-features = false }
-napi-derive = { version = "3.5.5", default-features = false }
+napi        = { git = "https://github.com/intellild/napi-rs.git", branch = "codex/raw-named-property-object-codegen", default-features = false }
+napi-build  = { git = "https://github.com/intellild/napi-rs.git", branch = "codex/raw-named-property-object-codegen", default-features = false }
+napi-derive = { git = "https://github.com/intellild/napi-rs.git", branch = "codex/raw-named-property-object-codegen", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,9 @@ xxhash-rust         = { version = "0.8.15", default-features = false }
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = ["camino", "dashmap", "hashbrown", "indexmap", "tokio", "once_cell", "ustr", "atomic_refcell"] }
 
 # Pinned
-napi        = { git = "https://github.com/intellild/napi-rs.git", rev = "b3c15a226c23e4c7bce6a07eb07c5445c3f3e443", default-features = false }
-napi-build  = { git = "https://github.com/intellild/napi-rs.git", rev = "b3c15a226c23e4c7bce6a07eb07c5445c3f3e443", default-features = false }
-napi-derive = { git = "https://github.com/intellild/napi-rs.git", rev = "b3c15a226c23e4c7bce6a07eb07c5445c3f3e443", default-features = false }
+napi        = { git = "https://github.com/intellild/napi-rs.git", rev = "d2fa3b605c96f7dd7abf67a0fabad4f20b160a84", default-features = false }
+napi-build  = { git = "https://github.com/intellild/napi-rs.git", rev = "d2fa3b605c96f7dd7abf67a0fabad4f20b160a84", default-features = false }
+napi-derive = { git = "https://github.com/intellild/napi-rs.git", rev = "d2fa3b605c96f7dd7abf67a0fabad4f20b160a84", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,9 @@ xxhash-rust         = { version = "0.8.15", default-features = false }
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = ["camino", "dashmap", "hashbrown", "indexmap", "tokio", "once_cell", "ustr", "atomic_refcell"] }
 
 # Pinned
-napi        = { git = "https://github.com/intellild/napi-rs.git", branch = "codex/raw-named-property-object-codegen", default-features = false }
-napi-build  = { git = "https://github.com/intellild/napi-rs.git", branch = "codex/raw-named-property-object-codegen", default-features = false }
-napi-derive = { git = "https://github.com/intellild/napi-rs.git", branch = "codex/raw-named-property-object-codegen", default-features = false }
+napi        = { git = "https://github.com/intellild/napi-rs.git", rev = "b3c15a226c23e4c7bce6a07eb07c5445c3f3e443", default-features = false }
+napi-build  = { git = "https://github.com/intellild/napi-rs.git", rev = "b3c15a226c23e4c7bce6a07eb07c5445c3f3e443", default-features = false }
+napi-derive = { git = "https://github.com/intellild/napi-rs.git", rev = "b3c15a226c23e4c7bce6a07eb07c5445c3f3e443", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }


### PR DESCRIPTION
## Summary

- Switch the workspace `napi`, `napi-build`, and `napi-derive` dependencies to `https://github.com/intellild/napi-rs.git`.
- Pin those git dependencies to revision `e86ab8c3c4c601d42ba168ccbd977ea36d8f4305` so the build does not drift with the source branch.
- Refresh `Cargo.lock` to use the same fixed git revision for `napi`, `napi-build`, `napi-derive-backend`, and `napi-sys`.

## Validation

- napi-rs: `cargo check -p napi-derive-backend -p napi`
- napi-rs: `yarn workspace @examples/napi build && yarn workspace @examples/napi test` (`222 tests passed`, `4 skipped`)
- napi-rs: `yarn workspace bench build && yarn workspace bench bench object.bench.ts --run`
- napi-rs: repeated `yarn workspace bench bench object.bench.ts --run` twice more to check benchmark stability
- Rspack: `cargo update -p napi -p napi-build -p napi-derive`
- Rspack: `cargo check -p rspack_node`

## napi-rs object bench

Baseline is `32d7166dcfd13a0f954d258cc4da433a726066bf`. After values are the average of three runs on `e86ab8c3c4c601d42ba168ccbd977ea36d8f4305`.

| case | baseline | after avg |
|---|---:|---:|
| required object field | 2,828,149 ops/sec | 3,435,280 ops/sec |
| missing optional object fields | 2,182,276 ops/sec | 2,502,201 ops/sec |
| nested optional js_name field | 1,919,303 ops/sec | 2,087,402 ops/sec |
| structured enum discriminant | 1,401,586 ops/sec | 1,401,135 ops/sec |

---
_by OpenAI Codex_