### PR TITLE
perf: use a dense ModuleGraph connection rollback journal

### DIFF
--- a/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_overlay_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_overlay_map.rs
@@ -1,17 +1,64 @@
-use super::OverlayValue;
 use crate::DependencyId;
 
+const UNCHANGED: u8 = 0;
+const CHANGED: u8 = 1;
+
+#[derive(Debug, Clone)]
+struct UndoEntry<V> {
+  index: u32,
+  value: Option<V>,
+}
+
+#[derive(Debug, Clone)]
+struct DenseRollback<V> {
+  original_len: usize,
+  /// Marks dependency ids whose original values are already in `entries`.
+  changed: Vec<u8>,
+  /// Stores only original values that must be restored.
+  entries: Vec<UndoEntry<V>>,
+}
+
+impl<V> DenseRollback<V> {
+  fn new(original_len: usize) -> Self {
+    Self {
+      original_len,
+      changed: Vec::new(),
+      entries: Vec::new(),
+    }
+  }
+
+  #[inline]
+  fn has_changed(&self, index: usize) -> bool {
+    self.changed.get(index).copied().unwrap_or(UNCHANGED) == CHANGED
+  }
+
+  #[inline]
+  fn record(&mut self, index: u32, value: Option<V>) {
+    let dense_index = index as usize;
+    if self.changed.len() <= dense_index {
+      self.changed.resize(dense_index + 1, UNCHANGED);
+    }
+
+    debug_assert_eq!(self.changed[dense_index], UNCHANGED);
+    self.changed[dense_index] = CHANGED;
+    self.entries.push(UndoEntry { index, value });
+  }
+}
+
+/// A dense dependency map whose checkpointed mutations are applied in place.
+/// Original values are recorded once so reads keep the same direct lookup path
+/// before and after a checkpoint.
 #[derive(Debug, Clone)]
 pub struct DenseDependencyIdOverlayMap<V> {
-  base: Vec<Option<V>>,
-  overlay: Option<Vec<Option<OverlayValue<V>>>>,
+  values: Vec<Option<V>>,
+  rollback: Option<DenseRollback<V>>,
 }
 
 impl<V> Default for DenseDependencyIdOverlayMap<V> {
   fn default() -> Self {
     Self {
-      base: Vec::new(),
-      overlay: None,
+      values: Vec::new(),
+      rollback: None,
     }
   }
 }
