### PR TITLE
perf: parallelize delayed chunk-group walks in code splitting

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -367,13 +367,20 @@ impl ChunkGraph {
   }
 
   pub fn connect_chunk_and_modules(&mut self, chunk: ChunkUkey, modules: &[ModuleIdentifier]) {
-    for module in modules.iter() {
-      let cgm = self.expect_chunk_graph_module_mut(*module);
-      cgm.chunks.insert(chunk);
-    }
-    let cgc = self.expect_chunk_graph_chunk_mut(chunk);
+    let cgc = self
+      .chunk_graph_chunk_by_chunk_ukey
+      .entry(chunk)
+      .or_default();
+    cgc.modules.reserve(modules.len());
     for module in modules.iter() {
       cgc.modules.insert(*module);
+    }
+    for module in modules.iter() {
+      let cgm = self
+        .chunk_graph_module_by_module_identifier
+        .entry(*module)
+        .or_default();
+      cgm.chunks.insert(chunk);
     }
   }
 

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -29,6 +29,10 @@ use crate::{
   merge_runtime,
 };
 
+mod parallel;
+
+use parallel::ParallelCodeSplitterState;
+
 pub(crate) type DependenciesBlockIdentifierMap<V> =
   std::collections::HashMap<DependenciesBlockIdentifier, V, BuildHasherDefault<FxHasher>>;
 pub(crate) type DependenciesBlockIdentifierSet =
