### PR TITLE
refactor: use rspack runtime identifiers

### DIFF
--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_style.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_style.ejs
@@ -1,7 +1,7 @@
-var dataWebpackPrefix = <%- _data_webpack_prefix %>;
+var dataRspackPrefix = <%- _data_rspack_prefix %>;
 
-function getDataWebpackId(identifier) {
-	return dataWebpackPrefix + identifier;
+function getDataRspackId(identifier) {
+	return dataRspackPrefix + identifier;
 }
 
 function applyStyle(styleElement, css) {
@@ -18,7 +18,7 @@ function findStyleElement(identifier) {
 	var elements = document.getElementsByTagName("style");
 	for (var i = 0; i < elements.length; i++) {
 		var el = elements[i];
-		if (el.getAttribute("data-rspack") == getDataWebpackId(identifier)) {
+		if (el.getAttribute("data-rspack") == getDataRspackId(identifier)) {
 			return el;
 		}
 	}

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -426,7 +426,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
       }
 
       if with_inject_style {
-        let data_webpack_prefix = if unique_name.is_empty() {
+        let data_rspack_prefix = if unique_name.is_empty() {
           json_stringify("rspack:")
         } else {
           json_stringify(&format!("{unique_name}:"))
@@ -441,7 +441,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
               runtime_template.render_runtime_globals(&RuntimeGlobals::SCRIPT_NONCE)
             ));
           }
-          code.push_str("style.setAttribute(\"data-rspack\", getDataWebpackId(key));");
+          code.push_str("style.setAttribute(\"data-rspack\", getDataRspackId(key));");
           code
         };
         let css_inject_style =
@@ -451,7 +451,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         let source_with_style = context.runtime_template.render(
           &self.template_id(TemplateId::WithStyle),
           Some(serde_json::json!({
-            "_data_webpack_prefix": data_webpack_prefix,
+            "_data_rspack_prefix": data_rspack_prefix,
             "_create_style": &create_style_element_code,
             "_css_inject_style": &css_inject_style,
             "_with_hmr": with_hmr,

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -167,7 +167,7 @@ async fn render(
       )
     };
     format!(
-      r#"function webpackLoadOptionalExternalModuleAmd({wrapper_arguments}) {{
+      r#"function __rspack_load_optional_external_module_amd({wrapper_arguments}) {{
       return factory({factory_arguments});
     }}"#
     )
@@ -280,7 +280,7 @@ async fn render(
 
   let mut source = ConcatSource::default();
   source.add(RawStringSource::from(
-    "(function webpackUniversalModuleDefinition(root, factory) {\n",
+    "(function __rspack_universal_module_definition(root, factory) {\n",
   ));
   let commonjs2_externals = {
     let side_effects_state_artifact = &compilation
@@ -425,7 +425,7 @@ fn externals_require_array(
           side_effects_state_artifact,
           exports_info_artifact,
         ) {
-          expr = format!("(function webpackLoadOptionalExternalModule() {{ try {{ return {expr}; }} catch(e) {{}} }}())");
+          expr = format!("(function __rspack_load_optional_external_module() {{ try {{ return {expr}; }} catch(e) {{}} }}())");
         }
         Ok(expr)
       })

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -53,7 +53,7 @@ impl ContainerEntryModule {
     share_scope: ShareScope,
     enhanced: bool,
   ) -> Self {
-    let lib_ident = format!("webpack/container/entry/{}", &name);
+    let lib_ident = format!("rspack/container/entry/{}", &name);
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
@@ -82,7 +82,7 @@ impl ContainerEntryModule {
   }
 
   pub fn new_share_container_entry(name: String, request: String, version: String) -> Self {
-    let lib_ident = format!("webpack/share/container/{}", &name);
+    let lib_ident = format!("rspack/share/container/{}", &name);
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),

--- a/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
@@ -89,7 +89,7 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
                 } else {
                   Default::default()
                 };
-                format!("webpack/container/reference/{key}{fallback_suffix}")
+                format!("rspack/container/reference/{key}{fallback_suffix}")
               }
             })
             .collect(),

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
@@ -1,7 +1,7 @@
 var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 	var hasRun = false;
 	var result;
