### PR TITLE
fix(binding): keep path data chunk compatible

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1020,7 +1020,13 @@ export interface JsPathData {
   runtime?: string
   url?: string
   id?: string
-  chunk?: Chunk
+  chunk?: Chunk | JsPathDataChunkLike
+}
+
+export interface JsPathDataChunkLike {
+  id?: string | number
+  name?: string
+  hash?: string
 }
 
 export interface JsResolveData {

--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, ptr::NonNull};
 
 use napi::{
   Either, Env, JsString,
-  bindgen_prelude::{Either3, FromNapiValue, Object, ToNapiValue},
+  bindgen_prelude::{Either3, FromNapiValue, Object, ToNapiValue, TypeName, ValidateNapiValue},
   sys,
 };
 use napi_derive::napi;
@@ -39,7 +39,7 @@ impl Chunk {
       Ok((compilation, chunk))
     } else {
       Err(napi::Error::from_reason(format!(
-        "Unable to access chunk with id = {:?} now. The module have been removed on the Rust side.",
+        "Unable to access chunk with ukey = {:?} now. The chunk has been removed on the Rust side.",
         self.chunk_ukey
       )))
     }
@@ -282,18 +282,6 @@ pub struct ChunkWrapper {
 
 unsafe impl Send for ChunkWrapper {}
 
-impl FromNapiValue for ChunkWrapper {
-  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
-    let chunk: &Chunk = unsafe { FromNapiValue::from_napi_value(env, napi_val)? };
-    let compilation = unsafe { chunk.compilation.as_ref() };
-    Ok(Self {
-      chunk_ukey: chunk.chunk_ukey,
-      compilation_id: compilation.id(),
-      compilation: chunk.compilation,
-    })
-  }
-}
-
 impl ChunkWrapper {
   pub fn new(chunk_ukey: rspack_core::ChunkUkey, compilation: &Compilation) -> Self {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -310,6 +298,56 @@ impl ChunkWrapper {
       let mut refs_by_compilation_id = refs.borrow_mut();
       refs_by_compilation_id.remove(&compilation_id)
     });
+  }
+
+  pub fn as_ref(&self) -> napi::Result<(&'static Compilation, &'static rspack_core::Chunk)> {
+    let compilation = unsafe { self.compilation.as_ref() };
+    if let Some(chunk) = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .get(&self.chunk_ukey)
+    {
+      Ok((compilation, chunk))
+    } else {
+      Err(napi::Error::from_reason(format!(
+        "Unable to access chunk with ukey = {:?} now. The chunk has been removed on the Rust side.",
+        self.chunk_ukey
+      )))
+    }
+  }
+}
+
+impl FromNapiValue for ChunkWrapper {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    unsafe {
+      let chunk: &Chunk = FromNapiValue::from_napi_value(env, napi_val)?;
+      let compilation = chunk.compilation.as_ref();
+
+      Ok(Self {
+        chunk_ukey: chunk.chunk_ukey,
+        compilation_id: compilation.id(),
+        compilation: chunk.compilation,
+      })
+    }
+  }
+}
+
+impl TypeName for ChunkWrapper {
+  fn type_name() -> &'static str {
+    "Chunk"
+  }
+
+  fn value_type() -> napi::ValueType {
+    napi::ValueType::Object
+  }
+}
+
+impl ValidateNapiValue for ChunkWrapper {
+  unsafe fn validate(
+    env: sys::napi_env,
+    napi_val: sys::napi_value,
+  ) -> napi::Result<sys::napi_value> {
+    unsafe { <&Chunk as ValidateNapiValue>::validate(env, napi_val) }
   }
 }
 

--- a/crates/rspack_binding_api/src/path_data.rs
+++ b/crates/rspack_binding_api/src/path_data.rs
@@ -1,6 +1,6 @@
 use napi::{
   Either,
-  bindgen_prelude::{FromNapiValue, Object, ToNapiValue},
+  bindgen_prelude::{FromNapiValue, Object, ToNapiValue, TypeName, ValidateNapiValue},
   sys,
 };
 use napi_derive::napi;
