### PR TITLE
fix(core): render string module ids without generic serialization

### DIFF
--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -12,7 +12,7 @@ use regex::{Captures, Regex};
 use rspack_collections::{Identifier, IdentifierSet};
 use rspack_dojang::{Context, Dojang, FunctionContainer, Operand};
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt, error};
-use rspack_util::{fx_hash::FxIndexSet, json_stringify};
+use rspack_util::{fx_hash::FxIndexSet, json_stringify, json_stringify_str};
 use rustc_hash::{FxHashMap, FxHashSet as HashSet};
 use serde_json::{Value, json};
 use swc_core::atoms::Atom;
@@ -687,6 +687,13 @@ pub struct ModuleCodeTemplate {
   runtime_requirements: RuntimeGlobals,
 }
 
+fn module_id_expr_value(module_id: &ModuleId) -> String {
+  module_id
+    .as_number()
+    .map(|id| id.to_string())
+    .unwrap_or_else(|| json_stringify_str(module_id.as_str()))
+}
+
 impl ModuleCodeTemplate {
   fn new(
     compiler_options: Arc<CompilerOptions>,
@@ -1047,7 +1054,7 @@ impl ModuleCodeTemplate {
         request: Some(request),
         ..Default::default()
       }),
-      json_stringify(module_id)
+      module_id_expr_value(module_id)
     )
   }
 
@@ -1698,6 +1705,20 @@ impl ChunkCodeTemplate {
       uses_runtime_context,
       uses_lexical_runtime_globals,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{ModuleId, module_id_expr_value};
+
+  #[test]
+  fn module_id_expr_value_renders_numbers_and_strings() {
+    assert_eq!(module_id_expr_value(&ModuleId::from("42")), "42");
+    assert_eq!(
+      module_id_expr_value(&ModuleId::from("javascript/dynamic|/repo/noSourceMaps.js")),
+      r#""javascript/dynamic|/repo/noSourceMaps.js""#
+    );
   }
 }
 


### PR DESCRIPTION
Avoid serializing ModuleId through the generic JSON path when rendering runtime module id expressions. String module ids are now escaped directly while numeric ids remain numeric literals.

## Summary

Fixes a Linux-runner-only CSS extract failure where build-time module ids could be rendered as duplicated strings, causing executeModule to look up a missing codegen result.

The generated code could contain ids like:

```js
__webpack_require__("javascript/dynamic|.../noSourceMaps.jsjavascript/dynamic|.../noSourceMaps.js")

```

while the codegen result map only contained the correct single id.

This changes module id expression rendering so numeric ids remain numeric literals and string ids are escaped directly via `json_stringify_str`, avoiding the generic serialization path.

## Related links

https://github.com/web-infra-dev/rspack/issues/14701

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
