### PR TITLE
fix(bench): pin glibc string-func dispatch to stabilize simulation benches

### DIFF
--- a/.github/workflows/bench-rust.yml
+++ b/.github/workflows/bench-rust.yml
@@ -94,6 +94,14 @@ jobs:
           TMPDIR: ${{ runner.temp }}/codspeed-valgrind-tmp
           CODSPEED_EXPERIMENTAL_FAIR_SCHED: true
           MIMALLOC_PURGE_DELAY: '-1'
+          # Pin glibc string-function selection to the SSE2 baseline. Simulation
+          # reports a pure instruction count, but glibc resolves memcpy/memmove/
+          # memset via CPU-feature ifunc dispatch, so the same binary yields a
+          # different instruction count on different runner CPUs (e.g. AVX512 vs
+          # AVX2). That environmental drift (~2%) shows up as phantom regressions
+          # on short, copy-heavy benches. Forcing one variant on every runner
+          # removes the cross-runner variance.
+          GLIBC_TUNABLES: glibc.cpu.hwcaps=-AVX512F,-AVX2,-AVX,-AVX_Fast_Unaligned_Load,-ERMS,-Prefer_ERMS,-SSE4_2,-SSSE3
         with:
           mode: simulation
           run: |


### PR DESCRIPTION
## Why

`rust@mangle_exports` (and other short, copy-heavy benches) intermittently report ~2% regressions/improvements on CodSpeed **Simulation** with no relevant code change.

Root cause, verified on a Linux devbox with the CodSpeed valgrind:

- Simulation reports a **pure instruction count** (`cacheMissSeconds = 0`, `cpuTotal == instructionsExecution`).
- On a **fixed machine** the instruction count is 100% deterministic (8 runs of an isolated `mangle_exports` bench → identical `Ir`, `D refs`, cache misses).
- glibc resolves `memcpy` / `memmove` / `memset` via **CPU-feature ifunc dispatch**. The same binary on runners with different CPUs selects different implementations with different instruction counts.
- Forcing different glibc string-function variants locally moves the measured `Ir` by ~2.3% (AVX `12,730,808` → SSE2 baseline `12,468,843` = −2.06%, ERMS `12,763,041`) — matching the observed noise.
- The flagged comparison run literally executed base and head on **different CPUs** (EPYC 9V74 Zen4 vs 7763 Zen3).

This also explains why disabling "include memory allocators" does not remove the noise: the variance lives in dynamically-linked libc string functions, not in the statically-linked mimalloc allocator.

## What

Pin glibc string-function selection to the x86-64 SSE2 baseline via `GLIBC_TUNABLES` in the **simulation** bench step only (walltime is untouched, since it measures real time). Every runner now uses the same `memcpy` variant regardless of CPU, so the reported instruction count no longer depends on which runner picked up the job.

Before: instruction count varies ~2% across runner CPUs → phantom regressions.
After: instruction count is runner-CPU-independent.

Trade-off: a one-time baseline shift for all simulation benchmarks when this lands (regression detection compares deltas, so this is harmless).
