### PR TITLE
chore(ci): surface Windows Defender status after disable attempt

### DIFF
--- a/.github/actions/windows-disable-cpu-hogs/action.yml
+++ b/.github/actions/windows-disable-cpu-hogs/action.yml
@@ -16,8 +16,8 @@ runs:
         reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
         reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
         Write-Host "== Windows Defender status (post disable attempt) =="
-        try {
-          Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
-        } catch {
-          Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
+        if (Get-Command Get-MpComputerStatus -ErrorAction SilentlyContinue) {
+          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
+        } else {
+          Write-Host "Windows Defender is not installed on this runner; the disable steps above are no-ops here."
         }

--- a/.github/actions/windows-disable-cpu-hogs/action.yml
+++ b/.github/actions/windows-disable-cpu-hogs/action.yml
@@ -1,0 +1,23 @@
+name: Disable CPU hogs (Windows)
+
+description: Disable Defender realtime monitoring, Windows Update and telemetry to reduce CI flakiness, then log the effective Defender status
+
+runs:
+  using: composite
+  steps:
+    - shell: powershell
+      run: |
+        $ErrorActionPreference = 'SilentlyContinue'
+        Set-MpPreference -DisableRealtimeMonitoring $true -Force
+        Add-MpPreference -ExclusionPath "C:\" -Force
+        Add-MpPreference -ExclusionPath "D:\" -Force
+        sc.exe config wuauserv start= disabled
+        Stop-Service wuauserv
+        reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+        reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+        Write-Host "== Windows Defender status (post disable attempt) =="
+        try {
+          Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
+        } catch {
+          Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
+        }

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -46,23 +46,8 @@ jobs:
 
       - name: Disable CPU hogs (Windows)
         if: runner.os == 'Windows'
-        shell: powershell
         continue-on-error: true
-        run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          Set-MpPreference -DisableRealtimeMonitoring $true -Force
-          Add-MpPreference -ExclusionPath "C:\" -Force
-          Add-MpPreference -ExclusionPath "D:\" -Force
-          sc.exe config wuauserv start= disabled
-          Stop-Service wuauserv
-          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
-          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
-          Write-Host "== Windows Defender status (post disable attempt) =="
-          try {
-            Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
-          } catch {
-            Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
-          }
+        uses: ./.github/actions/windows-disable-cpu-hogs
 
       - name: Download and install zstd
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -57,6 +57,12 @@ jobs:
           Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+          Write-Host "== Windows Defender status (post disable attempt) =="
+          try {
+            Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
+          } catch {
+            Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
+          }
 
       - name: Download and install zstd
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -126,6 +126,12 @@ jobs:
           Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+          Write-Host "== Windows Defender status (post disable attempt) =="
+          try {
+            Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
+          } catch {
+            Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
+          }
 
       - name: Download bindings
         uses: ./.github/actions/artifact/download

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -115,23 +115,8 @@ jobs:
 
       - name: Disable CPU hogs (Windows)
         if: runner.os == 'Windows'
-        shell: powershell
         continue-on-error: true
-        run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          Set-MpPreference -DisableRealtimeMonitoring $true -Force
-          Add-MpPreference -ExclusionPath "C:\" -Force
-          Add-MpPreference -ExclusionPath "D:\" -Force
-          sc.exe config wuauserv start= disabled
-          Stop-Service wuauserv
-          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
-          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
-          Write-Host "== Windows Defender status (post disable attempt) =="
-          try {
-            Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
-          } catch {
-            Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
-          }
+        uses: ./.github/actions/windows-disable-cpu-hogs
 
       - name: Download bindings
         uses: ./.github/actions/artifact/download

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -161,6 +161,12 @@ jobs:
           Stop-Service wuauserv
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
           reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+          Write-Host "== Windows Defender status (post disable attempt) =="
+          try {
+            Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
+          } catch {
+            Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
+          }
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -150,23 +150,8 @@ jobs:
 
       - name: Disable CPU hogs (Windows)
         if: runner.os == 'Windows'
-        shell: powershell
         continue-on-error: true
-        run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          Set-MpPreference -DisableRealtimeMonitoring $true -Force
-          Add-MpPreference -ExclusionPath "C:\" -Force
-          Add-MpPreference -ExclusionPath "D:\" -Force
-          sc.exe config wuauserv start= disabled
-          Stop-Service wuauserv
-          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
-          reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
-          Write-Host "== Windows Defender status (post disable attempt) =="
-          try {
-            Get-MpComputerStatus -ErrorAction Stop | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
-          } catch {
-            Write-Host "Get-MpComputerStatus failed: $($_.Exception.Message)"
-          }
+        uses: ./.github/actions/windows-disable-cpu-hogs
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup


### PR DESCRIPTION
The "Disable CPU hogs (Windows)" step runs with `continue-on-error: true` and `$ErrorActionPreference = 'SilentlyContinue'`, so a green check does **not** prove Defender realtime monitoring was actually disabled. `Set-MpPreference -DisableRealtimeMonitoring` is commonly rejected silently when Tamper Protection is enabled, and the swallowed error leaves us blind to it.

This makes the actual Defender state observable in the logs.

## Before
```
✓ Disable CPU hogs (Windows)   # green even if nothing was disabled
```

## After
```
== Windows Defender status (post disable attempt) ==
RealTimeProtectionEnabled : False
IsTamperProtected         : False
AntivirusEnabled          : True
```

Motivation: a recent `main` Windows build failed at `cargo codegen` with `serde_derive.dll: LoadLibraryExW failed: Invalid access to memory location. (os error 998)`. That loader flake is often attributed to AV scanning freshly-linked proc-macro DLLs, but we currently cannot confirm whether Defender is truly off on these runners. This unblocks that diagnosis without changing the disable behavior itself.