### PR TITLE
fix(ci): pick binary-size base by build-triggering commit

### DIFF
--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -56,19 +56,20 @@ class PendingBinaryDataError extends Error {
   }
 }
 
-// Baseline is `pr.base.sha` (the commit merged into the PR at run time), not the
-// fork point: PR CI builds from the merge ref, so head size already includes the
-// base tip. Walk main history skipping doc-only commits (they build no binding);
-// the first build-triggering commit is decisive. Use its size data, or — when it
-// isn't published yet (eco CI is slow) — fail loudly, attaching the nearest ancestor
-// that already has data as a non-authoritative reference for a rough number.
+// Baseline is the base commit actually merged into the PR to build the binding
+// (the merge commit's first parent), not the fork point: PR CI builds from the
+// merge ref, so head size already includes that base tip. Walk main history
+// skipping doc-only commits (they build no binding); the first build-triggering
+// commit is decisive. Use its size data, or — when it isn't published yet (eco CI
+// is slow) — fail loudly, attaching the nearest ancestor that already has data as
+// a non-authoritative reference for a rough number.
 async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
   if (!pr) {
     throw new Error('binary-limit action requires pull_request context');
   }
-  const baseSha = pr.base.sha;
+  const baseSha = await resolveBaseSha(github, owner, repo, context, pr);
   console.log(`Base branch commit: ${baseSha}`);
 
   let pendingBase = null;
