### PR TITLE
test: verify CI behavior for conflicting PR

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -627,7 +627,7 @@ impl EsmLibraryPlugin {
 
       // webpack require iterate the needed_namespace_objects and mutate `needed_namespace_objects`
       // at the same time, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L1514
-      // Which is impossible in rust, using a fixed point algorithm  to reach the same goal.
+      // Rust cannot mutate the collection while iterating, so repeat until no new module is found.
       loop {
         let mut changed = false;
 


### PR DESCRIPTION
## Summary

- Starts as a normal, mergeable comment-only pull request.
- A subsequent push replaces the head with a commit that intentionally conflicts with current `main`.
- Used to verify whether CI runs for the `pull_request` `synchronize` event when the PR has a merge conflict.
- This is an intentional CI fixture and should not be merged.

## Related links

- The conflict push overlaps the ESM linking change from #14758.

## Validation

- Initial head: `git diff --check` passes and the PR is mergeable.
- Conflict head: `git merge-tree --write-tree HEAD origin/main` reports a content conflict in `crates/rspack_plugin_esm_library/src/link.rs`.

## Checklist

- [x] Tests not required (comment-only conflict fixture).
- [x] Documentation not required.
