### PR TITLE
fix(css): strip resource query in source maps

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -37,6 +37,9 @@ fn css_source_map_module_name(module: &dyn Module, context: &Context) -> String 
   let Some((prefix, resource)) = identifier.rsplit_once('|') else {
     return identifier.to_string();
   };
+  let resource = resource
+    .split_once(['?', '#'])
+    .map_or(resource, |(resource, _)| resource);
 
   if resource.starts_with('/') || resource.as_bytes().get(1).is_some_and(|ch| *ch == b':') {
     return format!(
@@ -45,7 +48,7 @@ fn css_source_map_module_name(module: &dyn Module, context: &Context) -> String 
     );
   }
 
-  identifier.to_string()
+  format!("{prefix}|{resource}")
 }
 
 pub fn update_css_exports(exports: &mut CssExports, name: &str, css_export: CssExport) -> bool {


### PR DESCRIPTION
## Summary

Strip resource query and fragment from CSS module names before writing them into generated CSS source maps.

## Root cause

After `feat(css): support parser exportType`, CSS source map module names could be derived from module identifiers that include a resource query, producing entries such as `webpack:///./index.less?f6b9`. Webpack's native CSS source maps normalize this to `webpack:///./index.less`, and Rspack's existing `less-loader/with-source-map` tests assert the same behavior.

## Impact

This fixes rstack ecosystem CI failures in `less-loader/with-source-map`, where generated CSS source maps unexpectedly included the query suffix.

## Validation

- `cargo fmt --check`
- `cargo check -p rspack_plugin_css`
- Compared against a minimal webpack 5 native CSS + less-loader source-map case; webpack emits `webpack:///./src/index.less` even when the import includes a query.