### PR TITLE
fix(css): distinguish css wrapper sourcemap names

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -225,7 +225,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       }
     }
     let generated_source = self.concat_source.source().into_string_lossy().into_owned();
-    if self.module.get_source_map_kind().enabled() {
+    if self.module.get_source_map_kind().enabled() && !self.should_omit_javascript_source_map() {
       let source_name = css_source_map_module_name(
         self.module,
         &self.generate_context.compilation.options.context,
@@ -234,6 +234,12 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     } else {
       Ok(RawStringSource::from(generated_source).boxed())
     }
+  }
+
+  fn should_omit_javascript_source_map(&self) -> bool {
+    self.export_type.is_none()
+      && self.css_build_info.exports().is_none()
+      && !self.module.build_meta().is_css_module()
   }
 
   fn generate_js_exports(&mut self) -> Result<()> {

--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 fn css_javascript_source_map_module_name(module: &dyn Module, context: &Context) -> String {
-  format!("css {}", module.readable_identifier(context))
+  concat_string!("css ", module.readable_identifier(context))
 }
 
 pub fn update_css_exports(exports: &mut CssExports, name: &str, css_export: CssExport) -> bool {

--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -16,7 +16,6 @@ use rspack_error::Result;
 use rspack_util::{
   atom::Atom,
   fx_hash::{FxIndexMap, FxIndexSet},
-  identifier::make_paths_relative,
   itoa, json_stringify, json_stringify_str,
 };
 use rustc_hash::FxHashSet as HashSet;
@@ -31,21 +30,8 @@ use crate::{
   },
 };
 
-fn css_source_map_module_name(module: &dyn Module, context: &Context) -> String {
-  let identifier = module.identifier();
-  let identifier = identifier.as_str();
-  let Some((prefix, resource)) = identifier.rsplit_once('|') else {
-    return identifier.to_string();
-  };
-
-  if resource.starts_with('/') || resource.as_bytes().get(1).is_some_and(|ch| *ch == b':') {
-    return format!(
-      "{prefix}|{}",
-      make_paths_relative(context.as_str(), resource)
-    );
-  }
-
-  identifier.to_string()
+fn css_javascript_source_map_module_name(module: &dyn Module, context: &Context) -> String {
+  format!("css {}", module.readable_identifier(context))
 }
 
 pub fn update_css_exports(exports: &mut CssExports, name: &str, css_export: CssExport) -> bool {
@@ -225,8 +211,8 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       }
     }
     let generated_source = self.concat_source.source().into_string_lossy().into_owned();
-    if self.module.get_source_map_kind().enabled() && !self.should_omit_javascript_source_map() {
-      let source_name = css_source_map_module_name(
+    if self.module.get_source_map_kind().enabled() {
+      let source_name = css_javascript_source_map_module_name(
         self.module,
         &self.generate_context.compilation.options.context,
       );
@@ -234,12 +220,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     } else {
       Ok(RawStringSource::from(generated_source).boxed())
     }
-  }
-
-  fn should_omit_javascript_source_map(&self) -> bool {
-    self.export_type.is_none()
-      && self.css_build_info.exports().is_none()
-      && !self.module.build_meta().is_css_module()
   }
 
   fn generate_js_exports(&mut self) -> Result<()> {

--- a/tests/rspack-test/configCases/less-loader/with-source-map/index.js
+++ b/tests/rspack-test/configCases/less-loader/with-source-map/index.js
@@ -18,4 +18,8 @@ it("basic", () => {
 			"utf-8"
 		)
 	]);
+
+	const jsSourceMap = fs.readFileSync(__dirname + "/bundle0.js.map", "utf-8");
+	const jsMap = JSON.parse(jsSourceMap);
+	expect(jsMap.sources.some(source => source.includes("index.less"))).toBe(false);
 });

--- a/tests/rspack-test/configCases/less-loader/with-source-map/index.js
+++ b/tests/rspack-test/configCases/less-loader/with-source-map/index.js
@@ -21,5 +21,6 @@ it("basic", () => {
 
 	const jsSourceMap = fs.readFileSync(__dirname + "/bundle0.js.map", "utf-8");
 	const jsMap = JSON.parse(jsSourceMap);
-	expect(jsMap.sources.some(source => source.includes("index.less"))).toBe(false);
+	expect(jsMap.sources).not.toContain(source);
+	expect(jsMap.sources).toContain(source.replace("./index.less", "css ./index.less"));
 });

--- a/tests/rspack-test/configCases/source-map/css-modules-link-source-map/index.js
+++ b/tests/rspack-test/configCases/source-map/css-modules-link-source-map/index.js
@@ -1,0 +1,37 @@
+import * as styles from "./style.module.css";
+
+it("should map link-type CSS module class exports in the JS source map", () => {
+	const fs = require("fs");
+	const path = require("path");
+
+	expect(typeof styles.btn).toBe("string");
+	expect(typeof styles.card).toBe("string");
+
+	const sourceMap = JSON.parse(
+		fs.readFileSync(path.join(__dirname, "bundle0.js.map"), "utf-8")
+	);
+
+	expect(sourceMap).toHaveProperty("version", 3);
+	expect(Array.isArray(sourceMap.sources)).toBe(true);
+
+	// The CSS module's generated JS export wrapper should appear in the
+	// source map under the module's readable identifier.
+	let cssSource = "webpack:///css ./style.module.css";
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		cssSource = "rspack:///css ./style.module.css";
+	}
+	const cssSourceIndex = sourceMap.sources.indexOf(cssSource);
+	expect(cssSourceIndex).toBeGreaterThanOrEqual(0);
+
+	// `sourcesContent` must carry a non-empty entry for that source —
+	// without it the entry in `sources` would be unresolvable. The exact
+	// content (original CSS vs. generated JS wrapper) depends on whether
+	// the CSS module emits class exports; either way it must be non-empty.
+	expect(Array.isArray(sourceMap.sourcesContent)).toBe(true);
+	expect(typeof sourceMap.sourcesContent[cssSourceIndex]).toBe("string");
+	expect(sourceMap.sourcesContent[cssSourceIndex].length).toBeGreaterThan(0);
+
+	// The mapping must reference real generated JS positions, not be empty.
+	expect(typeof sourceMap.mappings).toBe("string");
+	expect(sourceMap.mappings.length).toBeGreaterThan(0);
+});

