### PR TITLE
fix(asset): preserve asset bytes for binary files

### DIFF
--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -267,7 +267,7 @@ impl ModuleType {
 
   /// Webpack arbitrary determines the binary type from [NormalModule.binary](https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/NormalModule.js#L302)
   pub fn is_binary(&self) -> bool {
-    self.is_asset_like() || self.is_wasm_like()
+    matches!(self, ModuleType::AssetBytes) || self.is_asset_like() || self.is_wasm_like()
   }
 
   pub fn as_str(&self) -> &'static str {

--- a/tests/rspack-test/configCases/asset-modules/bytes/index.js
+++ b/tests/rspack-test/configCases/asset-modules/bytes/index.js
@@ -1,5 +1,6 @@
 import * as style from "./style.css";
 import file from "./file.text" with { type: "bytes" };
+import png from "../../asset/_images/file.png" with { type: "bytes" };
 
 it("should work", async () => {
 	const decoder = new TextDecoder('utf-8');
@@ -11,6 +12,8 @@ it("should work", async () => {
 	const dynText = decoder.decode(dyn);
 
 	expect(dynText).toBe("a Ā 𐀀 文 🦄 Text");
+
+	expect(Array.from(png.slice(0, 4))).toEqual([137, 80, 78, 71]);
 
 	if (typeof getComputedStyle === "function") {
 		const style = getComputedStyle(document.body);

--- a/tests/rspack-test/configCases/asset-modules/bytes/rspack.config.js
+++ b/tests/rspack-test/configCases/asset-modules/bytes/rspack.config.js
@@ -9,7 +9,7 @@ module.exports = [
     module: {
       rules: [
         {
-          test: /\.svg$/,
+          test: /\.(png|svg)$/,
           type: 'asset/bytes',
         },
         {
@@ -26,7 +26,7 @@ module.exports = [
     module: {
       rules: [
         {
-          test: /\.svg$/,
+          test: /\.(png|svg)$/,
           type: 'asset/bytes',
         },
         {
@@ -46,7 +46,7 @@ module.exports = [
     module: {
       rules: [
         {
-          test: /\.svg$/,
+          test: /\.(png|svg)$/,
           type: 'asset/bytes',
         },
         {


### PR DESCRIPTION
## Summary

Fixes `asset/bytes` handling for non-UTF-8 binary assets by treating `ModuleType::AssetBytes` as binary during normal module build. This preserves the original `Buffer` through `RawBufferSource` instead of converting through a lossy UTF-8 string before the asset generator base64-encodes the bytes.

The root cause was that `asset/bytes` generated from `source.buffer()`, but the source had already been corrupted for invalid UTF-8 inputs because `AssetBytes` was not included in `ModuleType::is_binary()`.

## Related links

Fixes #14668

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `corepack pnpm --filter @rspack/binding run build:dev`
- `cd tests/rspack-test && corepack pnpm run test -t "configCases/asset-modules/bytes"`
- `cargo fmt -p rspack_core --check`
- `node ./node_modules/prettier/bin/prettier.cjs --check tests/rspack-test/configCases/asset-modules/bytes/index.js tests/rspack-test/configCases/asset-modules/bytes/rspack.config.js`
- `corepack pnpm run lint:js`