@@ -8,6 +8,55 @@ use napi_derive::napi;
 use crate::{asset::AssetInfo, chunk::ChunkWrapper};
 
 type JsPathDataId = Either<String, u32>;
+
+pub struct JsPathDataIdString(String);
+
+impl JsPathDataIdString {
+  fn as_str(&self) -> &str {
+    self.0.as_str()
+  }
+}
+
+impl FromNapiValue for JsPathDataIdString {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    unsafe { JsPathDataId::from_napi_value(env, napi_val).map(|id| Self(id_to_string(id))) }
+  }
+}
+
+impl TypeName for JsPathDataIdString {
+  fn type_name() -> &'static str {
+    "string | number"
+  }
+
+  fn value_type() -> napi::ValueType {
+    napi::ValueType::Unknown
+  }
+}
+
+impl ValidateNapiValue for JsPathDataIdString {
+  unsafe fn validate(
+    env: sys::napi_env,
+    napi_val: sys::napi_value,
+  ) -> napi::Result<sys::napi_value> {
+    unsafe { JsPathDataId::validate(env, napi_val) }
+  }
+}
+
+impl ToNapiValue for JsPathDataIdString {
+  unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> napi::Result<sys::napi_value> {
+    unsafe { ToNapiValue::to_napi_value(env, val.0) }
+  }
+}
+
+#[napi(object)]
+pub struct JsPathDataChunkLike {
+  #[napi(ts_type = "string | number")]
+  pub id: Option<JsPathDataIdString>,
+  pub name: Option<String>,
+  pub hash: Option<String>,
+}
+
+pub type JsPathDataChunk = Either<ChunkWrapper, JsPathDataChunkLike>;
 
 #[napi(object, object_from_js = false)]
 pub struct JsPathData {
@@ -17,22 +66,24 @@ pub struct JsPathData {
   pub runtime: Option<String>,
   pub url: Option<String>,
   pub id: Option<String>,
-  #[napi(ts_type = "Chunk")]
-  pub chunk: Option<ChunkWrapper>,
+  #[napi(ts_type = "Chunk | JsPathDataChunkLike")]
+  pub chunk: Option<JsPathDataChunk>,
 }
 
 impl JsPathData {
   pub fn from_path_data(path_data: rspack_core::PathData) -> JsPathData {
-    Self {
+    let chunk = path_data
+      .chunk
+      .map(|chunk| ChunkWrapper::new(chunk.chunk_ukey, chunk.compilation));
+
+    JsPathData {
       filename: path_data.filename.map(|s| s.to_string()),
       hash: path_data.hash.map(|s| s.to_string()),
       content_hash: path_data.content_hash.map(|s| s.to_string()),
       runtime: path_data.runtime.map(|s| s.to_string()),
       url: path_data.url.map(|s| s.to_string()),
       id: path_data.id.map(|s| s.to_string()),
-      chunk: path_data
-        .chunk
-        .map(|chunk| ChunkWrapper::new(chunk.chunk_ukey, chunk.compilation)),
+      chunk: chunk.map(Either::A),
     }
   }
 
@@ -40,7 +91,15 @@ impl JsPathData {
     &'a self,
     compilation: &'a rspack_core::Compilation,
   ) -> napi::Result<rspack_core::PathData<'a>> {
-    let chunk_ukey = self.chunk.as_ref().map(|chunk| chunk.chunk_ukey);
+    let real_chunk = self.chunk.as_ref().and_then(|chunk| match chunk {
+      Either::A(chunk) => Some(chunk),
+      Either::B(_) => None,
+    });
+    let raw_chunk = self.chunk.as_ref().and_then(|chunk| match chunk {
+      Either::A(_) => None,
+      Either::B(chunk) => Some(chunk),
+    });
+    let chunk_ukey = real_chunk.map(|chunk| chunk.chunk_ukey);
     let chunk = match chunk_ukey {
       Some(chunk_ukey) => {
         Some(
@@ -63,6 +122,13 @@ impl JsPathData {
         compilation.options.output.hash_digest_length,
       )
     });
+    let chunk_name = chunk
+      .and_then(|chunk| chunk.name_for_filename_template())
+      .or_else(|| raw_chunk.and_then(|chunk| chunk.name.as_deref()));
+    let chunk_hash = chunk_hash.or_else(|| raw_chunk.and_then(|chunk| chunk.hash.as_deref()));
+    let chunk_id = chunk
+      .and_then(|chunk| chunk.id().map(|id| id.as_str()))
+      .or_else(|| raw_chunk.and_then(|chunk| chunk.id.as_ref().map(|id| id.as_str())));
 
     Ok(rspack_core::PathData {
       filename: self.filename.as_deref(),
@@ -70,9 +136,9 @@ impl JsPathData {
         chunk_ukey,
         compilation,
       }),
-      chunk_name: chunk.and_then(|chunk| chunk.name_for_filename_template()),
+      chunk_name,
       chunk_hash,
-      chunk_id: chunk.and_then(|chunk| chunk.id().map(|id| id.as_str())),
+      chunk_id,
       module_id: None,
       hash: self.hash.as_deref(),
       content_hash: self.content_hash.as_deref(),
@@ -94,7 +160,7 @@ impl FromNapiValue for JsPathData {
         runtime: object.get::<String>("runtime")?,
         url: object.get::<String>("url")?,
         id: object.get::<JsPathDataId>("id")?.map(id_to_string),
-        chunk: object.get::<ChunkWrapper>("chunk")?,
+        chunk: object.get::<JsPathDataChunk>("chunk")?,
       })
     }
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -385,7 +385,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                 fake_filename
                   .render(
                     PathData::default()
-                      .chunk(*chunk_ukey, compilation)
+                      .chunk(chunk.ukey(), compilation)
                       .chunk_name_optional(chunk.name())
                       .chunk_id_optional(chunk.id().map(|id| id.as_str())),
                     None,
@@ -395,7 +395,6 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
               )
             }),
             PathData::default()
-              .chunk(*chunk_ukey, compilation)
               .chunk_id_optional(chunk_id.as_deref())
               .chunk_hash_optional(chunk_hash.as_deref())
               .chunk_name_optional(chunk_name.as_deref())

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -25,7 +25,8 @@ export type { AssetInfo } from '@rspack/binding';
 import * as liteTapable from '@rspack/lite-tapable';
 import type { Source } from 'webpack-sources';
 import type { EntryOptions, EntryPlugin } from './builtin-plugin';
-import { Chunk } from './Chunk';
+import './Chunk';
+import type { Chunk } from './Chunk';
 import type { ChunkGraph } from './ChunkGraph';
 import type { Compiler } from './Compiler';
 import type { ContextModuleFactory } from './ContextModuleFactory';
@@ -84,8 +85,15 @@ export type PathData = {
   runtime?: string;
   url?: string;
   id?: string | number;
-  chunk?: Chunk;
+  chunk?: Chunk | ChunkPathData;
   contentHashType?: string;
+};
+
+export type ChunkPathData = {
+  id?: string | number;
+  name?: string;
+  hash?: string;
+  contentHash?: Record<string, string> | string;
 };
 
 function normalizePathData(data: PathData = {}): JsPathData {
@@ -101,8 +109,22 @@ function normalizePathData(data: PathData = {}): JsPathData {
     pathData.id = String(data.id);
   }
 
-  if (data.chunk instanceof Chunk) {
-    pathData.chunk = data.chunk;
+  const chunk = data.chunk;
+  if (chunk) {
+    pathData.chunk = chunk;
+  }
+
+  if (chunk && pathData.contentHash === undefined) {
+    const contentHash = chunk.contentHash;
+    if (typeof contentHash === 'string') {
+      pathData.contentHash = contentHash;
+    } else if (
+      data.contentHashType &&
+      contentHash &&
+      typeof contentHash === 'object'
+    ) {
+      pathData.contentHash = contentHash[data.contentHashType];
+    }
   }
 
   return pathData;
@@ -755,33 +777,21 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
   getPath(filename: string, data: PathData = {}) {
     const pathData = normalizePathData(data);
-    if (data.contentHashType && data.chunk?.contentHash) {
-      pathData.contentHash = data.chunk.contentHash[data.contentHashType];
-    }
     return this.#inner.getPath(filename, pathData);
   }
 
   getPathWithInfo(filename: string, data: PathData = {}) {
     const pathData = normalizePathData(data);
-    if (data.contentHashType && data.chunk?.contentHash) {
-      pathData.contentHash = data.chunk.contentHash[data.contentHashType];
-    }
     return this.#inner.getPathWithInfo(filename, pathData);
   }
 
   getAssetPath(filename: string, data: PathData = {}) {
     const pathData = normalizePathData(data);
-    if (data.contentHashType && data.chunk?.contentHash) {
-      pathData.contentHash = data.chunk.contentHash[data.contentHashType];
-    }
     return this.#inner.getAssetPath(filename, pathData);
   }
 
   getAssetPathWithInfo(filename: string, data: PathData = {}) {
     const pathData = normalizePathData(data);
-    if (data.contentHashType && data.chunk?.contentHash) {
-      pathData.contentHash = data.chunk.contentHash[data.contentHashType];
-    }
     return this.#inner.getAssetPathWithInfo(filename, pathData);
   }
 

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -6,6 +6,7 @@ export type {
   Asset,
   AssetInfo,
   Assets,
+  ChunkPathData,
   CompilationParams,
   LogEntry,
   PathData,

--- a/tests/rspack-test/configCases/css-extract/chunk-filename-function/async.css
+++ b/tests/rspack-test/configCases/css-extract/chunk-filename-function/async.css
@@ -1,0 +1,3 @@
+.async {
+  color: red;
+}

--- a/tests/rspack-test/configCases/css-extract/chunk-filename-function/async.js
+++ b/tests/rspack-test/configCases/css-extract/chunk-filename-function/async.js
@@ -1,0 +1,3 @@
+import './async.css';
+
+export const value = 1;

--- a/tests/rspack-test/configCases/css-extract/chunk-filename-function/index.js
+++ b/tests/rspack-test/configCases/css-extract/chunk-filename-function/index.js
@@ -1,0 +1,15 @@
+it('should pass chunk to css extract chunkFilename function', async () => {
+  await expect(
+    import(/* webpackChunkName: "async" */ './async'),
+  ).resolves.toMatchObject({ value: 1 });
+
+  const fs = require('fs');
+  const css = fs.readFileSync(
+    `${__STATS__.outputPath}/expected.async.css`,
+    'utf-8',
+  );
+  const source = fs.readFileSync(`${__STATS__.outputPath}/main.js`, 'utf-8');
+
+  expect(css).toContain('color: red');
+  expect(source).toContain('expected.async.css');
+});

--- a/tests/rspack-test/configCases/css-extract/chunk-filename-function/rspack.config.js
+++ b/tests/rspack-test/configCases/css-extract/chunk-filename-function/rspack.config.js
@@ -1,0 +1,29 @@
+const { CssExtractRspackPlugin } = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  externals: {
+    fs: 'node-commonjs fs',
+  },
+  mode: 'development',
+  target: 'web',
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [CssExtractRspackPlugin.loader, 'css-loader'],
+        type: 'javascript/auto',
+      },
+    ],
+  },
+  plugins: [
+    new CssExtractRspackPlugin({
+      filename: '[name].css',
+      chunkFilename: ({ chunk }) => `expected.${chunk.name}.css`,
+    }),
+  ],
+};

