### PR TITLE
fix: respect runtime mode in mf identifiers

### DIFF
--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -12,6 +12,7 @@ use rspack_core::{
   ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
   StaticExportsSpec, impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
+  runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
@@ -23,7 +24,7 @@ use super::{
 };
 use crate::{
   ShareScope,
-  utils::{json_stringify, module_require_scope_name},
+  utils::{json_stringify, module_identifier_namespace, module_require_scope_name},
 };
 
 #[impl_source_map_config]
@@ -52,8 +53,10 @@ impl ContainerEntryModule {
     exposes: Vec<(String, ExposeOptions)>,
     share_scope: ShareScope,
     enhanced: bool,
+    runtime_mode: RuntimeMode,
   ) -> Self {
-    let lib_ident = format!("webpack/container/entry/{}", &name);
+    let namespace = module_identifier_namespace(runtime_mode);
+    let lib_ident = format!("{namespace}/container/entry/{name}");
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),
@@ -81,8 +84,14 @@ impl ContainerEntryModule {
     }
   }
 
-  pub fn new_share_container_entry(name: String, request: String, version: String) -> Self {
-    let lib_ident = format!("webpack/share/container/{}", &name);
+  pub fn new_share_container_entry(
+    name: String,
+    request: String,
+    version: String,
+    runtime_mode: RuntimeMode,
+  ) -> Self {
+    let namespace = module_identifier_namespace(runtime_mode);
+    let lib_ident = format!("{namespace}/share/container/{name}");
     Self {
       blocks: Vec::new(),
       dependencies: Vec::new(),

--- a/crates/rspack_plugin_mf/src/container/container_entry_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module_factory.rs
@@ -25,6 +25,7 @@ impl ModuleFactory for ContainerEntryModuleFactory {
           dep.name.clone(),
           dep.request.clone().expect("should have request"),
           dep.version.clone().expect("should have version"),
+          data.options.experiments.runtime_mode,
         )
         .boxed(),
       ))
@@ -35,6 +36,7 @@ impl ModuleFactory for ContainerEntryModuleFactory {
           dep.exposes.clone(),
           dep.share_scope.clone(),
           dep.enhanced,
+          data.options.experiments.runtime_mode,
         )
         .boxed(),
       ))

--- a/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_reference_plugin.rs
@@ -13,7 +13,7 @@ use super::{
   fallback_module_factory::FallbackModuleFactory, remote_module::RemoteModule,
   remote_runtime_module::RemoteRuntimeModule,
 };
-use crate::ShareScope;
+use crate::{ShareScope, utils::module_identifier_namespace};
 
 #[derive(Debug)]
 pub struct ContainerReferencePluginOptions {
@@ -72,6 +72,8 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
         && (request.len() == key_len || request[key_len..].starts_with('/'))
       {
         let internal_request = &request[key_len..];
+        let runtime_mode = data.options.experiments.runtime_mode;
+        let namespace = module_identifier_namespace(runtime_mode);
         let remote = RemoteModule::new(
           request.to_owned(),
           config
@@ -89,13 +91,14 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
                 } else {
                   Default::default()
                 };
-                format!("webpack/container/reference/{key}{fallback_suffix}")
+                format!("{namespace}/container/reference/{key}{fallback_suffix}")
               }
             })
             .collect(),
           format!(".{internal_request}"),
           config.share_scope.clone(),
           key.clone(),
+          runtime_mode,
         )
         .boxed();
         return Ok(Some(remote));

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
@@ -1,7 +1,7 @@
 var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 	var hasRun = false;
 	var result;