@@ -308,6 +312,9 @@ pub(crate) struct CodeSplitter {
   prepared_connection_map: IdentifierMap<PreparedBlockConnectionMap>,
 
   prepared_blocks_map: DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
+  prepared_async_entrypoints: AsyncDependenciesBlockIdentifierSet,
+
+  parallel_state: ParallelCodeSplitterState,
 }
 
 fn add_chunk_in_group(
@@ -379,6 +386,10 @@ fn get_active_state_of_connections(
 }
 
 impl CodeSplitter {
+  pub(crate) fn configure_parallel(&mut self) {
+    self.parallel_state.configure_from_env();
+  }
+
   pub(crate) fn chunk_group_info(&self, ukey: &CgiUkey) -> &ChunkGroupInfo {
     self
       .chunk_group_infos
@@ -983,7 +994,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         self.process_outdated_chunk_group_info(compilation);
       }
 
-      if self.queue.is_empty() {
+      if self.queue.is_empty() && !parallel::try_process_delayed_queue(self, compilation) {
         let queue_delay = std::mem::take(&mut self.queue_delayed);
         self.queue = queue_delay;
         self.queue.reverse();
@@ -1090,7 +1101,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         }
       }
     }
-
     {
       let mut processed_queue_buffer = itoa::Buffer::new();
       let processed_queue_str = processed_queue_buffer.format(self.stat_processed_queue_items);
@@ -1953,18 +1963,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             .available_modules_to_be_merged
             .push(resulting_available_modules.clone());
 
-          // get mutable reference to runtime
-          // if the runtime has been referenced, clone and create a new Arc
-          let target_runtime = if let Some(target_runtime) = Arc::get_mut(&mut target_cgi.runtime) {
-            target_runtime
-          } else {
-            target_cgi.runtime = Arc::new(target_cgi.runtime.as_ref().clone());
-            Arc::get_mut(&mut target_cgi.runtime).expect("should have runtime")
-          };
-
-          let runtime_len = target_runtime.len();
-          target_runtime.extend(&runtime);
-          (target_group, target_runtime.len() != runtime_len)
+          let updated = runtime
+            .iter()
+            .any(|runtime| !target_cgi.runtime.contains(runtime));
+          if updated {
+            Arc::make_mut(&mut target_cgi.runtime).extend(&runtime);
+          }
+          (target_group, updated)
         };
         target_groups.push(target_group);
 
@@ -2243,112 +2248,97 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
   fn process_chunk_groups_for_merging(&mut self, compilation: &mut Compilation) {
     self.stat_processed_chunk_groups_for_merging += self.chunk_groups_for_merging.len() as u32;
     let chunk_groups_for_merging = std::mem::take(&mut self.chunk_groups_for_merging);
-    let mut chunk_groups_merging_batches: Vec<Vec<(CgiUkey, Option<ProcessBlock>)>> = vec![vec![]];
-
-    // take chunk group infos and process parallelly
-    // cause the chunk group info keys may be duplicated with different process blocks
-    // so a new batch will be created when chunk group info key has been exists
     let mut taken_cgi = HashSet::<CgiUkey>::default();
-    for (info_ukey, process_block) in chunk_groups_for_merging {
-      if !taken_cgi.insert(info_ukey) {
-        chunk_groups_merging_batches.push(vec![]);
-        taken_cgi.clear();
-        taken_cgi.insert(info_ukey);
+    let mut chunk_groups_merging_tasks = Vec::new();
+    for (info_ukey, _) in &chunk_groups_for_merging {
+      if taken_cgi.insert(*info_ukey) {
+        let cgi = std::mem::take(self.chunk_group_info_mut(info_ukey));
+        chunk_groups_merging_tasks.push((*info_ukey, cgi));
       }
-      chunk_groups_merging_batches
-        .last_mut()
-        .expect("should have last batch")
-        .push((info_ukey, process_block));
     }
+    let chunk_group_merging_results = chunk_groups_merging_tasks
+      .into_par_iter()
+      .map(|(info_ukey, mut cgi)| {
+        let mut changed = false;
+        let available_modules_length = cgi.available_modules_to_be_merged.len() as u32;
 
-    for batch in chunk_groups_merging_batches {
-      let mut chunk_groups_merging_tasks = Vec::with_capacity(batch.len());
-      for (info_ukey, process_block) in batch {
-        let cgi = std::mem::take(self.chunk_group_info_mut(&info_ukey));
-        chunk_groups_merging_tasks.push((info_ukey, process_block, cgi));
-      }
+        if !cgi.available_modules_to_be_merged.is_empty() {
+          let mut available_modules_to_be_merged =
+            std::mem::take(&mut cgi.available_modules_to_be_merged).into_iter();
 
-      let mut chunk_group_merging_results = chunk_groups_merging_tasks
-        .into_par_iter()
-        .map(|(info_ukey, process_block, mut cgi)| {
-          let mut changed = false;
-          let available_modules_length = cgi.available_modules_to_be_merged.len() as u32;
+          if !cgi.min_available_modules_init
+            && let Some(available_modules) = available_modules_to_be_merged.next()
+          {
+            cgi.min_available_modules_init = true;
+            cgi.min_available_modules = available_modules;
+            changed = true;
+          }
 
-          if !cgi.available_modules_to_be_merged.is_empty() {
-            let available_modules_to_be_merged =
-              std::mem::take(&mut cgi.available_modules_to_be_merged);
-
-            for modules_to_be_merged in available_modules_to_be_merged {
-              if !cgi.min_available_modules_init {
-                cgi.min_available_modules_init = true;
-                cgi.min_available_modules = modules_to_be_merged;
-                changed = true;
-                continue;
-              }
-
-              let merged = cgi.min_available_modules.as_ref() & modules_to_be_merged.as_ref();
-              if &merged != cgi.min_available_modules.as_ref() {
-                cgi.min_available_modules = Arc::new(merged);
-                changed = true;
-              }
+          if let Some(available_modules) = available_modules_to_be_merged.next() {
+            let current = cgi.min_available_modules.clone();
+            let mut merged = current.as_ref().clone();
+            merged &= available_modules.as_ref();
+            for available_modules in available_modules_to_be_merged {
+              merged &= available_modules.as_ref();
+            }
+            if &merged != current.as_ref() {
+              cgi.min_available_modules = Arc::new(merged);
+              changed = true;
             }
           }
-
-          if changed {
-            cgi.invalidate_resulting_available_modules();
-          }
-
-          (
-            info_ukey,
-            Some(cgi),
-            process_block,
-            changed,
-            available_modules_length,
-          )
-        })
-        .collect::<Vec<_>>();
-
-      for (info_ukey, cgi, _, _, _) in &mut chunk_group_merging_results {
-        *self.chunk_group_info_mut(info_ukey) = cgi.take().expect("should have chunk group info");
-      }
-
-      for (info_ukey, _, process_block, changed, available_modules_length) in
-        chunk_group_merging_results
-      {
-        self.stat_merged_available_module_sets += available_modules_length;
+        }
 
         if changed {
-          self.outdated_chunk_group_info.insert(info_ukey);
+          cgi.invalidate_resulting_available_modules();
         }
 
-        let Some(process_block) = process_block else {
+        (info_ukey, cgi, changed, available_modules_length)
+      })
+      .collect::<Vec<_>>();
+
+    let mut changed_by_cgi =
+      HashMap::with_capacity_and_hasher(chunk_group_merging_results.len(), Default::default());
+    for (info_ukey, cgi, changed, available_modules_length) in chunk_group_merging_results {
+      *self.chunk_group_info_mut(&info_ukey) = cgi;
+      self.stat_merged_available_module_sets += available_modules_length;
+      changed_by_cgi.insert(info_ukey, changed);
+    }
+
+    // Replay roots in their original order after each unique chunk group has merged its pending
+    // available-module inputs once.
+    for (info_ukey, process_block) in chunk_groups_for_merging {
+      let changed = changed_by_cgi.remove(&info_ukey).unwrap_or(false);
+      if changed {
+        self.outdated_chunk_group_info.insert(info_ukey);
+      }
+
+      let Some(process_block) = process_block else {
+        continue;
+      };
+
+      let (initialized, cgi_ukey) = {
+        let cgi = self.chunk_group_info(&info_ukey);
+        (cgi.initialized, cgi.ukey)
+      };
+      let mut needs_walk = !initialized || changed;
+
+      let blocks = self.incoming_blocks_by_cgi.entry(cgi_ukey).or_default();
+      if blocks.insert(process_block.block) {
+        needs_walk = true;
+      }
+
+      if needs_walk {
+        self.chunk_group_info_mut(&info_ukey).initialized = true;
+
+        // check if we can use cache to initialize it
+        if !initialized && self.recover_from_cache(info_ukey, compilation) {
+          self.stat_use_cache += 1;
           continue;
-        };
-
-        let (initialized, cgi_ukey) = {
-          let cgi = self.chunk_group_info(&info_ukey);
-          (cgi.initialized, cgi.ukey)
-        };
-        let mut needs_walk = !initialized || changed;
-
-        let blocks = self.incoming_blocks_by_cgi.entry(cgi_ukey).or_default();
-        if blocks.insert(process_block.block) {
-          needs_walk = true;
         }
 
-        if needs_walk {
-          self.chunk_group_info_mut(&info_ukey).initialized = true;
-
-          // check if we can use cache to initialize it
-          if !initialized && self.recover_from_cache(info_ukey, compilation) {
-            self.stat_use_cache += 1;
-            continue;
-          }
-
-          self
-            .queue_delayed
-            .push(QueueAction::ProcessBlock(process_block));
-        }
+        self
+          .queue_delayed
+          .push(QueueAction::ProcessBlock(process_block));
       }
     }
   }
@@ -2439,7 +2429,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         ))
       })
       .collect::<IdentifierMap<_>>();
-
     let mut prepared_blocks_map = DependenciesBlockIdentifierMap::<
       Vec<AsyncDependenciesBlockIdentifier>,
     >::with_capacity_and_hasher(
@@ -2458,7 +2447,16 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       }
     }
 
+    self.prepared_async_entrypoints.clear();
     for (block_id, block) in mg.blocks() {
+      if block
+        .get_group_options()
+        .and_then(|options| options.entry_options())
+        .is_some()
+      {
+        self.prepared_async_entrypoints.insert(*block_id);
+      }
+
       let blocks = block.get_blocks();
 
       if !blocks.is_empty() {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter/parallel.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter/parallel.rs
@@ -1,0 +1,665 @@
+use std::{ffi::OsStr, sync::Arc};
+
+use num_bigint::BigUint;
+use rayon::prelude::*;
+use rspack_collections::IdentifierMap;
+use rustc_hash::FxHashSet as HashSet;
+
+use super::{
+  BlockConnectionMap, BlockModules, CodeSplitter, ConnectionIdList, DependenciesBlockIdentifier,
+  DependenciesBlockIdentifierMap, EMPTY_BLOCK_MODULES, PreparedBlockConnectionMap, ProcessBlock,
+  QueueAction, extract_block_modules,
+};
+use crate::{AsyncDependenciesBlockIdentifier, Compilation, ModuleIdentifier, RuntimeSpec};
+
+const PARALLEL_CODE_SPLITTING_ENV: &str = "RSPACK_EXPERIMENTAL_PARALLEL_CODE_SPLITTING";
+const MIN_PARALLEL_CHUNK_GROUPS: usize = 2;
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct ParallelCodeSplitterState {
+  enabled: bool,
+}
+
+fn is_parallel_code_splitting_enabled(value: Option<&OsStr>) -> bool {
+  value.is_none_or(|value| value != OsStr::new("0") && !value.is_empty())
+}
+
+impl ParallelCodeSplitterState {
+  pub(super) fn configure_from_env(&mut self) {
+    self.enabled =
+      is_parallel_code_splitting_enabled(std::env::var_os(PARALLEL_CODE_SPLITTING_ENV).as_deref());
+  }
+}
+
+#[derive(Debug)]
+struct ParallelWalkJob {
+  root: ProcessBlock,
+  runtime: Arc<RuntimeSpec>,
+  min_available_modules: Arc<BigUint>,
+  chunk_mask: BigUint,
+}
+
+#[derive(Debug)]
+enum WalkAction {
+  ProcessBlock {
+    block: DependenciesBlockIdentifier,
+    module: ModuleIdentifier,
+    queued: bool,
+  },
+  AddModule(ModuleIdentifier),
+  LeaveModule(ModuleIdentifier),
+}
+
+#[derive(Default)]
+struct VisitedBlocks(HashSet<(DependenciesBlockIdentifier, ModuleIdentifier)>);
+
+impl VisitedBlocks {
+  #[inline]
+  fn insert(&mut self, block: DependenciesBlockIdentifier, module: ModuleIdentifier) -> bool {
+    self.0.insert((block, module))
+  }
+}
+
+#[derive(Debug)]
+struct ParallelWalkResult {
+  job: ParallelWalkJob,
+  resulting_chunk_mask: BigUint,
+  block_modules_cache: BlockConnectionMap,
+  modules: Vec<ModuleIdentifier>,
+  post_order_modules: Vec<ModuleIdentifier>,
+  global_pre_order_candidates: Vec<ModuleIdentifier>,
+  global_post_order_candidates: Vec<ModuleIdentifier>,
+  async_blocks: Vec<(AsyncDependenciesBlockIdentifier, ModuleIdentifier)>,
+  skipped_items: Vec<ModuleIdentifier>,
+  skipped_connections: Vec<(ModuleIdentifier, ConnectionIdList)>,
+  processed_queue_items: u32,
+  processed_blocks: u32,
+}
+
+fn is_parallel_root(splitter: &CodeSplitter, root: &ProcessBlock) -> bool {
+  let chunk_group_info = splitter.chunk_group_info(&root.chunk_group_info);
+  chunk_group_info.chunk_loading && chunk_group_info.async_chunks
+}
+
+fn has_parallel_batch(splitter: &CodeSplitter) -> bool {
+  let mut keys = HashSet::default();
+  for action in &splitter.queue_delayed {
+    let QueueAction::ProcessBlock(root) = action else {
+      keys.clear();
+      continue;
+    };
+    if !is_parallel_root(splitter, root) {
+      keys.clear();
+      continue;
+    }
+
+    let key = (root.chunk_group_info, root.chunk);
+    if !keys.insert(key) {
+      keys.clear();
+      keys.insert(key);
+    }
+    if keys.len() >= MIN_PARALLEL_CHUNK_GROUPS {
+      return true;
+    }
+  }
+  false
+}
+
+/// Processes only the delayed roots produced by the legacy chunk-group merge loop. These roots
+/// have already received their current `min_available_modules` and runtime. Keeping this boundary
+/// avoids eagerly collecting work across connect/merge rounds, which is important for cycles and
+/// named chunk groups.
+pub(super) fn try_process_delayed_queue(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+) -> bool {
+  if !splitter.parallel_state.enabled
+    || rayon::current_num_threads() <= 1
+    || splitter.queue_delayed.len() < MIN_PARALLEL_CHUNK_GROUPS
+    || !has_parallel_batch(splitter)
+  {
+    return false;
+  }
+
+  let actions = std::mem::take(&mut splitter.queue_delayed);
+
+  let mut batch = Vec::new();
+  let mut keys = HashSet::default();
+  for action in actions {
+    match action {
+      QueueAction::ProcessBlock(root) if is_parallel_root(splitter, &root) => {
+        let key = (root.chunk_group_info, root.chunk);
+        if keys.contains(&key) {
+          flush_batch(splitter, compilation, &mut batch);
+          keys.clear();
+        }
+        keys.insert(key);
+        batch.push(root);
+      }
+      action => {
+        flush_batch(splitter, compilation, &mut batch);
+        keys.clear();
+        process_serial_action(splitter, compilation, action);
+      }
+    }
+  }
+  flush_batch(splitter, compilation, &mut batch);
+  true
+}
+
+fn flush_batch(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+  batch: &mut Vec<ProcessBlock>,
+) {
+  if batch.is_empty() {
+    return;
+  }
+  if batch.len() < MIN_PARALLEL_CHUNK_GROUPS {
+    for root in std::mem::take(batch) {
+      process_serial_action(splitter, compilation, QueueAction::ProcessBlock(root));
+    }
+    return;
+  }
+
+  let roots = std::mem::take(batch);
+  process_parallel_batch(splitter, compilation, roots);
+}
+
+fn process_serial_action(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+  action: QueueAction,
+) {
+  debug_assert!(splitter.queue.is_empty());
+  splitter.queue.push(action);
+  splitter.process_queue(compilation);
+  debug_assert!(splitter.queue.is_empty());
+}
+
+fn process_parallel_batch(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+  roots: Vec<ProcessBlock>,
+) {
+  let jobs = roots
+    .into_iter()
+    .map(|root| {
+      let chunk_group_info = splitter.chunk_group_info(&root.chunk_group_info);
+      ParallelWalkJob {
+        chunk_mask: splitter
+          .mask_by_chunk
+          .get(&root.chunk)
+          .expect("chunk must be in mask_by_chunk")
+          .clone(),
+        runtime: chunk_group_info.runtime.clone(),
+        min_available_modules: chunk_group_info.min_available_modules.clone(),
+        root,
+      }
+    })
+    .collect::<Vec<_>>();
+
+  let prepared_blocks_map = &splitter.prepared_blocks_map;
+  let prepared_connection_map = &splitter.prepared_connection_map;
+  let ordinal_by_module = &splitter.ordinal_by_module;
+  let block_modules_runtime_map = &splitter.block_modules_runtime_map;
+  let results = jobs
+    .into_par_iter()
+    .map(|job| {
+      let shared_block_modules = block_modules_runtime_map.get(&Some(job.runtime.clone()));
+      walk_root(
+        job,
+        compilation,
+        prepared_blocks_map,
+        prepared_connection_map,
+        ordinal_by_module,
+        shared_block_modules,
+      )
+    })
+    .collect::<Vec<_>>();
+
+  commit_results(splitter, compilation, results);
+}
+
+fn walk_root(
+  job: ParallelWalkJob,
+  compilation: &Compilation,
+  prepared_blocks_map: &DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
+  prepared_connection_map: &IdentifierMap<PreparedBlockConnectionMap>,
+  ordinal_by_module: &IdentifierMap<u64>,
+  shared_block_modules: Option<&BlockConnectionMap>,
+) -> ParallelWalkResult {
+  let mut actions = vec![WalkAction::ProcessBlock {
+    block: job.root.block,
+    module: job.root.module,
+    queued: true,
+  }];
+  let mut chunk_mask = job.chunk_mask.clone();
+  let mut block_modules_cache = BlockConnectionMap::default();
+  let mut visited_blocks = VisitedBlocks::default();
+  let mut modules = Vec::new();
+  let mut post_order_modules = Vec::new();
+  let mut async_blocks = Vec::new();
+  let mut skipped_items = Vec::new();
+  let mut skipped_connections = Vec::new();
+  let mut processed_queue_items = 0;
+  let mut processed_blocks = 0;
+
+  while let Some(action) = actions.pop() {
+    match action {
+      WalkAction::ProcessBlock {
+        block,
+        module,
+        queued,
+      } => {
+        if queued {
+          processed_queue_items += 1;
+        }
+        processed_blocks += 1;
+        if !visited_blocks.insert(block, module) {
+          continue;
+        }
+
+        let block_modules = get_block_modules(
+          block,
+          &job.runtime,
+          compilation,
+          prepared_blocks_map,
+          prepared_connection_map,
+          shared_block_modules,
+          &mut block_modules_cache,
+        );
+        for (target, active_state, connections) in block_modules.iter().rev() {
+          let ordinal = *ordinal_by_module.get(target).unwrap_or_else(|| {
+            panic!("expected a module ordinal for identifier '{target}', but none was found")
+          });
+          if chunk_mask.bit(ordinal) {
+            continue;
+          }
+          if !active_state.is_true() {
+            skipped_connections.push((*target, connections.clone()));
+            if active_state.is_false() {
+              continue;
+            }
+          }
+          if active_state.is_true() && job.min_available_modules.bit(ordinal) {
+            skipped_items.push(*target);
+          } else if active_state.is_true() {
+            actions.push(WalkAction::AddModule(*target));
+          } else {
+            actions.push(WalkAction::ProcessBlock {
+              block: DependenciesBlockIdentifier::Module(*target),
+              module,
+              queued: true,
+            });
+          }
+        }
+
+        if let Some(blocks) = prepared_blocks_map.get(&block) {
+          async_blocks.extend(blocks.iter().map(|block| (*block, module)));
+        }
+      }
+      WalkAction::AddModule(module) => {
+        processed_queue_items += 1;
+        let ordinal = *ordinal_by_module.get(&module).unwrap_or_else(|| {
+          panic!("expected a module ordinal for identifier '{module}', but none was found")
+        });
+        if chunk_mask.bit(ordinal) {
+          continue;
+        }
+        if job.min_available_modules.bit(ordinal) {
+          skipped_items.push(module);
+          continue;
+        }
+
+        modules.push(module);
+        chunk_mask.set_bit(ordinal, true);
+        actions.push(WalkAction::LeaveModule(module));
+        actions.push(WalkAction::ProcessBlock {
+          block: DependenciesBlockIdentifier::Module(module),
+          module,
+          queued: false,
+        });
+      }
+      WalkAction::LeaveModule(module) => {
+        processed_queue_items += 1;
+        post_order_modules.push(module);
+      }
+    }
+  }
+
+  // Global order indices are immutable while the workers are running. Do these graph lookups on
+  // the worker threads and leave only the first-seen candidate checks for the ordered commit.
+  let module_graph = compilation.get_module_graph();
+  let global_pre_order_candidates = modules
+    .iter()
+    .filter(|module| {
+      module_graph
+        .module_graph_module_by_identifier(module)
+        .is_none_or(|module| module.pre_order_index.is_none())
+    })
+    .copied()
+    .collect();
+  let global_post_order_candidates = post_order_modules
+    .iter()
+    .filter(|module| {
+      module_graph
+        .module_graph_module_by_identifier(module)
+        .is_none_or(|module| module.post_order_index.is_none())
+    })
+    .copied()
+    .collect();
+
+  ParallelWalkResult {
+    job,
+    resulting_chunk_mask: chunk_mask,
+    block_modules_cache,
+    modules,
+    post_order_modules,
+    global_pre_order_candidates,
+    global_post_order_candidates,
+    async_blocks,
+    skipped_items,
+    skipped_connections,
+    processed_queue_items,
+    processed_blocks,
+  }
+}
+
+fn get_block_modules(
+  block: DependenciesBlockIdentifier,
+  runtime: &Arc<RuntimeSpec>,
+  compilation: &Compilation,
+  prepared_blocks_map: &DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
+  prepared_connection_map: &IdentifierMap<PreparedBlockConnectionMap>,
+  shared_block_modules: Option<&BlockConnectionMap>,
+  cache: &mut BlockConnectionMap,
+) -> Arc<BlockModules> {
+  if let DependenciesBlockIdentifier::Module(module) = block
+    && !prepared_blocks_map.contains_key(&block)
+    && !prepared_connection_map.contains_key(&module)
+  {
+    return EMPTY_BLOCK_MODULES.clone();
+  }
+  if let Some(block_modules) = cache.get(&block) {
+    return block_modules.clone();
+  }
+  if let Some(block_modules) = shared_block_modules.and_then(|cache| cache.get(&block)) {
+    return block_modules.clone();
+  }
+
+  let root = block.get_root_block(compilation.get_module_graph());
+  extract_block_modules(
+    root,
+    Some(runtime.clone()),
+    compilation,
+    prepared_blocks_map,
+    prepared_connection_map,
+    cache,
+  );
+  cache
+    .get(&block)
+    .cloned()
+    .unwrap_or_else(|| Arc::new(Vec::new()))
+}
+
+fn result_is_stale(splitter: &CodeSplitter, result: &ParallelWalkResult) -> bool {
+  let chunk_group_info = splitter.chunk_group_info(&result.job.root.chunk_group_info);
+  let available_modules_changed = !Arc::ptr_eq(
+    &chunk_group_info.min_available_modules,
+    &result.job.min_available_modules,
+  ) && chunk_group_info.min_available_modules.as_ref()
+    != result.job.min_available_modules.as_ref();
+  let runtime_changed = !Arc::ptr_eq(&chunk_group_info.runtime, &result.job.runtime)
+    && chunk_group_info.runtime.as_ref() != result.job.runtime.as_ref();
+  if available_modules_changed || runtime_changed {
+    return true;
+  }
+
+  splitter
+    .mask_by_chunk
+    .get(&result.job.root.chunk)
+    .expect("chunk must be in mask_by_chunk")
+    != &result.job.chunk_mask
+}
+
+fn commit_results(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+  results: Vec<ParallelWalkResult>,
+) {
+  for result in &results {
+    cache_block_modules(splitter, result);
+  }
+
+  for result in results {
+    if result_is_stale(splitter, &result) {
+      process_serial_action(
+        splitter,
+        compilation,
+        QueueAction::ProcessBlock(result.job.root),
+      );
+      continue;
+    }
+    commit_result(splitter, compilation, result);
+  }
+}
+
+fn cache_block_modules(splitter: &mut CodeSplitter, result: &ParallelWalkResult) {
+  let chunk_group_info = splitter.chunk_group_info(&result.job.root.chunk_group_info);
+  if !Arc::ptr_eq(&chunk_group_info.runtime, &result.job.runtime)
+    && chunk_group_info.runtime.as_ref() != result.job.runtime.as_ref()
+  {
+    return;
+  }
+
+  let runtime_cache = splitter
+    .block_modules_runtime_map
+    .entry(Some(result.job.runtime.clone()))
+    .or_default();
+  for (block, modules) in &result.block_modules_cache {
+    if let std::collections::hash_map::Entry::Vacant(entry) = runtime_cache.entry(*block) {
+      entry.insert(modules.clone());
+    }
+  }
+}
+
+fn commit_result(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+  result: ParallelWalkResult,
+) {
+  let ParallelWalkResult {
+    job,
+    resulting_chunk_mask,
+    modules,
+    post_order_modules,
+    global_pre_order_candidates,
+    global_post_order_candidates,
+    async_blocks,
+    skipped_items,
+    skipped_connections,
+    processed_queue_items,
+    processed_blocks,
+    ..
+  } = result;
+  let chunk_group_info = job.root.chunk_group_info;
+  let chunk = job.root.chunk;
+
+  splitter.stat_processed_queue_items += processed_queue_items;
+  splitter.stat_processed_blocks += processed_blocks;
+
+  compilation
+    .build_chunk_graph_artifact
+    .chunk_graph
+    .connect_chunk_and_modules(chunk, &modules);
+  *splitter
+    .mask_by_chunk
+    .get_mut(&chunk)
+    .expect("chunk must be in mask_by_chunk") = resulting_chunk_mask;
+
+  let chunk_group_ukey = splitter.chunk_group_info(&chunk_group_info).chunk_group;
+  {
+    let chunk_group = compilation
+      .build_chunk_graph_artifact
+      .chunk_group_by_ukey
+      .expect_get_mut(&chunk_group_ukey);
+    chunk_group.module_pre_order_indices.reserve(modules.len());
+    for module in &modules {
+      if let std::collections::hash_map::Entry::Vacant(entry) =
+        chunk_group.module_pre_order_indices.entry(*module)
+      {
+        entry.insert(chunk_group.next_pre_order_index);
+        chunk_group.next_pre_order_index += 1;
+      }
+    }
+    chunk_group
+      .module_post_order_indices
+      .reserve(post_order_modules.len());
+    for module in &post_order_modules {
+      if let std::collections::hash_map::Entry::Vacant(entry) =
+        chunk_group.module_post_order_indices.entry(*module)
+      {
+        entry.insert(chunk_group.next_post_order_index);
+        chunk_group.next_post_order_index += 1;
+      }
+    }
+  }
+
+  {
+    let module_graph = compilation.get_module_graph_mut();
+    for module in &global_pre_order_candidates {
+      let module_graph_module = module_graph.module_graph_module_by_identifier_mut(module);
+      if module_graph_module.pre_order_index.is_none() {
+        module_graph_module.pre_order_index = Some(splitter.next_free_module_pre_order_index);
+        splitter.next_free_module_pre_order_index += 1;
+      }
+    }
+    for module in &global_post_order_candidates {
+      let module_graph_module = module_graph.module_graph_module_by_identifier_mut(module);
+      if module_graph_module.post_order_index.is_none() {
+        module_graph_module.post_order_index = Some(splitter.next_free_module_post_order_index);
+        splitter.next_free_module_post_order_index += 1;
+      }
+    }
+  }
+
+  commit_async_blocks(splitter, compilation, async_blocks, chunk_group_info, chunk);
+
+  let chunk_group_info = splitter.chunk_group_info_mut(&chunk_group_info);
+  chunk_group_info.skipped_items.extend(skipped_items);
+  chunk_group_info
+    .skipped_module_connections
+    .extend(skipped_connections);
+}
+
+fn commit_async_blocks(
+  splitter: &mut CodeSplitter,
+  compilation: &mut Compilation,
+  async_blocks: Vec<(AsyncDependenciesBlockIdentifier, ModuleIdentifier)>,
+  item_chunk_group_info: super::CgiUkey,
+  item_chunk: crate::ChunkUkey,
+) {
+  let Some(item_cgi) = splitter.chunk_group_infos.get_mut(&item_chunk_group_info) else {
+    return;
+  };
+  item_cgi
+    .outgoing_blocks
+    .extend(async_blocks.iter().map(|(block, _)| *block));
+
+  for (block, _) in &async_blocks {
+    splitter
+      .block_owner
+      .entry(*block)
+      .or_default()
+      .insert(item_chunk_group_info);
+  }
+
+  let mut pending_connections = Vec::with_capacity(async_blocks.len());
+  for (block, module) in async_blocks {
+    let target_cgi = splitter
+      .block_to_chunk_group
+      .get(&DependenciesBlockIdentifier::AsyncDependenciesBlock(block))
+      .copied();
+    if let Some(target_cgi) = target_cgi
+      && !splitter.prepared_async_entrypoints.contains(&block)
+    {
+      // `make_chunk_group` updates this edge before handling an existing block. Keep the same
+      // last-writer semantics when using the batched fast path because a transitive walk can reach
+      // the same block with a different module context.
+      splitter.edges.insert(block, module);
+      let target_chunk_group = splitter.chunk_group_info(&target_cgi).chunk_group;
+      let target_chunk = compilation
+        .build_chunk_graph_artifact
+        .chunk_group_by_ukey
+        .expect_get(&target_chunk_group)
+        .chunks[0];
+      pending_connections.push((
+        target_cgi,
+        Some(ProcessBlock {
+          block: block.into(),
+          module,
+          chunk_group_info: target_cgi,
+          chunk: target_chunk,
+        }),
+      ));
+      continue;
+    }
+
+    flush_async_connections(splitter, item_chunk_group_info, &mut pending_connections);
+    splitter.make_chunk_group(
+      block,
+      module,
+      item_chunk_group_info,
+      item_chunk,
+      compilation,
+    );
+  }
+  flush_async_connections(splitter, item_chunk_group_info, &mut pending_connections);
+}
+
+fn flush_async_connections(
+  splitter: &mut CodeSplitter,
+  item_chunk_group_info: super::CgiUkey,
+  pending_connections: &mut Vec<(super::CgiUkey, Option<ProcessBlock>)>,
+) {
+  if pending_connections.is_empty() {
+    return;
+  }
+  splitter
+    .queue_connect
+    .entry(item_chunk_group_info)
+    .or_default()
+    .extend(pending_connections.drain(..));
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ffi::OsStr;
+
+  use super::{
+    DependenciesBlockIdentifier, ModuleIdentifier, VisitedBlocks,
+    is_parallel_code_splitting_enabled,
+  };
+
+  #[test]
+  fn parallel_code_splitting_is_enabled_by_default_with_an_opt_out() {
+    assert!(is_parallel_code_splitting_enabled(None));
+    assert!(is_parallel_code_splitting_enabled(Some(OsStr::new("1"))));
+    assert!(!is_parallel_code_splitting_enabled(Some(OsStr::new("0"))));
+    assert!(!is_parallel_code_splitting_enabled(Some(OsStr::new(""))));
+  }
+
+  #[test]
+  fn visited_blocks_include_the_module_context() {
+    let block =
+      DependenciesBlockIdentifier::Module(ModuleIdentifier::from("shared dependencies block"));
+    let first_module = ModuleIdentifier::from("first module");
+    let second_module = ModuleIdentifier::from("second module");
+    let mut visited_blocks = VisitedBlocks::default();
+
+    assert!(visited_blocks.insert(block, first_module));
+    assert!(visited_blocks.insert(block, second_module));
+    assert!(!visited_blocks.insert(block, first_module));
+  }
+}

--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -21,6 +21,7 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
   } else {
     Default::default()
   };
+  splitter.configure_parallel();
 
   let all_modules = compilation
     .get_module_graph()

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-a.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-a.js
@@ -1,0 +1,19 @@
+import v0 from "./leaf-0";
+import v1 from "./leaf-1";
+import v2 from "./leaf-2";
+import v3 from "./leaf-3";
+import v4 from "./leaf-4";
+import v5 from "./leaf-5";
+import v6 from "./leaf-6";
+import v7 from "./leaf-7";
+import v8 from "./leaf-8";
+import v9 from "./leaf-9";
+import v10 from "./leaf-10";
+import v11 from "./leaf-11";
+import v12 from "./leaf-12";
+import v13 from "./leaf-13";
+import v14 from "./leaf-14";
+import v15 from "./leaf-15";
+import { cycleA } from "./cycle-a";
+
+export const value = `a:${[v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15]}:${cycleA}`;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-b.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-b.js
@@ -1,0 +1,19 @@
+import v0 from "./leaf-0";
+import v1 from "./leaf-1";
+import v2 from "./leaf-2";
+import v3 from "./leaf-3";
+import v4 from "./leaf-4";
+import v5 from "./leaf-5";
+import v6 from "./leaf-6";
+import v7 from "./leaf-7";
+import v8 from "./leaf-8";
+import v9 from "./leaf-9";
+import v10 from "./leaf-10";
+import v11 from "./leaf-11";
+import v12 from "./leaf-12";
+import v13 from "./leaf-13";
+import v14 from "./leaf-14";
+import v15 from "./leaf-15";
+import { cycleA } from "./cycle-a";
+
+export const value = `b:${[v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15]}:${cycleA}`;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-c.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-c.js
@@ -1,0 +1,19 @@
+import v0 from "./leaf-0";
+import v1 from "./leaf-1";
+import v2 from "./leaf-2";
+import v3 from "./leaf-3";
+import v4 from "./leaf-4";
+import v5 from "./leaf-5";
+import v6 from "./leaf-6";
+import v7 from "./leaf-7";
+import v8 from "./leaf-8";
+import v9 from "./leaf-9";
+import v10 from "./leaf-10";
+import v11 from "./leaf-11";
+import v12 from "./leaf-12";
+import v13 from "./leaf-13";
+import v14 from "./leaf-14";
+import v15 from "./leaf-15";
+import { cycleA } from "./cycle-a";
+
+export const value = `c:${[v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15]}:${cycleA}`;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-d.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/branch-d.js
@@ -1,0 +1,19 @@
+import v0 from "./leaf-0";
+import v1 from "./leaf-1";
+import v2 from "./leaf-2";
+import v3 from "./leaf-3";
+import v4 from "./leaf-4";
+import v5 from "./leaf-5";
+import v6 from "./leaf-6";
+import v7 from "./leaf-7";
+import v8 from "./leaf-8";
+import v9 from "./leaf-9";
+import v10 from "./leaf-10";
+import v11 from "./leaf-11";
+import v12 from "./leaf-12";
+import v13 from "./leaf-13";
+import v14 from "./leaf-14";
+import v15 from "./leaf-15";
+import { cycleA } from "./cycle-a";
+
+export const value = `d:${[v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15]}:${cycleA}`;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/cycle-a.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/cycle-a.js
@@ -1,0 +1,3 @@
+import "./cycle-b";
+
+export const cycleA = "a";

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/cycle-b.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/cycle-b.js
@@ -1,0 +1,3 @@
+import "./cycle-a";
+
+export const cycleB = "b";

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/index.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/index.js
@@ -1,0 +1,14 @@
+it("should rewalk parallel sibling blocks across entries when available modules change", async () => {
+	const first = await (await import("./module-b")).default;
+	const second = await import(
+		/* webpackChunkName: "parallel-module" */ "./module-a"
+	);
+
+	expect(first.default).toBe("module-c");
+	expect(second.values).toEqual([
+		"a:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15:a",
+		"b:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15:a",
+		"c:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15:a",
+		"d:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15:a"
+	]);
+});

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-0.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-0.js
@@ -1,0 +1,1 @@
+export default 0;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-1.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-1.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-10.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-10.js
@@ -1,0 +1,1 @@
+export default 10;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-11.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-11.js
@@ -1,0 +1,1 @@
+export default 11;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-12.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-12.js
@@ -1,0 +1,1 @@
+export default 12;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-13.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-13.js
@@ -1,0 +1,1 @@
+export default 13;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-14.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-14.js
@@ -1,0 +1,1 @@
+export default 14;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-15.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-15.js
@@ -1,0 +1,1 @@
+export default 15;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-2.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-2.js
@@ -1,0 +1,1 @@
+export default 2;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-3.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-3.js
@@ -1,0 +1,1 @@
+export default 3;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-4.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-4.js
@@ -1,0 +1,1 @@
+export default 4;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-5.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-5.js
@@ -1,0 +1,1 @@
+export default 5;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-6.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-6.js
@@ -1,0 +1,1 @@
+export default 6;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-7.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-7.js
@@ -1,0 +1,1 @@
+export default 7;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-8.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-8.js
@@ -1,0 +1,1 @@
+export default 8;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-9.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/leaf-9.js
@@ -1,0 +1,1 @@
+export default 9;

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/module-a.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/module-a.js
@@ -1,0 +1,6 @@
+import { value as a } from "./branch-a";
+import { value as b } from "./branch-b";
+import { value as c } from "./branch-c";
+import { value as d } from "./branch-d";
+
+export const values = [a, b, c, d];

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/module-b.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/module-b.js
@@ -1,0 +1,3 @@
+export default import(
+	/* webpackChunkName: "parallel-module" */ "./module-c"
+);

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/module-c.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/module-c.js
@@ -1,0 +1,1 @@
+export default "module-c";

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    first: './index.js',
+    // This entry gives the shared named chunk a different available-modules set.
+    second: './module-b.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+};

--- a/tests/rspack-test/configCases/chunk-graph/parallel-process-block/test.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/parallel-process-block/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["first.js"];
+	}
+};

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -20,6 +20,9 @@ use serde_json::json;
 use crate::groups::diagnostics::assert_no_compilation_errors;
 
 pub(crate) static NUM_MODULES: usize = 10000;
+const WIDE_CHUNK_GROUPS: usize = 64;
+const WIDE_BRANCHES_PER_GROUP: usize = 8;
+const WIDE_LEAVES_PER_BRANCH: usize = 16;
 
 pub(crate) async fn prepare_large_code_splitting_case(
   num: usize,
@@ -37,6 +40,74 @@ pub(crate) async fn prepare_large_code_splitting_case(
       .await
       .unwrap();
   }
+}
+
+async fn prepare_wide_code_splitting_case(
+  groups: usize,
+  branches_per_group: usize,
+  leaves_per_branch: usize,
+  fs: &MemoryFileSystem,
+) {
+  fs.create_dir_all("/src".into()).await.unwrap();
+  fs.create_dir_all("/src/wide".into()).await.unwrap();
+
+  let mut entry = String::new();
+  for group in 0..groups {
+    entry.push_str(&format!("import('/src/wide/group-{group}.js');\n"));
+    let mut group_source = String::new();
+    for branch in 0..branches_per_group {
+      group_source.push_str(&format!(
+        "import value{branch} from '/src/wide/group-{group}-branch-{branch}.js';\n"
+      ));
+
+      let mut branch_source = String::new();
+      for leaf in 0..leaves_per_branch {
+        let leaf_id = (group * branches_per_group + branch) * leaves_per_branch + leaf;
+        branch_source.push_str(&format!(
+          "import value{leaf} from '/src/wide/leaf-{leaf_id}.js';\n"
+        ));
+        fs.write(
+          format!("/src/wide/leaf-{leaf_id}.js").as_str().into(),
+          format!("export default {leaf_id};").as_bytes(),
+        )
+        .await
+        .unwrap();
+      }
+      branch_source.push_str("export default ");
+      branch_source.push_str(
+        &(0..leaves_per_branch)
+          .map(|leaf| format!("value{leaf}"))
+          .collect::<Vec<_>>()
+          .join(" + "),
+      );
+      branch_source.push_str(";\n");
+      fs.write(
+        format!("/src/wide/group-{group}-branch-{branch}.js")
+          .as_str()
+          .into(),
+        branch_source.as_bytes(),
+      )
+      .await
+      .unwrap();
+    }
+    group_source.push_str("export default ");
+    group_source.push_str(
+      &(0..branches_per_group)
+        .map(|branch| format!("value{branch}"))
+        .collect::<Vec<_>>()
+        .join(" + "),
+    );
+    group_source.push_str(";\n");
+    fs.write(
+      format!("/src/wide/group-{group}.js").as_str().into(),
+      group_source.as_bytes(),
+    )
+    .await
+    .unwrap();
+  }
+  fs.write("/src/wide-entry.js".into(), entry.as_bytes())
+    .await
+    .unwrap();
 }
 
 fn gen_static_leaf_module(index: usize, ctx: &mut Vec<(String, String)>) {
@@ -104,7 +175,10 @@ fn gen_dynamic_module(
 pub fn build_chunk_graph_benchmark(c: &mut Criterion) {
   within_compiler_context_for_testing_sync(|| {
     build_chunk_graph_benchmark_inner(c);
-  })
+  });
+  // The simulation target runs this with one Rayon worker to catch fallback overhead. The
+  // dedicated walltime target registers the same case with the real multi-threaded pool.
+  build_chunk_graph_wide_benchmark(c);
 }
 pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
   let rt = rspack_benchmark::build_tokio_rt();
@@ -196,10 +270,57 @@ pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
     compiler.compilation.exports_info_artifact = exports_info_artifact.into();
   });
 
