### PR TITLE
perf(swc): enable parallel wasmtime compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7939,6 +7939,7 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
+ "rayon",
  "rustix 1.1.4",
  "semver",
  "serde",

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -39,7 +39,7 @@ anyhow            = { workspace = true, optional = true }
 once_cell         = { workspace = true, optional = true }
 swc_plugin_runner = { workspace = true, optional = true }
 wasi-common       = { workspace = true, optional = true, features = ["sync", "wasmtime"] }
-wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift"] }
+wasmtime          = { workspace = true, optional = true, features = ["runtime", "cranelift", "parallel-compilation"] }
 
 rspack_regex = { workspace = true }
 signal-hook  = { workspace = true, optional = true }


### PR DESCRIPTION
## What changed

Enable Wasmtime's `parallel-compilation` feature for the SWC wasm plugin runtime in `rspack_util`.

This adds `rayon` to Wasmtime's enabled dependency set in `Cargo.lock`, allowing Wasmtime to compile module functions through its parallel compilation path when preparing wasm plugins.

## Why

`swc-plugin-coverage-instrument@0.0.32` contains 4,581 defined wasm functions. With Rspack's previous Wasmtime feature set, `wasmtime::Module::new` compiled those functions serially during cold plugin load. That made cold startup much slower than Wasmer for large SWC wasm plugins.

## Measured impact

Local benchmark on macOS arm64 / Apple M3 Max using `swc-plugin-coverage-instrument@0.0.32`:

| Scenario | Wasmtime with parallel compilation | Wasmer |
| --- | ---: | ---: |
| Cold load median | 359.7ms | 376.1ms |
| Cold `prepare_module` median | 343.6ms | 363.0ms |
| Stable hot load median | 14.5ms | 5.8ms |
| Stable transform median | 10.6ms | 9.4ms |

Before this change, the same Wasmtime cold load path was about 1.85s median, dominated by `prepare_module`.

## Notes

Focused checks run locally: `cargo check -p rspack_util --features plugin`, `cargo check -p rspack_util --features plugin --locked`, and `cargo fmt --all --check`.

`pnpm exec taplo format --check crates/rspack_util/Cargo.toml` could not run in this environment because the available pnpm is 11.7.0 while the repository requires 11.8.0.