### PR TITLE
refactor(module): introduce module meta and state

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -257,9 +257,9 @@ pub type ResolveContextModuleDependencies = Arc<
 pub struct ContextModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   options: ContextModuleOptions,
-  state: ModuleState,
+  state: Box<ModuleState>,
   #[debug(skip)]
   #[cacheable(with=Unsupported)]
   resolve_dependencies: ResolveContextModuleDependencies,
@@ -288,14 +288,14 @@ impl ContextModule {
     Self {
       dependencies: Vec::new(),
       blocks: Vec::new(),
-      meta: ModuleMeta::new(identifier, ModuleType::JsAuto, layer),
+      meta: Box::new(ModuleMeta::new(identifier, ModuleType::JsAuto, layer)),
       options,
-      state: ModuleState::new(
+      state: Box::new(ModuleState::new(
         build_info,
         BuildMeta::default()
           .with_exports_type(BuildMetaExportsType::Default)
           .with_default_object(BuildMetaDefaultObject::RedirectWarn),
-      ),
+      )),
       source_map_kind: SourceMapKind::empty(),
       resolve_dependencies,
     }

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -30,12 +30,12 @@ use crate::{
   BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, BuildResult, ChunkGraph,
   ChunkGroupOptions, CodeGenerationResult, Compilation, ContextElementDependency,
   DependenciesBlock, Dependency, DependencyCategory, DependencyId, DependencyLocation,
-  DynamicImportMode, ExportsType, FactoryMeta, FakeNamespaceObjectMode, GroupOptions,
-  ImportAttributes, ImportPhase, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleId, ModuleIdsArtifact,
-  ModuleLayer, ModuleType, RealDependencyLocation, ReferencedSpecifier, Resolve, RuntimeGlobals,
+  DynamicImportMode, ExportsType, FakeNamespaceObjectMode, GroupOptions, ImportAttributes,
+  ImportPhase, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
+  ModuleCodeTemplate, ModuleGraph, ModuleId, ModuleIdsArtifact, ModuleLayer, ModuleMeta,
+  ModuleState, ModuleType, RealDependencyLocation, ReferencedSpecifier, Resolve, RuntimeGlobals,
   RuntimeSpec, SourceType, contextify, get_exports_type_with_strict, get_outgoing_async_modules,
-  impl_module_meta_info, module_update_hash, property_access, to_path,
+  impl_module_identifier, impl_module_meta_info, module_update_hash, property_access, to_path,
 };
 
 static CHUNK_NAME_INDEX_PLACEHOLDER: &str = "[index]";
@@ -257,11 +257,9 @@ pub type ResolveContextModuleDependencies = Arc<
 pub struct ContextModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  identifier: Identifier,
+  meta: ModuleMeta,
   options: ContextModuleOptions,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
   #[debug(skip)]
   #[cacheable(with=Unsupported)]
   resolve_dependencies: ResolveContextModuleDependencies,
@@ -284,24 +282,27 @@ impl ContextModule {
     if let Some(strict) = strict {
       build_info.strict = strict;
     }
+    let identifier = create_identifier(&options, None);
+    let layer = options.layer.clone();
 
     Self {
       dependencies: Vec::new(),
       blocks: Vec::new(),
-      identifier: create_identifier(&options, None),
+      meta: ModuleMeta::new(identifier, ModuleType::JsAuto, layer),
       options,
-      factory_meta: None,
-      build_info,
-      build_meta: BuildMeta::default()
-        .with_exports_type(BuildMetaExportsType::Default)
-        .with_default_object(BuildMetaDefaultObject::RedirectWarn),
+      state: ModuleState::new(
+        build_info,
+        BuildMeta::default()
+          .with_exports_type(BuildMetaExportsType::Default)
+          .with_default_object(BuildMetaDefaultObject::RedirectWarn),
+      ),
       source_map_kind: SourceMapKind::empty(),
       resolve_dependencies,
     }
   }
 
   fn get_module_id<'a>(&self, module_ids: &'a ModuleIdsArtifact) -> &'a ModuleId {
