### PR TITLE
refactor(runtime): collect runtime writes from ejs define

### DIFF
--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -613,7 +613,7 @@ pub async fn process_chunks_runtime_requirements(
           .insert(runtime_requirements.lexical_requirements());
         metadata
           .context_setter_fields
-          .insert(runtime_requirements.write);
+          .insert(runtime_requirements.define);
         metadata
           .force_context_fields
           .insert(runtime_requirements.force_context);

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -1,4 +1,8 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{
+  fmt::Debug,
+  ops::{BitOr, BitOrAssign},
+  sync::Arc,
+};
 
 use async_trait::async_trait;
 use rspack_cacheable::cacheable;
@@ -23,13 +27,35 @@ pub struct RuntimeModuleGenerateContext<'a> {
 pub struct RuntimeModuleRuntimeRequirements {
   pub dependencies: RuntimeGlobals,
   pub weak: RuntimeGlobals,
-  pub write: RuntimeGlobals,
+  pub define: RuntimeGlobals,
   pub force_context: RuntimeGlobals,
 }
 
 impl RuntimeModuleRuntimeRequirements {
   pub fn lexical_requirements(&self) -> RuntimeGlobals {
-    self.dependencies | self.weak | self.write | self.force_context
+    self.dependencies | self.weak | self.define | self.force_context
+  }
+}
+
+impl BitOr for RuntimeModuleRuntimeRequirements {
+  type Output = Self;
+
+  fn bitor(self, rhs: Self) -> Self::Output {
+    Self {
+      dependencies: self.dependencies | rhs.dependencies,
+      weak: self.weak | rhs.weak,
+      define: self.define | rhs.define,
+      force_context: self.force_context | rhs.force_context,
+    }
+  }
+}
+
+impl BitOrAssign for RuntimeModuleRuntimeRequirements {
+  fn bitor_assign(&mut self, rhs: Self) {
+    self.dependencies.insert(rhs.dependencies);
+    self.weak.insert(rhs.weak);
+    self.define.insert(rhs.define);
+    self.force_context.insert(rhs.force_context);
   }
 }
 

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -174,6 +174,22 @@ impl RuntimeTemplate {
       })),
     );
 
+    let runtime_globals_cloned = runtime_globals.clone();
+    dojang.functions.insert(
+      "define".into(),
+      FunctionContainer::F1(Box::new(move |runtime_global: Operand| {
+        dojang_define(runtime_global, &runtime_globals_cloned)
+      })),
+    );
+
+    let runtime_globals_cloned = runtime_globals.clone();
+    dojang.functions.insert(
+      "weak".into(),
+      FunctionContainer::F1(Box::new(move |runtime_global: Operand| {
+        dojang_weak(runtime_global, &runtime_globals_cloned)
+      })),
+    );
+
     Self {
       compiler_options,
       runtime_mode,
@@ -498,6 +514,20 @@ fn dojang_array_destructure(
     };
     Operand::Value(Value::from(items))
   }
+}
+
+fn dojang_define(runtime_global: Operand, runtime_globals: &RuntimeGlobalsRenderMap) -> Operand {
+  // `define(...)` marks a runtime global assignment; the EJS extractor records it in `define`.
+  Operand::Value(Value::from(
+    to_cow(&runtime_global, runtime_globals).into_owned(),
+  ))
+}
+
+fn dojang_weak(runtime_global: Operand, runtime_globals: &RuntimeGlobalsRenderMap) -> Operand {
+  // `weak(...)` marks an optional runtime global read; the extractor records it in `weak`.
+  Operand::Value(Value::from(
+    to_cow(&runtime_global, runtime_globals).into_owned(),
+  ))
 }
 
 // information content of the comment

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -425,14 +425,12 @@ async fn runtime_requirements_in_tree(
   }
 
   if all_runtime_requirements.contains(RuntimeGlobals::CSS_INJECT_STYLE) {
-    runtime_requirements_mut.extend(
-      CssLoadingRuntimeModule::get_runtime_requirements_with_style().lexical_requirements(),
-    );
+    let requirements = CssLoadingRuntimeModule::get_runtime_requirements_with_style();
+    runtime_requirements_mut.extend(requirements.dependencies | requirements.define);
   }
   if all_runtime_requirements.contains(RuntimeGlobals::CSS_STYLE_SHEET) {
-    runtime_requirements_mut.extend(
-      CssLoadingRuntimeModule::get_runtime_requirements_with_style_sheet().lexical_requirements(),
-    );
+    let requirements = CssLoadingRuntimeModule::get_runtime_requirements_with_style_sheet();
+    runtime_requirements_mut.extend(requirements.dependencies | requirements.define);
   }
 
   if all_runtime_requirements

--- a/crates/rspack_plugin_css/src/runtime/css_loading_create_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_create_link.ejs
@@ -1,7 +1,7 @@
 link = document.createElement("link");
 link.setAttribute("data-rspack-native-css", "true");
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 <% if (_unique_name != "") { %>
 link.setAttribute("data-rspack", uniqueName + ":" + key);

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_prefetch_link.ejs
@@ -3,8 +3,8 @@ link.setAttribute("data-rspack-native-css", "true");
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = "prefetch";
 link.as = "style";

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_preload_link.ejs
@@ -1,7 +1,7 @@
 var link = document.createElement('link');
 link.setAttribute("data-rspack-native-css", "true");
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = "preload";
 link.as = "style";

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_style.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_style.ejs
@@ -31,7 +31,7 @@ function insertStyleElement(key) {
 	return style;
 }
 
-<%- _css_inject_style %> = <%- basicFunction("identifier, css") %> {
+<%- define(CSS_INJECT_STYLE) %> = <%- basicFunction("identifier, css") %> {
 	var element = findStyleElement(identifier);
 	if (element) {
 		applyStyle(element, css);
@@ -41,7 +41,7 @@ function insertStyleElement(key) {
 	}
 };
 
-<%- _css_inject_style %>.removeModules = <%- basicFunction("removedModules") %> {
+<%- weak(CSS_INJECT_STYLE) %>.removeModules = <%- basicFunction("removedModules") %> {
 	if (!removedModules) return;
 	var identifiers = Array.isArray(removedModules) ? removedModules : [removedModules];
 	for (var i = 0; i < identifiers.length; i++) {
@@ -53,9 +53,9 @@ function insertStyleElement(key) {
 	}
 };
 <% if (_with_hmr) { %>
-<%- HMR_DOWNLOAD_UPDATE_HANDLERS %>.cssInjectStyle = <%- basicFunction("chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList, css") %> {
+<%- weak(HMR_DOWNLOAD_UPDATE_HANDLERS) %>.cssInjectStyle = <%- basicFunction("chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList, css") %> {
 	if (removedModules) {
-		<%- _css_inject_style %>.removeModules(removedModules);
+		<%- weak(CSS_INJECT_STYLE) %>.removeModules(removedModules);
 	}
 };
 <% } else { %>

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_style_sheet.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_style_sheet.ejs
@@ -1,4 +1,4 @@
-<%- CSS_STYLE_SHEET %> = <%- basicFunction("cssText") %> {
+<%- define(CSS_STYLE_SHEET) %> = <%- basicFunction("cssText") %> {
 	var styleSheet = new CSSStyleSheet();
 	styleSheet._cssText = cssText;
 	if (typeof styleSheet.replaceSync === "function") {

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -8,7 +8,7 @@ use rspack_core::{
 };
 use rspack_plugin_runtime::{
   CreateLinkData, LinkPrefetchData, LinkPreloadData, RuntimeModuleChunkWrapper, RuntimePlugin,
-  chunk_has_css, extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  chunk_has_css, extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
   stringify_chunks,
 };
 use rspack_util::json_stringify;
@@ -28,71 +28,32 @@ static CSS_LOADING_WITH_STYLE_SHEET_TEMPLATE: &str =
   include_str!("./css_loading_with_style_sheet.ejs");
 
 static CSS_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_TEMPLATE));
+static CSS_LOADING_CREATE_LINK_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_CREATE_LINK_TEMPLATE));
 static CSS_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_WITH_LOADING_TEMPLATE));
 static CSS_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_HMR_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_WITH_HMR_TEMPLATE));
 static CSS_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PREFETCH_TEMPLATE,
-      RuntimeGlobals::default(),
-    ) | extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
-      RuntimeGlobals::SCRIPT_NONCE,
-    ),
-    weak: RuntimeGlobals::SCRIPT_NONCE,
-    ..Default::default()
+  LazyLock::new(|| {
+    extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PREFETCH_TEMPLATE)
+      | extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PREFETCH_LINK_TEMPLATE)
   });
 static CSS_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PRELOAD_TEMPLATE,
-      RuntimeGlobals::default(),
-    ) | extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
-      RuntimeGlobals::SCRIPT_NONCE,
-    ),
-    weak: RuntimeGlobals::SCRIPT_NONCE,
-    ..Default::default()
+  LazyLock::new(|| {
+    extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PRELOAD_TEMPLATE)
+      | extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE)
   });
 static CSS_LOADING_WITH_STYLE_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_STYLE_TEMPLATE,
-      RuntimeGlobals::CSS_INJECT_STYLE | RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS,
-    ),
-    write: RuntimeGlobals::CSS_INJECT_STYLE,
-    ..Default::default()
+    define: RuntimeGlobals::CSS_INJECT_STYLE,
+    ..extract_runtime_globals_from_ejs(CSS_LOADING_WITH_STYLE_TEMPLATE)
   });
 static CSS_LOADING_WITH_STYLE_SHEET_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
 > = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    CSS_LOADING_WITH_STYLE_SHEET_TEMPLATE,
-    RuntimeGlobals::CSS_STYLE_SHEET,
-  ),
-  write: RuntimeGlobals::CSS_STYLE_SHEET,
-  ..Default::default()
+  ..extract_runtime_globals_from_ejs(CSS_LOADING_WITH_STYLE_SHEET_TEMPLATE)
 });
 
 #[impl_runtime_module]
