### PR TITLE
docs: configure agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,20 @@ This project includes comprehensive documentation designed for AI assistants and
 
 These documents provide detailed context about the project structure, coding standards, common patterns, and domain-specific knowledge to help AI assistants better understand and contribute to the codebase.
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for `web-infra-dev/rspack`; external contributor PRs are also treated as a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default triage label vocabulary, except `needs-info` maps to `needs more info`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain docs layout. See `docs/agents/domain.md`.
+
 ## Resources
 
 - [Project Architecture](website/docs/en/contribute/development/project.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ Issues are tracked in GitHub Issues for `web-infra-dev/rspack`; external contrib
 
 ### Triage labels
 
-Use the repo's existing triage labels: `pending triage`, `need more info`, `codex`, `PR welcome`, and `not planned`. See `docs/agents/triage-labels.md`.
+Use the repo's existing triage labels: `pending triage`, `need more info`, `ready-for-agent`, `ready-for-human`, and `not planned`. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ Issues are tracked in GitHub Issues for `web-infra-dev/rspack`; external contrib
 
 ### Triage labels
 
-Use the default triage label vocabulary, except `needs-info` maps to `needs more info`. See `docs/agents/triage-labels.md`.
+Use the repo's existing triage labels: `pending triage`, `need more info`, `codex`, `PR welcome`, and `not planned`. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,179 @@
+# Rspack
+
+Rspack is the JavaScript bundling context for this repository. Use this glossary when discussing bundling behavior, webpack compatibility, extension points, and generated output.
+
+## Language
+
+### Product and compatibility
+
+**Rspack**:
+The JavaScript bundler maintained by this repository. Its product promise is high-performance bundling with strong webpack ecosystem compatibility.
+_Avoid_: rspack, Rspack bundler
+
+**Rstack**:
+The broader JavaScript toolchain ecosystem centered on Rspack, including related tools such as Rsbuild and Rslib.
+_Avoid_: Rspack ecosystem, RsPack stack
+
+**Webpack compatibility**:
+The property that an API, option, plugin, loader, runtime behavior, or output behavior matches webpack closely enough for existing webpack users and integrations to rely on it.
+_Avoid_: Webpack parity, compatible enough
+
+### Compilation model
+
+**Compiler**:
+The long-lived orchestrator for configuration, plugin registration, file systems, watch mode, and creation of compilations.
+_Avoid_: Builder, runner
+
+**Compilation**:
+A single build instance that owns module processing, graph construction, optimization, chunk creation, and asset generation.
+_Avoid_: Build, compiler run
+
+**Entry point**:
+A configured starting point from which Rspack begins discovering modules for a compilation.
+_Avoid_: Entry file, app root
+
+**Make phase**:
+The compilation phase where modules are built and the module graph is constructed.
+_Avoid_: Graph build, dependency collection
+
+**Seal phase**:
+The compilation phase where no more modules are added and the compilation is finalized for optimization and output planning.
+_Avoid_: Finalize phase, close phase
+
+**Emit phase**:
+The compilation phase where generated assets are written to the output file system.
+_Avoid_: Write phase, output phase
+
+### Module graph
+
+**Module**:
+A source or generated unit that Rspack can parse, transform, connect to other modules, and include in generated output.
+_Avoid_: File, script
+
+**Normal module**:
+A regular JavaScript, TypeScript, CSS, or asset module processed through the normal module pipeline.
+_Avoid_: Regular module, source module
+
+**Context module**:
+A module created to represent a dynamic require context, such as a directory pattern discovered from `require.context`.
+_Avoid_: Dynamic module, directory module
+
+**External module**:
+A module reference that Rspack leaves outside the bundle and expects the runtime environment to provide.
+_Avoid_: Excluded module, CDN module
+
+**Runtime module**:
+A generated module that provides bundler runtime behavior such as module loading, chunk loading, or Hot Module Replacement support.
+_Avoid_: Runtime code, bootstrap code
+
+**Dependency**:
+A relationship discovered from an entry point or module to another requested resource.
+_Avoid_: Edge, import
+
+**Module graph connection**:
+The resolved link in the module graph that connects a dependency from its origin to the module it resolves to.
+_Avoid_: Dependency edge, resolved dependency
+
+**Module graph**:
+The graph of modules, dependencies, and module graph connections built during compilation.
+_Avoid_: Dependency graph, import graph
+
+### Chunk and asset model
+
+**Chunk**:
+A group of modules that Rspack plans and emits together as part of the output loading strategy.
+_Avoid_: Bundle, output file
+
+**Entry chunk**:
+A chunk generated from an entry point and loaded as part of starting the application.
+_Avoid_: Main bundle, entry bundle
+
+**Async chunk**:
+A chunk loaded on demand, commonly produced by dynamic import or code splitting.
+_Avoid_: Lazy bundle, split bundle
+
+**Runtime chunk**:
+A chunk that carries runtime modules separately from application modules.
+_Avoid_: Runtime bundle, bootstrap bundle
+
+**Chunk graph**:
+The graph that records chunk relationships and which modules belong to which chunks.
+_Avoid_: Bundle graph, output graph
+
+**Asset**:
+An output artifact produced by compilation, such as JavaScript, CSS, images, source maps, or generated HTML.
+_Avoid_: File, emitted file
+
+**Asset info**:
+Metadata attached to an asset, such as size, related assets, or output hints.
+_Avoid_: Asset metadata, file metadata
+
+### Extension model
+
+**Plugin**:
+An extension that hooks into the compiler or compilation lifecycle to observe or modify bundling behavior.
+_Avoid_: Extension, addon
+
+**Builtin plugin**:
+A core plugin shipped by Rspack as part of its built-in behavior.
+_Avoid_: Internal plugin, native plugin
+
+**Hook**:
+A named lifecycle point where plugins can tap callbacks to observe or change compiler or compilation behavior.
+_Avoid_: Event, callback point
+
+**Tap**:
+The act of registering a plugin callback on a hook.
+_Avoid_: Listener registration, callback registration
+
+**Loader**:
+A transform that processes a module resource before Rspack parses it and adds it to the module graph.
+_Avoid_: Transformer, preprocessor
+
+**Loader chain**:
+The ordered sequence of loaders applied to a module resource.
+_Avoid_: Loader pipeline, transform chain
+
+**Loader context**:
+The object exposed to a loader that provides metadata, options, dependency registration, and other loader utilities.
+_Avoid_: Loader this, loader API object
+
+**Pitch loader**:
+A loader behavior that runs in the pitch phase before the normal loader chain executes.
+_Avoid_: Pre-loader, early loader
+
+### Resolution and optimization
+
+**Module resolution**:
+The process of turning a module request into the concrete module or external reference used by the compilation.
+_Avoid_: Path lookup, import resolution
+
+**Tree shaking**:
+The optimization that removes unused exports by analyzing how modules import and export values.
+_Avoid_: Dead code elimination
+
+**Code splitting**:
+The optimization that divides code into multiple chunks to control loading and caching behavior.
+_Avoid_: Bundle splitting, chunk splitting
+
+**Scope hoisting**:
+The optimization that concatenates compatible modules into a shared scope to reduce runtime overhead.
+_Avoid_: Module concatenation
+
+**Persistent cache**:
+The disk-backed cache that preserves reusable compilation work across process runs.
+_Avoid_: Disk cache, build cache
+
+### Development behavior
+
+**Hot Module Replacement**:
+Development behavior that updates affected modules in a running application without a full page reload.
+_Avoid_: Hot reload, live reload
+
+**Watch mode**:
+Development behavior where Rspack monitors input changes and starts new compilations automatically.
+_Avoid_: File watching, watch build
+
+**Dev server**:
+The development server that serves generated output and coordinates development features such as Hot Module Replacement.
+_Avoid_: Local server, development server

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,14 @@
+# Domain Docs
+
+This repo uses a single-context domain docs layout.
+
+Before exploring, engineering skills should read these when present:
+
+- `CONTEXT.md` at the repo root
+- `docs/adr/` for architectural decisions that touch the area being changed
+
+If these files do not exist, proceed silently. The domain-modeling flow can create them lazily when terms or decisions are resolved.
+
+When output names a domain concept, use the vocabulary from `CONTEXT.md`. If a needed concept is missing, note it as a possible gap for domain modeling.
+
+If output contradicts an existing ADR, surface that conflict explicitly.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,4 +1,4 @@
-# Domain Docs
+# Domain docs
 
 This repo uses a single-context domain docs layout.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,11 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+External contributor PRs are also a triage surface. `/triage` should include open PRs whose author association is `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE`, and should leave `OWNER`, `MEMBER`, and `COLLABORATOR` PRs alone.
+
+When a skill says "publish to the issue tracker", create a GitHub issue.
+
+When a skill says "fetch the relevant ticket", run `gh issue view <number> --comments`.
+
+Use `gh issue` for issues and `gh pr` for PRs. GitHub shares one number space across issues and PRs, so resolve ambiguous `#<number>` references with `gh pr view <number>` first, then fall back to `gh issue view <number>`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,7 +2,7 @@
 
 Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
 
-External contributor PRs are also a triage surface. `/triage` should include open PRs whose author association is `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE`, and should leave `OWNER`, `MEMBER`, and `COLLABORATOR` PRs alone.
+External contributor PRs are also a triage surface. `/triage` should include open PRs whose author association is `CONTRIBUTOR`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, or `NONE`, and should leave `OWNER`, `MEMBER`, and `COLLABORATOR` PRs alone.
 
 When a skill says "publish to the issue tracker", create a GitHub issue.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,4 +1,4 @@
-# Triage Labels
+# Triage labels
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -4,10 +4,10 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 | Label in mattpocock/skills | Label in our tracker | Meaning                                  |
 | -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs more info`    | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+| `needs-triage`             | `pending triage`     | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `need more info`     | Waiting on reporter for more information |
+| `ready-for-agent`          | `codex`              | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `PR welcome`         | Requires human implementation            |
+| `wontfix`                  | `not planned`        | Will not be actioned                     |
 
 When a skill mentions a role, use the corresponding label string from this table.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs more info`    | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -6,8 +6,8 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `pending triage`     | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `need more info`     | Waiting on reporter for more information |
-| `ready-for-agent`          | `codex`              | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `PR welcome`         | Requires human implementation            |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
 | `wontfix`                  | `not planned`        | Will not be actioned                     |
 
 When a skill mentions a role, use the corresponding label string from this table.


### PR DESCRIPTION
## Summary

Configure repo-local agent skill settings so engineering skills know how to use this repository's issue tracker, triage labels, and domain documentation layout.

This adds `docs/agents/` configuration for GitHub Issues, external contributor PR triage, the `needs more info` label mapping, and single-context domain docs. It also links those settings from `AGENTS.md`.

No tests were run because this is a documentation-only change.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
