### PR TITLE
perf: optimize persistent cache and incremental builds

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -85,7 +85,7 @@ impl BuildChunkGraphArtifact {
       return false;
     }
 
-    for module in affected_modules {
+    for module in affected_modules.iter().copied() {
       let outgoings: Vec<ModuleIdentifier> = {
         let mut res = vec![];
         let mut active_modules = IdentifierIndexMap::<Vec<_>>::default();

--- a/crates/rspack_core/src/cache/persistent/context.rs
+++ b/crates/rspack_core/src/cache/persistent/context.rs
@@ -20,13 +20,10 @@ const PATH_LOG_LIMIT: usize = 3;
 /// context for the next one.
 #[derive(Debug)]
 pub struct CacheContext {
-  /// Set when build dependencies have changed, meaning the cached data is
-  /// structurally stale.  Unlike `load_failed`, this flag persists across
-  /// builds in readonly mode because the cache cannot be rebuilt there.
-  invalid: bool,
   /// Per-build load gate.  Flipped to `true` on the first failed `load_*`
   /// call; all subsequent `load_*` calls become no-ops for this build.
-  /// Restored to `false` (or derived from `invalid`) by `reset`.
+  /// Cleared by `reset` for writable caches and kept sticky for readonly
+  /// caches, which cannot repair failed entries.
   load_failed: bool,
   /// When `true`, all `save_*` and scope `reset` calls to storage are skipped.
   ///
@@ -43,7 +40,6 @@ pub struct CacheContext {
 impl CacheContext {
   pub fn new(storage: BoxStorage, readonly: bool, logger: CompilationLogger) -> Self {
     Self {
-      invalid: false,
       load_failed: false,
       readonly,
       logger,
@@ -62,8 +58,8 @@ impl CacheContext {
     self.storage.cleanup_stale();
   }
 
-  /// Validates build dependencies and sets `invalid` + `load_failed` on
-  /// failure.  Resets the BUILD scope when invalid and not readonly.
+  /// Validates build dependencies and sets `load_failed` on failure. Resets
+  /// the BUILD scope when validation fails and the cache is not readonly.
   ///
   /// Normally called only once per compiler instance, guarded by the
   /// `initialized` flag in `PersistentCache::initialize`.
@@ -72,7 +68,6 @@ impl CacheContext {
     let start = self.logger().time("validate build dependencies");
     match build_deps.validate(&*self.storage).await {
       Ok(BuildDepsValidationResult::Valid { tracked_files }) => {
-        self.invalid = false;
         self.logger().info(format!(
           "build dependencies are valid ({tracked_files} tracked)"
         ));
@@ -81,7 +76,6 @@ impl CacheContext {
         modified_files,
         removed_files,
       }) => {
-        self.invalid = true;
         self.load_failed = true;
         let reason = format_path_changes(&modified_files, &removed_files);
         self.logger().warn(format!(
@@ -142,18 +136,18 @@ impl CacheContext {
       let mut removed_paths = ArcPathSet::default();
       let data = vec![
         snapshot
-          .calc_modified_paths(&*self.storage, SnapshotScope::FILE)
+          .calc_modified_paths_without_unchanged(&*self.storage, SnapshotScope::FILE)
           .await,
         snapshot
-          .calc_modified_paths(&*self.storage, SnapshotScope::CONTEXT)
+          .calc_modified_paths_without_unchanged(&*self.storage, SnapshotScope::CONTEXT)
           .await,
         snapshot
-          .calc_modified_paths(&*self.storage, SnapshotScope::MISSING)
+          .calc_modified_paths_without_unchanged(&*self.storage, SnapshotScope::MISSING)
           .await,
       ];
       for item in data {
         match item {
-          Ok((a, b, c, _)) => {
+          Ok((a, b, c)) => {
             is_hot_start = is_hot_start || a;
             modified_paths.extend(b);
             removed_paths.extend(c);
@@ -190,6 +184,19 @@ impl CacheContext {
       snapshot.reset(&mut *self.storage);
     }
     None
+  }
+
+  /// Clears dependency snapshots before a full rebuild without a recovered
+  /// make artifact.
+  ///
+  /// A cold compilation has no previous [`FileCounter`](crate::utils::FileCounter)
+  /// baseline, so it cannot report dependencies that disappeared from a
+  /// corrupted make artifact. Resetting here makes `save_snapshot` rewrite the
+  /// complete current dependency set instead of retaining stale keys.
+  pub fn reset_snapshot(&mut self, snapshot: &Snapshot) {
+    if !self.readonly {
+      snapshot.reset(&mut *self.storage);
+    }
   }
 
   /// Persists snapshot data for all three scopes. No-op in readonly mode.
@@ -298,19 +305,16 @@ impl CacheContext {
 
   /// Resets per-build state.
   ///
-  /// In non-readonly mode both flags are cleared; scope resets done during
-  /// this build ensure a clean slate next time.
+  /// In non-readonly mode the load-failure gate is cleared; scope resets done
+  /// during this build ensure a clean slate next time.
   ///
-  /// In readonly mode `invalid` is preserved (the cache is still stale and
-  /// cannot be rebuilt), so `load_failed` is derived from it — stale-cache
-  /// loads are skipped on the next build as well.  Transient errors
-  /// (`load_failed` without `invalid`) are cleared so the next build retries.
+  /// In readonly mode failures remain sticky for this compiler instance. The
+  /// cache cannot repair a corrupt structural artifact, and retrying later
+  /// scopes without successfully restoring meta can violate global ID
+  /// invariants. A new compiler instance will retry the cache from scratch.
   pub fn reset(&mut self) {
     if !self.readonly {
-      self.invalid = false;
       self.load_failed = false
-    } else {
-      self.load_failed = self.invalid;
     }
   }
 }
@@ -364,5 +368,68 @@ fn append_paths_group(output: &mut String, label: &str, paths: &ArcPathSet) {
   }
   if is_truncated {
     output.push_str("\n  - ...");
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use rspack_fs::MemoryFileSystem;
+
+  use super::*;
+  use crate::{
+    CompilationLogging,
+    cache::persistent::{
+      codec::CacheCodec,
+      snapshot::SnapshotOptions,
+      storage::{MemoryStorage, Storage},
+    },
+  };
+
+  #[tokio::test]
+  async fn should_reset_dependency_snapshots_after_make_recovery_failure() {
+    let mut storage = MemoryStorage::default();
+    storage.set(
+      SnapshotScope::FILE.name(),
+      b"stale-file".to_vec(),
+      b"stale-strategy".to_vec(),
+    );
+    let snapshot = Snapshot::new(
+      SnapshotOptions::default(),
+      Arc::new(MemoryFileSystem::default()),
+      Arc::new(CacheCodec::new(None)),
+    );
+    let mut context = CacheContext::new(
+      Box::new(storage),
+      false,
+      CompilationLogger::new("test".to_string(), CompilationLogging::default()),
+    );
+
+    context.reset_snapshot(&snapshot);
+
+    assert!(
+      context
+        .storage
+        .load(SnapshotScope::FILE.name())
+        .await
+        .unwrap()
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn should_keep_readonly_load_failures_sticky() {
+    let storage = MemoryStorage::default();
+    let mut context = CacheContext::new(
+      Box::new(storage),
+      true,
+      CompilationLogger::new("test".to_string(), CompilationLogging::default()),
+    );
+    context.load_failed = true;
+
+    context.reset();
+
+    assert!(context.load_failed);
   }
 }

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -210,14 +210,19 @@ impl Cache for PersistentCache {
       return;
     }
 
-    if let Some(artifact) = self.ctx.load_occasion(&self.make_occasion).await {
-      *compilation.build_module_graph_artifact = artifact;
-      for (module, _) in compilation
-        .build_module_graph_artifact
-        .get_module_graph()
-        .modules()
-      {
-        compilation.exports_info_artifact.new_exports_info(*module);
+    match self.ctx.load_occasion(&self.make_occasion).await {
+      Some(artifact) => {
+        *compilation.build_module_graph_artifact = artifact;
+        for (module, _) in compilation
+          .build_module_graph_artifact
+          .get_module_graph()
+          .modules()
+        {
+          compilation.exports_info_artifact.new_exports_info(*module);
+        }
+      }
+      None => {
+        self.ctx.reset_snapshot(&self.snapshot);
       }
     }
   }

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -4,13 +4,14 @@ use rayon::prelude::*;
 use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_collections::IdentifierSet;
 use rspack_error::Result;
+use rspack_tasks::get_current_dependency_id;
 use rustc_hash::FxHashSet;
 
 use super::alternatives::{TempDependency, TempModule};
 use crate::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, Dependency,
-  DependencyId, DependencyParents, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
-  ModuleIdentifier, RayonConsumer,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule,
+  DependenciesBlock, Dependency, DependencyId, DependencyParents, ModuleGraph,
+  ModuleGraphConnection, ModuleGraphModule, ModuleIdentifier, RayonConsumer,
   cache::persistent::{codec::CacheCodec, storage::Storage},
   compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
 };
@@ -25,6 +26,7 @@ struct Node<'a> {
   pub dependencies: Vec<(
     OwnedOrRef<'a, BoxDependency>,
     Option<OwnedOrRef<'a, AsyncDependenciesBlockIdentifier>>,
+    usize,
   )>,
   pub connections: Vec<OwnedOrRef<'a, ModuleGraphConnection>>,
   pub blocks: Vec<OwnedOrRef<'a, AsyncDependenciesBlock>>,
@@ -67,6 +69,8 @@ pub fn save_module_graph(
           (
             mg.dependency_by_id(dep_id).into(),
             mg.get_parent_block(dep_id).map(Into::into),
+            mg.get_parent_block_index(dep_id)
+              .expect("dependency should have a parent index"),
           )
         })
         .collect::<Vec<_>>();
@@ -99,7 +103,9 @@ pub fn save_module_graph(
           node.dependencies = node
             .dependencies
             .into_iter()
-            .map(|(dep, _)| (TempDependency::transform_from(dep), None))
+            .map(|(dep, _, index_in_block)| {
+              (TempDependency::transform_from(dep), None, index_in_block)
+            })
             .collect();
           node.blocks = vec![];
           if let Ok(bytes) = codec.encode(&node) {
@@ -126,26 +132,78 @@ pub async fn recovery_module_graph(
   storage: &dyn Storage,
   codec: &CacheCodec,
 ) -> Result<(ModuleGraph, ModuleToLazyMake, FxHashSet<DependencyId>)> {
-  let mut need_check_dep = vec![];
+  let mut recovered_connection_ids = vec![];
   let mut mg = ModuleGraph::default();
   let mut module_to_lazy_make = ModuleToLazyMake::default();
+  let mut recovery_error = None;
+  let max_dependency_id = get_current_dependency_id();
   storage
     .load(SCOPE)
     .await?
     .into_par_iter()
-    .map(|(_, v)| {
-      codec
-        .decode::<Node>(&v)
-        .expect("unexpected module graph deserialize failed")
-    })
+    .map(|(_, v)| codec.decode::<Node>(&v))
     .with_max_len(1)
-    .consume(|node| {
+    .consume(|result| {
+      let node = match result {
+        Ok(node) if recovery_error.is_none() => node,
+        Ok(_) => return,
+        Err(err) => {
+          recovery_error = Some(err);
+          return;
+        }
+      };
       let mgm = node.mgm.into_owned();
       let module = node.module.into_owned();
-      for (index_in_block, (dep, parent_block)) in node.dependencies.into_iter().enumerate() {
+      if mgm.module_identifier != module.identifier() {
+        recovery_error = Some(rspack_error::error!(format!(
+          "persistent cache module graph entry has mismatched module identifiers: {} and {}",
+          mgm.module_identifier,
+          module.identifier()
+        )));
+        return;
+      }
+      if mg
+        .module_graph_module_by_identifier(&mgm.module_identifier)
+        .is_some()
+        || mg.module_by_identifier(&mgm.module_identifier).is_some()
+      {
+        recovery_error = Some(rspack_error::error!(format!(
+          "persistent cache module graph contains duplicate module {}",
+          mgm.module_identifier
+        )));
+        return;
+      }
+      if mgm.all_dependencies().len() != node.dependencies.len() {
+        recovery_error = Some(rspack_error::error!(format!(
+          "persistent cache module graph has incomplete dependencies for {}",
+          module.identifier()
+        )));
+        return;
+      }
+      for (dependency_position, (dep, parent_block, index_in_block)) in
+        node.dependencies.into_iter().enumerate()
+      {
         let dep = dep.into_owned();
+        let dependency_id = *dep.id();
+        if let Err(err) = validate_dependency_id_range(dependency_id, max_dependency_id) {
+          recovery_error = Some(err);
+          return;
+        }
+        if mgm.all_dependencies()[dependency_position] != dependency_id {
+          recovery_error = Some(rspack_error::error!(format!(
+            "persistent cache module graph has inconsistent dependency order for {}",
+            module.identifier()
+          )));
+          return;
+        }
+        if mg.has_dependency(&dependency_id) {
+          recovery_error = Some(rspack_error::error!(format!(
+            "persistent cache module graph contains duplicate dependency {dependency_id:?}"
+          )));
+          return;
+        }
         mg.set_parents(
-          *dep.id(),
+          dependency_id,
           DependencyParents {
             block: parent_block.map(|b| b.into_owned()),
             module: module.identifier(),
@@ -154,27 +212,81 @@ pub async fn recovery_module_graph(
         );
         mg.add_dependency(dep);
       }
+      if module.get_blocks().len() != node.blocks.len() {
+        recovery_error = Some(rspack_error::error!(format!(
+          "persistent cache module graph has incomplete blocks for {}",
+          module.identifier()
+        )));
+        return;
+      }
+      if mgm.outgoing_connections().len() != node.connections.len() {
+        recovery_error = Some(rspack_error::error!(format!(
+          "persistent cache module graph has incomplete connections for {}",
+          module.identifier()
+        )));
+        return;
+      }
       for con in node.connections {
         let con = con.into_owned();
-        need_check_dep.push((con.dependency_id, *con.module_identifier()));
-        mg.cache_recovery_connection(con);
+        let dependency_id = con.dependency_id;
+        if !mgm.outgoing_connections().contains(&dependency_id)
+          || con.original_module_identifier != Some(module.identifier())
+        {
+          recovery_error = Some(rspack_error::error!(format!(
+            "persistent cache module graph has inconsistent connections for {}",
+            module.identifier()
+          )));
+          return;
+        }
+        match recover_connection(&mut mg, con) {
+          Ok(()) => recovered_connection_ids.push(dependency_id),
+          Err(err) => {
+            recovery_error = Some(err);
+            return;
+          }
+        }
       }
       for block in node.blocks {
         let block = block.into_owned();
+        let block_id = block.identifier();
+        if !module.get_blocks().contains(&block_id) {
+          recovery_error = Some(rspack_error::error!(format!(
+            "persistent cache module graph has an unexpected block {block_id:?} for {}",
+            module.identifier()
+          )));
+          return;
+        }
+        if mg.block_by_id(&block_id).is_some() {
+          recovery_error = Some(rspack_error::error!(format!(
+            "persistent cache module graph contains duplicate block {block_id:?}"
+          )));
+          return;
+        }
         mg.add_block(Box::new(block));
       }
-      if let Some(lazy_info) = node.lazy_info {
-        module_to_lazy_make
-          .update_module_lazy_dependencies(module.identifier(), Some(lazy_info.into_owned()));
+      let lazy_info = node.lazy_info.map(OwnedOrRef::into_owned);
+      if module.downcast_ref::<TempModule>().is_none()
+        && let Err(err) = validate_module_references(&mg, &module, &mgm)
+      {
+        recovery_error = Some(err);
+        return;
+      }
+      if let Some(lazy_dependencies) = lazy_info.as_ref()
+        && let Err(err) = validate_lazy_dependencies(&mg, module.identifier(), lazy_dependencies)
+      {
+        recovery_error = Some(err);
+        return;
+      }
+      if let Some(lazy_info) = lazy_info {
+        module_to_lazy_make.update_module_lazy_dependencies(module.identifier(), Some(lazy_info));
       }
       mg.add_module_graph_module(mgm);
       mg.add_module(module);
     });
-  // recovery incoming connections
-  for (dep_id, module_identifier) in need_check_dep {
-    let mgm = mg.module_graph_module_by_identifier_mut(&module_identifier);
-    mgm.add_incoming_connection(dep_id);
+  if let Some(err) = recovery_error {
+    return Err(err);
   }
+  recover_connection_targets(&mut mg, recovered_connection_ids)?;
 
   // recovery entry
   let mut entry_module: Vec<ModuleIdentifier> = vec![];
@@ -194,4 +306,270 @@ pub async fn recovery_module_graph(
 
   tracing::debug!("recovery {} module", mg.modules_len());
   Ok((mg, module_to_lazy_make, entry_dependencies))
+}
+
+fn validate_dependency_id_range(dependency_id: DependencyId, max_dependency_id: u32) -> Result<()> {
+  if dependency_id.as_u32() >= max_dependency_id {
+    return Err(rspack_error::error!(format!(
+      "persistent cache dependency {dependency_id:?} exceeds the restored meta ID range"
+    )));
+  }
+  Ok(())
+}
+
+fn validate_module_references(
+  module_graph: &ModuleGraph,
+  module: &BoxModule,
+  mgm: &ModuleGraphModule,
+) -> Result<()> {
+  let module_identifier = module.identifier();
+  let mut referenced_dependencies = module.get_dependencies().len();
+  for (index_in_block, dependency_id) in module.get_dependencies().iter().enumerate() {
+    validate_dependency_parent(
+      module_graph,
+      *dependency_id,
+      module_identifier,
+      None,
+      index_in_block,
+    )?;
+  }
+
+  for block_id in module.get_blocks() {
+    let block = module_graph.block_by_id(block_id).ok_or_else(|| {
+      rspack_error::error!(format!(
+        "persistent cache module graph references missing block {block_id:?}"
+      ))
+    })?;
+    if block.parent() != &module_identifier {
+      return Err(rspack_error::error!(format!(
+        "persistent cache block {block_id:?} has an inconsistent parent"
+      )));
+    }
+    referenced_dependencies += block.get_dependencies().len();
+    for (index_in_block, dependency_id) in block.get_dependencies().iter().enumerate() {
+      validate_dependency_parent(
+        module_graph,
+        *dependency_id,
+        module_identifier,
+        Some(block_id),
+        index_in_block,
+      )?;
+    }
+  }
+  if referenced_dependencies != mgm.all_dependencies().len() {
+    return Err(rspack_error::error!(format!(
+      "persistent cache module graph has incomplete dependency references for {module_identifier}"
+    )));
+  }
+
+  Ok(())
+}
+
+fn validate_lazy_dependencies(
+  module_graph: &ModuleGraph,
+  module_identifier: ModuleIdentifier,
+  lazy_dependencies: &LazyDependencies,
+) -> Result<()> {
+  for dependency_id in lazy_dependencies.all_lazy_dependencies() {
+    if !module_graph.has_dependency(&dependency_id)
+      || module_graph.get_parent_module(&dependency_id) != Some(&module_identifier)
+    {
+      return Err(rspack_error::error!(format!(
+        "persistent cache module graph has an invalid lazy dependency {dependency_id:?}"
+      )));
+    }
+  }
+  Ok(())
+}
+
+fn validate_dependency_parent(
+  module_graph: &ModuleGraph,
+  dependency_id: DependencyId,
+  module_identifier: ModuleIdentifier,
+  block_id: Option<&AsyncDependenciesBlockIdentifier>,
+  index_in_block: usize,
+) -> Result<()> {
+  if !module_graph.has_dependency(&dependency_id)
+    || module_graph.get_parent_module(&dependency_id) != Some(&module_identifier)
+    || module_graph.get_parent_block(&dependency_id) != block_id
+    || module_graph.get_parent_block_index(&dependency_id) != Some(index_in_block)
+  {
+    return Err(rspack_error::error!(format!(
+      "persistent cache dependency {dependency_id:?} has inconsistent parent metadata"
+    )));
+  }
+  Ok(())
+}
+
+fn recover_connection(
+  module_graph: &mut ModuleGraph,
+  connection: ModuleGraphConnection,
+) -> Result<()> {
+  let dependency_id = connection.dependency_id;
+  if !module_graph.has_dependency(&dependency_id) {
+    return Err(rspack_error::error!(format!(
+      "persistent cache module graph connection references missing dependency {dependency_id:?}"
+    )));
+  }
+  if module_graph
+    .connection_by_dependency_id(&dependency_id)
+    .is_some()
+  {
+    return Err(rspack_error::error!(format!(
+      "persistent cache module graph contains duplicate connection {dependency_id:?}"
+    )));
+  }
+  module_graph.cache_recovery_connection(connection);
+  Ok(())
+}
+
+fn recover_connection_targets(
+  module_graph: &mut ModuleGraph,
+  connection_ids: Vec<DependencyId>,
+) -> Result<()> {
+  for dependency_id in connection_ids {
+    let connection = module_graph
+      .connection_by_dependency_id(&dependency_id)
+      .expect("checked connection should exist");
+    let target_module = *connection.module_identifier();
+    let original_module = connection.original_module_identifier;
+    if module_graph
+      .module_graph_module_by_identifier(&target_module)
+      .is_none()
+    {
+      return Err(rspack_error::error!(format!(
+        "persistent cache module graph connection references missing target module {target_module}"
+      )));
+    }
+    if let Some(original_module) = original_module
+      && module_graph
+        .module_graph_module_by_identifier(&original_module)
+        .is_none()
+    {
+      return Err(rspack_error::error!(format!(
+        "persistent cache module graph connection references missing original module {original_module}"
+      )));
+    }
+
+    module_graph
+      .module_graph_module_by_identifier_mut(&target_module)
+      .add_incoming_connection(dependency_id);
+  }
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_tasks::{
+    set_current_dependency_id, within_compiler_context_for_testing,
+    within_compiler_context_for_testing_sync,
+  };
+
+  use super::*;
+  use crate::{
+    cache::persistent::storage::{MemoryStorage, Storage},
+    compilation::build_module_graph::LazyUntil,
+  };
+
+  #[tokio::test]
+  async fn should_return_error_for_corrupted_module_graph() {
+    within_compiler_context_for_testing(async {
+      let codec = CacheCodec::new(None);
+      let mut storage = MemoryStorage::default();
+      storage.set(SCOPE, b"module".to_vec(), b"corrupted".to_vec());
+
+      assert!(recovery_module_graph(&storage, &codec).await.is_err());
+    })
+    .await;
+  }
+
+  #[test]
+  fn should_return_error_for_connection_with_missing_dependency() {
+    within_compiler_context_for_testing_sync(|| {
+      let dependency = TempDependency::default();
+      let dependency_id = *dependency.id();
+      let connection = ModuleGraphConnection::new(
+        dependency_id,
+        Some(ModuleIdentifier::from("source")),
+        ModuleIdentifier::from("target"),
+        false,
+      );
+
+      assert!(recover_connection(&mut ModuleGraph::default(), connection).is_err());
+    });
+  }
+
+  #[test]
+  fn should_return_error_for_connection_with_missing_target() {
+    within_compiler_context_for_testing_sync(|| {
+      let dependency = TempDependency::default();
+      let dependency_id = *dependency.id();
+      let connection = ModuleGraphConnection::new(
+        dependency_id,
+        None,
+        ModuleIdentifier::from("missing-target"),
+        false,
+      );
+      let mut module_graph = ModuleGraph::default();
+      module_graph.add_dependency(Box::new(dependency));
+      recover_connection(&mut module_graph, connection).unwrap();
+
+      assert!(recover_connection_targets(&mut module_graph, vec![dependency_id]).is_err());
+    });
+  }
+
+  #[test]
+  fn should_reject_dependencies_outside_restored_meta_range() {
+    within_compiler_context_for_testing_sync(|| {
+      let dependency = TempDependency::default();
+      let dependency_id = *dependency.id();
+      set_current_dependency_id(dependency_id.as_u32());
+
+      assert!(validate_dependency_id_range(dependency_id, get_current_dependency_id()).is_err());
+    });
+  }
+
+  #[test]
+  fn should_reject_inconsistent_dependency_parent_metadata() {
+    within_compiler_context_for_testing_sync(|| {
+      let dependency = TempDependency::default();
+      let dependency_id = *dependency.id();
+      let module_identifier = ModuleIdentifier::from("module");
+      let mut module_graph = ModuleGraph::default();
+      module_graph.add_dependency(Box::new(dependency));
+      module_graph.set_parents(
+        dependency_id,
+        DependencyParents {
+          block: Some(AsyncDependenciesBlockIdentifier::from(
+            "missing-block".to_string(),
+          )),
+          module: module_identifier,
+          index_in_block: 0,
+        },
+      );
+
+      assert!(
+        validate_dependency_parent(&module_graph, dependency_id, module_identifier, None, 0)
+          .is_err()
+      );
+    });
+  }
+
+  #[test]
+  fn should_reject_missing_lazy_dependency() {
+    within_compiler_context_for_testing_sync(|| {
+      let dependency: BoxDependency = Box::new(TempDependency::default());
+      let mut lazy_dependencies = LazyDependencies::default();
+      lazy_dependencies.insert(&dependency, LazyUntil::Fallback);
+
+      assert!(
+        validate_lazy_dependencies(
+          &ModuleGraph::default(),
+          ModuleIdentifier::from("module"),
+          &lazy_dependencies
+        )
+        .is_err()
+      );
+    });
+  }
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/meta/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/meta/mod.rs
@@ -60,11 +60,27 @@ impl Occasion for MetaOccasion {
       return Ok(());
     };
 
-    let meta: Meta = self.codec.decode(&value).expect("should decode success");
+    let meta: Meta = self.codec.decode(&value)?;
     if get_current_dependency_id() != 0 {
       panic!("The global dependency id generator is not 0 when the persistent cache is restored.");
     }
     set_current_dependency_id(meta.max_dependencies_id);
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::cache::persistent::storage::{MemoryStorage, Storage};
+
+  #[tokio::test]
+  async fn should_return_error_for_corrupted_meta() {
+    let codec = Arc::new(CacheCodec::new(None));
+    let occasion = MetaOccasion::new(codec);
+    let mut storage = MemoryStorage::default();
+    storage.set(SCOPE, b"default".to_vec(), b"corrupted".to_vec());
+
+    assert!(occasion.recovery(&storage).await.is_err());
   }
 }

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -122,7 +122,11 @@ impl Snapshot {
     paths: impl Iterator<Item = ArcPath>,
   ) {
     for item in paths {
-      storage.remove(scope.name(), item.as_os_str().as_encoded_bytes())
+      let key = self
+        .codec
+        .encode(&item)
+        .expect("should encode snapshot path successfully");
+      storage.remove(scope.name(), &key)
     }
   }
 
@@ -133,14 +137,44 @@ impl Snapshot {
     storage: &dyn Storage,
     scope: SnapshotScope,
   ) -> Result<(bool, ArcPathSet, ArcPathSet, ArcPathSet)> {
+    self.calc_modified_paths_impl(storage, scope, true).await
+  }
+
+  /// Validate a snapshot without retaining unchanged paths.
+  ///
+  /// Normal dependency snapshots only need changed and deleted paths. Avoiding
+  /// the unchanged set saves an allocation and one hash-table insertion for
+  /// nearly every dependency on a typical warm restore.
+  pub async fn calc_modified_paths_without_unchanged(
+    &self,
+    storage: &dyn Storage,
+    scope: SnapshotScope,
+  ) -> Result<(bool, ArcPathSet, ArcPathSet)> {
+    let (is_hot_start, modified_paths, deleted_paths, _) =
+      self.calc_modified_paths_impl(storage, scope, false).await?;
+    Ok((is_hot_start, modified_paths, deleted_paths))
+  }
+
+  async fn calc_modified_paths_impl(
+    &self,
+    storage: &dyn Storage,
+    scope: SnapshotScope,
+    collect_unchanged: bool,
+  ) -> Result<(bool, ArcPathSet, ArcPathSet, ArcPathSet)> {
     let mut modified_path = ArcPathSet::default();
     let mut deleted_path = ArcPathSet::default();
-    let mut no_change_path = ArcPathSet::default();
     let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
     let codec = self.codec.clone();
 
     let data = storage.load(scope.name()).await?;
-    let is_hot_start = !data.is_empty();
+    if data.is_empty() {
+      return Ok((false, modified_path, deleted_path, ArcPathSet::default()));
+    }
+    let mut no_change_path = if collect_unchanged {
+      ArcPathSet::with_capacity_and_hasher(data.len(), Default::default())
+    } else {
+      ArcPathSet::default()
+    };
     data
       .into_iter()
       .map(|(key, value)| {
@@ -163,12 +197,14 @@ impl Snapshot {
           deleted_path.insert(path);
         }
         ValidateResult::NoChanged => {
-          no_change_path.insert(path);
+          if collect_unchanged {
+            no_change_path.insert(path);
+          }
         }
       })
       .await?;
 
-    Ok((is_hot_start, modified_path, deleted_path, no_change_path))
+    Ok((true, modified_path, deleted_path, no_change_path))
   }
 }
 
@@ -291,5 +327,50 @@ mod tests {
     assert!(modified_paths.contains(&p!("/node_modules/project/file1")));
     assert!(modified_paths.contains(&p!("/node_modules/lib/file1")));
     assert_eq!(no_change_paths.len(), 1);
+  }
+
+  #[tokio::test]
+  async fn should_remove_portable_snapshot_from_another_project_root() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    let mut storage = MemoryStorage::default();
+    let snapshot_a = Snapshot::new(
+      SnapshotOptions::default(),
+      fs.clone(),
+      Arc::new(CacheCodec::new(Some("/project-a".into()))),
+    );
+    let snapshot_b = Snapshot::new(
+      SnapshotOptions::default(),
+      fs.clone(),
+      Arc::new(CacheCodec::new(Some("/project-b".into()))),
+    );
+    let path_a = p!("/project-a/file.js");
+    let path_b = p!("/project-b/file.js");
+
+    fs.create_dir_all("/project-a".into()).await.unwrap();
+    fs.write("/project-a/file.js".into(), b"export {};".as_slice())
+      .await
+      .unwrap();
+    snapshot_a
+      .add(&mut storage, SnapshotScope::FILE, [path_a].into_iter())
+      .await;
+
+    let (is_hot_start, modified_paths, deleted_paths) = snapshot_a
+      .calc_modified_paths_without_unchanged(&storage, SnapshotScope::FILE)
+      .await
+      .unwrap();
+    assert!(is_hot_start);
+    assert!(modified_paths.is_empty());
+    assert!(deleted_paths.is_empty());
+
+    snapshot_b.remove(&mut storage, SnapshotScope::FILE, [path_b].into_iter());
+
+    let (is_hot_start, modified_paths, deleted_paths, no_change_paths) = snapshot_b
+      .calc_modified_paths(&storage, SnapshotScope::FILE)
+      .await
+      .unwrap();
+    assert!(!is_hot_start);
+    assert!(modified_paths.is_empty());
+    assert!(deleted_paths.is_empty());
+    assert!(no_change_paths.is_empty());
   }
 }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
@@ -548,11 +548,13 @@ impl CodeSplitter {
       (affected_modules, removed_modules)
     } else {
       (
-        compilation
-          .get_module_graph()
-          .modules_keys()
-          .copied()
-          .collect(),
+        Arc::new(
+          compilation
+            .get_module_graph()
+            .modules_keys()
+            .copied()
+            .collect(),
+        ),
         Default::default(),
       )
     };
@@ -575,7 +577,7 @@ impl CodeSplitter {
       }
     }
 
-    for m in affected_modules {
+    for m in affected_modules.iter().copied() {
       for module_map in self.block_modules_runtime_map.values_mut() {
         module_map.remove(&DependenciesBlockIdentifier::Module(m));
       }

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -395,10 +395,11 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
     let plugin_driver = compilation.plugin_driver.clone();
     process_modules_runtime_requirements(&mut compilation, modules.clone(), plugin_driver.clone())
       .await?;
+    let runtime_chunks = FxHashSet::from_iter([chunk_ukey]);
     process_chunks_runtime_requirements(
       &mut compilation,
-      FxHashSet::from_iter([chunk_ukey]),
-      FxHashSet::from_iter([chunk_ukey]),
+      &runtime_chunks,
+      &runtime_chunks,
       plugin_driver,
     )
     .await?;

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use rspack_hash::RspackHasher;
 use rustc_hash::FxHashSet;
@@ -121,12 +123,14 @@ pub async fn create_hash(
     ));
     chunks
   } else {
-    compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .keys()
-      .copied()
-      .collect()
+    Arc::new(
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .keys()
+        .copied()
+        .collect(),
+    )
   };
 
   let mut compilation_hasher = RspackHasher::from(&compilation.options.output);

--- a/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
@@ -45,7 +45,10 @@ async fn create_module_hashes_pass_impl(compilation: &mut Compilation) -> Result
     for revoked_module in revoked_modules {
       compilation.cgm_hash_artifact.remove(&revoked_module);
     }
-    let mut modules = mutations.get_affected_modules_with_chunk_graph(compilation);
+    let mut modules = mutations
+      .get_affected_modules_with_chunk_graph(compilation)
+      .as_ref()
+      .clone();
 
     // check if module runtime changes
     let mg = compilation.get_module_graph();

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use rspack_error::Result;
 
@@ -177,21 +179,25 @@ fn collect_dependencies_diagnostics(
         (modules, true)
       } else {
         (
-          build_module_graph_artifact
-            .get_module_graph()
-            .modules_keys()
-            .copied()
-            .collect(),
+          Arc::new(
+            build_module_graph_artifact
+              .get_module_graph()
+              .modules_keys()
+              .copied()
+              .collect(),
+          ),
           true,
         )
       }
     } else {
       (
-        build_module_graph_artifact
-          .get_module_graph()
-          .modules_keys()
-          .copied()
-          .collect(),
+        Arc::new(
+          build_module_graph_artifact
+            .get_module_graph()
+            .modules_keys()
+            .copied()
+            .collect(),
+        ),
         false,
       )
     }

--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -101,7 +103,7 @@ async fn runtime_requirements_pass_impl(compilation: &mut Compilation) -> Result
         .remove(removed_chunk);
     }
     let affected_chunks = mutations.get_affected_chunks_with_chunk_graph(compilation);
-    for affected_chunk in &affected_chunks {
+    for affected_chunk in affected_chunks.iter() {
       compilation
         .cgc_runtime_requirements_artifact
         .remove(affected_chunk);
@@ -127,17 +129,19 @@ async fn runtime_requirements_pass_impl(compilation: &mut Compilation) -> Result
     ));
     affected_chunks
   } else {
-    compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .keys()
-      .copied()
-      .collect()
+    Arc::new(
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .keys()
+        .copied()
+        .collect(),
+    )
   };
   process_chunks_runtime_requirements(
     compilation,
-    process_runtime_requirements_chunks,
-    runtime_chunks,
+    &process_runtime_requirements_chunks,
+    &runtime_chunks,
     plugin_driver.clone(),
   )
   .await?;
@@ -302,8 +306,8 @@ pub async fn process_modules_runtime_requirements(
 #[instrument(name = "Compilation:process_chunks_runtime_requirements", target=TRACING_BENCH_TARGET skip_all)]
 pub async fn process_chunks_runtime_requirements(
   compilation: &mut Compilation,
-  chunks: FxHashSet<ChunkUkey>,
-  entries: FxHashSet<ChunkUkey>,
+  chunks: &FxHashSet<ChunkUkey>,
+  entries: &FxHashSet<ChunkUkey>,
   plugin_driver: SharedPluginDriver,
 ) -> Result<()> {
   let logger = compilation.get_logger("rspack.Compilation");
@@ -407,7 +411,7 @@ pub async fn process_chunks_runtime_requirements(
 
   let start = logger.time("runtime requirements.entries");
   let mut hook_exposed_requirements_by_entry = FxHashMap::default();
-  for &entry_ukey in &entries {
+  for &entry_ukey in entries {
     let mut all_runtime_requirements = RuntimeGlobals::default();
     let mut runtime_modules_to_add: Vec<(ChunkUkey, Box<dyn RuntimeModule>)> = Vec::new();
 
@@ -500,7 +504,7 @@ pub async fn process_chunks_runtime_requirements(
   // and overwrite the runtime_module.generate() to get new source in create_chunk_assets
   // this needs full runtime requirements, so run hooks.runtime_module after runtime_requirements_in_tree
   let mut runtime_modules = mem::take(&mut compilation.runtime_modules);
-  for entry_ukey in &entries {
+  for entry_ukey in entries {
     let runtime_module_ids: Vec<_> = compilation
       .build_chunk_graph_artifact
       .chunk_graph

--- a/crates/rspack_core/src/incremental/mutations.rs
+++ b/crates/rspack_core/src/incremental/mutations.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use either::Either;
 use once_cell::sync::OnceCell;
@@ -14,9 +14,42 @@ use crate::{
 pub struct Mutations {
   inner: Vec<Mutation>,
 
-  affected_modules_with_module_graph: OnceCell<IdentifierSet>,
-  affected_modules_with_chunk_graph: OnceCell<IdentifierSet>,
-  affected_chunks_with_chunk_graph: OnceCell<FxHashSet<ChunkUkey>>,
+  affected_modules_with_module_graph: OnceCell<Arc<IdentifierSet>>,
+  affected_modules_with_chunk_graph: OnceCell<Arc<IdentifierSet>>,
+  affected_chunks_with_chunk_graph: OnceCell<Arc<FxHashSet<ChunkUkey>>>,
+}
+
+#[derive(Debug, Default)]
+struct AffectedCacheInvalidation {
+  modules_with_module_graph: bool,
+  modules_with_chunk_graph: bool,
+  chunks_with_chunk_graph: bool,
+}
+
+impl AffectedCacheInvalidation {
+  fn include(&mut self, mutation: &Mutation) {
+    match mutation {
+      Mutation::ModuleAdd { .. }
+      | Mutation::ModuleUpdate { .. }
+      | Mutation::DependencyUpdate { .. } => {
+        self.modules_with_module_graph = true;
+        self.modules_with_chunk_graph = true;
+      }
+      Mutation::ModuleSetAsync { .. } | Mutation::ModuleSetId { .. } => {
+        self.modules_with_chunk_graph = true;
+      }
+      Mutation::ChunkAdd { .. } | Mutation::ChunkRemove { .. } | Mutation::ChunkSetId { .. } => {
+        self.modules_with_chunk_graph = true;
+        self.chunks_with_chunk_graph = true;
+      }
+      Mutation::ModuleSetHashes { .. }
+      | Mutation::ChunkSplit { .. }
+      | Mutation::ChunksIntegrate { .. } => {
+        self.chunks_with_chunk_graph = true;
+      }
+      Mutation::ModuleRemove { .. } | Mutation::ChunkSetHashes { .. } => {}
+    }
+  }
 }
 
 impl fmt::Display for Mutations {
@@ -72,7 +105,10 @@ impl fmt::Display for Mutation {
 
 impl Mutations {
   pub fn add(&mut self, mutation: Mutation) {
+    let mut invalidation = AffectedCacheInvalidation::default();
+    invalidation.include(&mutation);
     self.inner.push(mutation);
+    self.invalidate_affected_caches(invalidation);
   }
 
   pub fn len(&self) -> usize {
@@ -81,6 +117,18 @@ impl Mutations {
 
   pub fn is_empty(&self) -> bool {
     self.inner.is_empty()
+  }
+
+  fn invalidate_affected_caches(&mut self, invalidation: AffectedCacheInvalidation) {
+    if invalidation.modules_with_module_graph {
+      self.affected_modules_with_module_graph.take();
+    }
+    if invalidation.modules_with_chunk_graph {
+      self.affected_modules_with_chunk_graph.take();
+    }
+    if invalidation.chunks_with_chunk_graph {
+      self.affected_chunks_with_chunk_graph.take();
+    }
   }
 }
 
@@ -115,7 +163,12 @@ impl IntoIterator for Mutations {
 
 impl Extend<Mutation> for Mutations {
   fn extend<T: IntoIterator<Item = Mutation>>(&mut self, iter: T) {
-    self.inner.extend(iter);
+    let mut invalidation = AffectedCacheInvalidation::default();
+    for mutation in iter {
+      invalidation.include(&mutation);
+      self.inner.push(mutation);
+    }
+    self.invalidate_affected_caches(invalidation);
   }
 }
 
@@ -123,7 +176,7 @@ impl Mutations {
   pub fn get_affected_modules_with_module_graph(
     &self,
     module_graph: &ModuleGraph,
-  ) -> IdentifierSet {
+  ) -> Arc<IdentifierSet> {
     self
       .affected_modules_with_module_graph
       .get_or_init(|| {
@@ -144,17 +197,27 @@ impl Mutations {
             _ => {}
           }
         }
-        compute_affected_modules_with_module_graph(module_graph, built_modules, built_dependencies)
+        Arc::new(compute_affected_modules_with_module_graph(
+          module_graph,
+          built_modules,
+          built_dependencies,
+        ))
       })
       .clone()
   }
 
-  pub fn get_affected_modules_with_chunk_graph(&self, compilation: &Compilation) -> IdentifierSet {
+  pub fn get_affected_modules_with_chunk_graph(
+    &self,
+    compilation: &Compilation,
+  ) -> Arc<IdentifierSet> {
     self
       .affected_modules_with_chunk_graph
       .get_or_init(|| {
         let mg = compilation.get_module_graph();
-        let mut modules = self.get_affected_modules_with_module_graph(mg);
+        let mut modules = self
+          .get_affected_modules_with_module_graph(mg)
+          .as_ref()
+          .clone();
         let mut chunks = FxHashSet::default();
         for mutation in self.iter() {
           match mutation {
@@ -202,7 +265,7 @@ impl Mutations {
             .chunk_graph
             .get_chunk_modules_identifier(chunk)
         }));
-        modules
+        Arc::new(modules)
       })
       .clone()
   }
@@ -210,11 +273,11 @@ impl Mutations {
   pub fn get_affected_chunks_with_chunk_graph(
     &self,
     compilation: &Compilation,
-  ) -> FxHashSet<ChunkUkey> {
+  ) -> Arc<FxHashSet<ChunkUkey>> {
     self
       .affected_chunks_with_chunk_graph
       .get_or_init(|| {
-        self.iter().fold(FxHashSet::default(), |mut acc, mutation| {
+        Arc::new(self.iter().fold(FxHashSet::default(), |mut acc, mutation| {
           match mutation {
             Mutation::ModuleSetHashes { module } => {
               acc.extend(
@@ -243,7 +306,7 @@ impl Mutations {
             _ => {}
           };
           acc
-        })
+        }))
       })
       .clone()
   }
@@ -355,4 +418,99 @@ fn compute_affected_modules_with_module_graph(
     transitive_affected_modules.extend(new_transitive_affected_modules);
   }
   all_affected_modules
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::ModuleGraphModule;
+
+  fn seed_affected_caches(mutations: &mut Mutations) {
+    mutations.affected_modules_with_module_graph.take();
+    mutations.affected_modules_with_chunk_graph.take();
+    mutations.affected_chunks_with_chunk_graph.take();
+    mutations
+      .affected_modules_with_module_graph
+      .set(Arc::new(IdentifierSet::default()))
+      .expect("module graph cache should be empty");
+    mutations
+      .affected_modules_with_chunk_graph
+      .set(Arc::new(IdentifierSet::default()))
+      .expect("chunk graph module cache should be empty");
+    mutations
+      .affected_chunks_with_chunk_graph
+      .set(Arc::new(FxHashSet::default()))
+      .expect("chunk graph chunk cache should be empty");
+  }
+
+  #[test]
+  fn should_invalidate_only_affected_caches_when_adding_mutations() {
+    let mut mutations = Mutations::default();
+    seed_affected_caches(&mut mutations);
+
+    mutations.add(Mutation::ModuleUpdate {
+      module: ModuleIdentifier::from("updated"),
+    });
+    assert!(mutations.affected_modules_with_module_graph.get().is_none());
+    assert!(mutations.affected_modules_with_chunk_graph.get().is_none());
+    assert!(mutations.affected_chunks_with_chunk_graph.get().is_some());
+
+    seed_affected_caches(&mut mutations);
+    mutations.add(Mutation::ChunkSetId {
+      chunk: ChunkUkey::new(),
+    });
+    assert!(mutations.affected_modules_with_module_graph.get().is_some());
+    assert!(mutations.affected_modules_with_chunk_graph.get().is_none());
+    assert!(mutations.affected_chunks_with_chunk_graph.get().is_none());
+
+    seed_affected_caches(&mut mutations);
+    mutations.add(Mutation::ChunkSetHashes {
+      chunk: ChunkUkey::new(),
+    });
+    assert!(mutations.affected_modules_with_module_graph.get().is_some());
+    assert!(mutations.affected_modules_with_chunk_graph.get().is_some());
+    assert!(mutations.affected_chunks_with_chunk_graph.get().is_some());
+  }
+
+  #[test]
+  fn should_invalidate_affected_caches_when_extending_mutations() {
+    let mut mutations = Mutations::default();
+    seed_affected_caches(&mut mutations);
+
+    mutations.extend([
+      Mutation::ModuleSetAsync {
+        module: ModuleIdentifier::from("async"),
+      },
+      Mutation::ModuleSetHashes {
+        module: ModuleIdentifier::from("hashed"),
+      },
+    ]);
+
+    assert!(mutations.affected_modules_with_module_graph.get().is_some());
+    assert!(mutations.affected_modules_with_chunk_graph.get().is_none());
+    assert!(mutations.affected_chunks_with_chunk_graph.get().is_none());
+  }
+
+  #[test]
+  fn should_refresh_and_share_affected_modules_after_relevant_mutation() {
+    let module = ModuleIdentifier::from("updated");
+    let mut module_graph = ModuleGraph::default();
+    module_graph.add_module_graph_module(ModuleGraphModule::new(module));
+    let mut mutations = Mutations::default();
+
+    let initial = mutations.get_affected_modules_with_module_graph(&module_graph);
+    assert!(initial.is_empty());
+
+    mutations.add(Mutation::ModuleUpdate { module });
+    let updated = mutations.get_affected_modules_with_module_graph(&module_graph);
+    assert!(updated.contains(&module));
+    let shared = mutations.get_affected_modules_with_module_graph(&module_graph);
+    assert!(Arc::ptr_eq(&updated, &shared));
+
+    mutations.add(Mutation::ChunkSetHashes {
+      chunk: ChunkUkey::new(),
+    });
+    let after_irrelevant_mutation = mutations.get_affected_modules_with_module_graph(&module_graph);
+    assert!(Arc::ptr_eq(&updated, &after_irrelevant_mutation));
+  }
 }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -618,6 +618,11 @@ impl ModuleGraph {
     self.inner.dependencies.insert(*dependency.id(), dependency);
   }
 
+  #[inline]
+  pub(crate) fn has_dependency(&self, dependency_id: &DependencyId) -> bool {
+    self.inner.dependencies.get(dependency_id).is_some()
+  }
+
   /// Get a dependency by ID, panicking if not found.
   ///
   /// **PREFERRED METHOD**: Use this for ALL internal Rust code including:

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -214,7 +214,7 @@ async fn finish_modules(
       modules.len(),
       module_graph.modules_len()
     ));
-    modules
+    modules.as_ref().clone()
   } else {
     module_graph.modules_keys().copied().collect()
   };

--- a/packages/rspack-test-tools/src/case/hot.ts
+++ b/packages/rspack-test-tools/src/case/hot.ts
@@ -48,7 +48,7 @@ export function createHotProcessor(
     },
     config: async (context: ITestContext) => {
       const compiler = context.getCompiler();
-      let options = defaultOptions(context, target);
+      let options = defaultOptions(context, target, incremental);
       options = await config(
         context,
         name,
@@ -56,9 +56,6 @@ export function createHotProcessor(
         options,
       );
       overrideOptions(context, options, target, updatePlugin);
-      if (incremental) {
-        options.incremental ??= 'advance-silent';
-      }
       mergeRspackOptions(options, rspackOptions);
       applyRuntimeModeTestDefines(options);
       compiler.setOptions(options);
@@ -154,7 +151,11 @@ function mergeRspackOptions(options: RspackOptions, override?: RspackOptions) {
   }
 }
 
-function defaultOptions(context: ITestContext, target: TTarget) {
+function defaultOptions(
+  context: ITestContext,
+  target: TTarget,
+  incremental: boolean,
+) {
   const options = {
     context: context.getSource(),
     mode: 'development',
@@ -182,8 +183,8 @@ function defaultOptions(context: ITestContext, target: TTarget) {
       moduleIds: 'named',
     },
     target,
-    // test incremental: "safe" here, we test default incremental in Incremental-*.test.js
-    incremental: 'safe',
+    // Incremental-* suites exercise all supported passes; regular hot suites use the safe preset.
+    incremental: incremental ? 'advance-silent' : 'safe',
   } as RspackOptions;
 
   options.plugins ??= [];

--- a/tests/rspack-test/cacheCases/make/refactorize_dep/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/make/refactorize_dep/__snapshots__/stats-2.txt
@@ -5,9 +5,7 @@ DEBUG LOG from rspack.persistentCache
 <i> meta persistent cache recovery succeeded
 <t> read meta from persistent cache: xx ms
 <t> read snapshot from persistent cache: xx ms
-<i> snapshot restored with detected changed dependencies:
-<i> removed paths (1):
-<i>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/make/refactorize_dep/data1.js
+<i> snapshot restored with no changed dependencies
 <i> make persistent cache recovery succeeded
 <t> read make from persistent cache: xx ms
 <t> write make to persistent cache: xx ms

--- a/xtask/benchmark/benches/benches.rs
+++ b/xtask/benchmark/benches/benches.rs
@@ -32,6 +32,7 @@ criterion_main!(
   cases::bundle_threejs_production_sourcemap::case,
   stages::flag_dependency_exports::stage,
   stages::flag_dependency_usage::stage,
+  stages::incremental_affected_modules_cache::stage,
   stages::create_module_ids::stage,
   stages::create_named_module_ids::stage,
   stages::split_chunks::stage,

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -21,7 +21,7 @@ use rspack_core::{
   SourceType, UsedExportsOption, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   cache::Cache,
-  incremental::IncrementalOptions,
+  incremental::{IncrementalOptions, Mutation, Mutations},
   pass::PassExt,
   rspack_sources::{RawStringSource, SourceExt},
 };
@@ -48,6 +48,92 @@ const SPLIT_CHUNKS_SHARED_MODULES: usize = 192;
 const SPLIT_CHUNKS_WINDOW: usize = 20;
 const SPLIT_CHUNKS_COMMON_MODULES: usize = 16;
 const MODULE_ASSET_SEED_COUNT: usize = 256;
+
+pub(crate) fn incremental_affected_modules_cache_benchmark(c: &mut Criterion, rt: &Runtime) {
+  let fs = Arc::new(MemoryFileSystem::default());
+  let random_table = load_random_table();
+  let mut compiler = create_general_stage_compiler(fs.clone());
+
+  rt.block_on(async {
+    fs.create_dir_all("/src".into())
+      .await
+      .expect("should not fail to create dir");
+    prepare_large_code_splitting_case(GENERAL_STAGE_NUM_MODULES, &random_table, &fs).await;
+    prepare_build_module_graph_phase(&mut compiler)
+      .await
+      .unwrap();
+  });
+
+  assert_no_compilation_errors(
+    &compiler.compilation,
+    "incremental affected modules cache setup",
+  );
+  let module_graph = compiler.compilation.get_module_graph();
+  let module_ids = module_graph.modules_keys().copied().collect::<Vec<_>>();
+  let make_warm_mutations = || {
+    let mut mutations = Mutations::default();
+    mutations.extend(
+      module_ids
+        .iter()
+        .copied()
+        .map(|module| Mutation::ModuleUpdate { module }),
+    );
+    let affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
+    assert_eq!(affected_modules.len(), module_graph.modules_len());
+    drop(affected_modules);
+    mutations
+  };
+  let mutations = make_warm_mutations();
+  let affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
+  assert_eq!(affected_modules.len(), module_graph.modules_len());
+  drop(affected_modules);
+
+  c.bench_function("rust@incremental_affected_modules_cached_shared", |b| {
+    b.iter(|| {
+      black_box(mutations.get_affected_modules_with_module_graph(module_graph));
+    });
+  });
+  c.bench_function("rust@incremental_affected_modules_cached_owned", |b| {
+    b.iter(|| {
+      black_box(
+        mutations
+          .get_affected_modules_with_module_graph(module_graph)
+          .as_ref()
+          .clone(),
+      );
+    });
+  });
+  c.bench_function(
+    "rust@incremental_affected_modules_cached_irrelevant_mutation",
+    |b| {
+      b.iter_batched(
+        make_warm_mutations,
+        |mut mutations| {
+          mutations.add(Mutation::ChunkSetHashes {
+            chunk: ChunkUkey::new(),
+          });
+          black_box(mutations.get_affected_modules_with_module_graph(module_graph));
+        },
+        BatchSize::PerIteration,
+      );
+    },
+  );
+  c.bench_function(
+    "rust@incremental_affected_modules_cache_invalidated_miss",
+    |b| {
+      b.iter_batched(
+        make_warm_mutations,
+        |mut mutations| {
+          mutations.add(Mutation::ModuleUpdate {
+            module: module_ids[0],
+          });
+          black_box(mutations.get_affected_modules_with_module_graph(module_graph));
+        },
+        BatchSize::PerIteration,
+      );
+    },
+  );
+}
 
 pub(crate) fn flag_dependency_exports_benchmark(c: &mut Criterion, rt: &Runtime) {
   let fs = Arc::new(MemoryFileSystem::default());

--- a/xtask/benchmark/stages/incremental_affected_modules_cache.rs
+++ b/xtask/benchmark/stages/incremental_affected_modules_cache.rs
@@ -1,0 +1,11 @@
+use criterion::criterion_group;
+use rspack_benchmark::Criterion;
+
+pub fn bench(c: &mut Criterion) {
+  super::run(
+    c,
+    crate::groups::compilation_stages::incremental_affected_modules_cache_benchmark,
+  );
+}
+
+criterion_group!(stage, bench);

--- a/xtask/benchmark/stages/mod.rs
+++ b/xtask/benchmark/stages/mod.rs
@@ -15,6 +15,7 @@ pub mod create_named_chunk_ids;
 pub mod create_named_module_ids;
 pub mod flag_dependency_exports;
 pub mod flag_dependency_usage;
+pub mod incremental_affected_modules_cache;
 pub mod mangle_exports;
 pub mod real_content_hash;
 pub mod runtime_requirements;


### PR DESCRIPTION
## Summary

- Harden persistent-cache recovery against corrupt or semantically inconsistent module graphs, metadata, connections, blocks, dependencies, and snapshots.
- Reduce warm-cache and incremental-build overhead with compact recovery bookkeeping, empty-snapshot fast paths, and shared `Arc`-backed affected-module caches with selective invalidation.
- Fix incremental hot-test defaults and add benchmarks for cached hits, irrelevant mutations, and invalidated recomputation.

## Why

Persistent cache corruption could panic or restore an incomplete graph, while snapshot recovery could retain stale entries or use non-portable deletion keys. Incremental mutation queries also cloned large affected-module sets repeatedly and could return stale memoized results after later mutations.

## Checks

- `cargo test -p rspack_core --lib` — 130 passed
- `cargo clippy -p rspack_core --lib -- -D warnings`
- `cargo check -p rspack_benchmark --benches`
- `pnpm run build:binding:dev`
- Persistent cache integration: 33 passed
- Incremental-web integration: 125 passed
- Commit hooks: Rust formatting and JavaScript lint passed

The final full JavaScript test rerun was blocked by the sandbox refusing the test server's `::1:3000` listener (`EPERM`); the targeted cache and incremental suites passed before that environment restriction recurred.
