### PR TITLE
fix(css): register css hmr runtime when native css has no module yet

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -8,10 +8,11 @@ use rspack_core::{
   Compilation, CompilationContentHash, CompilationId, CompilationParams, CompilationRenderManifest,
   CompilationRuntimeRequirementInTree, CompilerCompilation, CssBuildInfo, CssModuleRenderCondition,
   DependencyType, ManifestAssetType, Module, ModuleFactoryCreateData, ModuleGraph,
-  ModuleIdentifier, ModuleType, NormalModuleCreateData, NormalModuleFactoryAfterResolve,
-  NormalModuleFactoryModule, ParserAndGenerator, PathData, Plugin, PublicPath, RenderManifestEntry,
-  RuntimeGlobals, RuntimeModule, RuntimeModuleExt, SelfModuleFactory, SourceType,
-  css_module_render_conditions_identifier, get_css_chunk_filename_template,
+  ModuleIdentifier, ModuleRule, ModuleType, NormalModuleCreateData,
+  NormalModuleFactoryAfterResolve, NormalModuleFactoryModule, ParserAndGenerator, PathData, Plugin,
+  PublicPath, RenderManifestEntry, RuntimeGlobals, RuntimeModule, RuntimeModuleExt,
+  SelfModuleFactory, SourceType, css_module_render_conditions_identifier,
+  get_css_chunk_filename_template,
   rspack_sources::{BoxSource, CachedSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
@@ -377,6 +378,20 @@ async fn compilation(
   Ok(())
 }
 
+// Native CSS is configured through module rules (`type: "css*"`), so the runtime
+// chunk must carry the css hmr handler whenever such a rule exists, even before any
+// stylesheet is imported. Otherwise the first stylesheet added via HMR is emitted but
+// never requested, because the runtime baked at the initial build lacks `hmrC.css`.
+fn has_css_module_rule(rules: &[ModuleRule]) -> bool {
+  rules.iter().any(|rule| {
+    matches!(
+      rule.effect.r#type,
+      Some(ModuleType::Css | ModuleType::CssModule | ModuleType::CssAuto | ModuleType::CssGlobal)
+    ) || rule.one_of.as_deref().is_some_and(has_css_module_rule)
+      || rule.rules.as_deref().is_some_and(has_css_module_rule)
+  })
+}
+
 #[plugin_hook(CompilationRuntimeRequirementInTree for CssPlugin)]
 async fn runtime_requirements_in_tree(
   &self,
@@ -396,11 +411,23 @@ async fn runtime_requirements_in_tree(
     &ChunkLoading::Enable(ChunkLoadingType::Import),
     compilation,
   );
+  // A compilation configured for native css (via a `type: "css*"` module rule) but
+  // without any css module yet still needs the css hmr runtime baked into the initial
+  // chunk, so a stylesheet added by a later hot update can be requested. Once a css
+  // module exists the regular `HAS_CSS_MODULES` gating already covers this. The rule
+  // scan is only reached under HMR, so non-watch builds pay nothing.
+  let has_css_rule = all_runtime_requirements
+    .contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS)
+    && has_css_module_rule(&compilation.options.module.rules);
+  let hmr_needs_css_runtime =
+    has_css_rule && !all_runtime_requirements.contains(RuntimeGlobals::HAS_CSS_MODULES);
   let needs_css_loading_runtime = runtime_requirements.intersects(
     RuntimeGlobals::HAS_CSS_MODULES
       | RuntimeGlobals::CSS_INJECT_STYLE
       | RuntimeGlobals::CSS_STYLE_SHEET,
-  );
+  ) || (runtime_requirements
+    .contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS)
+    && has_css_rule);
 
   if !is_enabled_for_chunk
     && !runtime_requirements
@@ -416,10 +443,11 @@ async fn runtime_requirements_in_tree(
     ));
   }
 
-  if all_runtime_requirements.contains(RuntimeGlobals::HAS_CSS_MODULES)
+  if (all_runtime_requirements.contains(RuntimeGlobals::HAS_CSS_MODULES)
     && all_runtime_requirements.intersects(
       RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS | RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
-    )
+    ))
+    || hmr_needs_css_runtime
   {
     runtime_requirements_mut.extend(CssLoadingRuntimeModule::get_runtime_requirements_basic());
   }
@@ -450,6 +478,7 @@ async fn runtime_requirements_in_tree(
 
   if all_runtime_requirements
     .contains(RuntimeGlobals::HAS_CSS_MODULES | RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS)
+    || hmr_needs_css_runtime
   {
     runtime_requirements_mut.extend(CssLoadingRuntimeModule::get_runtime_requirements_with_hmr());
   }

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -285,8 +285,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
           &chunk_has_css,
         );
 