@@ -170,37 +131,45 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     let mut dependencies = RuntimeGlobals::default();
-    let weak = RuntimeGlobals::SCRIPT_NONCE;
+    let mut weak = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) {
       dependencies.insert(
         Self::get_runtime_requirements_basic() | Self::get_runtime_requirements_with_loading(),
       );
+      weak.insert(CSS_LOADING_CREATE_LINK_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
       dependencies
         .insert(Self::get_runtime_requirements_basic() | Self::get_runtime_requirements_with_hmr());
+      weak.insert(CSS_LOADING_CREATE_LINK_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::PREFETCH_CHUNK_HANDLERS) {
-      dependencies.insert(Self::get_runtime_requirements_with_prefetch());
+      let requirements = *CSS_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::PRELOAD_CHUNK_HANDLERS) {
-      dependencies.insert(Self::get_runtime_requirements_with_preload());
+      let requirements = *CSS_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
-    let mut write = RuntimeGlobals::default();
+    let mut define = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::CSS_INJECT_STYLE) {
       let requirements = Self::get_runtime_requirements_with_style();
       dependencies.insert(requirements.dependencies);
-      write.insert(requirements.write);
+      weak.insert(requirements.weak);
+      define.insert(requirements.define);
     }
     if runtime_requirements.contains(RuntimeGlobals::CSS_STYLE_SHEET) {
       let requirements = Self::get_runtime_requirements_with_style_sheet();
       dependencies.insert(requirements.dependencies);
-      write.insert(requirements.write);
+      weak.insert(requirements.weak);
+      define.insert(requirements.define);
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,
       weak,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_esm_library/src/runtime.rs
+++ b/crates/rspack_plugin_esm_library/src/runtime.rs
@@ -97,7 +97,7 @@ impl RuntimeModule for EsmEnsureChunkRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: RuntimeGlobals::REQUIRE_SCOPE | RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-      write: { RuntimeGlobals::ENSURE_CHUNK | RuntimeGlobals::ENSURE_CHUNK_HANDLERS },
+      define: { RuntimeGlobals::ENSURE_CHUNK | RuntimeGlobals::ENSURE_CHUNK_HANDLERS },
       ..Default::default()
     }
   }
@@ -194,7 +194,7 @@ var chunkMap = {{
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: RuntimeGlobals::REQUIRE_SCOPE | RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-      write: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
+      define: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -9,7 +9,7 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_plugin_runtime::{
   CreateLinkData, LinkPrefetchData, LinkPreloadData, RuntimeModuleChunkWrapper, RuntimePlugin,
-  extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -31,52 +31,22 @@ static CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE: &str =
   include_str!("./runtime/css_loading_with_preload_link.ejs");
 
 static CSS_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_TEMPLATE));
+static CSS_LOADING_CREATE_LINK_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_CREATE_LINK_TEMPLATE));
 static CSS_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_WITH_LOADING_TEMPLATE));
 static CSS_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_HMR_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_WITH_HMR_TEMPLATE));
 static CSS_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PREFETCH_TEMPLATE,
-      RuntimeGlobals::default(),
-    ) | extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
-      RuntimeGlobals::SCRIPT_NONCE,
-    ),
-    weak: RuntimeGlobals::SCRIPT_NONCE,
-    ..Default::default()
+  LazyLock::new(|| {
+    extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PREFETCH_TEMPLATE)
+      | extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PREFETCH_LINK_TEMPLATE)
   });
 static CSS_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PRELOAD_TEMPLATE,
-      RuntimeGlobals::default(),
-    ) | extract_runtime_globals_dependencies_from_ejs(
-      CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
-      RuntimeGlobals::SCRIPT_NONCE,
-    ),
-    weak: RuntimeGlobals::SCRIPT_NONCE,
-    ..Default::default()
+  LazyLock::new(|| {
+    extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PRELOAD_TEMPLATE)
+      | extract_runtime_globals_from_ejs(CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE)
   });
 
 #[impl_runtime_module]
@@ -181,24 +151,30 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     let mut dependencies = RuntimeGlobals::default();
-    let weak = RuntimeGlobals::SCRIPT_NONCE;
+    let mut weak = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) {
       dependencies.insert(
         CSS_LOADING_BASIC_RUNTIME_REQUIREMENTS.dependencies
           | CSS_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS.dependencies,
       );
+      weak.insert(CSS_LOADING_CREATE_LINK_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
       dependencies.insert(
         CSS_LOADING_BASIC_RUNTIME_REQUIREMENTS.dependencies
           | CSS_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS.dependencies,
       );
+      weak.insert(CSS_LOADING_CREATE_LINK_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::PREFETCH_CHUNK_HANDLERS) {
-      dependencies.insert(CSS_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS.dependencies);
+      let requirements = *CSS_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::PRELOAD_CHUNK_HANDLERS) {
-      dependencies.insert(CSS_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS.dependencies);
+      let requirements = *CSS_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_create_link.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_create_link.ejs
@@ -4,8 +4,8 @@ linkTag.rel = "stylesheet";
 <% if (_set_linktype != "") { %>
 linkTag.type = <%- _set_linktype %>;
 <% } %>
-if (<%- SCRIPT_NONCE %>) {
-  linkTag.nonce = <%- SCRIPT_NONCE %>;
+if (<%- weak(SCRIPT_NONCE) %>) {
+  linkTag.nonce = <%- weak(SCRIPT_NONCE) %>;
 }
 linkTag.href = fullhref;
 <% if (_with_fetch_priority) { %>

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_prefetch_link.ejs
@@ -2,8 +2,8 @@ var link = document.createElement('link');
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute('nonce', <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute('nonce', <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = "prefetch";
 link.as = "style";

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_preload_link.ejs
@@ -1,6 +1,6 @@
 var link = document.createElement('link');
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute('nonce', <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute('nonce', <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = "preload";
 link.as = "style";

--- a/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
+++ b/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
@@ -5,21 +5,17 @@ use rspack_core::{
   RuntimeModuleRuntimeRequirements, RuntimeTemplate, impl_runtime_module,
   runtime_mode::RuntimeMode,
 };
-use rspack_plugin_runtime::extract_runtime_globals_dependencies_from_ejs;
+use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
 use rspack_util::test::is_hot_test;
 
 static HOT_MODULE_REPLACEMENT_TEMPLATE: &str = include_str!("runtime/hot_module_replacement.ejs");
 static HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      HOT_MODULE_REPLACEMENT_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    write: RuntimeGlobals::INTERCEPT_MODULE_EXECUTION
-      | RuntimeGlobals::HMR_MODULE_DATA
-      | RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS
-      | RuntimeGlobals::HMR_INVALIDATE_MODULE_HANDLERS,
-    ..Default::default()
+  LazyLock::new(|| {
+    let mut requirements = extract_runtime_globals_from_ejs(HOT_MODULE_REPLACEMENT_TEMPLATE);
+    requirements
+      .define
+      .insert(RuntimeGlobals::INTERCEPT_MODULE_EXECUTION);
+    requirements
   });
 
 #[impl_runtime_module]
@@ -59,15 +55,6 @@ impl RuntimeModule for HotModuleReplacementRuntimeModule {
     &self,
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
-    rspack_core::RuntimeModuleRuntimeRequirements {
-      dependencies: HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS.dependencies,
-      write: {
-        RuntimeGlobals::INTERCEPT_MODULE_EXECUTION
-          | RuntimeGlobals::HMR_MODULE_DATA
-          | RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS
-          | RuntimeGlobals::HMR_INVALIDATE_MODULE_HANDLERS
-      },
-      ..Default::default()
-    }
+    *HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS
   }
 }

--- a/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
+++ b/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
@@ -17,7 +17,7 @@ var blockingPromisesWaiting = [];
 var currentUpdateApplyHandlers;
 var queuedInvalidatedModules;
 
-<%- HMR_MODULE_DATA %> = currentModuleData;
+<%- define(HMR_MODULE_DATA) %> = currentModuleData;
 <%- INTERCEPT_MODULE_EXECUTION %>.push(function (options) {
 	var module = options.module;
 	var require = createRequire(options.require, options.id<% if (_is_rspack_runtime_mode) { %>, options.context<% } %>);
@@ -29,8 +29,8 @@ var queuedInvalidatedModules;
 	<% if (_is_rspack_runtime_mode) { %>options.context.r = require;<% } %>
 });
 
-<%- HMR_DOWNLOAD_UPDATE_HANDLERS %> = {};
-<%- HMR_INVALIDATE_MODULE_HANDLERS %> = {};
+<%- define(HMR_DOWNLOAD_UPDATE_HANDLERS) %> = {};
+<%- define(HMR_INVALIDATE_MODULE_HANDLERS) %> = {};
 
 function createRequire(require, moduleId<% if (_is_rspack_runtime_mode) { %>, context<% } %>) {
 	var me = installedModules[moduleId];

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -428,7 +428,7 @@ pub(crate) async fn render_runtime_module_sources(
             let runtime_requirements = module.runtime_requirements(compilation);
             let generated_requirements = runtime_requirements.lexical_requirements();
             let context_requirements =
-              runtime_requirements.write | runtime_requirements.force_context;
+              runtime_requirements.define | runtime_requirements.force_context;
             if reject_custom_runtime_modules
               && module.get_constructor_name() == "RuntimeModuleFromJs"
             {

--- a/crates/rspack_plugin_javascript/src/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/runtime_context.rs
@@ -417,7 +417,7 @@ fn runtime_context_current_chunk_metadata(
       .insert(module_runtime_requirements.dependencies);
     metadata
       .context_setter_fields
-      .insert(module_runtime_requirements.write);
+      .insert(module_runtime_requirements.define);
     metadata
       .force_context_fields
       .insert(module_runtime_requirements.force_context);

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
@@ -50,5 +50,5 @@ var wrapStartup = function (prev, isEntry) {
 	};
 };
 
-<%- STARTUP %> = wrapStartup(<%- STARTUP %>);
-<%- STARTUP_ENTRYPOINT %> = wrapStartup(<%- STARTUP_ENTRYPOINT %>, 1);
+<%- define(STARTUP) %> = wrapStartup(<%- STARTUP %>);
+<%- define(STARTUP_ENTRYPOINT) %> = wrapStartup(<%- STARTUP_ENTRYPOINT %>, 1);

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_module.rs
@@ -55,12 +55,12 @@ impl RuntimeModule for EmbedFederationRuntimeModule {
     &self,
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
-    let mut write = RuntimeGlobals::STARTUP;
+    let mut define = RuntimeGlobals::STARTUP;
     if self.options.experiments.async_startup {
-      write.insert(RuntimeGlobals::STARTUP_ENTRYPOINT);
+      define.insert(RuntimeGlobals::STARTUP_ENTRYPOINT);
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write,
+      define,
       force_context: RuntimeGlobals::ENSURE_CHUNK_HANDLERS | RuntimeGlobals::HAS_OWN_PROPERTY,
       ..Default::default()
     }

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_sync.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_sync.ejs
@@ -1,6 +1,6 @@
 var prevStartup = <%- STARTUP %>;
 var hasRun = false;
-<%- STARTUP %> = function () {
+<%- define(STARTUP) %> = function () {
 	if (!hasRun) {
 		hasRun = true;
 <%- _module_executions %>	}

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   RuntimeModuleGenerateContext, RuntimeModuleRuntimeRequirements, RuntimeModuleStage,
   RuntimeTemplate, SourceType, impl_runtime_module,
 };
-use rspack_plugin_runtime::extract_runtime_globals_dependencies_from_ejs;
+use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 
@@ -19,12 +19,8 @@ use crate::{
 static REMOTES_LOADING_TEMPLATE: &str = include_str!("./remotesLoading.ejs");
 static REMOTES_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      REMOTES_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
     force_context: RuntimeGlobals::CURRENT_REMOTE_GET_SCOPE,
-    ..Default::default()
+    ..extract_runtime_globals_from_ejs(REMOTES_LOADING_TEMPLATE)
   });
 
 #[impl_runtime_module]

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   RuntimeModuleGenerateContext, RuntimeModuleRuntimeRequirements, RuntimeModuleStage,
   RuntimeTemplate, SourceType, impl_runtime_module,
 };
-use rspack_plugin_runtime::extract_runtime_globals_dependencies_from_ejs;
+use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
 use rspack_util::json_stringify_str;
 
 use super::consume_shared_plugin::ConsumeVersion;
@@ -18,29 +18,11 @@ static CONSUMES_COMMON_TEMPLATE: &str = include_str!("./consumesCommon.ejs");
 static CONSUMES_INITIAL_TEMPLATE: &str = include_str!("./consumesInitial.ejs");
 static CONSUMES_LOADING_TEMPLATE: &str = include_str!("./consumesLoading.ejs");
 static CONSUMES_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CONSUMES_COMMON_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CONSUMES_COMMON_TEMPLATE));
 static CONSUMES_INITIAL_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CONSUMES_INITIAL_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CONSUMES_INITIAL_TEMPLATE));
 static CONSUMES_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CONSUMES_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CONSUMES_LOADING_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]

--- a/crates/rspack_plugin_mf/src/sharing/initializeSharing.ejs
+++ b/crates/rspack_plugin_mf/src/sharing/initializeSharing.ejs
@@ -1,6 +1,6 @@
 var initPromises = {};
 var initTokens = {};
-<%- INITIALIZE_SHARING %> = function(name, initScope) {
+<%- define(INITIALIZE_SHARING) %> = function(name, initScope) {
 	if (!initScope) initScope = [];
 	// handling circular init calls
 	var initToken = initTokens[name];

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   Compilation, ModuleId, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
   RuntimeModuleRuntimeRequirements, RuntimeTemplate, SourceType, impl_runtime_module,
 };
-use rspack_plugin_runtime::extract_runtime_globals_dependencies_from_ejs;
+use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
 use rspack_util::{
   fx_hash::{FxLinkedHashMap, FxLinkedHashSet},
   json_stringify_str,
@@ -21,13 +21,8 @@ use crate::{
 static INITIALIZE_SHARING_TEMPLATE: &str = include_str!("./initializeSharing.ejs");
 static INITIALIZE_SHARING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      INITIALIZE_SHARING_TEMPLATE,
-      RuntimeGlobals::INITIALIZE_SHARING,
-    ),
-    write: RuntimeGlobals::INITIALIZE_SHARING,
     force_context: RuntimeGlobals::INITIALIZE_SHARING | RuntimeGlobals::SHARE_SCOPE_MAP,
-    ..Default::default()
+    ..extract_runtime_globals_from_ejs(INITIALIZE_SHARING_TEMPLATE)
   });
 
 #[impl_runtime_module]
@@ -53,7 +48,7 @@ impl RuntimeModule for ShareRuntimeModule {
         INITIALIZE_SHARING_RUNTIME_REQUIREMENTS.dependencies
           | runtime_require_scope_requirement(compilation)
       },
-      write: RuntimeGlobals::INITIALIZE_SHARING,
+      define: INITIALIZE_SHARING_RUNTIME_REQUIREMENTS.define,
       force_context: RuntimeGlobals::INITIALIZE_SHARING | RuntimeGlobals::SHARE_SCOPE_MAP,
       ..Default::default()
     }

--- a/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
+++ b/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
@@ -28,7 +28,7 @@ impl RuntimeModule for RscManifestRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::RSC_MANIFEST },
+      define: { RuntimeGlobals::RSC_MANIFEST },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -5,7 +5,8 @@ use regex::Regex;
 use rspack_collections::IdentifierLinkedMap;
 use rspack_core::{
   Chunk, ChunkCodeTemplate, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkLoading,
-  ChunkLoadingType, ChunkUkey, Compilation, PathData, RuntimeGlobals, RuntimeVariable, SourceType,
+  ChunkLoadingType, ChunkUkey, Compilation, PathData, RuntimeGlobals,
+  RuntimeModuleRuntimeRequirements, RuntimeVariable, SourceType,
   chunk_graph_chunk::ChunkIdSet,
   get_js_chunk_filename_template,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
@@ -400,35 +401,53 @@ static EJS_RUNTIME_GLOBALS_RE: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"<%\-\s*([A-Z][A-Z0-9_]*)\s*%>").expect("invalid EJS runtime globals regex")
 });
 
+static EJS_RUNTIME_GLOBAL_DEFINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"<%\-\s*define\(\s*([A-Z][A-Z0-9_]*)\s*\)\s*%>")
+    .expect("invalid EJS runtime global define regex")
+});
+
+static EJS_RUNTIME_GLOBAL_WEAK_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r"<%\-\s*weak\(\s*([A-Z][A-Z0-9_]*)\s*\)\s*%>")
+    .expect("invalid EJS runtime global weak regex")
+});
+
 /// Extracts all RuntimeGlobals references from an EJS template string.
 ///
 /// Matches patterns like `<%- PUBLIC_PATH %>` or `<%- GET_CHUNK_SCRIPT_FILENAME %>`
 /// where the identifier is uppercase letters, digits and underscores (RuntimeGlobals enum variant naming).
 /// Does not match other EJS placeholders such as `<%- basicFunction(...) %>` or `<%- _modules %>`.
