### PR TITLE
perf: defer persistent cache snapshot updates until save time

### DIFF
--- a/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
@@ -1,6 +1,6 @@
 mod helper;
 
-use std::{collections::VecDeque, path::PathBuf, sync::Arc};
+use std::{collections::VecDeque, future::Future, path::PathBuf, sync::Arc};
 
 use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet as HashSet;
 use self::helper::{Helper, is_node_package_path};
 use super::{
   snapshot::{Snapshot, SnapshotScope},
-  storage::Storage,
+  storage::{Storage, StorageUpdates},
 };
 use crate::CompilationLogger;
 
@@ -38,7 +38,7 @@ pub struct BuildDeps {
   added: ArcPathSet,
   /// The pending dependencies.
   ///
-  /// The next time the add method is called, this path will be additionally added.
+  /// The next update task will additionally add these paths.
   pending: ArcPathSet,
   /// The snapshot which is used to save build dependencies.
   snapshot: Arc<Snapshot>,
@@ -64,38 +64,45 @@ impl BuildDeps {
     storage.reset(SnapshotScope::BUILD.name());
   }
 
-  /// Add build dependencies
+  /// Saves update changes for build dependencies.
   ///
   /// For performance reasons, recursive searches will stop for build dependencies in node_modules.
-  pub async fn add(
+  pub fn save_updates_task(
     &mut self,
-    storage: &mut dyn Storage,
-    data: impl Iterator<Item = ArcPath>,
+    data: impl IntoIterator<Item = ArcPath>,
     logger: CompilationLogger,
-  ) {
-    let mut helper = Helper::new(self.fs.clone(), logger);
-    let mut new_deps = HashSet::default();
+  ) -> impl Future<Output = StorageUpdates> + Send + 'static {
+    let fs = self.fs.clone();
+    let snapshot = self.snapshot.clone();
+    let pending = std::mem::take(&mut self.pending);
+    let data = data.into_iter().collect::<Vec<_>>();
     let mut queue = VecDeque::new();
-    queue.extend(std::mem::take(&mut self.pending));
-    queue.extend(data);
-    while let Some(current) = queue.pop_front() {
-      if !self.added.insert(current.clone()) {
-        continue;
-      }
-      new_deps.insert(current.clone());
-      if is_node_package_path(&current) {
-        // node package path skip recursive search.
-        continue;
-      }
-      if let Some(children) = helper.resolve(current.assert_utf8()).await {
-        queue.extend(children.iter().map(|item| item.as_path().into()));
+    for item in pending.into_iter().chain(data) {
+      if self.added.insert(item.clone()) {
+        queue.push_back(item);
       }
     }
 
-    self
-      .snapshot
-      .add(storage, SnapshotScope::BUILD, new_deps.into_iter())
-      .await;
+    async move {
+      let mut helper = Helper::new(fs, logger);
+      let mut new_deps = HashSet::default();
+      while let Some(current) = queue.pop_front() {
+        if !new_deps.insert(current.clone()) {
+          continue;
+        }
+        if is_node_package_path(&current) {
+          // node package path skip recursive search.
+          continue;
+        }
+        if let Some(children) = helper.resolve(current.assert_utf8()).await {
+          queue.extend(children.iter().map(|item| item.as_path().into()));
+        }
+      }
+
+      snapshot
+        .save_scope_updates(SnapshotScope::BUILD, new_deps.into_iter().collect(), vec![])
+        .await
+    }
   }
 
   /// Validate build dependencies
@@ -129,7 +136,7 @@ mod test {
     super::{
       codec::CacheCodec,
       snapshot::{Snapshot, SnapshotOptions, SnapshotScope},
-      storage::{MemoryStorage, Storage},
+      storage::{MemoryStorage, Storage, StorageUpdates},
     },
     BuildDeps, BuildDepsValidationResult,
   };
@@ -153,6 +160,20 @@ mod test {
           .count()
       })
       .unwrap_or_default()
+  }
+
+  fn apply_scope_updates(
+    storage: &mut MemoryStorage,
+    scope: &'static str,
+    mut updates: StorageUpdates,
+  ) {
+    for (key, value) in updates.remove(scope).unwrap_or_default() {
+      if let Some(value) = value {
+        storage.set(scope, key, value);
+      } else {
+        storage.remove(scope, &key);
+      }
+    }
   }
 
   #[tokio::test]
@@ -199,9 +220,9 @@ mod test {
     let mut build_deps = BuildDeps::new(&options, fs.clone(), snapshot.clone());
 
     let (logger, logging) = test_logger("test");
-    build_deps
-      .add(&mut storage, vec![].into_iter(), logger)
-      .await;
+    let update_task = build_deps.save_updates_task(Vec::new(), logger);
+    assert_eq!(warn_count(&logging, "test"), 0);
+    apply_scope_updates(&mut storage, scope, update_task.await);
     assert_eq!(warn_count(&logging, "test"), 1);
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 9);
@@ -224,9 +245,8 @@ mod test {
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 0);
     let (logger, logging) = test_logger("test");
-    build_deps
-      .add(&mut storage, vec![].into_iter(), logger)
-      .await;
+    let update_task = build_deps.save_updates_task(Vec::new(), logger);
+    apply_scope_updates(&mut storage, scope, update_task.await);
     assert_eq!(warn_count(&logging, "test"), 0);
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 10);

