### PR TITLE
fix: invalidate only lazy compiler in multi compiler

### DIFF
--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -72,11 +72,7 @@ export const lazyCompilationMiddleware = (
 
       middlewareByCompiler.set(
         options.prefix,
-        lazyCompilationMiddlewareInternal(
-          compiler,
-          activeModules,
-          options.prefix,
-        ),
+        lazyCompilationMiddlewareInternal(c, activeModules, options.prefix),
       );
 
       applyPlugin(c, options, activeModules);

--- a/tests/rspack-test/multiCompilerCases/lazy-compilation-invalidation.js
+++ b/tests/rspack-test/multiCompilerCases/lazy-compilation-invalidation.js
@@ -1,0 +1,67 @@
+const { lazyCompilationMiddleware } = require("@rspack/core");
+const path = require("path");
+
+const context = path.join(__dirname, "../fixtures");
+const middlewareKey = "lazyCompilationMiddleware";
+
+/** @type {import('@rspack/test-tools').TMultiCompilerCaseConfig} */
+module.exports = {
+  description: "lazy compilation invalidates only its owning compiler",
+  options() {
+    return [
+      {
+        entry: "./esm/a.js",
+        context,
+        lazyCompilation: false,
+      },
+      {
+        entry: "./esm/b.js",
+        context,
+        lazyCompilation: {
+          entries: true,
+        },
+      },
+    ];
+  },
+  compiler(context, compiler) {
+    context.setValue(middlewareKey, lazyCompilationMiddleware(compiler));
+  },
+  async build(context, compiler) {
+    let multiCompilerInvalidations = 0;
+    let lazyCompilerInvalidations = 0;
+
+    compiler.watching = {
+      invalidate: () => {
+        multiCompilerInvalidations += 1;
+      },
+      close: callback => callback(),
+    };
+    compiler.compilers[1].watching = {
+      invalidate: () => {
+        lazyCompilerInvalidations += 1;
+      },
+      close: callback => {
+        compiler.compilers[1].watching = undefined;
+        callback();
+      },
+    };
+
+    const middleware = context.getValue(middlewareKey);
+    await middleware(
+      {
+        method: "POST",
+        url: "/_rspack/lazy/trigger__0",
+        body: ["lazy-entry"],
+      },
+      {
+        writeHead() {},
+        write() {},
+        end() {},
+      },
+      () => {},
+    );
+
+    expect(lazyCompilerInvalidations).toBe(1);
+    expect(multiCompilerInvalidations).toBe(0);
+  },
+};


### PR DESCRIPTION
## Summary

Fix `lazyCompilationMiddleware(MultiCompiler)` so a lazy activation invalidates only the child compiler that owns the matching lazy-compilation configuration.

The MultiCompiler branch already iterates over each lazy-enabled child as `c`, but passed the parent `compiler` to `lazyCompilationMiddlewareInternal`. The resulting `MultiWatching.invalidate()` invalidated every child compiler, including unrelated worker or server compilers.

This change passes `c` to the internal middleware and adds a focused MultiCompiler regression test that verifies:

- the lazy-enabled child compiler is invalidated once;
- the parent MultiCompiler is not invalidated.

## Related links

Fixes #14779

## Checklist

- [x] Tests updated.
- [x] Documentation not required.