-pub fn extract_runtime_globals_from_ejs(ejs_content: &str) -> RuntimeGlobals {
+fn extract_runtime_global_references_from_ejs(ejs_content: &str) -> RuntimeGlobals {
   let names = EJS_RUNTIME_GLOBALS_RE
     .captures_iter(ejs_content)
     .map(|cap| cap[1].to_string())
-    // script nonce is always optional
-    .filter(|name| name.as_str() != "SCRIPT_NONCE")
     .collect_vec();
   RuntimeGlobals::from_names(&names)
 }
 
-pub fn extract_runtime_globals_dependencies_from_ejs(
-  ejs_content: &str,
-  non_dependencies: RuntimeGlobals,
-) -> RuntimeGlobals {
-  let mut dependencies = extract_runtime_globals_from_ejs(ejs_content);
-  dependencies.remove(non_dependencies);
-  dependencies
+pub fn extract_runtime_globals_from_ejs(ejs_content: &str) -> RuntimeModuleRuntimeRequirements {
+  let mut dependencies = extract_runtime_global_references_from_ejs(ejs_content);
+  let define_names = EJS_RUNTIME_GLOBAL_DEFINE_RE
+    .captures_iter(ejs_content)
+    .map(|cap| cap[1].to_string())
+    .collect_vec();
+  let define = RuntimeGlobals::from_names(&define_names);
+  let weak_names = EJS_RUNTIME_GLOBAL_WEAK_RE
+    .captures_iter(ejs_content)
+    .map(|cap| cap[1].to_string())
+    .collect_vec();
+  let weak = RuntimeGlobals::from_names(&weak_names);
+  dependencies.remove(weak);
+  RuntimeModuleRuntimeRequirements {
+    dependencies,
+    weak,
+    define,
+    ..Default::default()
+  }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::{
-    RuntimeGlobals, extract_runtime_globals_dependencies_from_ejs, extract_runtime_globals_from_ejs,
-  };
+  use super::{RuntimeGlobals, extract_runtime_globals_from_ejs};
 
   fn expected_globals(names: &[&str]) -> RuntimeGlobals {
     let names: Vec<String> = names.iter().map(|s| (*s).to_string()).collect();
@@ -437,18 +456,22 @@ mod tests {
 
   #[test]
   fn test_extract_runtime_globals_empty() {
-    assert!(extract_runtime_globals_from_ejs("").is_empty());
-    assert!(extract_runtime_globals_from_ejs("plain text").is_empty());
+    assert!(extract_runtime_globals_from_ejs("").dependencies.is_empty());
+    assert!(
+      extract_runtime_globals_from_ejs("plain text")
+        .dependencies
+        .is_empty()
+    );
   }
 
   #[test]
   fn test_extract_runtime_globals_single() {
     assert_eq!(
-      extract_runtime_globals_from_ejs("<%- PUBLIC_PATH %>"),
+      extract_runtime_globals_from_ejs("<%- PUBLIC_PATH %>").dependencies,
       expected_globals(&["PUBLIC_PATH"])
     );
     assert_eq!(
-      extract_runtime_globals_from_ejs("var x = <%- REQUIRE %>;"),
+      extract_runtime_globals_from_ejs("var x = <%- REQUIRE %>;").dependencies,
       expected_globals(&["REQUIRE"])
     );
   }
@@ -458,7 +481,7 @@ mod tests {
     let ejs = r#"link.href = <%- PUBLIC_PATH %> + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId);
     if (<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId)) {}"#;
     assert_eq!(
-      extract_runtime_globals_from_ejs(ejs),
+      extract_runtime_globals_from_ejs(ejs).dependencies,
       expected_globals(&[
         "PUBLIC_PATH",
         "GET_CHUNK_SCRIPT_FILENAME",
@@ -471,7 +494,7 @@ mod tests {
   fn test_extract_runtime_globals_deduplicate() {
     let ejs = "<%- REQUIRE %>; <%- PUBLIC_PATH %>; <%- REQUIRE %>; <%- PUBLIC_PATH %>";
     assert_eq!(
-      extract_runtime_globals_from_ejs(ejs),
+      extract_runtime_globals_from_ejs(ejs).dependencies,
       expected_globals(&["REQUIRE", "PUBLIC_PATH"])
     );
   }
@@ -479,7 +502,7 @@ mod tests {
   #[test]
   fn test_extract_runtime_globals_with_spaces() {
     assert_eq!(
-      extract_runtime_globals_from_ejs("<%-  ENSURE_CHUNK  %>"),
+      extract_runtime_globals_from_ejs("<%-  ENSURE_CHUNK  %>").dependencies,
       expected_globals(&["ENSURE_CHUNK"])
     );
   }
@@ -492,7 +515,7 @@ mod tests {
     <%- _cross_origin %>
     <%- MODULE_CACHE %>"#;
     assert_eq!(
-      extract_runtime_globals_from_ejs(ejs),
+      extract_runtime_globals_from_ejs(ejs).dependencies,
       expected_globals(&["MODULE_CACHE"])
     );
   }
@@ -501,7 +524,7 @@ mod tests {
   fn test_extract_runtime_globals_uppercase_with_underscores() {
     let ejs = "<%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %> <%- HMR_DOWNLOAD_UPDATE_HANDLERS %>";
     assert_eq!(
-      extract_runtime_globals_from_ejs(ejs),
+      extract_runtime_globals_from_ejs(ejs).dependencies,
       expected_globals(&[
         "GET_CHUNK_UPDATE_SCRIPT_FILENAME",
         "HMR_DOWNLOAD_UPDATE_HANDLERS"
@@ -521,20 +544,26 @@ mod tests {
     if (__rspack_esm_runtime) __rspack_esm_runtime(<%- REQUIRE %>);
 };"#;
     assert_eq!(
-      extract_runtime_globals_from_ejs(ejs),
+      extract_runtime_globals_from_ejs(ejs).dependencies,
       expected_globals(&["HAS_OWN_PROPERTY", "MODULE_FACTORIES", "REQUIRE"])
     );
   }
 
   #[test]
-  fn test_extract_runtime_globals_dependencies_excludes_non_dependencies() {
-    let ejs = "<%- PUBLIC_PATH %>; <%- ENSURE_CHUNK_HANDLERS %>; <%- SCRIPT_NONCE %>;";
+  fn test_extract_runtime_globals_excludes_define_and_weak_from_dependencies() {
+    let ejs = "<%- PUBLIC_PATH %>; <%- define(ENSURE_CHUNK_HANDLERS) %>; <%- weak(SCRIPT_NONCE) %>; <%- weak(ON_CHUNKS_LOADED) %>;";
+    let requirements = extract_runtime_globals_from_ejs(ejs);
     assert_eq!(
-      extract_runtime_globals_dependencies_from_ejs(
-        ejs,
-        RuntimeGlobals::ENSURE_CHUNK_HANDLERS | RuntimeGlobals::SCRIPT_NONCE
-      ),
+      requirements.dependencies,
       expected_globals(&["PUBLIC_PATH"])
+    );
+    assert_eq!(
+      requirements.define,
+      expected_globals(&["ENSURE_CHUNK_HANDLERS"])
+    );
+    assert_eq!(
+      requirements.weak,
+      expected_globals(&["SCRIPT_NONCE", "ON_CHUNKS_LOADED"])
     );
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/amd_define.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/amd_define.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for AmdDefineRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::AMD_DEFINE },
+      define: { RuntimeGlobals::AMD_DEFINE },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/amd_options.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/amd_options.rs
@@ -22,7 +22,7 @@ impl RuntimeModule for AmdOptionsRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::AMD_OPTIONS },
+      define: { RuntimeGlobals::AMD_OPTIONS },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
@@ -39,7 +39,7 @@ impl RuntimeModule for AsyncRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: { RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_CACHE },
-      write: {
+      define: {
         RuntimeGlobals::ASYNC_MODULE
           | RuntimeGlobals::ASYNC_MODULE_EXPORT_SYMBOL
           | RuntimeGlobals::DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -76,7 +76,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
       } else {
         RuntimeGlobals::GLOBAL
       },
-      write: { RuntimeGlobals::PUBLIC_PATH },
+      define: { RuntimeGlobals::PUBLIC_PATH },
       force_context: RuntimeGlobals::PUBLIC_PATH,
       ..Default::default()
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
@@ -22,7 +22,7 @@ impl RuntimeModule for BaseUriRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::BASE_URI },
+      define: { RuntimeGlobals::BASE_URI },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for ChunkNameRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::CHUNK_NAME },
+      define: { RuntimeGlobals::CHUNK_NAME },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
@@ -56,7 +56,7 @@ impl RuntimeModule for ChunkPrefetchPreloadFunctionRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: { self.runtime_handlers },
-      write: { self.runtime_function | self.runtime_handlers },
+      define: { self.runtime_function | self.runtime_handlers },
       force_context: self.runtime_function,
       ..Default::default()
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
@@ -2,21 +2,15 @@ use std::sync::LazyLock;
 
 use itertools::Itertools;
 use rspack_core::{
-  ChunkUkey, Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
+  ChunkUkey, Compilation, RuntimeModule, RuntimeModuleGenerateContext,
   RuntimeModuleRuntimeRequirements, RuntimeModuleStage, RuntimeTemplate, impl_runtime_module,
 };
 
-use crate::extract_runtime_globals_dependencies_from_ejs;
+use crate::extract_runtime_globals_from_ejs;
 
 static CHUNK_PREFETCH_STARTUP_TEMPLATE: &str = include_str!("runtime/chunk_prefetch_startup.ejs");
 static CHUNK_PREFETCH_STARTUP_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CHUNK_PREFETCH_STARTUP_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CHUNK_PREFETCH_STARTUP_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
@@ -2,22 +2,16 @@ use std::sync::LazyLock;
 
 use rspack_cacheable::with::AsMap;
 use rspack_core::{
-  Compilation, IndexChunkIdMap, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
+  Compilation, IndexChunkIdMap, RuntimeModule, RuntimeModuleGenerateContext,
   RuntimeModuleRuntimeRequirements, RuntimeModuleStage, RuntimeTemplate,
   chunk_graph_chunk::ChunkId, impl_runtime_module,
 };
 
-use crate::extract_runtime_globals_dependencies_from_ejs;
+use crate::extract_runtime_globals_from_ejs;
 
 static CHUNK_PREFETCH_TRIGGER_TEMPLATE: &str = include_str!("runtime/chunk_prefetch_trigger.ejs");
 static CHUNK_PREFETCH_TRIGGER_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CHUNK_PREFETCH_TRIGGER_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CHUNK_PREFETCH_TRIGGER_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
@@ -2,22 +2,16 @@ use std::sync::LazyLock;
 
 use rspack_cacheable::with::AsMap;
 use rspack_core::{
-  Compilation, IndexChunkIdMap, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
+  Compilation, IndexChunkIdMap, RuntimeModule, RuntimeModuleGenerateContext,
   RuntimeModuleRuntimeRequirements, RuntimeModuleStage, RuntimeTemplate,
   chunk_graph_chunk::ChunkId, impl_runtime_module,
 };
 
-use crate::extract_runtime_globals_dependencies_from_ejs;
+use crate::extract_runtime_globals_from_ejs;
 
 static CHUNK_PRELOAD_TRIGGER_TEMPLATE: &str = include_str!("runtime/chunk_preload_trigger.ejs");
 static CHUNK_PRELOAD_TRIGGER_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      CHUNK_PRELOAD_TRIGGER_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(CHUNK_PRELOAD_TRIGGER_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]

--- a/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
@@ -24,7 +24,7 @@ impl RuntimeModule for CompatGetDefaultExportRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
-      write: { RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT },
+      define: { RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
@@ -24,7 +24,7 @@ impl RuntimeModule for CreateFakeNamespaceObjectRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: RuntimeGlobals::MAKE_NAMESPACE_OBJECT | RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
-      write: { RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT },
+      define: { RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for CreateScriptRuntimeModule {
           RuntimeGlobals::default()
         }
       },
-      write: { RuntimeGlobals::CREATE_SCRIPT },
+      define: { RuntimeGlobals::CREATE_SCRIPT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for CreateScriptUrlRuntimeModule {
           RuntimeGlobals::default()
         }
       },
-      write: { RuntimeGlobals::CREATE_SCRIPT_URL },
+      define: { RuntimeGlobals::CREATE_SCRIPT_URL },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
@@ -23,7 +23,7 @@ impl RuntimeModule for DefinePropertyGettersRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: RuntimeGlobals::HAS_OWN_PROPERTY,
-      write: { RuntimeGlobals::DEFINE_PROPERTY_GETTERS },
+      define: { RuntimeGlobals::DEFINE_PROPERTY_GETTERS },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
@@ -78,22 +78,22 @@ impl RuntimeModule for EnsureChunkRuntimeModule {
     compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     let mut dependencies = RuntimeGlobals::default();
-    let mut write = RuntimeGlobals::ENSURE_CHUNK;
+    let mut define = RuntimeGlobals::ENSURE_CHUNK;
     if let Some(chunk_ukey) = self.chunk() {
       if self.has_async_chunks
         || get_chunk_runtime_requirements(compilation, &chunk_ukey)
           .contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS)
       {
         dependencies.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
-        write.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+        define.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
       }
     } else if self.has_async_chunks {
       dependencies.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
-      write.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+      define.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for ESMModuleDecoratorRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::ESM_MODULE_DECORATOR },
+      define: { RuntimeGlobals::ESM_MODULE_DECORATOR },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -89,7 +89,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
           RuntimeGlobals::default()
         }
       },
-      write: {
+      define: {
         match self.source_type {
           SourceType::JavaScript => RuntimeGlobals::GET_CHUNK_SCRIPT_FILENAME,
           SourceType::Css => RuntimeGlobals::GET_CHUNK_CSS_FILENAME,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -34,7 +34,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
           RuntimeGlobals::default()
         }
       },
-      write: { RuntimeGlobals::GET_CHUNK_UPDATE_SCRIPT_FILENAME },
+      define: { RuntimeGlobals::GET_CHUNK_UPDATE_SCRIPT_FILENAME },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for GetFullHashRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::GET_FULL_HASH },
+      define: { RuntimeGlobals::GET_FULL_HASH },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -40,7 +40,7 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
           RuntimeGlobals::default()
         }
       },
-      write: { self.global },
+      define: { self.global },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -22,7 +22,7 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::GET_TRUSTED_TYPES_POLICY },
+      define: { RuntimeGlobals::GET_TRUSTED_TYPES_POLICY },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/global.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/global.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for GlobalRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::GLOBAL },
+      define: { RuntimeGlobals::GLOBAL },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for HasOwnPropertyRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::HAS_OWN_PROPERTY },
+      define: { RuntimeGlobals::HAS_OWN_PROPERTY },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -9,7 +9,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 
 use super::{generate_javascript_hmr_runtime, utils::get_output_dir};
 use crate::{
-  extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -28,53 +28,25 @@ static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
 
 static IMPORT_SCRIPTS_CHUNK_LOADING_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    IMPORT_SCRIPTS_CHUNK_LOADING_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(IMPORT_SCRIPTS_CHUNK_LOADING_TEMPLATE));
 static IMPORT_SCRIPTS_CHUNK_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    IMPORT_SCRIPTS_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
-    RuntimeGlobals::CREATE_SCRIPT_URL,
-  ),
-  weak: RuntimeGlobals::CREATE_SCRIPT_URL,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(IMPORT_SCRIPTS_CHUNK_LOADING_WITH_LOADING_TEMPLATE)
 });
 static IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_TEMPLATE,
-    RuntimeGlobals::CREATE_SCRIPT_URL,
-  ),
-  weak: RuntimeGlobals::CREATE_SCRIPT_URL,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_TEMPLATE)
 });
 static IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_MANIFEST_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