--- a/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
@@ -1,6 +1,6 @@
 mod helper;
 
-use std::{collections::VecDeque, future::Future, path::PathBuf, sync::Arc};
+use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 
 use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet as HashSet;
 use self::helper::{Helper, is_node_package_path};
 use super::{
   snapshot::{Snapshot, SnapshotScope},
-  storage::{Storage, StorageUpdates},
+  storage::Storage,
 };
 use crate::CompilationLogger;
 
@@ -67,13 +67,13 @@ impl BuildDeps {
   /// Saves update changes for build dependencies.
   ///
   /// For performance reasons, recursive searches will stop for build dependencies in node_modules.
-  pub fn save_updates_task(
+  pub async fn save_updates(
     &mut self,
+    storage: &mut dyn Storage,
     data: impl IntoIterator<Item = ArcPath>,
     logger: CompilationLogger,
-  ) -> impl Future<Output = StorageUpdates> + Send + 'static {
+  ) {
     let fs = self.fs.clone();
-    let snapshot = self.snapshot.clone();
     let pending = std::mem::take(&mut self.pending);
     let data = data.into_iter().collect::<Vec<_>>();
     let mut queue = VecDeque::new();
@@ -83,25 +83,34 @@ impl BuildDeps {
       }
     }
 
-    async move {
-      let mut helper = Helper::new(fs, logger);
-      let mut new_deps = HashSet::default();
-      while let Some(current) = queue.pop_front() {
-        if !new_deps.insert(current.clone()) {
-          continue;
-        }
-        if is_node_package_path(&current) {
-          // node package path skip recursive search.
-          continue;
-        }
-        if let Some(children) = helper.resolve(current.assert_utf8()).await {
-          queue.extend(children.iter().map(|item| item.as_path().into()));
-        }
+    let mut helper = Helper::new(fs, logger);
+    let mut new_deps = HashSet::default();
+    while let Some(current) = queue.pop_front() {
+      if !new_deps.insert(current.clone()) {
+        continue;
       }
+      if is_node_package_path(&current) {
+        // node package path skip recursive search.
+        continue;
+      }
+      if let Some(children) = helper.resolve(current.assert_utf8()).await {
+        queue.extend(children.iter().map(|item| item.as_path().into()));
+      }
+    }
 
-      snapshot
-        .save_scope_updates(SnapshotScope::BUILD, new_deps.into_iter().collect(), vec![])
-        .await
+    let mut updates = self
+      .snapshot
+      .save_scope_updates(SnapshotScope::BUILD, new_deps.into_iter().collect(), vec![])
+      .await;
+    for (key, value) in updates
+      .remove(SnapshotScope::BUILD.name())
+      .unwrap_or_default()
+    {
+      if let Some(value) = value {
+        storage.set(SnapshotScope::BUILD.name(), key, value);
+      } else {
+        storage.remove(SnapshotScope::BUILD.name(), &key);
+      }
     }
   }
 
@@ -136,7 +145,7 @@ mod test {
     super::{
       codec::CacheCodec,
       snapshot::{Snapshot, SnapshotOptions, SnapshotScope},
-      storage::{MemoryStorage, Storage, StorageUpdates},
+      storage::{MemoryStorage, Storage},
     },
     BuildDeps, BuildDepsValidationResult,
   };
@@ -160,20 +169,6 @@ mod test {
           .count()
       })
       .unwrap_or_default()
-  }
-
-  fn apply_scope_updates(
-    storage: &mut MemoryStorage,
-    scope: &'static str,
-    mut updates: StorageUpdates,
-  ) {
-    for (key, value) in updates.remove(scope).unwrap_or_default() {
-      if let Some(value) = value {
-        storage.set(scope, key, value);
-      } else {
-        storage.remove(scope, &key);
-      }
-    }
   }
 
   #[tokio::test]
