### PR TITLE
feat(rstest): emit build-resolved mock identity on mock calls

### DIFF
--- a/crates/rspack_plugin_rstest/src/lib.rs
+++ b/crates/rspack_plugin_rstest/src/lib.rs
@@ -3,6 +3,7 @@ mod esm_import_dependency;
 mod import_dependency;
 mod mock_method_dependency;
 mod mock_module_id_dependency;
+mod mock_resolved_info;
 mod module_path_name_dependency;
 mod parser_plugin;
 mod plugin;

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -7,6 +7,8 @@ use rspack_core::{
 };
 use rspack_util::json_stringify_str;
 
+use crate::mock_resolved_info::MockResolvedInfo;
+
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct MockMethodDependency {
@@ -26,6 +28,12 @@ pub struct MockMethodDependency {
   /// auto-mock form (whose request is carried by the synthetic-target
   /// dependency's suffix instead, to avoid colliding at the same offset).
   args_request_end: Option<u32>,
+  /// Build-resolved mock identity, rendered after the request at
+  /// `args_request_end` — it always rides the same carrier as the request, so
+  /// it is `None` in the same cases as `args_request_end` (1-arg auto-mock:
+  /// both ride the synthetic-target dependency instead), plus when the
+  /// declaring module's resource has no path.
+  resolved_info: Option<MockResolvedInfo>,
 }
 
 #[cacheable]
@@ -57,6 +65,7 @@ impl MockMethodDependency {
       hoist,
       method,
       args_request_end: None,
+      resolved_info: None,
     }
   }
 
@@ -76,12 +85,19 @@ impl MockMethodDependency {
       hoist,
       method,
       args_request_end: None,
+      resolved_info: None,
     }
   }
 
   /// Set the request-injection offset. See [`Self::args_request_end`].
   pub fn with_request_arg_end(mut self, end: Option<u32>) -> Self {
     self.args_request_end = end;
+    self
+  }
+
+  /// Attach the build-resolved mock identity. See [`Self::resolved_info`].
+  pub fn with_resolved_info(mut self, info: Option<MockResolvedInfo>) -> Self {
+    self.resolved_info = info;
     self
   }
 }
@@ -116,6 +132,7 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     let TemplateContext {
       init_fragments,
       runtime_template,
+      compilation,
       ..
     } = code_generatable_context;
     let dep = dep
@@ -153,7 +170,12 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     // valid for `rs.mock('x', f,)`) so a dynamic `import(request)` resolves to the
     // mock by request. See `args_request_end` for the `None` cases.
     if let Some(end) = dep.args_request_end {
-      source.replace(end, end, format!(", {}", json_stringify_str(request)), None);
+      let trailing = format!(
+        ", {}{}",
+        json_stringify_str(request),
+        MockResolvedInfo::render_trailing_arg(dep.resolved_info.as_ref(), compilation),
+      );
+      source.replace(end, end, trailing, None);
     }
   }
 }

--- a/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
-use crate::import_dependency::module_id_rstest;
+use crate::{import_dependency::module_id_rstest, mock_resolved_info::MockResolvedInfo};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -20,6 +20,11 @@ pub struct MockModuleIdDependency {
   category: DependencyCategory,
   pub suffix: Option<String>,
   missing_module_fallback: Option<String>,
+  /// Build-resolved mock identity, rendered after `suffix`. Carried by the
+  /// synthetic-target dependency of the 1-arg auto-mock form (whose
+  /// `target_dep` is the FIRST dependency — the real mocked module, not the
+  /// `__mocks__` target this dependency resolves).
+  resolved_info: Option<MockResolvedInfo>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -42,6 +47,7 @@ impl MockModuleIdDependency {
       category,
       suffix,
       missing_module_fallback: None,
+      resolved_info: None,
     }
   }
 