-    RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ),
-  write: RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE)
 });
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
-    RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ),
-  weak: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug, Default)]
@@ -167,22 +139,25 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
       | Self::get_runtime_requirements_with_loading()
       | RuntimeGlobals::MODULE_CACHE;
     let mut weak = RuntimeGlobals::default();
-    let mut write = RuntimeGlobals::BASE_URI;
+    let mut define = RuntimeGlobals::BASE_URI;
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr());
-      weak.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+      weak.insert(JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr_manifest());
-      write.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
+      define.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
     }
     if self.with_create_script_url {
-      weak.insert(RuntimeGlobals::CREATE_SCRIPT_URL);
+      weak.insert(IMPORT_SCRIPTS_CHUNK_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS.weak);
+      if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
+        weak.insert(IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS.weak);
+      }
     }
     RuntimeModuleRuntimeRequirements {
       dependencies,
       weak,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -10,7 +10,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 use super::generate_javascript_hmr_runtime;
 use crate::{
   LinkPrefetchData, LinkPreloadData, RuntimeModuleChunkWrapper, RuntimePlugin,
-  extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -37,86 +37,38 @@ static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
 
 static JSONP_CHUNK_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      JSONP_CHUNK_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_TEMPLATE));
 static JSONP_CHUNK_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_PREFETCH_TEMPLATE,