@@ -120,6 +121,25 @@ async function findBaseCommit(github, context) {
   throw new Error(
     `No base commit that triggered a linux binding build was found within ${MAX_PAGES} pages of commits from the base branch commit`,
   );
+}
+
+// For `pull_request` events `context.sha` is the ephemeral merge commit that CI
+// checks out (`refs/pull/N/merge`); its first parent is the base commit actually
+// merged in. `pr.base.sha` is only a stale snapshot of the base branch and drifts
+// behind once main advances, so prefer the merge parent and fall back to it only
+// when there is no merge commit (e.g. an unmergeable PR).
+async function resolveBaseSha(github, owner, repo, context, pr) {
+  const { data: mergeCommit } = await github.rest.repos.getCommit({
+    owner,
+    repo,
+    ref: context.sha,
+  });
+  const [base, head] = mergeCommit.parents ?? [];
+  if (mergeCommit.parents?.length === 2 && head?.sha === pr.head.sha) {
+    return base.sha;
+  }
+  console.log('context.sha is not a PR merge commit, using pr.base.sha');
+  return pr.base.sha;
 }
 
 // A binding is built (and size data produced) only for commits touching non-doc

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -180,7 +180,9 @@ async function fetchDataBySha(sha) {
   // being reported as "data not generated".
   if (res.status === 404) return null;
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${dataUrl}: ${res.status} ${res.statusText}`);
+    throw new Error(
+      `Failed to fetch ${dataUrl}: ${res.status} ${res.statusText}`,
+    );
   }
   return res.json();
 }

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -5,6 +5,11 @@ const fs = require('node:fs');
  * @param {Number} limit
  */
 module.exports = async function action({ github, context, limit }) {
+  const headSize = fs.statSync(
+    './crates/node_binding/rspack.linux-x64-gnu.node',
+  ).size;
+  console.log(`Head commit size: ${headSize}`);
+
   let baseCommit;
   let baseSize;
   try {
@@ -14,18 +19,13 @@ module.exports = async function action({ github, context, limit }) {
       await tryComment(
         github,
         context,
-        pendingBinarySizeComment(context, e.baseCommit),
+        pendingBinarySizeComment(context, headSize, e),
       );
     }
     throw e;
   }
 
-  const headSize = fs.statSync(
-    './crates/node_binding/rspack.linux-x64-gnu.node',
-  ).size;
-
   console.log(`Base commit size: ${baseSize}`);
-  console.log(`Head commit size: ${headSize}`);
 
   await tryComment(
     github,
@@ -45,21 +45,23 @@ const PER_PAGE = 30;
 const MAX_PAGES = 4;
 
 class PendingBinaryDataError extends Error {
-  constructor(baseCommit) {
+  constructor(baseCommit, fallback) {
     super(
       `Base commit ${baseCommit.sha} triggered a linux binding build but its ` +
         'binary size data has not been generated yet. Please re-run this workflow ' +
         'once the ecosystem-benchmark run for that commit has published its data.',
     );
     this.baseCommit = baseCommit;
+    this.fallback = fallback;
   }
 }
 
 // Baseline is `pr.base.sha` (the commit merged into the PR at run time), not the
 // fork point: PR CI builds from the merge ref, so head size already includes the
 // base tip. Walk main history skipping doc-only commits (they build no binding);
-// the first build-triggering commit is decisive — use its size data, or fail loudly
-// to force a re-run when it isn't published yet.
+// the first build-triggering commit is decisive. Use its size data, or — when it
+// isn't published yet (eco CI is slow) — fail loudly, attaching the nearest ancestor
+// that already has data as a non-authoritative reference for a rough number.
 async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
@@ -68,6 +70,8 @@ async function findBaseCommit(github, context) {
   }
   const baseSha = pr.base.sha;
   console.log(`Base branch commit: ${baseSha}`);
+
+  let pendingBase = null;
 
   for (let page = 1; page <= MAX_PAGES; page++) {
     const { data: commits } = await github.rest.repos.listCommits({
@@ -79,6 +83,18 @@ async function findBaseCommit(github, context) {
     });
 
     for (const commit of commits) {
+      if (pendingBase) {
+        const data = await fetchDataBySha(commit.sha);
+        if (data?.size) {
+          console.log(`Fallback reference ${commit.sha}: ${data.size}`);
+          throw new PendingBinaryDataError(pendingBase, {
+            baseCommit: commit,
+            baseSize: data.size,
+          });
+        }
+        continue;
+      }
+
       if (!(await triggersBinaryBuild(github, owner, repo, commit.sha))) {
         console.log(`Commit ${commit.sha} is doc-only, skipping to parent`);
         continue;
@@ -90,10 +106,15 @@ async function findBaseCommit(github, context) {
         return { baseCommit: commit, baseSize: data.size };
       }
 
-      throw new PendingBinaryDataError(commit);
+      console.log(`Commit ${commit.sha} has no data yet, seeking a fallback`);
+      pendingBase = commit;
     }
 
     if (commits.length < PER_PAGE) break;
+  }
+
+  if (pendingBase) {
+    throw new PendingBinaryDataError(pendingBase, null);
   }
 
   throw new Error(
@@ -187,28 +208,47 @@ function comparingInfo(context, baseCommit) {
   return `> Comparing [\`${headSha.slice(0, 7)}\`](${context.payload.repository.html_url}/commit/${headSha}) to  [${message} by ${author}](${baseCommit.html_url})\n\n`;
 }
 
-function pendingBinarySizeComment(context, baseCommit) {
-  return (
+function pendingBinarySizeComment(context, headSize, { baseCommit, fallback }) {
+  let body =
     comparingInfo(context, baseCommit) +
     '⏳ The base commit triggered a linux binding build, but its binary size data ' +
     'has not been generated yet, so the size comparison is skipped.\n\n' +
     `Please [re-run this workflow](${runUrl(context)}) once the ecosystem-benchmark ` +
-    'data for that commit is published.'
+    'data for that commit is published.';
+
+  if (fallback) {
+    body += `\n\n${referenceComparison(headSize, fallback)}`;
+  }
+
+  return body;
+}
+
+function referenceComparison(headSize, { baseCommit, baseSize }) {
+  const shortSha = baseCommit.sha.slice(0, 7);
+  return (
+    '> [!WARNING]\n' +
+    "> **Reference only — not the real baseline.** The base commit's data isn't " +
+    'ready yet, so this compares against the nearest earlier commit that has data ' +
+    `([\`${shortSha}\`](${baseCommit.html_url})) for a rough estimate:\n` +
+    '>\n' +
+    `> ${sizeDiffLine(headSize, baseSize)}`
   );
 }
 
 function compareBinarySize(headSize, baseSize, context, baseCommit) {
-  const info = comparingInfo(context, baseCommit);
+  return comparingInfo(context, baseCommit) + sizeDiffLine(headSize, baseSize);
+}
 
+function sizeDiffLine(headSize, baseSize) {
   const diff = headSize - baseSize;
   const percentage = (Math.abs(diff / baseSize) * 100).toFixed(2);
   if (diff > 0) {
-    return `${info}❌ Size increased by ${toHumanReadable(diff)} from ${toHumanReadable(baseSize)} to ${toHumanReadable(headSize)} (⬆️${percentage}%)`;
+    return `❌ Size increased by ${toHumanReadable(diff)} from ${toHumanReadable(baseSize)} to ${toHumanReadable(headSize)} (⬆️${percentage}%)`;
   }
   if (diff < 0) {
-    return `${info}🎉 Size decreased by ${toHumanReadable(-diff)} from ${toHumanReadable(baseSize)} to ${toHumanReadable(headSize)} (⬇️${percentage}%)`;
+    return `🎉 Size decreased by ${toHumanReadable(-diff)} from ${toHumanReadable(baseSize)} to ${toHumanReadable(headSize)} (⬇️${percentage}%)`;
   }
-  return `${info}🙈 Size remains the same at ${toHumanReadable(headSize)}`;
+  return `🙈 Size remains the same at ${toHumanReadable(headSize)}`;
 }
 
 function toHumanReadable(size) {

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -175,7 +175,13 @@ async function fetchDataBySha(sha) {
   const dataUrl = `${DATA_URL_BASE}/commits/${sha.slice(0, 2)}/${sha.slice(2)}/rspack-build.json`;
   console.log('fetching', dataUrl, '...');
   const res = await fetch(dataUrl);
-  if (!res.ok) return null;
+  // 404 means the size data hasn't been published for this commit yet; any other
+  // failure is transient/unexpected and should surface its real cause instead of
+  // being reported as "data not generated".
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${dataUrl}: ${res.status} ${res.statusText}`);
+  }
   return res.json();
 }
 

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -10,10 +10,8 @@ module.exports = async function action({ github, context, limit }) {
   try {
     ({ baseCommit, baseSize } = await findBaseCommit(github, context));
   } catch (e) {
-    // Data should exist for this base commit but hasn't been generated yet.
-    // Still leave a comment (with a re-run link) before failing the job.
     if (e instanceof PendingBinaryDataError) {
-      await commentBestEffort(
+      await tryComment(
         github,
         context,
         pendingBinarySizeComment(context, e.baseCommit),
@@ -29,7 +27,7 @@ module.exports = async function action({ github, context, limit }) {
   console.log(`Base commit size: ${baseSize}`);
   console.log(`Head commit size: ${headSize}`);
 
-  await commentBestEffort(
+  await tryComment(
     github,
     context,
     compareBinarySize(headSize, baseSize, context, baseCommit),
@@ -46,8 +44,6 @@ module.exports = async function action({ github, context, limit }) {
 const PER_PAGE = 30;
 const MAX_PAGES = 4;
 
-// Thrown when a base commit triggered a linux binding build but its binary size
-// data has not been published yet, so a re-run is needed rather than a comparison.
 class PendingBinaryDataError extends Error {
   constructor(baseCommit) {
     super(
@@ -59,20 +55,11 @@ class PendingBinaryDataError extends Error {
   }
 }
 
-// The baseline is the base branch commit that the PR is merged onto at run time
-// (`pr.base.sha`), not the fork point. For `pull_request` events CI builds the
-// binding from the merge ref (PR head merged with the base tip), so the measured
-// head size already includes the base branch's latest state and the correct
-// baseline is that base commit. Walk main history from there toward the parent and:
-//
-//   - Skip doc-only commits: they don't trigger the ecosystem-benchmark build, so
-//     they never have binary size data. The build (and thus data) is produced only
-//     when a commit changes a non-doc file, mirroring that workflow's trigger
-//     `paths-ignore: ['**/*.md', 'website/**']`.
-//   - The first commit that DID trigger a build is decisive. If its size data is
-//     published, use it. If not, the data simply hasn't been generated yet, so fail
-//     loudly to force a re-run instead of silently comparing against an older
-//     baseline that would misattribute intermediate changes to this PR.
+// Baseline is `pr.base.sha` (the commit merged into the PR at run time), not the
+// fork point: PR CI builds from the merge ref, so head size already includes the
+// base tip. Walk main history skipping doc-only commits (they build no binding);
+// the first build-triggering commit is decisive — use its size data, or fail loudly
+// to force a re-run when it isn't published yet.
 async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
@@ -114,9 +101,8 @@ async function findBaseCommit(github, context) {
   );
 }
 
-// A linux binding build (and thus binary size data) is produced only for a commit
-// that changes at least one non-doc file, mirroring the ecosystem-benchmark
-// workflow trigger `paths-ignore: ['**/*.md', 'website/**']`.
+// A binding is built (and size data produced) only for commits touching non-doc
+// files, mirroring ecosystem-benchmark's `paths-ignore: ['**/*.md', 'website/**']`.
 async function triggersBinaryBuild(github, owner, repo, sha) {
   const { data: commit } = await github.rest.repos.getCommit({
     owner,
@@ -132,7 +118,7 @@ function isDocFile(filename) {
   return filename.endsWith('.md') || filename.startsWith('website/');
 }
 
-async function commentBestEffort(github, context, comment) {
+async function tryComment(github, context, comment) {
   try {
     await commentToPullRequest(github, context, comment);
   } catch (e) {
@@ -175,9 +161,7 @@ async function fetchDataBySha(sha) {
   const dataUrl = `${DATA_URL_BASE}/commits/${sha.slice(0, 2)}/${sha.slice(2)}/rspack-build.json`;
   console.log('fetching', dataUrl, '...');
   const res = await fetch(dataUrl);
-  // 404 means the size data hasn't been published for this commit yet; any other
-  // failure is transient/unexpected and should surface its real cause instead of
-  // being reported as "data not generated".
+  // 404 = data not published yet; other failures should surface their real cause.
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new Error(

--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -5,7 +5,22 @@ const fs = require('node:fs');
  * @param {Number} limit
  */
 module.exports = async function action({ github, context, limit }) {
-  const { baseCommit, baseSize } = await findBaseCommit(github, context);
+  let baseCommit;
+  let baseSize;
+  try {
+    ({ baseCommit, baseSize } = await findBaseCommit(github, context));
+  } catch (e) {
+    // Data should exist for this base commit but hasn't been generated yet.
+    // Still leave a comment (with a re-run link) before failing the job.
+    if (e instanceof PendingBinaryDataError) {
+      await commentBestEffort(
+        github,
+        context,
+        pendingBinarySizeComment(context, e.baseCommit),
+      );
+    }
+    throw e;
+  }
 
   const headSize = fs.statSync(
     './crates/node_binding/rspack.linux-x64-gnu.node',
@@ -14,13 +29,11 @@ module.exports = async function action({ github, context, limit }) {
   console.log(`Base commit size: ${baseSize}`);
   console.log(`Head commit size: ${headSize}`);
 
-  const comment = compareBinarySize(headSize, baseSize, context, baseCommit);
-
-  try {
-    await commentToPullRequest(github, context, comment);
-  } catch (e) {
-    console.error('Failed to comment on pull request:', e);
-  }
+  await commentBestEffort(
+    github,
+    context,
+    compareBinarySize(headSize, baseSize, context, baseCommit),
+  );
 
   const increasedSize = headSize - baseSize;
   if (increasedSize > limit) {
@@ -33,53 +46,98 @@ module.exports = async function action({ github, context, limit }) {
 const PER_PAGE = 30;
 const MAX_PAGES = 4;
 
-// Start from the PR's merge base (fork point) rather than the base branch tip,
-// so the size diff reflects only this PR's changes and not drift merged into
-// the base branch after the PR forked. Walk its ancestors page by page and
-// return the newest commit that has recorded binary size data.
+// Thrown when a base commit triggered a linux binding build but its binary size
+// data has not been published yet, so a re-run is needed rather than a comparison.
+class PendingBinaryDataError extends Error {
+  constructor(baseCommit) {
+    super(
+      `Base commit ${baseCommit.sha} triggered a linux binding build but its ` +
+        'binary size data has not been generated yet. Please re-run this workflow ' +
+        'once the ecosystem-benchmark run for that commit has published its data.',
+    );
+    this.baseCommit = baseCommit;
+  }
+}
+
+// The baseline is the base branch commit that the PR is merged onto at run time
+// (`pr.base.sha`), not the fork point. For `pull_request` events CI builds the
+// binding from the merge ref (PR head merged with the base tip), so the measured
+// head size already includes the base branch's latest state and the correct
+// baseline is that base commit. Walk main history from there toward the parent and:
+//
+//   - Skip doc-only commits: they don't trigger the ecosystem-benchmark build, so
+//     they never have binary size data. The build (and thus data) is produced only
+//     when a commit changes a non-doc file, mirroring that workflow's trigger
+//     `paths-ignore: ['**/*.md', 'website/**']`.
+//   - The first commit that DID trigger a build is decisive. If its size data is
+//     published, use it. If not, the data simply hasn't been generated yet, so fail
+//     loudly to force a re-run instead of silently comparing against an older
+//     baseline that would misattribute intermediate changes to this PR.
 async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
   if (!pr) {
     throw new Error('binary-limit action requires pull_request context');
   }
-  const { data: comparison } =
-    await github.rest.repos.compareCommitsWithBasehead({
-      owner,
-      repo,
-      basehead: `${pr.base.sha}...${pr.head.sha}`,
-    });
-  const mergeBaseSha = comparison.merge_base_commit.sha;
-  console.log(`Merge base commit: ${mergeBaseSha}`);
+  const baseSha = pr.base.sha;
+  console.log(`Base branch commit: ${baseSha}`);
 
   for (let page = 1; page <= MAX_PAGES; page++) {
     const { data: commits } = await github.rest.repos.listCommits({
       owner,
       repo,
-      sha: mergeBaseSha,
+      sha: baseSha,
       per_page: PER_PAGE,
       page,
     });
 
     for (const commit of commits) {
-      console.log(commit.sha);
-      try {
-        const data = await fetchDataBySha(commit.sha);
-        if (data?.size) {
-          console.log(`Commit ${commit.sha} has binary size: ${data.size}`);
-          return { baseCommit: commit, baseSize: data.size };
-        }
-      } catch (e) {
-        console.log(e);
+      if (!(await triggersBinaryBuild(github, owner, repo, commit.sha))) {
+        console.log(`Commit ${commit.sha} is doc-only, skipping to parent`);
+        continue;
       }
+
+      const data = await fetchDataBySha(commit.sha);
+      if (data?.size) {
+        console.log(`Commit ${commit.sha} has binary size: ${data.size}`);
+        return { baseCommit: commit, baseSize: data.size };
+      }
+
+      throw new PendingBinaryDataError(commit);
     }
 
     if (commits.length < PER_PAGE) break;
   }
 
   throw new Error(
-    `No base binary size found within ${MAX_PAGES} pages of commits from the merge base`,
+    `No base commit that triggered a linux binding build was found within ${MAX_PAGES} pages of commits from the base branch commit`,
   );
+}
+
+// A linux binding build (and thus binary size data) is produced only for a commit
+// that changes at least one non-doc file, mirroring the ecosystem-benchmark
+// workflow trigger `paths-ignore: ['**/*.md', 'website/**']`.
+async function triggersBinaryBuild(github, owner, repo, sha) {
+  const { data: commit } = await github.rest.repos.getCommit({
+    owner,
+    repo,
+    ref: sha,
+  });
+  const files = commit.files ?? [];
+  if (files.length === 0) return true;
+  return files.some((file) => !isDocFile(file.filename));
+}
+
+function isDocFile(filename) {
+  return filename.endsWith('.md') || filename.startsWith('website/');
+}
+
+async function commentBestEffort(github, context, comment) {
+  try {
+    await commentToPullRequest(github, context, comment);
+  } catch (e) {
+    console.error('Failed to comment on pull request:', e);
+  }
 }
 
 async function commentToPullRequest(github, context, comment) {
@@ -113,10 +171,12 @@ async function commentToPullRequest(github, context, comment) {
   });
 }
 
-function fetchDataBySha(sha) {
+async function fetchDataBySha(sha) {
   const dataUrl = `${DATA_URL_BASE}/commits/${sha.slice(0, 2)}/${sha.slice(2)}/rspack-build.json`;
   console.log('fetching', dataUrl, '...');
-  return fetch(dataUrl).then((res) => res.json());
+  const res = await fetch(dataUrl);
+  if (!res.ok) return null;
+  return res.json();
 }
 
 const SIZE_LIMIT_HEADING = '## 📦 Binary Size-limit';
@@ -124,12 +184,29 @@ const SIZE_LIMIT_HEADING = '## 📦 Binary Size-limit';
 const DATA_URL_BASE =
   'https://raw.githubusercontent.com/web-infra-dev/rspack-ecosystem-benchmark/data';
 
-function compareBinarySize(headSize, baseSize, context, baseCommit) {
+function runUrl(context) {
+  return `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+}
+
+function comparingInfo(context, baseCommit) {
   const message = baseCommit.commit.message.split('\n')[0];
   const author = baseCommit.commit.author.name;
   const headSha = context.payload.pull_request?.head.sha || context.sha;
+  return `> Comparing [\`${headSha.slice(0, 7)}\`](${context.payload.repository.html_url}/commit/${headSha}) to  [${message} by ${author}](${baseCommit.html_url})\n\n`;
+}
 
-  const info = `> Comparing [\`${headSha.slice(0, 7)}\`](${context.payload.repository.html_url}/commit/${headSha}) to  [${message} by ${author}](${baseCommit.html_url})\n\n`;
+function pendingBinarySizeComment(context, baseCommit) {
+  return (
+    comparingInfo(context, baseCommit) +
+    '⏳ The base commit triggered a linux binding build, but its binary size data ' +
+    'has not been generated yet, so the size comparison is skipped.\n\n' +
+    `Please [re-run this workflow](${runUrl(context)}) once the ecosystem-benchmark ` +
+    'data for that commit is published.'
+  );
+}
+
+function compareBinarySize(headSize, baseSize, context, baseCommit) {
+  const info = comparingInfo(context, baseCommit);
 
   const diff = headSize - baseSize;
   const percentage = (Math.abs(diff / baseSize) * 100).toFixed(2);


### PR DESCRIPTION
## Why

The binary size check picked its baseline incorrectly:

- It compared against the PR's **fork point** (computed merge base). But for `pull_request` events CI builds the binding from the merge ref (PR head merged with the base tip), so the measured head size already includes the base branch's latest state — the correct baseline is the **base branch commit**, not the fork point.
- When walking ancestors it treated *"build ran but size data not published yet"* the same as *"commit produced no build"*, so it could silently fall back to an older commit and misattribute intermediate changes to this PR.

## What

- Start from `pr.base.sha` (the commit merged into the PR at run time, read straight from the event context) instead of the computed merge base.
- Walk main history skipping only **doc-only** commits — mirroring the ecosystem-benchmark trigger `paths-ignore: ['**/*.md', 'website/**']`, since those never produce a binding and thus never have size data.
- The first commit that **did** trigger a build is decisive:
  - size data published → use it as the baseline;
  - not published yet → **fail the job** so the data gets regenerated, and post a Binary Size-limit comment with a **re-run link**.

### Fallback reference when base data is pending

Ecosystem-benchmark is slow, so a fresh base commit can sit without published data for a while. Instead of leaving the failure comment empty, the walk keeps going past the pending base to the **nearest ancestor that already has data** and appends its comparison as a **reference**:

- The job still **fails** — the reference is never treated as authoritative and does not gate the size limit.
- The reference is rendered in a prominent `> [!WARNING]` block labelled *"Reference only — not the real baseline"*, so reviewers get a rough number to lean on for a direct merge without mistaking it for the real diff.
- If no ancestor with data is found either, the comment falls back to just the pending/re-run message.

## examples

### when base data not prepared
<img width="795" height="237" alt="image" src="https://github.com/user-attachments/assets/4ea1570f-ff50-4114-a8f1-7d5b21c12870" />

[run](https://github.com/web-infra-dev/rspack/actions/runs/28855824867/job/85688776961)