-	return function __webpack_require__mfStartupBase() {
+	return function __rspack_require_mfStartupBase() {
 		if (hasRun) return result;
 		hasRun = true;
 		result = (function () {
@@ -13,7 +13,7 @@ var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 var mfAsyncStartup = <%- REQUIRE %>.mfAsyncStartup = (function () {
 	var hasRun = false;
 	var result;
-	return function __webpack_require__mfAsyncStartup() {
+	return function __rspack_require_mfAsyncStartup() {
 		if (hasRun) return result;
 		hasRun = true;
 		var base = mfStartupBase && mfStartupBase();

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -39,7 +39,7 @@ impl FallbackModule {
     let mut requests_len_buffer = itoa::Buffer::new();
     let requests_len_minus_one = requests_len_buffer.format(requests.len() - 1);
     let lib_ident = format!(
-      "webpack/container/fallback/{}/and {} more",
+      "rspack/container/fallback/{}/and {} more",
       requests
         .first()
         .expect("should have at one more requests in FallbackModule"),

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -52,7 +52,7 @@ impl RemoteModule {
     remote_key: String,
   ) -> Self {
     let readable_identifier = format!("remote {}", &request);
-    let lib_ident = format!("webpack/container/remote/{}", &request);
+    let lib_ident = format!("rspack/container/remote/{}", &request);
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -78,7 +78,7 @@ impl ConsumeSharedModule {
       dependencies: Vec::new(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
       lib_ident: format!(
-        "webpack/sharing/consume/{}/{}{}",
+        "rspack/sharing/consume/{}/{}{}",
         &scopes_key,
         &options.share_key,
         options

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -68,7 +68,7 @@ impl ProvideSharedModule {
       blocks: Vec::new(),
       dependencies: Vec::new(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
-      lib_ident: format!("webpack/sharing/provide/{}/{}", &scopes_key, &name),
+      lib_ident: format!("rspack/sharing/provide/{}/{}", &scopes_key, &name),
       readable_identifier: identifier,
       name,
       share_scope,

--- a/crates/rspack_plugin_runtime/src/runtime_module/export_require.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/export_require.rs
@@ -4,6 +4,7 @@ use rspack_core::{
 };
 
 pub static EXPORT_REQUIRE_RUNTIME_MODULE_ID: &str = "export_webpack_require";
+pub static EXPORT_REQUIRE_RSPACK_RUNTIME_MODULE_ID: &str = "export_require";
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -11,7 +12,12 @@ pub struct ExportRequireRuntimeModule {}
 
 impl ExportRequireRuntimeModule {
   pub fn new(runtime_template: &RuntimeTemplate) -> Self {
-    Self::with_name(runtime_template, EXPORT_REQUIRE_RUNTIME_MODULE_ID)
+    let name = if runtime_template.runtime_module_prefix() == "rspack/runtime/" {
+      EXPORT_REQUIRE_RSPACK_RUNTIME_MODULE_ID
+    } else {
+      EXPORT_REQUIRE_RUNTIME_MODULE_ID
+    };
+    Self::with_name(runtime_template, name)
   }
 }
 

--- a/packages/rspack/src/container/ContainerReferencePlugin.ts
+++ b/packages/rspack/src/container/ContainerReferencePlugin.ts
@@ -80,7 +80,7 @@ export class ContainerReferencePlugin extends RspackBuiltinPlugin {
       let i = 0;
       for (const external of config.external) {
         if (external.startsWith('internal ')) continue;
-        const request = `webpack/container/reference/${key}${i ? `/fallback-${i}` : ''}`;
+        const request = `rspack/container/reference/${key}${i ? `/fallback-${i}` : ''}`;
         // In ESM output, module-like externals emit a static `import * as ... from "..."`
         // which can create a circular dependency for relative remotes (notably self-remotes like
         // `containerB: "./container.mjs"` with `runtimeChunk: "single"`). Prefer dynamic `import()`

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/runtimeModeSnapshot/snapshot.txt
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/runtimeModeSnapshot/snapshot.txt
@@ -5,7 +5,7 @@ node_modules_cell_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae0"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -23,7 +23,7 @@ node_modules_cell_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae1"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -41,8 +41,8 @@ node_modules_row_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8840"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { cell } = __rspack_context.r("webpack/sharing/consume/default/cell/cell")
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { cell } = __rspack_context.r("rspack/sharing/consume/default/cell/cell")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
@@ -60,8 +60,8 @@ node_modules_row_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8841"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { cell } = __rspack_context.r("webpack/sharing/consume/default/cell/cell")
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { cell } = __rspack_context.r("rspack/sharing/consume/default/cell/cell")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
@@ -5,7 +5,7 @@ node_modules_cell_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae0"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -23,7 +23,7 @@ node_modules_cell_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae1"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -41,8 +41,8 @@ node_modules_row_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8840"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
-const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+const { cell } = __webpack_require__("rspack/sharing/consume/default/cell/cell")
+const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
@@ -60,8 +60,8 @@ node_modules_row_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8841"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
-const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
+const { cell } = __webpack_require__("rspack/sharing/consume/default/cell/cell")
+const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })

--- a/tests/rspack-test/configCases/container-1-5/error-handling/index.js
+++ b/tests/rspack-test/configCases/container-1-5/error-handling/index.js
@@ -57,7 +57,7 @@ it("should allow to handle invalid remote module error with import()", async () 
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
 		})
 	);
 	// at this point sharing initialization runs and triggers a warning that 'invalid' remote can't be loaded
@@ -69,7 +69,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
 		})
 	);
 });
@@ -79,7 +79,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
 		})
 	);
 });

--- a/tests/rspack-test/configCases/container/error-handling/index.js
+++ b/tests/rspack-test/configCases/container/error-handling/index.js
@@ -57,7 +57,7 @@ it("should allow to handle invalid remote module error with import()", async () 
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
 		})
 	);
 	// at this point sharing initialization runs and triggers a warning that 'invalid' remote can't be loaded
@@ -69,7 +69,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
 		})
 	);
 });