-    RuntimeGlobals::default(),
-  ) | extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
-    RuntimeGlobals::SCRIPT_NONCE,
-  ),
-  weak: RuntimeGlobals::SCRIPT_NONCE,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_PREFETCH_TEMPLATE)
+    | extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_PREFETCH_LINK_TEMPLATE)
 });
 static JSONP_CHUNK_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_PRELOAD_TEMPLATE,
-    RuntimeGlobals::default(),
-  ) | extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
-    RuntimeGlobals::SCRIPT_NONCE,
-  ),
-  weak: RuntimeGlobals::SCRIPT_NONCE,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_PRELOAD_TEMPLATE)
+    | extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_PRELOAD_LINK_TEMPLATE)
 });
 static JSONP_CHUNK_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_HMR_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_HMR_TEMPLATE));
 static JSONP_CHUNK_LOADING_WITH_HMR_MANIFEST_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
-    RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ),
-  write: RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE)
 });
 static JSONP_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE)
 });
 static JSONP_CHUNK_LOADING_WITH_CALLBACK_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JSONP_CHUNK_LOADING_WITH_CALLBACK_TEMPLATE,
-    RuntimeGlobals::ON_CHUNKS_LOADED,
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_WITH_CALLBACK_TEMPLATE));
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
-    RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ),
-  weak: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -216,10 +168,10 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       | RuntimeGlobals::MODULE_FACTORIES
       | RuntimeGlobals::REQUIRE_SCOPE
       | RuntimeGlobals::MODULE_CACHE;
-    let mut weak = RuntimeGlobals::SCRIPT_NONCE;
-    let mut write = RuntimeGlobals::default();
+    let mut weak = RuntimeGlobals::default();
+    let mut define = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::BASE_URI) {
-      write.insert(RuntimeGlobals::BASE_URI);
+      define.insert(RuntimeGlobals::BASE_URI);
     }
     if runtime_requirements.contains(RuntimeGlobals::ON_CHUNKS_LOADED) {
       dependencies.insert(Self::get_runtime_requirements_with_on_chunk_load());
@@ -231,22 +183,26 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
           | RuntimeGlobals::ENSURE_CHUNK_HANDLERS
           | RuntimeGlobals::HMR_RUNTIME_STATE_PREFIX,
       );
-      weak.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+      weak.insert(JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr_manifest());
-      write.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
+      define.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
     }
     if runtime_requirements.contains(RuntimeGlobals::PREFETCH_CHUNK_HANDLERS) {
-      dependencies.insert(Self::get_runtime_requirements_with_prefetch());
+      let requirements = *JSONP_CHUNK_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::PRELOAD_CHUNK_HANDLERS) {
-      dependencies.insert(Self::get_runtime_requirements_with_preload());
+      let requirements = *JSONP_CHUNK_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     RuntimeModuleRuntimeRequirements {
       dependencies,
       weak,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -1,13 +1,22 @@
-use std::ptr::NonNull;
+use std::{ptr::NonNull, sync::LazyLock};
 
 use rspack_core::{
   ChunkUkey, Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
-  RuntimeTemplate, impl_runtime_module,
+  RuntimeModuleRuntimeRequirements, RuntimeTemplate, impl_runtime_module,
 };
 
 use crate::{
-  CreateScriptData, RuntimeModuleChunkWrapper, RuntimePlugin, get_chunk_runtime_requirements,
+  CreateScriptData, RuntimeModuleChunkWrapper, RuntimePlugin, extract_runtime_globals_from_ejs,
+  get_chunk_runtime_requirements,
 };
+
+static LOAD_SCRIPT_TEMPLATE: &str = include_str!("runtime/load_script.ejs");
+static LOAD_SCRIPT_CREATE_SCRIPT_TEMPLATE: &str =
+  include_str!("runtime/load_script_create_script.ejs");
+static LOAD_SCRIPT_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
+  LazyLock::new(|| extract_runtime_globals_from_ejs(LOAD_SCRIPT_TEMPLATE));
+static LOAD_SCRIPT_CREATE_SCRIPT_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
+  LazyLock::new(|| extract_runtime_globals_from_ejs(LOAD_SCRIPT_CREATE_SCRIPT_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -46,14 +55,15 @@ impl RuntimeModule for LoadScriptRuntimeModule {
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: {
-        let mut requirements = RuntimeGlobals::default();
+        let mut requirements = LOAD_SCRIPT_RUNTIME_REQUIREMENTS.dependencies
+          | LOAD_SCRIPT_CREATE_SCRIPT_RUNTIME_REQUIREMENTS.dependencies;
         if self.with_create_script_url {
           requirements.insert(RuntimeGlobals::CREATE_SCRIPT_URL);
         }
         requirements
       },
-      weak: RuntimeGlobals::SCRIPT_NONCE,
-      write: { RuntimeGlobals::LOAD_SCRIPT },
+      weak: LOAD_SCRIPT_CREATE_SCRIPT_RUNTIME_REQUIREMENTS.weak,
+      define: LOAD_SCRIPT_RUNTIME_REQUIREMENTS.define,
       ..Default::default()
     }
   }
@@ -62,11 +72,11 @@ impl RuntimeModule for LoadScriptRuntimeModule {
     vec![
       (
         self.template_id(TemplateId::Raw),
-        include_str!("runtime/load_script.ejs").to_string(),
+        LOAD_SCRIPT_TEMPLATE.to_string(),
       ),
       (
         self.template_id(TemplateId::CreateScript),
-        include_str!("runtime/load_script_create_script.ejs").to_string(),
+        LOAD_SCRIPT_CREATE_SCRIPT_TEMPLATE.to_string(),
       ),
     ]
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_deferred_namespace_object_runtime.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_deferred_namespace_object_runtime.rs
@@ -61,7 +61,7 @@ impl RuntimeModule for MakeDeferredNamespaceObjectRuntimeModule {
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,
-      write: { RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT },
+      define: { RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for MakeNamespaceObjectRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::MAKE_NAMESPACE_OBJECT },
+      define: { RuntimeGlobals::MAKE_NAMESPACE_OBJECT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_optimized_deferred_namespace_object_runtime.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_optimized_deferred_namespace_object_runtime.rs
@@ -62,7 +62,7 @@ impl RuntimeModule for MakeOptimizedDeferredNamespaceObjectRuntimeModule {
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,
-      write: { RuntimeGlobals::MAKE_OPTIMIZED_DEFERRED_NAMESPACE_OBJECT },
+      define: { RuntimeGlobals::MAKE_OPTIMIZED_DEFERRED_NAMESPACE_OBJECT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -11,7 +11,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 use super::utils::get_output_dir;
 use crate::{
   LinkPrefetchData, LinkPreloadData, RuntimeModuleChunkWrapper, RuntimePlugin,
-  extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
   runtime_module::{
     generate_javascript_hmr_runtime,
     utils::{get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks},
@@ -37,77 +37,33 @@ static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
 
 static MODULE_CHUNK_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      MODULE_CHUNK_LOADING_TEMPLATE,
-      RuntimeGlobals::ON_CHUNKS_LOADED,
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_TEMPLATE));
 static MODULE_CHUNK_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_LOADING_TEMPLATE));
 static MODULE_CHUNK_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_PREFETCH_TEMPLATE,
-    RuntimeGlobals::default(),
-  ) | extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
-    RuntimeGlobals::SCRIPT_NONCE,
-  ),
-  weak: RuntimeGlobals::SCRIPT_NONCE,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_PREFETCH_TEMPLATE)
+    | extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_PREFETCH_LINK_TEMPLATE)
 });
 static MODULE_CHUNK_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_PRELOAD_TEMPLATE,
-    RuntimeGlobals::default(),
-  ) | extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
-    RuntimeGlobals::SCRIPT_NONCE,
-  ),
-  weak: RuntimeGlobals::SCRIPT_NONCE,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_PRELOAD_TEMPLATE)
+    | extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_PRELOAD_LINK_TEMPLATE)
 });
 static MODULE_CHUNK_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_HMR_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_HMR_TEMPLATE));
 static MODULE_CHUNK_LOADING_WITH_HMR_MANIFEST_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    MODULE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