--- a/tests/rspack-test/configCases/filename-template/chunk-instance/index.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-instance/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should hand a real Chunk instance to the filename function and detect the entry chunk", async () => {
+  // The entry chunk was named via `entry-[name].js`, proving the filename
+  // function received a real Chunk instance and detected it as the entry chunk.
+  expect(fs.existsSync(path.resolve(__dirname, "entry-main.js"))).toBe(true);
+
+  // The dynamically imported chunk is not an entry chunk, so it was named via
+  // the `async-[name].js` branch.
+  const mod = await import(/* webpackChunkName: "lazy" */ "./lazy");
+  expect(mod.default).toBe(42);
+  expect(fs.existsSync(path.resolve(__dirname, "async-lazy.js"))).toBe(true);
+});

--- a/tests/rspack-test/configCases/filename-template/chunk-instance/lazy.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-instance/lazy.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/tests/rspack-test/configCases/filename-template/chunk-instance/rspack.config.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-instance/rspack.config.js
@@ -1,0 +1,60 @@
+let sawEntryChunk = false;
+let sawAsyncChunk = false;
+let sawNumberChunkId = false;
+
+function pickName(pathData) {
+  const chunk = pathData.chunk;
+
+  if (!chunk) {
+    return '[name].js';
+  }
+
+  const groupsIterable = chunk.groupsIterable ?? chunk._groupsIterable;
+  if (
+    chunk.constructor?.name !== 'Chunk' ||
+    typeof chunk.getEntryOptions !== 'function' ||
+    typeof groupsIterable?.[Symbol.iterator] !== 'function'
+  ) {
+    throw new Error('pathData.chunk is not a real Chunk instance');
+  }
+  if (typeof chunk.id === 'number') {
+    sawNumberChunkId = true;
+  }
+  const isEntryChunk = [...groupsIterable].some(
+    (group) => group.isInitial() && group.getEntrypointChunk() === chunk,
+  );
+  if (isEntryChunk) {
+    sawEntryChunk = true;
+  } else {
+    sawAsyncChunk = true;
+  }
+  return isEntryChunk ? 'entry-[name].js' : 'async-[name].js';
+}
+
+class AssertChunkPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('AssertChunkPlugin', () => {
+      sawEntryChunk = false;
+      sawAsyncChunk = false;
+      sawNumberChunkId = false;
+    });
+    compiler.hooks.done.tap('AssertChunkPlugin', () => {
+      expect(sawEntryChunk).toBe(true);
+      expect(sawAsyncChunk).toBe(true);
+      expect(sawNumberChunkId).toBe(true);
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: './index.js',
+  output: {
+    filename: pickName,
+    chunkFilename: pickName,
+  },
+  optimization: {
+    chunkIds: 'natural',
+  },
+  plugins: [new AssertChunkPlugin()],
+};

--- a/tests/rspack-test/configCases/filename-template/chunk-instance/test.config.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-instance/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function () {
+		return ["./entry-main.js"];
+	}
+};