-      let with_css_hmr = with_css_modules && with_hmr;
-      let with_link_runtime = with_css_hmr || with_loading || with_prefetch || with_preload;
+      let with_link_runtime = with_hmr || with_loading || with_prefetch || with_preload;
 
       if !with_link_runtime && !with_inject_style && !with_style_sheet {
         return Ok(String::new());
@@ -414,7 +413,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
           source.push_str(&source_with_preload);
         }
 
-        if with_css_hmr {
+        if with_hmr {
           let source_with_hmr = context.runtime_template.render(
             &self.template_id(TemplateId::WithHmr),
             Some(serde_json::json!({

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case add-first-native-css-import: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/__snapshots__/web/1.snap.txt
@@ -1,0 +1,217 @@
+# Case add-first-native-css-import: Step 1
+
+## Changed Files
+- mod.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: main.LAST_HASH.hot-update.js, size: 5079
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./mod.js
+
+#### Changed Runtime Modules
+- webpack/runtime/css_loading
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("main", {
+"./mod.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+
+
+/* export default */ const __rspack_default_export = ("with-css");
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get css chunk filename
+(() => {
+// This function allow to reference chunks
+__webpack_require__.k = (chunkId) => {
+  // return url for filenames not based on template
+  
+  // return url for filenames based on template
+  return "bundle.css"
+}
+})();
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+// webpack/runtime/css_loading
+(() => {
+var cssInstalledChunks = {"main": 0,};
+var cssLoadingUniqueName = "";
+function handleCssComposes(exports, composes) {
+	for (var i = 0; i < composes.length; i += 3) {
+		var moduleId = composes[i];
+		var composeFrom = composes[i + 1];
+		var composeVar = composes[i + 2];
+		var composedId = __webpack_require__(composeFrom)[composeVar];
+		exports[moduleId] = exports[moduleId] + " " + composedId
+	}
+}
+var loadingAttribute = "data-rspack-loading";
+var cssLoadStylesheet = (chunkId, url, done, hmr, fetchPriority) => {
+	var link,
+		needAttach,
+		key = "chunk-" + chunkId;
+	if (!hmr) {
+		var links = document.getElementsByTagName("link");
+		for (var i = 0; i < links.length; i++) {
+			var l = links[i];
+			var href = l.getAttribute("href") || l.href;
+			if (href && !href.startsWith(__webpack_require__.p)) {
+				href =
+					__webpack_require__.p + (href.startsWith("/") ? href.slice(1) : href);
+			}
+			if (
+				l.rel == "stylesheet" &&
+				((href && href.startsWith(url)) ||
+					l.getAttribute("data-rspack") == cssLoadingUniqueName + ":" + key)
+			) {
+				link = l;
+				break;
+			}
+		}
+		if (!done) return link;
+	}
+	if (!link) {
+		needAttach = true;
+		link = document.createElement("link");
+if (__webpack_require__.nc) {
+  link.setAttribute("nonce", __webpack_require__.nc);
+}
+
+
+link.setAttribute(loadingAttribute, 1);
+link.rel = "stylesheet";
+link.href = url;
+
+
+	}
+	var onLinkComplete = (prev, event) => {
+		link.onerror = link.onload = null;
+		link.removeAttribute(loadingAttribute);
+		clearTimeout(timeout);
+		if (event && event.type != "load" && link.parentNode) link.parentNode.removeChild(link);
+		done(event);
+		if (prev) return prev(event);
+	};
+	if (link.getAttribute(loadingAttribute)) {
+		var timeout = setTimeout(
+			onLinkComplete.bind(null, undefined, { type: "timeout", target: link }),
+			120000 
+		);
+		link.onerror = onLinkComplete.bind(null, link.onerror);
+		link.onload = onLinkComplete.bind(null, link.onload);
+	} else onLinkComplete(undefined, { type: "load", target: link });
+	if (hmr && hmr.getAttribute("fetchpriority")) link.setAttribute("fetchpriority", hmr.getAttribute("fetchpriority"));
+	hmr ? document.head.insertBefore(link, hmr) : needAttach && document.head.appendChild(link);
+	return link;
+};
+var cssOldTags = [];
+var cssNewTags = [];
+var cssApplyHandler = (options) => {
+	return {
+		dispose: () => { },
+		apply: () => {
+			cssNewTags.forEach((newTag) => {
+				newTag.sheet.disabled = false;
+			});
+			while (cssOldTags.length) {
+				var oldTag = cssOldTags.pop();
+				if (oldTag.parentNode) oldTag.parentNode.removeChild(oldTag);
+			}
+			while (cssNewTags.length) {
+				cssNewTags.pop();
+			}
+		}
+	};
+};
+var cssTextKeyOfLink = (link) => {
+	return Array.from(link.sheet.cssRules, (r) => (r.cssText)).join();
+};
+__webpack_require__.hmrC.css = (chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList) => {
+	if (typeof document === 'undefined') return;
+	applyHandlers.push(cssApplyHandler);
+	var seen = {};
+	chunkIds.forEach((chunkId) => {
+		var filename = __webpack_require__.k(chunkId);
+		if (!filename) return;
+		var url = __webpack_require__.p + filename;
+		if (seen[url]) {
+			return;
+		}
+		seen[url] = true;
+		var oldTag = cssLoadStylesheet(chunkId, url);
+		if (!oldTag) return;
+		promises.push(
+			new Promise((resolve, reject) => {
+				var link = cssLoadStylesheet(
+					chunkId,
+					url + (url.indexOf("?") < 0 ? "?" : "&") + "hmr=" + Date.now(),
+					(event) => {
+						if (event.type !== "load") {
+							var error = new Error();
+							var errorType = event && event.type;
+							var realSrc = event && event.target && event.target.src;
+							error.message =
+								"Loading css hot update chunk " +
+								chunkId +
+								" failed.\n(" +
+								errorType +
+								": " +
+								realSrc +
+								")";
+							error.name = "ChunkLoadError";
+							error.type = errorType;
+							error.request = realSrc;
+							reject(error);
+						} else {
+							try {
+								if (cssTextKeyOfLink(oldTag) == cssTextKeyOfLink(link)) {
+									if (link.parentNode) link.parentNode.removeChild(link);
+									return resolve();
+								}
+							} catch (e) {}
+							cssOldTags.push(oldTag);
+							cssNewTags.push(link);
+							link.sheet.disabled = true;
+							resolve();
+						}
+					},
+					oldTag
+				);
+			})
+		);
+	});
+};
+
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/index.js
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/index.js
@@ -1,0 +1,15 @@
+import value from "./mod.js";
+
+it("registers the css hmr handler when native css is configured but not yet imported", async () => {
+	expect(value).toBe("no-css");
+	// Root cause of #14747: the css hmr handler must be baked into the initial
+	// runtime chunk even though the initial compilation has no css module yet,
+	// otherwise the first css added by a later hot update can never be requested.
+	expect(__webpack_require__.hmrC.css).toBeInstanceOf(Function);
+
+	// Adding the first css must not throw when the handler runs (it needs the
+	// css chunk filename runtime to be provided alongside the handler).
+	await NEXT_HMR();
+});
+
+module.hot.accept("./mod.js");

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/mod.js
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/mod.js
@@ -1,0 +1,5 @@
+export default "no-css";
+---
+import "./style.css";
+
+export default "with-css";

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/rspack.config.js
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/auto',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/style.css
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/style.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/tests/rspack-test/hotCases/css/add-first-native-css-import/test.config.js
+++ b/tests/rspack-test/hotCases/css/add-first-native-css-import/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	documentType: "jsdom"
+};

--- a/tests/rspack-test/statsOutputCases/hot+production/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/hot+production/__snapshots__/stats.txt
@@ -1,4 +1,4 @@
 asset main.js xx KiB [emitted] (name: main)
-runtime modules xx KiB 9 modules
+runtime modules xx KiB 11 modules
 ./index.js xx bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s


### PR DESCRIPTION
## Why

When a native-css project's initial build has **no css module**, `CssPlugin` never injects `CssLoadingRuntimeModule`, so the `hmrC.css` download handler is missing from the initial runtime chunk. The runtime chunk is not re-emitted on HMR, so once the first stylesheet is added by a hot update there is no handler to request it — the JS update applies while styles silently never load.

`CssExtractRspackPlugin` already registers its css loading runtime whenever HMR is enabled, so the same "first stylesheet ever" scenario works for extracted css. Native css should follow the same rule.

## What

Register the css hmr runtime (and provide its `GET_CHUNK_CSS_FILENAME` / `PUBLIC_PATH` dependencies) whenever HMR is enabled **and** a native css module rule (`type: "css*"`) is configured — even if the compilation has no css module yet. Detection scans module rules (native css is enabled via rules, not the deprecated `experiments.css`), and the scan only runs under HMR, so non-watch builds are unaffected.

Added a hot case asserting `__webpack_require__.hmrC.css` is registered when native css is configured but not yet imported.

## Scope

This is the **registration** half of #14747. The handler logic that actually attaches the newly-added stylesheet (removing the `if (!oldTag) return` bail and driving from the `css.c` / `css.r` hot-update manifest) lands in #14682; together they make the first css load end-to-end. Registration must happen here because the runtime chunk is baked once at the initial build.

ref #14747, #14682