### PR TITLE
chore(ci): compare binary size against PR merge base

### DIFF
--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -5,16 +5,12 @@ const fs = require('node:fs');
  * @param {Number} limit
  */
 module.exports = async function action({ github, context, limit }) {
-  const commits = await github.rest.repos.listCommits({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    per_page: 30,
-  });
+  const commits = await listCommitsFromMergeBase(github, context);
 
   let baseSize = 0;
   let baseCommit = null;
 
-  for (const commit of commits.data) {
+  for (const commit of commits) {
     console.log(commit.sha);
     try {
       const data = await fetchDataBySha(commit.sha);
@@ -30,7 +26,7 @@ module.exports = async function action({ github, context, limit }) {
   }
 
   if (!baseCommit) {
-    const error = `No base binary size found within ${commits.data.length} commits`;
+    const error = `No base binary size found within ${commits.length} commits`;
     console.log(error);
     throw new Error(error);
   }
@@ -57,6 +53,32 @@ module.exports = async function action({ github, context, limit }) {
     );
   }
 };
+
+// Start from the PR's merge base (fork point) rather than the base branch tip,
+// so the size diff reflects only this PR's changes and not drift merged into
+// the base branch after the PR forked. Walk its ancestors to the newest commit
+// that has recorded binary size data.
+async function listCommitsFromMergeBase(github, context) {
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+
+  const { data: comparison } =
+    await github.rest.repos.compareCommitsWithBasehead({
+      owner,
+      repo,
+      basehead: `${pr.base.sha}...${pr.head.sha}`,
+    });
+  const mergeBaseSha = comparison.merge_base_commit.sha;
+  console.log(`Merge base commit: ${mergeBaseSha}`);
+
+  const { data } = await github.rest.repos.listCommits({
+    owner,
+    repo,
+    sha: mergeBaseSha,
+    per_page: 30,
+  });
+  return data;
+}
 
 async function commentToPullRequest(github, context, comment) {
   const { data: comments } = await github.rest.issues.listComments({

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -40,7 +40,9 @@ const MAX_PAGES = 4;
 async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
-
+  if (!pr) {
+    throw new Error('binary-limit action requires pull_request context');
+  }
   const { data: comparison } =
     await github.rest.repos.compareCommitsWithBasehead({
       owner,

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -5,31 +5,7 @@ const fs = require('node:fs');
  * @param {Number} limit
  */
 module.exports = async function action({ github, context, limit }) {
-  const commits = await listCommitsFromMergeBase(github, context);
-
-  let baseSize = 0;
-  let baseCommit = null;
-
-  for (const commit of commits) {
-    console.log(commit.sha);
-    try {
-      const data = await fetchDataBySha(commit.sha);
-      if (data?.size) {
-        baseCommit = commit;
-        baseSize = data.size;
-        console.log(`Commit ${commit.sha} has binary size: ${data.size}`);
-        break;
-      }
-    } catch (e) {
-      console.log(e);
-    }
-  }
-
-  if (!baseCommit) {
-    const error = `No base binary size found within ${commits.length} commits`;
-    console.log(error);
-    throw new Error(error);
-  }
+  const { baseCommit, baseSize } = await findBaseCommit(github, context);
 
   const headSize = fs.statSync(
     './crates/node_binding/rspack.linux-x64-gnu.node',
@@ -54,11 +30,14 @@ module.exports = async function action({ github, context, limit }) {
   }
 };
 
+const PER_PAGE = 30;
+const MAX_PAGES = 4;
+
 // Start from the PR's merge base (fork point) rather than the base branch tip,
 // so the size diff reflects only this PR's changes and not drift merged into
-// the base branch after the PR forked. Walk its ancestors to the newest commit
-// that has recorded binary size data.
-async function listCommitsFromMergeBase(github, context) {
+// the base branch after the PR forked. Walk its ancestors page by page and
+// return the newest commit that has recorded binary size data.
+async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
 
@@ -71,13 +50,34 @@ async function listCommitsFromMergeBase(github, context) {
   const mergeBaseSha = comparison.merge_base_commit.sha;
   console.log(`Merge base commit: ${mergeBaseSha}`);
 
-  const { data } = await github.rest.repos.listCommits({
-    owner,
-    repo,
-    sha: mergeBaseSha,
-    per_page: 30,
-  });
-  return data;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const { data: commits } = await github.rest.repos.listCommits({
+      owner,
+      repo,
+      sha: mergeBaseSha,
+      per_page: PER_PAGE,
+      page,
+    });
+
+    for (const commit of commits) {
+      console.log(commit.sha);
+      try {
+        const data = await fetchDataBySha(commit.sha);
+        if (data?.size) {
+          console.log(`Commit ${commit.sha} has binary size: ${data.size}`);
+          return { baseCommit: commit, baseSize: data.size };
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    if (commits.length < PER_PAGE) break;
+  }
+
+  throw new Error(
+    `No base binary size found within ${MAX_PAGES} pages of commits from the merge base`,
+  );
 }
 
 async function commentToPullRequest(github, context, comment) {


### PR DESCRIPTION
## Summary

The binary size check picked its base by walking back from the **tip of the default branch** and taking the newest commit with recorded size data.

When a PR forks from an older commit and `main` later merges other size-affecting changes, that drift is attributed to the PR: the reported diff becomes `size(fork point + PR) − size(latest main)` instead of the PR's own contribution.

This walks back from the PR's **merge base** (fork point) instead, so the diff reflects only the PR's changes.

- Before: base = newest commit on `main` with data → includes base-branch drift
- After: base = merge base, or its newest ancestor with data → isolates the PR

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
