### PR TITLE
refactor: avoid runtime module iife in rspack mode

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1498,7 +1498,7 @@ impl CompilationRuntimeModule for CompilationRuntimeModuleTap {
           .cow_replace(compilation.runtime_template.runtime_module_prefix(), "")
           .into_owned(),
         stage: module.stage().into(),
-        isolate: module.should_isolate(),
+        isolate: module.should_isolate(compilation.options.experiments.runtime_mode),
       },
       chunk: ChunkWrapper::new(*chunk_ukey, compilation),
     };

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -101,17 +101,19 @@ fn create_execute_runtime_source(
       .get(runtime_id, None)
       .get(&SourceType::JavaScript)
       .expect("runtime module should have runtime source");
+    let should_isolate =
+      runtime_module.should_isolate(compilation.options.experiments.runtime_mode);
     source.push_str(
       &render_runtime_module_source(
         runtime_module.identifier(),
         runtime_module_source.clone(),
-        runtime_module.should_isolate(compilation.options.experiments.runtime_mode),
+        should_isolate,
         compilation
           .options
           .output
           .environment
           .supports_arrow_function(),
-        false,
+        !should_isolate,
       )
       .source()
       .into_string_lossy(),

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -105,12 +105,13 @@ fn create_execute_runtime_source(
       &render_runtime_module_source(
         runtime_module.identifier(),
         runtime_module_source.clone(),
-        runtime_module.should_isolate(),
+        runtime_module.should_isolate(compilation.options.experiments.runtime_mode),
         compilation
           .options
           .output
           .environment
           .supports_arrow_function(),
+        false,
       )
       .source()
       .into_string_lossy(),

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -16,6 +16,7 @@ use tokio::sync::OnceCell;
 use crate::{
   ChunkUkey, CodeGenerationResult, Compilation, Module, ModuleCodeGenerationContext,
   RuntimeCodeTemplate, RuntimeGlobals, RuntimeSpec, RuntimeTemplate, SourceType,
+  runtime_mode::RuntimeMode,
 };
 
 pub struct RuntimeModuleGenerateContext<'a> {
@@ -210,8 +211,8 @@ pub trait RuntimeModule:
     false
   }
   // if wrap iife
-  fn should_isolate(&self) -> bool {
-    true
+  fn should_isolate(&self, runtime_mode: RuntimeMode) -> bool {
+    matches!(runtime_mode, RuntimeMode::Webpack)
   }
   fn template(&self) -> Vec<(String, String)> {
     vec![]

--- a/crates/rspack_core/src/runtime_module_source.rs
+++ b/crates/rspack_core/src/runtime_module_source.rs
@@ -6,6 +6,7 @@ pub fn render_runtime_module_source(
   source: BoxSource,
   should_isolate: bool,
   supports_arrow_function: bool,
+  add_separator: bool,
 ) -> BoxSource {
   let mut sources = ConcatSource::default();
   if source.size() == 0 {
@@ -27,6 +28,8 @@ pub fn render_runtime_module_source(
     } else {
       "\n}();\n"
     }));
+  } else if add_separator {
+    sources.add(RawStringSource::from_static(";\n"));
   }
 
   sources.boxed()

--- a/crates/rspack_plugin_css/src/runtime/css_loading.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading.ejs
@@ -9,7 +9,7 @@ function handleCssComposes(exports, composes) {
 	}
 }
 var loadingAttribute = "data-rspack-loading";
-var loadStylesheet = <%- basicFunction("chunkId, url, done, hmr, fetchPriority") %> {
+var cssLoadStylesheet = <%- basicFunction("chunkId, url, done, hmr, fetchPriority") %> {
 	var link,
 		needAttach,
 		key = "chunk-" + chunkId;

--- a/crates/rspack_plugin_css/src/runtime/css_loading.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading.ejs
@@ -1,4 +1,4 @@
-var uniqueName = "<%- _unique_name %>";
+var cssLoadingUniqueName = "<%- _unique_name %>";
 function handleCssComposes(exports, composes) {
 	for (var i = 0; i < composes.length; i += 3) {
 		var moduleId = composes[i];
@@ -25,7 +25,7 @@ var cssLoadStylesheet = <%- basicFunction("chunkId, url, done, hmr, fetchPriorit
 			if (
 				l.rel == "stylesheet" &&
 				((href && href.startsWith(url)) ||
-					l.getAttribute("data-rspack") == uniqueName + ":" + key)
+					l.getAttribute("data-rspack") == cssLoadingUniqueName + ":" + key)
 			) {
 				link = l;
 				break;

--- a/crates/rspack_plugin_css/src/runtime/css_loading_create_link.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_create_link.ejs
@@ -3,7 +3,7 @@ if (<%- weak(SCRIPT_NONCE) %>) {
   link.setAttribute("nonce", <%- weak(SCRIPT_NONCE) %>);
 }
 <% if (_unique_name != "") { %>
-link.setAttribute("data-rspack", uniqueName + ":" + key);
+link.setAttribute("data-rspack", cssLoadingUniqueName + ":" + key);
 <% } %>
 <% if (_with_fetch_priority) { %>
 if (fetchPriority) {

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_hmr.ejs
@@ -1,28 +1,28 @@
-var oldTags = [];
-var newTags = [];
-var applyHandler = <%- basicFunction("options") %> {
+var cssOldTags = [];
+var cssNewTags = [];
+var cssApplyHandler = <%- basicFunction("options") %> {
 	return {
 		dispose: <%- basicFunction("") %> { },
 		apply: <%- basicFunction("") %> {
-			newTags.forEach(<%- basicFunction("newTag") %> {
+			cssNewTags.forEach(<%- basicFunction("newTag") %> {
 				newTag.sheet.disabled = false;
 			});
-			while (oldTags.length) {
-				var oldTag = oldTags.pop();
+			while (cssOldTags.length) {
+				var oldTag = cssOldTags.pop();
 				if (oldTag.parentNode) oldTag.parentNode.removeChild(oldTag);
 			}
-			while (newTags.length) {
-				newTags.pop();
+			while (cssNewTags.length) {
+				cssNewTags.pop();
 			}
 		}
 	};
 };
-var cssTextKey = <%- basicFunction("link") %> {
+var cssTextKeyOfLink = <%- basicFunction("link") %> {
 	return Array.from(link.sheet.cssRules, <%- returningFunction("r.cssText", "r") %>).join();
 };
 <%- HMR_DOWNLOAD_UPDATE_HANDLERS %>.css = <%- basicFunction("chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList") %> {
 	if (typeof document === 'undefined') return;
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(cssApplyHandler);
 	var seen = {};
 	chunkIds.forEach(<%- basicFunction("chunkId") %> {
 		var filename = <%- GET_CHUNK_CSS_FILENAME %>(chunkId);
@@ -32,11 +32,11 @@ var cssTextKey = <%- basicFunction("link") %> {
 			return;
 		}
 		seen[url] = true;
-		var oldTag = loadStylesheet(chunkId, url);
+		var oldTag = cssLoadStylesheet(chunkId, url);
 		if (!oldTag) return;
 		promises.push(
 			new Promise(<%- basicFunction("resolve, reject") %> {
-				var link = loadStylesheet(
+				var link = cssLoadStylesheet(
 					chunkId,
 					url + (url.indexOf("?") < 0 ? "?" : "&") + "hmr=" + Date.now(),
 					<%- basicFunction("event") %> {
@@ -58,14 +58,14 @@ var cssTextKey = <%- basicFunction("link") %> {
 							reject(error);
 						} else {
 							try {
-								if (cssTextKey(oldTag) == cssTextKey(link)) {
+								if (cssTextKeyOfLink(oldTag) == cssTextKeyOfLink(link)) {
 									if (link.parentNode) link.parentNode.removeChild(link);
 									return resolve();
 								}
 							} catch (e) {}
+							cssOldTags.push(oldTag);
+							cssNewTags.push(link);
 							link.sheet.disabled = true;
-							oldTags.push(oldTag);
-							newTags.push(link);
 							resolve();
 						}
 					},

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_loading.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_loading.ejs
@@ -1,7 +1,7 @@
 <%- ENSURE_CHUNK_HANDLERS %>.css = <%- basicFunction("chunkId, promises, fetchPriority") %> {
 	// css chunk loading
-	var installedChunkData = <%- HAS_OWN_PROPERTY %>(installedChunks, chunkId)
-		? installedChunks[chunkId]
+	var installedChunkData = <%- HAS_OWN_PROPERTY %>(cssInstalledChunks, chunkId)
+		? cssInstalledChunks[chunkId]
 		: undefined;
 	if (installedChunkData !== 0) {
 		// 0 means "already installed".
@@ -13,7 +13,7 @@
 			if (<%- _css_matcher %>) {
 				// setup Promise in chunk cache
 				var promise = new Promise(function (resolve, reject) {
-					installedChunkData = installedChunks[chunkId] = [resolve, reject];
+					installedChunkData = cssInstalledChunks[chunkId] = [resolve, reject];
 				});
 				promises.push((installedChunkData[2] = promise));
 
@@ -22,9 +22,9 @@
 				// create error before stack unwound to get useful stacktrace later
 				var error = new Error();
 				var loadingEnded = function (event) {
-					if (<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId)) {
-						installedChunkData = installedChunks[chunkId];
-						if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+					if (<%- HAS_OWN_PROPERTY %>(cssInstalledChunks, chunkId)) {
+						installedChunkData = cssInstalledChunks[chunkId];
+						if (installedChunkData !== 0) cssInstalledChunks[chunkId] = undefined;
 						if (installedChunkData) {
 							if (event.type !== "load") {
 								var errorType = event && event.type;
@@ -42,16 +42,16 @@
 								error.request = realSrc;
 								installedChunkData[1](error);
 							} else {
-								installedChunks[chunkId] = 0;
+								cssInstalledChunks[chunkId] = 0;
 								installedChunkData[0]();
 							}
 						}
 					}
 				};
 				if (typeof document !== 'undefined') {
-					loadStylesheet(chunkId, url, loadingEnded, undefined, fetchPriority);
+					cssLoadStylesheet(chunkId, url, loadingEnded, undefined, fetchPriority);
 				} else { loadingEnded({ type: 'load' }); }
-			} else installedChunks[chunkId] = 0;
+			} else cssInstalledChunks[chunkId] = 0;
 		}
 	}
 };

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_prefetch.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_prefetch.ejs
@@ -1,6 +1,6 @@
 <%- PREFETCH_CHUNK_HANDLERS %>.s =<%- basicFunction("chunkId") %> {
-  if ((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _css_matcher %> ) {
-    installedChunks[chunkId] = null;
+  if ((!<%- HAS_OWN_PROPERTY %>(cssInstalledChunks, chunkId) || cssInstalledChunks[chunkId] === undefined) && <%- _css_matcher %> ) {
+    cssInstalledChunks[chunkId] = null;
     <% if (_is_neutral_platform) { %>if (typeof document === 'undefined') return;<% } %>
 
     <%- _create_prefetch_link %>

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_preload.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_preload.ejs
@@ -1,6 +1,6 @@
 <%- PRELOAD_CHUNK_HANDLERS %>.s = <%- basicFunction("chunkId") %> {
-  if ((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _css_matcher %>) {
-    installedChunks[chunkId] = null;
+  if ((!<%- HAS_OWN_PROPERTY %>(cssInstalledChunks, chunkId) || cssInstalledChunks[chunkId] === undefined) && <%- _css_matcher %>) {
+    cssInstalledChunks[chunkId] = null;
     <% if (_is_neutral_platform) { %>if (typeof document === 'undefined') return;<% } %>
 
     <%- _create_preload_link %>

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -302,7 +302,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         // One entry initial chunk maybe is other entry dynamic chunk, so here
         // only render chunk without css. See packages/rspack/tests/runtimeCases/runtime/split-css-chunk test.
         source.push_str(&format!(
-          "var installedChunks = {};\n",
+          "var cssInstalledChunks = {};\n",
           &stringify_chunks(&initial_chunk_ids, 0)
         ));
 

--- a/crates/rspack_plugin_esm_library/src/runtime.rs
+++ b/crates/rspack_plugin_esm_library/src/runtime.rs
@@ -154,26 +154,26 @@ impl RuntimeModule for EsmChunkLoadingRuntimeModule {
     chunk_imports.sort_unstable();
 
     Ok(format!(
-      r#"var installedChunks = {{}};
-var chunkMap = {{
+      r#"var esmInstalledChunks = {{}};
+var esmChunkMap = {{
 {chunk_imports}
 }};
 {ensure_chunk_handlers}.j = function(chunkId, promises) {{
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {{
 		promises.push(installedChunkData);
 		return;
 	}}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {{
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}}, function(error) {{
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	}});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 }};
 "#,

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -142,6 +142,10 @@ impl RuntimeModule for CssLoadingRuntimeModule {
     RuntimeModuleStage::Attach
   }
 
+  fn should_isolate(&self, _runtime_mode: rspack_core::runtime_mode::RuntimeMode) -> bool {
+    true
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading.ejs
@@ -1,5 +1,5 @@
 if (typeof document === "undefined") return;
-var createStylesheet = function (
+var extractCssCreateStylesheet = function (
 	chunkId, fullhref, oldTag, resolve, reject, fetchPriority
 ) {
 	<%- _create_link %>
@@ -23,7 +23,7 @@ var createStylesheet = function (
 	<%- _insert %>
 	return linkTag;
 }
-var findStylesheet = function (href, fullhref) {
+var extractCssFindStylesheet = function (href, fullhref) {
 	var existingLinkTags = document.getElementsByTagName("link");
 	for (var i = 0; i < existingLinkTags.length; i++) {
 		var tag = existingLinkTags[i];
@@ -42,11 +42,11 @@ var findStylesheet = function (href, fullhref) {
 	}
 }
 
-var loadStylesheet = function (chunkId, fetchPriority) {
+var extractCssLoadStylesheet = function (chunkId, fetchPriority) {
 	return new Promise(function (resolve, reject) {
 		var href = <%- REQUIRE_SCOPE %>.miniCssF(chunkId);
 		var fullhref = <%- PUBLIC_PATH %> + href;
-		if (findStylesheet(href, fullhref)) return resolve();
-		createStylesheet(chunkId, fullhref, null, resolve, reject, fetchPriority);
+		if (extractCssFindStylesheet(href, fullhref)) return resolve();
+		extractCssCreateStylesheet(chunkId, fullhref, null, resolve, reject, fetchPriority);
 	})
 }

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_hmr.ejs
@@ -1,24 +1,24 @@
-var oldTags = [];
-var newTags = [];
-var cssTextKey = function (link) {
+var extractCssOldTags = [];
+var extractCssNewTags = [];
+var extractCssTextKey = function (link) {
 	return Array.from(link.sheet.cssRules, function (r) { return r.cssText; }).join();
 }
-var applyHandler = function (options) {
+var extractCssApplyHandler = function (options) {
 	return {
 		dispose: function () {},
 		apply: function () {
-			for (var i = 0; i < newTags.length; i++) newTags[i].sheet.disabled = false;
-			for (var i = 0; i < oldTags.length; i++) {
-				var oldTag = oldTags[i];
+			for (var i = 0; i < extractCssNewTags.length; i++) extractCssNewTags[i].sheet.disabled = false;
+			for (var i = 0; i < extractCssOldTags.length; i++) {
+				var oldTag = extractCssOldTags[i];
 				if (oldTag.parentNode) oldTag.parentNode.removeChild(oldTag);
 			}
-			oldTags.length = 0;
-			newTags.length = 0;
+			extractCssOldTags.length = 0;
+			extractCssNewTags.length = 0;
 		}
 	}
 }
 <%- HMR_DOWNLOAD_UPDATE_HANDLERS %>.miniCss = function (chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(extractCssApplyHandler);
 	var seen = {};
 	chunkIds.forEach(function (chunkId) {
 		var href = <%- REQUIRE_SCOPE %>.miniCssF(chunkId);
@@ -26,10 +26,10 @@ var applyHandler = function (options) {
 		var fullhref = <%- PUBLIC_PATH %> + href;
 		if (seen[fullhref]) return;
 		seen[fullhref] = true;
-		var oldTag = findStylesheet(href, fullhref);
+		var oldTag = extractCssFindStylesheet(href, fullhref);
 		if (!oldTag) return;
 		promises.push(new Promise(function (resolve, reject) {
-			var tag = createStylesheet(
+			var tag = extractCssCreateStylesheet(
 				chunkId,
 
 				/**
@@ -40,14 +40,14 @@ var applyHandler = function (options) {
 				oldTag,
 				function () {
 					try {
-						if (cssTextKey(oldTag) === cssTextKey(tag)) {
+						if (extractCssTextKey(oldTag) === extractCssTextKey(tag)) {
 							if (tag.parentNode) tag.parentNode.removeChild(tag);
 							return resolve();
 						}
 					} catch (e) {}
 					tag.sheet.disabled = true;
-					oldTags.push(oldTag);
-					newTags.push(tag);
+					extractCssOldTags.push(oldTag);
+					extractCssNewTags.push(tag);
 					resolve();
 				},
 				reject

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_loading.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_loading.ejs
@@ -8,7 +8,7 @@ var installedCssChunks = {
 	if (installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId])
 	else if (installedCssChunks[chunkId] !== 0 && cssChunks[chunkId])
 		promises.push(
-			installedCssChunks[chunkId] = loadStylesheet(chunkId, fetchPriority).then(
+			installedCssChunks[chunkId] = extractCssLoadStylesheet(chunkId, fetchPriority).then(
 				function () {
 					installedCssChunks[chunkId] = 0;
 				},

--- a/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
+++ b/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
@@ -1,5 +1,5 @@
 var currentModuleData = {};
-var installedModules = <%- MODULE_CACHE %>;
+var hmrInstalledModules = <%- MODULE_CACHE %>;
 
 // module and require creation
 var currentChildModule;
@@ -33,12 +33,12 @@ var queuedInvalidatedModules;
 <%- define(HMR_INVALIDATE_MODULE_HANDLERS) %> = {};
 
 function createRequire(require, moduleId<% if (_is_rspack_runtime_mode) { %>, context<% } %>) {
-	var me = installedModules[moduleId];
+	var me = hmrInstalledModules[moduleId];
 	if (!me) return require;
 	var fn = function (request) {
 		if (me.hot.active) {
-			if (installedModules[request]) {
-				var parents = installedModules[request].parents;
+			if (hmrInstalledModules[request]) {
+				var parents = hmrInstalledModules[request].parents;
 				if (parents.indexOf(moduleId) === -1) {
 					parents.push(moduleId);
 				}

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -398,8 +398,8 @@ pub(crate) async fn render_runtime_module_sources(
   chunk_ukey: &ChunkUkey,
   runtime_template: &ChunkCodeTemplate,
   reject_custom_runtime_modules: bool,
-  isolate_runtime_modules: bool,
 ) -> Result<Vec<RuntimeModuleSourceItem>> {
+  let runtime_mode = compilation.options.experiments.runtime_mode;
   let runtime_module_sources = rspack_parallel::scope::<_, Result<_>>(|token| {
     compilation
       .build_chunk_graph_artifact
@@ -469,11 +469,13 @@ pub(crate) async fn render_runtime_module_sources(
                 }
               }
             };
+            let should_isolate = module.should_isolate(runtime_mode);
             let sources = render_runtime_module_source(
               module.identifier(),
               source,
-              isolate_runtime_modules && module.should_isolate(),
+              should_isolate,
               supports_arrow_function,
+              matches!(runtime_mode, RuntimeMode::Rspack) && !should_isolate,
             );
             Ok((sources, generated_requirements, context_requirements))
           },
@@ -494,7 +496,7 @@ async fn render_webpack_runtime_modules(
   runtime_template: &ChunkCodeTemplate,
 ) -> Result<BoxSource> {
   let runtime_module_sources =
-    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, false, true).await?;
+    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, false).await?;
   let mut sources = ConcatSource::default();
 
   for (runtime_module_source, _, _) in runtime_module_sources {

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -391,7 +391,7 @@ pub async fn render_runtime_modules(
   }
 }
 
-pub(crate) type RuntimeModuleSourceItem = (BoxSource, RuntimeGlobals, RuntimeGlobals);
+pub(crate) type RuntimeModuleSourceItem = (BoxSource, RuntimeGlobals, RuntimeGlobals, bool);
 
 pub(crate) async fn render_runtime_module_sources(
   compilation: &Compilation,
@@ -423,6 +423,7 @@ pub(crate) async fn render_runtime_module_sources(
                 ConcatSource::default().boxed(),
                 RuntimeGlobals::default(),
                 RuntimeGlobals::default(),
+                false,
               ));
             }
             let runtime_requirements = module.runtime_requirements(compilation);
@@ -470,6 +471,8 @@ pub(crate) async fn render_runtime_module_sources(
               }
             };
             let should_isolate = module.should_isolate(runtime_mode);
+            let needs_top_level = matches!(runtime_mode, RuntimeMode::Rspack)
+              && module.get_constructor_name() == "ExportRequireRuntimeModule";
             let sources = render_runtime_module_source(
               module.identifier(),
               source,
@@ -477,7 +480,12 @@ pub(crate) async fn render_runtime_module_sources(
               supports_arrow_function,
               matches!(runtime_mode, RuntimeMode::Rspack) && !should_isolate,
             );
-            Ok((sources, generated_requirements, context_requirements))
+            Ok((
+              sources,
+              generated_requirements,
+              context_requirements,
+              needs_top_level,
+            ))
           },
         );
       })
@@ -499,7 +507,7 @@ async fn render_webpack_runtime_modules(
     render_runtime_module_sources(compilation, chunk_ukey, runtime_template, false).await?;
   let mut sources = ConcatSource::default();
 
-  for (runtime_module_source, _, _) in runtime_module_sources {
+  for (runtime_module_source, _, _, _) in runtime_module_sources {
     sources.add(runtime_module_source);
   }
 

--- a/crates/rspack_plugin_javascript/src/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/runtime_context.rs
@@ -86,11 +86,7 @@ pub async fn render_runtime_chunk_runtime_modules(
     hmr_state_keys.push(key);
   }
 
-  let isolate = has_modules && !compilation.options.output.module;
-  if isolate {
-    sources.add(RawStringSource::from("(function() {\n".to_string()));
-  }
-
+  let isolate = has_modules;
   let render_runtime_global = |runtime_global: RuntimeGlobals| {
     if runtime_global == RuntimeGlobals::REQUIRE {
       Some(runtime_template.render_runtime_variable(&RuntimeVariable::Require))
@@ -116,7 +112,8 @@ pub async fn render_runtime_chunk_runtime_modules(
       None
     }
   };
-  sources.add(RawStringSource::from(
+  let mut wrapped_sources = ConcatSource::default();
+  wrapped_sources.add(RawStringSource::from(
     metadata.render_lexical_declarations(Some(&render_runtime_global)),
   ));
   if metadata
@@ -124,13 +121,17 @@ pub async fn render_runtime_chunk_runtime_modules(
     .intersects(*HMR_RUNTIME_STATE_GLOBALS)
   {
     for key in &hmr_state_keys {
-      sources.add(RawStringSource::from(format!("var hmrS_{key};\n")));
+      wrapped_sources.add(RawStringSource::from(format!("var hmrS_{key};\n")));
     }
   }
-  for (runtime_module_source, generated_requirements, context_requirements) in
+  for (runtime_module_source, generated_requirements, context_requirements, needs_top_level) in
     runtime_module_sources
   {
-    sources.add(runtime_module_source);
+    if isolate && needs_top_level {
+      sources.add(runtime_module_source);
+    } else {
+      wrapped_sources.add(runtime_module_source);
+    }
     let mut context_fields = metadata.context_fields().intersection(context_requirements);
     if is_hmr_runtime {
       context_fields.insert(generated_requirements.renderable_require_scope());
@@ -150,7 +151,7 @@ pub async fn render_runtime_chunk_runtime_modules(
       if setters.contains(runtime_global)
         && (is_hmr_runtime || LIVE_BINDING_CONTEXT_GLOBALS.contains(runtime_global))
       {
-        sources.add(RawStringSource::from(format!(
+        wrapped_sources.add(RawStringSource::from(format!(
           "Object.defineProperty({}, {}, {{ configurable: true, get: function() {{ return {}; }}, set: function(value) {{ {} = value; }} }});\n",
           runtime_context,
           rspack_util::json_stringify(key),
@@ -158,7 +159,7 @@ pub async fn render_runtime_chunk_runtime_modules(
           lexical_name
         )));
       } else {
-        sources.add(RawStringSource::from(format!(
+        wrapped_sources.add(RawStringSource::from(format!(
           "{}{} = {};\n",
           runtime_context,
           property_access([key], 0),
@@ -168,7 +169,11 @@ pub async fn render_runtime_chunk_runtime_modules(
     }
   }
   if isolate {
+    sources.add(RawStringSource::from("(function() {\n".to_string()));
+    sources.add(wrapped_sources);
     sources.add(RawStringSource::from("\n}).call(this);\n".to_string()));
+  } else {
+    sources.add(wrapped_sources);
   }
 
   Ok(sources.boxed())
@@ -214,7 +219,7 @@ pub async fn render_chunk_runtime_modules(
     metadata.render_lexical_declarations(Some(&render_runtime_global)),
   ));
 
-  for (runtime_module_source, generated_requirements, context_requirements) in
+  for (runtime_module_source, generated_requirements, context_requirements, _) in
     runtime_module_sources
   {
     sources.add(runtime_module_source);
@@ -328,7 +333,7 @@ pub async fn render_hot_update_chunk_runtime_modules(
     "var {require}={runtime_context}.r,{modules}={runtime_context}.m,{module_cache}={runtime_context}.c;\n"
   )));
 
-  for (runtime_module_source, generated_requirements, _) in runtime_module_sources {
+  for (runtime_module_source, generated_requirements, _, _) in runtime_module_sources {
     sources.add(runtime_module_source);
     let mut context_fields = metadata
       .context_fields()

--- a/crates/rspack_plugin_javascript/src/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/runtime_context.rs
@@ -44,7 +44,7 @@ pub async fn render_runtime_chunk_runtime_modules(
   runtime_template: &ChunkCodeTemplate,
 ) -> Result<BoxSource> {
   let runtime_module_sources =
-    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true, true).await?;
+    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true).await?;
   let mut sources = ConcatSource::default();
   if runtime_module_sources.is_empty() {
     return Ok(sources.boxed());
@@ -180,7 +180,7 @@ pub async fn render_chunk_runtime_modules(
   runtime_template: &ChunkCodeTemplate,
 ) -> Result<BoxSource> {
   let runtime_module_sources =
-    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true, true).await?;
+    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true).await?;
   let mut sources = ConcatSource::default();
   if runtime_module_sources.is_empty() {
     return Ok(sources.boxed());
@@ -264,7 +264,7 @@ pub async fn render_hot_update_chunk_runtime_modules(
   runtime_template: &ChunkCodeTemplate,
 ) -> Result<BoxSource> {
   let runtime_module_sources =
-    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true, false).await?;
+    render_runtime_module_sources(compilation, chunk_ukey, runtime_template, true).await?;
   let mut sources = ConcatSource::default();
   if runtime_module_sources.is_empty() {
     return Ok(sources.boxed());

--- a/crates/rspack_plugin_mf/src/sharing/consumesCommon.ejs
+++ b/crates/rspack_plugin_mf/src/sharing/consumesCommon.ejs
@@ -519,4 +519,4 @@ var resolveHandler = function(data) {
 	if (fallback) return function() { return loadFallback.apply(null, args); }
 	return function() { return load.apply(null, args); }
 };
-var installedModules = {};
+var consumeSharedInstalledModules = {};

--- a/crates/rspack_plugin_mf/src/sharing/consumesInitial.ejs
+++ b/crates/rspack_plugin_mf/src/sharing/consumesInitial.ejs
@@ -1,7 +1,7 @@
 <%- REQUIRE_SCOPE %>.consumesLoadingData.initialConsumes.forEach(function(id) {
   <%- MODULE_FACTORIES %>[id] = function(module) {
     // Handle case when module is used sync
-    installedModules[id] = 0;
+    consumeSharedInstalledModules[id] = 0;
     delete <%- MODULE_CACHE %>[id];
     var factory = resolveHandler(<%- REQUIRE_SCOPE %>.consumesLoadingData.moduleIdToConsumeDataMapping[id])();
     if (typeof factory !== "function")

--- a/crates/rspack_plugin_mf/src/sharing/consumesLoading.ejs
+++ b/crates/rspack_plugin_mf/src/sharing/consumesLoading.ejs
@@ -3,16 +3,16 @@
 	var chunkMapping = <%- REQUIRE_SCOPE %>.consumesLoadingData.chunkMapping;
 	if(<%- HAS_OWN_PROPERTY %>(chunkMapping, chunkId)) {
 		chunkMapping[chunkId].forEach(function(id) {
-			if(<%- HAS_OWN_PROPERTY %>(installedModules, id)) return promises.push(installedModules[id]);
+			if(<%- HAS_OWN_PROPERTY %>(consumeSharedInstalledModules, id)) return promises.push(consumeSharedInstalledModules[id]);
 			var onFactory = function(factory) {
-				installedModules[id] = 0;
+				consumeSharedInstalledModules[id] = 0;
 				<%- MODULE_FACTORIES %>[id] = function(module) {
 					delete <%- MODULE_CACHE %>[id];
 					module.exports = factory();
 				}
 			};
 			var onError = function(error) {
-				delete installedModules[id];
+				delete consumeSharedInstalledModules[id];
 				<%- MODULE_FACTORIES %>[id] = function(module) {
 					delete <%- MODULE_CACHE %>[id];
 					throw error;
@@ -21,7 +21,7 @@
 			try {
 				var promise = resolveHandler(moduleIdToConsumeDataMapping[id])();
 				if(promise.then) {
-					promises.push(installedModules[id] = promise.then(onFactory)['catch'](onError));
+					promises.push(consumeSharedInstalledModules[id] = promise.then(onFactory)['catch'](onError));
 				} else onFactory(promise);
 			} catch(e) { onError(e); }
 		});

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_runtime_module.rs
@@ -35,6 +35,11 @@ impl RuntimeModule for SharedUsedExportsOptimizerRuntimeModule {
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Attach
   }
+
+  fn should_isolate(&self, _runtime_mode: rspack_core::runtime_mode::RuntimeMode) -> bool {
+    true
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/export_require.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/export_require.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeTemplate,
-  impl_runtime_module,
+  impl_runtime_module, runtime_mode::RuntimeMode,
 };
 
 pub static EXPORT_REQUIRE_RUNTIME_MODULE_ID: &str = "export_webpack_require";
@@ -42,7 +42,7 @@ export {{ {export_temp_name} as {export_name} }};
     ))
   }
 
-  fn should_isolate(&self) -> bool {
+  fn should_isolate(&self, _runtime_mode: RuntimeMode) -> bool {
     false
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -228,14 +228,14 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
     if with_hmr {
       let state_expression = render_hmr_runtime_state_expression(runtime_template, "importScripts");
       source.push_str(&format!(
-        "var installedChunks = {} = {} || {};\n",
+        "var importScriptsInstalledChunks = {} = {} || {};\n",
         state_expression,
         state_expression,
         &stringify_chunks(&initial_chunks, 1)
       ));
     } else {
       source.push_str(&format!(
-        "var installedChunks = {};\n",
+        "var importScriptsInstalledChunks = {};\n",
         &stringify_chunks(&initial_chunks, 1)
       ));
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -312,7 +312,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = {}{};
+      var jsonpInstalledChunks = {}{};
       "#,
       match with_hmr {
         true => {
@@ -326,7 +326,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
 
     if with_loading {
       let body = if matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
-        "installedChunks[chunkId] = 0;".to_string()
+        "jsonpInstalledChunks[chunkId] = 0;".to_string()
       } else {
         runtime_template.render(
           &self.template_id(TemplateId::Raw),

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -313,7 +313,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = {}{};
+      var moduleInstalledChunks = {}{};
       "#,
       match with_hmr {
         true => {
@@ -341,7 +341,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
     if with_loading {
       let body = if matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
-        "installedChunks[chunkId] = 0;".to_string()
+        "moduleInstalledChunks[chunkId] = 0;".to_string()
       } else {
         runtime_template.render(
           &self.template(TemplateId::WithLoading),
@@ -352,7 +352,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
             "_match_fallback":    if matches!(has_js_matcher, BooleanMatcher::Condition(true)) {
               ""
             } else {
-              "else installedChunks[chunkId] = 0;\n"
+              "else moduleInstalledChunks[chunkId] = 0;\n"
             },
           })),
         )?
@@ -440,7 +440,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
     if with_external_install_chunk {
       source.push_str(&format!(
         r#"
-        {} = installChunk;
+        {} = moduleInstallChunk;
         "#,
         runtime_template.render_runtime_globals(&RuntimeGlobals::EXTERNAL_INSTALL_CHUNK)
       ));
@@ -452,7 +452,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
       source.push_str(&format!(
         r#"
         {}.j = function(chunkId) {{
-            return installedChunks[chunkId] === 0;
+            return moduleInstalledChunks[chunkId] === 0;
         }}
         "#,
         runtime_template.render_runtime_globals(&RuntimeGlobals::ON_CHUNKS_LOADED)

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -267,14 +267,14 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
     if with_hmr {
       let state_expression = render_hmr_runtime_state_expression(runtime_template, "readFileVm");
       source.push_str(&format!(
-        "var installedChunks = {} = {} || {};\n",
+        "var readFileVmInstalledChunks = {} = {} || {};\n",
         state_expression,
         state_expression,
         &stringify_chunks(&initial_chunks, 0)
       ));
     } else {
       source.push_str(&format!(
-        "var installedChunks = {};\n",
+        "var readFileVmInstalledChunks = {};\n",
         &stringify_chunks(&initial_chunks, 0)
       ));
     }
@@ -302,7 +302,7 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
 
     if with_loading {
       let body = if matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
-        "installedChunks[chunkId] = 0;".to_string()
+        "readFileVmInstalledChunks[chunkId] = 0;".to_string()
       } else {
         runtime_template.render(
           &self.template_id(TemplateId::WithLoading),
@@ -312,7 +312,7 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
             "_match_fallback": if matches!(has_js_matcher, BooleanMatcher::Condition(true)) {
               ""
             } else {
-              "else installedChunks[chunkId] = 0;\n"
+              "else readFileVmInstalledChunks[chunkId] = 0;\n"
             },
           })),
         )?

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -277,14 +277,14 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
     if with_hmr {
       let state_expression = render_hmr_runtime_state_expression(runtime_template, "require");
       source.push_str(&format!(
-        "var installedChunks = {} = {} || {};\n",
+        "var requireInstalledChunks = {} = {} || {};\n",
         state_expression,
         state_expression,
         &stringify_chunks(&initial_chunks, 1)
       ));
     } else {
       source.push_str(&format!(
-        "var installedChunks = {};\n",
+        "var requireInstalledChunks = {};\n",
         &stringify_chunks(&initial_chunks, 1)
       ));
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_prefetch_trigger.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_prefetch_trigger.ejs
@@ -1,7 +1,7 @@
-var chunkToChildrenMap = <%- _chunk_map %>;
+var chunkPrefetchChunkToChildrenMap = <%- _chunk_map %>;
 <%- ENSURE_CHUNK_HANDLERS %>.prefetch = <%- basicFunction("chunkId, promises") %> {
   Promise.all(promises).then(<%- basicFunction("") %> {
-    var chunks = chunkToChildrenMap[chunkId];
+    var chunks = chunkPrefetchChunkToChildrenMap[chunkId];
     Array.isArray(chunks) && chunks.map(<%- PREFETCH_CHUNK %>);
   });
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_preload_trigger.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_preload_trigger.ejs
@@ -1,5 +1,5 @@
-var chunkToChildrenMap = <%- _chunk_map %>;
+var chunkPreloadChunkToChildrenMap = <%- _chunk_map %>;
 <%- ENSURE_CHUNK_HANDLERS %>.preload =  <%- basicFunction("chunkId") %> {
-  var chunks = chunkToChildrenMap[chunkId];
+  var chunks = chunkPreloadChunkToChildrenMap[chunkId];
   Array.isArray(chunks) && chunks.map(<%- PRELOAD_CHUNK %>);
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading.ejs
@@ -1,5 +1,5 @@
 // importScripts chunk loading
-var installChunk = <%- basicFunction("data") %> {
+var importScriptsInstallChunk = <%- basicFunction("data") %> {
     <%- destructureArray("chunkIds, moreModules, runtime", "data") %>
     for (var moduleId in moreModules) {
         if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {
@@ -7,10 +7,10 @@ var installChunk = <%- basicFunction("data") %> {
         }
     }
     if (runtime) runtime(<%- REQUIRE_SCOPE %>);
-    while (chunkIds.length) installedChunks[chunkIds.pop()] = 1;
-    parentChunkLoadingFunction(data);
+    while (chunkIds.length) importScriptsInstalledChunks[chunkIds.pop()] = 1;
+    importScriptsParentChunkLoadingFunction(data);
 };
 
-var chunkLoadingGlobal = <%- _chunk_loading_global_init_expr %>;
-var parentChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);
-chunkLoadingGlobal.push = installChunk;
+var importScriptsChunkLoadingGlobal = <%- _chunk_loading_global_init_expr %>;
+var importScriptsParentChunkLoadingFunction = importScriptsChunkLoadingGlobal.push.bind(importScriptsChunkLoadingGlobal);
+importScriptsChunkLoadingGlobal.push = importScriptsInstallChunk;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function importScriptsLoadUpdateChunk(chunkId, updatedModulesList) {
   var success = false;
   <%- _global_object %>[<%- _hot_update_global %>] = <%- basicFunction("_, moreModules, runtime") %> {
       for (var moduleId in moreModules) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
@@ -3,11 +3,11 @@ function importScriptsLoadUpdateChunk(chunkId, updatedModulesList) {
   <%- _global_object %>[<%- _hot_update_global %>] = <%- basicFunction("_, moreModules, runtime") %> {
       for (var moduleId in moreModules) {
           if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {
-              currentUpdate[moduleId] = moreModules[moduleId];
+              hotCurrentUpdate[moduleId] = moreModules[moduleId];
               if (updatedModulesList) updatedModulesList.push(moduleId);
           }
       }
-      if (runtime) currentUpdateRuntime.push(runtime);
+      if (runtime) hotCurrentUpdateRuntime.push(runtime);
       success = true;
   };
   // start update chunk loading

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_loading.ejs
@@ -1,9 +1,9 @@
 <%- ENSURE_CHUNK_HANDLERS %>.i = <%- basicFunction("chunkId, promises") %> {
     <% if (_js_matcher == "false") { %>
-    installedChunks[chunkId] = 1;
+    importScriptsInstalledChunks[chunkId] = 1;
     <% } else { %>
     // "1" is the signal for "already loaded
-    if (!installedChunks[chunkId]) {
+    if (!importScriptsInstalledChunks[chunkId]) {
         if (<%- _js_matcher %>) {
             <% if (_with_create_script_url) { %>
             importScripts(<%- weak(CREATE_SCRIPT_URL) %>(<%- PUBLIC_PATH %> + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)));

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
@@ -2,7 +2,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function <%- _apply_handler %>(options) {
+function hotApplyHandler(options) {
 	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) delete <%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -415,7 +415,7 @@ function <%- _apply_handler %>(options) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(<%- _apply_handler %>);
+		applyHandlers.push(hotApplyHandler);
 	}
 	if (!<%- HAS_OWN_PROPERTY %>(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = <%- MODULE_FACTORIES %>[moduleId];
@@ -430,7 +430,7 @@ function <%- _apply_handler %>(options) {
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(<%- _apply_handler %>);
+	applyHandlers.push(hotApplyHandler);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
@@ -2,7 +2,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function applyHandler(options) {
+function <%- _apply_handler %>(options) {
 	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) delete <%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -209,7 +209,7 @@ function applyHandler(options) {
 	return {
 		dispose: function () {
 			currentUpdateRemovedChunks.forEach(function (chunkId) {
-				delete installedChunks[chunkId];
+				delete <%- _installed_chunks %>[chunkId];
 			});
 			currentUpdateRemovedChunks = undefined;
 
@@ -415,7 +415,7 @@ function applyHandler(options) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(applyHandler);
+		applyHandlers.push(<%- _apply_handler %>);
 	}
 	if (!<%- HAS_OWN_PROPERTY %>(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = <%- MODULE_FACTORIES %>[moduleId];
@@ -430,7 +430,7 @@ function applyHandler(options) {
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(<%- _apply_handler %>);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {
@@ -440,10 +440,10 @@ function applyHandler(options) {
 	currentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
-			<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) &&
-			installedChunks[chunkId] !== undefined
+			<%- HAS_OWN_PROPERTY %>(<%- _installed_chunks %>, chunkId) &&
+			<%- _installed_chunks %>[chunkId] !== undefined
 		) {
-			promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+			promises.push(<%- _load_update_chunk %>(chunkId, updatedModulesList));
 			currentUpdateChunks[chunkId] = true;
 		} else {
 			currentUpdateChunks[chunkId] = false;
@@ -456,7 +456,7 @@ function applyHandler(options) {
 				<%- HAS_OWN_PROPERTY %>(currentUpdateChunks, chunkId) &&
 				!currentUpdateChunks[chunkId]
 			) {
-				promises.push(loadUpdateChunk(chunkId));
+				promises.push(<%- _load_update_chunk %>(chunkId));
 				currentUpdateChunks[chunkId] = true;
 			}
 		};

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
@@ -1,10 +1,10 @@
-var currentUpdateChunks;
-var currentUpdate;
-var currentUpdateRemovedChunks;
-var currentUpdateRuntime;
+var hotCurrentUpdateChunks;
+var hotCurrentUpdate;
+var hotCurrentUpdateRemovedChunks;
+var hotCurrentUpdateRuntime;
 function hotApplyHandler(options) {
 	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) delete <%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr;
-	currentUpdateChunks = undefined;
+	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
 		var outdatedDependencies = {};
@@ -101,9 +101,9 @@ function hotApplyHandler(options) {
 		throw Error("RuntimeError: factory is undefined(" + <%- MODULE_ID %> + ")");
 	};
 
-	for (var moduleId in currentUpdate) {
-		if (<%- HAS_OWN_PROPERTY %>(currentUpdate, moduleId)) {
-			var newModuleFactory = currentUpdate[moduleId];
+	for (var moduleId in hotCurrentUpdate) {
+		if (<%- HAS_OWN_PROPERTY %>(hotCurrentUpdate, moduleId)) {
+			var newModuleFactory = hotCurrentUpdate[moduleId];
 			var result = newModuleFactory ? getAffectedModuleEffects(moduleId) : {
 				type: "disposed",
 				moduleId: moduleId
@@ -177,7 +177,7 @@ function hotApplyHandler(options) {
 			}
 		}
 	}
-	currentUpdate = undefined;
+	hotCurrentUpdate = undefined;
 
 	var outdatedSelfAcceptedModules = [];
 	for (var j = 0; j < outdatedModules.length; j++) {
@@ -208,10 +208,10 @@ function hotApplyHandler(options) {
 	var moduleOutdatedDependencies;
 	return {
 		dispose: function () {
-			currentUpdateRemovedChunks.forEach(function (chunkId) {
+			hotCurrentUpdateRemovedChunks.forEach(function (chunkId) {
 				delete <%- _installed_chunks %>[chunkId];
 			});
-			currentUpdateRemovedChunks = undefined;
+			hotCurrentUpdateRemovedChunks = undefined;
 
 			var idx;
 			var queue = outdatedModules.slice();
@@ -279,9 +279,9 @@ function hotApplyHandler(options) {
 			}
 
 			// run new runtime modules
-			for (var i = 0; i < currentUpdateRuntime.length; i++) {
+			for (var i = 0; i < hotCurrentUpdateRuntime.length; i++) {
 				<% if (_is_hot_test) { %>
-				currentUpdateRuntime[i](new Proxy(<%- REQUIRE_SCOPE %>, {
+				hotCurrentUpdateRuntime[i](new Proxy(<%- REQUIRE_SCOPE %>, {
 					set(target, prop, value, receiver) {
 						if (self.__HMR_UPDATED_RUNTIME__) {
 							self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`<%- REQUIRE_SCOPE %>.${prop}`);
@@ -290,7 +290,7 @@ function hotApplyHandler(options) {
 					}
 				}));
 				<% } else { %>
-				currentUpdateRuntime[i](<%- REQUIRE_SCOPE %>);
+				hotCurrentUpdateRuntime[i](<%- REQUIRE_SCOPE %>);
 				<% } %>
 			}
 
@@ -411,14 +411,14 @@ function hotApplyHandler(options) {
 }
 
 <%- HMR_INVALIDATE_MODULE_HANDLERS %>.<%- _loading_method %> = function (moduleId, applyHandlers) {
-	if (!currentUpdate) {
-		currentUpdate = {};
-		currentUpdateRuntime = [];
-		currentUpdateRemovedChunks = [];
+	if (!hotCurrentUpdate) {
+		hotCurrentUpdate = {};
+		hotCurrentUpdateRuntime = [];
+		hotCurrentUpdateRemovedChunks = [];
 		applyHandlers.push(hotApplyHandler);
 	}
-	if (!<%- HAS_OWN_PROPERTY %>(currentUpdate, moduleId)) {
-		currentUpdate[moduleId] = <%- MODULE_FACTORIES %>[moduleId];
+	if (!<%- HAS_OWN_PROPERTY %>(hotCurrentUpdate, moduleId)) {
+		hotCurrentUpdate[moduleId] = <%- MODULE_FACTORIES %>[moduleId];
 	}
 };
 
@@ -431,33 +431,33 @@ function hotApplyHandler(options) {
 	updatedModulesList
 ) {
 	applyHandlers.push(hotApplyHandler);
-	currentUpdateChunks = {};
-	currentUpdateRemovedChunks = removedChunks;
-	currentUpdate = removedModules.reduce(function (obj, key) {
+	hotCurrentUpdateChunks = {};
+	hotCurrentUpdateRemovedChunks = removedChunks;
+	hotCurrentUpdate = removedModules.reduce(function (obj, key) {
 		obj[key] = false;
 		return obj;
 	}, {});
-	currentUpdateRuntime = [];
+	hotCurrentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
 			<%- HAS_OWN_PROPERTY %>(<%- _installed_chunks %>, chunkId) &&
 			<%- _installed_chunks %>[chunkId] !== undefined
 		) {
 			promises.push(<%- _load_update_chunk %>(chunkId, updatedModulesList));
-			currentUpdateChunks[chunkId] = true;
+			hotCurrentUpdateChunks[chunkId] = true;
 		} else {
-			currentUpdateChunks[chunkId] = false;
+			hotCurrentUpdateChunks[chunkId] = false;
 		}
 	});
 	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) {
 		<%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr = function (chunkId, promises) {
 			if (
-				currentUpdateChunks &&
-				<%- HAS_OWN_PROPERTY %>(currentUpdateChunks, chunkId) &&
-				!currentUpdateChunks[chunkId]
+				hotCurrentUpdateChunks &&
+				<%- HAS_OWN_PROPERTY %>(hotCurrentUpdateChunks, chunkId) &&
+				!hotCurrentUpdateChunks[chunkId]
 			) {
 				promises.push(<%- _load_update_chunk %>(chunkId));
-				currentUpdateChunks[chunkId] = true;
+				hotCurrentUpdateChunks[chunkId] = true;
 			}
 		};
 	}

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading.ejs
@@ -1,6 +1,6 @@
 // JSONP chunk loading for javascript
-var installedChunkData = <%- HAS_OWN_PROPERTY %>(installedChunks, chunkId)
-	? installedChunks[chunkId]
+var installedChunkData = <%- HAS_OWN_PROPERTY %>(jsonpInstalledChunks, chunkId)
+	? jsonpInstalledChunks[chunkId]
 	: undefined;
 if (installedChunkData !== 0) {
 	// 0 means "already installed".
@@ -11,7 +11,7 @@ if (installedChunkData !== 0) {
 	} else {
 		if (<%- _js_matcher %>) {
 			// setup Promise in chunk cache
-			var promise = new Promise(<%- expressionFunction("installedChunkData = installedChunks[chunkId] = [resolve, reject]", "resolve, reject") %>);
+			var promise = new Promise(<%- expressionFunction("installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]", "resolve, reject") %>);
 			promises.push((installedChunkData[2] = promise));
 
 			// start chunk loading
@@ -19,9 +19,9 @@ if (installedChunkData !== 0) {
 			// create error before stack unwound to get useful stacktrace later
 			var error = new Error();
 			var loadingEnded = function (event) {
-				if (<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId)) {
-					installedChunkData = installedChunks[chunkId];
-					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+				if (<%- HAS_OWN_PROPERTY %>(jsonpInstalledChunks, chunkId)) {
+					installedChunkData = jsonpInstalledChunks[chunkId];
+					if (installedChunkData !== 0) jsonpInstalledChunks[chunkId] = undefined;
 					if (installedChunkData) {
 						var errorType =
 							event && (event.type === 'load' ? 'missing' : event.type);
@@ -42,6 +42,6 @@ if (installedChunkData !== 0) {
 				}
 			};
 			<%- LOAD_SCRIPT %>(url, loadingEnded, "chunk-" + chunkId, chunkId<%- _fetch_priority %>);
-		} <% if (_js_matcher != "true") { %>else installedChunks[chunkId] = 0; <% } %>
+		} <% if (_js_matcher != "true") { %>else jsonpInstalledChunks[chunkId] = 0; <% } %>
 	}
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading.ejs
@@ -42,6 +42,6 @@ if (installedChunkData !== 0) {
 				}
 			};
 			<%- LOAD_SCRIPT %>(url, loadingEnded, "chunk-" + chunkId, chunkId<%- _fetch_priority %>);
-		} <% if (_js_matcher != "true") { %>else jsonpInstalledChunks[chunkId] = 0; <% } %>
+		} <% if (_js_matcher != "true") { %>else jsonpInstalledChunks[chunkId] = 0;<% } %>
 	}
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.ejs
@@ -4,7 +4,7 @@ var __rspack_jsonp = <%- basicFunction("parentChunkLoadingFunction, data") %> {
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId, chunkId, i = 0;
-	if (chunkIds.some(<%- returningFunction("installedChunks[id] !== 0", "id") %>)) {
+	if (chunkIds.some(<%- returningFunction("jsonpInstalledChunks[id] !== 0", "id") %>)) {
 		for (moduleId in moreModules) {
 			if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {
 				<%- MODULE_FACTORIES %>[moduleId] = moreModules[moduleId];
@@ -16,18 +16,18 @@ var __rspack_jsonp = <%- basicFunction("parentChunkLoadingFunction, data") %> {
 	for (; i < chunkIds.length; i++) {
 		chunkId = chunkIds[i];
 		if (
-			<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) &&
-			installedChunks[chunkId]
+			<%- HAS_OWN_PROPERTY %>(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId]
 		) {
-			installedChunks[chunkId][0]();
+			jsonpInstalledChunks[chunkId][0]();
 		}
-		installedChunks[chunkId] = 0;
+		jsonpInstalledChunks[chunkId] = 0;
 	}
 	<% if (_with_on_chunk_load) { %>
 	return <%- weak(ON_CHUNKS_LOADED) %>(result);
 	<% } %>
 };
 
-var chunkLoadingGlobal = <%- _chunk_loading_global_init_expr %>;
-chunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
-chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+var jsonpChunkLoadingGlobal = <%- _chunk_loading_global_init_expr %>;
+jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
+jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.ejs
@@ -1,6 +1,6 @@
 var currentUpdatedModulesList;
 var waitingUpdateResolves = {};
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 	currentUpdatedModulesList = updatedModulesList;
 	return new Promise(<%- basicFunction("resolve, reject") %> {
 		waitingUpdateResolves[chunkId] = resolve;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.ejs
@@ -1,16 +1,16 @@
-var currentUpdatedModulesList;
-var waitingUpdateResolves = {};
+var hotCurrentUpdatedModulesList;
+var hotWaitingUpdateResolves = {};
 function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
-	currentUpdatedModulesList = updatedModulesList;
+	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise(<%- basicFunction("resolve, reject") %> {
-		waitingUpdateResolves[chunkId] = resolve;
+		hotWaitingUpdateResolves[chunkId] = resolve;
 		// start update chunk loading
 		var url = <%- PUBLIC_PATH %> + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId);
 		// create error before stack unwound to get useful stacktrace later
 		var error = new Error();
 		var loadingEnded = <%- basicFunction("event") %> {
-			if (waitingUpdateResolves[chunkId]) {
-				waitingUpdateResolves[chunkId] = undefined;
+			if (hotWaitingUpdateResolves[chunkId]) {
+				hotWaitingUpdateResolves[chunkId] = undefined;
 				var errorType =
 					event && (event.type === 'load' ? 'missing' : event.type);
 				var realSrc = event && event.target && event.target.src;
@@ -35,13 +35,13 @@ function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 <%- _global_object %>[<%- _hot_update_global %>] = <%- basicFunction("chunkId, moreModules, runtime") %> {
 	for (var moduleId in moreModules) {
 		if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {
-			currentUpdate[moduleId] = moreModules[moduleId];
-			if (currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+			hotCurrentUpdate[moduleId] = moreModules[moduleId];
+			if (hotCurrentUpdatedModulesList) hotCurrentUpdatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
-	if (waitingUpdateResolves[chunkId]) {
-		waitingUpdateResolves[chunkId]();
-		waitingUpdateResolves[chunkId] = undefined;
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
+	if (hotWaitingUpdateResolves[chunkId]) {
+		hotWaitingUpdateResolves[chunkId]();
+		hotWaitingUpdateResolves[chunkId] = undefined;
 	}
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_on_chunk_load.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_on_chunk_load.ejs
@@ -1,1 +1,1 @@
-<%- ON_CHUNKS_LOADED %>.j = <%- returningFunction("installedChunks[chunkId] === 0", "chunkId") %>;
+<%- ON_CHUNKS_LOADED %>.j = <%- returningFunction("jsonpInstalledChunks[chunkId] === 0", "chunkId") %>;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_prefetch.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_prefetch.ejs
@@ -1,6 +1,6 @@
 <%- PREFETCH_CHUNK_HANDLERS %>.j = <%- basicFunction("chunkId") %> {
-  if ((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _js_matcher %>) {
-    installedChunks[chunkId] = null;
+  if ((!<%- HAS_OWN_PROPERTY %>(jsonpInstalledChunks, chunkId) || jsonpInstalledChunks[chunkId] === undefined) && <%- _js_matcher %>) {
+    jsonpInstalledChunks[chunkId] = null;
     <%- _link_prefetch %>
     document.head.appendChild(link);
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_preload.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_preload.ejs
@@ -1,6 +1,6 @@
 <%- PRELOAD_CHUNK_HANDLERS %>.j = <%- basicFunction("chunkId") %> {
-  if ((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _js_matcher %>) {
-    installedChunks[chunkId] = null;
+  if ((!<%- HAS_OWN_PROPERTY %>(jsonpInstalledChunks, chunkId) || jsonpInstalledChunks[chunkId] === undefined) && <%- _js_matcher %>) {
+    jsonpInstalledChunks[chunkId] = null;
     <%- _link_preload %>
     document.head.appendChild(link);
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs
@@ -1,4 +1,4 @@
-var installChunk = <%- basicFunction("data") %> {
+var moduleInstallChunk = <%- basicFunction("data") %> {
     var __rspack_esm_ids = data.__rspack_esm_ids;
     var moreModules = data.<%- _modules %>;
     var __rspack_esm_runtime = data.__rspack_esm_runtime;
@@ -13,10 +13,10 @@ var installChunk = <%- basicFunction("data") %> {
     if (__rspack_esm_runtime) __rspack_esm_runtime(<%- REQUIRE_SCOPE %>);
     for (; i < __rspack_esm_ids.length; i++) {
         chunkId = __rspack_esm_ids[i];
-        if (<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) && installedChunks[chunkId]) {
-            installedChunks[chunkId][0]();
+        if (<%- HAS_OWN_PROPERTY %>(moduleInstalledChunks, chunkId) && moduleInstalledChunks[chunkId]) {
+            moduleInstalledChunks[chunkId][0]();
         }
-        installedChunks[__rspack_esm_ids[i]] = 0;
+        moduleInstalledChunks[__rspack_esm_ids[i]] = 0;
     }
     <% if (_with_on_chunk_load) { %><%- weak(ON_CHUNKS_LOADED) %>();<% } %>
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-  function loadUpdateChunk(chunkId, updatedModulesList) {
+  function moduleLoadUpdateChunk(chunkId, updatedModulesList) {
     return new Promise( <%- basicFunction("resolve, reject")  %> {
       // start update chunk loading
       var url = <%- PUBLIC_PATH %> + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr.ejs
@@ -5,10 +5,10 @@
       var onResolve = <%- basicFunction("obj") %> {
         var updatedModules = obj.<%- _modules %>;
         var updatedRuntime = obj.__rspack_esm_runtime;
-        if (updatedRuntime) currentUpdateRuntime.push(updatedRuntime);
+        if (updatedRuntime) hotCurrentUpdateRuntime.push(updatedRuntime);
         for (var moduleId in updatedModules) {
           if ((<%- HAS_OWN_PROPERTY %>)(updatedModules, moduleId)) {
-            currentUpdate[moduleId] = updatedModules[moduleId];
+            hotCurrentUpdate[moduleId] = updatedModules[moduleId];
             if (updatedModulesList) updatedModulesList.push(moduleId);
           }
         }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_loading.ejs
@@ -1,5 +1,5 @@
 // import() chunk loading for javascript
-var installedChunkData = <%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) ? installedChunks[chunkId] : undefined;
+var installedChunkData = <%- HAS_OWN_PROPERTY %>(moduleInstalledChunks, chunkId) ? moduleInstalledChunks[chunkId] : undefined;
 if (installedChunkData !== 0) { // 0 means "already installed".'
     // a Promise means "currently loading".
     if (installedChunkData) {
@@ -7,12 +7,12 @@ if (installedChunkData !== 0) { // 0 means "already installed".'
     } else {
         if (<%- _js_matcher %>) {
             // setup Promise in chunk cache
-            var promise = <%- _import_function_name %>("<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)).then(installChunk, <%- basicFunction("e") %> {
-                if (installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;
+            var promise = <%- _import_function_name %>("<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)).then(moduleInstallChunk, <%- basicFunction("e") %> {
+                if (moduleInstalledChunks[chunkId] !== 0) moduleInstalledChunks[chunkId] = undefined;
                 throw e;
             });
             var promise = Promise.race([promise, new Promise(<%- basicFunction("resolve") %> {
-                installedChunkData = installedChunks[chunkId] = [resolve];
+                installedChunkData = moduleInstalledChunks[chunkId] = [resolve];
             })]);
             promises.push(installedChunkData[1] = promise);
         }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_prefetch.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_prefetch.ejs
@@ -1,7 +1,7 @@
 <%- PREFETCH_CHUNK_HANDLERS %>.j = <%- basicFunction("chunkId") %> {
     <% if (_is_neutral_platform) { %>if (typeof document === 'undefined') return;<% } %>
-    if((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _js_matcher %>) {
-        installedChunks[chunkId] = null;
+    if((!<%- HAS_OWN_PROPERTY %>(moduleInstalledChunks, chunkId) || moduleInstalledChunks[chunkId] === undefined) && <%- _js_matcher %>) {
+        moduleInstalledChunks[chunkId] = null;
         <%- _link_prefetch %>
         document.head.appendChild(link);
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_preload.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_preload.ejs
@@ -1,7 +1,7 @@
 <%- PRELOAD_CHUNK_HANDLERS %>.j = <%- basicFunction("chunkId") %> {
     <% if (_is_neutral_platform) { %>if (typeof document === 'undefined') return;<% } %>
-    if((!<%- HAS_OWN_PROPERTY %>(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && <%- _js_matcher %>) {
-        installedChunks[chunkId] = null;
+    if((!<%- HAS_OWN_PROPERTY %>(moduleInstalledChunks, chunkId) || moduleInstalledChunks[chunkId] === undefined) && <%- _js_matcher %>) {
+        moduleInstalledChunks[chunkId] = null;
         <%- _link_preload %>
         document.head.appendChild(link);
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading.ejs
@@ -1,4 +1,4 @@
-var installChunk = <%- basicFunction("chunk") %> {
+var readFileVmInstallChunk = <%- basicFunction("chunk") %> {
   var moreModules = chunk.modules, chunkIds = chunk.ids,
     runtime = chunk.runtime;
   for (var moduleId in moreModules) {
@@ -8,10 +8,10 @@ var installChunk = <%- basicFunction("chunk") %> {
   }
   if (runtime) runtime(<%- REQUIRE_SCOPE %> );
   for (var i = 0; i < chunkIds.length; i++) {
-    if (installedChunks[chunkIds[i]]) {
-      installedChunks[chunkIds[i]][0]();
+    if (readFileVmInstalledChunks[chunkIds[i]]) {
+      readFileVmInstalledChunks[chunkIds[i]][0]();
     }
-    installedChunks[chunkIds[i]] = 0;
+    readFileVmInstalledChunks[chunkIds[i]] = 0;
   }
   <%- _with_on_chunk_loaded %>
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_external_install_chunk.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_external_install_chunk.ejs
@@ -1,2 +1,2 @@
 module.exports = <%- REQUIRE_SCOPE %>;
-<%- define(EXTERNAL_INSTALL_CHUNK) %> = installChunk;
+<%- define(EXTERNAL_INSTALL_CHUNK) %> = readFileVmInstallChunk;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr.ejs
@@ -9,11 +9,11 @@ function readFileVmLoadUpdateChunk(chunkId, updatedModulesList) {
 			var runtime = update.runtime;
 			for(var moduleId in updatedModules) {
 				if(<%- HAS_OWN_PROPERTY %>(updatedModules, moduleId)) {
-					currentUpdate[moduleId] = updatedModules[moduleId];
+					hotCurrentUpdate[moduleId] = updatedModules[moduleId];
 					if(updatedModulesList) updatedModulesList.push(moduleId);
 				}
 			}
-			if(runtime) currentUpdateRuntime.push(runtime);
+			if(runtime) hotCurrentUpdateRuntime.push(runtime);
 			resolve();
 		});
 	});

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function readFileVmLoadUpdateChunk(chunkId, updatedModulesList) {
 	return new Promise(function(resolve, reject) {
 		var filename = require('path').join(__dirname, "" + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId));
 		require('fs').readFile(filename, 'utf-8', function(err, content) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_loading.ejs
@@ -1,4 +1,4 @@
-var installedChunkData = installedChunks[chunkId];
+var installedChunkData = readFileVmInstalledChunks[chunkId];
 if (installedChunkData !== 0) {  // 0 means "already installed".
   // array of [resolve, reject, promise] means "currently loading"
   if (installedChunkData) {
@@ -7,7 +7,7 @@ if (installedChunkData !== 0) {  // 0 means "already installed".
     if (<%- _js_matcher %>) {  // all chunks have JS
       // load the chunk and return promise to it
       var promise = new Promise(function (resolve, reject) {
-        installedChunkData = installedChunks[chunkId] = [resolve, reject];
+        installedChunkData = readFileVmInstalledChunks[chunkId] = [resolve, reject];
         var filename = require('path').join(
           __dirname, "<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId));
         require('fs').readFile(filename, 'utf-8', function (err, content) {
@@ -18,7 +18,7 @@ if (installedChunkData !== 0) {  // 0 means "already installed".
             content + '\n})',
             filename)(
               chunk, require, require('path').dirname(filename), filename);
-          installChunk(chunk);
+          readFileVmInstallChunk(chunk);
         });
       });
       promises.push(installedChunkData[2] = promise);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_on_chunk_load.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_on_chunk_load.ejs
@@ -1,1 +1,1 @@
-<%- ON_CHUNKS_LOADED %>.readFileVm = <%- returningFunction("installedChunks[chunkId]===0", "chunkId" ) %>;
+<%- ON_CHUNKS_LOADED %>.readFileVm = <%- returningFunction("readFileVmInstalledChunks[chunkId]===0", "chunkId" ) %>;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.ejs
@@ -1,6 +1,6 @@
 // object to store loaded chunks
 // "1" means "loaded", otherwise not loaded yet
-var installChunk = <%- basicFunction("chunk") %> {
+var requireInstallChunk = <%- basicFunction("chunk") %> {
 	var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
 	for (var moduleId in moreModules) {
 		if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {
@@ -8,6 +8,6 @@ var installChunk = <%- basicFunction("chunk") %> {
 		}
 	}
 	if (runtime) runtime(<%- REQUIRE_SCOPE %>);
-	for (var i = 0; i < chunkIds.length; i++) installedChunks[chunkIds[i]] = 1;
+	for (var i = 0; i < chunkIds.length; i++) requireInstalledChunks[chunkIds[i]] = 1;
 	<%- _with_on_chunk_loaded %>
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_external_install_chunk.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_external_install_chunk.ejs
@@ -1,2 +1,2 @@
 module.exports = <%- REQUIRE_SCOPE %>;
-<%- define(EXTERNAL_INSTALL_CHUNK) %> = installChunk;
+<%- define(EXTERNAL_INSTALL_CHUNK) %> = requireInstallChunk;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr.ejs
@@ -4,9 +4,9 @@ function requireLoadUpdateChunk(chunkId, updatedModulesList) {
 	var runtime = update.runtime;
 	for (var moduleId in updatedModules) {
 		if (<%- HAS_OWN_PROPERTY %>(updatedModules, moduleId)) {
-			currentUpdate[moduleId] = updatedModules[moduleId];
+			hotCurrentUpdate[moduleId] = updatedModules[moduleId];
 			if (updatedModulesList) updatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function requireLoadUpdateChunk(chunkId, updatedModulesList) {
 	var update = require("./" + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId));
 	var updatedModules = update.modules;
 	var runtime = update.runtime;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_loading.ejs
@@ -1,4 +1,4 @@
 // require() chunk loading for javascript
 <%- ENSURE_CHUNK_HANDLERS %>.require = <%- basicFunction("chunkId, promises") %> {
-  installedChunks[chunkId] = 1;
+  requireInstalledChunks[chunkId] = 1;
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_loading_matcher.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_loading_matcher.ejs
@@ -1,9 +1,9 @@
 // require() chunk loading for javascript
 <%- ENSURE_CHUNK_HANDLERS %>.require = <%- basicFunction("chunkId, promises") %> {
 	// "1" is the signal for "already loaded"
-	if (!installedChunks[chunkId]) {
+	if (!requireInstalledChunks[chunkId]) {
 		if (<%- _js_matcher %>) {
-			installChunk(require("<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)));
-		} else installedChunks[chunkId] = 1;
+			requireInstallChunk(require("<%- _output_dir %>" + <%- GET_CHUNK_SCRIPT_FILENAME %>(chunkId)));
+		} else requireInstalledChunks[chunkId] = 1;
 	}
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_on_chunk_load.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_on_chunk_load.ejs
@@ -1,1 +1,1 @@
-<%- ON_CHUNKS_LOADED %>.require = <%- returningFunction("installedChunks[chunkId]", "chunkId") %>
+<%- ON_CHUNKS_LOADED %>.require = <%- returningFunction("requireInstalledChunks[chunkId]", "chunkId") %>

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -251,10 +251,14 @@ pub fn generate_javascript_hmr_runtime(
   method: &str,
   runtime_template: &RuntimeCodeTemplate,
 ) -> Result<String> {
+  let hmr_name_prefix = method;
   runtime_template.render(
     key,
     Some(serde_json::json!({
       "_loading_method": method,
+      "_installed_chunks": format!("{hmr_name_prefix}InstalledChunks"),
+      "_load_update_chunk": format!("{hmr_name_prefix}LoadUpdateChunk"),
+      "_apply_handler": format!("{hmr_name_prefix}ApplyHandler"),
       "_is_hot_test": is_hot_test(),
     })),
   )

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -251,14 +251,12 @@ pub fn generate_javascript_hmr_runtime(
   method: &str,
   runtime_template: &RuntimeCodeTemplate,
 ) -> Result<String> {
-  let hmr_name_prefix = method;
   runtime_template.render(
     key,
     Some(serde_json::json!({
       "_loading_method": method,
-      "_installed_chunks": format!("{hmr_name_prefix}InstalledChunks"),
-      "_load_update_chunk": format!("{hmr_name_prefix}LoadUpdateChunk"),
-      "_apply_handler": format!("{hmr_name_prefix}ApplyHandler"),
+      "_installed_chunks": format!("{method}InstalledChunks"),
+      "_load_update_chunk": format!("{method}LoadUpdateChunk"),
       "_is_hot_test": is_hot_test(),
     })),
   )

--- a/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
@@ -5,7 +5,7 @@ use futures::future::BoxFuture;
 use rspack_cacheable::with::Unsupported;
 use rspack_core::{
   RuntimeModule, RuntimeModuleGenerateContext, RuntimeModuleStage, RuntimeTemplate,
-  impl_runtime_module,
+  impl_runtime_module, runtime_mode::RuntimeMode,
 };
 
 type GenerateFn = Arc<dyn Fn() -> BoxFuture<'static, rspack_error::Result<String>> + Send + Sync>;
@@ -59,7 +59,7 @@ impl RuntimeModule for RuntimeModuleFromJs {
     self.dependent_hash
   }
 
-  fn should_isolate(&self) -> bool {
+  fn should_isolate(&self, _runtime_mode: RuntimeMode) -> bool {
     self.isolate
   }
 

--- a/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/index.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/index.js
@@ -1,0 +1,9 @@
+it("loads async chunks", async () => {
+	const [{ value }, style] = await Promise.all([
+		import("./lazy"),
+		import("./style.css")
+	]);
+
+	expect(value).toBe(42);
+	expect(style).toEqual(nsObj({}));
+});

--- a/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/lazy.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/lazy.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/rspack.config.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/rspack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  experiments: {
+    runtimeMode: 'rspack',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/auto',
+      },
+    ],
+  },
+  output: {
+    uniqueName: 'runtime-review',
+  },
+  target: 'web',
+};

--- a/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/style.css
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/style.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/test.config.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-css-js-loading-unique-name/test.config.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	afterExecute(options) {
+		const source = fs.readFileSync(
+			path.resolve(options.output.path, "bundle0.js"),
+			"utf-8"
+		);
+
+		expect(source).toContain('var uniqueName = "runtime-review:";');
+		expect(source).toContain('var cssLoadingUniqueName = "runtime-review";');
+		expect(source).toContain("uniqueName + key");
+		expect(source).toContain('cssLoadingUniqueName + ":" + key');
+		expect(source).not.toContain('var uniqueName = "runtime-review";');
+	}
+};

--- a/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/index.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/index.js
@@ -1,0 +1,7 @@
+export { value } from "./lib";
+
+import { value } from "./lib";
+
+it("keeps runtime module lexical variables scoped in ESM output", () => {
+	expect(value).toBe(42);
+});

--- a/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/lib.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/lib.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/rspack.config.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  experiments: {
+    outputModule: true,
+    runtimeMode: 'rspack',
+  },
+  output: {
+    filename: 'main.mjs',
+    module: true,
+  },
+  optimization: {
+    concatenateModules: false,
+    usedExports: false,
+  },
+  target: 'es2020',
+};

--- a/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/test.config.js
+++ b/tests/rspack-test/configCases/runtime/runtime-mode-output-module-runtime-iife/test.config.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const path = require("path");
+
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	afterExecute(options) {
+		const source = fs.readFileSync(
+			path.resolve(options.output.path, "main.mjs"),
+			"utf-8"
+		);
+
+		expect(source).toMatch(/var __rspack_modules\s*=/);
+		expect(source).toMatch(
+			/__rspack_context\.r = __rspack_require;\n\n\(function\(\) \{\nvar hasOwnProperty, definePropertyGetters, makeNamespaceObject;/
+		);
+		expect(source).toContain("// rspack/runtime/define_property_getters");
+		expect(source).toContain("// rspack/runtime/make_namespace_object");
+		expect(source).not.toMatch(
+			/__rspack_context\.r = __rspack_require;\n\nvar hasOwnProperty, definePropertyGetters, makeNamespaceObject;/
+		);
+	}
+};

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/esm.snap.txt
@@ -133,8 +133,8 @@ __webpack_require__.r = (exports) => {
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = {"index_js": 0,"main": 0,};
-      var installChunk = (data) => {
+      var moduleInstalledChunks = {"index_js": 0,"main": 0,};
+      var moduleInstallChunk = (data) => {
     var __rspack_esm_ids = data.__rspack_esm_ids;
     var moreModules = data.__webpack_modules__;
     var __rspack_esm_runtime = data.__rspack_esm_runtime;
@@ -149,16 +149,16 @@ __webpack_require__.r = (exports) => {
     if (__rspack_esm_runtime) __rspack_esm_runtime(__webpack_require__);
     for (; i < __rspack_esm_ids.length; i++) {
         chunkId = __rspack_esm_ids[i];
-        if (__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
-            installedChunks[chunkId][0]();
+        if (__webpack_require__.o(moduleInstalledChunks, chunkId) && moduleInstalledChunks[chunkId]) {
+            moduleInstalledChunks[chunkId][0]();
         }
-        installedChunks[__rspack_esm_ids[i]] = 0;
+        moduleInstalledChunks[__rspack_esm_ids[i]] = 0;
     }
     
 };
 // no chunk on demand loading
 
-        __webpack_require__.C = installChunk;
+        __webpack_require__.C = moduleInstallChunk;
         // no on chunks loaded
 // no HMR
 // no HMR manifest

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-css/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-css/__snapshots__/esm.snap.txt
@@ -208,7 +208,7 @@ __webpack_require__.p = scriptUrl;
 // webpack/runtime/css loading
 (() => {
 if (typeof document === "undefined") return;
-var createStylesheet = function (
+var extractCssCreateStylesheet = function (
 	chunkId, fullhref, oldTag, resolve, reject, fetchPriority
 ) {
 	var linkTag = document.createElement("link");
@@ -252,7 +252,7 @@ if (fetchPriority) {
           }
 	return linkTag;
 }
-var findStylesheet = function (href, fullhref) {
+var extractCssFindStylesheet = function (href, fullhref) {
 	var existingLinkTags = document.getElementsByTagName("link");
 	for (var i = 0; i < existingLinkTags.length; i++) {
 		var tag = existingLinkTags[i];
@@ -271,12 +271,12 @@ var findStylesheet = function (href, fullhref) {
 	}
 }
 
-var loadStylesheet = function (chunkId, fetchPriority) {
+var extractCssLoadStylesheet = function (chunkId, fetchPriority) {
 	return new Promise(function (resolve, reject) {
 		var href = __webpack_require__.miniCssF(chunkId);
 		var fullhref = __webpack_require__.p + href;
-		if (findStylesheet(href, fullhref)) return resolve();
-		createStylesheet(chunkId, fullhref, null, resolve, reject, fetchPriority);
+		if (extractCssFindStylesheet(href, fullhref)) return resolve();
+		extractCssCreateStylesheet(chunkId, fullhref, null, resolve, reject, fetchPriority);
 	})
 }
 
@@ -294,7 +294,7 @@ __webpack_require__.f.miniCss = function (chunkId, promises, fetchPriority) {
 	if (installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId])
 	else if (installedCssChunks[chunkId] !== 0 && cssChunks[chunkId])
 		promises.push(
-			installedCssChunks[chunkId] = loadStylesheet(chunkId, fetchPriority).then(
+			installedCssChunks[chunkId] = extractCssLoadStylesheet(chunkId, fetchPriority).then(
 				function () {
 					installedCssChunks[chunkId] = 0;
 				},
@@ -312,26 +312,26 @@ __webpack_require__.f.miniCss = function (chunkId, promises, fetchPriority) {
 })();
 // webpack/runtime/esm_chunk_loading
 (() => {
-var installedChunks = {};
-var chunkMap = {
+var esmInstalledChunks = {};
+var esmChunkMap = {
 "a": function() { return import("./a.mjs"); }
 };
 __webpack_require__.f.j = function(chunkId, promises) {
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {
 		promises.push(installedChunkData);
 		return;
 	}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}, function(error) {
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 };
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-lazy/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-lazy/__snapshots__/esm.snap.txt
@@ -199,27 +199,27 @@ __webpack_require__.r = (exports) => {
 })();
 // webpack/runtime/esm_chunk_loading
 (() => {
-var installedChunks = {};
-var chunkMap = {
+var esmInstalledChunks = {};
+var esmChunkMap = {
 "a": function() { return import("./a.mjs"); },
 "b": function() { return import("./b.mjs"); }
 };
 __webpack_require__.f.j = function(chunkId, promises) {
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {
 		promises.push(installedChunkData);
 		return;
 	}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}, function(error) {
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 };
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-chunk/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-chunk/__snapshots__/esm.snap.txt
@@ -206,28 +206,28 @@ __webpack_require__.r = (exports) => {
 })();
 // webpack/runtime/esm_chunk_loading
 (() => {
-var installedChunks = {};
-var chunkMap = {
+var esmInstalledChunks = {};
+var esmChunkMap = {
 "a": function() { return import("./a.mjs"); },
 "b": function() { return import("./b.mjs"); },
 "shared-chunk": function() { return import("./shared-chunk.mjs"); }
 };
 __webpack_require__.f.j = function(chunkId, promises) {
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {
 		promises.push(installedChunkData);
 		return;
 	}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}, function(error) {
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 };
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-entry/__snapshots__/esm.snap.txt
@@ -191,26 +191,26 @@ __webpack_require__.r = (exports) => {
 })();
 // webpack/runtime/esm_chunk_loading
 (() => {
-var installedChunks = {};
-var chunkMap = {
+var esmInstalledChunks = {};
+var esmChunkMap = {
 "a": function() { return import("./a.mjs"); }
 };
 __webpack_require__.f.j = function(chunkId, promises) {
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {
 		promises.push(installedChunkData);
 		return;
 	}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}, function(error) {
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 };
 
@@ -301,26 +301,26 @@ __webpack_require__.r = (exports) => {
 })();
 // webpack/runtime/esm_chunk_loading
 (() => {
-var installedChunks = {};
-var chunkMap = {
+var esmInstalledChunks = {};
+var esmChunkMap = {
 "b": function() { return import("./b.mjs"); }
 };
 __webpack_require__.f.j = function(chunkId, promises) {
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {
 		promises.push(installedChunkData);
 		return;
 	}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}, function(error) {
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 };
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-prefetch-preload/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-prefetch-preload/__snapshots__/esm.snap.txt
@@ -348,28 +348,28 @@ __webpack_require__.p = scriptUrl;
 })();
 // webpack/runtime/esm_chunk_loading
 (() => {
-var installedChunks = {};
-var chunkMap = {
+var esmInstalledChunks = {};
+var esmChunkMap = {
 "a": function() { return import("./a.mjs"); },
 "b": function() { return import("./b.mjs"); },
 "c": function() { return import("./c.mjs"); }
 };
 __webpack_require__.f.j = function(chunkId, promises) {
-	var installedChunkData = installedChunks[chunkId];
+	var installedChunkData = esmInstalledChunks[chunkId];
 	if(installedChunkData === 0) return;
 	if(installedChunkData) {
 		promises.push(installedChunkData);
 		return;
 	}
-	var loadChunk = chunkMap[chunkId];
+	var loadChunk = esmChunkMap[chunkId];
 	if(!loadChunk) return;
 	var promise = loadChunk().then(function() {
-		installedChunks[chunkId] = 0;
+		esmInstalledChunks[chunkId] = 0;
 	}, function(error) {
-		delete installedChunks[chunkId];
+		delete esmInstalledChunks[chunkId];
 		throw error;
 	});
-	installedChunks[chunkId] = promise;
+	esmInstalledChunks[chunkId] = promise;
 	promises.push(promise);
 };
 
@@ -380,12 +380,12 @@ __webpack_require__.f.j = function(chunkId, promises) {
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = {"runtime": 0,};
+      var moduleInstalledChunks = {"runtime": 0,};
       // no install chunk// no chunk on demand loading
 __webpack_require__.F.j = (chunkId) => {
 
-    if((!__webpack_require__.o(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && "runtime" != chunkId) {
-        installedChunks[chunkId] = null;
+    if((!__webpack_require__.o(moduleInstalledChunks, chunkId) || moduleInstalledChunks[chunkId] === undefined) && "runtime" != chunkId) {
+        moduleInstalledChunks[chunkId] = null;
         var link = document.createElement('link');
 
 if (__webpack_require__.nc) {
@@ -400,8 +400,8 @@ link.href = __webpack_require__.p + __webpack_require__.u(chunkId);
 };
 __webpack_require__.H.j = (chunkId) => {
 
-    if((!__webpack_require__.o(installedChunks, chunkId) || installedChunks[chunkId] === undefined) && "runtime" != chunkId) {
-        installedChunks[chunkId] = null;
+    if((!__webpack_require__.o(moduleInstalledChunks, chunkId) || moduleInstalledChunks[chunkId] === undefined) && "runtime" != chunkId) {
+        moduleInstalledChunks[chunkId] = null;
         var link = document.createElement('link');
 if (__webpack_require__.nc) {
   link.setAttribute("nonce", __webpack_require__.nc);
@@ -416,7 +416,7 @@ link.href = __webpack_require__.p + __webpack_require__.u(chunkId);
 // no external install chunk
 
         __webpack_require__.O.j = function(chunkId) {
-            return installedChunks[chunkId] === 0;
+            return moduleInstalledChunks[chunkId] === 0;
         }
         // no HMR
 // no HMR manifest
@@ -424,11 +424,12 @@ link.href = __webpack_require__.p + __webpack_require__.u(chunkId);
 })();
 // webpack/runtime/chunk_preload_trigger
 (() => {
-var chunkToChildrenMap = {"b":["c","c","c"]};
+var chunkPreloadChunkToChildrenMap = {"b":["c","c","c"]};
 __webpack_require__.f.preload =  (chunkId) => {
-  var chunks = chunkToChildrenMap[chunkId];
+  var chunks = chunkPreloadChunkToChildrenMap[chunkId];
   Array.isArray(chunks) && chunks.map(__webpack_require__.G);
 };
+
 })();
 
 export { __webpack_require__ };

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 - Bundle: vendors-node_modules_vendor_js.js
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
 - Update: main.LAST_HASH.hot-update.js, size: 660
-- Update: runtime~main.LAST_HASH.hot-update.js, size: 18983
+- Update: runtime~main.LAST_HASH.hot-update.js, size: 19123
 - Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
 
 ## Manifest
@@ -108,12 +108,12 @@ __webpack_require__.h = () => ("CURRENT_HASH")
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"runtime~main": 0,};
+      var jsonpInstalledChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"runtime~main": 0,};
       
         __webpack_require__.f.j = function (chunkId, promises) {
           // JSONP chunk loading for javascript
-var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
-	? installedChunks[chunkId]
+var installedChunkData = __webpack_require__.o(jsonpInstalledChunks, chunkId)
+	? jsonpInstalledChunks[chunkId]
 	: undefined;
 if (installedChunkData !== 0) {
 	// 0 means "already installed".
@@ -124,7 +124,7 @@ if (installedChunkData !== 0) {
 	} else {
 		if ("runtime~main" != chunkId) {
 			// setup Promise in chunk cache
-			var promise = new Promise((resolve, reject) => (installedChunkData = installedChunks[chunkId] = [resolve, reject]));
+			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));
 
 			// start chunk loading
@@ -132,9 +132,9 @@ if (installedChunkData !== 0) {
 			// create error before stack unwound to get useful stacktrace later
 			var error = new Error();
 			var loadingEnded = function (event) {
-				if (__webpack_require__.o(installedChunks, chunkId)) {
-					installedChunkData = installedChunks[chunkId];
-					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+				if (__webpack_require__.o(jsonpInstalledChunks, chunkId)) {
+					installedChunkData = jsonpInstalledChunks[chunkId];
+					if (installedChunkData !== 0) jsonpInstalledChunks[chunkId] = undefined;
 					if (installedChunkData) {
 						var errorType =
 							event && (event.type === 'load' ? 'missing' : event.type);
@@ -155,14 +155,14 @@ if (installedChunkData !== 0) {
 				}
 			};
 			__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
-		} else installedChunks[chunkId] = 0; 
+		} else jsonpInstalledChunks[chunkId] = 0; 
 	}
 }
 
         }
         var currentUpdatedModulesList;
 var waitingUpdateResolves = {};
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 	currentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
 		waitingUpdateResolves[chunkId] = resolve;
@@ -211,7 +211,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function applyHandler(options) {
+function jsonpApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -418,7 +418,7 @@ function applyHandler(options) {
 	return {
 		dispose: function () {
 			currentUpdateRemovedChunks.forEach(function (chunkId) {
-				delete installedChunks[chunkId];
+				delete jsonpInstalledChunks[chunkId];
 			});
 			currentUpdateRemovedChunks = undefined;
 
@@ -622,7 +622,7 @@ __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(applyHandler);
+		applyHandlers.push(jsonpApplyHandler);
 	}
 	if (!__webpack_require__.o(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
@@ -637,7 +637,7 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(jsonpApplyHandler);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {
@@ -647,10 +647,10 @@ __webpack_require__.hmrC.jsonp = function (
 	currentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId] !== undefined
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId] !== undefined
 		) {
-			promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
 			currentUpdateChunks[chunkId] = true;
 		} else {
 			currentUpdateChunks[chunkId] = false;
@@ -663,7 +663,7 @@ __webpack_require__.hmrC.jsonp = function (
 				__webpack_require__.o(currentUpdateChunks, chunkId) &&
 				!currentUpdateChunks[chunkId]
 			) {
-				promises.push(loadUpdateChunk(chunkId));
+				promises.push(jsonpLoadUpdateChunk(chunkId));
 				currentUpdateChunks[chunkId] = true;
 			}
 		};
@@ -683,14 +683,14 @@ __webpack_require__.hmrM = () => {
 		}
 	);
 };
-__webpack_require__.O.j = (chunkId) => (installedChunks[chunkId] === 0);
+__webpack_require__.O.j = (chunkId) => (jsonpInstalledChunks[chunkId] === 0);
 // install a JSONP callback for chunk loading
 var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	var [chunkIds, moreModules, runtime] = data;
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId, chunkId, i = 0;
-	if (chunkIds.some((id) => (installedChunks[id] !== 0))) {
+	if (chunkIds.some((id) => (jsonpInstalledChunks[id] !== 0))) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];
@@ -702,21 +702,21 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	for (; i < chunkIds.length; i++) {
 		chunkId = chunkIds[i];
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId]
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId]
 		) {
-			installedChunks[chunkId][0]();
+			jsonpInstalledChunks[chunkId][0]();
 		}
-		installedChunks[chunkId] = 0;
+		jsonpInstalledChunks[chunkId] = 0;
 	}
 	
 	return __webpack_require__.O(result);
 	
 };
 
-var chunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
-chunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
-chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+var jsonpChunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
+jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
+jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));
 
 })();
 

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 - Bundle: vendors-node_modules_vendor_js.js
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
 - Update: main.LAST_HASH.hot-update.js, size: 660
-- Update: runtime~main.LAST_HASH.hot-update.js, size: 19123
+- Update: runtime~main.LAST_HASH.hot-update.js, size: 19242
 - Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
 
 ## Manifest
@@ -155,24 +155,24 @@ if (installedChunkData !== 0) {
 				}
 			};
 			__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
-		} else jsonpInstalledChunks[chunkId] = 0; 
+		} else jsonpInstalledChunks[chunkId] = 0;
 	}
 }
 
         }
-        var currentUpdatedModulesList;
-var waitingUpdateResolves = {};
+        var hotCurrentUpdatedModulesList;
+var hotWaitingUpdateResolves = {};
 function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
-	currentUpdatedModulesList = updatedModulesList;
+	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
-		waitingUpdateResolves[chunkId] = resolve;
+		hotWaitingUpdateResolves[chunkId] = resolve;
 		// start update chunk loading
 		var url = __webpack_require__.p + __webpack_require__.hu(chunkId);
 		// create error before stack unwound to get useful stacktrace later
 		var error = new Error();
 		var loadingEnded = (event) => {
-			if (waitingUpdateResolves[chunkId]) {
-				waitingUpdateResolves[chunkId] = undefined;
+			if (hotWaitingUpdateResolves[chunkId]) {
+				hotWaitingUpdateResolves[chunkId] = undefined;
 				var errorType =
 					event && (event.type === 'load' ? 'missing' : event.type);
 				var realSrc = event && event.target && event.target.src;
@@ -197,23 +197,23 @@ function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 self["rspackHotUpdate"] = (chunkId, moreModules, runtime) => {
 	for (var moduleId in moreModules) {
 		if (__webpack_require__.o(moreModules, moduleId)) {
-			currentUpdate[moduleId] = moreModules[moduleId];
-			if (currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+			hotCurrentUpdate[moduleId] = moreModules[moduleId];
+			if (hotCurrentUpdatedModulesList) hotCurrentUpdatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
-	if (waitingUpdateResolves[chunkId]) {
-		waitingUpdateResolves[chunkId]();
-		waitingUpdateResolves[chunkId] = undefined;
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
+	if (hotWaitingUpdateResolves[chunkId]) {
+		hotWaitingUpdateResolves[chunkId]();
+		hotWaitingUpdateResolves[chunkId] = undefined;
 	}
 };
-var currentUpdateChunks;
-var currentUpdate;
-var currentUpdateRemovedChunks;
-var currentUpdateRuntime;
-function jsonpApplyHandler(options) {
+var hotCurrentUpdateChunks;
+var hotCurrentUpdate;
+var hotCurrentUpdateRemovedChunks;
+var hotCurrentUpdateRuntime;
+function hotApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
-	currentUpdateChunks = undefined;
+	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
 		var outdatedDependencies = {};
@@ -310,9 +310,9 @@ function jsonpApplyHandler(options) {
 		throw Error("RuntimeError: factory is undefined(" + module.id + ")");
 	};
 
-	for (var moduleId in currentUpdate) {
-		if (__webpack_require__.o(currentUpdate, moduleId)) {
-			var newModuleFactory = currentUpdate[moduleId];
+	for (var moduleId in hotCurrentUpdate) {
+		if (__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+			var newModuleFactory = hotCurrentUpdate[moduleId];
 			var result = newModuleFactory ? getAffectedModuleEffects(moduleId) : {
 				type: "disposed",
 				moduleId: moduleId
@@ -386,7 +386,7 @@ function jsonpApplyHandler(options) {
 			}
 		}
 	}
-	currentUpdate = undefined;
+	hotCurrentUpdate = undefined;
 
 	var outdatedSelfAcceptedModules = [];
 	for (var j = 0; j < outdatedModules.length; j++) {
@@ -417,10 +417,10 @@ function jsonpApplyHandler(options) {
 	var moduleOutdatedDependencies;
 	return {
 		dispose: function () {
-			currentUpdateRemovedChunks.forEach(function (chunkId) {
+			hotCurrentUpdateRemovedChunks.forEach(function (chunkId) {
 				delete jsonpInstalledChunks[chunkId];
 			});
-			currentUpdateRemovedChunks = undefined;
+			hotCurrentUpdateRemovedChunks = undefined;
 
 			var idx;
 			var queue = outdatedModules.slice();
@@ -488,9 +488,9 @@ function jsonpApplyHandler(options) {
 			}
 
 			// run new runtime modules
-			for (var i = 0; i < currentUpdateRuntime.length; i++) {
+			for (var i = 0; i < hotCurrentUpdateRuntime.length; i++) {
 				
-				currentUpdateRuntime[i](new Proxy(__webpack_require__, {
+				hotCurrentUpdateRuntime[i](new Proxy(__webpack_require__, {
 					set(target, prop, value, receiver) {
 						if (self.__HMR_UPDATED_RUNTIME__) {
 							self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`__webpack_require__.${prop}`);
@@ -618,14 +618,14 @@ function jsonpApplyHandler(options) {
 }
 
 __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
-	if (!currentUpdate) {
-		currentUpdate = {};
-		currentUpdateRuntime = [];
-		currentUpdateRemovedChunks = [];
-		applyHandlers.push(jsonpApplyHandler);
+	if (!hotCurrentUpdate) {
+		hotCurrentUpdate = {};
+		hotCurrentUpdateRuntime = [];
+		hotCurrentUpdateRemovedChunks = [];
+		applyHandlers.push(hotApplyHandler);
 	}
-	if (!__webpack_require__.o(currentUpdate, moduleId)) {
-		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
+	if (!__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+		hotCurrentUpdate[moduleId] = __webpack_require__.m[moduleId];
 	}
 };
 
@@ -637,34 +637,34 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(jsonpApplyHandler);
-	currentUpdateChunks = {};
-	currentUpdateRemovedChunks = removedChunks;
-	currentUpdate = removedModules.reduce(function (obj, key) {
+	applyHandlers.push(hotApplyHandler);
+	hotCurrentUpdateChunks = {};
+	hotCurrentUpdateRemovedChunks = removedChunks;
+	hotCurrentUpdate = removedModules.reduce(function (obj, key) {
 		obj[key] = false;
 		return obj;
 	}, {});
-	currentUpdateRuntime = [];
+	hotCurrentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
 			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
 			jsonpInstalledChunks[chunkId] !== undefined
 		) {
 			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
-			currentUpdateChunks[chunkId] = true;
+			hotCurrentUpdateChunks[chunkId] = true;
 		} else {
-			currentUpdateChunks[chunkId] = false;
+			hotCurrentUpdateChunks[chunkId] = false;
 		}
 	});
 	if (__webpack_require__.f) {
 		__webpack_require__.f.jsonpHmr = function (chunkId, promises) {
 			if (
-				currentUpdateChunks &&
-				__webpack_require__.o(currentUpdateChunks, chunkId) &&
-				!currentUpdateChunks[chunkId]
+				hotCurrentUpdateChunks &&
+				__webpack_require__.o(hotCurrentUpdateChunks, chunkId) &&
+				!hotCurrentUpdateChunks[chunkId]
 			) {
 				promises.push(jsonpLoadUpdateChunk(chunkId));
-				currentUpdateChunks[chunkId] = true;
+				hotCurrentUpdateChunks[chunkId] = true;
 			}
 		};
 	}

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: [runtime of chunk2_js].LAST_HASH.hot-update.json, size: 60
 - Manifest: main.LAST_HASH.hot-update.json, size: 41
-- Update: main.LAST_HASH.hot-update.js, size: 18382
+- Update: main.LAST_HASH.hot-update.js, size: 18512
 
 ## Manifest
 
@@ -64,12 +64,12 @@ __webpack_require__.h = () => ("CURRENT_HASH")
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
+      var jsonpInstalledChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
       
         __webpack_require__.f.j = function (chunkId, promises) {
           // JSONP chunk loading for javascript
-var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
-	? installedChunks[chunkId]
+var installedChunkData = __webpack_require__.o(jsonpInstalledChunks, chunkId)
+	? jsonpInstalledChunks[chunkId]
 	: undefined;
 if (installedChunkData !== 0) {
 	// 0 means "already installed".
@@ -80,7 +80,7 @@ if (installedChunkData !== 0) {
 	} else {
 		if (true) {
 			// setup Promise in chunk cache
-			var promise = new Promise((resolve, reject) => (installedChunkData = installedChunks[chunkId] = [resolve, reject]));
+			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));
 
 			// start chunk loading
@@ -88,9 +88,9 @@ if (installedChunkData !== 0) {
 			// create error before stack unwound to get useful stacktrace later
 			var error = new Error();
 			var loadingEnded = function (event) {
-				if (__webpack_require__.o(installedChunks, chunkId)) {
-					installedChunkData = installedChunks[chunkId];
-					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+				if (__webpack_require__.o(jsonpInstalledChunks, chunkId)) {
+					installedChunkData = jsonpInstalledChunks[chunkId];
+					if (installedChunkData !== 0) jsonpInstalledChunks[chunkId] = undefined;
 					if (installedChunkData) {
 						var errorType =
 							event && (event.type === 'load' ? 'missing' : event.type);
@@ -118,7 +118,7 @@ if (installedChunkData !== 0) {
         }
         var currentUpdatedModulesList;
 var waitingUpdateResolves = {};
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 	currentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
 		waitingUpdateResolves[chunkId] = resolve;
@@ -167,7 +167,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function applyHandler(options) {
+function jsonpApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -374,7 +374,7 @@ function applyHandler(options) {
 	return {
 		dispose: function () {
 			currentUpdateRemovedChunks.forEach(function (chunkId) {
-				delete installedChunks[chunkId];
+				delete jsonpInstalledChunks[chunkId];
 			});
 			currentUpdateRemovedChunks = undefined;
 
@@ -578,7 +578,7 @@ __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(applyHandler);
+		applyHandlers.push(jsonpApplyHandler);
 	}
 	if (!__webpack_require__.o(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
@@ -593,7 +593,7 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(jsonpApplyHandler);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {
@@ -603,10 +603,10 @@ __webpack_require__.hmrC.jsonp = function (
 	currentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId] !== undefined
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId] !== undefined
 		) {
-			promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
 			currentUpdateChunks[chunkId] = true;
 		} else {
 			currentUpdateChunks[chunkId] = false;
@@ -619,7 +619,7 @@ __webpack_require__.hmrC.jsonp = function (
 				__webpack_require__.o(currentUpdateChunks, chunkId) &&
 				!currentUpdateChunks[chunkId]
 			) {
-				promises.push(loadUpdateChunk(chunkId));
+				promises.push(jsonpLoadUpdateChunk(chunkId));
 				currentUpdateChunks[chunkId] = true;
 			}
 		};
@@ -645,7 +645,7 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId, chunkId, i = 0;
-	if (chunkIds.some((id) => (installedChunks[id] !== 0))) {
+	if (chunkIds.some((id) => (jsonpInstalledChunks[id] !== 0))) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];
@@ -657,19 +657,19 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	for (; i < chunkIds.length; i++) {
 		chunkId = chunkIds[i];
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId]
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId]
 		) {
-			installedChunks[chunkId][0]();
+			jsonpInstalledChunks[chunkId][0]();
 		}
-		installedChunks[chunkId] = 0;
+		jsonpInstalledChunks[chunkId] = 0;
 	}
 	
 };
 
-var chunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
-chunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
-chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+var jsonpChunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
+jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
+jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));
 
 })();
 

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: [runtime of chunk2_js].LAST_HASH.hot-update.json, size: 60
 - Manifest: main.LAST_HASH.hot-update.json, size: 41
-- Update: main.LAST_HASH.hot-update.js, size: 18512
+- Update: main.LAST_HASH.hot-update.js, size: 18632
 
 ## Manifest
 
@@ -116,19 +116,19 @@ if (installedChunkData !== 0) {
 }
 
         }
-        var currentUpdatedModulesList;
-var waitingUpdateResolves = {};
+        var hotCurrentUpdatedModulesList;
+var hotWaitingUpdateResolves = {};
 function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
-	currentUpdatedModulesList = updatedModulesList;
+	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
-		waitingUpdateResolves[chunkId] = resolve;
+		hotWaitingUpdateResolves[chunkId] = resolve;
 		// start update chunk loading
 		var url = __webpack_require__.p + __webpack_require__.hu(chunkId);
 		// create error before stack unwound to get useful stacktrace later
 		var error = new Error();
 		var loadingEnded = (event) => {
-			if (waitingUpdateResolves[chunkId]) {
-				waitingUpdateResolves[chunkId] = undefined;
+			if (hotWaitingUpdateResolves[chunkId]) {
+				hotWaitingUpdateResolves[chunkId] = undefined;
 				var errorType =
 					event && (event.type === 'load' ? 'missing' : event.type);
 				var realSrc = event && event.target && event.target.src;
@@ -153,23 +153,23 @@ function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 self["rspackHotUpdate"] = (chunkId, moreModules, runtime) => {
 	for (var moduleId in moreModules) {
 		if (__webpack_require__.o(moreModules, moduleId)) {
-			currentUpdate[moduleId] = moreModules[moduleId];
-			if (currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+			hotCurrentUpdate[moduleId] = moreModules[moduleId];
+			if (hotCurrentUpdatedModulesList) hotCurrentUpdatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
-	if (waitingUpdateResolves[chunkId]) {
-		waitingUpdateResolves[chunkId]();
-		waitingUpdateResolves[chunkId] = undefined;
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
+	if (hotWaitingUpdateResolves[chunkId]) {
+		hotWaitingUpdateResolves[chunkId]();
+		hotWaitingUpdateResolves[chunkId] = undefined;
 	}
 };
-var currentUpdateChunks;
-var currentUpdate;
-var currentUpdateRemovedChunks;
-var currentUpdateRuntime;
-function jsonpApplyHandler(options) {
+var hotCurrentUpdateChunks;
+var hotCurrentUpdate;
+var hotCurrentUpdateRemovedChunks;
+var hotCurrentUpdateRuntime;
+function hotApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
-	currentUpdateChunks = undefined;
+	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
 		var outdatedDependencies = {};
@@ -266,9 +266,9 @@ function jsonpApplyHandler(options) {
 		throw Error("RuntimeError: factory is undefined(" + module.id + ")");
 	};
 
-	for (var moduleId in currentUpdate) {
-		if (__webpack_require__.o(currentUpdate, moduleId)) {
-			var newModuleFactory = currentUpdate[moduleId];
+	for (var moduleId in hotCurrentUpdate) {
+		if (__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+			var newModuleFactory = hotCurrentUpdate[moduleId];
 			var result = newModuleFactory ? getAffectedModuleEffects(moduleId) : {
 				type: "disposed",
 				moduleId: moduleId
@@ -342,7 +342,7 @@ function jsonpApplyHandler(options) {
 			}
 		}
 	}
-	currentUpdate = undefined;
+	hotCurrentUpdate = undefined;
 
 	var outdatedSelfAcceptedModules = [];
 	for (var j = 0; j < outdatedModules.length; j++) {
@@ -373,10 +373,10 @@ function jsonpApplyHandler(options) {
 	var moduleOutdatedDependencies;
 	return {
 		dispose: function () {
-			currentUpdateRemovedChunks.forEach(function (chunkId) {
+			hotCurrentUpdateRemovedChunks.forEach(function (chunkId) {
 				delete jsonpInstalledChunks[chunkId];
 			});
-			currentUpdateRemovedChunks = undefined;
+			hotCurrentUpdateRemovedChunks = undefined;
 
 			var idx;
 			var queue = outdatedModules.slice();
@@ -444,9 +444,9 @@ function jsonpApplyHandler(options) {
 			}
 
 			// run new runtime modules
-			for (var i = 0; i < currentUpdateRuntime.length; i++) {
+			for (var i = 0; i < hotCurrentUpdateRuntime.length; i++) {
 				
-				currentUpdateRuntime[i](new Proxy(__webpack_require__, {
+				hotCurrentUpdateRuntime[i](new Proxy(__webpack_require__, {
 					set(target, prop, value, receiver) {
 						if (self.__HMR_UPDATED_RUNTIME__) {
 							self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`__webpack_require__.${prop}`);
@@ -574,14 +574,14 @@ function jsonpApplyHandler(options) {
 }
 
 __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
-	if (!currentUpdate) {
-		currentUpdate = {};
-		currentUpdateRuntime = [];
-		currentUpdateRemovedChunks = [];
-		applyHandlers.push(jsonpApplyHandler);
+	if (!hotCurrentUpdate) {
+		hotCurrentUpdate = {};
+		hotCurrentUpdateRuntime = [];
+		hotCurrentUpdateRemovedChunks = [];
+		applyHandlers.push(hotApplyHandler);
 	}
-	if (!__webpack_require__.o(currentUpdate, moduleId)) {
-		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
+	if (!__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+		hotCurrentUpdate[moduleId] = __webpack_require__.m[moduleId];
 	}
 };
 
@@ -593,34 +593,34 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(jsonpApplyHandler);
-	currentUpdateChunks = {};
-	currentUpdateRemovedChunks = removedChunks;
-	currentUpdate = removedModules.reduce(function (obj, key) {
+	applyHandlers.push(hotApplyHandler);
+	hotCurrentUpdateChunks = {};
+	hotCurrentUpdateRemovedChunks = removedChunks;
+	hotCurrentUpdate = removedModules.reduce(function (obj, key) {
 		obj[key] = false;
 		return obj;
 	}, {});
-	currentUpdateRuntime = [];
+	hotCurrentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
 			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
 			jsonpInstalledChunks[chunkId] !== undefined
 		) {
 			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
-			currentUpdateChunks[chunkId] = true;
+			hotCurrentUpdateChunks[chunkId] = true;
 		} else {
-			currentUpdateChunks[chunkId] = false;
+			hotCurrentUpdateChunks[chunkId] = false;
 		}
 	});
 	if (__webpack_require__.f) {
 		__webpack_require__.f.jsonpHmr = function (chunkId, promises) {
 			if (
-				currentUpdateChunks &&
-				__webpack_require__.o(currentUpdateChunks, chunkId) &&
-				!currentUpdateChunks[chunkId]
+				hotCurrentUpdateChunks &&
+				__webpack_require__.o(hotCurrentUpdateChunks, chunkId) &&
+				!hotCurrentUpdateChunks[chunkId]
 			) {
 				promises.push(jsonpLoadUpdateChunk(chunkId));
-				currentUpdateChunks[chunkId] = true;
+				hotCurrentUpdateChunks[chunkId] = true;
 			}
 		};
 	}

--- a/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
-- Update: main.LAST_HASH.hot-update.js, size: 18512
+- Update: main.LAST_HASH.hot-update.js, size: 18632
 
 ## Manifest
 
@@ -100,19 +100,19 @@ if (installedChunkData !== 0) {
 }
 
         }
-        var currentUpdatedModulesList;
-var waitingUpdateResolves = {};
+        var hotCurrentUpdatedModulesList;
+var hotWaitingUpdateResolves = {};
 function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
-	currentUpdatedModulesList = updatedModulesList;
+	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
-		waitingUpdateResolves[chunkId] = resolve;
+		hotWaitingUpdateResolves[chunkId] = resolve;
 		// start update chunk loading
 		var url = __webpack_require__.p + __webpack_require__.hu(chunkId);
 		// create error before stack unwound to get useful stacktrace later
 		var error = new Error();
 		var loadingEnded = (event) => {
-			if (waitingUpdateResolves[chunkId]) {
-				waitingUpdateResolves[chunkId] = undefined;
+			if (hotWaitingUpdateResolves[chunkId]) {
+				hotWaitingUpdateResolves[chunkId] = undefined;
 				var errorType =
 					event && (event.type === 'load' ? 'missing' : event.type);
 				var realSrc = event && event.target && event.target.src;
@@ -137,23 +137,23 @@ function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 self["rspackHotUpdate"] = (chunkId, moreModules, runtime) => {
 	for (var moduleId in moreModules) {
 		if (__webpack_require__.o(moreModules, moduleId)) {
-			currentUpdate[moduleId] = moreModules[moduleId];
-			if (currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+			hotCurrentUpdate[moduleId] = moreModules[moduleId];
+			if (hotCurrentUpdatedModulesList) hotCurrentUpdatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
-	if (waitingUpdateResolves[chunkId]) {
-		waitingUpdateResolves[chunkId]();
-		waitingUpdateResolves[chunkId] = undefined;
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
+	if (hotWaitingUpdateResolves[chunkId]) {
+		hotWaitingUpdateResolves[chunkId]();
+		hotWaitingUpdateResolves[chunkId] = undefined;
 	}
 };
-var currentUpdateChunks;
-var currentUpdate;
-var currentUpdateRemovedChunks;
-var currentUpdateRuntime;
-function jsonpApplyHandler(options) {
+var hotCurrentUpdateChunks;
+var hotCurrentUpdate;
+var hotCurrentUpdateRemovedChunks;
+var hotCurrentUpdateRuntime;
+function hotApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
-	currentUpdateChunks = undefined;
+	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
 		var outdatedDependencies = {};
@@ -250,9 +250,9 @@ function jsonpApplyHandler(options) {
 		throw Error("RuntimeError: factory is undefined(" + module.id + ")");
 	};
 
-	for (var moduleId in currentUpdate) {
-		if (__webpack_require__.o(currentUpdate, moduleId)) {
-			var newModuleFactory = currentUpdate[moduleId];
+	for (var moduleId in hotCurrentUpdate) {
+		if (__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+			var newModuleFactory = hotCurrentUpdate[moduleId];
 			var result = newModuleFactory ? getAffectedModuleEffects(moduleId) : {
 				type: "disposed",
 				moduleId: moduleId
@@ -326,7 +326,7 @@ function jsonpApplyHandler(options) {
 			}
 		}
 	}
-	currentUpdate = undefined;
+	hotCurrentUpdate = undefined;
 
 	var outdatedSelfAcceptedModules = [];
 	for (var j = 0; j < outdatedModules.length; j++) {
@@ -357,10 +357,10 @@ function jsonpApplyHandler(options) {
 	var moduleOutdatedDependencies;
 	return {
 		dispose: function () {
-			currentUpdateRemovedChunks.forEach(function (chunkId) {
+			hotCurrentUpdateRemovedChunks.forEach(function (chunkId) {
 				delete jsonpInstalledChunks[chunkId];
 			});
-			currentUpdateRemovedChunks = undefined;
+			hotCurrentUpdateRemovedChunks = undefined;
 
 			var idx;
 			var queue = outdatedModules.slice();
@@ -428,9 +428,9 @@ function jsonpApplyHandler(options) {
 			}
 
 			// run new runtime modules
-			for (var i = 0; i < currentUpdateRuntime.length; i++) {
+			for (var i = 0; i < hotCurrentUpdateRuntime.length; i++) {
 				
-				currentUpdateRuntime[i](new Proxy(__webpack_require__, {
+				hotCurrentUpdateRuntime[i](new Proxy(__webpack_require__, {
 					set(target, prop, value, receiver) {
 						if (self.__HMR_UPDATED_RUNTIME__) {
 							self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`__webpack_require__.${prop}`);
@@ -558,14 +558,14 @@ function jsonpApplyHandler(options) {
 }
 
 __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
-	if (!currentUpdate) {
-		currentUpdate = {};
-		currentUpdateRuntime = [];
-		currentUpdateRemovedChunks = [];
-		applyHandlers.push(jsonpApplyHandler);
+	if (!hotCurrentUpdate) {
+		hotCurrentUpdate = {};
+		hotCurrentUpdateRuntime = [];
+		hotCurrentUpdateRemovedChunks = [];
+		applyHandlers.push(hotApplyHandler);
 	}
-	if (!__webpack_require__.o(currentUpdate, moduleId)) {
-		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
+	if (!__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+		hotCurrentUpdate[moduleId] = __webpack_require__.m[moduleId];
 	}
 };
 
@@ -577,34 +577,34 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(jsonpApplyHandler);
-	currentUpdateChunks = {};
-	currentUpdateRemovedChunks = removedChunks;
-	currentUpdate = removedModules.reduce(function (obj, key) {
+	applyHandlers.push(hotApplyHandler);
+	hotCurrentUpdateChunks = {};
+	hotCurrentUpdateRemovedChunks = removedChunks;
+	hotCurrentUpdate = removedModules.reduce(function (obj, key) {
 		obj[key] = false;
 		return obj;
 	}, {});
-	currentUpdateRuntime = [];
+	hotCurrentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
 			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
 			jsonpInstalledChunks[chunkId] !== undefined
 		) {
 			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
-			currentUpdateChunks[chunkId] = true;
+			hotCurrentUpdateChunks[chunkId] = true;
 		} else {
-			currentUpdateChunks[chunkId] = false;
+			hotCurrentUpdateChunks[chunkId] = false;
 		}
 	});
 	if (__webpack_require__.f) {
 		__webpack_require__.f.jsonpHmr = function (chunkId, promises) {
 			if (
-				currentUpdateChunks &&
-				__webpack_require__.o(currentUpdateChunks, chunkId) &&
-				!currentUpdateChunks[chunkId]
+				hotCurrentUpdateChunks &&
+				__webpack_require__.o(hotCurrentUpdateChunks, chunkId) &&
+				!hotCurrentUpdateChunks[chunkId]
 			) {
 				promises.push(jsonpLoadUpdateChunk(chunkId));
-				currentUpdateChunks[chunkId] = true;
+				hotCurrentUpdateChunks[chunkId] = true;
 			}
 		};
 	}

--- a/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
-- Update: main.LAST_HASH.hot-update.js, size: 18382
+- Update: main.LAST_HASH.hot-update.js, size: 18512
 
 ## Manifest
 
@@ -48,12 +48,12 @@ __webpack_require__.h = () => ("CURRENT_HASH")
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
+      var jsonpInstalledChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
       
         __webpack_require__.f.j = function (chunkId, promises) {
           // JSONP chunk loading for javascript
-var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
-	? installedChunks[chunkId]
+var installedChunkData = __webpack_require__.o(jsonpInstalledChunks, chunkId)
+	? jsonpInstalledChunks[chunkId]
 	: undefined;
 if (installedChunkData !== 0) {
 	// 0 means "already installed".
@@ -64,7 +64,7 @@ if (installedChunkData !== 0) {
 	} else {
 		if (true) {
 			// setup Promise in chunk cache
-			var promise = new Promise((resolve, reject) => (installedChunkData = installedChunks[chunkId] = [resolve, reject]));
+			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));
 
 			// start chunk loading
@@ -72,9 +72,9 @@ if (installedChunkData !== 0) {
 			// create error before stack unwound to get useful stacktrace later
 			var error = new Error();
 			var loadingEnded = function (event) {
-				if (__webpack_require__.o(installedChunks, chunkId)) {
-					installedChunkData = installedChunks[chunkId];
-					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+				if (__webpack_require__.o(jsonpInstalledChunks, chunkId)) {
+					installedChunkData = jsonpInstalledChunks[chunkId];
+					if (installedChunkData !== 0) jsonpInstalledChunks[chunkId] = undefined;
 					if (installedChunkData) {
 						var errorType =
 							event && (event.type === 'load' ? 'missing' : event.type);
@@ -102,7 +102,7 @@ if (installedChunkData !== 0) {
         }
         var currentUpdatedModulesList;
 var waitingUpdateResolves = {};
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 	currentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
 		waitingUpdateResolves[chunkId] = resolve;
@@ -151,7 +151,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function applyHandler(options) {
+function jsonpApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -358,7 +358,7 @@ function applyHandler(options) {
 	return {
 		dispose: function () {
 			currentUpdateRemovedChunks.forEach(function (chunkId) {
-				delete installedChunks[chunkId];
+				delete jsonpInstalledChunks[chunkId];
 			});
 			currentUpdateRemovedChunks = undefined;
 
@@ -562,7 +562,7 @@ __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(applyHandler);
+		applyHandlers.push(jsonpApplyHandler);
 	}
 	if (!__webpack_require__.o(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
@@ -577,7 +577,7 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(jsonpApplyHandler);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {
@@ -587,10 +587,10 @@ __webpack_require__.hmrC.jsonp = function (
 	currentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId] !== undefined
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId] !== undefined
 		) {
-			promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
 			currentUpdateChunks[chunkId] = true;
 		} else {
 			currentUpdateChunks[chunkId] = false;
@@ -603,7 +603,7 @@ __webpack_require__.hmrC.jsonp = function (
 				__webpack_require__.o(currentUpdateChunks, chunkId) &&
 				!currentUpdateChunks[chunkId]
 			) {
-				promises.push(loadUpdateChunk(chunkId));
+				promises.push(jsonpLoadUpdateChunk(chunkId));
 				currentUpdateChunks[chunkId] = true;
 			}
 		};
@@ -629,7 +629,7 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId, chunkId, i = 0;
-	if (chunkIds.some((id) => (installedChunks[id] !== 0))) {
+	if (chunkIds.some((id) => (jsonpInstalledChunks[id] !== 0))) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];
@@ -641,19 +641,19 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	for (; i < chunkIds.length; i++) {
 		chunkId = chunkIds[i];
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId]
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId]
 		) {
-			installedChunks[chunkId][0]();
+			jsonpInstalledChunks[chunkId][0]();
 		}
-		installedChunks[chunkId] = 0;
+		jsonpInstalledChunks[chunkId] = 0;
 	}
 	
 };
 
-var chunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
-chunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
-chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+var jsonpChunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
+jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
+jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));
 
 })();
 

--- a/tests/rspack-test/hotCases/module/access-dropped-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/module/access-dropped-module/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 15425
+- Update: main.LAST_HASH.hot-update.js, size: 15545
 
 ## Manifest
 
@@ -50,19 +50,19 @@ __webpack_require__.h = () => ("CURRENT_HASH")
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
       var jsonpInstalledChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
-      var currentUpdatedModulesList;
-var waitingUpdateResolves = {};
+      var hotCurrentUpdatedModulesList;
+var hotWaitingUpdateResolves = {};
 function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
-	currentUpdatedModulesList = updatedModulesList;
+	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
-		waitingUpdateResolves[chunkId] = resolve;
+		hotWaitingUpdateResolves[chunkId] = resolve;
 		// start update chunk loading
 		var url = __webpack_require__.p + __webpack_require__.hu(chunkId);
 		// create error before stack unwound to get useful stacktrace later
 		var error = new Error();
 		var loadingEnded = (event) => {
-			if (waitingUpdateResolves[chunkId]) {
-				waitingUpdateResolves[chunkId] = undefined;
+			if (hotWaitingUpdateResolves[chunkId]) {
+				hotWaitingUpdateResolves[chunkId] = undefined;
 				var errorType =
 					event && (event.type === 'load' ? 'missing' : event.type);
 				var realSrc = event && event.target && event.target.src;
@@ -87,23 +87,23 @@ function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 self["rspackHotUpdate"] = (chunkId, moreModules, runtime) => {
 	for (var moduleId in moreModules) {
 		if (__webpack_require__.o(moreModules, moduleId)) {
-			currentUpdate[moduleId] = moreModules[moduleId];
-			if (currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+			hotCurrentUpdate[moduleId] = moreModules[moduleId];
+			if (hotCurrentUpdatedModulesList) hotCurrentUpdatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
-	if (waitingUpdateResolves[chunkId]) {
-		waitingUpdateResolves[chunkId]();
-		waitingUpdateResolves[chunkId] = undefined;
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
+	if (hotWaitingUpdateResolves[chunkId]) {
+		hotWaitingUpdateResolves[chunkId]();
+		hotWaitingUpdateResolves[chunkId] = undefined;
 	}
 };
-var currentUpdateChunks;
-var currentUpdate;
-var currentUpdateRemovedChunks;
-var currentUpdateRuntime;
-function jsonpApplyHandler(options) {
+var hotCurrentUpdateChunks;
+var hotCurrentUpdate;
+var hotCurrentUpdateRemovedChunks;
+var hotCurrentUpdateRuntime;
+function hotApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
-	currentUpdateChunks = undefined;
+	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
 		var outdatedDependencies = {};
@@ -200,9 +200,9 @@ function jsonpApplyHandler(options) {
 		throw Error("RuntimeError: factory is undefined(" + module.id + ")");
 	};
 
-	for (var moduleId in currentUpdate) {
-		if (__webpack_require__.o(currentUpdate, moduleId)) {
-			var newModuleFactory = currentUpdate[moduleId];
+	for (var moduleId in hotCurrentUpdate) {
+		if (__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+			var newModuleFactory = hotCurrentUpdate[moduleId];
 			var result = newModuleFactory ? getAffectedModuleEffects(moduleId) : {
 				type: "disposed",
 				moduleId: moduleId
@@ -276,7 +276,7 @@ function jsonpApplyHandler(options) {
 			}
 		}
 	}
-	currentUpdate = undefined;
+	hotCurrentUpdate = undefined;
 
 	var outdatedSelfAcceptedModules = [];
 	for (var j = 0; j < outdatedModules.length; j++) {
@@ -307,10 +307,10 @@ function jsonpApplyHandler(options) {
 	var moduleOutdatedDependencies;
 	return {
 		dispose: function () {
-			currentUpdateRemovedChunks.forEach(function (chunkId) {
+			hotCurrentUpdateRemovedChunks.forEach(function (chunkId) {
 				delete jsonpInstalledChunks[chunkId];
 			});
-			currentUpdateRemovedChunks = undefined;
+			hotCurrentUpdateRemovedChunks = undefined;
 
 			var idx;
 			var queue = outdatedModules.slice();
@@ -378,9 +378,9 @@ function jsonpApplyHandler(options) {
 			}
 
 			// run new runtime modules
-			for (var i = 0; i < currentUpdateRuntime.length; i++) {
+			for (var i = 0; i < hotCurrentUpdateRuntime.length; i++) {
 				
-				currentUpdateRuntime[i](new Proxy(__webpack_require__, {
+				hotCurrentUpdateRuntime[i](new Proxy(__webpack_require__, {
 					set(target, prop, value, receiver) {
 						if (self.__HMR_UPDATED_RUNTIME__) {
 							self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`__webpack_require__.${prop}`);
@@ -508,14 +508,14 @@ function jsonpApplyHandler(options) {
 }
 
 __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
-	if (!currentUpdate) {
-		currentUpdate = {};
-		currentUpdateRuntime = [];
-		currentUpdateRemovedChunks = [];
-		applyHandlers.push(jsonpApplyHandler);
+	if (!hotCurrentUpdate) {
+		hotCurrentUpdate = {};
+		hotCurrentUpdateRuntime = [];
+		hotCurrentUpdateRemovedChunks = [];
+		applyHandlers.push(hotApplyHandler);
 	}
-	if (!__webpack_require__.o(currentUpdate, moduleId)) {
-		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
+	if (!__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+		hotCurrentUpdate[moduleId] = __webpack_require__.m[moduleId];
 	}
 };
 
@@ -527,34 +527,34 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(jsonpApplyHandler);
-	currentUpdateChunks = {};
-	currentUpdateRemovedChunks = removedChunks;
-	currentUpdate = removedModules.reduce(function (obj, key) {
+	applyHandlers.push(hotApplyHandler);
+	hotCurrentUpdateChunks = {};
+	hotCurrentUpdateRemovedChunks = removedChunks;
+	hotCurrentUpdate = removedModules.reduce(function (obj, key) {
 		obj[key] = false;
 		return obj;
 	}, {});
-	currentUpdateRuntime = [];
+	hotCurrentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
 			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
 			jsonpInstalledChunks[chunkId] !== undefined
 		) {
 			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
-			currentUpdateChunks[chunkId] = true;
+			hotCurrentUpdateChunks[chunkId] = true;
 		} else {
-			currentUpdateChunks[chunkId] = false;
+			hotCurrentUpdateChunks[chunkId] = false;
 		}
 	});
 	if (__webpack_require__.f) {
 		__webpack_require__.f.jsonpHmr = function (chunkId, promises) {
 			if (
-				currentUpdateChunks &&
-				__webpack_require__.o(currentUpdateChunks, chunkId) &&
-				!currentUpdateChunks[chunkId]
+				hotCurrentUpdateChunks &&
+				__webpack_require__.o(hotCurrentUpdateChunks, chunkId) &&
+				!hotCurrentUpdateChunks[chunkId]
 			) {
 				promises.push(jsonpLoadUpdateChunk(chunkId));
-				currentUpdateChunks[chunkId] = true;
+				hotCurrentUpdateChunks[chunkId] = true;
 			}
 		};
 	}

--- a/tests/rspack-test/hotCases/module/access-dropped-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/module/access-dropped-module/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 15375
+- Update: main.LAST_HASH.hot-update.js, size: 15425
 
 ## Manifest
 
@@ -49,10 +49,10 @@ __webpack_require__.h = () => ("CURRENT_HASH")
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
+      var jsonpInstalledChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
       var currentUpdatedModulesList;
 var waitingUpdateResolves = {};
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 	currentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
 		waitingUpdateResolves[chunkId] = resolve;
@@ -101,7 +101,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function applyHandler(options) {
+function jsonpApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -308,7 +308,7 @@ function applyHandler(options) {
 	return {
 		dispose: function () {
 			currentUpdateRemovedChunks.forEach(function (chunkId) {
-				delete installedChunks[chunkId];
+				delete jsonpInstalledChunks[chunkId];
 			});
 			currentUpdateRemovedChunks = undefined;
 
@@ -512,7 +512,7 @@ __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(applyHandler);
+		applyHandlers.push(jsonpApplyHandler);
 	}
 	if (!__webpack_require__.o(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
@@ -527,7 +527,7 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(jsonpApplyHandler);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {
@@ -537,10 +537,10 @@ __webpack_require__.hmrC.jsonp = function (
 	currentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId] !== undefined
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId] !== undefined
 		) {
-			promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
 			currentUpdateChunks[chunkId] = true;
 		} else {
 			currentUpdateChunks[chunkId] = false;
@@ -553,7 +553,7 @@ __webpack_require__.hmrC.jsonp = function (
 				__webpack_require__.o(currentUpdateChunks, chunkId) &&
 				!currentUpdateChunks[chunkId]
 			) {
-				promises.push(loadUpdateChunk(chunkId));
+				promises.push(jsonpLoadUpdateChunk(chunkId));
 				currentUpdateChunks[chunkId] = true;
 			}
 		};

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42334
+- Update: main.LAST_HASH.hot-update.js, size: 42560
 
 ## Manifest
 
@@ -623,11 +623,11 @@ var resolveHandler = function(data) {
 	if (fallback) return function() { return loadFallback.apply(null, args); }
 	return function() { return load.apply(null, args); }
 };
-var installedModules = {};
+var consumeSharedInstalledModules = {};
 __webpack_require__.consumesLoadingData.initialConsumes.forEach(function(id) {
   __webpack_require__.m[id] = function(module) {
     // Handle case when module is used sync
-    installedModules[id] = 0;
+    consumeSharedInstalledModules[id] = 0;
     delete __webpack_require__.c[id];
     var factory = resolveHandler(__webpack_require__.consumesLoadingData.moduleIdToConsumeDataMapping[id])();
     if (typeof factory !== "function")
@@ -642,16 +642,16 @@ __webpack_require__.f.consumes = function(chunkId, promises) {
 	var chunkMapping = __webpack_require__.consumesLoadingData.chunkMapping;
 	if(__webpack_require__.o(chunkMapping, chunkId)) {
 		chunkMapping[chunkId].forEach(function(id) {
-			if(__webpack_require__.o(installedModules, id)) return promises.push(installedModules[id]);
+			if(__webpack_require__.o(consumeSharedInstalledModules, id)) return promises.push(consumeSharedInstalledModules[id]);
 			var onFactory = function(factory) {
-				installedModules[id] = 0;
+				consumeSharedInstalledModules[id] = 0;
 				__webpack_require__.m[id] = function(module) {
 					delete __webpack_require__.c[id];
 					module.exports = factory();
 				}
 			};
 			var onError = function(error) {
-				delete installedModules[id];
+				delete consumeSharedInstalledModules[id];
 				__webpack_require__.m[id] = function(module) {
 					delete __webpack_require__.c[id];
 					throw error;
@@ -660,7 +660,7 @@ __webpack_require__.f.consumes = function(chunkId, promises) {
 			try {
 				var promise = resolveHandler(moduleIdToConsumeDataMapping[id])();
 				if(promise.then) {
-					promises.push(installedModules[id] = promise.then(onFactory)['catch'](onError));
+					promises.push(consumeSharedInstalledModules[id] = promise.then(onFactory)['catch'](onError));
 				} else onFactory(promise);
 			} catch(e) { onError(e); }
 		});
@@ -674,12 +674,12 @@ __webpack_require__.f.consumes = function(chunkId, promises) {
       // object to store loaded and loading chunks
       // undefined = chunk not loaded, null = chunk preloaded/prefetched
       // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-      var installedChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
+      var jsonpInstalledChunks = __webpack_require__.hmrS_jsonp = __webpack_require__.hmrS_jsonp || {"main": 0,};
       
         __webpack_require__.f.j = function (chunkId, promises) {
           // JSONP chunk loading for javascript
-var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
-	? installedChunks[chunkId]
+var installedChunkData = __webpack_require__.o(jsonpInstalledChunks, chunkId)
+	? jsonpInstalledChunks[chunkId]
 	: undefined;
 if (installedChunkData !== 0) {
 	// 0 means "already installed".
@@ -690,7 +690,7 @@ if (installedChunkData !== 0) {
 	} else {
 		if ("webpack_sharing_consume_default_common2_common_2" != chunkId) {
 			// setup Promise in chunk cache
-			var promise = new Promise((resolve, reject) => (installedChunkData = installedChunks[chunkId] = [resolve, reject]));
+			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));
 
 			// start chunk loading
@@ -698,9 +698,9 @@ if (installedChunkData !== 0) {
 			// create error before stack unwound to get useful stacktrace later
 			var error = new Error();
 			var loadingEnded = function (event) {
-				if (__webpack_require__.o(installedChunks, chunkId)) {
-					installedChunkData = installedChunks[chunkId];
-					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+				if (__webpack_require__.o(jsonpInstalledChunks, chunkId)) {
+					installedChunkData = jsonpInstalledChunks[chunkId];
+					if (installedChunkData !== 0) jsonpInstalledChunks[chunkId] = undefined;
 					if (installedChunkData) {
 						var errorType =
 							event && (event.type === 'load' ? 'missing' : event.type);
@@ -721,14 +721,14 @@ if (installedChunkData !== 0) {
 				}
 			};
 			__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
-		} else installedChunks[chunkId] = 0; 
+		} else jsonpInstalledChunks[chunkId] = 0; 
 	}
 }
 
         }
         var currentUpdatedModulesList;
 var waitingUpdateResolves = {};
-function loadUpdateChunk(chunkId, updatedModulesList) {
+function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 	currentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
 		waitingUpdateResolves[chunkId] = resolve;
@@ -777,7 +777,7 @@ var currentUpdateChunks;
 var currentUpdate;
 var currentUpdateRemovedChunks;
 var currentUpdateRuntime;
-function applyHandler(options) {
+function jsonpApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	currentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -984,7 +984,7 @@ function applyHandler(options) {
 	return {
 		dispose: function () {
 			currentUpdateRemovedChunks.forEach(function (chunkId) {
-				delete installedChunks[chunkId];
+				delete jsonpInstalledChunks[chunkId];
 			});
 			currentUpdateRemovedChunks = undefined;
 
@@ -1188,7 +1188,7 @@ __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
 		currentUpdate = {};
 		currentUpdateRuntime = [];
 		currentUpdateRemovedChunks = [];
-		applyHandlers.push(applyHandler);
+		applyHandlers.push(jsonpApplyHandler);
 	}
 	if (!__webpack_require__.o(currentUpdate, moduleId)) {
 		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
@@ -1203,7 +1203,7 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(applyHandler);
+	applyHandlers.push(jsonpApplyHandler);
 	currentUpdateChunks = {};
 	currentUpdateRemovedChunks = removedChunks;
 	currentUpdate = removedModules.reduce(function (obj, key) {
@@ -1213,10 +1213,10 @@ __webpack_require__.hmrC.jsonp = function (
 	currentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId] !== undefined
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId] !== undefined
 		) {
-			promises.push(loadUpdateChunk(chunkId, updatedModulesList));
+			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
 			currentUpdateChunks[chunkId] = true;
 		} else {
 			currentUpdateChunks[chunkId] = false;
@@ -1229,7 +1229,7 @@ __webpack_require__.hmrC.jsonp = function (
 				__webpack_require__.o(currentUpdateChunks, chunkId) &&
 				!currentUpdateChunks[chunkId]
 			) {
-				promises.push(loadUpdateChunk(chunkId));
+				promises.push(jsonpLoadUpdateChunk(chunkId));
 				currentUpdateChunks[chunkId] = true;
 			}
 		};
@@ -1255,7 +1255,7 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId, chunkId, i = 0;
-	if (chunkIds.some((id) => (installedChunks[id] !== 0))) {
+	if (chunkIds.some((id) => (jsonpInstalledChunks[id] !== 0))) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];
@@ -1267,19 +1267,19 @@ var __rspack_jsonp = (parentChunkLoadingFunction, data) => {
 	for (; i < chunkIds.length; i++) {
 		chunkId = chunkIds[i];
 		if (
-			__webpack_require__.o(installedChunks, chunkId) &&
-			installedChunks[chunkId]
+			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
+			jsonpInstalledChunks[chunkId]
 		) {
-			installedChunks[chunkId][0]();
+			jsonpInstalledChunks[chunkId][0]();
 		}
-		installedChunks[chunkId] = 0;
+		jsonpInstalledChunks[chunkId] = 0;
 	}
 	
 };
 
-var chunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
-chunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
-chunkLoadingGlobal.push = __rspack_jsonp.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+var jsonpChunkLoadingGlobal = self["rspackChunk"] = self["rspackChunk"] || [];
+jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
+jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));
 
 })();
 

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42560
+- Update: main.LAST_HASH.hot-update.js, size: 42679
 
 ## Manifest
 
@@ -721,24 +721,24 @@ if (installedChunkData !== 0) {
 				}
 			};
 			__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
-		} else jsonpInstalledChunks[chunkId] = 0; 
+		} else jsonpInstalledChunks[chunkId] = 0;
 	}
 }
 
         }
-        var currentUpdatedModulesList;
-var waitingUpdateResolves = {};
+        var hotCurrentUpdatedModulesList;
+var hotWaitingUpdateResolves = {};
 function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
-	currentUpdatedModulesList = updatedModulesList;
+	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise((resolve, reject) => {
-		waitingUpdateResolves[chunkId] = resolve;
+		hotWaitingUpdateResolves[chunkId] = resolve;
 		// start update chunk loading
 		var url = __webpack_require__.p + __webpack_require__.hu(chunkId);
 		// create error before stack unwound to get useful stacktrace later
 		var error = new Error();
 		var loadingEnded = (event) => {
-			if (waitingUpdateResolves[chunkId]) {
-				waitingUpdateResolves[chunkId] = undefined;
+			if (hotWaitingUpdateResolves[chunkId]) {
+				hotWaitingUpdateResolves[chunkId] = undefined;
 				var errorType =
 					event && (event.type === 'load' ? 'missing' : event.type);
 				var realSrc = event && event.target && event.target.src;
@@ -763,23 +763,23 @@ function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
 self["rspackHotUpdate"] = (chunkId, moreModules, runtime) => {
 	for (var moduleId in moreModules) {
 		if (__webpack_require__.o(moreModules, moduleId)) {
-			currentUpdate[moduleId] = moreModules[moduleId];
-			if (currentUpdatedModulesList) currentUpdatedModulesList.push(moduleId);
+			hotCurrentUpdate[moduleId] = moreModules[moduleId];
+			if (hotCurrentUpdatedModulesList) hotCurrentUpdatedModulesList.push(moduleId);
 		}
 	}
-	if (runtime) currentUpdateRuntime.push(runtime);
-	if (waitingUpdateResolves[chunkId]) {
-		waitingUpdateResolves[chunkId]();
-		waitingUpdateResolves[chunkId] = undefined;
+	if (runtime) hotCurrentUpdateRuntime.push(runtime);
+	if (hotWaitingUpdateResolves[chunkId]) {
+		hotWaitingUpdateResolves[chunkId]();
+		hotWaitingUpdateResolves[chunkId] = undefined;
 	}
 };
-var currentUpdateChunks;
-var currentUpdate;
-var currentUpdateRemovedChunks;
-var currentUpdateRuntime;
-function jsonpApplyHandler(options) {
+var hotCurrentUpdateChunks;
+var hotCurrentUpdate;
+var hotCurrentUpdateRemovedChunks;
+var hotCurrentUpdateRuntime;
+function hotApplyHandler(options) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
-	currentUpdateChunks = undefined;
+	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
 		var outdatedModules = [updateModuleId];
 		var outdatedDependencies = {};
@@ -876,9 +876,9 @@ function jsonpApplyHandler(options) {
 		throw Error("RuntimeError: factory is undefined(" + module.id + ")");
 	};
 
-	for (var moduleId in currentUpdate) {
-		if (__webpack_require__.o(currentUpdate, moduleId)) {
-			var newModuleFactory = currentUpdate[moduleId];
+	for (var moduleId in hotCurrentUpdate) {
+		if (__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+			var newModuleFactory = hotCurrentUpdate[moduleId];
 			var result = newModuleFactory ? getAffectedModuleEffects(moduleId) : {
 				type: "disposed",
 				moduleId: moduleId
@@ -952,7 +952,7 @@ function jsonpApplyHandler(options) {
 			}
 		}
 	}
-	currentUpdate = undefined;
+	hotCurrentUpdate = undefined;
 
 	var outdatedSelfAcceptedModules = [];
 	for (var j = 0; j < outdatedModules.length; j++) {
@@ -983,10 +983,10 @@ function jsonpApplyHandler(options) {
 	var moduleOutdatedDependencies;
 	return {
 		dispose: function () {
-			currentUpdateRemovedChunks.forEach(function (chunkId) {
+			hotCurrentUpdateRemovedChunks.forEach(function (chunkId) {
 				delete jsonpInstalledChunks[chunkId];
 			});
-			currentUpdateRemovedChunks = undefined;
+			hotCurrentUpdateRemovedChunks = undefined;
 
 			var idx;
 			var queue = outdatedModules.slice();
@@ -1054,9 +1054,9 @@ function jsonpApplyHandler(options) {
 			}
 
 			// run new runtime modules
-			for (var i = 0; i < currentUpdateRuntime.length; i++) {
+			for (var i = 0; i < hotCurrentUpdateRuntime.length; i++) {
 				
-				currentUpdateRuntime[i](new Proxy(__webpack_require__, {
+				hotCurrentUpdateRuntime[i](new Proxy(__webpack_require__, {
 					set(target, prop, value, receiver) {
 						if (self.__HMR_UPDATED_RUNTIME__) {
 							self.__HMR_UPDATED_RUNTIME__.javascript.updatedRuntime.push(`__webpack_require__.${prop}`);
@@ -1184,14 +1184,14 @@ function jsonpApplyHandler(options) {
 }
 
 __webpack_require__.hmrI.jsonp = function (moduleId, applyHandlers) {
-	if (!currentUpdate) {
-		currentUpdate = {};
-		currentUpdateRuntime = [];
-		currentUpdateRemovedChunks = [];
-		applyHandlers.push(jsonpApplyHandler);
+	if (!hotCurrentUpdate) {
+		hotCurrentUpdate = {};
+		hotCurrentUpdateRuntime = [];
+		hotCurrentUpdateRemovedChunks = [];
+		applyHandlers.push(hotApplyHandler);
 	}
-	if (!__webpack_require__.o(currentUpdate, moduleId)) {
-		currentUpdate[moduleId] = __webpack_require__.m[moduleId];
+	if (!__webpack_require__.o(hotCurrentUpdate, moduleId)) {
+		hotCurrentUpdate[moduleId] = __webpack_require__.m[moduleId];
 	}
 };
 
@@ -1203,34 +1203,34 @@ __webpack_require__.hmrC.jsonp = function (
 	applyHandlers,
 	updatedModulesList
 ) {
-	applyHandlers.push(jsonpApplyHandler);
-	currentUpdateChunks = {};
-	currentUpdateRemovedChunks = removedChunks;
-	currentUpdate = removedModules.reduce(function (obj, key) {
+	applyHandlers.push(hotApplyHandler);
+	hotCurrentUpdateChunks = {};
+	hotCurrentUpdateRemovedChunks = removedChunks;
+	hotCurrentUpdate = removedModules.reduce(function (obj, key) {
 		obj[key] = false;
 		return obj;
 	}, {});
-	currentUpdateRuntime = [];
+	hotCurrentUpdateRuntime = [];
 	chunkIds.forEach(function (chunkId) {
 		if (
 			__webpack_require__.o(jsonpInstalledChunks, chunkId) &&
 			jsonpInstalledChunks[chunkId] !== undefined
 		) {
 			promises.push(jsonpLoadUpdateChunk(chunkId, updatedModulesList));
-			currentUpdateChunks[chunkId] = true;
+			hotCurrentUpdateChunks[chunkId] = true;
 		} else {
-			currentUpdateChunks[chunkId] = false;
+			hotCurrentUpdateChunks[chunkId] = false;
 		}
 	});
 	if (__webpack_require__.f) {
 		__webpack_require__.f.jsonpHmr = function (chunkId, promises) {
 			if (
-				currentUpdateChunks &&
-				__webpack_require__.o(currentUpdateChunks, chunkId) &&
-				!currentUpdateChunks[chunkId]
+				hotCurrentUpdateChunks &&
+				__webpack_require__.o(hotCurrentUpdateChunks, chunkId) &&
+				!hotCurrentUpdateChunks[chunkId]
 			) {
 				promises.push(jsonpLoadUpdateChunk(chunkId));
-				currentUpdateChunks[chunkId] = true;
+				hotCurrentUpdateChunks[chunkId] = true;
 			}
 		};
 	}

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 0e3e67e28ce91314.js xx KiB [emitted] [immutable] (name: main)
-asset bc31427e1753f078.js xx bytes [emitted] [immutable]
+asset 888fc24a99342c5a.js xx KiB [emitted] [immutable] (name: main)
+asset 5cd84ab679fd62af.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/immutable/__snapshots__/stats.txt
@@ -1,2 +1,2 @@
-asset 0084781062c3c233.js xx KiB [emitted] [immutable] (name: main)
-asset 5cd84ab679fd62af.js xx bytes [emitted] [immutable]
+asset 0e3e67e28ce91314.js xx KiB [emitted] [immutable] (name: main)
+asset bc31427e1753f078.js xx bytes [emitted] [immutable]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -1,16 +1,16 @@
 asset a-runtime~main-11cd436bbbc1c116.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset a-main-fb8023f736486ad3.js xx bytes [emitted] [immutable] (name: main)
-asset a-all-a_js-4ca357ac14402f03.js xx bytes [emitted] [immutable] (id hint: all)
-Entrypoint main xx KiB = a-runtime~main-11cd436bbbc1c116.js xx KiB a-all-a_js-4ca357ac14402f03.js xx bytes a-main-fb8023f736486ad3.js xx bytes
+asset a-main-c77a3d065156afc1.js xx bytes [emitted] [immutable] (name: main)
+asset a-all-a_js-51f880c5bf774503.js xx bytes [emitted] [immutable] (id hint: all)
+Entrypoint main xx KiB = a-runtime~main-11cd436bbbc1c116.js xx KiB a-all-a_js-51f880c5bf774503.js xx bytes a-main-c77a3d065156afc1.js xx bytes
 runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
 asset b-runtime~main-22cf12a92560e0a4.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset b-main-b4d8619e4a217935.js xx bytes [emitted] [immutable] (name: main)
-asset b-all-b_js-49e1ddee2036c3e4.js xx bytes [emitted] [immutable] (id hint: all)
-asset b-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-22cf12a92560e0a4.js xx KiB b-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes b-all-b_js-49e1ddee2036c3e4.js xx bytes b-main-b4d8619e4a217935.js xx bytes
+asset b-main-e089c161fcafa0a5.js xx bytes [emitted] [immutable] (name: main)
+asset b-all-b_js-63ff151d1000e301.js xx bytes [emitted] [immutable] (id hint: all)
+asset b-vendors-node_modules_vendor_js-927ca68fe3cfdb29.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = b-runtime~main-22cf12a92560e0a4.js xx KiB b-vendors-node_modules_vendor_js-927ca68fe3cfdb29.js xx bytes b-all-b_js-63ff151d1000e301.js xx bytes b-main-e089c161fcafa0a5.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -18,12 +18,12 @@ cacheable modules xx bytes
 Rspack x.x.x compiled successfully in X s
 
 assets by chunk xx bytes (id hint: all)
-  asset c-all-b_js-79aa5bf7e0cd20d1.js xx bytes [emitted] [immutable] (id hint: all)
-  asset c-all-c_js-c122d59f831c8fdf.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-82901c810b5921e7.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset c-main-7dc8e2972d294bc1.js xx bytes [emitted] [immutable] (name: main)
-asset c-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-82901c810b5921e7.js xx KiB c-all-c_js-c122d59f831c8fdf.js xx bytes c-main-7dc8e2972d294bc1.js xx bytes
+  asset c-all-b_js-e3933abfcccbcbe8.js xx bytes [emitted] [immutable] (id hint: all)
+  asset c-all-c_js-e739a3749165ad2d.js xx bytes [emitted] [immutable] (id hint: all)
+asset c-runtime~main-2a2946b44c8c50c3.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-main-98aad2badde92840.js xx bytes [emitted] [immutable] (name: main)
+asset c-vendors-node_modules_vendor_js-927ca68fe3cfdb29.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = c-runtime~main-2a2946b44c8c50c3.js xx KiB c-all-c_js-e739a3749165ad2d.js xx bytes c-main-98aad2badde92840.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/issue-7577/__snapshots__/stats.txt
@@ -1,16 +1,16 @@
-asset a-runtime~main-89d37a4a40b85501.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset a-main-c77a3d065156afc1.js xx bytes [emitted] [immutable] (name: main)
-asset a-all-a_js-51f880c5bf774503.js xx bytes [emitted] [immutable] (id hint: all)
-Entrypoint main xx KiB = a-runtime~main-89d37a4a40b85501.js xx KiB a-all-a_js-51f880c5bf774503.js xx bytes a-main-c77a3d065156afc1.js xx bytes
+asset a-runtime~main-11cd436bbbc1c116.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset a-main-fb8023f736486ad3.js xx bytes [emitted] [immutable] (name: main)
+asset a-all-a_js-4ca357ac14402f03.js xx bytes [emitted] [immutable] (id hint: all)
+Entrypoint main xx KiB = a-runtime~main-11cd436bbbc1c116.js xx KiB a-all-a_js-4ca357ac14402f03.js xx bytes a-main-fb8023f736486ad3.js xx bytes
 runtime modules xx KiB 3 modules
 ./a.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s
 
-asset b-runtime~main-5ec620e8a6a95605.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset b-main-e089c161fcafa0a5.js xx bytes [emitted] [immutable] (name: main)
-asset b-all-b_js-63ff151d1000e301.js xx bytes [emitted] [immutable] (id hint: all)
-asset b-vendors-node_modules_vendor_js-927ca68fe3cfdb29.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = b-runtime~main-5ec620e8a6a95605.js xx KiB b-vendors-node_modules_vendor_js-927ca68fe3cfdb29.js xx bytes b-all-b_js-63ff151d1000e301.js xx bytes b-main-e089c161fcafa0a5.js xx bytes
+asset b-runtime~main-22cf12a92560e0a4.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset b-main-b4d8619e4a217935.js xx bytes [emitted] [immutable] (name: main)
+asset b-all-b_js-49e1ddee2036c3e4.js xx bytes [emitted] [immutable] (id hint: all)
+asset b-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = b-runtime~main-22cf12a92560e0a4.js xx KiB b-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes b-all-b_js-49e1ddee2036c3e4.js xx bytes b-main-b4d8619e4a217935.js xx bytes
 runtime modules xx KiB 5 modules
 cacheable modules xx bytes
   ./b.js xx bytes [built] [code generated]
@@ -18,12 +18,12 @@ cacheable modules xx bytes
 Rspack x.x.x compiled successfully in X s
 
 assets by chunk xx bytes (id hint: all)
-  asset c-all-b_js-e3933abfcccbcbe8.js xx bytes [emitted] [immutable] (id hint: all)
-  asset c-all-c_js-e739a3749165ad2d.js xx bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-82b8d871fff5ef32.js xx KiB [emitted] [immutable] (name: runtime~main)
-asset c-main-98aad2badde92840.js xx bytes [emitted] [immutable] (name: main)
-asset c-vendors-node_modules_vendor_js-927ca68fe3cfdb29.js xx bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main xx KiB = c-runtime~main-82b8d871fff5ef32.js xx KiB c-all-c_js-e739a3749165ad2d.js xx bytes c-main-98aad2badde92840.js xx bytes
+  asset c-all-b_js-79aa5bf7e0cd20d1.js xx bytes [emitted] [immutable] (id hint: all)
+  asset c-all-c_js-c122d59f831c8fdf.js xx bytes [emitted] [immutable] (id hint: all)
+asset c-runtime~main-82901c810b5921e7.js xx KiB [emitted] [immutable] (name: runtime~main)
+asset c-main-7dc8e2972d294bc1.js xx bytes [emitted] [immutable] (name: main)
+asset c-vendors-node_modules_vendor_js-a3c489db3ba6a06e.js xx bytes [emitted] [immutable] (id hint: vendors)
+Entrypoint main xx KiB = c-runtime~main-82901c810b5921e7.js xx KiB c-all-c_js-c122d59f831c8fdf.js xx bytes c-main-7dc8e2972d294bc1.js xx bytes
 runtime modules xx KiB 13 modules
 cacheable modules xx bytes
   ./c.js xx bytes [built] [code generated]

--- a/tests/rspack-test/statsOutputCases/worker-public-path/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/worker-public-path/__snapshots__/stats.txt
@@ -1,4 +1,4 @@
-asset main-15761c218915b021.js xx KiB [emitted] [immutable] (name: main)
+asset main-74dd31c2d0aa96d3.js xx KiB [emitted] [immutable] (name: main)
 asset 860-51401646dd4abc59.js xx bytes [emitted] [immutable]
 runtime modules xx KiB 4 modules
 cacheable modules xx bytes


### PR DESCRIPTION
## Summary

- Rename top-level variables emitted by runtime modules so names are scoped to their owning runtime module.
- Update JavaScript HMR runtime template parameters for per-loading-method helper names.
- Refresh affected runtime, ESM output, hot snapshot, and stats snapshots.

## Notes

This keeps the change focused on generated runtime variable names and avoids the earlier replace-based webpack-mode workaround.