-	return function __webpack_require__mfStartupBase() {
+	return function __rspack_require_mfStartupBase() {
 		if (hasRun) return result;
 		hasRun = true;
 		result = (function () {
@@ -13,7 +13,7 @@ var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 var mfAsyncStartup = <%- REQUIRE %>.mfAsyncStartup = (function () {
 	var hasRun = false;
 	var result;
-	return function __webpack_require__mfAsyncStartup() {
+	return function __rspack_require_mfAsyncStartup() {
 		if (hasRun) return result;
 		hasRun = true;
 		var base = mfStartupBase && mfStartupBase();

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -10,13 +10,14 @@ use rspack_core::{
   ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
   RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
+  runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::{itoa, source_map::SourceMapKind};
 
 use super::fallback_item_dependency::FallbackItemDependency;
-use crate::utils::json_stringify;
+use crate::utils::{json_stringify, module_identifier_namespace};
 
 #[impl_source_map_config]
 #[cacheable]
@@ -34,12 +35,13 @@ pub struct FallbackModule {
 }
 
 impl FallbackModule {
-  pub fn new(requests: Vec<String>) -> Self {
+  pub fn new(requests: Vec<String>, runtime_mode: RuntimeMode) -> Self {
     let identifier = format!("fallback {}", requests.join(" "));
     let mut requests_len_buffer = itoa::Buffer::new();
     let requests_len_minus_one = requests_len_buffer.format(requests.len() - 1);
+    let namespace = module_identifier_namespace(runtime_mode);
     let lib_ident = format!(
-      "webpack/container/fallback/{}/and {} more",
+      "{namespace}/container/fallback/{}/and {} more",
       requests
         .first()
         .expect("should have at one more requests in FallbackModule"),

--- a/crates/rspack_plugin_mf/src/container/fallback_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module_factory.rs
@@ -14,7 +14,7 @@ impl ModuleFactory for FallbackModuleFactory {
       .downcast_ref::<FallbackDependency>()
       .expect("dependency of FallbackModuleFactory should be FallbackDependency");
     Ok(ModuleFactoryResult::new_with_module(
-      FallbackModule::new(dep.requests.clone()).boxed(),
+      FallbackModule::new(dep.requests.clone(), data.options.experiments.runtime_mode).boxed(),
     ))
   }
 }

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -10,6 +10,7 @@ use rspack_core::{
   ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
   impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
+  runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
@@ -21,7 +22,7 @@ use super::{
 };
 use crate::{
   CodeGenerationDataShareInit, ShareInitData, ShareScope,
-  sharing::share_runtime_module::DataInitInfo,
+  sharing::share_runtime_module::DataInitInfo, utils::module_identifier_namespace,
 };
 
 #[impl_source_map_config]
@@ -50,9 +51,11 @@ impl RemoteModule {
     internal_request: String,
     share_scope: ShareScope,
     remote_key: String,
+    runtime_mode: RuntimeMode,
   ) -> Self {
     let readable_identifier = format!("remote {}", &request);
-    let lib_ident = format!("webpack/container/remote/{}", &request);
+    let namespace = module_identifier_namespace(runtime_mode);
+    let lib_ident = format!("{namespace}/container/remote/{request}");
     Self {
       blocks: Default::default(),
       dependencies: Default::default(),

--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -90,6 +90,13 @@ mod utils {
     simd_json::to_string(v).unwrap_or_else(|e| panic!("{e}: {v:?} should able to json stringify"))
   }
 
+  pub fn module_identifier_namespace(runtime_mode: RuntimeMode) -> &'static str {
+    match runtime_mode {
+      RuntimeMode::Webpack => "webpack",
+      RuntimeMode::Rspack => "rspack",
+    }
+  }
+
   pub fn runtime_require_scope_name(runtime_template: &RuntimeCodeTemplate) -> String {
     if runtime_template.render_mode().is_legacy() {
       runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE)

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -9,6 +9,7 @@ use rspack_core::{
   DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
   ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
   impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
@@ -18,7 +19,7 @@ use super::{
   consume_shared_fallback_dependency::ConsumeSharedFallbackDependency,
   consume_shared_runtime_module::CodeGenerationDataConsumeShared,
 };
-use crate::{ConsumeOptions, ShareScope};
+use crate::{ConsumeOptions, ShareScope, utils::module_identifier_namespace};
 
 #[impl_source_map_config]
 #[cacheable]
@@ -42,8 +43,9 @@ impl ConsumeSharedModule {
     &self.options.share_scope
   }
 
-  pub fn new(context: Context, options: ConsumeOptions) -> Self {
+  pub fn new(context: Context, options: ConsumeOptions, runtime_mode: RuntimeMode) -> Self {
     let scopes_key = options.share_scope.key();
+    let namespace = module_identifier_namespace(runtime_mode);
     let identifier = format!(
       "consume shared module ({}) {}@{}{}{}{}{}",
       &scopes_key,
@@ -78,7 +80,7 @@ impl ConsumeSharedModule {
       dependencies: Vec::new(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
       lib_ident: format!(
-        "webpack/sharing/consume/{}/{}{}",
+        "{namespace}/sharing/consume/{}/{}{}",
         &scopes_key,
         &options.share_key,
         options

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   CompilationParams, CompilerThisCompilation, Context, DependencyCategory, DependencyType,
   ModuleExt, ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryCreateModule,
   NormalModuleFactoryFactorize, Plugin, ResolveOptionsWithDependencyType, ResolveResult, Resolver,
-  RuntimeGlobals, RuntimeModule,
+  RuntimeGlobals, RuntimeModule, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Diagnostic, Result, error};
 use rspack_hash::{RspackHash, RspackHasher};
@@ -287,6 +287,7 @@ impl ConsumeSharedPlugin {
     context: &Context,
     request: &str,
     config: Arc<ConsumeOptions>,
+    runtime_mode: RuntimeMode,
     mut add_diagnostic: impl FnMut(Diagnostic),
   ) -> ConsumeSharedModule {
     let direct_fallback = matches!(&config.import, Some(i) if RELATIVE_REQUEST.is_match(i) | ABSOLUTE_REQUEST.is_match(i));
@@ -342,6 +343,7 @@ impl ConsumeSharedPlugin {
         eager: config.eager,
         tree_shaking_mode: config.tree_shaking_mode.clone(),
       },
+      runtime_mode,
     )
   }
 }
@@ -388,9 +390,13 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
 
   if let Some(matched) = consumes.unresolved.get(request) {
     let module = self
-      .create_consume_shared_module(&data.context, request, matched.clone(), |d| {
-        data.diagnostics.push(d)
-      })
+      .create_consume_shared_module(
+        &data.context,
+        request,
+        matched.clone(),
+        data.options.experiments.runtime_mode,
+        |d| data.diagnostics.push(d),
+      )
       .await;
     return Ok(Some(module.boxed()));
   }
@@ -413,6 +419,7 @@ async fn factorize(&self, data: &mut ModuleFactoryCreateData) -> Result<Option<B
             eager: options.eager,
             tree_shaking_mode: options.tree_shaking_mode.clone(),
           }),
+          data.options.experiments.runtime_mode,
           |d| data.diagnostics.push(d),
         )
         .await;
@@ -441,9 +448,13 @@ async fn create_module(
 
   if let Some(options) = consumes.resolved.get(resource) {
     let module = self
-      .create_consume_shared_module(&data.context, resource, options.clone(), |d| {
-        data.diagnostics.push(d)
-      })
+      .create_consume_shared_module(
+        &data.context,
+        resource,
+        options.clone(),
+        data.options.experiments.runtime_mode,
+        |d| data.diagnostics.push(d),
+      )
       .await;
     return Ok(Some(module.boxed()));
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -8,7 +8,7 @@ use rspack_core::{
   BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
   DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
   ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
-  impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
@@ -21,7 +21,7 @@ use super::{
     CodeGenerationDataShareInit, DataInitInfo, ProvideSharedInfo, ShareInitData,
   },
 };
-use crate::{ConsumeVersion, ShareScope};
+use crate::{ConsumeVersion, ShareScope, utils::module_identifier_namespace};
 
 #[impl_source_map_config]
 #[cacheable]
@@ -58,8 +58,10 @@ impl ProvideSharedModule {
     required_version: Option<ConsumeVersion>,
     strict_version: Option<bool>,
     tree_shaking_mode: Option<String>,
+    runtime_mode: RuntimeMode,
   ) -> Self {
     let scopes_key = share_scope.key();
+    let namespace = module_identifier_namespace(runtime_mode);
     let identifier = format!(
       "provide shared module ({}) {}@{} = {}",
       &scopes_key, &name, &version, &request
@@ -68,7 +70,7 @@ impl ProvideSharedModule {
       blocks: Vec::new(),
       dependencies: Vec::new(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
-      lib_ident: format!("webpack/sharing/provide/{}/{}", &scopes_key, &name),
+      lib_ident: format!("{namespace}/sharing/provide/{scopes_key}/{name}"),
       readable_identifier: identifier,
       name,
       share_scope,

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module_factory.rs
@@ -32,6 +32,7 @@ impl ModuleFactory for ProvideSharedModuleFactory {
         dep.required_version.clone(),
         dep.strict_version,
         dep.tree_shaking_mode.clone(),
+        data.options.experiments.runtime_mode,
       )
       .boxed(),
     ))

--- a/packages/rspack/src/container/ContainerReferencePlugin.ts
+++ b/packages/rspack/src/container/ContainerReferencePlugin.ts
@@ -74,13 +74,17 @@ export class ContainerReferencePlugin extends RspackBuiltinPlugin {
 
   raw(compiler: Compiler): BuiltinPlugin {
     const { remoteType, remotes } = this._options;
+    const bundlerName =
+      compiler.options.experiments.runtimeMode === 'rspack'
+        ? 'rspack'
+        : 'webpack';
     const remoteExternals: Record<string, string> = {};
     const importExternals: Record<string, string> = {};
     for (const [key, config] of remotes) {
       let i = 0;
       for (const external of config.external) {
         if (external.startsWith('internal ')) continue;
-        const request = `webpack/container/reference/${key}${i ? `/fallback-${i}` : ''}`;
+        const request = `${bundlerName}/container/reference/${key}${i ? `/fallback-${i}` : ''}`;
         // In ESM output, module-like externals emit a static `import * as ... from "..."`
         // which can create a circular dependency for relative remotes (notably self-remotes like
         // `containerB: "./container.mjs"` with `runtimeChunk: "single"`). Prefer dynamic `import()`

--- a/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/runtimeModeSnapshot/snapshot.txt
+++ b/tests/rspack-test/configCases/chunk-ids/stable-chunk-ids-with-duplicate-chunks/__snapshot__/runtimeModeSnapshot/snapshot.txt
@@ -5,7 +5,7 @@ node_modules_cell_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae0"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -23,7 +23,7 @@ node_modules_cell_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_cell_index_js-_86ae1"];
 exports.modules = {
 "./node_modules/cell/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.cell = function(cell) {
     return tmpl(`<td>CELL</td>`, { CELL: cell })
@@ -41,8 +41,8 @@ node_modules_row_index_js-XXX0.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8840"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { cell } = __rspack_context.r("webpack/sharing/consume/default/cell/cell")
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { cell } = __rspack_context.r("rspack/sharing/consume/default/cell/cell")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })
@@ -60,8 +60,8 @@ node_modules_row_index_js-XXX1.bundle0.js
 exports.ids = ["node_modules_row_index_js-_b8841"];
 exports.modules = {
 "./node_modules/row/index.js"(module, __unused_rspack_exports, __rspack_context) {
-const { cell } = __rspack_context.r("webpack/sharing/consume/default/cell/cell")
-const { tmpl } = __rspack_context.r("webpack/sharing/consume/default/templater/templater")
+const { cell } = __rspack_context.r("rspack/sharing/consume/default/cell/cell")
+const { tmpl } = __rspack_context.r("rspack/sharing/consume/default/templater/templater")
 
 module.exports.row = function(cells) {
     return tmpl(`<tr>CELLS</tr>`, { CELLS: cells.map(c => cell(c)).join('\n') })

--- a/tests/rspack-test/configCases/container-1-5/error-handling/index.js
+++ b/tests/rspack-test/configCases/container-1-5/error-handling/index.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const bundlerName = globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK
+	? "rspack"
+	: "webpack";
+
 let warnings = [];
 let oldWarn;
 
@@ -56,8 +60,7 @@ it("should allow to handle remote loading error with top-level-await import()", 
 it("should allow to handle invalid remote module error with import()", async () => {
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
-			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+			message: `Module "./invalid" does not exist in container.\nwhile loading "./invalid" from ${bundlerName}/container/reference/remote`
 		})
 	);
 	// at this point sharing initialization runs and triggers a warning that 'invalid' remote can't be loaded
@@ -68,8 +71,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	const { error } = await import("./invalid-module-cjs");
 	expect(error).toEqual(
 		expect.objectContaining({
-			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+			message: `Module "./invalid" does not exist in container.\nwhile loading "./invalid" from ${bundlerName}/container/reference/remote`
 		})
 	);
 });
@@ -78,8 +80,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	const { error } = await import("./invalid-module-tl-await");
 	expect(error).toEqual(
 		expect.objectContaining({
-			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+			message: `Module "./invalid" does not exist in container.\nwhile loading "./invalid" from ${bundlerName}/container/reference/remote`
 		})
 	);
 });

--- a/tests/rspack-test/configCases/container/error-handling/index.js
+++ b/tests/rspack-test/configCases/container/error-handling/index.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const bundlerName = globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK
+	? "rspack"
+	: "webpack";
+
 let warnings = [];
 let oldWarn;
 
@@ -56,8 +60,7 @@ it("should allow to handle remote loading error with top-level-await import()", 
 it("should allow to handle invalid remote module error with import()", async () => {
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
-			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+			message: `Module "./invalid" does not exist in container.\nwhile loading "./invalid" from ${bundlerName}/container/reference/remote`
 		})
 	);
 	// at this point sharing initialization runs and triggers a warning that 'invalid' remote can't be loaded
@@ -68,8 +71,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	const { error } = await import("./invalid-module-cjs");
 	expect(error).toEqual(
 		expect.objectContaining({
-			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+			message: `Module "./invalid" does not exist in container.\nwhile loading "./invalid" from ${bundlerName}/container/reference/remote`
 		})
 	);
 });
@@ -78,8 +80,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	const { error } = await import("./invalid-module-tl-await");
 	expect(error).toEqual(
 		expect.objectContaining({
-			message:
-				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
+			message: `Module "./invalid" does not exist in container.\nwhile loading "./invalid" from ${bundlerName}/container/reference/remote`
 		})
 	);
 });

--- a/tests/rspack-test/configCases/sharing/reshake-share/index.js
+++ b/tests/rspack-test/configCases/sharing/reshake-share/index.js
@@ -1,6 +1,10 @@
 import * as uiLib from 'ui-lib';
 import * as uiLibDep from 'ui-lib-dep';
 
+const bundlerName = globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK
+	? "rspack"
+	: "webpack";
+
 const fs = require("fs");
 const path = require("path");
 __webpack_require__.p = 'PUBLIC_PATH';
@@ -56,7 +60,7 @@ it("correct handle share dep while secondary tree shaking", async () => {
     const uiLibShareContainerModule = eval("require")(uiLibShareContainerPath).secondary_tree_shaking_share_t_ui_lib_100;
 		await uiLibShareContainerModule.init({},{
 		installInitialConsumes: async ({webpackRequire})=>{
-			webpackRequire.m['webpack/sharing/consume/default/ui-lib-dep'] = (m)=>{
+			webpackRequire.m[`${bundlerName}/sharing/consume/default/ui-lib-dep`] = (m)=>{
 				m.exports = {
 					Message: 'Message',
 				}


### PR DESCRIPTION
## Summary

- restore Rspack-prefixed Module Federation container and sharing identifiers when `experiments.runtimeMode` is `rspack`
- preserve webpack-compatible identifiers when `runtimeMode` is `webpack`
- keep container-reference external keys aligned across the JavaScript and Rust implementations, and rename internal async-startup helper functions without changing their runtime properties

## Related links

- Follows up on #14739
- Reapplies the Module Federation identifier changes reverted by #14761 with runtime-mode compatibility

## Validation

- `pnpm run build:cli:dev`
- `cargo check -p rspack_plugin_mf`
- `RuntimeModeConfig.part1.test.js` (536 tests passed)
- `RuntimeModeConfig.part3.test.js` (700 tests passed)
- `Config.part1.test.js` and `Config.part3.test.js` (1250 tests passed)
- `Serial.test.js` (58 tests passed, including async-startup coverage)
- `cargo fmt --all -- --check`
- Prettier and JavaScript lint via pre-commit hooks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