-    RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ),
-  write: RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE)
 });
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
-    RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ),
-  weak: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -209,35 +165,39 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
     };
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     let mut dependencies = Self::get_runtime_requirements_basic();
-    let mut weak = RuntimeGlobals::SCRIPT_NONCE;
-    let mut write = RuntimeGlobals::default();
+    let mut weak = RuntimeGlobals::default();
+    let mut define = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::BASE_URI) {
-      write.insert(RuntimeGlobals::BASE_URI);
+      define.insert(RuntimeGlobals::BASE_URI);
     }
     if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_loading());
     }
     if runtime_requirements.contains(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK) {
-      write.insert(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
+      define.insert(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr() | RuntimeGlobals::MODULE_CACHE);
-      weak.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+      weak.insert(JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr_manifest());
-      write.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
+      define.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
     }
     if runtime_requirements.contains(RuntimeGlobals::PREFETCH_CHUNK_HANDLERS) {
-      dependencies.insert(Self::get_runtime_requirements_with_prefetch());
+      let requirements = *MODULE_CHUNK_LOADING_WITH_PREFETCH_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::PRELOAD_CHUNK_HANDLERS) {
-      dependencies.insert(Self::get_runtime_requirements_with_preload());
+      let requirements = *MODULE_CHUNK_LOADING_WITH_PRELOAD_RUNTIME_REQUIREMENTS;
+      dependencies.insert(requirements.dependencies);
+      weak.insert(requirements.weak);
     }
     RuntimeModuleRuntimeRequirements {
       dependencies,
       weak,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for NodeModuleDecoratorRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::NODE_MODULE_DECORATOR },
+      define: { RuntimeGlobals::NODE_MODULE_DECORATOR },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/nonce.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/nonce.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for NonceRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::SCRIPT_NONCE },
+      define: { RuntimeGlobals::SCRIPT_NONCE },
       force_context: RuntimeGlobals::SCRIPT_NONCE,
       ..Default::default()
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for OnChunkLoadedRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::ON_CHUNKS_LOADED },
+      define: { RuntimeGlobals::ON_CHUNKS_LOADED },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -22,7 +22,7 @@ impl RuntimeModule for PublicPathRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::PUBLIC_PATH },
+      define: { RuntimeGlobals::PUBLIC_PATH },
       force_context: RuntimeGlobals::PUBLIC_PATH,
       ..Default::default()
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -9,7 +9,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 
 use super::{generate_javascript_hmr_runtime, utils::get_output_dir};
 use crate::{
-  extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -30,70 +30,32 @@ static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
 
 static READFILE_CHUNK_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      READFILE_CHUNK_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_TEMPLATE));
 static READFILE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    READFILE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE)
 });
 static READFILE_CHUNK_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    READFILE_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> =
+  LazyLock::new(|| extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_WITH_LOADING_TEMPLATE));
 static READFILE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    READFILE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_TEMPLATE,
-    RuntimeGlobals::EXTERNAL_INSTALL_CHUNK,
-  ),
-  write: RuntimeGlobals::EXTERNAL_INSTALL_CHUNK,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_TEMPLATE)
 });
 static READFILE_CHUNK_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    READFILE_CHUNK_LOADING_WITH_HMR_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_WITH_HMR_TEMPLATE));
 static READFILE_CHUNK_LOADING_WITH_HMR_MANIFEST_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    READFILE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
-    RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ),
-  write: RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE)
 });
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
-    RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ),
-  weak: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -200,32 +162,32 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     let mut dependencies = Self::get_runtime_requirements_basic() | RuntimeGlobals::MODULE_CACHE;
     let mut weak = RuntimeGlobals::default();
-    let mut write = RuntimeGlobals::default();
+    let mut define = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::BASE_URI) {
-      write.insert(RuntimeGlobals::BASE_URI);
+      define.insert(RuntimeGlobals::BASE_URI);
     }
     if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_loading());
     }
     if runtime_requirements.contains(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK) {
       dependencies.insert(Self::get_runtime_requirements_with_external_install_chunk());
-      write.insert(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
+      define.insert(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
     }
     if runtime_requirements.contains(RuntimeGlobals::ON_CHUNKS_LOADED) {
       dependencies.insert(Self::get_runtime_requirements_with_on_chunk_load());
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr());
-      weak.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+      weak.insert(JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr_manifest());
-      write.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
+      define.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
     }
     RuntimeModuleRuntimeRequirements {
       dependencies,
       weak,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for RelativeUrlRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::RELATIVE_URL },
+      define: { RuntimeGlobals::RELATIVE_URL },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -9,7 +9,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 
 use super::{generate_javascript_hmr_runtime, utils::get_output_dir};
 use crate::{
-  extract_runtime_globals_dependencies_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -32,79 +32,36 @@ static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
 
 static REQUIRE_CHUNK_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
-  LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-    dependencies: extract_runtime_globals_dependencies_from_ejs(
-      REQUIRE_CHUNK_LOADING_TEMPLATE,
-      RuntimeGlobals::default(),
-    ),
-    ..Default::default()
-  });
+  LazyLock::new(|| extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_TEMPLATE));
 static REQUIRE_CHUNK_LOADING_WITH_LOADING_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    REQUIRE_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_WITH_LOADING_TEMPLATE));
 static REQUIRE_CHUNK_LOADING_WITH_LOADING_MATCHER_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    REQUIRE_CHUNK_LOADING_WITH_LOADING_MATCHER_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_WITH_LOADING_MATCHER_TEMPLATE)
 });
 static REQUIRE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    REQUIRE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE)
 });
 static REQUIRE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    REQUIRE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_TEMPLATE,
-    RuntimeGlobals::EXTERNAL_INSTALL_CHUNK,
-  ),
-  write: RuntimeGlobals::EXTERNAL_INSTALL_CHUNK,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_TEMPLATE)
 });
 static REQUIRE_CHUNK_LOADING_WITH_HMR_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    REQUIRE_CHUNK_LOADING_WITH_HMR_TEMPLATE,
-    RuntimeGlobals::default(),
-  ),
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_WITH_HMR_TEMPLATE));
 static REQUIRE_CHUNK_LOADING_WITH_HMR_MANIFEST_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    REQUIRE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
-    RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ),
-  write: RuntimeGlobals::HMR_DOWNLOAD_MANIFEST,
-  ..Default::default()
+> = LazyLock::new(|| {
+  extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE)
 });
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
-> = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
-  dependencies: extract_runtime_globals_dependencies_from_ejs(
-    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
-    RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ),
-  weak: RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-  ..Default::default()
-});
+> = LazyLock::new(|| extract_runtime_globals_from_ejs(JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -211,32 +168,32 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
     let mut dependencies = Self::get_runtime_requirements_basic() | RuntimeGlobals::MODULE_CACHE;
     let mut weak = RuntimeGlobals::default();
-    let mut write = RuntimeGlobals::default();
+    let mut define = RuntimeGlobals::default();
     if runtime_requirements.contains(RuntimeGlobals::BASE_URI) {
-      write.insert(RuntimeGlobals::BASE_URI);
+      define.insert(RuntimeGlobals::BASE_URI);
     }
     if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_loading());
     }
     if runtime_requirements.contains(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK) {
       dependencies.insert(Self::get_runtime_requirements_with_external_install_chunk());
-      write.insert(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
+      define.insert(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
     }
     if runtime_requirements.contains(RuntimeGlobals::ON_CHUNKS_LOADED) {
       dependencies.insert(Self::get_runtime_requirements_with_on_chunk_load());
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr());
-      weak.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+      weak.insert(JAVASCRIPT_HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS.weak);
     }
     if runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST) {
       dependencies.insert(Self::get_runtime_requirements_with_hmr_manifest());
-      write.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
+      define.insert(RuntimeGlobals::HMR_DOWNLOAD_MANIFEST);
     }
     RuntimeModuleRuntimeRequirements {
       dependencies,
       weak,
-      write,
+      define,
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
@@ -27,7 +27,7 @@ impl RuntimeModule for RspackUniqueIdRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::RSPACK_UNIQUE_ID },
+      define: { RuntimeGlobals::RSPACK_UNIQUE_ID },
       force_context: RuntimeGlobals::RSPACK_UNIQUE_ID,
       ..Default::default()
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
@@ -22,7 +22,7 @@ impl RuntimeModule for RspackVersionRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::RSPACK_VERSION },
+      define: { RuntimeGlobals::RSPACK_VERSION },
       force_context: RuntimeGlobals::RSPACK_VERSION,
       ..Default::default()
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/async_module.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/async_module.ejs
@@ -1,10 +1,10 @@
 var hasSymbol = typeof Symbol === "function";
 var rspackQueues = hasSymbol ? Symbol("rspack queues") : "__rspack_queues";
-var rspackExports = <%- ASYNC_MODULE_EXPORT_SYMBOL %> = hasSymbol ? Symbol("rspack exports") : "<%- EXPORTS %>";
+var rspackExports = <%- define(ASYNC_MODULE_EXPORT_SYMBOL) %> = hasSymbol ? Symbol("rspack exports") : "<%- EXPORTS %>";
 var rspackError = hasSymbol ? Symbol("rspack error") : "__rspack_error";
 var rspackDone = hasSymbol ? Symbol("rspack done") : "__rspack_done";
