### PR TITLE
refactor(cli): use @rstackjs/load-config

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@discoveryjs/json-ext": "^1.1.0",
     "@microsoft/api-extractor": "^7.58.9",
+    "@rstackjs/load-config": "^0.1.1",
     "@rslib/core": "^0.23.2",
     "@rspack/core": "workspace:*",
     "@rspack/dev-server": "^2.1.0",

--- a/packages/rspack-cli/rslib.config.ts
+++ b/packages/rspack-cli/rslib.config.ts
@@ -12,6 +12,16 @@ export default defineConfig({
       },
     },
   ],
+  output: {
+    externals: [
+      ({ request }, callback) => {
+        if (request === 'jiti') {
+          return callback(undefined, '../compiled/jiti/index.js');
+        }
+        return callback();
+      },
+    ],
+  },
   source: {
     tsconfigPath: './tsconfig.build.json',
     define: {

--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -307,7 +307,6 @@ export class RspackCLI {
 
     const { loadedConfig, configPath } = config;
 
-    // Handle extends property if the loaded config is not a function
     const { config: extendedConfig, pathMap } = await loadExtendedConfig(
       loadedConfig,
       configPath,

--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -16,11 +16,7 @@ import { BuildCommand } from './commands/build';
 import { PreviewCommand } from './commands/preview';
 import { ServeCommand } from './commands/serve';
 import type { RspackCLIColors, RspackCLILogger } from './types';
-import {
-  loadExtendedConfig,
-  loadRspackConfig,
-  resolveRspackConfigExport,
-} from './utils/loadConfig';
+import { loadExtendedConfig, loadRspackConfig } from './utils/loadConfig';
 import type {
   CommonOptions,
   CommonOptionsForBuildAndServe,
@@ -310,14 +306,10 @@ export class RspackCLI {
     }
 
     const { loadedConfig, configPath } = config;
-    const resolvedConfig = await resolveRspackConfigExport(
-      loadedConfig,
-      options,
-    );
 
     // Handle extends property if the loaded config is not a function
     const { config: extendedConfig, pathMap } = await loadExtendedConfig(
-      resolvedConfig,
+      loadedConfig,
       configPath,
       process.cwd(),
       options,

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -28,6 +28,7 @@ const loadConfigByPath = async (
     path: configPath,
     loader: options.configLoader,
     configParams,
+    fresh: true,
   });
 
   if (!isRspackConfig(content)) {

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -32,7 +32,9 @@ const loadConfigByPath = async (
 
   if (!isRspackConfig(content)) {
     throw new Error(
-      `The config must be an object or an array, get ${String(content)}`,
+      `[rspack-cli:loadConfig] The config at "${configPath}" must be an object or an array, got ${String(
+        content,
+      )}`,
     );
   }
 

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { loadConfig as baseLoadConfig } from '@rstackjs/load-config';
 import type { MultiRspackOptions, RspackOptions } from '@rspack/core';
-import { merge } from 'rspack-merge';
 import findConfig from './findConfig';
 import type { CommonOptions } from './options';
 
@@ -11,132 +11,33 @@ const require = createRequire(import.meta.url);
 
 const DEFAULT_CONFIG_NAME = 'rspack.config' as const;
 
-const JS_CONFIG_EXTENSION_REGEXP = /\.(?:js|mjs|cjs)$/;
-const CONFIG_LOADER_VALUES = ['auto', 'jiti', 'native'] as const;
-type ConfigLoader = (typeof CONFIG_LOADER_VALUES)[number];
-type JitiFactory = (
-  id: string,
-  opts: {
-    moduleCache: boolean;
-    interopDefault: boolean;
-    nativeModules: string[];
-  },
-) => {
-  import<T = unknown>(
-    path: string,
-    opts: {
-      default: boolean;
-    },
-  ): Promise<T>;
-};
+export type LoadedRspackConfig = RspackOptions | MultiRspackOptions;
 
-const PREBUNDLED_JITI_PATH = new URL(
-  '../compiled/jiti/index.js',
-  import.meta.url,
-).href;
+type RspackConfigParams = [Record<string, any>, CommonOptions];
 
-const supportsNativeTypeScript = () => {
-  const features = process.features as NodeJS.ProcessFeatures & {
-    typescript?: boolean;
-  };
-
-  return Boolean(
-    features.typescript || process.versions.bun || process.versions.deno,
-  );
-};
-
-const normalizeConfigLoader = (
-  configLoader: CommonOptions['configLoader'],
-): ConfigLoader => {
-  const normalizedLoader = configLoader ?? 'auto';
-
-  if (CONFIG_LOADER_VALUES.includes(normalizedLoader as ConfigLoader)) {
-    return normalizedLoader as ConfigLoader;
-  }
-
-  throw new Error(
-    `config loader "${normalizedLoader}" is not supported. Expected one of: ${CONFIG_LOADER_VALUES.join(
-      ', ',
-    )}.`,
-  );
-};
-
-const resolveDefaultExport = <T>(result: T): T =>
-  result &&
-  typeof result === 'object' &&
-  'default' in (result as Record<string, unknown>)
-    ? ((result as Record<string, unknown>).default as T)
-    : result;
-
-const loadConfigWithNativeLoader = async <T = unknown>(
-  configPath: string,
-): Promise<T> => {
-  const configFileURL = pathToFileURL(configPath).href;
-  const loadedModule = await import(`${configFileURL}?t=${Date.now()}`);
-  return resolveDefaultExport(loadedModule as T);
-};
-
-let jitiInstancePromise: Promise<ReturnType<JitiFactory>> | undefined;
-
-const getJiti = async () => {
-  if (!jitiInstancePromise) {
-    jitiInstancePromise = import(
-      /* webpackIgnore: true */ PREBUNDLED_JITI_PATH
-    ).then((module) => {
-      const createJiti =
-        'createJiti' in module
-          ? (module.createJiti as JitiFactory)
-          : (module.default as JitiFactory);
-
-      return createJiti(import.meta.filename, {
-        moduleCache: false,
-        interopDefault: true,
-        nativeModules: ['typescript'],
-      });
-    });
-  }
-  return jitiInstancePromise;
-};
-
-const loadConfigWithJiti = async <T = unknown>(configPath: string) => {
-  const jiti = await getJiti();
-  return jiti.import(configPath, { default: true }) as Promise<T>;
-};
-
-const loadConfigByPath = async <T = unknown>(
+const loadConfigByPath = async (
   configPath: string,
   options: CommonOptions,
-): Promise<T> => {
-  const configLoader = normalizeConfigLoader(options.configLoader);
-  const useNative = Boolean(
-    configLoader === 'native' ||
-    (configLoader === 'auto' && supportsNativeTypeScript()),
-  );
+): Promise<LoadedRspackConfig> => {
+  const configParams = [options.env, options] as RspackConfigParams;
 
-  if (useNative || JS_CONFIG_EXTENSION_REGEXP.test(configPath)) {
-    try {
-      return await loadConfigWithNativeLoader<T>(configPath);
-    } catch (error) {
-      if (configLoader === 'native') {
-        throw error;
-      }
-    }
+  const { content } = await baseLoadConfig<
+    LoadedRspackConfig,
+    RspackConfigParams
+  >({
+    path: configPath,
+    loader: options.configLoader,
+    configParams,
+  });
+
+  if (!isRspackConfig(content)) {
+    throw new Error(
+      `The config must be an object or an array, get ${String(content)}`,
+    );
   }
 
-  return loadConfigWithJiti<T>(configPath);
+  return content;
 };
-
-export type LoadedRspackConfig =
-  | undefined
-  | RspackOptions
-  | MultiRspackOptions
-  | ((
-      env: Record<string, any>,
-      argv?: Record<string, any>,
-    ) =>
-      | RspackOptions
-      | MultiRspackOptions
-      | Promise<RspackOptions | MultiRspackOptions>);
 
 const isConfigObject = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -145,42 +46,6 @@ const isRspackConfig = (
   value: unknown,
 ): value is RspackOptions | MultiRspackOptions =>
   Array.isArray(value) || isConfigObject(value);
-
-export const resolveRspackConfigExport = async (
-  configExport: LoadedRspackConfig,
-  options: CommonOptions,
-): Promise<RspackOptions | MultiRspackOptions> => {
-  let loadedConfig: unknown = configExport;
-
-  if (typeof loadedConfig === 'function') {
-    let functionResult = loadedConfig(
-      options.env as Record<string, any>,
-      options,
-    );
-
-    if (typeof (functionResult as Promise<unknown>).then === 'function') {
-      functionResult = await functionResult;
-    }
-
-    if (functionResult === undefined) {
-      throw new Error(
-        '[rspack-cli:loadConfig] The config function must return a config object.',
-      );
-    }
-
-    loadedConfig = functionResult;
-  }
-
-  if (!isRspackConfig(loadedConfig)) {
-    throw new Error(
-      `[rspack-cli:loadConfig] The config must be an object, an array, or a function that returns one, get ${String(
-        loadedConfig,
-      )}`,
-    );
-  }
-
-  return loadedConfig;
-};
 
 const checkIsMultiRspackOptions = (
   config: RspackOptions | MultiRspackOptions,
@@ -335,19 +200,13 @@ export async function loadExtendedConfig(
     }
 
     // Load the extended configuration
-    const loadedConfig = await loadConfigByPath<LoadedRspackConfig>(
-      resolvedPath,
-      options,
-    );
-    const resolvedConfig = await resolveRspackConfigExport(
-      loadedConfig,
-      options,
-    );
+    const loadedConfig = await loadConfigByPath(resolvedPath, options);
+    const { merge } = await import('rspack-merge');
 
     // Recursively load extended configurations from the extended config
     const { config: extendedConfig, pathMap: extendedPathMap } =
       (await loadExtendedConfig(
-        resolvedConfig,
+        loadedConfig,
         resolvedPath,
         cwd,
         options,
@@ -392,10 +251,7 @@ export async function loadRspackConfig(
   }
 
   // load config
-  const loadedConfig = await loadConfigByPath<LoadedRspackConfig>(
-    configPath,
-    options,
-  );
+  const loadedConfig = await loadConfigByPath(configPath, options);
 
   return { loadedConfig, configPath };
 }

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -13,18 +13,18 @@ const DEFAULT_CONFIG_NAME = 'rspack.config' as const;
 
 export type LoadedRspackConfig = RspackOptions | MultiRspackOptions;
 
-type RspackConfigParams = [Record<string, any>, CommonOptions];
+type ConfigParams = [
+  Record<string, unknown> | string[] | undefined,
+  CommonOptions,
+];
 
 const loadConfigByPath = async (
   configPath: string,
   options: CommonOptions,
 ): Promise<LoadedRspackConfig> => {
-  const configParams = [options.env, options] as RspackConfigParams;
+  const configParams: ConfigParams = [options.env, options];
 
-  const { content } = await baseLoadConfig<
-    LoadedRspackConfig,
-    RspackConfigParams
-  >({
+  const { content } = await baseLoadConfig<LoadedRspackConfig, ConfigParams>({
     path: configPath,
     loader: options.configLoader,
     configParams,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       '@rspack/test-tools':
         specifier: workspace:*
         version: link:../rspack-test-tools
+      '@rstackjs/load-config':
+        specifier: ^0.1.1
+        version: 0.1.1(jiti@2.7.0)
       cac:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2929,6 +2932,14 @@ packages:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
       '@rspress/core':
+        optional: true
+
+  '@rstackjs/load-config@0.1.1':
+    resolution: {integrity: sha512-YYtqGoM5DrrmZLGaYSUAC66qhhfjAfwXVvBScGJIfPXGa878rK0SJeO6b44W2pYfikm8yefzyV0OeedWO/PKkw==}
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
         optional: true
 
   '@rstest/core@0.10.6':
@@ -9123,6 +9134,10 @@ snapshots:
   '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.16)':
     optionalDependencies:
       '@rspress/core': 2.0.16(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+
+  '@rstackjs/load-config@0.1.1(jiti@2.7.0)':
+    optionalDependencies:
+      jiti: 2.7.0
 
   '@rstest/core@0.10.6(@module-federation/runtime-tools@2.6.0)(core-js@3.49.0)(jsdom@26.1.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ minimumReleaseAgeExclude:
   - 'rsbuild-plugin-*'
   - '@swc/*'
   - 'heading-case'
+  - '@rstackjs/load-config'
 
 patchedDependencies:
   webpack-sources@3.5.0: patches/webpack-sources@3.5.0.patch


### PR DESCRIPTION
## Summary

This PR replaces rspack-cli's custom config loader implementation with `@rstackjs/load-config` so config resolution uses the shared Rstack loader behavior.

## Related links

https://github.com/rstackjs/load-config

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).