--- a/tests/rspack-test/configCases/hooks/compat-path-data-chunk-contenthash/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/compat-path-data-chunk-contenthash/rspack.config.js
@@ -4,14 +4,17 @@ class Plugin {
   apply(compiler) {
     let called = false;
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
-      const p = compilation.getPath('[contenthash]', {
-        contentHash: 'xxx1',
-        chunk: {
-          contentHash: 'xxx2',
-        },
+      compilation.hooks.processAssets.tap(pluginName, () => {
+        const mainChunk = Array.from(compilation.chunks).find(
+          (chunk) => chunk.name === 'main',
+        );
+        const p = compilation.getPath('[contenthash]', {
+          contentHash: 'xxx1',
+          chunk: mainChunk,
+        });
+        called = true;
+        expect(p).toBe('xxx1');
       });
-      called = true;
-      expect(p).toBe('xxx1');
     });
     compiler.hooks.done.tap(pluginName, (stats) => {
       let json = stats.toJson();

--- a/tests/rspack-test/configCases/hooks/get-path-custom-chunk/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/get-path-custom-chunk/rspack.config.js
@@ -22,19 +22,89 @@ class Plugin {
         );
 
         expect(
-          compilation.getPath('[name]-[chunkhash]-[contenthash]', {
+          compilation.getPath('[name]-[chunkhash]', {
             chunk: mainChunk,
-            contentHashType: 'javascript',
           }),
-        ).toBe(`${mainChunk.name}-${mainChunk.renderedHash}-${contentHash}`);
+        ).toBe(`${mainChunk.name}-${mainChunk.renderedHash}`);
+
+        const rawChunkPathData = {
+          name: 'chunkname',
+          id: 'chunkid',
+          hash: 'chunkhash',
+          contentHash: {
+            javascript: 'contenthash',
+          },
+        };
 
         expect(
-          compilation.getPath('[name]', {
+          compilation.getPath('[id]-[name]-[chunkhash]-[contenthash]', {
+            chunk: rawChunkPathData,
+            contentHashType: 'javascript',
+          }),
+        ).toBe('chunkid-chunkname-chunkhash-contenthash');
+
+        expect(
+          compilation.getPath('[name]-[chunkhash]-[contenthash]', {
             chunk: {
-              name: 'main',
+              id: 'chunkid',
+              hash: 'chunkhash',
+              contentHash: {
+                javascript: 'contenthash',
+              },
+            },
+            contentHashType: 'javascript',
+          }),
+        ).toBe('chunkid-chunkhash-contenthash');
+
+        expect(
+          compilation.getPath('[name]-[chunkhash]-[contenthash]', {
+            chunk: {
+              id: 'chunkid',
+              hash: 'chunkhash',
+              contentHash: 'contenthash',
             },
           }),
-        ).toBe('[name]');
+        ).toBe('chunkid-chunkhash-contenthash');
+
+        expect(
+          compilation.getPath('[id]-[name]', {
+            chunk: {
+              id: 42,
+            },
+          }),
+        ).toBe('42-42');
+
+        expect(
+          compilation.getPath('[contenthash]', {
+            contentHash: 'asset-contenthash',
+            chunk: {
+              contentHash: 'chunk-contenthash',
+            },
+          }),
+        ).toBe('asset-contenthash');
+
+        expect(
+          compilation.getAssetPathWithInfo(
+            'static/css/[name].[contenthash].css',
+            {
+              chunk: {
+                name: 'style',
+                hash: 'chunkhash',
+                contentHash: 'contenthash',
+              },
+            },
+          ).path,
+        ).toBe('static/css/style.contenthash.css');
+
+        expect(
+          compilation.getAssetPathWithInfo(
+            'static/css/[name].[contenthash].css',
+            {
+              chunk: rawChunkPathData,
+              contentHashType: 'javascript',
+            },
+          ).path,
+        ).toBe('static/css/chunkname.contenthash.css');
       });
     });
     compiler.hooks.done.tap(pluginName, (stats) => {


### PR DESCRIPTION
## Summary

- keep filename path data compatible with webpack by accepting either a real `Chunk` or a raw chunk path data object in `data.chunk`
- preserve raw chunk `id`, `name`, `hash`, and `contentHash` handling for path template placeholders
- add regression coverage for the rsbuild-style `getAssetPathWithInfo` call with raw chunk path data

## Why

Rsbuild's CSS `?url` path generation calls `compilation.getAssetPathWithInfo` with a plain chunk-like object. Webpack supports this shape through `ChunkPathData`, so Rspack should keep accepting it while also supporting real `Chunk` instances.

## Testing

- `CI=true PATH=/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/tmp/pnpm-11-8-wrapper:$PATH /Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node /Users/bytedance/.cache/node/corepack/pnpm/11.8.0/bin/pnpm.cjs run test -t "configCases/hooks/get-path-custom-chunk"`
- `git diff --check HEAD~1 HEAD`