### PR TITLE
perf(mangle_exports): pre-size per-module maps and vecs

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -95,10 +95,10 @@ struct MangleableExport<'a> {
 fn prepare_mangleable_exports<'a>(
   export_list: &'a [ExportInfoCache],
 ) -> PreparedMangleableExports<'a> {
-  let mut changes = vec![];
+  let mut changes = Vec::with_capacity(export_list.len());
   let mut nested_exports = vec![];
-  let mut used_names = FxHashSet::default();
-  let mut mangleable_exports = Vec::new();
+  let mut used_names = FxHashSet::with_capacity_and_hasher(export_list.len(), Default::default());
+  let mut mangleable_exports = Vec::with_capacity(export_list.len());
 
   for export_info in export_list {
     match &export_info.can_mangle {
@@ -147,8 +147,6 @@ async fn optimize_code_generation(
 
   let mg = build_module_graph_artifact.get_module_graph_mut();
 
-  let mut exports_info_cache = FxHashMap::default();
-
   let mut q = mg
     .modules()
     .map(|(mid, module)| {
@@ -159,6 +157,8 @@ async fn optimize_code_generation(
       (exports_info_artifact.get_exports_info(mid), is_namespace)
     })
     .collect_vec();
+
+  let mut exports_info_cache = FxHashMap::with_capacity_and_hasher(q.len(), Default::default());
 
   while !q.is_empty() {
     let items = std::mem::take(&mut q);
@@ -315,7 +315,8 @@ fn mangle_exports_info(
 
   if deterministic {
     let used_names_len = used_names.len();
-    let mut export_info_used_name = FxHashMap::default();
+    let mut export_info_used_name =
+      FxHashMap::with_capacity_and_hasher(mangleable_exports.len(), Default::default());
     assign_deterministic_ids(
       mangleable_exports,
       |e| e.name.as_str(),


### PR DESCRIPTION
## Why

The `mangleExports` pass allocates a fresh set of collections **per module** — the exports cache, the mangleable-export list, the used-name set, the assigned-name map, and the change list — none with a capacity hint. Each one therefore rehashes / reallocates and memcpys its contents several times as it fills, even though the final size is known up front from the module's export count.

Measured on a Linux devbox under the CodSpeed valgrind (isolated `mangle_exports` bench, same machine, same glibc memcpy variant, so the delta is purely the code change):

| | instructions (Ir) |
| --- | --- |
| before | 12,730,808 |
| after | 11,346,595 |
| **delta** | **−10.9%** |

The two `reserve_rehash` hot spots (~201k Ir each) and the `grow_amortized` / `finish_grow` reallocation chain effectively disappear.

## What

Reserve capacity for the per-module collections from the known export count.

No behavior change:
- `assign_deterministic_ids` assigns names from a **sorted** list, resolving collisions via set membership — both capacity-independent, so the same name maps to the same export.
- `batch_set_export_info_used_name` applies each export's used name independently, so map iteration order does not affect the final module graph.
