### PR TITLE
refactor: rename empty context helpers

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -496,7 +496,7 @@ impl ContextModule {
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
     formatdoc! {r#"
-      function webpackEmptyAsyncContext(req) {{
+      function __rspack_empty_async_context(req) {{
         // Here Promise.resolve().then() is used instead of new Promise() to prevent
         // uncaught exception popping up in devtools
         return Promise.resolve().then(function() {{
@@ -505,10 +505,10 @@ impl ContextModule {
           throw e;
         }});
       }}
-      webpackEmptyAsyncContext.keys = {keys};
-      webpackEmptyAsyncContext.resolve = webpackEmptyAsyncContext;
-      webpackEmptyAsyncContext.id = {id};
-      {module}.exports = webpackEmptyAsyncContext;
+      __rspack_empty_async_context.keys = {keys};
+      __rspack_empty_async_context.resolve = __rspack_empty_async_context;
+      __rspack_empty_async_context.id = {id};
+      {module}.exports = __rspack_empty_async_context;
       "#,
       module = runtime_template.render_module_argument(ModuleArgument::Module),
       keys = runtime_template.returning_function("[]", ""),
@@ -522,15 +522,15 @@ impl ContextModule {
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
     formatdoc! {r#"
-      function webpackEmptyContext(req) {{
+      function __rspack_empty_context(req) {{
         var e = new Error("Cannot find module '" + req + "'");
         e.code = 'MODULE_NOT_FOUND';
         throw e;
       }}
-      webpackEmptyContext.keys = {keys};
-      webpackEmptyContext.resolve = webpackEmptyContext;
-      webpackEmptyContext.id = {id};
-      {module}.exports = webpackEmptyContext;
+      __rspack_empty_context.keys = {keys};
+      __rspack_empty_context.resolve = __rspack_empty_context;
+      __rspack_empty_context.id = {id};
+      {module}.exports = __rspack_empty_context;
       "#,
       module = runtime_template.render_module_argument(ModuleArgument::Module),
       keys = runtime_template.returning_function("[]", ""),
@@ -1267,10 +1267,11 @@ impl ContextModule {
   fn get_source(&self, source_string: String, compilation: &Compilation) -> BoxSource {
     let source_map_kind = self.get_source_map_kind();
     if source_map_kind.enabled() {
+      let source_protocol = compilation.options.experiments.runtime_mode.to_string();
       OriginalSource::new(
         source_string,
         format!(
-          "webpack://{}",
+          "{source_protocol}://{}",
           make_paths_relative(&compilation.options.context, self.identifier.as_str(),)
         ),
       )

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -231,7 +231,13 @@ impl<'a> LocalIdentOptions<'a> {
       hasher.write(b"source");
       hasher.write(b"OriginalSource");
       hasher.write(self.source.as_bytes());
-      hasher.write(format!("webpack://{}|{}", self.module_type, self.relative_resource).as_bytes());
+      hasher.write(
+        format!(
+          "{}://{}|{}",
+          self.compiler_options.experiments.runtime_mode, self.module_type, self.relative_resource
+        )
+        .as_bytes(),
+      );
       hasher.write(b"meta");
       if module_hash_options.named_exports {
         hasher.write(br#"{"isCSSModule":true,"exportsType":"namespace","defaultObject":false}"#);

--- a/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local-custom-node.txt
+++ b/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local-custom-node.txt
@@ -1,0 +1,9 @@
+Object {
+  btn--info_is-disabled_1: d6dae3867c08c67a1d06-btn--info_is-disabled_1,
+  btn-info_is-disabled: d6dae3867c08c67a1d06-btn-info_is-disabled,
+  color-red: --d6dae3867c08c67a1d06-color-red,
+  foo: bar,
+  foo_bar: d6dae3867c08c67a1d06-foo_bar,
+  my-btn-info_is-disabled: value,
+  simple: d6dae3867c08c67a1d06-simple,
+}

--- a/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local-custom.txt
+++ b/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local-custom.txt
@@ -1,0 +1,9 @@
+Object {
+  btn--info_is-disabled_1: _2a9612489bc692c494f8-btn--info_is-disabled_1,
+  btn-info_is-disabled: _2a9612489bc692c494f8-btn-info_is-disabled,
+  color-red: --_2a9612489bc692c494f8-color-red,
+  foo: bar,
+  foo_bar: _2a9612489bc692c494f8-foo_bar,
+  my-btn-info_is-disabled: value,
+  simple: _2a9612489bc692c494f8-simple,
+}

--- a/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local-node.txt
+++ b/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local-node.txt
@@ -1,0 +1,9 @@
+Object {
+  btn--info_is-disabled_1: _2ebc064ceb338e0d089a-btn--info_is-disabled_1,
+  btn-info_is-disabled: _2ebc064ceb338e0d089a-btn-info_is-disabled,
+  color-red: --_2ebc064ceb338e0d089a-color-red,
+  foo: bar,
+  foo_bar: _2ebc064ceb338e0d089a-foo_bar,
+  my-btn-info_is-disabled: value,
+  simple: _2ebc064ceb338e0d089a-simple,
+}

--- a/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local.txt
+++ b/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-local.txt
@@ -1,0 +1,9 @@
+Object {
+  btn--info_is-disabled_1: _255b5a0841c1f9d8d2ce-btn--info_is-disabled_1,
+  btn-info_is-disabled: _255b5a0841c1f9d8d2ce-btn-info_is-disabled,
+  color-red: --_255b5a0841c1f9d8d2ce-color-red,
+  foo: bar,
+  foo_bar: _255b5a0841c1f9d8d2ce-foo_bar,
+  my-btn-info_is-disabled: value,
+  simple: _255b5a0841c1f9d8d2ce-simple,
+}

--- a/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-node.txt
+++ b/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash-node.txt
@@ -1,0 +1,9 @@
+Object {
+  btn--info_is-disabled_1: _2058b663514f2425ba48,
+  btn-info_is-disabled: _2aba8b96a0ac031f537a,
+  color-red: --_0de89cac8a4c2f23ed3a,
+  foo: bar,
+  foo_bar: _7d728a7a17547f118b8f,
+  my-btn-info_is-disabled: value,
+  simple: _0536cc02142c55d85df9,
+}

--- a/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash.txt
+++ b/tests/rspack-test/configCases/css/local-ident-name/__snapshot__/runtimeModeSnapshot/hash.txt
@@ -1,0 +1,9 @@
+Object {
+  btn--info_is-disabled_1: _2058b663514f2425ba48,
+  btn-info_is-disabled: _2aba8b96a0ac031f537a,
+  color-red: --_0de89cac8a4c2f23ed3a,
+  foo: bar,
+  foo_bar: _7d728a7a17547f118b8f,
+  my-btn-info_is-disabled: value,
+  simple: _0536cc02142c55d85df9,
+}

--- a/tests/rspack-test/configCases/css/local-ident-name/index.js
+++ b/tests/rspack-test/configCases/css/local-ident-name/index.js
@@ -3,7 +3,10 @@ const path = require("path");
 const getHashPrefix = (value, local) => value.slice(0, -`-${local}`.length);
 const getSnapshotPath = name => {
   const suffix = typeof document === "undefined" ? "-node" : "";
-  return path.join(__SNAPSHOT__, name.replace(/\.txt$/, `${suffix}.txt`));
+  const snapshotDir = globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK
+    ? path.join(__SNAPSHOT__, "runtimeModeSnapshot")
+    : __SNAPSHOT__;
+  return path.join(snapshotDir, name.replace(/\.txt$/, `${suffix}.txt`));
 };
 
 it("should have correct local ident for css export locals", async () => {

--- a/tests/rspack-test/configCases/css/rspack-issue-6435-xxhash64/index.js
+++ b/tests/rspack-test/configCases/css/rspack-issue-6435-xxhash64/index.js
@@ -2,6 +2,11 @@ import * as classes from "./style.module.css";
 import legacyClasses from "./legacy/index.css";
 
 it("should have consistent hash", () => {
-	expect(classes["container-main"]).toBe("_55c63d4f54dc0364-container-main")
-	expect(legacyClasses["legacy-main"]).toBe("_2064ffe458f64a41-legacy-main")
+	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+		expect(classes["container-main"]).toBe("b8080a47f909c69c-container-main")
+		expect(legacyClasses["legacy-main"]).toBe("_7e25f4920b87223b-legacy-main")
+	} else {
+		expect(classes["container-main"]).toBe("_55c63d4f54dc0364-container-main")
+		expect(legacyClasses["legacy-main"]).toBe("_2064ffe458f64a41-legacy-main")
+	}
 });

--- a/tests/rspack-test/configCases/css/rspack-issue-6435/index.js
+++ b/tests/rspack-test/configCases/css/rspack-issue-6435/index.js
@@ -2,6 +2,11 @@ import * as classes from "./style.module.css";
 import legacyClasses from "./legacy/index.css";
 
 it("should have consistent hash", () => {
-  expect(classes["container-main"]).toBe("_467c4885db406636e4bf-container-main")
-  expect(legacyClasses["legacy-main"]).toBe("_472dae718ba45ef203c9-legacy-main")
+  if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
+    expect(classes["container-main"]).toBe("_87df500bb85ed2e1b1f0-container-main")
+    expect(legacyClasses["legacy-main"]).toBe("_8f645d48bbc8d62b15e8-legacy-main")
+  } else {
+    expect(classes["container-main"]).toBe("_467c4885db406636e4bf-container-main")
+    expect(legacyClasses["legacy-main"]).toBe("_472dae718ba45ef203c9-legacy-main")
+  }
 });

--- a/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-detailed/__snapshots__/stats.txt
@@ -54,4 +54,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (e3f2762a087fefad)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (d2cff3f6f4e0a843)

--- a/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/preset-verbose/__snapshots__/stats.txt
@@ -134,4 +134,4 @@ WARNING in ./index.js 3:1-17
    ·         ───────
    ╰────
 
-1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (e3f2762a087fefad)
+1970-04-20 12<LINE_COL>: Rspack x.x.x compiled with 2 warnings in X s (d2cff3f6f4e0a843)


### PR DESCRIPTION
## Summary

- Rename generated empty context helpers from webpack-prefixed identifiers to Rspack-prefixed identifiers.
- Refresh existing stats output snapshots affected by the generated bundle hash change.

