### PR TITLE
perf: avoid runtime module async wrappers

### DIFF
--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -3,9 +3,7 @@ use rspack_hash::RspackHasher;
 use rustc_hash::FxHashSet;
 
 use super::*;
-use crate::{
-  ModuleCodeGenerationContext, cache::Cache, compilation::pass::PassExt, logger::Logger,
-};
+use crate::{cache::Cache, compilation::pass::PassExt, logger::Logger};
 
 pub struct ChunkHashResult {
   pub hash: RspackHashDigest,
@@ -177,7 +175,13 @@ pub async fn create_hash(
         let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
         s.spawn(|(compilation, runtime_module_identifier)| async {
           let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
-          let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+          let digest = crate::runtime_module_get_runtime_hash(
+            runtime_module.as_ref(),
+            runtime_module.common(),
+            compilation,
+            None,
+          )
+          .await?;
           Ok((*runtime_module_identifier, digest))
         });
       })
@@ -352,7 +356,13 @@ pub async fn create_hash(
           let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
           s.spawn(|(compilation, runtime_module_identifier)| async {
             let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
-            let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+            let digest = crate::runtime_module_get_runtime_hash(
+              runtime_module.as_ref(),
+              runtime_module.common(),
+              compilation,
+              None,
+            )
+            .await?;
             Ok((*runtime_module_identifier, digest))
           });
         })
@@ -419,7 +429,13 @@ pub async fn create_hash(
     {
       let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
       if runtime_module.full_hash() || runtime_module.dependent_hash() {
-        let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+        let digest = crate::runtime_module_get_runtime_hash(
+          runtime_module.as_ref(),
+          runtime_module.common(),
+          compilation,
+          None,
+        )
+        .await?;
         compilation
           .runtime_modules_hash
           .insert(*runtime_module_identifier, digest);
@@ -489,19 +505,12 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
         let s = unsafe { token.used((compilation_ref, runtime_module_identifier, runtime_module)) };
         s.spawn(
           |(compilation, runtime_module_identifier, runtime_module)| async {
-            let mut runtime_template = compilation.runtime_template.create_module_code_template();
-            let mut code_generation_context = ModuleCodeGenerationContext {
+            let source = crate::runtime_module_get_generated_code(
+              runtime_module.as_ref(),
+              runtime_module.common(),
               compilation,
-              runtime: None,
-              concatenation_scope: None,
-              runtime_template: &mut runtime_template,
-            };
-            let result = runtime_module
-              .code_generation(&mut code_generation_context)
-              .await?;
-            let source = result
-              .get(&SourceType::Runtime)
-              .expect("should have source");
+            )
+            .await?;
             Ok((*runtime_module_identifier, source.clone()))
           },
         )

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -511,7 +511,7 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
               compilation,
             )
             .await?;
-            Ok((*runtime_module_identifier, source.clone()))
+            Ok((*runtime_module_identifier, source))
           },
         )
       })

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -511,7 +511,7 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
               compilation,
             )
             .await?;
