### PR TITLE
chore: update napi-rs dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.11.1"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 
 [[package]]
 name = "darling"
@@ -2774,13 +2774,13 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.6"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+checksum = "c0c00e5dfe26391abeed44a9c41ae583c3045694d6ae865e2019826869dd5aa0"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "ctor 0.11.1",
+ "ctor 1.0.7",
  "futures",
  "napi-build",
  "napi-sys",
@@ -2793,18 +2793,18 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.5"
+version = "3.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+checksum = "d4ba572deef53e2c386759a8c2014175a62679d74ff83adc205c8bc0e0285727"
 dependencies = [
  "convert_case 0.11.0",
- "ctor 0.11.1",
+ "ctor 1.0.7",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -2813,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.4"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+checksum = "ddd961eb2aa8965e3f29722d754f3a86907eb1984e2fbcbe3fe87b9a02d6bfba"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -2826,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+checksum = "1f5bcdf71abd3a50d00b49c1c2c75251cb3c913777d6139cd37dabc093a5e400"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,9 +122,9 @@ xxhash-rust         = { version = "0.8.15", default-features = false }
 allocative = { package = "rspack-allocative", version = "0.3.5", default-features = false, features = ["camino", "dashmap", "hashbrown", "indexmap", "tokio", "once_cell", "ustr", "atomic_refcell"] }
 
 # Pinned
-napi        = { version = "3.8.6", default-features = false }
-napi-build  = { version = "2.3.1", default-features = false }
-napi-derive = { version = "3.5.5", default-features = false }
+napi        = { version = "3.10.1", default-features = false }
+napi-build  = { version = "2.3.2", default-features = false }
+napi-derive = { version = "3.5.9", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }


### PR DESCRIPTION
## Summary

- update the pinned Rust napi-rs crates to the latest versions: `napi` 3.10.1, `napi-build` 2.3.2, and `napi-derive` 3.5.9
- refresh related transitive lockfile entries for `napi-sys`, `napi-derive-backend`, and `ctor`

## Example

For native binding builds, this keeps Rspack aligned with the latest napi-rs runtime and macro codegen. For example, generated binding code now resolves against `napi-derive` 3.5.9 and the corresponding `napi-derive-backend` 5.1.1 instead of mixing older lockfile entries with newer manifest constraints.

## Validation

- Confirmed npm-side `@napi-rs/cli` 3.7.2 and `@napi-rs/wasm-runtime` 1.1.6 are already latest.
- `pnpm install --lockfile-only` was attempted with `pnpm@11.8.0`, but the newer `emnapi` 1.11.2 packages are blocked by the repository `minimumReleaseAge` policy, so no JS dependency changes were kept.
- `cargo metadata --locked` was attempted, but cargo repeatedly stalled while updating the crates.io index in this environment. The Rust lockfile updates were matched against crates.io API metadata and checksums.

---
_by OpenAI Codex_