@@ -56,6 +62,12 @@ impl MockModuleIdDependency {
 
   pub fn has_missing_module_fallback(&self) -> bool {
     self.missing_module_fallback.is_some()
+  }
+
+  /// Attach the build-resolved mock identity. See [`Self::resolved_info`].
+  pub fn with_resolved_info(mut self, info: Option<MockResolvedInfo>) -> Self {
+    self.resolved_info = info;
+    self
   }
 }
 
@@ -168,10 +180,20 @@ impl DependencyTemplate for MockModuleIdDependencyTemplate {
       )
     };
 
+    let resolved_info = MockResolvedInfo::render_trailing_arg(
+      dep.resolved_info.as_ref(),
+      code_generatable_context.compilation,
+    );
+
     source.replace(
       dep.range.start,
       dep.range.end,
-      format!("{}{}", module_id, dep.suffix.as_deref().unwrap_or("")),
+      format!(
+        "{}{}{}",
+        module_id,
+        dep.suffix.as_deref().unwrap_or(""),
+        resolved_info
+      ),
       None,
     );
   }

--- a/crates/rspack_plugin_rstest/src/mock_resolved_info.rs
+++ b/crates/rspack_plugin_rstest/src/mock_resolved_info.rs
@@ -1,0 +1,61 @@
+use rspack_cacheable::cacheable;
+use rspack_core::{Compilation, DependencyId};
+use rspack_util::json_stringify_str;
+
+/// Build-resolved identity of a mocked module, emitted as the trailing
+/// argument of the generated `rstest_mock`/`rstest_unmock` call:
+/// `{"o": <declaring file>, "r": <resolved target | null>}`.
+///
+/// `o` is the absolute path of the module declaring the `rs.mock` call,
+/// captured at parse time. `r` is read from the module graph at
+/// template-render time via the mocked target's `DependencyId`, so it
+/// reflects the final resolution (aliases, extensions, externals): an
+/// absolute file path for a bundled module, the external request (e.g. a
+/// `node:` builtin spelling) for an external, or `null` when unresolved.
+///
+/// The runtime keys native (out-of-bundle) mocks by this identity instead of
+/// re-deriving the resolution itself. Old runtimes ignore the extra argument.
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct MockResolvedInfo {
+  /// The mocked target's module dependency; its resolution is read at render time.
+  pub target_dep: DependencyId,
+  /// Absolute path of the module declaring the `rs.mock` call.
+  pub origin_path: String,
+}
+
+impl MockResolvedInfo {
+  pub fn render(&self, compilation: &Compilation) -> String {
+    let module_graph = compilation.get_module_graph();
+    let resolved = module_graph
+      .get_module_by_dependency_id(&self.target_dep)
+      .and_then(|module| {
+        if let Some(normal) = module.as_normal_module() {
+          // Absolute path only (no query/fragment): the runtime keys native
+          // mocks by file, matching Node's resolution of the same specifier.
+          normal
+            .resource_resolved_data()
+            .path()
+            .map(|path| path.as_str())
+        } else {
+          module
+            .as_external_module()
+            .map(|external| external.get_request().primary())
+        }
+      });
+    format!(
+      "{{\"o\":{},\"r\":{}}}",
+      json_stringify_str(&self.origin_path),
+      resolved.map_or_else(|| "null".to_string(), json_stringify_str),
+    )
+  }
+
+  /// Render the identity as the `", {json}"` trailing-argument segment, or
+  /// `""` for `None`. The separator/position half of the contract lives here,
+  /// next to the payload, so every emitting template shares one shape.
+  pub fn render_trailing_arg(info: Option<&Self>, compilation: &Compilation) -> String {
+    info.map_or_else(String::new, |info| {
+      format!(", {}", info.render(compilation))
+    })
+  }
+}

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -1,6 +1,7 @@
 use camino::Utf8PathBuf;
 use rspack_core::{
-  AsyncDependenciesBlock, ConstDependency, DependencyRange, ImportAttributes, ImportPhase,
+  AsyncDependenciesBlock, ConstDependency, DependencyId, DependencyRange, ImportAttributes,
+  ImportPhase,
 };
 use rspack_plugin_javascript::{
   JavascriptParserPlugin,
@@ -24,6 +25,7 @@ use crate::{
   dynamic_import_origin_dependency::RstestDynamicImportOriginDependency,
   mock_method_dependency::{MockMethod, MockMethodDependency},
   mock_module_id_dependency::MockModuleIdDependency,
+  mock_resolved_info::MockResolvedInfo,
   module_path_name_dependency::{ModulePathNameDependency, NameType},
   require_resolve_origin_dependency::RstestRequireResolveOriginDependency,
 };
@@ -326,6 +328,20 @@ impl RstestParserPlugin {
     lit_str.map(|s| s.to_string())
   }
 
+  /// Build the `{o, r}` identity payload for a mocked target dependency.
+  /// Always emitted; @rstest/core requires it (older runtimes simply ignore
+  /// the extra trailing argument).
+  fn mock_resolved_info(
+    &self,
+    parser: &JavascriptParser,
+    target_dep: DependencyId,
+  ) -> Option<MockResolvedInfo> {
+    parser.resource_data.path().map(|path| MockResolvedInfo {
+      target_dep,
+      origin_path: path.as_str().to_string(),
+    })
+  }
+
   #[allow(clippy::too_many_arguments)]
   fn process_mock(
     &self,
@@ -354,8 +370,10 @@ impl RstestParserPlugin {
             },
             if has_b { Some(", ".to_string()) } else { None },
           );
+          let target_dep_id = dep.id;
           parser.add_dependency(Box::new(dep));
 
+          let request_arg_end = (!has_b).then(|| first_arg.span().real_hi());
           parser.add_presentational_dependency(Box::new(
             MockMethodDependency::new(
               call_expr.span().into(),
@@ -367,11 +385,12 @@ impl RstestParserPlugin {
             // has_b=false (1-arg `rs.unmock('X')`): append request after the id.
             // has_b=true (1-arg auto-mock): request rides the synthetic-target
             // suffix below instead — skip here to avoid a same-offset collision.
-            .with_request_arg_end(if has_b {
-              None
-            } else {
-              Some(first_arg.span().real_hi())
-            }),
+            // The resolved info always rides the same carrier as the request,
+            // so it is derived from `request_arg_end` rather than gated twice.
+            .with_request_arg_end(request_arg_end)
+            .with_resolved_info(
+              request_arg_end.and_then(|_| self.mock_resolved_info(parser, target_dep_id)),
+            ),
           ));
 
           if has_b {
@@ -395,7 +414,10 @@ impl RstestParserPlugin {
               // `__mocks__` file exists, fall back to Vitest-style automocking by
               // passing `{ mock: true }` to the runtime, equivalent to
               // `rs.mock('X', { mock: true })`.
-              .with_missing_module_fallback("{ mock: true }".to_string()),
+              .with_missing_module_fallback("{ mock: true }".to_string())
+              // Identity of the REAL mocked module (the first dependency), not
+              // the `__mocks__` target this synthetic dependency resolves.
+              .with_resolved_info(self.mock_resolved_info(parser, target_dep_id)),
             ));
           }
         }
@@ -425,6 +447,7 @@ impl RstestParserPlugin {
             None,
           );
 
+          let target_dep_id = module_dep.id;
           parser.add_presentational_dependency(Box::new(
             MockMethodDependency::new(
               call_expr.span().into(),
@@ -434,7 +457,8 @@ impl RstestParserPlugin {
               method,
             )
             // 2-arg `rs.mock('X', factory)`: append request after the factory.
-            .with_request_arg_end(Some(second_arg.span().real_hi())),
+            .with_request_arg_end(Some(second_arg.span().real_hi()))
+            .with_resolved_info(self.mock_resolved_info(parser, target_dep_id)),
           ));
           parser.add_dependency(Box::new(module_dep));
         } else {

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/index.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/index.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+
+// Build-resolved mock identity: the RstestPlugin appends
+// `{o: <declaring file>, r: <resolved target | null>}` as the trailing
+// argument of every generated `rstest_mock`/`rstest_unmock` call, so the
+// @rstest/core runtime keys native (out-of-bundle) mocks by the build's own
+// resolution instead of re-deriving it.
+it('appends the build-resolved {o, r} identity to rstest_mock/rstest_unmock calls', () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, 'mockResolvedInfo.mjs'),
+		'utf-8',
+	);
+
+	// 2-arg factory mock of a bundled relative target: `o` is the declaring
+	// fixture file, `r` the target's absolute path (both end with the expected
+	// file names; separators/roots are platform-specific).
+	expect(content).toMatch(
+		/rstest_mock\("\.\/src\/dep\.js[^"]*",[\s\S]*?,\s*"\.\/dep\.js",\s*\{"o":"[^"]*fixture\.js","r":"[^"]*dep\.js"\}\)/,
+	);
+
+	// 2-arg factory mock of an externalized builtin: `r` is the external
+	// request spelling, not a file path.
+	expect(content).toMatch(
+		/rstest_mock\("node:os[^"]*",[\s\S]*?,\s*"node:os",\s*\{"o":"[^"]*fixture\.js","r":"node:os"\}\)/,
+	);
+
+	// Unresolvable package: the mock is still emitted (rstest allows missing
+	// modules) and `r` is a json null.
+	expect(content).toMatch(
+		/"missing-pkg-for-resolved-info",\s*\{"o":"[^"]*fixture\.js","r":null\}\)/,
+	);
+
+	// 1-arg auto-mock without a `__mocks__` file: the identity rides the
+	// synthetic-target dependency, after the `{ mock: true }` fallback and the
+	// request literal — and `r` is the REAL module's path, not a mock target.
+	expect(content).toMatch(
+		/rstest_mock\("\.\/src\/autoDep\.js[^"]*",\s*\{ mock: true \},\s*"\.\/autoDep\.js",\s*\{"o":"[^"]*fixture\.js","r":"[^"]*autoDep\.js"\}\)/,
+	);
+
+	// 1-arg unmock: the identity follows the request on the method call.
+	expect(content).toMatch(
+		/rstest_unmock\([\s\S]*?,\s*"\.\/unmockDep\.js",\s*\{"o":"[^"]*fixture\.js","r":"[^"]*unmockDep\.js"\}\)/,
+	);
+});

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/rspack.config.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const {
+  experiments: { RstestPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+  // Entry 1: codegen target — emitted as `.mjs` and inspected by entry 2,
+  // never run.
+  {
+    entry: './src/fixture.js',
+    target: 'node',
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: 'mockResolvedInfo.mjs',
+      module: true,
+      chunkFormat: 'module',
+    },
+    externalsType: 'module-import',
+    externals: {
+      'node:os': 'node:os',
+    },
+    optimization: {
+      concatenateModules: false,
+      minimize: false,
+      moduleIds: 'named',
+      chunkIds: 'named',
+    },
+    plugins: [
+      new RstestPlugin({
+        injectModulePathName: true,
+        hoistMockModule: true,
+        importMetaPathName: true,
+        manualMockRoot: path.resolve(__dirname, '__mocks__'),
+      }),
+    ],
+  },
+  // Entry 2: the test. Reads entry 1 output and asserts the codegen contract.
+  {
+    entry: {
+      main: './index.js',
+    },
+    output: {
+      filename: '[name].js',
+    },
+    externalsPresets: {
+      node: true,
+    },
+  },
+];

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/src/autoDep.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/src/autoDep.js
@@ -1,0 +1,1 @@
+export const value = 'REAL_AUTO';

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/src/dep.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/src/dep.js
@@ -1,0 +1,1 @@
+export const value = 'REAL';

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/src/fixture.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/src/fixture.js
@@ -1,0 +1,24 @@
+// Codegen target (NOT executed) for the build-resolved mock identity.
+//
+// Every generated `rstest_mock`/`rstest_unmock` call carries a trailing
+// `{o, r}` argument: `o` is the absolute path of THIS file (the declaring
+// module), `r` the build-resolved target — an absolute path for a bundled
+// module, the external request for an external, or `null` when unresolved.
+
+// Bundled relative target -> `r` is src/dep.js's absolute path.
+rs.mock('./dep.js', () => ({ value: 'MOCKED' }));
+
+// Externalized builtin -> `r` is the external request spelling.
+rs.mock('node:os', () => ({ hostname: () => 'MOCKED' }));
+
+// Unresolvable package (rstest allows mocking missing modules) -> `r` is null.
+rs.mock('missing-pkg-for-resolved-info', () => ({ value: 'MOCKED' }));
+
+// 1-arg auto-mock (no `__mocks__` file): the identity rides the synthetic
+// target dependency, after the request literal.
+rs.mock('./autoDep.js');
+
+// 1-arg unmock: the identity follows the request on the method call itself.
+rs.unmock('./unmockDep.js');
+
+export const keep = () => 'keep';

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/src/unmockDep.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/src/unmockDep.js
@@ -1,0 +1,1 @@
+export const value = 'REAL_UNMOCK';

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/test.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: function () {
+		return ['main.js'];
+	},
+};