-            Ok((*runtime_module_identifier, source))
+            Ok((*runtime_module_identifier, source.clone()))
           },
         )
       })

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -244,6 +244,7 @@ pub trait NamedRuntimeModule {
 }
 
 pub trait CustomSourceRuntimeModule {
+  fn common(&self) -> &RuntimeModuleCommon;
   fn set_custom_source(&mut self, source: String);
   fn get_custom_source(&self) -> Option<String>;
   fn get_constructor_name(&self) -> String;

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -111,8 +111,8 @@ impl RuntimeModuleCommon {
     self.custom_source = Some(source);
   }
 
-  pub fn get_custom_source(&self) -> Option<String> {
-    self.custom_source.clone()
+  pub fn get_custom_source(&self) -> Option<&str> {
+    self.custom_source.as_deref()
   }
 
   pub fn get_source_map_kind(&self) -> &SourceMapKind {
@@ -225,7 +225,7 @@ pub trait RuntimeModule:
     context: &RuntimeModuleGenerateContext<'_>,
   ) -> rspack_error::Result<String> {
     if let Some(custom_source) = self.get_custom_source() {
-      Ok(custom_source)
+      Ok(custom_source.to_owned())
     } else {
       self.generate(context).await
     }
@@ -246,7 +246,7 @@ pub trait NamedRuntimeModule {
 pub trait CustomSourceRuntimeModule {
   fn common(&self) -> &RuntimeModuleCommon;
   fn set_custom_source(&mut self, source: String);
-  fn get_custom_source(&self) -> Option<String>;
+  fn get_custom_source(&self) -> Option<&str>;
   fn get_constructor_name(&self) -> String;
 }
 

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -69,6 +69,10 @@ pub fn impl_runtime_module(
     }
 
     impl #impl_generics ::rspack_core::CustomSourceRuntimeModule for #name #ty_generics #where_clause {
+      fn common(&self) -> &::rspack_core::RuntimeModuleCommon {
+        &self.common
+      }
+
       fn set_custom_source(&mut self, source: String) -> () {
         self.common.set_custom_source(source);
       }

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -76,7 +76,7 @@ pub fn impl_runtime_module(
       fn set_custom_source(&mut self, source: String) -> () {
         self.common.set_custom_source(source);
       }
-      fn get_custom_source(&self) -> Option<String> {
+      fn get_custom_source(&self) -> Option<&str> {
         self.common.get_custom_source()
       }
       fn get_constructor_name(&self) -> String {


### PR DESCRIPTION
## Summary

This PR reduces overhead in runtime-module hashing and code-generation paths.

- Calls `runtime_module_get_runtime_hash` directly for runtime-module hash updates instead of going through `Module::get_runtime_hash`.
- Calls `runtime_module_get_generated_code` directly during runtime-module code generation instead of constructing a generic module code-generation context and extracting `SourceType::Runtime` from the result map.
- Adds `CustomSourceRuntimeModule::common()` through the runtime-module derive macro so these direct helpers can reuse the existing `RuntimeModuleCommon` state.
- Changes `get_custom_source()` to return a borrowed `&str`, avoiding an intermediate `String` clone on custom runtime source checks and keeping ownership conversion at the actual source-generation boundary.

This path scales with the number of runtime modules processed during `create_hash`, including parallel runtime-module hash work and runtime module code generation. The change is deliberately narrow: it removes boxed async trait-wrapper/result-map overhead and avoids one avoidable custom-source clone while preserving the same runtime-module helper functions used by the existing module implementation.

Expected impact: lower CPU overhead and less temporary allocation in full-hash creation and custom runtime source handling for builds with many runtime modules.

Benchmark notes:

- Local focused CodSpeed-compatible compilation-stage benchmark `rust@create_full_hash` improved from `8.0172 ms` to `4.0416 ms` median (`-52.204%`, `p < 0.05`) in simulation mode before the custom-source borrowing follow-up.
- Latest PR Rust Bench ran `cargo-codspeed@4.4.1` in simulation mode and measured `xtask/benchmark/stages/create_full_hash.rs::stage::bench::rust@create_full_hash` under Callgrind/Valgrind.
- Latest CodSpeed PR report for commit `abb314c`: "Merging this PR will not alter performance" with `43` untouched benchmarks and `47` skipped benchmarks; no performance regressions were reported.
- Latest Rust Bench run hash: `f279ebf4dccd0ac4cb064120deb221d81fac594003af8528f58bbd0d30c3d524`.
- Latest Rust Bench job uploaded Valgrind artifact `codspeed-valgrind-tmp-x86_64-unknown-linux-gnu`; artifact ID `8089510776`, final size `19060346` bytes.
- An experimental follow-up that removed one extra generated-source clone was reverted because CodSpeed reported a `rust@create_concatenate_module` regression on that head.

## Related links

- Optimization reference: https://tweedegolf.nl/en/blog/235/debloat-your-async-rust/
- Latest PR Rust Bench: https://github.com/web-infra-dev/rspack/actions/runs/28732933374/job/85201875448
- CodSpeed report: https://app.codspeed.io/web-infra-dev/rspack/branches/perf%2Fruntime-module-async-wrappers
- Latest Ecosystem Benchmark: https://github.com/web-infra-dev/rspack/actions/runs/28727100640

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