-var rspackDefer = <%- DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL %> = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";
-<%- DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES %> = <%- basicFunction("asyncDeps") %> {
+var rspackDefer = <%- define(DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL) %> = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";
+<%- define(DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES) %> = <%- basicFunction("asyncDeps") %> {
 	var hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {
 		var cache = <%- _module_cache %>[id];
 		return !cache || cache[rspackDone] === false;
@@ -57,7 +57,7 @@ var wrapDeps = <%- basicFunction("deps") %> {
 		return ret;
 	});
 };
-<%- ASYNC_MODULE %> = <%- basicFunction("module, body, hasAwait") %> {
+<%- define(ASYNC_MODULE) %> = <%- basicFunction("module, body, hasAwait") %> {
 	var queue;
 	hasAwait && ((queue = []).d = -1);
 	var depQueues = new Set();

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/auto_public_path.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/auto_public_path.ejs
@@ -23,7 +23,7 @@ if (!scriptUrl && document) {
 if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");
 scriptUrl = scriptUrl.replace(/^blob:/, "").replace(/#.*$/, "").replace(/\?.*$/, "").replace(/\/[^\/]+$/, "/");
 <% if (_undo_path == "") { %>
-<%- PUBLIC_PATH %> = scriptUrl;
+<%- define(PUBLIC_PATH) %> = scriptUrl;
 <% } else { %>
-<%- PUBLIC_PATH %> = scriptUrl + '<%- _undo_path %>';
+<%- define(PUBLIC_PATH) %> = scriptUrl + '<%- _undo_path %>';
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.ejs
@@ -1,5 +1,5 @@
 // getDefaultExport function for compatibility with non-ESM modules
-<%- COMPAT_GET_DEFAULT_EXPORT %> = <%- basicFunction("module") %> {
+<%- define(COMPAT_GET_DEFAULT_EXPORT) %> = <%- basicFunction("module") %> {
 	var getter = module && module.__esModule ?
 		<%- returningFunction("module['default']", "") %> :
 		<%- returningFunction("module", "") %>;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_fake_namespace_object.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_fake_namespace_object.ejs
@@ -6,7 +6,7 @@ var leafPrototypes;
 // mode & 4: return value when already ns object
 // mode & 16: return value when it's Promise-like
 // mode & 8|1: behave like require
-<%- CREATE_FAKE_NAMESPACE_OBJECT %> = function(value, mode) {
+<%- define(CREATE_FAKE_NAMESPACE_OBJECT) %> = function(value, mode) {
 	if(mode & 1) value = <%- __this %>(value);
 	if(mode & 8) return value;
 	if(typeof value === 'object' && value) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_script.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_script.ejs
@@ -1,5 +1,5 @@
 <% if (_trusted_types) { %>
-<%- CREATE_SCRIPT %> = <%- returningFunction(GET_TRUSTED_TYPES_POLICY + "().createScript(script)", "script" ) %>
+<%- define(CREATE_SCRIPT) %> = <%- returningFunction(GET_TRUSTED_TYPES_POLICY + "().createScript(script)", "script" ) %>
 <% } else { %>
-<%- CREATE_SCRIPT %> = <%- returningFunction("script", "script" ) %>
+<%- define(CREATE_SCRIPT) %> = <%- returningFunction("script", "script" ) %>
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_script_url.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_script_url.ejs
@@ -1,5 +1,5 @@
 <% if (_trusted_types) { %>
-<%- CREATE_SCRIPT_URL %> = <%- returningFunction(GET_TRUSTED_TYPES_POLICY + "().createScriptURL(url)", "url" ) %>
+<%- define(CREATE_SCRIPT_URL) %> = <%- returningFunction(GET_TRUSTED_TYPES_POLICY + "().createScriptURL(url)", "url" ) %>
 <% } else { %>
-<%- CREATE_SCRIPT_URL %> = <%- returningFunction("url", "url" ) %>
+<%- define(CREATE_SCRIPT_URL) %> = <%- returningFunction("url", "url" ) %>
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/define_property_getters.ejs
@@ -1,4 +1,4 @@
-<%- DEFINE_PROPERTY_GETTERS %> = <%- basicFunction("exports, getters, values") %> {
+<%- define(DEFINE_PROPERTY_GETTERS) %> = <%- basicFunction("exports, getters, values") %> {
 	var define = <%- basicFunction("defs, kind") %> {
 		for(var key in defs) {
 			if(<%- HAS_OWN_PROPERTY %>(defs, key) && !<%- HAS_OWN_PROPERTY %>(exports, key)) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk.ejs
@@ -1,7 +1,7 @@
-<%- ENSURE_CHUNK_HANDLERS %> = {};
+<%- define(ENSURE_CHUNK_HANDLERS) %> = {};
 // This file contains only the entry chunk.
 // The chunk loading function for additional chunks
-<%- ENSURE_CHUNK %> = <%- basicFunction("chunkId" + _fetch_priority) %> {
+<%- define(ENSURE_CHUNK) %> = <%- basicFunction("chunkId" + _fetch_priority) %> {
 	return Promise.all(
 		Object.keys(<%- ENSURE_CHUNK_HANDLERS %>).reduce(<%- basicFunction("promises, key") %> {
 			<%- ENSURE_CHUNK_HANDLERS %>[key](chunkId, promises<%- _fetch_priority %>);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk_with_inline.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk_with_inline.ejs
@@ -1,4 +1,4 @@
 // The chunk loading function for additional chunks
 // Since all referenced chunks are already included
 // in this file, this function is empty here.
-<%- ENSURE_CHUNK %> = <%- returningFunction("Promise.resolve()", "") %> 
+<%- define(ENSURE_CHUNK) %> = <%- returningFunction("Promise.resolve()", "") %> 

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/esm_module_decorator.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/esm_module_decorator.ejs
@@ -1,4 +1,4 @@
-<%- ESM_MODULE_DECORATOR %> = <%- basicFunction("module") %> {
+<%- define(ESM_MODULE_DECORATOR) %> = <%- basicFunction("module") %> {
   module = Object.create(module);
   if (!module.children) module.children = [];
   Object.defineProperty(module, 'exports', {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_chunk_update_filename.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_chunk_update_filename.ejs
@@ -1,1 +1,1 @@
-<%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %> = <%- returningFunction(_filename, "chunkId") %>
+<%- define(GET_CHUNK_UPDATE_SCRIPT_FILENAME) %> = <%- returningFunction(_filename, "chunkId") %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_full_hash.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_full_hash.ejs
@@ -1,1 +1,1 @@
-<%- GET_FULL_HASH %> = <%- returningFunction(_hash, "" ) %>
+<%- define(GET_FULL_HASH) %> = <%- returningFunction(_hash, "" ) %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_trusted_types_policy.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_trusted_types_policy.ejs
@@ -1,5 +1,5 @@
 var policy;
-<%- GET_TRUSTED_TYPES_POLICY  %> = <%- basicFunction("") %> {
+<%- define(GET_TRUSTED_TYPES_POLICY) %> = <%- basicFunction("") %> {
     // Create Trusted Type policy if Trusted Types are available and the policy doesn't exist yet.
     if (policy === undefined) {
         policy = {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_unique_id.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_unique_id.ejs
@@ -1,1 +1,1 @@
-<%- RSPACK_UNIQUE_ID %> = "bundler=<%- _bundler_name %>@<%- _bundler_version %>";
+<%- define(RSPACK_UNIQUE_ID) %> = "bundler=<%- _bundler_name %>@<%- _bundler_version %>";

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_version.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_version.ejs
@@ -1,1 +1,1 @@
-<%- RSPACK_VERSION %> = <%- returningFunction(_version, "") %>
+<%- define(RSPACK_VERSION) %> = <%- returningFunction(_version, "") %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/global.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/global.ejs
@@ -1,4 +1,4 @@
-<%- GLOBAL %> = (<%- basicFunction("") %> {
+<%- define(GLOBAL) %> = (<%- basicFunction("") %> {
 	if (typeof globalThis === 'object') return globalThis;
 	try {
 		return this || new Function('return this')();

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/has_own_property.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/has_own_property.ejs
@@ -1,1 +1,1 @@
-<%- HAS_OWN_PROPERTY %> = <%- returningFunction("Object.prototype.hasOwnProperty.call(obj, prop)", "obj, prop") %>
+<%- define(HAS_OWN_PROPERTY) %> = <%- returningFunction("Object.prototype.hasOwnProperty.call(obj, prop)", "obj, prop") %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
@@ -12,7 +12,7 @@ function loadUpdateChunk(chunkId, updatedModulesList) {
   };
   // start update chunk loading
   <% if (_with_create_script_url) { %>
-  importScripts(<%- CREATE_SCRIPT_URL %>(<%- PUBLIC_PATH %> + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId)));
+  importScripts(<%- weak(CREATE_SCRIPT_URL) %>(<%- PUBLIC_PATH %> + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId)));
   <% } else { %>
   importScripts(<%- PUBLIC_PATH %> + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId));
   <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr_manifest.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr_manifest.ejs
@@ -1,4 +1,4 @@
-<%- HMR_DOWNLOAD_MANIFEST %> = <%- basicFunction("") %> {
+<%- define(HMR_DOWNLOAD_MANIFEST) %> = <%- basicFunction("") %> {
   if (typeof fetch === "undefined") throw new Error("No browser support: need fetch API");
   return fetch(<%- PUBLIC_PATH %> + <%- GET_UPDATE_MANIFEST_FILENAME %>()).then(
   <%- basicFunction("response") %> {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_loading.ejs
@@ -6,7 +6,7 @@
     if (!installedChunks[chunkId]) {
         if (<%- _js_matcher %>) {
             <% if (_with_create_script_url) { %>
-            importScripts(<%- CREATE_SCRIPT_URL %>(<%- PUBLIC_PATH %> + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)));
+            importScripts(<%- weak(CREATE_SCRIPT_URL) %>(<%- PUBLIC_PATH %> + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)));
             <% } else { %>
             importScripts(<%- PUBLIC_PATH %> + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId));
             <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
@@ -3,7 +3,7 @@ var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
 function applyHandler(options) {
-	if (<%- ENSURE_CHUNK_HANDLERS %>) delete <%- ENSURE_CHUNK_HANDLERS %>.<%- _loading_method %>Hmr;
+	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) delete <%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
@@ -449,8 +449,8 @@ function applyHandler(options) {
 			currentUpdateChunks[chunkId] = false;
 		}
 	});
-	if (<%- ENSURE_CHUNK_HANDLERS %>) {
-		<%- ENSURE_CHUNK_HANDLERS %>.<%- _loading_method %>Hmr = function (chunkId, promises) {
+	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) {
+		<%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr = function (chunkId, promises) {
 			if (
 				currentUpdateChunks &&
 				<%- HAS_OWN_PROPERTY %>(currentUpdateChunks, chunkId) &&

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.ejs
@@ -24,7 +24,7 @@ var __rspack_jsonp = <%- basicFunction("parentChunkLoadingFunction, data") %> {
 		installedChunks[chunkId] = 0;
 	}
 	<% if (_with_on_chunk_load) { %>
-	return <%- ON_CHUNKS_LOADED %>(result);
+	return <%- weak(ON_CHUNKS_LOADED) %>(result);
 	<% } %>
 };
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr_manifest.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr_manifest.ejs
@@ -1,4 +1,4 @@
-<%- HMR_DOWNLOAD_MANIFEST %> = <%- basicFunction("") %> {
+<%- define(HMR_DOWNLOAD_MANIFEST) %> = <%- basicFunction("") %> {
 	if (typeof fetch === "undefined")
 		throw new Error("No browser support: need fetch API");
 	return fetch(<%- PUBLIC_PATH %> + <%- GET_UPDATE_MANIFEST_FILENAME %>()).then(

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_prefetch_link.ejs
@@ -2,8 +2,8 @@ var link = document.createElement('link');
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = 'prefetch';
 link.as = 'script';

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_preload_link.ejs
@@ -2,8 +2,8 @@ var link = document.createElement('link');
 <% if (_script_type != "false" && _script_type != "module") { %>
 link.type = "<%- _script_type %>";
 <% } %>
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 <% if (_script_type == "module") { %>
 link.rel = 'modulepreload';

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script.ejs
@@ -2,7 +2,7 @@ var inProgress = {};
 
 <%- _unique_prefix %>
 // loadScript function to load a script via script tag
-<%- LOAD_SCRIPT %> = function (url, done, key, chunkId<%- _fetch_priority %>) {
+<%- define(LOAD_SCRIPT) %> = function (url, done, key, chunkId<%- _fetch_priority %>) {
 	if (inProgress[url]) {
 		inProgress[url].push(done);
 		return;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script_create_script.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script_create_script.ejs
@@ -3,8 +3,8 @@ script = document.createElement('script');
 script.type = '<%- _script_type %>';
 <% } %>
 script.timeout = <%- _chunk_load_timeout %>;
-if (<%- SCRIPT_NONCE %>) {
-  script.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  script.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 <% if (_unique_prefix) { %>
 script.setAttribute("data-rspack", uniqueName + key);
@@ -15,7 +15,7 @@ if(fetchPriority) {
 }
 <% } %>
 <% if (_with_create_script_url) { %>
-script.src = <%- CREATE_SCRIPT_URL %>(url);
+script.src = <%- weak(CREATE_SCRIPT_URL) %>(url);
 <% } else { %>
 script.src = url;
 <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/make_deferred_namespace_object.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/make_deferred_namespace_object.ejs
@@ -1,4 +1,4 @@
-<%- MAKE_DEFERRED_NAMESPACE_OBJECT %> = <%- basicFunction("moduleId, mode") %> {
+<%- define(MAKE_DEFERRED_NAMESPACE_OBJECT) %> = <%- basicFunction("moduleId, mode") %> {
   var cachedModule = <%- _module_cache %>[moduleId];
   if (cachedModule && cachedModule.error === undefined) {
     var exports = cachedModule.exports;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/make_namespace_object.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/make_namespace_object.ejs
@@ -1,5 +1,5 @@
 // define __esModule on exports
-<%- MAKE_NAMESPACE_OBJECT %> = <%- basicFunction("exports") %> {
+<%- define(MAKE_NAMESPACE_OBJECT) %> = <%- basicFunction("exports") %> {
 	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 	}

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/make_optimized_deferred_namespace_object.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/make_optimized_deferred_namespace_object.ejs
@@ -1,4 +1,4 @@
-<%- MAKE_OPTIMIZED_DEFERRED_NAMESPACE_OBJECT %> = function(moduleId, mode, asyncDeps) {
+<%- define(MAKE_OPTIMIZED_DEFERRED_NAMESPACE_OBJECT) %> = function(moduleId, mode, asyncDeps) {
 	var r = <%- REQUIRE %>;
 	<% if (_has_async) { %>
 	var isAsync = asyncDeps && asyncDeps.length;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs
@@ -18,5 +18,5 @@ var installChunk = <%- basicFunction("data") %> {
         }
         installedChunks[__rspack_esm_ids[i]] = 0;
     }
-    <% if (_with_on_chunk_load) { %><%- ON_CHUNKS_LOADED %>();<% } %>
+    <% if (_with_on_chunk_load) { %><%- weak(ON_CHUNKS_LOADED) %>();<% } %>
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr_manifest.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr_manifest.ejs
@@ -1,4 +1,4 @@
-<%- HMR_DOWNLOAD_MANIFEST %> = <%- basicFunction("") %> {
+<%- define(HMR_DOWNLOAD_MANIFEST) %> = <%- basicFunction("") %> {
     return <%- _import_function_name %>(/* webpackIgnore: true */ <%- PUBLIC_PATH %> + <%- GET_UPDATE_MANIFEST_FILENAME %>())
         .then( <%- basicFunction("obj") %> {
             return obj.default;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_prefetch_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_prefetch_link.ejs
@@ -2,8 +2,8 @@ var link = document.createElement('link');
 <% if (_cross_origin != "") { %>
 link.crossOrigin = '<%- _cross_origin %>';
 <% } %>
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute('nonce', <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute('nonce', <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = 'prefetch';
 link.as = 'script';

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_preload_link.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_preload_link.ejs
@@ -1,6 +1,6 @@
 var link = document.createElement('link');
-if (<%- SCRIPT_NONCE %>) {
-  link.setAttribute("nonce", <%- SCRIPT_NONCE %>);
+if (<%- weak(SCRIPT_NONCE) %>) {
+  link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 link.rel = 'modulepreload';
 link.href = <%- PUBLIC_PATH %> + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/node_module_decorator.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/node_module_decorator.ejs
@@ -1,4 +1,4 @@
-<%- NODE_MODULE_DECORATOR %> = <%- basicFunction("module") %> {
+<%- define(NODE_MODULE_DECORATOR) %> = <%- basicFunction("module") %> {
   module.paths = [];
   if (!module.children) module.children = [];
   return module;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/on_chunk_loaded.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/on_chunk_loaded.ejs
@@ -1,5 +1,5 @@
 var deferred = [];
-<%- ON_CHUNKS_LOADED %> = <%- basicFunction("result, chunkIds, fn, priority") %> {
+<%- define(ON_CHUNKS_LOADED) %> = <%- basicFunction("result, chunkIds, fn, priority") %> {
 	if (chunkIds) {
 		priority = priority || 0;
 		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_external_install_chunk.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_external_install_chunk.ejs
@@ -1,2 +1,2 @@
 module.exports = <%- REQUIRE_SCOPE %>;
-<%- EXTERNAL_INSTALL_CHUNK %> = installChunk;
+<%- define(EXTERNAL_INSTALL_CHUNK) %> = installChunk;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr_manifest.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr_manifest.ejs
@@ -1,4 +1,4 @@
-<%- HMR_DOWNLOAD_MANIFEST %> = <%- basicFunction("") %> {
+<%- define(HMR_DOWNLOAD_MANIFEST) %> = <%- basicFunction("") %> {
 	return new Promise(<%- basicFunction("resolve, reject") %> {
 		var filename = require('path').join(__dirname, "<%- _output_dir %>" + <%- GET_UPDATE_MANIFEST_FILENAME %>());
 		require('fs').readFile(filename, 'utf-8', <%- basicFunction("err, content") %> {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/relative_url.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/relative_url.ejs
@@ -1,4 +1,4 @@
-<%- RELATIVE_URL %> = function RelativeURL(url) {
+<%- define(RELATIVE_URL) %> = function RelativeURL(url) {
   var realUrl = new URL(url, "x:/");
   var values = {};
   for (var key in realUrl) values[key] = realUrl[key];

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_external_install_chunk.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_external_install_chunk.ejs
@@ -1,2 +1,2 @@
 module.exports = <%- REQUIRE_SCOPE %>;
-<%- EXTERNAL_INSTALL_CHUNK %> = installChunk;
+<%- define(EXTERNAL_INSTALL_CHUNK) %> = installChunk;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr_manifest.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr_manifest.ejs
@@ -1,4 +1,4 @@
-<%- HMR_DOWNLOAD_MANIFEST %> = <%- basicFunction("") %> {
+<%- define(HMR_DOWNLOAD_MANIFEST) %> = <%- basicFunction("") %> {
 	return Promise.resolve()
 		.then(<%- basicFunction("") %> {
 			return require("./" + <%- GET_UPDATE_MANIFEST_FILENAME %>());

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies.ejs
@@ -1,4 +1,4 @@
 var next = <%- STARTUP %>
-<%- STARTUP %> = <%- basicFunction("") %> {
+<%- define(STARTUP) %> = <%- basicFunction("") %> {
   <%- _body %>
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_entrypoint.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_entrypoint.ejs
@@ -1,4 +1,4 @@
-<%- STARTUP_ENTRYPOINT %> = <%- basicFunction("result, chunkIds, fn") %> {
+<%- define(STARTUP_ENTRYPOINT) %> = <%- basicFunction("result, chunkIds, fn") %> {
   // arguments: chunkIds, moduleId are deprecated
   var moduleId = chunkIds;
   if (!fn) chunkIds = result, fn = <%- returningFunction("$$RUNTIME_GLOBAL_REQUIRE$$($$RUNTIME_GLOBAL_ENTRY_MODULE_ID$$ = moduleId)", "") %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_entrypoint_with_async.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_entrypoint_with_async.ejs
@@ -1,4 +1,4 @@
-<%- STARTUP_ENTRYPOINT %> = <%- basicFunction("result, chunkIds, fn") %> {
+<%- define(STARTUP_ENTRYPOINT) %> = <%- basicFunction("result, chunkIds, fn") %> {
   // arguments: chunkIds, moduleId are deprecated
   var moduleId = chunkIds;
   if (!fn) chunkIds = result, fn = <%- returningFunction("$$RUNTIME_GLOBAL_REQUIRE$$($$RUNTIME_GLOBAL_ENTRY_MODULE_ID$$ = moduleId)", "") %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/to_binary.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/to_binary.ejs
@@ -1,5 +1,5 @@
 // define to binary helper
-<%- TO_BINARY %> = <% if (_is_neutral_platform) { %>typeof Buffer !== 'undefined' ? <% } %>
+<%- define(TO_BINARY) %> = <% if (_is_neutral_platform) { %>typeof Buffer !== 'undefined' ? <% } %>
   <% if (_is_node_platform || _is_neutral_platform) { %>
     <%- returningFunction("new Uint8Array(Buffer.from(base64, 'base64'))", "base64") %>
   <% } %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
@@ -21,7 +21,7 @@ impl RuntimeModule for RuntimeIdRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::RUNTIME_ID },
+      define: { RuntimeGlobals::RUNTIME_ID },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -32,7 +32,7 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
     }
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,
-      write: { RuntimeGlobals::STARTUP },
+      define: { RuntimeGlobals::STARTUP },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_entrypoint.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_entrypoint.rs
@@ -42,7 +42,7 @@ impl RuntimeModule for StartupEntrypointRuntimeModule {
       dependencies: RuntimeGlobals::REQUIRE
         | RuntimeGlobals::ENSURE_CHUNK
         | RuntimeGlobals::ENSURE_CHUNK_INCLUDE_ENTRIES,
-      write: { RuntimeGlobals::STARTUP_ENTRYPOINT },
+      define: { RuntimeGlobals::STARTUP_ENTRYPOINT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/system_context.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/system_context.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for SystemContextRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::SYSTEM_CONTEXT },
+      define: { RuntimeGlobals::SYSTEM_CONTEXT },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/to_binary.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/to_binary.rs
@@ -20,7 +20,7 @@ impl RuntimeModule for ToBinaryRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::TO_BINARY },
+      define: { RuntimeGlobals::TO_BINARY },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -95,7 +95,7 @@ impl RuntimeModule for AsyncWasmCompileRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: { RuntimeGlobals::COMPILE_WASM },
+      define: { RuntimeGlobals::COMPILE_WASM },
       ..Default::default()
     }
   }
@@ -138,7 +138,7 @@ impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
     _compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
-      write: RuntimeGlobals::INSTANTIATE_WASM,
+      define: RuntimeGlobals::INSTANTIATE_WASM,
       force_context: RuntimeGlobals::INSTANTIATE_WASM,
       ..Default::default()
     }


### PR DESCRIPTION
## Summary

- Add a dojang `define(...)` helper for runtime EJS templates so define requirements can be collected from templates.
- Rename the EJS requirement extractor to `extract_runtime_globals_from_ejs` and return full runtime module requirements, including `dependencies`, `weak`, and `define`.
- Update runtime EJS assignment sites to use `define(...)` while keeping direct and chained assignment shapes intact.

## Motivation

`runtimeMode = rspack` previously relied on hard-coded define requirements in several runtime modules. This makes define collection easier to miss when templates change. Marking definition sites in EJS keeps the define requirement next to the emitted assignment and avoids counting `define(...)` itself as a direct dependency.