@@ -220,9 +215,9 @@ mod test {
     let mut build_deps = BuildDeps::new(&options, fs.clone(), snapshot.clone());
 
     let (logger, logging) = test_logger("test");
-    let update_task = build_deps.save_updates_task(Vec::new(), logger);
+    let update_task = build_deps.save_updates(&mut storage, Vec::new(), logger);
     assert_eq!(warn_count(&logging, "test"), 0);
-    apply_scope_updates(&mut storage, scope, update_task.await);
+    update_task.await;
     assert_eq!(warn_count(&logging, "test"), 1);
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 9);
@@ -245,8 +240,8 @@ mod test {
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 0);
     let (logger, logging) = test_logger("test");
-    let update_task = build_deps.save_updates_task(Vec::new(), logger);
-    apply_scope_updates(&mut storage, scope, update_task.await);
+    let update_task = build_deps.save_updates(&mut storage, Vec::new(), logger);
+    update_task.await;
     assert_eq!(warn_count(&logging, "test"), 0);
     let data = storage.load(scope).await.expect("should load success");
     assert_eq!(data.len(), 10);

--- a/crates/rspack_core/src/cache/persistent/context.rs
+++ b/crates/rspack_core/src/cache/persistent/context.rs
@@ -108,7 +108,7 @@ impl CacheContext {
 
   /// Saves build dependency hashes. No-op in readonly mode.
   #[tracing::instrument("Cache::Context::save_build_deps", skip_all)]
-  pub fn save_build_deps(
+  pub async fn save_build_deps(
     &mut self,
     build_deps: &mut BuildDeps,
     added: impl Iterator<Item = ArcPath>,
@@ -122,9 +122,9 @@ impl CacheContext {
       .time("write build dependencies to persistent cache");
     let logger = self.logger().clone();
     let added = added.collect::<Vec<_>>();
-    self
-      .storage
-      .add_update_task(Box::pin(build_deps.save_updates_task(added, logger)));
+    build_deps
+      .save_updates(&mut *self.storage, added, logger)
+      .await;
     self.logger().time_end(start);
   }
 

--- a/crates/rspack_core/src/cache/persistent/context.rs
+++ b/crates/rspack_core/src/cache/persistent/context.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write as _;
+use std::{fmt::Write as _, sync::Arc};
 
 use rspack_paths::{ArcPath, ArcPathSet};
 
@@ -108,7 +108,7 @@ impl CacheContext {
 
   /// Saves build dependency hashes. No-op in readonly mode.
   #[tracing::instrument("Cache::Context::save_build_deps", skip_all)]
-  pub async fn save_build_deps(
+  pub fn save_build_deps(
     &mut self,
     build_deps: &mut BuildDeps,
     added: impl Iterator<Item = ArcPath>,
@@ -121,7 +121,10 @@ impl CacheContext {
       .logger()
       .time("write build dependencies to persistent cache");
     let logger = self.logger().clone();
-    build_deps.add(&mut *self.storage, added, logger).await;
+    let added = added.collect::<Vec<_>>();
+    self
+      .storage
+      .add_update_task(Box::pin(build_deps.save_updates_task(added, logger)));
     self.logger().time_end(start);
   }
 
@@ -194,9 +197,9 @@ impl CacheContext {
 
   /// Persists snapshot data for all three scopes. No-op in readonly mode.
   #[tracing::instrument("Cache::Context::save_snapshot", skip_all)]
-  pub async fn save_snapshot(
+  pub fn save_snapshot(
     &mut self,
-    snapshot: &Snapshot,
+    snapshot: Arc<Snapshot>,
     file_deps: (impl Iterator<Item = ArcPath>, impl Iterator<Item = ArcPath>),
     context_deps: (impl Iterator<Item = ArcPath>, impl Iterator<Item = ArcPath>),
     missing_deps: (impl Iterator<Item = ArcPath>, impl Iterator<Item = ArcPath>),
@@ -209,18 +212,16 @@ impl CacheContext {
     let (file_added, file_removed) = file_deps;
     let (context_added, context_removed) = context_deps;
     let (missing_added, missing_removed) = missing_deps;
-    snapshot.remove(&mut *self.storage, SnapshotScope::FILE, file_removed);
-    snapshot.remove(&mut *self.storage, SnapshotScope::CONTEXT, context_removed);
-    snapshot.remove(&mut *self.storage, SnapshotScope::MISSING, missing_removed);
-    snapshot
-      .add(&mut *self.storage, SnapshotScope::FILE, file_added)
-      .await;
-    snapshot
-      .add(&mut *self.storage, SnapshotScope::CONTEXT, context_added)
-      .await;
-    snapshot
-      .add(&mut *self.storage, SnapshotScope::MISSING, missing_added)
-      .await;
+    let file_deps = (file_added.collect(), file_removed.collect());
+    let context_deps = (context_added.collect(), context_removed.collect());
+    let missing_deps = (missing_added.collect(), missing_removed.collect());
+    self
+      .storage
+      .add_update_task(Box::pin(snapshot.save_updates_task(
+        file_deps,
+        context_deps,
+        missing_deps,
+      )));
     self.logger().time_end(start);
   }
 

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -190,10 +190,13 @@ impl Cache for PersistentCache {
         missing_removed.cloned(),
       ),
     );
-    self.ctx.save_build_deps(
-      &mut self.build_deps,
-      build_added.chain(build_updated).cloned(),
-    );
+    self
+      .ctx
+      .save_build_deps(
+        &mut self.build_deps,
+        build_added.chain(build_updated).cloned(),
+      )
+      .await;
 
     self.ctx.save_storage();
     self.ctx.reset();

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -175,31 +175,25 @@ impl Cache for PersistentCache {
     let (_, context_added, context_updated, context_removed) = compilation.context_dependencies();
     let (_, missing_added, missing_updated, missing_removed) = compilation.missing_dependencies();
     let (_, build_added, build_updated, _) = compilation.build_dependencies();
-    self
-      .ctx
-      .save_snapshot(
-        &self.snapshot,
-        (
-          file_added.chain(file_updated).cloned(),
-          file_removed.cloned(),
-        ),
-        (
-          context_added.chain(context_updated).cloned(),
-          context_removed.cloned(),
-        ),
-        (
-          missing_added.chain(missing_updated).cloned(),
-          missing_removed.cloned(),
-        ),
-      )
-      .await;
-    self
-      .ctx
-      .save_build_deps(
-        &mut self.build_deps,
-        build_added.chain(build_updated).cloned(),
-      )
-      .await;
+    self.ctx.save_snapshot(
+      self.snapshot.clone(),
+      (
+        file_added.chain(file_updated).cloned(),
+        file_removed.cloned(),
+      ),
+      (
+        context_added.chain(context_updated).cloned(),
+        context_removed.cloned(),
+      ),
+      (
+        missing_added.chain(missing_updated).cloned(),
+        missing_removed.cloned(),
+      ),
+    );
+    self.ctx.save_build_deps(
+      &mut self.build_deps,
+      build_added.chain(build_updated).cloned(),
+    );
 
     self.ctx.save_storage();
     self.ctx.reset();

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -2,7 +2,7 @@ mod option;
 mod scope;
 mod strategy;
 
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
@@ -119,26 +119,16 @@ impl Snapshot {
     changes
   }
 
-  fn remove_updates(
-    scope: SnapshotScope,
-    paths: Vec<ArcPath>,
-  ) -> (String, Vec<(Vec<u8>, Option<Vec<u8>>)>) {
-    (
-      scope.name().to_string(),
-      paths
-        .into_iter()
-        .map(|item| (item.as_os_str().as_encoded_bytes().to_vec(), None))
-        .collect(),
-    )
-  }
-
   pub async fn save_scope_updates(
     &self,
     scope: SnapshotScope,
     added: Vec<ArcPath>,
     removed: Vec<ArcPath>,
   ) -> StorageUpdates {
-    let (scope_name, mut scope_updates) = Self::remove_updates(scope, removed);
+    let mut scope_updates: Vec<_> = removed
+      .into_iter()
+      .map(|item| (item.as_os_str().as_encoded_bytes().to_vec(), None))
+      .collect();
     scope_updates.extend(
       self
         .add_changes(scope, added)
@@ -149,41 +139,42 @@ impl Snapshot {
 
     let mut updates = StorageUpdates::default();
     if !scope_updates.is_empty() {
-      updates.insert(scope_name, scope_updates.into_iter().collect());
+      updates.insert(
+        scope.name().to_string(),
+        scope_updates.into_iter().collect(),
+      );
     }
     updates
   }
 
-  pub fn save_updates_task(
+  pub async fn save_updates_task(
     self: Arc<Self>,
     file_deps: (Vec<ArcPath>, Vec<ArcPath>),
     context_deps: (Vec<ArcPath>, Vec<ArcPath>),
     missing_deps: (Vec<ArcPath>, Vec<ArcPath>),
-  ) -> impl Future<Output = StorageUpdates> + Send + 'static {
-    async move {
-      let mut updates = StorageUpdates::default();
-      let (file_added, file_removed) = file_deps;
-      let (context_added, context_removed) = context_deps;
-      let (missing_added, missing_removed) = missing_deps;
+  ) -> StorageUpdates {
+    let mut updates = StorageUpdates::default();
+    let (file_added, file_removed) = file_deps;
+    let (context_added, context_removed) = context_deps;
+    let (missing_added, missing_removed) = missing_deps;
 
-      updates.extend(
-        self
-          .save_scope_updates(SnapshotScope::FILE, file_added, file_removed)
-          .await,
-      );
-      updates.extend(
-        self
-          .save_scope_updates(SnapshotScope::CONTEXT, context_added, context_removed)
-          .await,
-      );
-      updates.extend(
-        self
-          .save_scope_updates(SnapshotScope::MISSING, missing_added, missing_removed)
-          .await,
-      );
+    updates.extend(
+      self
+        .save_scope_updates(SnapshotScope::FILE, file_added, file_removed)
+        .await,
+    );
+    updates.extend(
+      self
+        .save_scope_updates(SnapshotScope::CONTEXT, context_added, context_removed)
+        .await,
+    );
+    updates.extend(
+      self
+        .save_scope_updates(SnapshotScope::MISSING, missing_added, missing_removed)
+        .await,
+    );
 
-      updates
-    }
+    updates
   }
 
   #[allow(clippy::type_complexity)]

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -2,7 +2,7 @@ mod option;
 mod scope;
 mod strategy;
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
@@ -15,7 +15,10 @@ pub use self::{
   scope::SnapshotScope,
   strategy::Strategy,
 };
-use super::{codec::CacheCodec, storage::Storage};
+use super::{
+  codec::CacheCodec,
+  storage::{Storage, StorageUpdates},
+};
 use crate::FutureConsumer;
 
 /// Snapshot is used to check if files have been modified or deleted.
@@ -84,17 +87,17 @@ impl Snapshot {
     storage.reset(SnapshotScope::MISSING.name());
   }
 
-  #[tracing::instrument("Cache::Snapshot::add", skip_all)]
-  pub async fn add(
+  async fn add_changes(
     &self,
-    storage: &mut dyn Storage,
     scope: SnapshotScope,
-    paths: impl Iterator<Item = ArcPath>,
-  ) {
+    paths: Vec<ArcPath>,
+  ) -> Vec<(Vec<u8>, Vec<u8>)> {
     let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
     let codec = self.codec.clone();
+    let mut changes = Vec::new();
     // TODO merge package version file
     paths
+      .into_iter()
       .map(|path| {
         let helper = helper.clone();
         let options = self.options.clone();
@@ -109,20 +112,77 @@ impl Snapshot {
       })
       .fut_consume(|data| {
         if let Some((key, value)) = data {
-          storage.set(scope.name(), key, value);
+          changes.push((key, value));
         }
       })
       .await;
+    changes
   }
 
-  pub fn remove(
-    &self,
-    storage: &mut dyn Storage,
+  fn remove_updates(
     scope: SnapshotScope,
-    paths: impl Iterator<Item = ArcPath>,
-  ) {
-    for item in paths {
-      storage.remove(scope.name(), item.as_os_str().as_encoded_bytes())
+    paths: Vec<ArcPath>,
+  ) -> (String, Vec<(Vec<u8>, Option<Vec<u8>>)>) {
+    (
+      scope.name().to_string(),
+      paths
+        .into_iter()
+        .map(|item| (item.as_os_str().as_encoded_bytes().to_vec(), None))
+        .collect(),
+    )
+  }
+
+  pub async fn save_scope_updates(
+    &self,
+    scope: SnapshotScope,
+    added: Vec<ArcPath>,
+    removed: Vec<ArcPath>,
+  ) -> StorageUpdates {
+    let (scope_name, mut scope_updates) = Self::remove_updates(scope, removed);
+    scope_updates.extend(
+      self
+        .add_changes(scope, added)
+        .await
+        .into_iter()
+        .map(|(key, value)| (key, Some(value))),
+    );
+
+    let mut updates = StorageUpdates::default();
+    if !scope_updates.is_empty() {
+      updates.insert(scope_name, scope_updates.into_iter().collect());
+    }
+    updates
+  }
+
+  pub fn save_updates_task(
+    self: Arc<Self>,
+    file_deps: (Vec<ArcPath>, Vec<ArcPath>),
+    context_deps: (Vec<ArcPath>, Vec<ArcPath>),
+    missing_deps: (Vec<ArcPath>, Vec<ArcPath>),
+  ) -> impl Future<Output = StorageUpdates> + Send + 'static {
+    async move {
+      let mut updates = StorageUpdates::default();
+      let (file_added, file_removed) = file_deps;
+      let (context_added, context_removed) = context_deps;
+      let (missing_added, missing_removed) = missing_deps;
+
+      updates.extend(
+        self
+          .save_scope_updates(SnapshotScope::FILE, file_added, file_removed)
+          .await,
+      );
+      updates.extend(
+        self
+          .save_scope_updates(SnapshotScope::CONTEXT, context_added, context_removed)
+          .await,
+      );
+      updates.extend(
+        self
+          .save_scope_updates(SnapshotScope::MISSING, missing_added, missing_removed)
+          .await,
+      );
+
+      updates
     }
   }
 
@@ -181,8 +241,9 @@ mod tests {
 
   use super::{
     super::{codec::CacheCodec, storage::MemoryStorage},
-    PathMatcher, Snapshot, SnapshotOptions, SnapshotScope,
+    Snapshot, SnapshotOptions, SnapshotScope,
   };
+  use crate::cache::persistent::storage::Storage;
 
   macro_rules! p {
     ($tt:tt) => {
@@ -191,105 +252,47 @@ mod tests {
   }
 
   #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-  async fn should_snapshot_work() {
+  async fn should_generate_snapshot_save_updates() {
     let fs = Arc::new(MemoryFileSystem::default());
     let mut storage = MemoryStorage::default();
     let codec = Arc::new(CacheCodec::new(None));
-    let options = SnapshotOptions::new(
-      vec![PathMatcher::String("constant".into())],
-      vec![PathMatcher::String("node_modules/project".into())],
-      vec![PathMatcher::String("node_modules".into())],
-    );
+    let snapshot = Arc::new(Snapshot::new(SnapshotOptions::default(), fs.clone(), codec));
 
-    fs.create_dir_all("/node_modules/project".into())
-      .await
-      .unwrap();
-    fs.create_dir_all("/node_modules/lib".into()).await.unwrap();
+    fs.create_dir_all("/".into()).await.unwrap();
     fs.write("/file1".into(), "abc".as_bytes()).await.unwrap();
-    fs.write("/constant".into(), "abc".as_bytes())
-      .await
-      .unwrap();
-    fs.write(
-      "/node_modules/project/package.json".into(),
-      r#"{"version":"1.0.0"}"#.as_bytes(),
-    )
-    .await
-    .unwrap();
-    fs.write("/node_modules/project/file1".into(), "abc".as_bytes())
-      .await
-      .unwrap();
-    fs.write(
-      "/node_modules/lib/package.json".into(),
-      r#"{"version":"1.1.0"}"#.as_bytes(),
-    )
-    .await
-    .unwrap();
-    fs.write("/node_modules/lib/file1".into(), "abc".as_bytes())
-      .await
-      .unwrap();
 
-    let snapshot = Snapshot::new(options, fs.clone(), codec);
-
-    snapshot
-      .add(
-        &mut storage,
-        SnapshotScope::FILE,
-        [
-          p!("/file1"),
-          p!("/constant"),
-          p!("/node_modules/project/file1"),
-          p!("/node_modules/lib/file1"),
-        ]
-        .into_iter(),
+    let mut updates = snapshot
+      .clone()
+      .save_updates_task(
+        (vec![p!("/file1")], vec![]),
+        (vec![], vec![]),
+        (vec![], vec![]),
       )
       .await;
+    for (key, value) in updates.remove(SnapshotScope::FILE.name()).unwrap() {
+      if let Some(value) = value {
+        storage.set(SnapshotScope::FILE.name(), key, value);
+      } else {
+        storage.remove(SnapshotScope::FILE.name(), &key);
+      }
+    }
+
+    let (is_hot_start, modified_paths, deleted_paths, no_change_paths) = snapshot
+      .calc_modified_paths(&storage, SnapshotScope::FILE)
+      .await
+      .unwrap();
+    assert!(is_hot_start);
+    assert!(modified_paths.is_empty());
+    assert!(deleted_paths.is_empty());
+    assert!(no_change_paths.contains(&p!("/file1")));
+
     std::thread::sleep(std::time::Duration::from_millis(100));
     fs.write("/file1".into(), "abcd".as_bytes()).await.unwrap();
-    fs.write("/constant".into(), "abcd".as_bytes())
-      .await
-      .unwrap();
-    fs.write("/node_modules/project/file1".into(), "abcd".as_bytes())
-      .await
-      .unwrap();
-    fs.write("/node_modules/lib/file1".into(), "abcd".as_bytes())
-      .await
-      .unwrap();
-
-    let (is_hot_start, modified_paths, deleted_paths, no_change_paths) = snapshot
+    let (_, modified_paths, deleted_paths, _) = snapshot
       .calc_modified_paths(&storage, SnapshotScope::FILE)
       .await
       .unwrap();
-    assert!(is_hot_start);
-    assert!(deleted_paths.is_empty());
-    assert!(!modified_paths.contains(&p!("/constant")));
     assert!(modified_paths.contains(&p!("/file1")));
-    assert!(modified_paths.contains(&p!("/node_modules/project/file1")));
-    assert!(!modified_paths.contains(&p!("/node_modules/lib/file1")));
-    assert_eq!(no_change_paths.len(), 1);
-
-    fs.write(
-      "/node_modules/lib/package.json".into(),
-      r#"{"version":"1.3.0"}"#.as_bytes(),
-    )
-    .await
-    .unwrap();
-    snapshot
-      .add(
-        &mut storage,
-        SnapshotScope::FILE,
-        [p!("/file1")].into_iter(),
-      )
-      .await;
-    let (is_hot_start, modified_paths, deleted_paths, no_change_paths) = snapshot
-      .calc_modified_paths(&storage, SnapshotScope::FILE)
-      .await
-      .unwrap();
-    assert!(is_hot_start);
     assert!(deleted_paths.is_empty());
-    assert!(!modified_paths.contains(&p!("/constant")));
-    assert!(!modified_paths.contains(&p!("/file1")));
-    assert!(modified_paths.contains(&p!("/node_modules/project/file1")));
-    assert!(modified_paths.contains(&p!("/node_modules/lib/file1")));
-    assert_eq!(no_change_paths.len(), 1);
   }
 }

--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use rspack_cacheable::{cacheable, utils::PortablePath, with::As};
 use rspack_fs::IntermediateFileSystem;
 use rspack_paths::Utf8PathBuf;
-pub use rspack_storage::{BoxStorage, MemoryStorage, Storage, Version};
-use rspack_storage::{FileSystemOptions, FileSystemStorage};
+use rspack_storage::FileSystemOptions;
+pub use rspack_storage::{
+  BoxStorage, FileSystemStorage, MemoryStorage, Storage, StorageUpdates, Version,
+};
 
 /// Storage Options
 ///

--- a/crates/rspack_storage/src/filesystem/mod.rs
+++ b/crates/rspack_storage/src/filesystem/mod.rs
@@ -7,16 +7,18 @@ mod version;
 
 use std::sync::{Arc, Mutex};
 
-use rustc_hash::FxHashMap as HashMap;
-
 use self::{db::DB, meta::Meta, scope_fs::ScopeFileSystem, task_queue::TaskQueue};
 pub use self::{options::FileSystemOptions, version::Version};
-use crate::{Error, Result, Storage};
+use crate::{Error, Result, Storage, StorageUpdateTask, StorageUpdates};
 
-/// Type alias for in-memory update changes: key -> optional_value
-type BucketChangesMap = HashMap<Vec<u8>, Option<Vec<u8>>>;
+#[derive(Default)]
+struct UpdateTasks(Vec<StorageUpdateTask>);
 
-const STALE_DIR_NAME: &str = "_stale";
+impl std::fmt::Debug for UpdateTasks {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("UpdateTasks").field(&self.0.len()).finish()
+  }
+}
 
 fn spawn_cleanup_stale_versions(stale_fs: ScopeFileSystem) {
   tokio::spawn(async move {
@@ -102,7 +104,9 @@ pub struct FileSystemStorage {
   task_queue: TaskQueue,
   /// In-memory staged update operations, grouped by scope
   /// Value of Some(value) indicates write, None indicates deletion
-  updates: HashMap<String, BucketChangesMap>,
+  updates: StorageUpdates,
+  /// Async tasks that delay collecting updates until save.
+  update_tasks: Mutex<UpdateTasks>,
   /// Storage options
   options: FileSystemOptions,
   /// Next scheduled time for metadata refresh (cleanup + access time update)
@@ -118,6 +122,7 @@ impl FileSystemStorage {
       db: DB::new(fs.child_fs(options.version.as_str())),
       task_queue: TaskQueue::default(),
       updates: Default::default(),
+      update_tasks: Default::default(),
       next_meta_refresh_time: Default::default(),
       fs,
       options,
@@ -125,6 +130,7 @@ impl FileSystemStorage {
   }
 
   pub fn stale_fs(&self) -> ScopeFileSystem {
+    const STALE_DIR_NAME: &str = "_stale";
     self.fs.child_fs(STALE_DIR_NAME)
   }
 }
@@ -150,17 +156,29 @@ impl Storage for FileSystemStorage {
     scope_update.insert(key.to_vec(), None);
   }
 
+  fn add_update_task(&mut self, task: StorageUpdateTask) {
+    self
+      .update_tasks
+      .lock()
+      .expect("should lock update tasks")
+      .0
+      .push(task);
+  }
+
   fn save(&mut self) {
     // Take all pending updates and clear the memory buffer
     let updates = std::mem::take(&mut self.updates);
+    let update_tasks = std::mem::take(
+      &mut *self
+        .update_tasks
+        .get_mut()
+        .expect("should get update tasks"),
+    )
+    .0;
 
     // Queue the write and metadata refresh together so cleanup observes the
     // latest version without blocking `save()`.
     let db = self.db.clone();
-    let changes = updates
-      .into_iter()
-      .map(|(k, v)| (k, v.into_iter().collect()))
-      .collect();
     let max_pack_size = self.options.max_pack_size;
     let fs = self.fs.clone();
     let stale_fs = self.stale_fs();
@@ -170,6 +188,16 @@ impl Storage for FileSystemStorage {
     let next_meta_refresh_time = self.next_meta_refresh_time.clone();
 
     self.task_queue.add_task(async move {
+      let mut updates = updates;
+      for task in update_tasks {
+        for (scope, update) in task.await {
+          updates.entry(scope).or_default().extend(update);
+        }
+      }
+      let changes = updates
+        .into_iter()
+        .map(|(k, v)| (k, v.into_iter().collect()))
+        .collect();
       if db.save(changes, max_pack_size).await {
         refresh_metadata(
           fs,

--- a/crates/rspack_storage/src/lib.rs
+++ b/crates/rspack_storage/src/lib.rs
@@ -8,11 +8,22 @@ mod error;
 mod filesystem;
 mod memory;
 
+use futures::future::BoxFuture;
+use rustc_hash::FxHashMap as HashMap;
+
 pub use self::{
   error::{Error, Result},
   filesystem::{FileSystemOptions, FileSystemStorage, Version},
   memory::MemoryStorage,
 };
+
+/// Scope-grouped storage updates.
+///
+/// Each item is `(key, Some(value))` for writes and `(key, None)` for removals.
+pub type StorageUpdates = HashMap<String, HashMap<Vec<u8>, Option<Vec<u8>>>>;
+
+/// Asynchronously collected storage updates.
+pub type StorageUpdateTask = BoxFuture<'static, StorageUpdates>;
 
 /// Persistent storage abstraction interface
 ///
@@ -27,6 +38,12 @@ pub trait Storage: std::fmt::Debug + Sync + Send {
 
   /// Removes a key from the specified scope (staged in memory)
   fn remove(&mut self, scope: &'static str, key: &[u8]);
+
+  /// Adds asynchronously collected updates to the next persistence operation.
+  ///
+  /// Storage implementations that support background persistence should merge
+  /// the returned updates into the next [`Storage::save`] call.
+  fn add_update_task(&mut self, _task: StorageUpdateTask) {}
 
   /// Enqueues a persistence operation, writing all staged memory changes to storage.
   ///


### PR DESCRIPTION
## Summary
- Collect snapshot and build-dependency updates as deferred tasks instead of applying them immediately
- Merge deferred updates into `FileSystemStorage::save` so persistence work stays batched
- Update persistent cache call sites and tests to validate the new update flow

## Testing
- Added/updated Rust tests for snapshot update generation and build-dependency update application
- Not run (not requested)