### PR TITLE
fix(watcher): serialize watch and close on the native watcher

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -470,8 +470,8 @@ export declare class NativeWatcher {
    * # Safety
    *
    * This function is unsafe because it uses `&mut self` to call the watcher asynchronously.
-   * It's important to ensure that the watcher is not used in any other places before this function is finished.
-   * You must ensure that the watcher not call watch, close or pause in the same time, otherwise it may lead to undefined behavior.
+   * `watch` and `close` are serialized internally, but calling `pause` while this function is
+   * in flight is still undefined behavior.
    */
   close(): Promise<void>
   pause(): void

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -117,7 +117,7 @@ serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 simd-json                              = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "test-util", "tracing", "parking_lot"] }
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -2,6 +2,7 @@ use std::{
   boxed::Box,
   panic::AssertUnwindSafe,
   path::{Path, PathBuf},
+  sync::Arc,
   time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -59,6 +60,8 @@ pub struct NativeWatchUndelayedEvent {
 pub struct NativeWatcher {
   watcher: FsWatcher,
   closed: bool,
+  watch_task: Option<tokio::task::JoinHandle<()>>,
+  watcher_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 fn timestamp_to_system_time(millis: u64) -> SystemTime {
@@ -81,6 +84,8 @@ impl NativeWatcher {
     Self {
       watcher,
       closed: false,
+      watch_task: None,
+      watcher_lock: Arc::new(tokio::sync::Mutex::new(())),
     }
   }
 
@@ -110,8 +115,15 @@ impl NativeWatcher {
 
     let start_time = start_time.get_u64().1;
 
+    if let Some(prev) = self.watch_task.take() {
+      prev.abort();
+    }
+
+    let watcher_lock = Arc::clone(&self.watcher_lock);
+    let mut watch_task = None;
     reference.share_with(env, |native_watcher| {
-      rspack_napi::runtime::spawn(async move {
+      watch_task = Some(rspack_napi::runtime::spawn_handle(async move {
+        let _guard = watcher_lock.lock_owned().await;
         native_watcher
           .watcher
           .watch(
@@ -123,9 +135,10 @@ impl NativeWatcher {
             Box::new(js_event_handler_undelayed),
           )
           .await
-      });
+      }));
       Ok(())
     })?;
+    self.watch_task = watch_task;
 
     Ok(())
   }
@@ -160,6 +173,10 @@ impl NativeWatcher {
     let shared_reference = reference.share_with(Env::from_raw(env.raw()), |native_watcher| {
       rspack_napi::runtime::spawn(async move {
         let result = AssertUnwindSafe(async {
+          if let Some(task) = native_watcher.watch_task.take() {
+            task.abort();
+          }
+          let _guard = Arc::clone(&native_watcher.watcher_lock).lock_owned().await;
           native_watcher
             .watcher
             .close()

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -161,8 +161,8 @@ impl NativeWatcher {
   /// # Safety
   ///
   /// This function is unsafe because it uses `&mut self` to call the watcher asynchronously.
-  /// It's important to ensure that the watcher is not used in any other places before this function is finished.
-  /// You must ensure that the watcher not call watch, close or pause in the same time, otherwise it may lead to undefined behavior.
+  /// `watch` and `close` are serialized internally, but calling `pause` while this function is
+  /// in flight is still undefined behavior.
   pub unsafe fn close<'env>(
     &mut self,
     env: &'env Env,

--- a/crates/rspack_napi/src/runtime.rs
+++ b/crates/rspack_napi/src/runtime.rs
@@ -38,6 +38,14 @@ where
   std::mem::drop(spawn_inner(future));
 }
 
+pub fn spawn_handle<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+where
+  F: Future + Send + 'static,
+  F::Output: Send + 'static,
+{
+  spawn_inner(future)
+}
+
 pub fn block_on<F: Future>(future: F) -> F::Output {
   with_runtime(|runtime| runtime.block_on(future))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,9 @@ importers:
       '@prefresh/utils':
         specifier: 1.2.1
         version: 1.2.1
+      '@rspack/binding':
+        specifier: workspace:*
+        version: link:../../crates/node_binding
       '@rspack/binding-testing':
         specifier: workspace:*
         version: link:../../crates/rspack_binding_builder_testing

--- a/tests/rspack-test/NativeWatcherLifecycle.test.js
+++ b/tests/rspack-test/NativeWatcherLifecycle.test.js
@@ -1,0 +1,59 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const binding = require("@rspack/binding");
+
+const ITERATIONS = 30;
+const WATCHES_PER_ITERATION = 5;
+const FILE_COUNT = 400;
+
+let dir;
+let files;
+let dirs;
+
+const startWatch = watcher => {
+	watcher.watch(
+		[files, []],
+		[dirs, []],
+		[[], []],
+		BigInt(Date.now()),
+		() => {},
+		() => {}
+	);
+};
+
+describe("NativeWatcher lifecycle", () => {
+	beforeAll(() => {
+		dir = fs.mkdtempSync(path.join(os.tmpdir(), "rspack-native-watcher-"));
+		files = [];
+		dirs = [dir];
+		for (let i = 0; i < FILE_COUNT; i++) {
+			const sub = path.join(dir, `sub${i % 20}`);
+			fs.mkdirSync(sub, { recursive: true });
+			const file = path.join(sub, `f${i}.js`);
+			fs.writeFileSync(file, `module.exports = ${i};`);
+			files.push(file);
+			if (!dirs.includes(sub)) {
+				dirs.push(sub);
+			}
+		}
+	});
+
+	afterAll(() => {
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("does not crash when watch and close race on the same watcher", async () => {
+		for (let i = 0; i < ITERATIONS; i++) {
+			const watcher = new binding.NativeWatcher({ aggregateTimeout: 1 });
+
+			for (let j = 0; j < WATCHES_PER_ITERATION; j++) {
+				startWatch(watcher);
+			}
+
+			await watcher.close();
+
+			expect(() => startWatch(watcher)).toThrow(/has been closed/);
+		}
+	});
+});

--- a/tests/rspack-test/package.json
+++ b/tests/rspack-test/package.json
@@ -18,6 +18,7 @@
     "@module-federation/runtime-tools": "2.7.0",
     "@prefresh/core": "1.5.10",
     "@prefresh/utils": "1.2.1",
+    "@rspack/binding": "workspace:*",
     "@rspack/binding-testing": "workspace:*",
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",


### PR DESCRIPTION
## Why

On macOS, tearing down and restarting the native watcher (`experiments.nativeWatcher`) intermittently aborts the process:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
    reason: '-[OS_os_log addObject:]: unrecognized selector sent to instance ...'
libc++abi: terminating due to uncaught exception of type NSException  →  SIGABRT
```

Symbolicated crash stack (release-debug build), on a tokio worker thread:

```
notify::fsevent::FsEventWatcher::append_path        // CFArrayAppendValue(self.paths, ...)
notify::fsevent::FsEventWatcher::watch
rspack_watcher::disk_watcher::DiskWatcher::watch
rspack_watcher::FsWatcher::wait_for_event
rspack_binding_api::native_watcher::NativeWatcher::watch   // spawned task
```

A use-after-free between two entry points that were never kept apart:

- `watch()` spawns a **detached** task and returns to JS immediately. The task registers paths with FSEvents via `append_path`, which mutates the watcher's `CFMutableArray` (`self.paths`).
- `close()` drops the watcher — `Drop` → `CFRelease(self.paths)`.
- They land on the *same* instance: `NativeWatchFileSystem` memoizes one `NativeWatcher` per compiler and clears `#inner` only after `close()`'s promise resolves. The `# Safety` note on `close` asserted callers must not overlap the two, but nothing enforced it.

So `append_path` writes into the CFArray while `close` frees it. The freed slot gets reused by an `os_log` object, and the next `CFArrayAppendValue` dispatches `addObject:` to a non-array → NSException → SIGABRT.

**Where the window is.** `DiskWatcher::watch` calls into notify only for patterns it isn't already watching, and on macOS `WatcherRootAnalyzer` collapses every dependency into a single recursive common root that is stable across rebuilds. `append_path` therefore runs on a watcher's **first** `watch()` — one recursive FSEvents subscription over the whole project root, which is far from instantaneous — while steady-state rebuilds dedupe to a no-op. The race is a `close()` (or a second `watch()`, which would also see an empty pattern set) landing inside that first registration.

Instrumenting a real consumer confirms it is reachable: Rstest rebuilds its dev server whenever a config file changes, and its watch-mode restart test edits the config while startup is still in progress. `close()` arrives **3 ms** after the first `watch()` on the same memoized `NativeWatcher`, and the process aborts in `append_path`.

This is distinct from the `analyzer/root.rs` path-tree assert — it still reproduces with that fix applied.

## What

Serialize the two entry points that reach the disk watcher with an async mutex:

- a watch task acquires it **before** touching the watcher, and holds it across the whole `watcher.watch()`;
- `close` aborts the in-flight watch task, then acquires the same mutex before tearing the watcher down.

`watch` and `close` are the only paths that reach `DiskWatcher` (`FsWatcher::watch` → `wait_for_event` → `disk_watcher.watch()`, and `FsWatcher::close` → `disk_watcher.close()`). `pause` and `trigger_event` take `&self` and only touch the executor / trigger, never the FSEvents state, so they stay outside the lock — the `# Safety` note is updated to say exactly that.

Cancellation-safe by construction: a future can only be dropped at an `.await`, never mid-FFI, so an aborted task always releases the guard with the watcher in a consistent state. Holding the mutex in `close` is proof that no task is inside `append_path`. It cannot deadlock either — `abort()` always precedes the lock wait, so the current holder is guaranteed to reach an await and release.

Also adds `rspack_napi::runtime::spawn_handle`, which returns the `JoinHandle` needed to abort (the existing `spawn` drops it).

> **Rejected alternative** (raised in review): have each new watch task `abort()` **and `await`** its predecessor. Not cancellation-safe — `close` aborting the head of the chain cancels it at its `prev.await`, which drops the predecessor's `JoinHandle` and **detaches** it; the abandoned tasks keep running into `append_path` while `close` drops the watcher. The test below reproduced both the resulting SIGSEGV and a hang (notify's `stop()` spinning forever on `CFRunLoopIsWaiting` against corrupted state), which is why this uses a lock.

## Test

`tests/rspack-test/NativeWatcherLifecycle.test.js` drives `binding.NativeWatcher` directly: overlapping watch tasks on a fresh watcher followed by an immediate close, repeated. The file set is large enough that the work preceding `append_path` (path-manager update, mtime baselines, path-tree rebuild) keeps the registration in flight long enough for the close to land on it. It runs in the `nativeWatcher` project (`retry: 0`, `maxConcurrency: 1`) so a native abort cannot be masked by a retry.

## Verification

macOS arm64, binding built from this branch:

| | pre-fix | abort+await chain | this PR (mutex) |
| --- | --- | --- | --- |
| `NativeWatcherLifecycle` | **6/6 crash** | 4/6 fail (3 hang, 1 SIGSEGV) | **6/6 pass** |


close: https://github.com/web-infra-dev/rspack/issues/14790