@@ -79,7 +79,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
 		})
 	);
 });

--- a/tests/rspack-test/configCases/sharing/reshake-share/index.js
+++ b/tests/rspack-test/configCases/sharing/reshake-share/index.js
@@ -56,7 +56,7 @@ it("correct handle share dep while secondary tree shaking", async () => {
     const uiLibShareContainerModule = eval("require")(uiLibShareContainerPath).secondary_tree_shaking_share_t_ui_lib_100;
 		await uiLibShareContainerModule.init({},{
 		installInitialConsumes: async ({webpackRequire})=>{
-			webpackRequire.m['webpack/sharing/consume/default/ui-lib-dep'] = (m)=>{
+			webpackRequire.m['rspack/sharing/consume/default/ui-lib-dep'] = (m)=>{
 				m.exports = {
 					Message: 'Message',
 				}

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -52,7 +52,7 @@ __rspack_context.r = __rspack_require;
 // expose the modules object (__rspack_modules)
 __rspack_context.m = __rspack_modules;
 
-// rspack/runtime/export_webpack_require
+// rspack/runtime/export_require
 var __rspack_contexttemp = __rspack_context;
 export { __rspack_contexttemp as __rspack_context };
 ;

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42679
+- Update: main.LAST_HASH.hot-update.js, size: 42669
 
 ## Manifest
 
@@ -43,11 +43,11 @@ __webpack_require__.d(__webpack_exports__, {
   "default": () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
   getValue: () => (getValue)
 });
-/* import */ var common__rspack_import_0 = __webpack_require__("webpack/sharing/consume/default/common/./common?1");
+/* import */ var common__rspack_import_0 = __webpack_require__("rspack/sharing/consume/default/common/./common?1");
 /* import */ var common__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(common__rspack_import_0);
 
 
-const getValue = () => __webpack_require__.e(/* import() */ "webpack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "webpack/sharing/consume/default/common2/./common?2", 23));
+const getValue = () => __webpack_require__.e(/* import() */ "rspack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "rspack/sharing/consume/default/common2/./common?2", 23));
 
 
 },
@@ -101,7 +101,7 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 // webpack/runtime/consumes_loading
 (() => {
 
-__webpack_require__.consumesLoadingData = { chunkMapping: {"main":["webpack/sharing/consume/default/common/./common?1"],"webpack_sharing_consume_default_common2_common_2":["webpack/sharing/consume/default/common2/./common?2"]}, moduleIdToConsumeDataMapping: {"webpack/sharing/consume/default/common/./common?1": { shareScope: "default", shareKey: "common", import: "./common?1", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: true, fallback: () => (() => (__webpack_require__("./common.js?1"))), treeShakingMode: null }, "webpack/sharing/consume/default/common2/./common?2": { shareScope: "default", shareKey: "common2", import: "./common?2", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: false, fallback: () => (__webpack_require__.e("common_js_2").then(() => (() => (__webpack_require__("./common.js?2"))))), treeShakingMode: null }}, initialConsumes: ["webpack/sharing/consume/default/common/./common?1"] };
+__webpack_require__.consumesLoadingData = { chunkMapping: {"main":["rspack/sharing/consume/default/common/./common?1"],"rspack_sharing_consume_default_common2_common_2":["rspack/sharing/consume/default/common2/./common?2"]}, moduleIdToConsumeDataMapping: {"rspack/sharing/consume/default/common/./common?1": { shareScope: "default", shareKey: "common", import: "./common?1", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: true, fallback: () => (() => (__webpack_require__("./common.js?1"))), treeShakingMode: null }, "rspack/sharing/consume/default/common2/./common?2": { shareScope: "default", shareKey: "common2", import: "./common?2", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: false, fallback: () => (__webpack_require__.e("common_js_2").then(() => (() => (__webpack_require__("./common.js?2"))))), treeShakingMode: null }}, initialConsumes: ["rspack/sharing/consume/default/common/./common?1"] };
 var splitAndConvert = function(str) {
   return str.split(".").map(function(item) {
     return +item == item ? +item : item;
@@ -688,7 +688,7 @@ if (installedChunkData !== 0) {
 	if (installedChunkData) {
 		promises.push(installedChunkData[2]);
 	} else {
-		if ("webpack_sharing_consume_default_common2_common_2" != chunkId) {
+		if ("rspack_sharing_consume_default_common2_common_2" != chunkId) {
 			// setup Promise in chunk cache
 			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));

--- a/tests/rspack-test/serialCases/container-1-5/2-transitive-overriding/index.js
+++ b/tests/rspack-test/serialCases/container-1-5/2-transitive-overriding/index.js
@@ -19,8 +19,8 @@ it("should have good module ids", async () => {
 	[
 		"./b.js",
 		"./modules.js",
-		"webpack/container/entry/container-with-shared",
-		"webpack/sharing/consume/default/shared/./shared"
+		"rspack/container/entry/container-with-shared",
+		"rspack/sharing/consume/default/shared/./shared"
 	].forEach(m => expect(m0).toContain(m));
 	[
 		"./a.js",
@@ -28,18 +28,18 @@ it("should have good module ids", async () => {
 		"./modules-from-remote.js",
 		"./modules.js",
 		"./shared.js",
-		"webpack/container/entry/container-no-shared",
-		"webpack/container/reference/container-with-shared",
-		"webpack/container/remote/container-with-shared/b",
-		"webpack/container/remote/container-with-shared/modules"
+		"rspack/container/entry/container-no-shared",
+		"rspack/container/reference/container-with-shared",
+		"rspack/container/remote/container-with-shared/b",
+		"rspack/container/remote/container-with-shared/modules"
 	].forEach(m => expect(m1).toContain(m));
 	[
 		"./index.js",
 		"./shared.js",
-		"webpack/container/reference/container-no-shared",
-		"webpack/container/remote/container-no-shared/a",
-		"webpack/container/remote/container-no-shared/b",
-		"webpack/container/remote/container-no-shared/modules",
-		"webpack/container/remote/container-no-shared/modules-from-remote"
+		"rspack/container/reference/container-no-shared",
+		"rspack/container/remote/container-no-shared/a",
+		"rspack/container/remote/container-no-shared/b",
+		"rspack/container/remote/container-no-shared/modules",
+		"rspack/container/remote/container-no-shared/modules-from-remote"
 	].forEach(m => expect(m2).toContain(m));
 });

--- a/tests/rspack-test/serialCases/container/2-transitive-overriding/index.js
+++ b/tests/rspack-test/serialCases/container/2-transitive-overriding/index.js
@@ -19,26 +19,26 @@ it("should have good module ids", async () => {
 	expect(m0).toEqual([
 		"./b.js",
 		"./modules.js",
-		"webpack/container/entry/container-with-shared",
-		"webpack/sharing/consume/default/shared/./shared"
+		"rspack/container/entry/container-with-shared",
+		"rspack/sharing/consume/default/shared/./shared"
 	]);
 	expect(m1).toEqual([
 		"./a.js",
 		"./b.js",
 		"./modules-from-remote.js",
 		"./modules.js",
-		"webpack/container/entry/container-no-shared",
-		"webpack/container/reference/container-with-shared",
-		"webpack/container/remote/container-with-shared/b",
-		"webpack/container/remote/container-with-shared/modules"
+		"rspack/container/entry/container-no-shared",
+		"rspack/container/reference/container-with-shared",
+		"rspack/container/remote/container-with-shared/b",
+		"rspack/container/remote/container-with-shared/modules"
 	]);
 	expect(m2).toEqual([
 		"./index.js",
 		"./shared.js",
-		"webpack/container/reference/container-no-shared",
-		"webpack/container/remote/container-no-shared/a",
-		"webpack/container/remote/container-no-shared/b",
-		"webpack/container/remote/container-no-shared/modules",
-		"webpack/container/remote/container-no-shared/modules-from-remote"
+		"rspack/container/reference/container-no-shared",
+		"rspack/container/remote/container-no-shared/a",
+		"rspack/container/remote/container-no-shared/b",
+		"rspack/container/remote/container-no-shared/modules",
+		"rspack/container/remote/container-no-shared/modules-from-remote"
 	]);
 });

--- a/tests/rspack-test/serialCases/container/reference-hoisting/index.js
+++ b/tests/rspack-test/serialCases/container/reference-hoisting/index.js
@@ -1,7 +1,7 @@
 it("should have the hoisted container references", () => {
 	const wpm = __webpack_modules__;
-	expect(wpm).toHaveProperty("webpack/container/reference/containerA");
-	expect(wpm).toHaveProperty("webpack/container/reference/containerB");
+	expect(wpm).toHaveProperty("rspack/container/reference/containerA");
+	expect(wpm).toHaveProperty("rspack/container/reference/containerB");
 });
 
 it("should load the component from container", () => {


### PR DESCRIPTION
## Summary

This updates Rspack runtime-facing identifiers that were still emitted with webpack-specific names.

The change covers Module Federation module identifiers for sharing, container entries, remotes, fallbacks, and container references; the JavaScript container reference wrapper now registers the matching `rspack/container/reference/*` externals. It also renames rspack-mode runtime identifiers such as `export_webpack_require`, CSS loading data helpers, Module Federation startup helper names, and generated UMD helper variables.

Snapshots and expectations that assert these generated identifiers were updated to match the new output.
