### PR TITLE
perf: reduce module graph hash allocations

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -11,6 +11,7 @@ use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::ext::DynHash;
 use rustc_hash::{FxHashSet, FxHasher};
 use serde::{Serialize, Serializer};
+use smallvec::SmallVec;
 use ustr::Ustr;
 
 use crate::{
@@ -339,48 +340,46 @@ impl ChunkGraph {
       .get_module_graph_hash_without_connections(module, compilation, runtime)
       .hash(&mut hasher);
 
-    let mut visited_modules = IdentifierSet::default();
-    visited_modules.insert(module.identifier());
+    let mut visited_modules = SmallVec::<[ModuleIdentifier; 8]>::new();
+    visited_modules.push(module.identifier());
 
-    let hash_modules = mg
-      .get_outgoing_deps_in_order(&module.identifier())
-      .filter_map(|c| {
-        let connection = mg.connection_by_dependency_id(c)?;
-        let module_identifier = connection.module_identifier();
-        if visited_modules.contains(module_identifier) {
-          return None;
-        }
-        let active_state = connection.active_state(
-          mg,
-          runtime,
-          mg_cache,
-          side_effects_state_artifact,
-          &compilation.exports_info_artifact,
-        );
-        if active_state.is_false() {
-          return None;
-        }
-        visited_modules.insert(*module_identifier);
-        for_each_runtime(
-          runtime,
-          |runtime| {
-            let runtime = runtime.map(|r| RuntimeSpec::from_iter([*r]));
-            let active_state = connection.active_state(
-              mg,
-              runtime.as_ref(),
-              mg_cache,
-              side_effects_state_artifact,
-              &compilation.exports_info_artifact,
-            );
-            active_state.hash(&mut hasher);
-          },
-          true,
-        );
-        Some(module_identifier)
-      })
-      .collect::<Vec<_>>();
+    for c in mg.get_outgoing_deps_in_order(&module.identifier()) {
+      let Some(connection) = mg.connection_by_dependency_id(c) else {
+        continue;
+      };
+      let module_identifier = connection.module_identifier();
+      if visited_modules.contains(module_identifier) {
+        continue;
+      }
+      let active_state = connection.active_state(
+        mg,
+        runtime,
+        mg_cache,
+        side_effects_state_artifact,
+        &compilation.exports_info_artifact,
+      );
+      if active_state.is_false() {
+        continue;
+      }
+      visited_modules.push(*module_identifier);
+      for_each_runtime(
+        runtime,
+        |runtime| {
+          let runtime = runtime.map(|r| RuntimeSpec::from_iter([*r]));
+          let active_state = connection.active_state(
+            mg,
+            runtime.as_ref(),
+            mg_cache,
+            side_effects_state_artifact,
+            &compilation.exports_info_artifact,
+          );
+          active_state.hash(&mut hasher);
+        },
+        true,
+      );
+    }
 
-    for module_identifier in hash_modules {
+    for module_identifier in visited_modules.iter().skip(1) {
       let module = mg
         .module_by_identifier(module_identifier)
         .expect("should have module")

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -340,15 +340,20 @@ impl ChunkGraph {
       .get_module_graph_hash_without_connections(module, compilation, runtime)
       .hash(&mut hasher);
 
-    let mut visited_modules = SmallVec::<[ModuleIdentifier; 8]>::new();
+    const INLINE_VISITED_MODULES: usize = 8;
+    let mut visited_modules = SmallVec::<[ModuleIdentifier; INLINE_VISITED_MODULES]>::new();
     visited_modules.push(module.identifier());
+    let mut visited_modules_set: Option<IdentifierSet> = None;
 
     for c in mg.get_outgoing_deps_in_order(&module.identifier()) {
       let Some(connection) = mg.connection_by_dependency_id(c) else {
         continue;
       };
       let module_identifier = connection.module_identifier();
-      if visited_modules.contains(module_identifier) {
+      if visited_modules_set.as_ref().map_or_else(
+        || visited_modules.contains(module_identifier),
+        |set| set.contains(module_identifier),
+      ) {
         continue;
       }
       let active_state = connection.active_state(
@@ -362,6 +367,11 @@ impl ChunkGraph {
         continue;
       }
       visited_modules.push(*module_identifier);
+      if let Some(set) = &mut visited_modules_set {
+        set.insert(*module_identifier);
+      } else if visited_modules.len() > INLINE_VISITED_MODULES {
+        visited_modules_set = Some(visited_modules.iter().copied().collect());
+      }
       for_each_runtime(
         runtime,
         |runtime| {


### PR DESCRIPTION
## Summary

Optimize `ChunkGraph::get_module_graph_hash` by replacing the per-module `IdentifierSet` plus collected `Vec` with a single `SmallVec<[ModuleIdentifier; 8]>`.

The visited module list is typically small in the module graph hash hot path, so the inline vector keeps the common case allocation-free while preserving the existing ordered second pass over connected modules.

## Performance rationale

`create_module_hashes` runs this code across many modules. The previous implementation allocated both a hash set for deduplication and a vector for ordered hashing per module. This change uses one compact ordered container for both membership checks and later iteration, reducing temporary allocation and hash set work in the common low fan-out case.