-    ChunkGraph::get_module_id(module_ids, self.identifier).expect("module id not found")
+    ChunkGraph::get_module_id(module_ids, self.identifier()).expect("module id not found")
   }
 
   pub fn get_context_options(&self) -> &ContextOptions {
@@ -621,10 +622,11 @@ impl ContextModule {
         let block_info = self.get_sorted_context_block_info(compilation);
 
         let mut entries = String::with_capacity(block_info.len() * 96);
+        let identifier = self.identifier();
         for (i, info) in block_info.iter().enumerate() {
           let mut import_promise = runtime_template.module_namespace_promise(
             compilation,
-            self.identifier,
+            identifier,
             &info.dep_id,
             Some(&info.block_id),
             &info.user_request,
@@ -1267,11 +1269,12 @@ impl ContextModule {
   fn get_source(&self, source_string: String, compilation: &Compilation) -> BoxSource {
     let source_map_kind = self.get_source_map_kind();
     if source_map_kind.enabled() {
+      let identifier = self.identifier();
       OriginalSource::new(
         source_string,
         format!(
           "webpack://{}",
-          make_paths_relative(&compilation.options.context, self.identifier.as_str(),)
+          make_paths_relative(&compilation.options.context, identifier.as_str(),)
         ),
       )
       .boxed()
@@ -1306,11 +1309,7 @@ impl DependenciesBlock for ContextModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ContextModule {
-  impl_module_meta_info!();
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::JsAuto
-  }
+  impl_module_meta_info!(meta, state);
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
@@ -1344,7 +1343,7 @@ impl Module for ContextModule {
 
   fn lib_ident(&self, options: LibIdentOptions) -> Option<Cow<'_, str>> {
     let mut id = String::new();
-    if let Some(layer) = &self.options.layer {
+    if let Some(layer) = self.get_layer() {
       id += "(";
       id += layer;
       id += ")/";
@@ -1424,7 +1423,7 @@ impl Module for ContextModule {
         None,
       ));
       let mut block = AsyncDependenciesBlock::new(
-        (*self.identifier).into(),
+        self.identifier(),
         Some(loc),
         None,
         context_element_dependencies
@@ -1470,7 +1469,7 @@ impl Module for ContextModule {
         let prefetch_order = group_options.and_then(|o| o.prefetch_order);
         let fetch_priority = group_options.and_then(|o| o.fetch_priority);
         let mut block = AsyncDependenciesBlock::new(
-          (*self.identifier).into(),
+          self.identifier(),
           None,
           Some(&context_element_dependency.user_request.clone()),
           vec![Box::new(context_element_dependency)],
@@ -1494,7 +1493,7 @@ impl Module for ContextModule {
     if !self.options.resource.as_str().is_empty() {
       let mut context_dependencies: ArcPathSet = Default::default();
       context_dependencies.insert(self.options.resource.as_std_path().into());
-      self.build_info.context_dependencies = context_dependencies;
+      self.build_info_mut().context_dependencies = context_dependencies;
     }
 
     Ok(BuildResult {
@@ -1547,9 +1546,7 @@ impl Module for ContextModule {
 impl_empty_diagnosable_trait!(ContextModule);
 
 impl Identifiable for ContextModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 fn create_identifier(options: &ContextModuleOptions, resource: Option<&str>) -> Identifier {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -436,12 +436,12 @@ fn resolve_external_type<'a>(
 pub struct ExternalModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   pub request: ExternalRequest,
   pub external_type: ExternalType,
   /// Request intended by user (without loaders from config)
   user_request: String,
-  state: ModuleState,
+  state: Box<ModuleState>,
   dependency_meta: DependencyMeta,
   place_in_initial: bool,
 }
@@ -476,7 +476,7 @@ impl ExternalModule {
     Self {
       dependencies: Vec::new(),
       blocks: Vec::new(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         Identifier::from({
           let resolved_type = resolve_external_type(external_type.as_str(), &dependency_meta);
           let request_str = simd_json::to_string(&request).expect("invalid json to_string");
@@ -498,15 +498,15 @@ impl ExternalModule {
         }),
         ModuleType::JsDynamic,
         None,
-      ),
+      )),
       request,
       external_type,
       user_request,
-      state: ModuleState::with_build_info(BuildInfo {
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         top_level_declarations: Some(FxHashSet::default()),
         strict: true,
         ..Default::default()
-      }),
+      })),
       source_map_kind: SourceMapKind::empty(),
       dependency_meta,
       place_in_initial,

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -10,15 +10,15 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use serde::Serialize;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey,
-  CodeGenerationDataUrl, CodeGenerationResult, Compilation, ConcatenationScope, Context,
-  DependenciesBlock, DependencyId, ExportProvided, ExternalType, FactoryMeta, ImportAttributes,
-  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module,
-  ModuleArgument, ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
-  StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports, UsedNameItem,
-  extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMetaExportsType,
+  BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl,
+  CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
+  ExportProvided, ExternalType, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
+  ModuleCodeTemplate, ModuleGraph, ModuleMeta, ModuleState, ModuleType, NAMESPACE_OBJECT_EXPORT,
+  NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
+  StaticExportsSpec, UsageState, UsedExports, UsedNameItem, extract_url_and_global,
+  impl_module_identifier, impl_module_meta_info, module_update_hash, property_access,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -436,14 +436,12 @@ fn resolve_external_type<'a>(
 pub struct ExternalModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  pub id: Identifier,
+  meta: ModuleMeta,
   pub request: ExternalRequest,
   pub external_type: ExternalType,
   /// Request intended by user (without loaders from config)
   user_request: String,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
   dependency_meta: DependencyMeta,
   place_in_initial: bool,
 }
@@ -478,35 +476,37 @@ impl ExternalModule {
     Self {
       dependencies: Vec::new(),
       blocks: Vec::new(),
-      id: Identifier::from({
-        let resolved_type = resolve_external_type(external_type.as_str(), &dependency_meta);
-        let request_str = simd_json::to_string(&request).expect("invalid json to_string");
-        let attrs_str = dependency_meta
-          .attributes
-          .as_ref()
-          .map_or(String::new(), |attrs| {
-            format!(
-              " {}",
-              simd_json::to_string(attrs).expect("invalid json to_string")
-            )
-          });
-        let phase_str = if dependency_meta.phase == ImportPhase::Evaluation {
-          String::new()
-        } else {
-          format!(" phase={}", dependency_meta.phase.as_str())
-        };
-        format!("external {resolved_type} {request_str}{attrs_str}{phase_str}")
-      }),
+      meta: ModuleMeta::new(
+        Identifier::from({
+          let resolved_type = resolve_external_type(external_type.as_str(), &dependency_meta);
+          let request_str = simd_json::to_string(&request).expect("invalid json to_string");
+          let attrs_str = dependency_meta
+            .attributes
+            .as_ref()
+            .map_or(String::new(), |attrs| {
+              format!(
+                " {}",
+                simd_json::to_string(attrs).expect("invalid json to_string")
+              )
+            });
+          let phase_str = if dependency_meta.phase == ImportPhase::Evaluation {
+            String::new()
+          } else {
+            format!(" phase={}", dependency_meta.phase.as_str())
+          };
+          format!("external {resolved_type} {request_str}{attrs_str}{phase_str}")
+        }),
+        ModuleType::JsDynamic,
+        None,
+      ),
       request,
       external_type,
       user_request,
-      factory_meta: None,
-      build_info: BuildInfo {
+      state: ModuleState::with_build_info(BuildInfo {
         top_level_declarations: Some(FxHashSet::default()),
         strict: true,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: SourceMapKind::empty(),
       dependency_meta,
       place_in_initial,
@@ -522,7 +522,7 @@ impl ExternalModule {
   }
 
   pub fn set_id(&mut self, id: Identifier) {
-    self.id = id;
+    self.meta.set_identifier(id);
   }
 
   pub fn get_external_type(&self) -> &ExternalType {
@@ -651,7 +651,7 @@ impl ExternalModule {
           .build_module_graph_artifact
           .side_effects_state_artifact;
         let check_external_variable = if module_graph.is_optional(
-          &self.id,
+          &self.identifier(),
           module_graph_cache,
           side_effects_state_artifact,
           &compilation.exports_info_artifact,
@@ -691,7 +691,7 @@ impl ExternalModule {
           .build_module_graph_artifact
           .side_effects_state_artifact;
         let check_external_variable = if module_graph.is_optional(
-          &self.id,
+          &self.identifier(),
           module_graph_cache,
           side_effects_state_artifact,
           &compilation.exports_info_artifact,
@@ -992,7 +992,7 @@ if(typeof {global} !== "undefined") return resolve();
           "undefined".to_string()
         };
         let check_external_variable = if module_graph.is_optional(
-          &self.id,
+          &self.identifier(),
           module_graph_cache,
           &compilation
             .build_module_graph_artifact
@@ -1020,9 +1020,7 @@ if(typeof {global} !== "undefined") return resolve();
 }
 
 impl Identifiable for ExternalModule {
-  fn identifier(&self) -> Identifier {
-    self.id
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for ExternalModule {
@@ -1050,7 +1048,7 @@ impl DependenciesBlock for ExternalModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ExternalModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn get_concatenation_bailout_reason(
     &self,
@@ -1064,10 +1062,6 @@ impl Module for ExternalModule {
       }
       _ => None,
     }
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::JsDynamic
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -1126,49 +1120,50 @@ impl Module for ExternalModule {
     build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
-    self.build_info.module = build_context.compiler_options.output.module;
+    self.build_info_mut().module = build_context.compiler_options.output.module;
     let resolved_external_type = self.resolve_external_type();
     let request = match &self.request {
       ExternalRequest::Single(request) => Some(request),
       ExternalRequest::Map(map) => map.get(&self.external_type),
     };
+    let request_has_rest = request.is_some_and(|r| r.has_rest());
     let mut can_mangle = false;
     let mut exports_type = BuildMetaExportsType::Dynamic;
 
     #[allow(clippy::collapsible_match)]
     match resolved_external_type {
-      "this" => self.build_info.strict = false,
+      "this" => self.build_info_mut().strict = false,
       "system" => {
-        if !request.is_some_and(|r| r.has_rest()) {
+        if !request_has_rest {
           exports_type = BuildMetaExportsType::Namespace;
           can_mangle = true;
         }
       }
       "module" => {
-        if self.build_info.module {
-          if !request.is_some_and(|r| r.has_rest()) {
+        if self.build_info().module {
+          if !request_has_rest {
             exports_type = BuildMetaExportsType::Namespace;
             can_mangle = true;
           }
         } else {
-          self.build_meta.set_has_top_level_await(true);
-          if !request.is_some_and(|r| r.has_rest()) {
+          self.build_meta_mut().set_has_top_level_await(true);
+          if !request_has_rest {
             exports_type = BuildMetaExportsType::Namespace;
             can_mangle = false;
           }
         }
       }
-      "script" | "promise" => self.build_meta.set_has_top_level_await(true),
+      "script" | "promise" => self.build_meta_mut().set_has_top_level_await(true),
       "import" => {
-        self.build_meta.set_has_top_level_await(true);
-        if !request.is_some_and(|r| r.has_rest()) {
+        self.build_meta_mut().set_has_top_level_await(true);
+        if !request_has_rest {
           exports_type = BuildMetaExportsType::Namespace;
           can_mangle = false;
         }
       }
       _ => {}
     }
-    self.build_meta.set_exports_type(exports_type);
+    self.build_meta_mut().set_exports_type(exports_type);
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: vec![Box::new(StaticExportsDependency::new(
@@ -1249,12 +1244,12 @@ impl Module for ExternalModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHasher::from(&compilation.options.output);
     use rspack_hash::RspackHash as _;
-    self.id.as_str().hash(&mut hasher);
+    self.identifier().as_str().hash(&mut hasher);
     let side_effects_state_artifact = &compilation
       .build_module_graph_artifact
       .side_effects_state_artifact;
     let is_optional = compilation.get_module_graph().is_optional(
-      &self.id,
+      &self.identifier(),
       &compilation.module_graph_cache_artifact,
       side_effects_state_artifact,
       &compilation.exports_info_artifact,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -651,6 +651,108 @@ pub struct FactoryMeta {
 pub type ModuleIdentifier = Identifier;
 pub type ResourceIdentifier = Identifier;
 
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct ModuleMeta {
+  identifier: ModuleIdentifier,
+  module_type: ModuleType,
+  layer: Option<ModuleLayer>,
+}
+
+impl Default for ModuleMeta {
+  fn default() -> Self {
+    Self {
+      identifier: Default::default(),
+      module_type: ModuleType::JsAuto,
+      layer: None,
+    }
+  }
+}
+
+impl ModuleMeta {
+  pub fn new(
+    identifier: ModuleIdentifier,
+    module_type: ModuleType,
+    layer: Option<ModuleLayer>,
+  ) -> Self {
+    Self {
+      identifier,
+      module_type,
+      layer,
+    }
+  }
+
+  pub fn identifier(&self) -> ModuleIdentifier {
+    self.identifier
+  }
+
+  pub fn set_identifier(&mut self, identifier: ModuleIdentifier) {
+    self.identifier = identifier;
+  }
+
+  pub fn module_type(&self) -> &ModuleType {
+    &self.module_type
+  }
+
+  pub fn layer(&self) -> Option<&ModuleLayer> {
+    self.layer.as_ref()
+  }
+}
+
+#[cacheable]
+#[derive(Debug, Clone, Default)]
+pub struct ModuleState {
+  factory_meta: Option<FactoryMeta>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
+}
+
+impl ModuleState {
+  pub fn new(build_info: BuildInfo, build_meta: BuildMeta) -> Self {
+    Self {
+      factory_meta: None,
+      build_info,
+      build_meta,
+    }
+  }
+
+  pub fn with_build_info(build_info: BuildInfo) -> Self {
+    Self::new(build_info, Default::default())
+  }
+
+  pub fn factory_meta(&self) -> Option<&FactoryMeta> {
+    self.factory_meta.as_ref()
+  }
+
+  pub fn set_factory_meta(&mut self, factory_meta: FactoryMeta) {
+    self.factory_meta = Some(factory_meta);
+  }
+
+  pub fn build_info(&self) -> &BuildInfo {
+    &self.build_info
+  }
+
+  pub fn build_info_mut(&mut self) -> &mut BuildInfo {
+    &mut self.build_info
+  }
+
+  pub fn build_meta(&self) -> &BuildMeta {
+    &self.build_meta
+  }
+
+  pub fn build_meta_mut(&mut self) -> &mut BuildMeta {
+    &mut self.build_meta
+  }
+
+  pub fn parse_meta_mut(&mut self) -> (Option<&FactoryMeta>, &mut BuildInfo, &mut BuildMeta) {
+    (
+      self.factory_meta.as_ref(),
+      &mut self.build_info,
+      &mut self.build_meta,
+    )
+  }
+}
+
 #[derive(Debug)]
 pub struct ModuleCodeGenerationContext<'a> {
   pub compilation: &'a Compilation,
@@ -1068,29 +1170,46 @@ impl dyn Module {
 
 #[macro_export]
 macro_rules! impl_module_meta_info {
-  () => {
+  ($meta:ident, $state:ident) => {
+    fn module_type(&self) -> &$crate::ModuleType {
+      self.$meta.module_type()
+    }
+
+    fn get_layer(&self) -> Option<&$crate::ModuleLayer> {
+      self.$meta.layer()
+    }
+
     fn factory_meta(&self) -> Option<&$crate::FactoryMeta> {
-      self.factory_meta.as_ref()
+      self.$state.factory_meta()
     }
 
     fn set_factory_meta(&mut self, v: $crate::FactoryMeta) {
-      self.factory_meta = Some(v);
+      self.$state.set_factory_meta(v);
     }
 
     fn build_info(&self) -> &$crate::BuildInfo {
-      &self.build_info
+      self.$state.build_info()
     }
 
     fn build_info_mut(&mut self) -> &mut $crate::BuildInfo {
-      &mut self.build_info
+      self.$state.build_info_mut()
     }
 
     fn build_meta(&self) -> &$crate::BuildMeta {
-      &self.build_meta
+      self.$state.build_meta()
     }
 
     fn build_meta_mut(&mut self) -> &mut $crate::BuildMeta {
-      &mut self.build_meta
+      self.$state.build_meta_mut()
+    }
+  };
+}
+
+#[macro_export]
+macro_rules! impl_module_identifier {
+  ($meta:ident) => {
+    fn identifier(&self) -> $crate::ModuleIdentifier {
+      self.$meta.identifier()
     }
   };
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -29,14 +29,15 @@ use crate::{
   AsyncDependenciesBlockIdentifier, BoxDependencyTemplate, BoxLoader, BoxModule,
   BoxModuleDependency, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph,
   CodeGenerationResult, Compilation, ConnectionState, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions, Module,
+  GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions, Module,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
-  ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin,
-  RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, contextify,
+  ModuleLayer, ModuleMeta, ModuleState, ModuleType, OptimizationBailoutItem, OutputOptions,
+  ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions,
+  RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
+  SourceType, contextify,
   diagnostics::ModuleBuildError,
-  get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
-  module_update_hash,
+  get_context, impl_module_identifier, impl_module_meta_info, module_analyzed_side_effect_free,
+  module_declared_side_effect_free, module_update_hash,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -97,7 +98,7 @@ pub struct NormalModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
 
-  id: ModuleIdentifier,
+  meta: ModuleMeta,
   /// Context of this module
   context: Box<Context>,
   /// Request with loaders from config
@@ -106,10 +107,6 @@ pub struct NormalModule {
   user_request: String,
   /// Request without resolving
   raw_request: String,
-  /// The resolved module type of a module
-  module_type: ModuleType,
-  /// Layer of the module
-  layer: Option<ModuleLayer>,
   /// Affiliated parser and generator to the module type
   parser_and_generator: Box<dyn ParserAndGenerator>,
   /// Resource matched with inline match resource, (`!=!` syntax)
@@ -141,9 +138,7 @@ pub struct NormalModule {
   code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
   presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
 
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
   parsed: bool,
 
   source_map_kind: SourceMapKind,
@@ -200,13 +195,11 @@ impl NormalModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      id: ModuleIdentifier::from(id.as_ref()),
+      meta: ModuleMeta::new(ModuleIdentifier::from(id.as_ref()), module_type, layer),
       context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
       request,
       user_request,
       raw_request,
-      module_type,
-      layer,
       parser_and_generator,
       parser_and_generator_options,
       match_resource,
@@ -221,16 +214,14 @@ impl NormalModule {
       diagnostics: Default::default(),
       code_generation_dependencies: None,
       presentational_dependencies: None,
-      factory_meta: None,
-      build_info,
-      build_meta: Default::default(),
+      state: ModuleState::with_build_info(build_info),
       parsed: false,
       source_map_kind: SourceMapKind::empty(),
     }
   }
 
   pub fn id(&self) -> ModuleIdentifier {
-    self.id
+    self.identifier()
   }
 
   pub fn match_resource(&self) -> Option<&ResourceData> {
@@ -313,10 +304,7 @@ impl NormalModule {
 }
 
 impl Identifiable for NormalModule {
-  #[inline]
-  fn identifier(&self) -> ModuleIdentifier {
-    self.id
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for NormalModule {
@@ -344,9 +332,7 @@ impl DependenciesBlock for NormalModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for NormalModule {
-  fn module_type(&self) -> &ModuleType {
-    &self.module_type
-  }
+  impl_module_meta_info!(meta, state);
 
   fn source_types(&self, module_graph: &ModuleGraph) -> &[SourceType] {
     self.parser_and_generator.source_types(self, module_graph)
@@ -431,27 +417,30 @@ impl Module for NormalModule {
     self = loader_result.context.module;
 
     if let Some(err) = err {
-      self.build_info.cacheable = loader_result.cacheable;
-      self.build_info.file_dependencies = loader_result
-        .file_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
-      self.build_info.context_dependencies = loader_result
-        .context_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
-      self.build_info.missing_dependencies = loader_result
-        .missing_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
-      self.build_info.build_dependencies = loader_result
-        .build_dependencies
-        .into_iter()
-        .map(Into::into)
-        .collect();
+      {
+        let build_info = self.build_info_mut();
+        build_info.cacheable = loader_result.cacheable;
+        build_info.file_dependencies = loader_result
+          .file_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+        build_info.context_dependencies = loader_result
+          .context_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+        build_info.missing_dependencies = loader_result
+          .missing_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+        build_info.build_dependencies = loader_result
+          .build_dependencies
+          .into_iter()
+          .map(Into::into)
+          .collect();
+      }
 
       self.source = None;
 
@@ -467,8 +456,9 @@ impl Module for NormalModule {
       )));
       self.diagnostics.push(diagnostic);
 
-      self.build_info.hash =
-        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
+      let hash =
+        Some(self.init_build_hash(&build_context.compiler_options.output, self.build_meta()));
+      self.build_info_mut().hash = hash;
       return Ok(BuildResult {
         module: BoxModule::new(self),
         dependencies: Vec::new(),
@@ -493,7 +483,7 @@ impl Module for NormalModule {
         GeneratorOptions::AssetResource(g) => g.binary,
         _ => None,
       })
-      .unwrap_or_else(|| self.module_type.is_binary());
+      .unwrap_or_else(|| self.module_type().is_binary());
 
     let content = if is_binary {
       Content::Buffer(loader_result.content.into_bytes())
@@ -505,27 +495,30 @@ impl Module for NormalModule {
       loader_result.source_map.map(|source_map| *source_map),
     )?;
 
-    self.build_info.cacheable = loader_result.cacheable;
-    self.build_info.file_dependencies = loader_result
-      .file_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    self.build_info.context_dependencies = loader_result
-      .context_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    self.build_info.missing_dependencies = loader_result
-      .missing_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    self.build_info.build_dependencies = loader_result
-      .build_dependencies
-      .into_iter()
-      .map(Into::into)
-      .collect();
+    {
+      let build_info = self.build_info_mut();
+      build_info.cacheable = loader_result.cacheable;
+      build_info.file_dependencies = loader_result
+        .file_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+      build_info.context_dependencies = loader_result
+        .context_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+      build_info.missing_dependencies = loader_result
+        .missing_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+      build_info.build_dependencies = loader_result
+        .build_dependencies
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    }
 
     if no_parse {
       self.parsed = false;
@@ -533,8 +526,9 @@ impl Module for NormalModule {
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
-      self.build_info.hash =
-        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
+      let hash =
+        Some(self.init_build_hash(&build_context.compiler_options.output, self.build_meta()));
+      self.build_info_mut().hash = hash;
 
       return Ok(BuildResult {
         module: BoxModule::new(self),
@@ -544,6 +538,10 @@ impl Module for NormalModule {
       });
     }
 
+    let module_identifier = self.identifier();
+    let module_type = *self.module_type();
+    let module_layer = self.get_layer().cloned();
+    let (factory_meta, build_info, build_meta) = self.state.parse_meta_mut();
     let (
       ParseResult {
         source,
@@ -559,11 +557,11 @@ impl Module for NormalModule {
       .parse(ParseContext {
         source: source.clone(),
         module_context: &self.context,
-        module_identifier: self.id,
+        module_identifier,
         module_parser_options: self.parser_and_generator_options.parser_options(),
         module_generator_options: self.parser_and_generator_options.generator_options(),
-        module_type: &self.module_type,
-        module_layer: self.layer.as_ref(),
+        module_type: &module_type,
+        module_layer: module_layer.as_ref(),
         module_user_request: &self.user_request,
         module_match_resource: self.match_resource.as_ref(),
         module_source_map_kind: self.source_map_kind,
@@ -571,16 +569,16 @@ impl Module for NormalModule {
         resource_data: &self.resource_data,
         compiler_options: &build_context.compiler_options,
         additional_data: loader_result.additional_data,
-        factory_meta: self.factory_meta.as_ref(),
-        build_info: &mut self.build_info,
-        build_meta: &mut self.build_meta,
+        factory_meta,
+        build_info,
+        build_meta,
         parse_meta: loader_result.parse_meta,
         runtime_template: &build_context.runtime_template,
       })
       .await?
       .split_into_parts();
     if diagnostics.iter().any(|d| d.is_error()) {
-      self.build_meta = Default::default();
+      *self.build_meta_mut() = Default::default();
     }
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
@@ -601,8 +599,9 @@ impl Module for NormalModule {
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
 
-    self.build_info.hash =
-      Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
+    let hash =
+      Some(self.init_build_hash(&build_context.compiler_options.output, self.build_meta()));
+    self.build_info_mut().hash = hash;
 
     Ok(BuildResult {
       module: BoxModule::new(self),
@@ -693,7 +692,7 @@ impl Module for NormalModule {
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHasher::from(&compilation.options.output);
-    self.build_info.hash.hash(&mut hasher);
+    self.build_info().hash.hash(&mut hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
     if self.source.is_some() {
       let runtime_hash = self
@@ -722,7 +721,7 @@ impl Module for NormalModule {
 
   fn lib_ident(&self, options: LibIdentOptions) -> Option<Cow<'_, str>> {
     let mut ident = String::new();
-    if let Some(layer) = &self.layer {
+    if let Some(layer) = self.get_layer() {
       ident += "(";
       ident += layer;
       ident += ")/";
@@ -759,10 +758,6 @@ impl Module for NormalModule {
     Some(self.context.clone())
   }
 
-  fn get_layer(&self) -> Option<&ModuleLayer> {
-    self.layer.as_ref()
-  }
-
   // Port from https://github.com/webpack/webpack/blob/main/lib/NormalModule.js#L1120
   fn get_side_effects_connection_state(
     &self,
@@ -773,7 +768,7 @@ impl Module for NormalModule {
     connection_state_cache: &mut IdentifierMap<ConnectionState>,
   ) -> ConnectionState {
     module_graph_cache.cached_get_side_effects_connection_state(self.id(), || {
-      if let Some(state) = connection_state_cache.get(&self.id) {
+      if let Some(state) = connection_state_cache.get(&self.id()) {
         return *state;
       }
 
@@ -800,14 +795,14 @@ impl Module for NormalModule {
           if matches!(state, ConnectionState::Active(true)) {
             // TODO add optimization bailout
             module_chain.remove(&self.identifier());
-            connection_state_cache.insert(self.id, ConnectionState::Active(true));
+            connection_state_cache.insert(self.id(), ConnectionState::Active(true));
             return ConnectionState::Active(true);
           } else if !matches!(state, ConnectionState::CircularConnection) {
             current = current + state;
           }
         }
         module_chain.remove(&self.identifier());
-        connection_state_cache.insert(self.id, current);
+        connection_state_cache.insert(self.id(), current);
         return current;
       }
       ConnectionState::Active(true)
@@ -822,30 +817,6 @@ impl Module for NormalModule {
     self
       .parser_and_generator
       .get_concatenation_bailout_reason(self, mg, cg)
-  }
-
-  fn factory_meta(&self) -> Option<&FactoryMeta> {
-    self.factory_meta.as_ref()
-  }
-
-  fn set_factory_meta(&mut self, factory_meta: FactoryMeta) {
-    self.factory_meta = Some(factory_meta);
-  }
-
-  fn build_info(&self) -> &BuildInfo {
-    &self.build_info
-  }
-
-  fn build_info_mut(&mut self) -> &mut BuildInfo {
-    &mut self.build_info
-  }
-
-  fn build_meta(&self) -> &BuildMeta {
-    &self.build_meta
-  }
-
-  fn build_meta_mut(&mut self) -> &mut BuildMeta {
-    &mut self.build_meta
   }
 }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -98,7 +98,7 @@ pub struct NormalModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
 
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   /// Context of this module
   context: Box<Context>,
   /// Request with loaders from config
@@ -138,7 +138,7 @@ pub struct NormalModule {
   code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
   presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
 
-  state: ModuleState,
+  state: Box<ModuleState>,
   parsed: bool,
 
   source_map_kind: SourceMapKind,
@@ -195,7 +195,11 @@ impl NormalModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      meta: ModuleMeta::new(ModuleIdentifier::from(id.as_ref()), module_type, layer),
+      meta: Box::new(ModuleMeta::new(
+        ModuleIdentifier::from(id.as_ref()),
+        module_type,
+        layer,
+      )),
       context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
       request,
       user_request,
@@ -214,7 +218,7 @@ impl NormalModule {
       diagnostics: Default::default(),
       code_generation_dependencies: None,
       presentational_dependencies: None,
-      state: ModuleState::with_build_info(build_info),
+      state: Box::new(ModuleState::with_build_info(build_info)),
       parsed: false,
       source_map_kind: SourceMapKind::empty(),
     }

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -29,10 +29,10 @@ pub struct RawModule {
   source_str: String,
   #[cacheable(with=AsOption<AsPreset>)]
   source: Option<BoxSource>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   readable_identifier: String,
   runtime_requirements: RuntimeGlobals,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 static RAW_MODULE_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -49,14 +49,14 @@ impl RawModule {
       dependencies: Default::default(),
       source_str,
       source: None,
-      meta: ModuleMeta::new(identifier, ModuleType::JsAuto, None),
+      meta: Box::new(ModuleMeta::new(identifier, ModuleType::JsAuto, None)),
       readable_identifier,
       runtime_requirements,
-      state: ModuleState::with_build_info(BuildInfo {
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         cacheable: true,
         strict: true,
         ..Default::default()
-      }),
+      })),
       source_map_kind: SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -12,12 +12,12 @@ use rspack_sources::{BoxSource, OriginalSource, RawStringSource, SourceExt};
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 
 use crate::{
-  BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation,
-  ConnectionState, Context, DependenciesBlock, DependencyId, FactoryMeta, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleType,
+  BoxModule, BuildContext, BuildInfo, BuildResult, CodeGenerationResult, Compilation,
+  ConnectionState, Context, DependenciesBlock, DependencyId, Module, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleMeta, ModuleState, ModuleType,
   RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType,
-  dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_meta_info,
-  module_declared_side_effect_free, module_update_hash,
+  dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_identifier,
+  impl_module_meta_info, module_declared_side_effect_free, module_update_hash,
 };
 
 #[impl_source_map_config]
@@ -29,12 +29,10 @@ pub struct RawModule {
   source_str: String,
   #[cacheable(with=AsOption<AsPreset>)]
   source: Option<BoxSource>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   readable_identifier: String,
   runtime_requirements: RuntimeGlobals,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
 }
 
 static RAW_MODULE_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -51,25 +49,21 @@ impl RawModule {
       dependencies: Default::default(),
       source_str,
       source: None,
-      identifier,
+      meta: ModuleMeta::new(identifier, ModuleType::JsAuto, None),
       readable_identifier,
       runtime_requirements,
-      factory_meta: None,
-      build_info: BuildInfo {
+      state: ModuleState::with_build_info(BuildInfo {
         cacheable: true,
         strict: true,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: SourceMapKind::empty(),
     }
   }
 }
 
 impl Identifiable for RawModule {
-  fn identifier(&self) -> ModuleIdentifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for RawModule {
@@ -97,11 +91,7 @@ impl DependenciesBlock for RawModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for RawModule {
-  impl_module_meta_info!();
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::JsAuto
-  }
+  impl_module_meta_info!(meta, state);
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     RAW_MODULE_SOURCE_TYPES
@@ -132,7 +122,7 @@ impl Module for RawModule {
     if self.get_source_map_kind().enabled() {
       cgr.add(
         SourceType::JavaScript,
-        OriginalSource::new(self.source_str.clone(), self.identifier.to_string()).boxed(),
+        OriginalSource::new(self.source_str.clone(), self.identifier().to_string()).boxed(),
       );
     } else {
       cgr.add(

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -20,29 +20,29 @@ use crate::{
 #[cacheable]
 #[derive(Debug)]
 pub struct SelfModule {
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   readable_identifier: String,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 impl SelfModule {
   pub fn new(module_identifier: ModuleIdentifier) -> Self {
     let identifier = format!("self {module_identifier}");
     Self {
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(identifier.as_str()),
         ModuleType::Fallback,
         None,
-      ),
+      )),
       readable_identifier: identifier,
       blocks: Default::default(),
       dependencies: Default::default(),
-      state: ModuleState::with_build_info(BuildInfo {
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      }),
+      })),
       source_map_kind: SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::RspackHashDigest;
 use rspack_macros::impl_source_map_config;
@@ -10,48 +10,46 @@ use rspack_sources::BoxSource;
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier,
-  ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildResult, ChunkUkey,
+  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
+  Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleMeta, ModuleState,
+  ModuleType, RuntimeSpec, SourceType, impl_module_identifier, impl_module_meta_info,
 };
 
 #[impl_source_map_config]
 #[cacheable]
 #[derive(Debug)]
 pub struct SelfModule {
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   readable_identifier: String,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
 }
 
 impl SelfModule {
   pub fn new(module_identifier: ModuleIdentifier) -> Self {
     let identifier = format!("self {module_identifier}");
     Self {
-      identifier: ModuleIdentifier::from(identifier.as_str()),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(identifier.as_str()),
+        ModuleType::Fallback,
+        None,
+      ),
       readable_identifier: identifier,
       blocks: Default::default(),
       dependencies: Default::default(),
-      factory_meta: None,
-      build_info: BuildInfo {
+      state: ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: SourceMapKind::empty(),
     }
   }
 }
 
 impl Identifiable for SelfModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for SelfModule {
@@ -79,14 +77,10 @@ impl DependenciesBlock for SelfModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for SelfModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
-    self.identifier.len() as f64
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::Fallback
+    self.identifier().len() as f64
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -23,9 +23,9 @@ pub struct DllModule {
   // TODO: it should be set to EntryDependency.loc
   name: String,
 
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
 
-  state: ModuleState,
+  state: Box<ModuleState>,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
 
@@ -46,11 +46,11 @@ impl DllModule {
     } = dep.clone();
 
     Self {
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         format!("dll {name}").as_str().into(),
         ModuleType::JsDynamic,
         None,
-      ),
+      )),
       entries,
       context,
       name,

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -2,13 +2,13 @@ use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  CodeGenerationResult, Compilation, Context, DependenciesBlock, Dependency, DependencyId,
-  EntryDependency, FactoryMeta, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info,
-  impl_source_map_config, module_update_hash,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildResult, CodeGenerationResult,
+  Compilation, Context, DependenciesBlock, Dependency, DependencyId, EntryDependency, Module,
+  ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleMeta, ModuleState, ModuleType,
+  RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions, impl_module_identifier,
+  impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -23,11 +23,9 @@ pub struct DllModule {
   // TODO: it should be set to EntryDependency.loc
   name: String,
 
-  factory_meta: Option<FactoryMeta>,
+  meta: ModuleMeta,
 
-  build_info: BuildInfo,
-
-  build_meta: BuildMeta,
+  state: ModuleState,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
 
@@ -48,9 +46,14 @@ impl DllModule {
     } = dep.clone();
 
     Self {
-      name,
+      meta: ModuleMeta::new(
+        format!("dll {name}").as_str().into(),
+        ModuleType::JsDynamic,
+        None,
+      ),
       entries,
       context,
+      name,
       ..Default::default()
     }
   }
@@ -59,11 +62,7 @@ impl DllModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for DllModule {
-  impl_module_meta_info!();
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::JsDynamic
-  }
+  impl_module_meta_info!(meta, state);
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
@@ -141,9 +140,7 @@ impl Module for DllModule {
 }
 
 impl Identifiable for DllModule {
-  fn identifier(&self) -> Identifier {
-    format!("dll {}", self.name).as_str().into()
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for DllModule {

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -33,8 +33,8 @@ pub struct DelegatedModule {
   delegate_data: DllManifestContentItem,
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  meta: ModuleMeta,
-  state: ModuleState,
+  meta: Box<ModuleMeta>,
+  state: Box<ModuleState>,
 }
 
 impl DelegatedModule {
@@ -58,7 +58,11 @@ impl DelegatedModule {
       user_request,
       original_request,
       delegate_data: data,
-      meta: ModuleMeta::new(identifier.as_str().into(), ModuleType::JsDynamic, None),
+      meta: Box::new(ModuleMeta::new(
+        identifier.as_str().into(),
+        ModuleType::JsDynamic,
+        None,
+      )),
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -2,13 +2,13 @@ use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
-  ModuleDependency, ModuleGraph, ModuleId, ModuleType, RuntimeSpec, SourceType,
-  StaticExportsDependency, StaticExportsSpec, ValueCacheVersions, impl_module_meta_info,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildResult,
+  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
+  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleDependency, ModuleGraph, ModuleId,
+  ModuleMeta, ModuleState, ModuleType, RuntimeSpec, SourceType, StaticExportsDependency,
+  StaticExportsSpec, ValueCacheVersions, impl_module_identifier, impl_module_meta_info,
   impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
 };
@@ -33,9 +33,8 @@ pub struct DelegatedModule {
   delegate_data: DllManifestContentItem,
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  meta: ModuleMeta,
+  state: ModuleState,
 }
 
 impl DelegatedModule {
@@ -46,13 +45,20 @@ impl DelegatedModule {
     user_request: String,
     original_request: Option<String>,
   ) -> Self {
+    let request = data.id.clone();
+    let identifier = format!(
+      "delegated {} from {}",
+      request.as_ref().map(|r| r.to_string()).unwrap_or_default(),
+      source_request
+    );
     Self {
       source_request,
-      request: data.id.clone(),
+      request,
       delegation_type,
       user_request,
       original_request,
       delegate_data: data,
+      meta: ModuleMeta::new(identifier.as_str().into(), ModuleType::JsDynamic, None),
       ..Default::default()
     }
   }
@@ -61,11 +67,7 @@ impl DelegatedModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for DelegatedModule {
-  impl_module_meta_info!();
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::JsDynamic
-  }
+  impl_module_meta_info!(meta, state);
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &[SourceType::JavaScript]
@@ -109,7 +111,7 @@ impl Module for DelegatedModule {
         false,
       )) as BoxDependency,
     ];
-    self.build_meta = self.delegate_data.build_meta.clone();
+    *self.build_meta_mut() = self.delegate_data.build_meta.clone();
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies,
@@ -203,18 +205,7 @@ impl Module for DelegatedModule {
 }
 
 impl Identifiable for DelegatedModule {
-  fn identifier(&self) -> Identifier {
-    format!(
-      "delegated {} from {}",
-      self
-        .request
-        .as_ref()
-        .map(|r| r.to_string())
-        .unwrap_or_default(),
-      self.source_request
-    )
-    .into()
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for DelegatedModule {

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -30,8 +30,8 @@ pub(crate) struct CssModule {
   pub(crate) css_layer: Option<String>,
   pub(crate) identifier_index: u32,
 
-  meta: ModuleMeta,
-  state: ModuleState,
+  meta: Box<ModuleMeta>,
+  state: Box<ModuleState>,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
@@ -63,8 +63,8 @@ impl CssModule {
       identifier_index: dep.identifier_index,
       blocks: vec![],
       dependencies: vec![],
-      meta: ModuleMeta::new(identifier__, *MODULE_TYPE, module_layer),
-      state: ModuleState::with_build_info(BuildInfo {
+      meta: Box::new(ModuleMeta::new(identifier__, *MODULE_TYPE, module_layer)),
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         cacheable: dep.cacheable,
         strict: true,
         file_dependencies: dep.file_dependencies,
@@ -72,7 +72,7 @@ impl CssModule {
         missing_dependencies: dep.missing_dependencies,
         build_dependencies: dep.build_dependencies,
         ..Default::default()
-      }),
+      })),
       source_map_kind: rspack_util::source_map::SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -1,11 +1,12 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  CodeGenerationResult, Compilation, CompilerOptions, DependenciesBlock, DependencyId, FactoryMeta,
-  Module, ModuleCodeGenerationContext, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
-  ModuleFactoryResult, ModuleGraph, ModuleLayer, RuntimeSpec, SourceType, impl_module_meta_info,
-  impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildResult,
+  CodeGenerationResult, Compilation, CompilerOptions, DependenciesBlock, DependencyId, Module,
+  ModuleCodeGenerationContext, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
+  ModuleFactoryResult, ModuleGraph, ModuleMeta, ModuleState, RuntimeSpec, SourceType,
+  impl_module_identifier, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
@@ -23,28 +24,24 @@ pub(crate) struct CssModule {
   pub(crate) identifier: String,
   pub(crate) content: String,
   pub(crate) _context: String,
-  pub(crate) module_layer: Option<ModuleLayer>,
   pub(crate) media: Option<String>,
   pub(crate) supports: Option<String>,
   pub(crate) source_map: Option<String>,
   pub(crate) css_layer: Option<String>,
   pub(crate) identifier_index: u32,
 
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  meta: ModuleMeta,
+  state: ModuleState,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-
-  identifier__: Identifier,
 }
 
 impl CssModule {
   pub fn new(dep: CssDependency) -> Self {
     let mut identifier_index_buffer = itoa::Buffer::new();
     let identifier_index_str = identifier_index_buffer.format(dep.identifier_index);
-    let identifier__ = format!(
+    let identifier__: Identifier = format!(
       "css|{}|{}|{}|{}|{}}}",
       dep.identifier,
       identifier_index_str,
@@ -53,11 +50,11 @@ impl CssModule {
       dep.media.as_deref().unwrap_or_default(),
     )
     .into();
+    let module_layer = dep.module_layer.clone();
 
     Self {
       identifier: dep.identifier,
       content: dep.content,
-      module_layer: dep.module_layer.clone(),
       css_layer: dep.css_layer.clone(),
       _context: dep.context,
       media: dep.media,
@@ -66,8 +63,8 @@ impl CssModule {
       identifier_index: dep.identifier_index,
       blocks: vec![],
       dependencies: vec![],
-      factory_meta: None,
-      build_info: BuildInfo {
+      meta: ModuleMeta::new(identifier__, *MODULE_TYPE, module_layer),
+      state: ModuleState::with_build_info(BuildInfo {
         cacheable: dep.cacheable,
         strict: true,
         file_dependencies: dep.file_dependencies,
@@ -75,10 +72,8 @@ impl CssModule {
         missing_dependencies: dep.missing_dependencies,
         build_dependencies: dep.build_dependencies,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: rspack_util::source_map::SourceMapKind::empty(),
-      identifier__,
     }
   }
 
@@ -100,7 +95,7 @@ impl CssModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for CssModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn readable_identifier(&self, context: &rspack_core::Context) -> std::borrow::Cow<'_, str> {
     let index_suffix = if self.identifier_index > 0 {
@@ -152,10 +147,6 @@ impl Module for CssModule {
     None
   }
 
-  fn module_type(&self) -> &rspack_core::ModuleType {
-    &MODULE_TYPE
-  }
-
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &*SOURCE_TYPE
   }
@@ -169,7 +160,7 @@ impl Module for CssModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
-    self.build_info.hash = Some(self.compute_hash(&build_context.compiler_options));
+    self.build_info_mut().hash = Some(self.compute_hash(&build_context.compiler_options));
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: vec![],
@@ -193,19 +184,13 @@ impl Module for CssModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
-    self.build_info.hash.hash(&mut hasher);
+    self.build_info().hash.hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
-  }
-
-  fn get_layer(&self) -> Option<&ModuleLayer> {
-    self.module_layer.as_ref()
   }
 }
 
 impl Identifiable for CssModule {
-  fn identifier(&self) -> rspack_collections::Identifier {
-    self.identifier__
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for CssModule {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -47,8 +47,8 @@ fn has_closure_library(output: &OutputOptions) -> bool {
 #[cacheable]
 #[derive(Debug)]
 pub(crate) struct LazyCompilationProxyModule {
-  meta: ModuleMeta,
-  state: ModuleState,
+  meta: Box<ModuleMeta>,
+  state: Box<ModuleState>,
 
   readable_identifier: String,
   lib_ident: Option<String>,
@@ -103,7 +103,11 @@ impl LazyCompilationProxyModule {
     };
 
     Self {
-      meta: ModuleMeta::new(identifier, MODULE_TYPE, create_data.issuer_layer.clone()),
+      meta: Box::new(ModuleMeta::new(
+        identifier,
+        MODULE_TYPE,
+        create_data.issuer_layer.clone(),
+      )),
       state: Default::default(),
       readable_identifier,
       lib_ident,

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -4,11 +4,11 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::AsVec};
 use rspack_collections::Identifiable;
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResult, Compilation, Context,
-  DependenciesBlock, DependencyId, DependencyRange, FactoryMeta, ImportPhase, LibIdentOptions,
-  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleFactoryCreateData, ModuleGraph,
-  ModuleIdentifier, ModuleLayer, ModuleType, OutputOptions, RuntimeGlobals, RuntimeSpec,
-  SourceType, ValueCacheVersions, impl_module_meta_info, module_update_hash,
+  BuildResult, ChunkGraph, CodeGenerationResult, Compilation, Context, DependenciesBlock,
+  DependencyId, DependencyRange, ImportPhase, LibIdentOptions, Module, ModuleArgument,
+  ModuleCodeGenerationContext, ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleMeta,
+  ModuleState, ModuleType, OutputOptions, RuntimeGlobals, RuntimeSpec, SourceType,
+  ValueCacheVersions, impl_module_identifier, impl_module_meta_info, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -47,12 +47,10 @@ fn has_closure_library(output: &OutputOptions) -> bool {
 #[cacheable]
 #[derive(Debug)]
 pub(crate) struct LazyCompilationProxyModule {
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
-  factory_meta: Option<FactoryMeta>,
+  meta: ModuleMeta,
+  state: ModuleState,
 
   readable_identifier: String,
-  identifier: ModuleIdentifier,
   lib_ident: Option<String>,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
@@ -61,7 +59,6 @@ pub(crate) struct LazyCompilationProxyModule {
   source_map_kind: SourceMapKind,
 
   context: Box<Context>,
-  layer: Option<ModuleLayer>,
   dep_options: DependencyOptions,
   resource: String,
   active: bool,
@@ -106,17 +103,14 @@ impl LazyCompilationProxyModule {
     };
 
     Self {
-      build_info: Default::default(),
-      build_meta: Default::default(),
-      factory_meta: None,
+      meta: ModuleMeta::new(identifier, MODULE_TYPE, create_data.issuer_layer.clone()),
+      state: Default::default(),
       readable_identifier,
       lib_ident,
-      identifier,
       source_map_kind: SourceMapKind::empty(),
       blocks: vec![],
       dependencies: vec![],
       context: Box::new(create_data.context.clone()),
-      layer: create_data.issuer_layer.clone(),
       dep_options,
       resource,
       active,
@@ -136,22 +130,14 @@ impl_empty_diagnosable_trait!(LazyCompilationProxyModule);
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for LazyCompilationProxyModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &SOURCE_TYPE
   }
 
-  fn module_type(&self) -> &ModuleType {
-    &MODULE_TYPE
-  }
-
   fn get_context(&self) -> Option<Box<Context>> {
     Some(self.context.clone())
-  }
-
-  fn get_layer(&self) -> Option<&ModuleLayer> {
-    self.layer.as_ref()
   }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
@@ -206,7 +192,7 @@ impl Module for LazyCompilationProxyModule {
       let dep = LazyCompilationDependency::new(self.dep_options.clone());
 
       blocks.push(Box::new(AsyncDependenciesBlock::new(
-        self.identifier,
+        self.identifier(),
         None,
         None,
         vec![Box::new(dep)],
@@ -261,7 +247,7 @@ impl Module for LazyCompilationProxyModule {
       runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
       ChunkGraph::get_module_id(&compilation.module_ids_artifact, *client_module)
         .expect("should have module id"),
-      simd_json::to_string(&self.identifier).expect("should serialize identifier")
+      simd_json::to_string(&self.identifier()).expect("should serialize identifier")
     );
 
     let module_argument = runtime_template.render_module_argument(ModuleArgument::Module);
@@ -333,15 +319,13 @@ impl Module for LazyCompilationProxyModule {
     let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
     self.active.hash(&mut hasher);
-    self.identifier.hash(&mut hasher);
+    self.identifier().hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }
 }
 
 impl Identifiable for LazyCompilationProxyModule {
-  fn identifier(&self) -> rspack_collections::Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for LazyCompilationProxyModule {

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use rspack_collections::Identifiable;
 use rspack_core::{
   Chunk, ChunkCodeTemplate, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
   CompilationParams, CompilerCompilation, ExportsInfoArtifact, ExternalModule, ExternalRequest,
@@ -139,7 +140,7 @@ async fn render(
       .side_effects_state_artifact;
     for module in &externals {
       if module_graph.is_optional(
-        &module.id,
+        &module.identifier(),
         module_graph_cache,
         side_effects_state_artifact,
         &compilation.exports_info_artifact,
@@ -420,7 +421,7 @@ fn externals_require_array(
           format!("require({primary})")
         };
         if module_graph.is_optional(
-          &m.id,
+          &m.identifier(),
           module_graph_cache,
           side_effects_state_artifact,
           exports_info_artifact,

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -2,15 +2,16 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
   BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, ChunkGroupOptions, CodeGenerationResult,
   CodeGenerationRuntimeRequirementsWrite, Compilation, Context, DependenciesBlock, Dependency,
-  DependencyId, DependencyType, ExportsArgument, FactoryMeta, GroupOptions, LibIdentOptions,
-  Module, ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleDependency, ModuleGraph,
-  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
-  StaticExportsSpec, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  DependencyId, DependencyType, ExportsArgument, GroupOptions, LibIdentOptions, Module,
+  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleDependency, ModuleGraph, ModuleIdentifier,
+  ModuleMeta, ModuleState, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  StaticExportsDependency, StaticExportsSpec, impl_module_identifier, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -32,13 +33,11 @@ use crate::{
 pub struct ContainerEntryModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   lib_ident: String,
   exposes: Vec<(String, ExposeOptions)>,
   share_scope: ShareScope,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
   enhanced: bool,
   request: Option<String>,
   version: Option<String>,
@@ -57,21 +56,26 @@ impl ContainerEntryModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      identifier: ModuleIdentifier::from(format!(
-        "container entry ({}) {}",
-        share_scope.key(),
-        json_stringify(&exposes),
-      )),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(format!(
+          "container entry ({}) {}",
+          share_scope.key(),
+          json_stringify(&exposes),
+        )),
+        ModuleType::JsDynamic,
+        None,
+      ),
       lib_ident,
       exposes,
       share_scope,
-      factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
-        ..Default::default()
-      },
-      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
+      state: ModuleState::new(
+        BuildInfo {
+          strict: true,
+          top_level_declarations: Some(FxHashSet::default()),
+          ..Default::default()
+        },
+        BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
+      ),
       enhanced,
       request: None,
       version: None,
@@ -86,17 +90,22 @@ impl ContainerEntryModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      identifier: ModuleIdentifier::from(format!("share container entry {}@{}", &name, &version,)),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(format!("share container entry {}@{}", &name, &version,)),
+        ModuleType::ShareContainerShared,
+        None,
+      ),
       lib_ident,
       exposes: vec![],
       share_scope: ShareScope::Multiple(vec![]),
-      factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
-        ..Default::default()
-      },
-      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
+      state: ModuleState::new(
+        BuildInfo {
+          strict: true,
+          top_level_declarations: Some(FxHashSet::default()),
+          ..Default::default()
+        },
+        BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
+      ),
       enhanced: false,
       request: Some(request),
       version: Some(version),
@@ -116,9 +125,7 @@ impl ContainerEntryModule {
 }
 
 impl Identifiable for ContainerEntryModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for ContainerEntryModule {
@@ -146,18 +153,10 @@ impl DependenciesBlock for ContainerEntryModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ContainerEntryModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    if self.dependency_type == DependencyType::ShareContainerEntry {
-      &ModuleType::ShareContainerShared
-    } else {
-      &ModuleType::JsDynamic
-    }
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -202,7 +201,7 @@ impl Module for ContainerEntryModule {
       // Container logic
       for (name, options) in &self.exposes {
         let mut block = AsyncDependenciesBlock::new(
-          self.identifier,
+          self.identifier(),
           None,
           Some(name),
           options

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -33,11 +33,11 @@ use crate::{
 pub struct ContainerEntryModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   lib_ident: String,
   exposes: Vec<(String, ExposeOptions)>,
   share_scope: ShareScope,
-  state: ModuleState,
+  state: Box<ModuleState>,
   enhanced: bool,
   request: Option<String>,
   version: Option<String>,
@@ -56,7 +56,7 @@ impl ContainerEntryModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(format!(
           "container entry ({}) {}",
           share_scope.key(),
@@ -64,18 +64,18 @@ impl ContainerEntryModule {
         )),
         ModuleType::JsDynamic,
         None,
-      ),
+      )),
       lib_ident,
       exposes,
       share_scope,
-      state: ModuleState::new(
+      state: Box::new(ModuleState::new(
         BuildInfo {
           strict: true,
           top_level_declarations: Some(FxHashSet::default()),
           ..Default::default()
         },
         BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
-      ),
+      )),
       enhanced,
       request: None,
       version: None,
@@ -90,22 +90,22 @@ impl ContainerEntryModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(format!("share container entry {}@{}", &name, &version,)),
         ModuleType::ShareContainerShared,
         None,
-      ),
+      )),
       lib_ident,
       exposes: vec![],
       share_scope: ShareScope::Multiple(vec![]),
-      state: ModuleState::new(
+      state: Box::new(ModuleState::new(
         BuildInfo {
           strict: true,
           top_level_declarations: Some(FxHashSet::default()),
           ..Default::default()
         },
         BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
-      ),
+      )),
       enhanced: false,
       request: Some(request),
       version: Some(version),

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildResult,
+  ChunkGraph, ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock,
+  DependencyId, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleMeta, ModuleState, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  impl_module_identifier, impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -24,13 +24,11 @@ use crate::utils::json_stringify;
 pub struct FallbackModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   readable_identifier: String,
   lib_ident: String,
   requests: Vec<String>,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
 }
 
 impl FallbackModule {
@@ -48,25 +46,25 @@ impl FallbackModule {
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),
-      identifier: ModuleIdentifier::from(identifier.as_str()),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(identifier.as_str()),
+        ModuleType::Fallback,
+        None,
+      ),
       readable_identifier: identifier,
       lib_ident,
       requests,
-      factory_meta: None,
-      build_info: BuildInfo {
+      state: ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: SourceMapKind::empty(),
     }
   }
 }
 
 impl Identifiable for FallbackModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for FallbackModule {
@@ -94,14 +92,10 @@ impl DependenciesBlock for FallbackModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for FallbackModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     self.requests.len() as f64 * 5.0 + 42.0
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::Fallback
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -24,11 +24,11 @@ use crate::utils::json_stringify;
 pub struct FallbackModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   readable_identifier: String,
   lib_ident: String,
   requests: Vec<String>,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 impl FallbackModule {
@@ -46,18 +46,18 @@ impl FallbackModule {
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(identifier.as_str()),
         ModuleType::Fallback,
         None,
-      ),
+      )),
       readable_identifier: identifier,
       lib_ident,
       requests,
-      state: ModuleState::with_build_info(BuildInfo {
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      }),
+      })),
       source_map_kind: SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, CodeGenerationResult, Compilation, Context, DependenciesBlock,
-  Dependency, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
-  impl_module_meta_info, impl_source_map_config, module_update_hash,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildResult,
+  ChunkGraph, CodeGenerationResult, Compilation, Context, DependenciesBlock, Dependency,
+  DependencyId, ExportsType, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleMeta, ModuleState, ModuleType, RuntimeSpec, SourceType,
+  impl_module_identifier, impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -30,7 +30,7 @@ use crate::{
 pub struct RemoteModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   readable_identifier: String,
   lib_ident: String,
   request: String,
@@ -38,9 +38,7 @@ pub struct RemoteModule {
   pub internal_request: String,
   pub share_scope: ShareScope,
   pub remote_key: String,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
 }
 
 impl RemoteModule {
@@ -56,12 +54,16 @@ impl RemoteModule {
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),
-      identifier: ModuleIdentifier::from(format!(
-        "remote ({}) {} {}",
-        share_scope.key(),
-        external_requests.join(" "),
-        internal_request
-      )),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(format!(
+          "remote ({}) {} {}",
+          share_scope.key(),
+          external_requests.join(" "),
+          internal_request
+        )),
+        ModuleType::Remote,
+        None,
+      ),
       readable_identifier,
       lib_ident,
       request,
@@ -69,21 +71,17 @@ impl RemoteModule {
       internal_request,
       share_scope,
       remote_key,
-      factory_meta: None,
-      build_info: BuildInfo {
+      state: ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: SourceMapKind::empty(),
     }
   }
 }
 
 impl Identifiable for RemoteModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for RemoteModule {
@@ -111,14 +109,10 @@ impl DependenciesBlock for RemoteModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for RemoteModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     6.0
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::Remote
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -30,7 +30,7 @@ use crate::{
 pub struct RemoteModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   readable_identifier: String,
   lib_ident: String,
   request: String,
@@ -38,7 +38,7 @@ pub struct RemoteModule {
   pub internal_request: String,
   pub share_scope: ShareScope,
   pub remote_key: String,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 impl RemoteModule {
@@ -54,7 +54,7 @@ impl RemoteModule {
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(format!(
           "remote ({}) {} {}",
           share_scope.key(),
@@ -63,7 +63,7 @@ impl RemoteModule {
         )),
         ModuleType::Remote,
         None,
-      ),
+      )),
       readable_identifier,
       lib_ident,
       request,
@@ -71,10 +71,10 @@ impl RemoteModule {
       internal_request,
       share_scope,
       remote_key,
-      state: ModuleState::with_build_info(BuildInfo {
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      }),
+      })),
       source_map_kind: SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -28,12 +28,12 @@ pub struct ConsumeSharedModule {
   #[cacheable(with=Unsupported)]
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   lib_ident: String,
   readable_identifier: String,
   context: Context,
   options: ConsumeOptions,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 impl ConsumeSharedModule {
@@ -75,11 +75,11 @@ impl ConsumeSharedModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(identifier.as_ref()),
         ModuleType::ConsumeShared,
         None,
-      ),
+      )),
       lib_ident: format!(
         "webpack/sharing/consume/{}/{}{}",
         &scopes_key,

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -2,13 +2,14 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
-  DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
-  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
-  impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
+  ExportsType, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier,
+  ModuleMeta, ModuleState, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  impl_module_identifier, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
@@ -27,14 +28,12 @@ pub struct ConsumeSharedModule {
   #[cacheable(with=Unsupported)]
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   lib_ident: String,
   readable_identifier: String,
   context: Context,
   options: ConsumeOptions,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
 }
 
 impl ConsumeSharedModule {
@@ -76,7 +75,11 @@ impl ConsumeSharedModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      identifier: ModuleIdentifier::from(identifier.as_ref()),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(identifier.as_ref()),
+        ModuleType::ConsumeShared,
+        None,
+      ),
       lib_ident: format!(
         "webpack/sharing/consume/{}/{}{}",
         &scopes_key,
@@ -90,18 +93,14 @@ impl ConsumeSharedModule {
       readable_identifier: identifier,
       context,
       options,
-      factory_meta: None,
-      build_info: Default::default(),
-      build_meta: Default::default(),
+      state: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
 }
 
 impl Identifiable for ConsumeSharedModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for ConsumeSharedModule {
@@ -129,14 +128,10 @@ impl DependenciesBlock for ConsumeSharedModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ConsumeSharedModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::ConsumeShared
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -181,7 +176,7 @@ impl Module for ConsumeSharedModule {
       if self.options.eager {
         dependencies.push(dep as BoxDependency);
       } else {
-        let block = AsyncDependenciesBlock::new(self.identifier, None, None, vec![dep], None);
+        let block = AsyncDependenciesBlock::new(self.identifier(), None, None, vec![dep], None);
         blocks.push(Box::new(block));
       }
     }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -30,7 +30,7 @@ use crate::{ConsumeVersion, ShareScope};
 pub struct ProvideSharedModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   lib_ident: String,
   readable_identifier: String,
   name: String,
@@ -42,7 +42,7 @@ pub struct ProvideSharedModule {
   required_version: Option<ConsumeVersion>,
   strict_version: Option<bool>,
   tree_shaking_mode: Option<String>,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 impl ProvideSharedModule {
@@ -66,11 +66,11 @@ impl ProvideSharedModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      meta: ModuleMeta::new(
+      meta: Box::new(ModuleMeta::new(
         ModuleIdentifier::from(identifier.as_ref()),
         ModuleType::ProvideShared,
         None,
-      ),
+      )),
       lib_ident: format!("webpack/sharing/provide/{}/{}", &scopes_key, &name),
       readable_identifier: identifier,
       name,
@@ -82,10 +82,10 @@ impl ProvideSharedModule {
       required_version,
       strict_version,
       tree_shaking_mode,
-      state: ModuleState::with_build_info(BuildInfo {
+      state: Box::new(ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      }),
+      })),
       source_map_kind: SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -2,13 +2,14 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
-  DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
-  impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  BuildInfo, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
+  DependencyId, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleMeta, ModuleState, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  impl_module_identifier, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
@@ -29,7 +30,7 @@ use crate::{ConsumeVersion, ShareScope};
 pub struct ProvideSharedModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   lib_ident: String,
   readable_identifier: String,
   name: String,
@@ -41,9 +42,7 @@ pub struct ProvideSharedModule {
   required_version: Option<ConsumeVersion>,
   strict_version: Option<bool>,
   tree_shaking_mode: Option<String>,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: ModuleState,
 }
 
 impl ProvideSharedModule {
@@ -67,7 +66,11 @@ impl ProvideSharedModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      identifier: ModuleIdentifier::from(identifier.as_ref()),
+      meta: ModuleMeta::new(
+        ModuleIdentifier::from(identifier.as_ref()),
+        ModuleType::ProvideShared,
+        None,
+      ),
       lib_ident: format!("webpack/sharing/provide/{}/{}", &scopes_key, &name),
       readable_identifier: identifier,
       name,
@@ -79,12 +82,10 @@ impl ProvideSharedModule {
       required_version,
       strict_version,
       tree_shaking_mode,
-      factory_meta: None,
-      build_info: BuildInfo {
+      state: ModuleState::with_build_info(BuildInfo {
         strict: true,
         ..Default::default()
-      },
-      build_meta: Default::default(),
+      }),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -106,9 +107,7 @@ impl ProvideSharedModule {
 }
 
 impl Identifiable for ProvideSharedModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for ProvideSharedModule {
@@ -136,14 +135,10 @@ impl DependenciesBlock for ProvideSharedModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ProvideSharedModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::ProvideShared
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -173,7 +168,7 @@ impl Module for ProvideSharedModule {
     if self.eager {
       dependencies.push(dep as BoxDependency);
     } else {
-      let block = AsyncDependenciesBlock::new(self.identifier, None, None, vec![dep], None);
+      let block = AsyncDependenciesBlock::new(self.identifier(), None, None, vec![dep], None);
       blocks.push(Box::new(block));
     }
 

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -6,14 +6,14 @@ use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsCacheable, AsMap, AsVec},
 };
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::Identifiable;
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
   BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, CodeGenerationResult, Compilation,
-  Context, DependenciesBlock, Dependency, DependencyId, DependencyRange, FactoryMeta, ImportPhase,
-  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleLayer,
-  ModuleType, ReferencedSpecifier, RuntimeSpec, SourceType, contextify, impl_module_meta_info,
-  impl_source_map_config, module_update_hash,
+  Context, DependenciesBlock, Dependency, DependencyId, DependencyRange, ImportPhase,
+  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleMeta,
+  ModuleState, ModuleType, ReferencedSpecifier, RuntimeSpec, SourceType, contextify,
+  impl_module_identifier, impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -35,7 +35,7 @@ use crate::{
 pub struct RscEntryModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  identifier: ModuleIdentifier,
+  meta: ModuleMeta,
   lib_ident: String,
   client_modules: Vec<ClientModuleImport>,
   root_client_modules: Vec<ClientModuleImport>,
@@ -46,10 +46,7 @@ pub struct RscEntryModule {
   name: Arc<str>,
   /// When true, client modules are loaded eagerly (not as code-split points).
   is_server_side_rendering: bool,
-  factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
-  layer: Option<ModuleLayer>,
+  state: ModuleState,
 }
 
 impl RscEntryModule {
@@ -79,7 +76,7 @@ impl RscEntryModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      identifier,
+      meta: ModuleMeta::new(identifier, ModuleType::JsDynamic, layer),
       lib_ident,
       client_modules,
       root_client_modules,
@@ -87,15 +84,15 @@ impl RscEntryModule {
       css_imports_by_server_entry,
       name,
       is_server_side_rendering,
-      factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(FxHashSet::default()),
-        ..Default::default()
-      },
-      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
+      state: ModuleState::new(
+        BuildInfo {
+          strict: true,
+          top_level_declarations: Some(FxHashSet::default()),
+          ..Default::default()
+        },
+        BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
+      ),
       source_map_kind: SourceMapKind::empty(),
-      layer,
     }
   }
 
@@ -187,9 +184,7 @@ impl RscEntryModule {
 }
 
 impl Identifiable for RscEntryModule {
-  fn identifier(&self) -> Identifier {
-    self.identifier
-  }
+  impl_module_identifier!(meta);
 }
 
 impl DependenciesBlock for RscEntryModule {
@@ -217,14 +212,10 @@ impl DependenciesBlock for RscEntryModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for RscEntryModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(meta, state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0
-  }
-
-  fn module_type(&self) -> &ModuleType {
-    &ModuleType::JsDynamic
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -241,10 +232,6 @@ impl Module for RscEntryModule {
 
   fn lib_ident(&self, _options: LibIdentOptions) -> Option<Cow<'_, str>> {
     Some(self.lib_ident.as_str().into())
-  }
-
-  fn get_layer(&self) -> Option<&ModuleLayer> {
-    self.layer.as_ref()
   }
 
   async fn build(
@@ -326,7 +313,7 @@ impl Module for RscEntryModule {
 
         let block_modifier = format!("server-entry={server_entry}");
         let block = AsyncDependenciesBlock::new(
-          self.identifier,
+          self.identifier(),
           None,
           Some(&block_modifier),
           block_dependencies,
@@ -349,7 +336,7 @@ impl Module for RscEntryModule {
           .collect::<Vec<_>>();
 
         let block = AsyncDependenciesBlock::new(
-          self.identifier,
+          self.identifier(),
           None,
           None,
           dependencies,
@@ -365,7 +352,7 @@ impl Module for RscEntryModule {
           self.is_server_side_rendering,
         );
         let block = AsyncDependenciesBlock::new(
-          self.identifier,
+          self.identifier(),
           None,
           None,
           vec![Box::new(dep) as Box<dyn Dependency>],

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -35,7 +35,7 @@ use crate::{
 pub struct RscEntryModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
-  meta: ModuleMeta,
+  meta: Box<ModuleMeta>,
   lib_ident: String,
   client_modules: Vec<ClientModuleImport>,
   root_client_modules: Vec<ClientModuleImport>,
@@ -46,7 +46,7 @@ pub struct RscEntryModule {
   name: Arc<str>,
   /// When true, client modules are loaded eagerly (not as code-split points).
   is_server_side_rendering: bool,
-  state: ModuleState,
+  state: Box<ModuleState>,
 }
 
 impl RscEntryModule {
@@ -76,7 +76,7 @@ impl RscEntryModule {
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
-      meta: ModuleMeta::new(identifier, ModuleType::JsDynamic, layer),
+      meta: Box::new(ModuleMeta::new(identifier, ModuleType::JsDynamic, layer)),
       lib_ident,
       client_modules,
       root_client_modules,
@@ -84,14 +84,14 @@ impl RscEntryModule {
       css_imports_by_server_entry,
       name,
       is_server_side_rendering,
-      state: ModuleState::new(
+      state: Box::new(ModuleState::new(
         BuildInfo {
           strict: true,
           top_level_declarations: Some(FxHashSet::default()),
           ..Default::default()
         },
         BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
-      ),
+      )),
       source_map_kind: SourceMapKind::empty(),
     }
   }

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rspack_collections::{IdentifierMap, IdentifierSet};
+use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_core::{
   BuildModuleGraphArtifact, Compilation, DependenciesBlock, Dependency, DependencyId,
   DependencyTemplate, ExportsInfoArtifact, ExternalModule, ImportPhase, InitFragmentExt,
@@ -51,7 +51,7 @@ pub fn cutout_star_re_export_externals(
 
       if dep.as_any().is::<ESMImportSideEffectDependency>() {
         side_effects_deps_by_module
-          .entry(external_module.id)
+          .entry(external_module.identifier())
           .or_default()
           .push(*dep_id);
       } else if let Some(esm_export_dep) = dep
@@ -61,7 +61,7 @@ pub fn cutout_star_re_export_externals(
         && esm_export_dep.other_star_exports.is_some()
       {
         *star_export_deps_by_module
-          .entry(external_module.id)
+          .entry(external_module.identifier())
           .or_insert(0) += 1;
 
         connections_to_disable.insert(*dep_id);


### PR DESCRIPTION
## Summary

Introduce shared `ModuleMeta` and `ModuleState` containers for regular module implementations.

- `ModuleMeta` now stores stable, frequently-read module metadata such as identifier, module type, and layer.
- `ModuleState` now stores build-time mutable state such as factory metadata, build info, and build meta.
- Common `Module` and `Identifiable` accessors now expand through `impl_module_meta_info!(meta, state)` and `impl_module_identifier!(meta)`.
- Migrated core modules plus DLL, extract CSS, lazy compilation, RSC, and Module Federation module implementations.

## Example

Before this refactor, modules such as `NormalModule`, `RawModule`, and Module Federation modules each repeated fields like `identifier`, `module_type`, `factory_meta`, `build_info`, and `build_meta`, then repeated nearly identical trait accessor implementations.

After this refactor, those modules store shared metadata and state as `meta: ModuleMeta` and `state: ModuleState`, and module code updates build data through accessors such as `self.build_info_mut().hash = ...` and `self.build_meta_mut().set_exports_type(...)`. This keeps future state movement localized to `ModuleState` instead of touching every module implementation.

## Notes

`ConcatenatedModule` keeps its custom implementation because its build metadata is still proxied through `root_module_ctxt`, so it does not fit the same direct `ModuleState` shape yet.

## Validation

- `cargo fmt --all`
- `cargo check -p rspack_core -p rspack_plugin_dll -p rspack_plugin_extract_css -p rspack_plugin_lazy_compilation -p rspack_plugin_rsc -p rspack_plugin_mf -p rspack_plugin_rslib`

---
_by OpenAI Codex_