### PR TITLE
chore(deps): bump rspack_resolver to 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5346,9 +5346,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6100e7101c2c83cb129f76a19c3d44753966cd03e29b52031d05af440aa7e7"
+checksum = "adde60ec77d32748df78a55b3ac103d98c1f08c038cc0b3df8020243bda46117"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ rayon               = { version = "1.12.0", default-features = false }
 regex               = { version = "1.12.4", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.11", default-features = false, features = ["std"] }
 regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
-rspack_resolver     = { version = "=0.9.3", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
+rspack_resolver     = { version = "=0.9.4", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }


### PR DESCRIPTION
## Why

Bumps `rspack_resolver` from `0.9.3` to `0.9.4`.

The release ships [rspack-resolver#284](https://github.com/rstackjs/rspack-resolver/pull/284) (`fix(tsconfig): dedupe project reference dependencies`), which fixes a memory/CPU blow-up when resolving `tsconfig.json` **project references**.

Before, every module resolution against a config with `references` walked the reference graph recursively (with a per-resolve visited-set), and each merged config re-accumulated `file_dependencies` in a `Vec` with duplicates. On large monorepos with deep, diamond-shaped reference graphs (A → B → C, shared deps) this produced quadratic work and unbounded dependency duplication — enough to OOM (`exit 137`) a real Platform build.

After: transitive references are flattened and de-duplicated **once** at load time, `file_dependencies` are stored in insertion-ordered sets, and `TsConfig::resolve` iterates the precomputed flat list directly — no per-resolve recursion or hashing. Same "nearest tsconfig wins" resolution semantics, far less memory and work.

The release also includes a `cargo deny` housekeeping fix (`crossbeam-epoch`).

## Verification

- `cargo check -p rspack_core` passes against `0.9.4` (public API unchanged — all changes are `pub(crate)`).
- Only the version pin + `Cargo.lock` checksum change; no transitive dependency drift.
