### PR TITLE
fix(binding): clean up chunk wrappers when compiler is GCed

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -540,7 +540,9 @@ impl ObjectFinalize for JsCompiler {
       references.remove(&compiler_id);
     });
 
+    self.cleanup_last_compilation(&self.compiler.compilation);
     ModuleObject::cleanup_by_compiler_id(&compiler_id);
+
     if !self.unsafe_fast_drop {
       unsafe {
         ManuallyDrop::drop(&mut self.compiler);

--- a/tests/rspack-test/compilerCases/fixtures/tsfn-lifecycle/gc-check-chunk.cjs
+++ b/tests/rspack-test/compilerCases/fixtures/tsfn-lifecycle/gc-check-chunk.cjs
@@ -1,0 +1,83 @@
+const rspack = require("@rspack/core");
+const { createFsFromVolume, Volume } = require("memfs");
+const {
+  closeCompiler,
+  createGCTracker,
+  runCompiler,
+} = require("./helpers.cjs");
+
+async function main() {
+  const gcTracker = createGCTracker();
+  const fixtureDir = __dirname;
+  let observedChunks = false;
+
+  let compiler = rspack({
+    context: fixtureDir,
+    mode: "development",
+    entry: "./entry.js",
+    output: {
+      path: "/",
+      filename: "bundle.js",
+    },
+    plugins: [
+      {
+        apply(compiler) {
+          compiler.hooks.compilation.tap(
+            "TsfnLifecycleChunks",
+            compilation => {
+              compilation.hooks.afterProcessAssets.tap(
+                "TsfnLifecycleChunks",
+                () => {
+                  const chunks = Array.from(compilation.chunks);
+                  const chunkGroups = Array.from(compilation.chunkGroups);
+
+                  if (chunks.length === 0) {
+                    throw new Error("expected at least one chunk");
+                  }
+
+                  if (chunkGroups.length === 0) {
+                    throw new Error("expected at least one chunk group");
+                  }
+
+                  let chunk = chunks[0];
+                  let chunkGroup = chunkGroups[0];
+
+                  gcTracker.track(chunk, "chunk");
+                  gcTracker.track(chunkGroup, "chunk group");
+
+                  chunk = null;
+                  chunkGroup = null;
+                  chunks.length = 0;
+                  chunkGroups.length = 0;
+                  observedChunks = true;
+                },
+              );
+            },
+          );
+        },
+      },
+    ],
+  });
+  compiler.outputFileSystem = createFsFromVolume(new Volume());
+
+  let stats = await runCompiler(compiler);
+  if (!observedChunks) {
+    throw new Error("chunks were not observed");
+  }
+
+  gcTracker.track(compiler, "chunk compiler");
+
+  await closeCompiler(compiler);
+
+  stats = null;
+  compiler = null;
+
+  await gcTracker.waitForCollection("chunk compiler");
+  await gcTracker.waitForCollection("chunk");
+  await gcTracker.waitForCollection("chunk group");
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/rspack-test/compilerCases/tsfn-lifecycle.js
+++ b/tests/rspack-test/compilerCases/tsfn-lifecycle.js
@@ -80,6 +80,20 @@ module.exports = [
     },
   },
   {
+    description:
+      "should garbage collect chunks after compiler is garbage collected",
+    async build() {
+      await runChild(
+        path.join(
+          __dirname,
+          "fixtures",
+          "tsfn-lifecycle",
+          "gc-check-chunk.cjs",
+        ),
+      );
+    },
+  },
+  {
     description: "should report a clear error when APIs are called after close",
     async build() {
       await runChild(


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Clean up the last compilation from `JsCompiler::finalize` so cached JS wrappers are released when the compiler is garbage collected.
- Add a GC regression case for `Chunk` and `ChunkGroup` wrappers after compiler close and collection.
- Related to #14734.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
