### PR TITLE
chore(ci): bump rstackjs/setup-node to v0.0.2

### DIFF
--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Install Node.js
       if: ${{ startsWith(runner.name, 'rspack-darwin-') }}
-      uses: rstackjs/setup-node@cc72f1c242ef8813f650223fbae3c29d450ae29e # v0.0.1
+      uses: rstackjs/setup-node@3ff0cf4618911930967df3bf1afa93fda4abaf1b # v0.0.2
       with:
         registry-url: https://registry.npmmirror.com
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
## Why

Bump the pinned `rstackjs/setup-node` (used on `rspack-darwin-*` self-hosted runners) from v0.0.1 to v0.0.2, which syncs the fork with upstream `actions/setup-node` (main).

The fork-specific npmmirror fallback (`DEFAULT_NODE_MIRROR`) is verified to be intact at the new commit.