### PR TITLE
fix: recreate persistent cache directories during save

### DIFF
--- a/crates/rspack_storage/src/filesystem/scope_fs.rs
+++ b/crates/rspack_storage/src/filesystem/scope_fs.rs
@@ -71,6 +71,9 @@ impl ScopeFileSystem {
   ) -> Result<()> {
     let from_file = from.workspace.join(relative_path.as_ref());
     let to_file = to.workspace.join(relative_path.as_ref());
+    to.fs
+      .create_dir_all(to_file.parent().expect("should have parent"))
+      .await?;
     if let Err(e) = from.fs.rename(&from_file, &to_file).await {
       // If the source file is not found, ignore the error.
       let e: Error = e.into();

--- a/tests/rspack-test/watchCases/cache/persistent-cache-delete/0/index.js
+++ b/tests/rspack-test/watchCases/cache/persistent-cache-delete/0/index.js
@@ -1,0 +1,84 @@
+import { existsSync, readdirSync, rmSync } from "fs";
+import value from "./value";
+
+const cacheDir = __CACHE_DIR__;
+
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function listCacheFiles() {
+	if (!existsSync(cacheDir)) {
+		return [];
+	}
+
+	const files = [];
+	const walk = dir => {
+		let entries;
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch (error) {
+			if (error && error.code === "ENOENT") {
+				return;
+			}
+			throw error;
+		}
+		for (const entry of entries) {
+			const file = `${dir}/${entry.name}`;
+			if (entry.isDirectory()) {
+				walk(file);
+			} else {
+				files.push(file);
+			}
+		}
+	};
+	walk(cacheDir);
+	return files;
+}
+
+function hasCommittedPackFile() {
+	return listCacheFiles().some(
+		file => file.endsWith(".pack") && !file.includes("/.temp/")
+	);
+}
+
+async function waitForPackFiles() {
+	const start = Date.now();
+	while (Date.now() - start < 5000) {
+		if (hasCommittedPackFile()) {
+			return;
+		}
+		await sleep(100);
+	}
+	throw new Error("Timed out waiting for persistent cache pack files");
+}
+
+async function removeCacheDir() {
+	const start = Date.now();
+	while (Date.now() - start < 5000) {
+		try {
+			rmSync(cacheDir, { recursive: true, force: true });
+			if (listCacheFiles().length === 0) {
+				return;
+			}
+		} catch (error) {
+			if (error && error.code !== "ENOTEMPTY") {
+				throw error;
+			}
+		}
+		await sleep(100);
+	}
+	throw new Error("Timed out removing persistent cache directory");
+}
+
+it("should keep writing persistent cache after the cache directory is removed", async () => {
+	expect(value).toBe(WATCH_STEP);
+	await waitForPackFiles();
+
+	if (WATCH_STEP === "0") {
+		await removeCacheDir();
+		expect(listCacheFiles().length).toBe(0);
+	} else {
+		expect(WATCH_STEP).toBe("1");
+	}
+});

--- a/tests/rspack-test/watchCases/cache/persistent-cache-delete/0/value.js
+++ b/tests/rspack-test/watchCases/cache/persistent-cache-delete/0/value.js
@@ -1,0 +1,1 @@
+export default "0";

--- a/tests/rspack-test/watchCases/cache/persistent-cache-delete/1/value.js
+++ b/tests/rspack-test/watchCases/cache/persistent-cache-delete/1/value.js
@@ -1,0 +1,1 @@
+export default "1";

--- a/tests/rspack-test/watchCases/cache/persistent-cache-delete/rspack.config.js
+++ b/tests/rspack-test/watchCases/cache/persistent-cache-delete/rspack.config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const { DefinePlugin } = require('@rspack/core');
+
+/** @type {(_env: unknown, args: { tempPath: string }) => import("@rspack/core").Configuration} */
+module.exports = (_env, { tempPath }) => {
+  const cacheDir = path.join(tempPath, 'node_modules/.cache/rspack');
+
+  return {
+    mode: 'development',
+    cache: {
+      type: 'persistent',
+      storage: {
+        type: 'filesystem',
+        directory: cacheDir,
+      },
+    },
+    watchOptions: {
+      ignored: /node_modules/,
+    },
+    plugins: [
+      new DefinePlugin({
+        __CACHE_DIR__: JSON.stringify(cacheDir),
+      }),
+    ],
+  };
+};


### PR DESCRIPTION
## Summary

- Recreate persistent cache destination directories before moving staged files so watch-mode saves can write packs after the cache directory is removed.
- Add a JS watch regression that deletes the persistent cache directory between rebuilds and verifies pack files are written again.

## Related links

Closes #14723

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
