### PR TITLE
chore(ci): bump rstack-ecosystem-ci dispatch action to latest main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
     if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ecca2c865c3830f56824fe7a3c6513bac77f5c8f # v0.3.4
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@edf483f3a550a8257aab674f076879b23047f350 # main (unreleased #64)
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -65,7 +65,7 @@ jobs:
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ecca2c865c3830f56824fe7a3c6513bac77f5c8f # v0.3.4
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@edf483f3a550a8257aab674f076879b23047f350 # main (unreleased #64)
         with:
           github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev


### PR DESCRIPTION
## Why

`rstack-ecosystem-ci#64` swapped the Docker-based `trigger-workflow-and-wait` for a JS `workflow_dispatch` implementation in the dispatch action. That change is on `main` but not yet tagged, so our pinned `v0.3.4` (`ecca2c8`) still runs the old Docker path.

This bumps both eco-CI action references to the latest `main` hash (`edf483f3`) so we exercise the new JS dispatch end-to-end.

| | before | after |
| --- | --- | --- |
| `ci.yml` (`ecosystem_ci_per_commit`) | `ecca2c8` v0.3.4 | `edf483f3` main #64 |
| `ecosystem-ci.yml` (`ecosystem_ci_dispatch`) | `ecca2c8` v0.3.4 | `edf483f3` main #64 |
