### PR TITLE
fix(concatenation): inline-value check must precede deferred pure checks

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -773,6 +773,16 @@ fn connection_active_for_esm_import_specifier(
   module_graph: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
 ) -> bool {
+  if !connection_active_inline_value_for_esm_import_specifier(
+    dependency,
+    connection,
+    runtime,
+    module_graph,
+    exports_info_artifact,
+  ) {
+    return false;
+  }
+
   if let Some(used_by_exports) = dependency.used_by_exports.as_ref() {
     if has_impure_deferred_pure_checks(module_graph, exports_info_artifact, used_by_exports) {
       return true;
@@ -783,7 +793,7 @@ fn connection_active_for_esm_import_specifier(
     }
   }
 
-  let active_by_used_exports = match dependency.used_by_exports.as_ref() {
+  match dependency.used_by_exports.as_ref() {
     Some(_) => connection_active_used_by_exports(
       connection,
       runtime,
@@ -792,16 +802,7 @@ fn connection_active_for_esm_import_specifier(
       dependency.used_by_exports.as_ref(),
     ),
     None => true,
-  };
-
-  active_by_used_exports
-    && connection_active_inline_value_for_esm_import_specifier(
-      dependency,
-      connection,
-      runtime,
-      module_graph,
-      exports_info_artifact,
-    )
+  }
 }
 
 impl DependencyConditionFn for ESMImportSpecifierDependencyCondition {

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/index.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/index.js
@@ -1,0 +1,9 @@
+it("should not require an inlined const module from a concatenated module", async () => {
+  const [{ read }, { readOther }] = await Promise.all([
+    import("pkg/async-root"),
+    import("pkg/async-other")
+  ]);
+
+  expect(read()).toBe(42);
+  expect(readOther()).toBe(42);
+});

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/index.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/index.js
@@ -1,0 +1,1 @@
+export { maybeImpure } from "./maybe-impure";

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/maybe-impure.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/maybe-impure.js
@@ -1,0 +1,8 @@
+import { touch } from "./side-effect";
+
+export function maybeImpure(value) {
+  return function read() {
+    touch();
+    return value;
+  };
+}

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/package.json
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "callee",
+  "version": "1.0.0",
+  "sideEffects": false
+}

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/side-effect.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/callee/side-effect.js
@@ -1,0 +1,7 @@
+let calls = 0;
+
+calls++;
+
+export function touch() {
+  calls++;
+}

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/async-other.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/async-other.js
@@ -1,0 +1,3 @@
+import { readOther } from "./consumer-other";
+
+export { readOther };

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/async-root.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/async-root.js
@@ -1,0 +1,3 @@
+import { read } from "./consumer";
+
+export { read };

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/constants/index.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/constants/index.js
@@ -1,0 +1,1 @@
+export { VALUE } from "./value";

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/constants/value.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/constants/value.js
@@ -1,0 +1,1 @@
+export const VALUE = 42;

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/consumer-other.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/consumer-other.js
@@ -1,0 +1,8 @@
+import { maybeImpure } from "callee";
+import { VALUE } from "./constants/index";
+
+const result = maybeImpure(VALUE);
+
+export function readOther() {
+  return result();
+}

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/consumer.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/consumer.js
@@ -1,0 +1,8 @@
+import { maybeImpure } from "callee";
+import { VALUE } from "./constants/index";
+
+const result = maybeImpure(VALUE);
+
+export function read() {
+  return result();
+}

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/package.json
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/node_modules/pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pkg",
+  "version": "1.0.0",
+  "sideEffects": false
+}

--- a/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/rspack.config.js
+++ b/tests/rspack-test/configCases/inline-const/concatenate-deferred-pure-check/rspack.config.js
@@ -1,0 +1,12 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    concatenateModules: true,
+    inlineExports: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    usedExports: true,
+  },
+};


### PR DESCRIPTION
## Summary

Fix #14661

`connection_active_for_esm_import_specifier` checked `has_impure_deferred_pure_checks` before the inline-value check, so a connection whose export was inlined (inline-const) could still be reported active. Module concatenation then emitted an external `require()` to a module that inlining had already dropped from every chunk, panicking with `should have module id`.

This runs the inline-value check first and returns inactive when the export is inlined, regardless of deferred pure checks. Side effects are unaffected (tracked by a separate side-effect import dependency). Only the `inlined && impure-deferred-check` case changes; every other case is unchanged.

Regression introduced by the 2.1 inline-const optimization (broke in 2.1.0, last good 2.0.1).

## Related links

- Issue: https://github.com/web-infra-dev/rspack/issues/14661
- Minimal reproduction: https://github.com/guru-irl/rspack-inline-const-panic-repro

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
