### PR TITLE
test: isolate emit-isolated-dts case to fix cross-suite dts write race

### DIFF
--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/index.ts
@@ -17,7 +17,7 @@ it("should emit declaration assets only through RslibPlugin", () => {
   const dts = fs.readFileSync(
     path.resolve(
       __dirname,
-      "../../../../configCases/rslib/emit-isolated-dts/dist/types/index.d.ts",
+      "../src/dist/types/index.d.ts",
     ),
     "utf-8",
   );
@@ -36,7 +36,7 @@ it("should emit declaration assets only through RslibPlugin", () => {
   const typeOnlyDts = fs.readFileSync(
     path.resolve(
       __dirname,
-      "../../../../configCases/rslib/emit-isolated-dts/dist/types/types/foo.d.ts",
+      "../src/dist/types/types/foo.d.ts",
     ),
     "utf-8",
   );
@@ -47,7 +47,7 @@ it("should emit declaration assets only through RslibPlugin", () => {
   const aliasDts = fs.readFileSync(
     path.resolve(
       __dirname,
-      "../../../../configCases/rslib/emit-isolated-dts/dist/types/alias/foo.d.ts",
+      "../src/dist/types/alias/foo.d.ts",
     ),
     "utf-8",
   );
@@ -58,7 +58,7 @@ it("should emit declaration assets only through RslibPlugin", () => {
   const aliasMixedDts = fs.readFileSync(
     path.resolve(
       __dirname,
-      "../../../../configCases/rslib/emit-isolated-dts/dist/types/alias/mixed.d.ts",
+      "../src/dist/types/alias/mixed.d.ts",
     ),
     "utf-8",
   );
@@ -70,7 +70,7 @@ it("should emit declaration assets only through RslibPlugin", () => {
   const mtsDts = fs.readFileSync(
     path.resolve(
       __dirname,
-      "../../../../configCases/rslib/emit-isolated-dts/dist/types/module.d.mts",
+      "../src/dist/types/module.d.mts",
     ),
     "utf-8",
   );

--- a/tests/rspack-test/configCases/rslib/emit-isolated-dts/test.config.js
+++ b/tests/rspack-test/configCases/rslib/emit-isolated-dts/test.config.js
@@ -1,0 +1,6 @@
+// Compile from a per-suite copy so the dts files emitted into `dist/types`
+// (resolved against the case context) are private to this run and the
+// parallel Config.* / RuntimeModeConfig.* suites don't truncate each other.
+module.exports = {
+  isolateSource: true,
+};


### PR DESCRIPTION
### Why

`Config.part3` and `RuntimeModeConfig.part3` both build `configCases/rslib/emit-isolated-dts` in parallel worker processes, and the case emits its dts assets (`declarationDir: './dist/types'`, resolved against the case context) into the **shared source directory** — so both suites write the exact same files.

Asset writes are not atomic (truncate, then write), and on first creation the two emits race each other past `compareBeforeEmit`: one suite can truncate a file the other suite has just finished writing, right while that suite's test reads it. On the slow WASM runner the truncate→write window stretched to ≥49ms, swallowing the initial read and all 3 retries: [Test WASM / Test Node 24 failure](https://github.com/web-infra-dev/rspack/actions/runs/28498792365/job/84471805685) (`expected '' to contain 'export type Foo'`).

Evidence from that job's event report: `Config.part3` read `dist/types/alias/foo.d.ts` as empty at `06:52:10.077–10.126` (4 reads), while `RuntimeModeConfig.part3` read the same file complete at `06:52:10.134` — the concurrent write completed in between. Reproduced locally with the wasm binding from that run: a 1ms file-size poller caught the complete file being truncated back to 0 bytes in 11/20 runs of the two suites together, and 0/20 when either suite runs alone.

### What

Opt the case into `isolateSource` (same fix as #14462) so each suite compiles from its own private copy and the dts lands under the per-suite dist dir, and point the assertions at the isolated location (`<dist>/src/dist/types`). Verified with the WASM binding: the shared source dir is never written again, both suites pass 10/10 stress runs.