--- a/tests/rspack-test/configCases/rstest/mock-resolved-info/warnings.js
+++ b/tests/rspack-test/configCases/rstest/mock-resolved-info/warnings.js
@@ -1,0 +1,9 @@
+"use strict";
+
+// The fixture mocks an unresolvable package on purpose (asserting `r: null`);
+// the optional mock dependency downgrades the miss to this warning. (The
+// 1-arg auto-mock's missing `__mocks__` file warns nothing — it falls back to
+// `{ mock: true }` by design.)
+module.exports = [
+	/Can't resolve 'missing-pkg-for-resolved-info'/,
+];


### PR DESCRIPTION
## Summary

Append `{o, r}` as the trailing argument of every generated `rstest_mock`/`rstest_unmock` call:

- `o` — absolute path of the module declaring the `rs.mock` call, captured at parse time.
- `r` — the build-resolved target, read from the module graph at template-render time so it reflects the final resolution (aliases, extensions, externals): an absolute file path for a bundled module, the external request spelling (e.g. a `node:` builtin) for an external, or `null` when unresolved.

```js
// rs.mock('./dep.js', factory) in /abs/src/fixture.js →
__webpack_require__.rstest_mock("./src/dep.js", factory, "./dep.js", {"o":"/abs/src/fixture.js","r":"/abs/src/dep.js"})
// rs.mock('node:os', factory) →
__webpack_require__.rstest_mock("node:os", factory, "node:os", {"o":"/abs/src/fixture.js","r":"node:os"})
```

