### PR TITLE
fix: respect RSPACK_BINDING in loader workers

### DIFF
--- a/packages/rspack/rslib.config.ts
+++ b/packages/rspack/rslib.config.ts
@@ -170,17 +170,16 @@ const codmodPlugin: RsbuildPlugin = {
     }
 
     api.onAfterBuild(() => {
-      const dist = fs.readFileSync(
-        require.resolve(path.resolve(import.meta.dirname, 'dist/index.js')),
-        'utf-8',
-      );
-      const root = parse(Lang.JavaScript, dist).root();
-      const edits = [...replaceBinding(root)];
+      for (const filename of ['index.js', 'worker.js']) {
+        const distPath = require.resolve(
+          path.resolve(import.meta.dirname, 'dist', filename),
+        );
+        const dist = fs.readFileSync(distPath, 'utf-8');
+        const root = parse(Lang.JavaScript, dist).root();
+        const edits = [...replaceBinding(root)];
 
-      fs.writeFileSync(
-        require.resolve(path.resolve(import.meta.dirname, 'dist/index.js')),
-        root.commitEdits(edits),
-      );
+        fs.writeFileSync(distPath, root.commitEdits(edits));
+      }
     });
   },
 };


### PR DESCRIPTION
## Summary

- apply the custom binding rewrite to both `dist/index.js` and `dist/worker.js`
- ensure the main compiler and parallel-loader workers load the same binding when `RSPACK_BINDING` is set
- fix the post-build hook, which previously processed only the main entry bundle
- checked with the `@rspack/core` build, generated bundle assertions, Prettier, and Rslint

## Related links

- Fixes #14771

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).