### PR TITLE
fix: revert Module Federation runtime identifiers

### DIFF
--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -53,7 +53,7 @@ impl ContainerEntryModule {
     share_scope: ShareScope,
     enhanced: bool,
   ) -> Self {
-    let lib_ident = format!("rspack/container/entry/{}", &name);
+    let lib_ident = format!("webpack/container/entry/{}", &name);
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
@@ -82,7 +82,7 @@ impl ContainerEntryModule {
   }
 
   pub fn new_share_container_entry(name: String, request: String, version: String) -> Self {
-    let lib_ident = format!("rspack/share/container/{}", &name);
+    let lib_ident = format!("webpack/share/container/{}", &name);
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),

--- a/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
@@ -89,7 +89,7 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
                 } else {
                   Default::default()
                 };
-                format!("rspack/container/reference/{key}{fallback_suffix}")
+                format!("webpack/container/reference/{key}{fallback_suffix}")
               }
             })
             .collect(),

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
@@ -1,7 +1,7 @@
 var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 	var hasRun = false;
 	var result;
-	return function __rspack_require_mfStartupBase() {
+	return function __webpack_require__mfStartupBase() {
 		if (hasRun) return result;
 		hasRun = true;
 		result = (function () {
@@ -13,7 +13,7 @@ var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 var mfAsyncStartup = <%- REQUIRE %>.mfAsyncStartup = (function () {
 	var hasRun = false;
 	var result;
-	return function __rspack_require_mfAsyncStartup() {
+	return function __webpack_require__mfAsyncStartup() {
 		if (hasRun) return result;
 		hasRun = true;
 		var base = mfStartupBase && mfStartupBase();

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -39,7 +39,7 @@ impl FallbackModule {
     let mut requests_len_buffer = itoa::Buffer::new();
     let requests_len_minus_one = requests_len_buffer.format(requests.len() - 1);
     let lib_ident = format!(
-      "rspack/container/fallback/{}/and {} more",
+      "webpack/container/fallback/{}/and {} more",
       requests
         .first()
         .expect("should have at one more requests in FallbackModule"),

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -52,7 +52,7 @@ impl RemoteModule {
     remote_key: String,
   ) -> Self {
     let readable_identifier = format!("remote {}", &request);
-    let lib_ident = format!("rspack/container/remote/{}", &request);
+    let lib_ident = format!("webpack/container/remote/{}", &request);
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -78,7 +78,7 @@ impl ConsumeSharedModule {
       dependencies: Vec::new(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
       lib_ident: format!(
-        "rspack/sharing/consume/{}/{}{}",
+        "webpack/sharing/consume/{}/{}{}",
         &scopes_key,
         &options.share_key,
         options

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -68,7 +68,7 @@ impl ProvideSharedModule {
       blocks: Vec::new(),
       dependencies: Vec::new(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
-      lib_ident: format!("rspack/sharing/provide/{}/{}", &scopes_key, &name),
+      lib_ident: format!("webpack/sharing/provide/{}/{}", &scopes_key, &name),
       readable_identifier: identifier,
       name,
       share_scope,

--- a/packages/rspack/src/container/ContainerReferencePlugin.ts
+++ b/packages/rspack/src/container/ContainerReferencePlugin.ts
@@ -80,7 +80,7 @@ export class ContainerReferencePlugin extends RspackBuiltinPlugin {
       let i = 0;
       for (const external of config.external) {
         if (external.startsWith('internal ')) continue;
-        const request = `rspack/container/reference/${key}${i ? `/fallback-${i}` : ''}`;
+        const request = `webpack/container/reference/${key}${i ? `/fallback-${i}` : ''}`;
         // In ESM output, module-like externals emit a static `import * as ... from "..."`
         // which can create a circular dependency for relative remotes (notably self-remotes like
         // `containerB: "./container.mjs"` with `runtimeChunk: "single"`). Prefer dynamic `import()`

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/runtimeModeSnapshot/snapshot.txt
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/runtimeModeSnapshot/snapshot.txt
@@ -5,7 +5,7 @@ node_modules_cell_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae0"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
+const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -23,7 +23,7 @@ node_modules_cell_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae1"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
+const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -41,8 +41,8 @@ node_modules_row_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8840"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { cell } = __rspack_context.r("rspack/sharing/consume/default/cell/cell")
-const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
+const { cell } = __rspack_context.r("webpack/sharing/consume/default/cell/cell")
+const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
@@ -60,8 +60,8 @@ node_modules_row_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8841"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { cell } = __rspack_context.r("rspack/sharing/consume/default/cell/cell")
-const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
+const { cell } = __rspack_context.r("webpack/sharing/consume/default/cell/cell")
+const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/snapshot.txt
@@ -5,7 +5,7 @@ node_modules_cell_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae0"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -23,7 +23,7 @@ node_modules_cell_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae1"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -41,8 +41,8 @@ node_modules_row_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8840"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { cell } = __webpack_require__("rspack/sharing/consume/default/cell/cell")
-const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
+const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
@@ -60,8 +60,8 @@ node_modules_row_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8841"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __webpack_require__) {
-const { cell } = __webpack_require__("rspack/sharing/consume/default/cell/cell")
-const { tmpl } = __webpack_require__("rspack/sharing/consume/default/templater/templater")
+const { cell } = __webpack_require__("webpack/sharing/consume/default/cell/cell")
+const { tmpl } = __webpack_require__("webpack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })

--- a/tests/rspack-test/configCases/container-1-5/error-handling/index.js
+++ b/tests/rspack-test/configCases/container-1-5/error-handling/index.js
@@ -57,7 +57,7 @@ it("should allow to handle invalid remote module error with import()", async () 
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 	// at this point sharing initialization runs and triggers a warning that 'invalid' remote can't be loaded
@@ -69,7 +69,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });
@@ -79,7 +79,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });

--- a/tests/rspack-test/configCases/container/error-handling/index.js
+++ b/tests/rspack-test/configCases/container/error-handling/index.js
@@ -57,7 +57,7 @@ it("should allow to handle invalid remote module error with import()", async () 
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 	// at this point sharing initialization runs and triggers a warning that 'invalid' remote can't be loaded
@@ -69,7 +69,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });
@@ -79,7 +79,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from rspack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });

--- a/tests/rspack-test/configCases/sharing/reshake-share/index.js
+++ b/tests/rspack-test/configCases/sharing/reshake-share/index.js
@@ -56,7 +56,7 @@ it("correct handle share dep while secondary tree shaking", async () => {
     const uiLibShareContainerModule = eval("require")(uiLibShareContainerPath).secondary_tree_shaking_share_t_ui_lib_100;
 		await uiLibShareContainerModule.init({},{
 		installInitialConsumes: async ({webpackRequire})=>{
-			webpackRequire.m['rspack/sharing/consume/default/ui-lib-dep'] = (m)=>{
+			webpackRequire.m['webpack/sharing/consume/default/ui-lib-dep'] = (m)=>{
 				m.exports = {
 					Message: 'Message',
 				}

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42669
+- Update: main.LAST_HASH.hot-update.js, size: 42679
 
 ## Manifest
 
@@ -43,11 +43,11 @@ __webpack_require__.d(__webpack_exports__, {
   "default": () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
   getValue: () => (getValue)
 });
-/* import */ var common__rspack_import_0 = __webpack_require__("rspack/sharing/consume/default/common/./common?1");
+/* import */ var common__rspack_import_0 = __webpack_require__("webpack/sharing/consume/default/common/./common?1");
 /* import */ var common__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(common__rspack_import_0);
 
 
-const getValue = () => __webpack_require__.e(/* import() */ "rspack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "rspack/sharing/consume/default/common2/./common?2", 23));
+const getValue = () => __webpack_require__.e(/* import() */ "webpack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "webpack/sharing/consume/default/common2/./common?2", 23));
 
 
 },
@@ -101,7 +101,7 @@ __webpack_require__.h = () => ("CURRENT_HASH")
 // webpack/runtime/consumes_loading
 (() => {
 
-__webpack_require__.consumesLoadingData = { chunkMapping: {"main":["rspack/sharing/consume/default/common/./common?1"],"rspack_sharing_consume_default_common2_common_2":["rspack/sharing/consume/default/common2/./common?2"]}, moduleIdToConsumeDataMapping: {"rspack/sharing/consume/default/common/./common?1": { shareScope: "default", shareKey: "common", import: "./common?1", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: true, fallback: () => (() => (__webpack_require__("./common.js?1"))), treeShakingMode: null }, "rspack/sharing/consume/default/common2/./common?2": { shareScope: "default", shareKey: "common2", import: "./common?2", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: false, fallback: () => (__webpack_require__.e("common_js_2").then(() => (() => (__webpack_require__("./common.js?2"))))), treeShakingMode: null }}, initialConsumes: ["rspack/sharing/consume/default/common/./common?1"] };
+__webpack_require__.consumesLoadingData = { chunkMapping: {"main":["webpack/sharing/consume/default/common/./common?1"],"webpack_sharing_consume_default_common2_common_2":["webpack/sharing/consume/default/common2/./common?2"]}, moduleIdToConsumeDataMapping: {"webpack/sharing/consume/default/common/./common?1": { shareScope: "default", shareKey: "common", import: "./common?1", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: true, fallback: () => (() => (__webpack_require__("./common.js?1"))), treeShakingMode: null }, "webpack/sharing/consume/default/common2/./common?2": { shareScope: "default", shareKey: "common2", import: "./common?2", requiredVersion: "1.1.1", strictVersion: true, singleton: false, eager: false, fallback: () => (__webpack_require__.e("common_js_2").then(() => (() => (__webpack_require__("./common.js?2"))))), treeShakingMode: null }}, initialConsumes: ["webpack/sharing/consume/default/common/./common?1"] };
 var splitAndConvert = function(str) {
   return str.split(".").map(function(item) {
     return +item == item ? +item : item;
@@ -688,7 +688,7 @@ if (installedChunkData !== 0) {
 	if (installedChunkData) {
 		promises.push(installedChunkData[2]);
 	} else {
-		if ("rspack_sharing_consume_default_common2_common_2" != chunkId) {
+		if ("webpack_sharing_consume_default_common2_common_2" != chunkId) {
 			// setup Promise in chunk cache
 			var promise = new Promise((resolve, reject) => (installedChunkData = jsonpInstalledChunks[chunkId] = [resolve, reject]));
 			promises.push((installedChunkData[2] = promise));

--- a/tests/rspack-test/serialCases/container-1-5/2-transitive-overriding/index.js
+++ b/tests/rspack-test/serialCases/container-1-5/2-transitive-overriding/index.js
@@ -19,8 +19,8 @@ it("should have good module ids", async () => {
 	[
 		"./b.js",
 		"./modules.js",
-		"rspack/container/entry/container-with-shared",
-		"rspack/sharing/consume/default/shared/./shared"
+		"webpack/container/entry/container-with-shared",
+		"webpack/sharing/consume/default/shared/./shared"
 	].forEach(m => expect(m0).toContain(m));
 	[
 		"./a.js",
@@ -28,18 +28,18 @@ it("should have good module ids", async () => {
 		"./modules-from-remote.js",
 		"./modules.js",
 		"./shared.js",
-		"rspack/container/entry/container-no-shared",
-		"rspack/container/reference/container-with-shared",
-		"rspack/container/remote/container-with-shared/b",
-		"rspack/container/remote/container-with-shared/modules"
+		"webpack/container/entry/container-no-shared",
+		"webpack/container/reference/container-with-shared",
+		"webpack/container/remote/container-with-shared/b",
+		"webpack/container/remote/container-with-shared/modules"
 	].forEach(m => expect(m1).toContain(m));
 	[
 		"./index.js",
 		"./shared.js",
-		"rspack/container/reference/container-no-shared",
-		"rspack/container/remote/container-no-shared/a",
-		"rspack/container/remote/container-no-shared/b",
-		"rspack/container/remote/container-no-shared/modules",
-		"rspack/container/remote/container-no-shared/modules-from-remote"
+		"webpack/container/reference/container-no-shared",
+		"webpack/container/remote/container-no-shared/a",
+		"webpack/container/remote/container-no-shared/b",
+		"webpack/container/remote/container-no-shared/modules",
+		"webpack/container/remote/container-no-shared/modules-from-remote"
 	].forEach(m => expect(m2).toContain(m));
 });

--- a/tests/rspack-test/serialCases/container/2-transitive-overriding/index.js
+++ b/tests/rspack-test/serialCases/container/2-transitive-overriding/index.js
@@ -19,26 +19,26 @@ it("should have good module ids", async () => {
 	expect(m0).toEqual([
 		"./b.js",
 		"./modules.js",
-		"rspack/container/entry/container-with-shared",
-		"rspack/sharing/consume/default/shared/./shared"
+		"webpack/container/entry/container-with-shared",
+		"webpack/sharing/consume/default/shared/./shared"
 	]);
 	expect(m1).toEqual([
 		"./a.js",
 		"./b.js",
 		"./modules-from-remote.js",
 		"./modules.js",
-		"rspack/container/entry/container-no-shared",
-		"rspack/container/reference/container-with-shared",
-		"rspack/container/remote/container-with-shared/b",
-		"rspack/container/remote/container-with-shared/modules"
+		"webpack/container/entry/container-no-shared",
+		"webpack/container/reference/container-with-shared",
+		"webpack/container/remote/container-with-shared/b",
+		"webpack/container/remote/container-with-shared/modules"
 	]);
 	expect(m2).toEqual([
 		"./index.js",
 		"./shared.js",
-		"rspack/container/reference/container-no-shared",
-		"rspack/container/remote/container-no-shared/a",
-		"rspack/container/remote/container-no-shared/b",
-		"rspack/container/remote/container-no-shared/modules",
-		"rspack/container/remote/container-no-shared/modules-from-remote"
+		"webpack/container/reference/container-no-shared",
+		"webpack/container/remote/container-no-shared/a",
+		"webpack/container/remote/container-no-shared/b",
+		"webpack/container/remote/container-no-shared/modules",
+		"webpack/container/remote/container-no-shared/modules-from-remote"
 	]);
 });

--- a/tests/rspack-test/serialCases/container/reference-hoisting/index.js
+++ b/tests/rspack-test/serialCases/container/reference-hoisting/index.js
@@ -1,7 +1,7 @@
 it("should have the hoisted container references", () => {
 	const wpm = __webpack_modules__;
-	expect(wpm).toHaveProperty("rspack/container/reference/containerA");
-	expect(wpm).toHaveProperty("rspack/container/reference/containerB");
+	expect(wpm).toHaveProperty("webpack/container/reference/containerA");
+	expect(wpm).toHaveProperty("webpack/container/reference/containerB");
 });
 
 it("should load the component from container", () => {


### PR DESCRIPTION
## Summary

- restore webpack-compatible Module Federation container and sharing identifiers changed by #14739
- restore the matching container-reference externals and embedded MF helper names
- refresh affected config, hot, and runtime-mode snapshots while preserving non-MF runtime identifier changes

## Related links

- Reverts the Module Federation portions of #14739

## Validation

- `pnpm run build:cli:dev`
- focused config/runtime-mode tests for chunk IDs, container error handling, and sharing reshake
- `serialCases/container` (28 tests passed)
- `hotCases/sharing/share-plugin`
- `cargo fmt --all -- --check`
- Prettier and JS lint via pre-commit hooks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).