## Why

@rstest/core keys its native (out-of-bundle) mocks — served through Node `module.registerHooks` to natively-loaded modules — by this identity instead of re-deriving the resolution at runtime. This fixes a relative `rs.mock` declared outside the test file (wrong resolution base) and absorbs build-vs-Node resolution divergence (pnpm realpath, exports conditions, extension aliases). The consumer side landed in web-infra-dev/rstest#1485.

## Design notes

- **No new option**: emission is unconditional whenever `hoistMockModule` is on. The identity rides the same carrier as the existing trailing request literal — the method call itself for the 2-arg and 1-arg unmock forms, the synthetic-target dependency for the 1-arg auto-mock form — so an older @rstest/core simply ignores the extra trailing argument, exactly as it already does for the request literal.
- `MockResolvedInfo` owns both halves of the codegen contract: the `{o, r}` payload (`render`) and the `", …"` trailing-argument glue (`render_trailing_arg`), shared by both dependency templates.

## Test

`tests/rspack-test/configCases/rstest/mock-resolved-info/` pins the five codegen shapes: 2-arg mock of a bundled relative target, 2-arg mock of an externalized builtin, unresolvable package (`r: null`), 1-arg auto-mock (`{ mock: true }` fallback still carries the identity), and 1-arg unmock.