--- a/tests/rspack-test/configCases/source-map/css-modules-link-source-map/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/css-modules-link-source-map/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  mode: 'development',
+  devtool: 'source-map',
+  externals: ['source-map'],
+  externalsType: 'commonjs',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/auto',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/source-map/css-modules-link-source-map/style.module.css
+++ b/tests/rspack-test/configCases/source-map/css-modules-link-source-map/style.module.css
@@ -1,0 +1,7 @@
+.btn {
+	color: red;
+}
+
+.card {
+	padding: 10px;
+}


### PR DESCRIPTION
## Summary

- Keep source maps for generated CSS JavaScript wrappers.
- Give CSS JavaScript wrapper maps a webpack-compatible `css ${readableIdentifier}` source name so they do not collide with the extracted CSS asset source name.
- Use `concat_string!` for the generated CSS wrapper source-map name.
- Add coverage to `less-loader/with-source-map` and port webpack's `css-modules-link-source-map` case to assert CSS Modules wrappers use the distinct `css ./style.module.css` source.

## Example

For `less-loader/with-source-map`, both `bundle0.css.map` and `bundle0.js.map` previously resolved to the same source name, `rspack:///./index.less`. SourceMapDevToolPlugin deduplicates source names globally, so depending on asset processing order either map could receive the fallback hash query, e.g. `index.less?225c`. That made the CSS map assertion flaky even though HMR was not enabled.

Webpack avoids this by naming the CSS JavaScript wrapper through `CssModule.readableIdentifier()`, which is prefixed as `css ./index.less`. This change mirrors that distinction in Rspack: the CSS asset map remains `rspack:///./index.less`, and the JavaScript wrapper map becomes `rspack:///css ./index.less`. The copied CSS Modules test covers the same naming shape for `style.module.css`.

## Validation

- `rustfmt --edition 2024 crates/rspack_plugin_css/src/parser_and_generator/generator.rs --check`
- `cargo check -p rspack_plugin_css`
- Pre-commit hook: `rustfmt`, `prettier --write`, `pnpm run lint:js`

Not fully run locally: the focused JS test needs a rebuilt native binding, but local `pnpm` is `11.7.0` while this repo requires `11.8.0`.

---
_by OpenAI Codex_