@@ -19,50 +66,62 @@ impl<V> Default for DenseDependencyIdOverlayMap<V> {
 impl<V> DenseDependencyIdOverlayMap<V> {
   #[inline]
   pub fn checkpoint(&mut self) {
-    self.overlay.get_or_insert_with(Vec::new);
+    if self.rollback.is_none() {
+      self.rollback = Some(DenseRollback::new(self.values.len()));
+    }
   }
 
   #[inline]
   pub fn reset(&mut self) {
-    self.overlay = None;
+    let Some(rollback) = self.rollback.take() else {
+      return;
+    };
+    let DenseRollback {
+      original_len,
+      entries,
+      ..
+    } = rollback;
+
+    for entry in entries {
+      self.values[entry.index as usize] = entry.value;
+    }
+    self.values.truncate(original_len);
   }
 
   #[inline]
   pub fn insert(&mut self, key: DependencyId, value: V) {
     let index = key.as_u32() as usize;
-    if self.overlay.is_some() {
-      Self::ensure_len(self.overlay(), index);
-      self.overlay.as_mut().expect("overlay checked above")[index] =
-        Some(OverlayValue::Value(value));
-    } else {
-      Self::ensure_len(&mut self.base, index);
-      self.base[index] = Some(value);
+    Self::ensure_len(&mut self.values, index);
+    let previous = self.values[index].replace(value);
+
+    if let Some(rollback) = &mut self.rollback
+      && !rollback.has_changed(index)
+    {
+      rollback.record(key.as_u32(), previous);
     }
   }
 
   #[inline]
   pub fn remove(&mut self, key: &DependencyId) {
     let index = key.as_u32() as usize;
-    if self.overlay.is_some() {
-      Self::ensure_len(self.overlay(), index);
-      self.overlay.as_mut().expect("overlay checked above")[index] = Some(OverlayValue::Tombstone);
-    } else if let Some(value) = self.base.get_mut(index) {
-      *value = None;
+    let Some(value) = self.values.get_mut(index) else {
+      return;
+    };
+    let Some(previous) = value.take() else {
+      return;
+    };
+
+    if let Some(rollback) = &mut self.rollback
+      && !rollback.has_changed(index)
+    {
+      rollback.record(key.as_u32(), Some(previous));
     }
   }
 
   #[inline]
   pub fn get(&self, key: &DependencyId) -> Option<&V> {
     let index = key.as_u32() as usize;
-    if let Some(overlay) = &self.overlay
-      && let Some(Some(value)) = overlay.get(index)
-    {
-      return match value {
-        OverlayValue::Value(value) => Some(value),
-        OverlayValue::Tombstone => None,
-      };
-    }
-    self.base.get(index).and_then(Option::as_ref)
+    self.values.get(index).and_then(Option::as_ref)
   }
 
   #[inline]
@@ -71,38 +130,19 @@ impl<V> DenseDependencyIdOverlayMap<V> {
     V: Clone,
   {
     let index = key.as_u32() as usize;
-    if self.overlay.is_some() {
-      self.materialize_overlay_value(index);
-      let overlay = self.overlay.as_mut().expect("overlay checked above");
-      match overlay.get_mut(index).and_then(Option::as_mut) {
-        Some(OverlayValue::Value(value)) => Some(value),
-        _ => None,
-      }
-    } else {
-      self.base.get_mut(index).and_then(Option::as_mut)
+    if self
+      .rollback
+      .as_ref()
+      .is_some_and(|rollback| !rollback.has_changed(index))
+    {
+      let original = self.values.get(index)?.as_ref()?.clone();
+      self
+        .rollback
+        .as_mut()
+        .expect("rollback checked above")
+        .record(key.as_u32(), Some(original));
     }
-  }
-
-  #[inline]
-  fn materialize_overlay_value(&mut self, index: usize)
-  where
-    V: Clone,
-  {
-    let overlay = self.overlay.as_ref().expect("overlay checked above");
-    if matches!(overlay.get(index), Some(Some(_))) {
-      return;
-    }
-
-    if let Some(value) = self.base.get(index).and_then(Option::as_ref).cloned() {
-      Self::ensure_len(self.overlay(), index);
-      self.overlay.as_mut().expect("overlay checked above")[index] =
-        Some(OverlayValue::Value(value));
-    }
-  }
-
-  #[inline]
-  fn overlay(&mut self) -> &mut Vec<Option<OverlayValue<V>>> {
-    self.overlay.get_or_insert_with(Vec::new)
+    self.values.get_mut(index).and_then(Option::as_mut)
   }
 
   #[inline]
@@ -118,7 +158,7 @@ mod tests {
   use crate::{DependencyId, module_graph::rollback::DenseDependencyIdOverlayMap};
 
   #[test]
-  fn checkpoint_inserts_apply_only_to_overlay() {
+  fn checkpoint_inserts_are_rolled_back() {
     let mut map = DenseDependencyIdOverlayMap::default();
     let a = DependencyId::from(0);
     let b = DependencyId::from(1);
@@ -138,7 +178,7 @@ mod tests {
   }
 
   #[test]
-  fn remove_in_overlay_masks_base() {
+  fn remove_after_checkpoint_is_rolled_back() {
     let mut map = DenseDependencyIdOverlayMap::default();
     let a = DependencyId::from(0);
     let b = DependencyId::from(7);
@@ -158,18 +198,71 @@ mod tests {
   }
 
   #[test]
-  fn get_mut_clones_base_into_overlay() {
+  fn get_mut_records_the_original_value() {
     let mut map = DenseDependencyIdOverlayMap::default();
     let a = DependencyId::from(3);
 
     map.insert(a, 1);
     map.checkpoint();
-    *map.get_mut(&a).expect("should clone base into overlay") = 5;
+    *map.get_mut(&a).expect("should record the original value") = 5;
 
     assert_eq!(map.get(&a), Some(&5));
 
     map.reset();
 
     assert_eq!(map.get(&a), Some(&1));
+  }
+
+  #[test]
+  fn repeated_get_mut_records_the_original_value_once() {
+    let mut map = DenseDependencyIdOverlayMap::default();
+    let id = DependencyId::from(3);
+
+    map.insert(id, 1);
+    map.checkpoint();
+    *map.get_mut(&id).expect("should record the original value") = 2;
+    *map.get_mut(&id).expect("should reuse the rollback entry") = 3;
+
+    let rollback = map.rollback.as_ref().expect("should have rollback data");
+    assert_eq!(rollback.entries.len(), 1);
+
+    map.reset();
+
+    assert_eq!(map.get(&id), Some(&1));
+  }
+
+  #[test]
+  fn repeated_writes_record_the_original_value_once() {
+    let mut map = DenseDependencyIdOverlayMap::default();
+    let id = DependencyId::from(7);
+
+    map.checkpoint();
+    map.insert(id, 1);
+    map.insert(id, 2);
+    map.remove(&id);
+
+    let rollback = map.rollback.as_ref().expect("should have rollback data");
+    assert_eq!(rollback.changed.len(), 8);
+    assert_eq!(rollback.entries.len(), 1);
+    assert_eq!(map.get(&id), None);
+  }
+
+  #[test]
+  fn sparse_rollback_stores_only_changed_values() {
+    let mut map = DenseDependencyIdOverlayMap::default();
+    let id = DependencyId::from(1024);
+
+    map.checkpoint();
+    map.insert(id, 1);
+
+    let rollback = map.rollback.as_ref().expect("should have rollback data");
+    assert_eq!(rollback.changed.len(), 1025);
+    assert_eq!(rollback.entries.len(), 1);
+    assert_eq!(map.get(&id), Some(&1));
+
+    map.reset();
+
+    assert!(map.values.is_empty());
+    assert_eq!(map.get(&id), None);
   }
 }


### PR DESCRIPTION
## Summary

- apply checkpointed connection mutations directly to the dense base vector so every connection read keeps the fast single-vector lookup path
- record each dependency's original connection only once in a compact undo journal
- use a one-byte changed marker per covered dependency ID and store values only for connections that are actually modified
- restore original values and truncate newly added dependency slots when the ModuleGraph checkpoint is reset
- cover insert, remove, repeated write, repeated mutable access, and sparse dependency rollback behavior

This targets the high-cardinality dependency path in ModuleGraph. Connection reads heavily outnumber checkpoint mutations during module concatenation, so moving rollback work to the mutation/reset side removes the overlay branch and secondary value lookup from the hot read path.

The focused `rust@create_concatenate_module` Callgrind stage improved from 47,436,218 to 47,026,994 instructions on the same local build path: -409,224 Ir (-0.86%). Three consecutive final measurements produced the same result. Compared with the previous compact-overlay implementation in this PR, the journal removes 512,454 Ir (-1.08%).

Checked with six focused Rust rollback tests, `pnpm run build:cli:dev`, `pnpm run test:unit` (46 files and 8,787 tests passed), Rust/JS formatting, and `cargo clippy -p rspack_core --all-targets`. The workspace-wide all-features Clippy command remains blocked by the existing rkyv 0.7/0.8 conflict in `rspack_cacheable`.

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated.
- [x] Documentation is not required for this internal data structure change.
