### PR TITLE
fix: invalidate the target compiler for lazy compilation

### DIFF
--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -72,11 +72,7 @@ export const lazyCompilationMiddleware = (
 
       middlewareByCompiler.set(
         options.prefix,
-        lazyCompilationMiddlewareInternal(
-          compiler,
-          activeModules,
-          options.prefix,
-        ),
+        lazyCompilationMiddlewareInternal(c, activeModules, options.prefix),
       );
 
       applyPlugin(c, options, activeModules);


### PR DESCRIPTION
## Summary

When using lazy compilation with a MultiCompiler, each compiler-specific middleware received the parent MultiCompiler. Activating a module therefore invalidated every watcher.

Pass the corresponding compiler to the middleware so only its watcher is invalidated.

## Related links

Closes #14778

## Validation

- `pnpm --filter @rspack/core build`
- `git diff --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).