+  register_build_chunk_graph_benchmark(c, "rust@build_chunk_graph", compiler, NUM_MODULES / 10);
+}
+
+pub fn build_chunk_graph_wide_benchmark(c: &mut Criterion) {
+  within_compiler_context_for_testing_sync(|| {
+    build_chunk_graph_wide_benchmark_inner(c);
+  });
+}
+
+fn build_chunk_graph_wide_benchmark_inner(c: &mut Criterion) {
+  let rt = rspack_benchmark::build_tokio_rt();
+  let _guard = rt.enter();
+  let wide_fs = Arc::new(MemoryFileSystem::default());
+  let mut wide_compiler = Compiler::builder()
+    .context("/")
+    .entry("main", "/src/wide-entry.js")
+    .input_filesystem(wide_fs.clone())
+    .output_filesystem(wide_fs.clone())
+    .optimization(Optimization::builder())
+    .incremental(IncrementalOptions::empty_passes())
+    .build()
+    .unwrap();
+  reset_compilation_state(&mut wide_compiler);
+  rt.block_on(async {
+    prepare_wide_code_splitting_case(
+      WIDE_CHUNK_GROUPS,
+      WIDE_BRANCHES_PER_GROUP,
+      WIDE_LEAVES_PER_BRANCH,
+      &wide_fs,
+    )
+    .await;
+    prepare_chunk_graph_compilation(&mut wide_compiler).await;
+  });
+  register_build_chunk_graph_benchmark(
+    c,
+    "rust@build_chunk_graph_wide",
+    wide_compiler,
+    WIDE_CHUNK_GROUPS + 1,
+  );
+}
+
+fn register_build_chunk_graph_benchmark(
+  c: &mut Criterion,
+  name: &'static str,
+  compiler: Compiler,
+  expected_chunks: usize,
+) {
   assert_no_compilation_errors(&compiler.compilation, "build_chunk_graph benchmark setup");
   let compiler = RefCell::new(compiler);
 
-  c.bench_function("rust@build_chunk_graph", |b| {
+  c.bench_function(name, |b| {
     b.iter_batched_ref(
       || {
         let mut compiler = compiler.borrow_mut();
@@ -215,12 +336,75 @@ pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
             .build_chunk_graph_artifact
             .chunk_by_ukey
             .len(),
-          NUM_MODULES / 10
+          expected_chunks
         );
       },
       BatchSize::PerIteration,
     );
   });
+}
+
+async fn prepare_chunk_graph_compilation(compiler: &mut Compiler) {
+  let mut compilation_params = compiler.new_compilation_params();
+  compiler
+    .plugin_driver
+    .compiler_hooks
+    .this_compilation
+    .call(&mut compiler.compilation, &mut compilation_params)
+    .await
+    .unwrap();
+  compiler
+    .plugin_driver
+    .compiler_hooks
+    .compilation
+    .call(&mut compiler.compilation, &mut compilation_params)
+    .await
+    .unwrap();
+  compiler
+    .plugin_driver
+    .compiler_hooks
+    .make
+    .call(&mut compiler.compilation)
+    .await
+    .unwrap();
+  build_module_graph_pass(&mut compiler.compilation)
+    .await
+    .unwrap();
+
+  let mut side_effects_optimize_artifact =
+    compiler.compilation.side_effects_optimize_artifact.steal();
+  let mut diagnostics: Vec<Diagnostic> = vec![];
+  let mut build_module_graph_artifact = compiler.compilation.build_module_graph_artifact.steal();
+  let mut exports_info_artifact = compiler.compilation.exports_info_artifact.steal();
+  while matches!(
+    compiler
+      .plugin_driver
+      .compilation_hooks
+      .optimize_dependencies
+      .call(
+        &compiler.compilation,
+        &mut side_effects_optimize_artifact,
+        &mut build_module_graph_artifact,
+        &mut exports_info_artifact,
+        &mut diagnostics
+      )
+      .await
+      .unwrap(),
+    Some(true)
+  ) {}
+  compiler.compilation.build_module_graph_artifact = build_module_graph_artifact.into();
+  compiler.compilation.exports_info_artifact = exports_info_artifact.into();
+  compiler.compilation.side_effects_optimize_artifact = side_effects_optimize_artifact.into();
+  compiler.compilation.extend_diagnostics(diagnostics);
+
+  let make_artifact = compiler.compilation.build_module_graph_artifact.steal();
+  let exports_info_artifact = compiler.compilation.exports_info_artifact.steal();
+  let (make_artifact, exports_info_artifact) =
+    finish_build_module_graph(&compiler.compilation, make_artifact, exports_info_artifact)
+      .await
+      .unwrap();
+  compiler.compilation.build_module_graph_artifact = make_artifact.into();
+  compiler.compilation.exports_info_artifact = exports_info_artifact.into();
 }
 
 pub fn build_module_graph_benchmark(c: &mut Criterion) {

--- a/xtask/benchmark/benches/walltime.rs
+++ b/xtask/benchmark/benches/walltime.rs
@@ -6,6 +6,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use rspack_tasks::{CompilerContext, within_compiler_context, within_compiler_context_sync};
 
 use crate::groups::{
+  build_chunk_graph::build_chunk_graph_wide_benchmark,
   bundle::{
     threejs_10x,
     util::{CompilerBuilderGenerator, derive_projects},
@@ -88,5 +89,9 @@ impl Drop for NativeOutputCleanup {
 }
 
 criterion_group!(benchmark_setup, configure_rayon_for_benchmark);
-criterion_group!(walltime_benches, threejs_10x_bundle_benchmark);
+criterion_group!(
+  walltime_benches,
+  threejs_10x_bundle_benchmark,
+  build_chunk_graph_wide_benchmark
+);
 criterion_main!(benchmark_setup, walltime_benches);

--- a/xtask/benchmark/benches/walltime_groups/mod.rs
+++ b/xtask/benchmark/benches/walltime_groups/mod.rs
@@ -1,3 +1,7 @@
+#[allow(dead_code)]
+#[path = "../groups/build_chunk_graph.rs"]
+pub mod build_chunk_graph;
+
 pub mod bundle;
 
 #[path = "../groups/diagnostics.rs"]


### PR DESCRIPTION
## Summary

- keep the existing `build_chunk_graph` queue, connect/merge loop, named chunk, and cycle behavior as the source of truth
- parallelize only independent async `ProcessBlock` roots already emitted into the legacy delayed queue
- snapshot each root's `min_available_modules`, runtime, and chunk mask, then perform the read-only graph walk with Rayon
- validate speculative results immediately before ordered commit and rerun stale roots through the original serial queue
- merge all pending available-module masks once per unique chunk group, then replay roots in the original order
- preserve the serial walk identity as `(dependencies block, module context)`, including the module context forwarded to async blocks
- batch existing non-entrypoint async-block connections during commit, while flushing before legacy chunk-group creation paths
- avoid runtime clones, empty leaf-module extraction, and duplicate global-order checks on the commit path
- enable the parallel path by default; set `RSPACK_EXPERIMENTAL_PARALLEL_CODE_SPLITTING=0` for an emergency serial rollback

This does not collect pending roots ahead of the existing merge loop. The old loop still decides when work becomes available, which preserves its handling of cycles and `webpackChunkName` merges.

## Performance

### Aeolus `apps/abi`

Production full build, cold Rspack cache for every sample, release binding, and the `Compilation:code_splitting` span:

| mode | samples | median | mean |
| --- | --- | ---: | ---: |
| serial delayed-root path | 389 / 343 / 345 / 343 ms | 344 ms | 355 ms |
| parallel delayed-root path | 190 / 191 / 190 / 186 ms | 190 ms | 189.3 ms |

The isolated code-splitting phase improved by **44.8% at the median** and **46.7% at the mean**. Full-build wall time improved by 2.1% at the median (26.88 s to 26.33 s); code splitting is a small share of the full build.

### In-repo walltime benchmark

The benchmark builds 64 independent async chunk groups, each with 8 branches and 16 leaves. It is registered in the walltime target so Rayon uses the real multi-threaded pool; the simulation target still covers single-thread fallback overhead.

| mode | median |
| --- | ---: |
| serial rollback | 4.396 ms |
| parallel default | 2.479 ms |

Criterion reported **-43.9%** (`p < 0.05`) for the code-splitting benchmark.

The local stripped Darwin ARM64 CI-profile binding also decreased by 16,552 bytes versus the previously failing PR head after removing temporary phase/cardinality instrumentation. Linux CI remains the authoritative binary-size check.

## Correctness

The regression case covers a shared named async chunk, changing available-module inputs, shared modules across roots, and a cyclic dependency.

Every speculative result is validated immediately before its ordered commit. A stale result is rerun synchronously with the original `process_queue`; later independent results remain eligible and are validated against any state changed by that rerun. Default-on and serial-rollback builds emit byte-identical files for both config and runtime-mode variants of the regression case.
