### PR TITLE
fix(mf): emit manifest assets with forward-slash names on Windows

### DIFF
--- a/packages/rspack/src/container/ModuleFederationManifestPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationManifestPlugin.ts
@@ -173,14 +173,17 @@ export function getFileName(
   const insertSuffix = (name: string, suffix: string): string => {
     return name.replace(JSON_EXT, `${suffix}${JSON_EXT}`);
   };
+  // Asset names always use forward slashes, even on Windows where
+  // `path.join` produces backslash separators.
+  const toAssetName = (name: string): string => name.replace(/\\/g, '/');
   const manifestFileName = fileName ? addExt(fileName) : MANIFEST_FILE_NAME;
   const statsFileName = fileName
     ? insertSuffix(manifestFileName, '-stats')
     : STATS_FILE_NAME;
 
   return {
-    statsFileName: join(filePath, statsFileName),
-    manifestFileName: join(filePath, manifestFileName),
+    statsFileName: toAssetName(join(filePath, statsFileName)),
+    manifestFileName: toAssetName(join(filePath, manifestFileName)),
   };
 }
 

--- a/tests/rspack-test/configCases/container-1-5/manifest-file-path-separator/expose-a.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest-file-path-separator/expose-a.js
@@ -1,0 +1,1 @@
+export default 'expose-a';

--- a/tests/rspack-test/configCases/container-1-5/manifest-file-path-separator/index.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest-file-path-separator/index.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should emit manifest assets with forward-slash names for a Windows-style filePath", () => {
+	const assetNames = __STATS__.assets.map(asset => asset.name);
+	expect(assetNames).toContain("custom/path/mf-manifest.json");
+	expect(assetNames).toContain("custom/path/mf-stats.json");
+	for (const name of assetNames) {
+		expect(name).not.toContain("\\");
+	}
+});
+
+it("should write valid manifest files to the forward-slash location", () => {
+	const manifestPath = path.join(
+		__dirname,
+		"custom",
+		"path",
+		"mf-manifest.json"
+	);
+	const statsPath = path.join(__dirname, "custom", "path", "mf-stats.json");
+	expect(fs.existsSync(manifestPath)).toBe(true);
+	expect(fs.existsSync(statsPath)).toBe(true);
+	const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+	const stats = JSON.parse(fs.readFileSync(statsPath, "utf-8"));
+	expect(manifest.name).toBe("container");
+	expect(stats.name).toBe("container");
+});

--- a/tests/rspack-test/configCases/container-1-5/manifest-file-path-separator/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/manifest-file-path-separator/rspack.config.js
@@ -1,0 +1,30 @@
+const { ModuleFederationPlugin } = require('@rspack/core').container;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  externals: {
+    fs: 'node-commonjs fs',
+    path: 'node-commonjs path',
+  },
+  optimization: {
+    chunkIds: 'named',
+    moduleIds: 'named',
+  },
+  output: {
+    chunkFilename: '[name].js',
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'container',
+      filename: 'container.js',
+      library: { type: 'commonjs-module' },
+      manifest: {
+        // Windows-style separator, as `path.join` produces on Windows.
+        filePath: 'custom\\path',
+      },
+      exposes: {
+        './expose-a': './expose-a.js',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes #14309.

When `manifest.filePath` is set, `getFileName()` builds the emitted asset names with `path.join`, so on Windows they come out backslash-separated: `client\mf-stats.json`. Compilation asset names always use forward slashes. `@module-federation/manifest`'s `StatsPlugin` looks the assets up by the forward-slash names, finds nothing, and emits both files a second time, as @hpoepping diagnosed in the issue.

This normalizes both names to forward slashes in `getFileName()`, so every consumer of the names (the Rust manifest plugin's `emit_asset`, `IndependentSharedPlugin`, `SharedUsedExportsOptimizerPlugin`) stays consistent. It also handles a user-supplied `filePath` that already contains backslashes.

Verified on windows-latest with a minimal rsbuild + `@module-federation/enhanced` host and `manifest.filePath: 'client/'` (`@rspack/core` 2.1.2). Before the fix, both slash variants exist as separate compilation assets and each file is written twice:

```
mf asset names reported by the compiler:
  ["client/mf-stats.json", "client/mf-manifest.json",
   "client\\mf-stats.json", "client\\mf-manifest.json"]

build output:
  dist\client\mf-manifest.json    0.77 kB      dist\client\mf-manifest.json    0.91 kB
  dist\client\mf-stats.json       0.82 kB      dist\client\mf-stats.json       0.96 kB
```

The double emission is deterministic. The two writes then race for the same path on disk, so the on-disk result ranges from stale manifest content to the appended invalid JSON in the issue report. With the fix, the same app emits each file once, at the forward-slash path, matching the macOS output byte for byte.

New test case `configCases/container-1-5/manifest-file-path-separator` feeds a Windows-shaped `filePath` (`custom\path`) through the real emission pipeline and asserts that no asset name contains a backslash and that the manifest parses at the forward-slash location. It fails before the fix and passes after, on every platform.

## Related links

- #14309

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
