### PR TITLE
fix: preserve createRequire().resolve with literal import.meta.url when requireResolve is disabled

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -75,7 +75,10 @@ struct PendingCreatedRequire {
 struct DeferredCreateRequireCallee {
   settings: ESMSpecifierData,
   range: DependencyRange,
+  ids: Vec<Atom>,
   asi_safe: bool,
+  direct_import: bool,
+  ns_access: bool,
   branch_guard: Option<DependencyBranchGuard>,
 }
 
@@ -994,14 +997,30 @@ fn deferred_create_require_callee(
   callee: &Expr,
   call_span: Span,
 ) -> Option<DeferredCreateRequireCallee> {
-  let ident = callee.as_ident()?;
-  let settings = parser
-    .get_tag_data::<ESMSpecifierData>(&Atom::from(ident.sym.as_str()), ESM_SPECIFIER_TAG)?
-    .clone();
+  let (settings, range, ids, direct_import, ns_access) = if let Some(ident) = callee.as_ident() {
+    let settings = parser
+      .get_tag_data::<ESMSpecifierData>(&Atom::from(ident.sym.as_str()), ESM_SPECIFIER_TAG)?
+      .clone();
+    let ids = settings.ids.clone().into_vec();
+    (settings, ident.span.into(), ids, true, false)
+  } else {
+    let member = callee.as_member()?;
+    let namespace = member.obj.as_ident()?;
+    let settings = parser
+      .get_tag_data::<ESMSpecifierData>(&Atom::from(namespace.sym.as_str()), ESM_SPECIFIER_TAG)?
+      .clone();
+    let mut ids = settings.ids.clone().into_vec();
+    ids.push(static_member_name(member)?);
+    let ns_access = settings.namespace_import && !ids.is_empty();
+    (settings, callee.span().into(), ids, false, ns_access)
+  };
   Some(DeferredCreateRequireCallee {
     settings,
-    range: ident.span.into(),
+    range,
+    ids,
     asi_safe: !parser.is_asi_position(call_span.real_lo()),
+    direct_import,
+    ns_access,
     branch_guard: parser.current_branch_guard.clone(),
   })
 }
@@ -1013,10 +1032,12 @@ fn add_deferred_create_require_callee_dependency(
   let DeferredCreateRequireCallee {
     settings,
     range,
+    ids,
     asi_safe,
+    direct_import,
+    ns_access,
     branch_guard,
   } = callee;
-  let ids = settings.ids.clone().into_vec();
   let mut dep = ESMImportSpecifierDependency::new(
     settings.source,
     settings.name,
@@ -1026,14 +1047,19 @@ fn add_deferred_create_require_callee_dependency(
     range,
     ids,
     true,
-    true,
-    false,
+    direct_import,
+    ns_access,
     ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
     None,
     settings.phase,
     settings.attributes,
     parser.to_dependency_location(range),
   );
+  dep.namespace_object_as_context = parser
+    .javascript_options
+    .strict_this_context_on_imports
+    .unwrap_or(false)
+    && !direct_import;
   if let Some(branch_guard) = branch_guard {
     dep.set_branch_guard(branch_guard);
   }
@@ -1084,12 +1110,11 @@ fn pre_tag_created_require_declarator(
   let Some(callee) = call.callee.as_expr() else {
     return;
   };
-  let Some(callee_ident) = callee.as_ident() else {
-    return;
-  };
-  if !is_create_require_specifier(parser, &Atom::from(callee_ident.sym.as_str()))
-    || !can_defer_create_require_call(parser, &call.args)
-  {
+  let is_create_require_callee = callee
+    .as_ident()
+    .is_some_and(|ident| is_create_require_specifier(parser, &Atom::from(ident.sym.as_str())))
+    || is_create_require_namespace_member(parser, callee);
+  if !is_create_require_callee || !can_defer_create_require_call(parser, &call.args) {
     return;
   }
   let Some(argument) = parse_create_require_argument(parser, call, false) else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -642,14 +642,19 @@ fn should_replace_create_require_argument(parser: &mut JavascriptParser, arg: &E
 }
 
 #[inline(never)]
-fn should_clear_create_require_call(parser: &mut JavascriptParser, args: &[ExprOrSpread]) -> bool {
+fn can_defer_create_require_call(parser: &mut JavascriptParser, args: &[ExprOrSpread]) -> bool {
   args.len() == 1
-    && !matches!(parser.javascript_options.require_resolve, Some(false))
     && args[0].spread.is_none()
     && args[0]
       .expr
       .as_member()
       .is_some_and(|member| is_meta_url(parser, member))
+}
+
+#[inline(never)]
+fn should_clear_create_require_call(parser: &mut JavascriptParser, args: &[ExprOrSpread]) -> bool {
+  !matches!(parser.javascript_options.require_resolve, Some(false))
+    && can_defer_create_require_call(parser, args)
 }
 
 #[inline(never)]
@@ -1083,7 +1088,7 @@ fn pre_tag_created_require_declarator(
     return;
   };
   if !is_create_require_specifier(parser, &Atom::from(callee_ident.sym.as_str()))
-    || !should_clear_create_require_call(parser, &call.args)
+    || !can_defer_create_require_call(parser, &call.args)
   {
     return;
   }
@@ -1997,9 +2002,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_argument(parser, call, false)
     {
       let clear_call = should_clear_create_require_call(parser, &call.args);
-      let deferred_callee = (declaration.kind() == VariableDeclarationKind::Const && clear_call)
-        .then(|| deferred_create_require_callee(parser, callee, call.span))
-        .flatten();
+      let deferred_callee = (declaration.kind() == VariableDeclarationKind::Const
+        && can_defer_create_require_call(parser, &call.args))
+      .then(|| deferred_create_require_callee(parser, callee, call.span))
+      .flatten();
+      let walk_callee = !clear_call && deferred_callee.is_none();
       tag_created_require_declarator(
         parser,
         &binding.id,
@@ -2009,7 +2016,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         deferred_callee,
         argument,
       );
-      if !clear_call {
+      if walk_callee {
         walk_create_require_callee(parser, call);
       }
       return Some(true);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -16,16 +16,18 @@ use swc_experimental_ecma_ast::{
 use url::Url;
 
 use super::{
-  JavascriptParserPlugin,
+  InnerGraphParserPlugin, JavascriptParserPlugin,
   esm_import_dependency_parser_plugin::{ESM_SPECIFIER_TAG, ESMSpecifierData},
   get_url_request,
+  inner_graph::state::InnerGraphUsageOperation,
   url_plugin::is_meta_url,
 };
 use crate::{
   dependency::{
     CommonJsFullRequireDependency, CommonJsRequireContextDependency, CommonJsRequireDependency,
-    RequireHeaderDependency, RequireResolveContextDependency, RequireResolveDependency,
-    RequireResolveHeaderDependency, local_module_dependency::LocalModuleDependency,
+    DependencyBranchGuard, ESMImportSpecifierDependency, RequireHeaderDependency,
+    RequireResolveContextDependency, RequireResolveDependency, RequireResolveHeaderDependency,
+    local_module_dependency::LocalModuleDependency,
   },
   magic_comment::try_extract_magic_comment,
   utils::eval::{self, BasicEvaluatedExpression},
@@ -45,12 +47,83 @@ pub const CREATED_REQUIRE_IDENTIFIER_TAG: &str = "createRequire()";
 pub struct CreatedRequireTagData {
   pub(crate) context: Context,
   pub(crate) side_effects: String,
+  // The deferred `const req = createRequire(import.meta.url)` declaration, if any.
+  pub(crate) pending_call: Option<Span>,
+  // Whether unhandled uses may keep using the real runtime require object.
+  pub(crate) preserve_unhandled: bool,
 }
 
 struct CreateRequireArgument {
   value: String,
   context: Context,
   replace_argument: bool,
+}
+
+#[derive(Default)]
+pub struct CreatedRequireReferencesState {
+  pending: rustc_hash::FxHashMap<Span, PendingCreatedRequire>,
+  exported_locals: rustc_hash::FxHashSet<Atom>,
+}
+
+struct PendingCreatedRequire {
+  must_keep: bool,
+  callee: DeferredCreateRequireCallee,
+  arg_span: Span,
+  arg_value: String,
+}
+
+struct DeferredCreateRequireCallee {
+  settings: ESMSpecifierData,
+  range: DependencyRange,
+  asi_safe: bool,
+  branch_guard: Option<DependencyBranchGuard>,
+}
+
+impl CreatedRequireReferencesState {
+  fn add_pending(
+    &mut self,
+    call_span: Span,
+    callee: DeferredCreateRequireCallee,
+    arg_span: Span,
+    arg_value: String,
+  ) {
+    // Normal walk refreshes provisional pre-walk data after earlier references may mark it.
+    let must_keep = self
+      .pending
+      .get(&call_span)
+      .is_some_and(|pending| pending.must_keep);
+    self.pending.insert(
+      call_span,
+      PendingCreatedRequire {
+        must_keep,
+        callee,
+        arg_span,
+        arg_value,
+      },
+    );
+  }
+
+  fn mark_must_keep(&mut self, call_span: Span) {
+    if let Some(pending) = self.pending.get_mut(&call_span) {
+      pending.must_keep = true;
+    }
+  }
+
+  fn take_pending(&mut self) -> Vec<(Span, PendingCreatedRequire)> {
+    let mut pending = std::mem::take(&mut self.pending)
+      .into_iter()
+      .collect::<Vec<_>>();
+    pending.sort_unstable_by_key(|(span, _)| span.real_lo());
+    pending
+  }
+
+  pub(crate) fn record_exported_local(&mut self, name: Atom) {
+    self.exported_locals.insert(name);
+  }
+
+  fn take_exported_locals(&mut self) -> rustc_hash::FxHashSet<Atom> {
+    std::mem::take(&mut self.exported_locals)
+  }
 }
 
 #[derive(Debug, Default)]
@@ -818,6 +891,8 @@ fn evaluate_created_require<'a>(
     Some(CreatedRequireTagData {
       context: argument.context,
       side_effects,
+      pending_call: None,
+      preserve_unhandled: false,
     }),
   );
   let mut evaluated = BasicEvaluatedExpression::with_range(range.real_lo(), range.real_hi());
@@ -909,6 +984,140 @@ fn add_unsupported_create_require_member_warning(parser: &mut JavascriptParser, 
   );
 }
 
+fn deferred_create_require_callee(
+  parser: &mut JavascriptParser,
+  callee: &Expr,
+  call_span: Span,
+) -> Option<DeferredCreateRequireCallee> {
+  let ident = callee.as_ident()?;
+  let settings = parser
+    .get_tag_data::<ESMSpecifierData>(&Atom::from(ident.sym.as_str()), ESM_SPECIFIER_TAG)?
+    .clone();
+  Some(DeferredCreateRequireCallee {
+    settings,
+    range: ident.span.into(),
+    asi_safe: !parser.is_asi_position(call_span.real_lo()),
+    branch_guard: parser.current_branch_guard.clone(),
+  })
+}
+
+fn add_deferred_create_require_callee_dependency(
+  parser: &mut JavascriptParser,
+  callee: DeferredCreateRequireCallee,
+) {
+  let DeferredCreateRequireCallee {
+    settings,
+    range,
+    asi_safe,
+    branch_guard,
+  } = callee;
+  let ids = settings.ids.clone().into_vec();
+  let mut dep = ESMImportSpecifierDependency::new(
+    settings.source,
+    settings.name,
+    settings.source_order,
+    false,
+    asi_safe,
+    range,
+    ids,
+    true,
+    true,
+    false,
+    ESMImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+    None,
+    settings.phase,
+    settings.attributes,
+    parser.to_dependency_location(range),
+  );
+  if let Some(branch_guard) = branch_guard {
+    dep.set_branch_guard(branch_guard);
+  }
+  let dep_idx = parser.next_dependency_idx();
+  parser.add_dependency(Box::new(dep));
+  InnerGraphParserPlugin::on_usage(
+    parser,
+    InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
+  );
+}
+
+fn keep_deferred_create_require_call(
+  parser: &mut JavascriptParser,
+  pending: PendingCreatedRequire,
+) {
+  add_deferred_create_require_callee_dependency(parser, pending.callee);
+  if parser.compiler_options.output.module {
+    let import_meta_name = &parser.compiler_options.output.import_meta_name;
+    if import_meta_name != expr_name::IMPORT_META {
+      parser.add_presentational_dependency(Box::new(ConstDependency::new(
+        pending.arg_span.into(),
+        format!("{import_meta_name}.url").into(),
+      )));
+    }
+  } else {
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      pending.arg_span.into(),
+      json_stringify_str(&pending.arg_value).into(),
+    )));
+  }
+}
+
+fn pre_tag_created_require_declarator(
+  parser: &mut JavascriptParser,
+  declarator: &VarDeclarator,
+  declaration: VariableDeclaration<'_>,
+) {
+  // Register metadata only; the normal declarator walk still creates or clears dependencies.
+  if declaration.kind() != VariableDeclarationKind::Const {
+    return;
+  }
+  let Some(binding) = declarator.name.as_ident() else {
+    return;
+  };
+  let Some(call) = declarator.init.as_ref().and_then(Expr::as_call) else {
+    return;
+  };
+  let Some(callee) = call.callee.as_expr() else {
+    return;
+  };
+  let Some(callee_ident) = callee.as_ident() else {
+    return;
+  };
+  if !is_create_require_specifier(parser, &Atom::from(callee_ident.sym.as_str()))
+    || !should_clear_create_require_call(parser, &call.args)
+  {
+    return;
+  }
+  let Some(argument) = parse_create_require_argument(parser, call, false) else {
+    return;
+  };
+  let Some(deferred_callee) = deferred_create_require_callee(parser, callee, call.span) else {
+    return;
+  };
+  let CreateRequireArgument {
+    value,
+    context,
+    replace_argument: _,
+  } = argument;
+  let name = Atom::from(binding.id.sym.as_str());
+  parser.define_variable(name.clone());
+  parser.tag_variable(
+    name,
+    CREATED_REQUIRE_IDENTIFIER_TAG,
+    Some(CreatedRequireTagData {
+      context,
+      side_effects: String::new(),
+      pending_call: Some(call.span),
+      preserve_unhandled: true,
+    }),
+  );
+  parser.created_require_references.add_pending(
+    call.span,
+    deferred_callee,
+    call.args[0].expr.span(),
+    value,
+  );
+}
+
 #[cold]
 #[inline(never)]
 fn tag_created_require_declarator(
@@ -917,6 +1126,7 @@ fn tag_created_require_declarator(
   call_span: Span,
   clear_call: bool,
   args: &[ExprOrSpread],
+  deferred_callee: Option<DeferredCreateRequireCallee>,
   argument: CreateRequireArgument,
 ) {
   let CreateRequireArgument {
@@ -924,6 +1134,7 @@ fn tag_created_require_declarator(
     context,
     replace_argument,
   } = argument;
+  let deferred = deferred_callee.is_some();
   let binding_name = Atom::from(binding.sym.as_str());
   parser.define_variable(binding_name.clone());
   parser.tag_variable(
@@ -932,9 +1143,15 @@ fn tag_created_require_declarator(
     Some(CreatedRequireTagData {
       context,
       side_effects: String::new(),
+      pending_call: deferred.then_some(call_span),
+      preserve_unhandled: deferred || !clear_call,
     }),
   );
-  if clear_call {
+  if let Some(callee) = deferred_callee {
+    parser
+      .created_require_references
+      .add_pending(call_span, callee, args[0].expr.span(), value);
+  } else if clear_call {
     clear_create_require_call(parser, call_span);
   } else if replace_argument {
     parser.add_presentational_dependency(Box::new(ConstDependency::new(
@@ -1017,6 +1234,26 @@ fn current_created_require_context(parser: &JavascriptParser) -> Option<Context>
     })
     .map(CreatedRequireTagData::downcast)
     .map(|data| data.context)
+}
+
+fn preserve_unhandled_created_require(parser: &mut JavascriptParser) -> bool {
+  let data = parser
+    .current_tag_info
+    .and_then(|tag_info| {
+      parser
+        .definitions_db
+        .expect_get_tag_info(tag_info)
+        .data
+        .as_deref()
+    })
+    .map(CreatedRequireTagData::downcast_ref);
+  let Some(data) = data.filter(|data| data.preserve_unhandled) else {
+    return false;
+  };
+  if let Some(call_span) = data.pending_call {
+    parser.created_require_references.mark_must_keep(call_span);
+  }
+  true
 }
 
 #[cold]
@@ -1305,10 +1542,12 @@ impl CommonJsImportsParserPlugin {
     expr: &CallExpr,
   ) -> Option<bool> {
     if expr.args.len() != 1 || expr.args[0].spread.is_some() {
+      preserve_unhandled_created_require(parser);
       parser.walk_expr_or_spread(&expr.args);
       return Some(true);
     }
     if matches!(parser.javascript_options.require_resolve, Some(false)) {
+      preserve_unhandled_created_require(parser);
       parser.walk_expr_or_spread(&expr.args);
       return Some(true);
     }
@@ -1680,6 +1919,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     declarator: &VarDeclarator,
     declaration: VariableDeclaration<'_>,
   ) -> Option<bool> {
+    if parser.javascript_options.is_create_require_enabled() {
+      pre_tag_created_require_declarator(parser, declarator, declaration);
+    }
+
     if !should_parse_commonjs_require(parser) {
       return None;
     }
@@ -1701,7 +1944,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     &self,
     parser: &mut JavascriptParser<'p>,
     declarator: &VarDeclarator,
-    _stmt: VariableDeclaration<'_>,
+    declaration: VariableDeclaration<'_>,
   ) -> Option<bool> {
     if !parser.javascript_options.is_create_require_enabled() {
       return None;
@@ -1709,12 +1952,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
 
     let init = declarator.init.as_ref()?;
     if let Some(init) = init.as_ident()
-      && let Some(context) = parser
+      && let Some(data) = parser
         .get_tag_data::<CreatedRequireTagData>(
           &Atom::from(init.sym.as_str()),
           CREATED_REQUIRE_IDENTIFIER_TAG,
         )
-        .map(|data| data.context.clone())
+        .cloned()
       && let Some(binding) = declarator.name.as_ident()
     {
       let name = Atom::from(binding.id.sym.as_str());
@@ -1723,8 +1966,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         name,
         CREATED_REQUIRE_IDENTIFIER_TAG,
         Some(CreatedRequireTagData {
-          context,
           side_effects: String::new(),
+          ..data
         }),
       );
       return Some(true);
@@ -1754,12 +1997,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_argument(parser, call, false)
     {
       let clear_call = should_clear_create_require_call(parser, &call.args);
+      let deferred_callee = (declaration.kind() == VariableDeclarationKind::Const && clear_call)
+        .then(|| deferred_create_require_callee(parser, callee, call.span))
+        .flatten();
       tag_created_require_declarator(
         parser,
         &binding.id,
         call.span,
         clear_call,
         &call.args,
+        deferred_callee,
         argument,
       );
       if !clear_call {
@@ -1774,7 +2021,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_new_argument(parser, init, false)
       && let Some(args) = init.args.as_deref()
     {
-      tag_created_require_declarator(parser, &binding.id, init.span, false, args, argument);
+      tag_created_require_declarator(parser, &binding.id, init.span, false, args, None, argument);
       parser.walk_expression(&init.callee);
       return Some(true);
     }
@@ -1830,6 +2077,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     }
 
     if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
+      if preserve_unhandled_created_require(parser) {
+        return Some(true);
+      }
       let context = current_created_require_context(parser);
       return self.require_as_expression_handler(parser, ident, context);
     }
@@ -1847,13 +2097,23 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     member_ranges: &[Span],
   ) -> Option<bool> {
     if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
-      handle_created_require_member(
-        parser,
-        _expr.span(),
-        require_cache_range(_expr, member_ranges, members),
-        members,
-        "undefined".into(),
-      );
+      if members
+        .first()
+        .is_some_and(|member| member.as_ref() == "cache")
+      {
+        add_require_cache_dependency(
+          parser,
+          require_cache_range(_expr, member_ranges, members).into(),
+        );
+      } else if !preserve_unhandled_created_require(parser) {
+        handle_created_require_member(
+          parser,
+          _expr.span(),
+          require_cache_range(_expr, member_ranges, members),
+          members,
+          "undefined".into(),
+        );
+      }
       return Some(true);
     }
 
@@ -1893,6 +2153,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       }
       if members.len() == 1 && members[0].as_ref() == "resolve" {
         return self.process_created_require_resolve_call(parser, expr);
+      }
+      if members
+        .first()
+        .is_some_and(|member| member.as_ref() != "cache")
+        && preserve_unhandled_created_require(parser)
+      {
+        parser.walk_expr_or_spread(&expr.args);
+        return Some(true);
       }
       if ids.len() != members.len() {
         parser.walk_expr_or_spread(&expr.args);
@@ -1937,7 +2205,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
 
   fn rename(&self, parser: &mut JavascriptParser<'p>, expr: &Expr, for_name: &str) -> Option<bool> {
     if for_name == CREATED_REQUIRE_IDENTIFIER_TAG {
-      if let Some(ident) = expr.as_ident() {
+      if !preserve_unhandled_created_require(parser)
+        && let Some(ident) = expr.as_ident()
+      {
         let context = current_created_require_context(parser);
         self.require_as_expression_handler(parser, ident, context)?;
       }
@@ -2357,6 +2627,23 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
           dep.set_referenced_specifiers(references);
         }
         _ => unreachable!(),
+      }
+    }
+
+    for name in parser.created_require_references.take_exported_locals() {
+      let pending_call = parser
+        .get_tag_data::<CreatedRequireTagData>(&name, CREATED_REQUIRE_IDENTIFIER_TAG)
+        .and_then(|data| data.pending_call);
+      if let Some(call_span) = pending_call {
+        parser.created_require_references.mark_must_keep(call_span);
+      }
+    }
+
+    for (call_span, pending) in parser.created_require_references.take_pending() {
+      if pending.must_keep {
+        keep_deferred_create_require_call(parser, pending);
+      } else {
+        clear_create_require_call(parser, call_span);
       }
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -118,6 +118,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
     export_name: &Atom,
     export_name_span: Span,
   ) -> Option<bool> {
+    if parser.javascript_options.is_create_require_enabled() {
+      parser
+        .created_require_references
+        .record_exported_local(local_id.clone());
+    }
     InnerGraphParserPlugin::add_variable_usage(
       parser,
       local_id,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -41,9 +41,9 @@ pub(crate) use self::{
   common_js_exports_parse_plugin::CommonJsExportsParserPlugin,
   common_js_imports_parse_plugin::{
     CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
-    CommonJsImportsParserPlugin, CreatedRequireTagData, RequireReferencesState,
-    evaluate_create_require_new_expression, is_create_require_namespace_member,
-    is_create_require_specifier,
+    CommonJsImportsParserPlugin, CreatedRequireReferencesState, CreatedRequireTagData,
+    RequireReferencesState, evaluate_create_require_new_expression,
+    is_create_require_namespace_member, is_create_require_specifier,
   },
   common_js_plugin::CommonJsPlugin,
   compatibility_plugin::CompatibilityPlugin,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -44,8 +44,9 @@ use crate::{
   dependency::{DependencyBranchGuard, local_module::LocalModule},
   parser_and_generator::ParserRuntimeRequirementsData,
   parser_plugin::{
-    self, ImportsReferencesState, InnerGraphParserPlugin, JavaScriptParserPluginDrive,
-    JavascriptParserPlugin, RequireReferencesState, inner_graph::state::InnerGraphState,
+    self, CreatedRequireReferencesState, ImportsReferencesState, InnerGraphParserPlugin,
+    JavaScriptParserPluginDrive, JavascriptParserPlugin, RequireReferencesState,
+    inner_graph::state::InnerGraphState,
   },
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{
@@ -416,6 +417,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) destructuring_assignment_properties: DestructuringAssignmentPropertiesMap,
   pub(crate) dynamic_import_references: ImportsReferencesState,
   pub(crate) common_js_require_references: RequireReferencesState,
+  pub(crate) created_require_references: CreatedRequireReferencesState,
   pub(crate) worker_index: u32,
   pub(crate) parser_exports_state: Option<bool>,
   pub(crate) local_modules: Vec<LocalModule>,
@@ -598,6 +600,7 @@ impl<'parser> JavascriptParser<'parser> {
       destructuring_assignment_properties: Default::default(),
       dynamic_import_references: Default::default(),
       common_js_require_references: Default::default(),
+      created_require_references: Default::default(),
       semicolons,
       statement_path: Default::default(),
       current_tag_info: None,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -730,16 +730,16 @@ impl JavascriptParser<'_> {
       return Some(true);
     }
     if let Some(rename_identifier) = self.get_rename_identifier(&expr.right)
-      && let Some(context) = self
+      && let Some(data) = self
         .get_tag_data::<CreatedRequireTagData>(&rename_identifier, CREATED_REQUIRE_IDENTIFIER_TAG)
-        .map(|data| data.context.clone())
+        .cloned()
     {
       self.tag_variable(
         ident_name.clone(),
         CREATED_REQUIRE_IDENTIFIER_TAG,
         Some(CreatedRequireTagData {
-          context,
           side_effects: String::new(),
+          ..data
         }),
       );
       if !expr.right.is_ident() {
@@ -763,16 +763,16 @@ impl JavascriptParser<'_> {
   }
 
   fn copy_create_require_assignment_result(&mut self, binding: Atom, target: &Atom) {
-    if let Some(context) = self
+    if let Some(data) = self
       .get_tag_data::<CreatedRequireTagData>(target, CREATED_REQUIRE_IDENTIFIER_TAG)
-      .map(|data| data.context.clone())
+      .cloned()
     {
       self.tag_variable(
         binding,
         CREATED_REQUIRE_IDENTIFIER_TAG,
         Some(CreatedRequireTagData {
-          context,
           side_effects: String::new(),
+          ..data
         }),
       );
     } else if let Some(info) = self.get_variable_info(target)

--- a/tests/rspack-test/configCases/require/create-require-branch-guard/index.js
+++ b/tests/rspack-test/configCases/require/create-require-branch-guard/index.js
@@ -1,0 +1,11 @@
+import * as module from "./shim.js";
+import { createRequire } from "./shim.js";
+
+if ("createRequire" in module) {
+	const req = createRequire(import.meta.url);
+	globalThis.__createRequireUnknownMember = req.unknown;
+}
+
+it("should keep the createRequire import branch guard", () => {
+	expect(globalThis.__createRequireUnknownMember).toBeUndefined();
+});

--- a/tests/rspack-test/configCases/require/create-require-branch-guard/rspack.config.js
+++ b/tests/rspack-test/configCases/require/create-require-branch-guard/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  module: {
+    parser: {
+      javascript: {
+        createRequire: 'createRequire from ./shim.js',
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/require/create-require-branch-guard/shim.js
+++ b/tests/rspack-test/configCases/require/create-require-branch-guard/shim.js
@@ -1,0 +1,1 @@
+export const other = 1;

--- a/tests/rspack-test/configCases/require/module-require-escape/warnings.js
+++ b/tests/rspack-test/configCases/require/module-require-escape/warnings.js
@@ -1,3 +1,0 @@
-module.exports = [
-	/require function is used in a way in which dependencies cannot be statically extracted/
-];

--- a/tests/rspack-test/configCases/require/module-require/warnings.js
+++ b/tests/rspack-test/configCases/require/module-require/warnings.js
@@ -12,8 +12,6 @@ const warnings = [
 	/the request of a dependency is an expression/,
 	/The accessed createRequire\(\) member is not supported by Rspack/,
 	/The accessed createRequire\(\) member is not supported by Rspack/,
-	/The accessed createRequire\(\) member is not supported by Rspack/,
-	/The accessed createRequire\(\) member is not supported by Rspack/,
 	/The accessed createRequire\(\) member is not supported by Rspack/
 ];
 

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/__snapshots__/esm.snap.txt
@@ -1,0 +1,88 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
+import {fileURLToPath as __rspack_fileURLToPath} from "node:url";
+import {dirname as __rspack_dirname} from "node:path";
+var __rspack_import_meta_dirname__ = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));
+import { createRequire as __rspack_createRequire } from "node:module";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+__webpack_require__.add({
+"./dep.js"
+/*!****************!*\
+  !*** ./dep.js ***!
+  \****************/
+(module) {
+module.exports = "dep";
+
+
+},
+});
+// node:module
+const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+// ./only-require.js
+
+
+const req = /* createRequire() */ undefined;
+
+const bundledValue = __webpack_require__(/*! ./dep.js */ "./dep.js");
+
+// ./index.js
+
+
+
+const index_req = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+const resolved = index_req.resolve("path");
+
+it("should preserve import.meta.url when requireResolve is disabled", async () => {
+	const fs = await import(/* webpackIgnore: true */ "node:fs");
+	const path = await import(/* webpackIgnore: true */ "node:path");
+	const source = fs.readFileSync(path.join(__rspack_import_meta_dirname__, "main.mjs"), "utf-8");
+	const runtimeCreateRequire =
+		"(0,external_node_module_namespaceObject." + "createRequire)(import.meta.url)";
+
+	expect(source.split(runtimeCreateRequire)).toHaveLength(2);
+	expect(source).not.toContain("file:" + "//");
+	expect(source).toContain("/* createRequire() */ undefined");
+	expect(resolved).toBe("path");
+	expect(bundledValue).toBe("dep");
+});
+
+export { resolved };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,89 @@
+```mjs title=main.mjs
+import { __rspack_context } from "./runtime.mjs";
+
+import {fileURLToPath as __rspack_fileURLToPath} from "node:url";
+import {dirname as __rspack_dirname} from "node:path";
+var __rspack_import_meta_dirname__ = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));
+import { createRequire as __rspack_createRequire } from "node:module";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+__rspack_context.m.add({
+"./dep.js"
+/*!****************!*\
+  !*** ./dep.js ***!
+  \****************/
+(module) {
+module.exports = "dep";
+
+
+},
+});
+// node:module
+const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+// ./only-require.js
+
+
+const req = /* createRequire() */ undefined;
+
+const bundledValue = __rspack_context.r(/*! ./dep.js */ "./dep.js");
+
+// ./index.js
+
+
+
+const index_req = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+const resolved = index_req.resolve("path");
+
+it("should preserve import.meta.url when requireResolve is disabled", async () => {
+	const fs = await import(/* webpackIgnore: true */ "node:fs");
+	const path = await import(/* webpackIgnore: true */ "node:path");
+	const source = fs.readFileSync(path.join(__rspack_import_meta_dirname__, "main.mjs"), "utf-8");
+	const runtimeCreateRequire =
+		"(0,external_node_module_namespaceObject." + "createRequire)(import.meta.url)";
+
+	expect(source.split(runtimeCreateRequire)).toHaveLength(2);
+	expect(source).not.toContain("file:" + "//");
+	expect(source).toContain("/* createRequire() */ undefined");
+	expect(resolved).toBe("path");
+	expect(bundledValue).toBe("dep");
+});
+
+export { resolved };
+
+```
+
+```mjs title=runtime.mjs
+
+var __rspack_modules = {};
+// The module cache
+var __rspack_module_cache = {};
+// The require function
+function __rspack_require(moduleId) {
+// Check if module is in cache
+var cachedModule = __rspack_module_cache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__rspack_module_cache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+
+// Return the exports of the module
+return module.exports;
+}
+var __rspack_context = {};
+__rspack_context.r = __rspack_require;
+// expose the modules object (__rspack_modules)
+__rspack_context.m = __rspack_modules;
+
+var moduleFactories=__rspack_modules;
+// rspack/runtime/esm_register_module
+moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
+;
+
+export { __rspack_context };
+
+```

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/dep.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/dep.js
@@ -1,0 +1,1 @@
+module.exports = "dep";

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/index.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/index.js
@@ -1,0 +1,20 @@
+import { createRequire } from "node:module";
+import { bundledValue } from "./only-require.js";
+
+const req = createRequire(import.meta.url);
+
+export const resolved = req.resolve("path");
+
+it("should preserve import.meta.url when requireResolve is disabled", async () => {
+	const fs = await import(/* webpackIgnore: true */ "node:fs");
+	const path = await import(/* webpackIgnore: true */ "node:path");
+	const source = fs.readFileSync(path.join(__dirname, "main.mjs"), "utf-8");
+	const runtimeCreateRequire =
+		"(0,external_node_module_namespaceObject." + "createRequire)(import.meta.url)";
+
+	expect(source.split(runtimeCreateRequire)).toHaveLength(2);
+	expect(source).not.toContain("file:" + "//");
+	expect(source).toContain("/* createRequire() */ undefined");
+	expect(resolved).toBe("path");
+	expect(bundledValue).toBe("dep");
+});

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/only-require.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/only-require.js
@@ -1,0 +1,5 @@
+import { createRequire } from "node:module";
+
+const req = createRequire(import.meta.url);
+
+export const bundledValue = req("./dep.js");

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/rspack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  module: {
+    parser: {
+      javascript: {
+        createRequire: true,
+        requireResolve: false,
+      },
+    },
+  },
+};

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/esm.snap.txt
@@ -19,12 +19,27 @@ module.exports = "loader";
 });
 // node:module
 const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+
+var external_node_module_default = /*#__PURE__*/__webpack_require__.n(external_node_module_namespaceObject);// ./default-require.js
+
+
+const defaultRequire = external_node_module_default().createRequire(import.meta.url);
+
+const defaultUnknown = defaultRequire.unknown;
+
 // ./exported-require.js
 
 
 const exportedRequire = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
 
 
+
+// ./namespace-require.js
+
+
+const namespaceRequire = external_node_module_namespaceObject.createRequire(import.meta.url);
+
+const namespaceUnknown = namespaceRequire.unknown;
 
 // ./pre-declared-require.js
 
@@ -54,6 +69,8 @@ function load() {
 const pre_declared_require_call_req = /* createRequire() */ undefined;
 
 // ./index.js
+
+
 
 
 
@@ -89,6 +106,8 @@ it("should consume createRequire(import.meta.url) like webpack", async () => {
 	expect(index_value).toBe("loader");
 	expect(loader).toBe("./libCssExtractLoader.js");
 	expect(unknownMember).toBe(undefined);
+	expect(namespaceUnknown).toBe(undefined);
+	expect(defaultUnknown).toBe(undefined);
 	expect(requireAsValueType).toBe("function");
 	expect(exportedRequire.resolve("path")).toBe("path");
 	expect(getRequire().resolve("path")).toBe("path");
@@ -125,10 +144,40 @@ return module.exports;
 // expose the modules object (__webpack_modules__)
 __webpack_require__.m = __webpack_modules__;
 
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
 // webpack/runtime/esm_register_module
 (() => {
 __webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
 
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 })();
 
 export { __webpack_require__ };

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/esm.snap.txt
@@ -19,13 +19,56 @@ module.exports = "loader";
 });
 // node:module
 const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+// ./exported-require.js
+
+
+const exportedRequire = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+
+
+// ./pre-declared-require.js
+
+
+function getRequire() {
+	return req;
+}
+
+const req = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+function getNestedRequire() {
+	function readRequire() {
+		return nestedReq;
+	}
+
+	const nestedReq = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+	return readRequire();
+}
+
+// ./pre-declared-require-call.js
+
+
+function load() {
+	return __webpack_require__(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+}
+
+const pre_declared_require_call_req = /* createRequire() */ undefined;
+
 // ./index.js
 
 
-const req = /* createRequire() */ undefined;
 
-const value = __webpack_require__(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+
+
+const index_req = /* createRequire() */ undefined;
+const requireWithUnknownMember = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+const requireAsValue = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+const identity = value => value;
+
+const index_value = __webpack_require__(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
 const loader = /*require.resolve*/(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+const unknownMember = requireWithUnknownMember.unknown;
+const requireAsValueType = typeof identity(requireAsValue);
 
 it("should consume createRequire(import.meta.url) like webpack", async () => {
 	const fs = await import(/* webpackIgnore: true */ "node:fs");
@@ -33,21 +76,27 @@ it("should consume createRequire(import.meta.url) like webpack", async () => {
 	const source = fs.readFileSync(path.join(__rspack_import_meta_dirname__, "main.mjs"), "utf-8");
 	const fileUrlScheme = "file:" + "//";
 	const normalizedRoot = "<" + "ROOT>";
-	const unresolvedCreateRequire =
-		"external_node_module_namespaceObject." + "createRequire(import.meta.url)";
+	const runtimeCreateRequire =
+		"(0,external_node_module_namespaceObject." + "createRequire)(import.meta.url)";
 
 	expect(source).not.toContain(fileUrlScheme);
 	expect(source).not.toContain("createRequire('" + normalizedRoot);
 	expect(source).not.toContain('createRequire("' + normalizedRoot);
-	expect(source).not.toContain(unresolvedCreateRequire);
+	expect(source.split(runtimeCreateRequire)).toHaveLength(6);
 	expect(source).toContain("/* createRequire() */ undefined");
 	expect(source).toContain("__webpack_require__(");
 	expect(source).toContain("/*require.resolve*/");
-	expect(value).toBe("loader");
+	expect(index_value).toBe("loader");
 	expect(loader).toBe("./libCssExtractLoader.js");
+	expect(unknownMember).toBe(undefined);
+	expect(requireAsValueType).toBe("function");
+	expect(exportedRequire.resolve("path")).toBe("path");
+	expect(getRequire().resolve("path")).toBe("path");
+	expect(getNestedRequire().resolve("path")).toBe("path");
+	expect(load()).toBe("loader");
 });
 
-export { loader, value };
+export { index_value as value, loader, requireAsValueType, unknownMember };
 
 ```
 

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -19,13 +19,56 @@ module.exports = "loader";
 });
 // node:module
 const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+// ./exported-require.js
+
+
+const exportedRequire = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+
+
+// ./pre-declared-require.js
+
+
+function getRequire() {
+	return req;
+}
+
+const req = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+function getNestedRequire() {
+	function readRequire() {
+		return nestedReq;
+	}
+
+	const nestedReq = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+	return readRequire();
+}
+
+// ./pre-declared-require-call.js
+
+
+function load() {
+	return __rspack_context.r(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+}
+
+const pre_declared_require_call_req = /* createRequire() */ undefined;
+
 // ./index.js
 
 
-const req = /* createRequire() */ undefined;
 
-const value = __rspack_context.r(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+
+
+const index_req = /* createRequire() */ undefined;
+const requireWithUnknownMember = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+const requireAsValue = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
+
+const identity = value => value;
+
+const index_value = __rspack_context.r(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
 const loader = /*require.resolve*/(/*! ./libCssExtractLoader.js */ "./libCssExtractLoader.js");
+const unknownMember = requireWithUnknownMember.unknown;
+const requireAsValueType = typeof identity(requireAsValue);
 
 it("should consume createRequire(import.meta.url) like webpack", async () => {
 	const fs = await import(/* webpackIgnore: true */ "node:fs");
@@ -33,21 +76,27 @@ it("should consume createRequire(import.meta.url) like webpack", async () => {
 	const source = fs.readFileSync(path.join(__rspack_import_meta_dirname__, "main.mjs"), "utf-8");
 	const fileUrlScheme = "file:" + "//";
 	const normalizedRoot = "<" + "ROOT>";
-	const unresolvedCreateRequire =
-		"external_node_module_namespaceObject." + "createRequire(import.meta.url)";
+	const runtimeCreateRequire =
+		"(0,external_node_module_namespaceObject." + "createRequire)(import.meta.url)";
 
 	expect(source).not.toContain(fileUrlScheme);
 	expect(source).not.toContain("createRequire('" + normalizedRoot);
 	expect(source).not.toContain('createRequire("' + normalizedRoot);
-	expect(source).not.toContain(unresolvedCreateRequire);
+	expect(source.split(runtimeCreateRequire)).toHaveLength(6);
 	expect(source).toContain("/* createRequire() */ undefined");
 	expect(source).toContain("__webpack_require__(");
 	expect(source).toContain("/*require.resolve*/");
-	expect(value).toBe("loader");
+	expect(index_value).toBe("loader");
 	expect(loader).toBe("./libCssExtractLoader.js");
+	expect(unknownMember).toBe(undefined);
+	expect(requireAsValueType).toBe("function");
+	expect(exportedRequire.resolve("path")).toBe("path");
+	expect(getRequire().resolve("path")).toBe("path");
+	expect(getNestedRequire().resolve("path")).toBe("path");
+	expect(load()).toBe("loader");
 });
 
-export { loader, value };
+export { index_value as value, loader, requireAsValueType, unknownMember };
 
 ```
 

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -19,12 +19,27 @@ module.exports = "loader";
 });
 // node:module
 const external_node_module_namespaceObject = __rspack_createRequire_require("node:module");
+
+var external_node_module_default = /*#__PURE__*/__rspack_context.n(external_node_module_namespaceObject);// ./default-require.js
+
+
+const defaultRequire = external_node_module_default().createRequire(import.meta.url);
+
+const defaultUnknown = defaultRequire.unknown;
+
 // ./exported-require.js
 
 
 const exportedRequire = (0,external_node_module_namespaceObject.createRequire)(import.meta.url);
 
 
+
+// ./namespace-require.js
+
+
+const namespaceRequire = external_node_module_namespaceObject.createRequire(import.meta.url);
+
+const namespaceUnknown = namespaceRequire.unknown;
 
 // ./pre-declared-require.js
 
@@ -54,6 +69,8 @@ function load() {
 const pre_declared_require_call_req = /* createRequire() */ undefined;
 
 // ./index.js
+
+
 
 
 
@@ -89,6 +106,8 @@ it("should consume createRequire(import.meta.url) like webpack", async () => {
 	expect(index_value).toBe("loader");
 	expect(loader).toBe("./libCssExtractLoader.js");
 	expect(unknownMember).toBe(undefined);
+	expect(namespaceUnknown).toBe(undefined);
+	expect(defaultUnknown).toBe(undefined);
 	expect(requireAsValueType).toBe("function");
 	expect(exportedRequire.resolve("path")).toBe("path");
 	expect(getRequire().resolve("path")).toBe("path");
@@ -128,9 +147,34 @@ __rspack_context.r = __rspack_require;
 __rspack_context.m = __rspack_modules;
 
 var moduleFactories=__rspack_modules;
+// rspack/runtime/compat_get_default_export
+// getDefaultExport function for compatibility with non-ESM modules
+var compatGetDefaultExport = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	definePropertyGetters(getter, { a: getter });
+	return getter;
+};
+;
+__rspack_context.n = compatGetDefaultExport;
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
 // rspack/runtime/esm_register_module
 moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
 ;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
 
 export { __rspack_context };
 

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/default-require.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/default-require.js
@@ -1,0 +1,5 @@
+import moduleDefault from "node:module";
+
+const defaultRequire = moduleDefault.createRequire(import.meta.url);
+
+export const defaultUnknown = defaultRequire.unknown;

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/exported-require.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/exported-require.js
@@ -1,0 +1,5 @@
+import { createRequire } from "node:module";
+
+const exportedRequire = createRequire(import.meta.url);
+
+export { exportedRequire };

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/index.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/index.js
@@ -1,5 +1,7 @@
 import { createRequire } from "node:module";
+import { defaultUnknown } from "./default-require.js";
 import { exportedRequire } from "./exported-require.js";
+import { namespaceUnknown } from "./namespace-require.js";
 import {
 	getNestedRequire,
 	getRequire
@@ -36,6 +38,8 @@ it("should consume createRequire(import.meta.url) like webpack", async () => {
 	expect(value).toBe("loader");
 	expect(loader).toBe("./libCssExtractLoader.js");
 	expect(unknownMember).toBe(undefined);
+	expect(namespaceUnknown).toBe(undefined);
+	expect(defaultUnknown).toBe(undefined);
 	expect(requireAsValueType).toBe("function");
 	expect(exportedRequire.resolve("path")).toBe("path");
 	expect(getRequire().resolve("path")).toBe("path");

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/index.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/index.js
@@ -1,9 +1,21 @@
 import { createRequire } from "node:module";
+import { exportedRequire } from "./exported-require.js";
+import {
+	getNestedRequire,
+	getRequire
+} from "./pre-declared-require.js";
+import { load } from "./pre-declared-require-call.js";
 
 const req = createRequire(import.meta.url);
+const requireWithUnknownMember = createRequire(import.meta.url);
+const requireAsValue = createRequire(import.meta.url);
+
+const identity = value => value;
 
 export const value = req("./libCssExtractLoader.js");
 export const loader = req.resolve("./libCssExtractLoader.js");
+export const unknownMember = requireWithUnknownMember.unknown;
+export const requireAsValueType = typeof identity(requireAsValue);
 
 it("should consume createRequire(import.meta.url) like webpack", async () => {
 	const fs = await import(/* webpackIgnore: true */ "node:fs");
@@ -11,16 +23,22 @@ it("should consume createRequire(import.meta.url) like webpack", async () => {
 	const source = fs.readFileSync(path.join(__dirname, "main.mjs"), "utf-8");
 	const fileUrlScheme = "file:" + "//";
 	const normalizedRoot = "<" + "ROOT>";
-	const unresolvedCreateRequire =
-		"external_node_module_namespaceObject." + "createRequire(import.meta.url)";
+	const runtimeCreateRequire =
+		"(0,external_node_module_namespaceObject." + "createRequire)(import.meta.url)";
 
 	expect(source).not.toContain(fileUrlScheme);
 	expect(source).not.toContain("createRequire('" + normalizedRoot);
 	expect(source).not.toContain('createRequire("' + normalizedRoot);
-	expect(source).not.toContain(unresolvedCreateRequire);
+	expect(source.split(runtimeCreateRequire)).toHaveLength(6);
 	expect(source).toContain("/* createRequire() */ undefined");
 	expect(source).toContain("__webpack_require__(");
 	expect(source).toContain("/*require.resolve*/");
 	expect(value).toBe("loader");
 	expect(loader).toBe("./libCssExtractLoader.js");
+	expect(unknownMember).toBe(undefined);
+	expect(requireAsValueType).toBe("function");
+	expect(exportedRequire.resolve("path")).toBe("path");
+	expect(getRequire().resolve("path")).toBe("path");
+	expect(getNestedRequire().resolve("path")).toBe("path");
+	expect(load()).toBe("loader");
 });

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/namespace-require.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/namespace-require.js
@@ -1,0 +1,5 @@
+import * as moduleNamespace from "node:module";
+
+const namespaceRequire = moduleNamespace.createRequire(import.meta.url);
+
+export const namespaceUnknown = namespaceRequire.unknown;

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/pre-declared-require-call.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/pre-declared-require-call.js
@@ -1,0 +1,7 @@
+import { createRequire } from "node:module";
+
+export function load() {
+	return req("./libCssExtractLoader.js");
+}
+
+const req = createRequire(import.meta.url);

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/pre-declared-require.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/pre-declared-require.js
@@ -1,0 +1,16 @@
+import { createRequire } from "node:module";
+
+export function getRequire() {
+	return req;
+}
+
+const req = createRequire(import.meta.url);
+
+export function getNestedRequire() {
+	function readRequire() {
+		return nestedReq;
+	}
+
+	const nestedReq = createRequire(import.meta.url);
+	return readRequire();
+}

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/test.config.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/test.config.js
@@ -11,8 +11,11 @@ module.exports = {
 		expect(source).not.toContain("file://");
 		expect(source).not.toContain("createRequire('<ROOT>");
 		expect(source).not.toContain('createRequire("<ROOT>');
-		expect(source).not.toContain(
+		expect(source).toContain(
 			"external_node_module_namespaceObject.createRequire(import.meta.url)"
+		);
+		expect(source).toContain(
+			"external_node_module_default().createRequire(import.meta.url)"
 		);
 		expect(source).toContain("/* createRequire() */ undefined");
 		expect(source).toContain("__webpack_require__(");


### PR DESCRIPTION
## Summary

When `module.parser.javascript.requireResolve` is `false`, a created require's `.resolve(...)` is preserved to run at runtime instead of being rewritten to a module id.

The created require is treated as a **real require object** whenever it is used as one — decided per declaration:

- **`.resolve(...)`** (incl. the 2-arg `require.resolve(request, options)` form), **any other member** (`r.main`, `r.resolve.paths(...)`, ...), or used **as a bare value** (`helper(r)`, `export { r }`, `return r`, ...) → the declaration is **kept** and rendered via rspack's injected `__rspack_createRequire` helper, and those accesses hit the **real** require. (webpack instead rewrites value-use to a context-require + "Critical dependency" warning, and non-`cache`/`resolve` members to `undefined` + "unsupported" warning — this is the improvement.)
- A plain invoke **`r("./x")`** is still bundled (`__webpack_require__`), and **`r.cache`** still maps to the bundler module cache.
- So a created require used **only** as bundled invokes (or unused) is **cleared to `/* createRequire() */ undefined`** — no dead `import.meta.url` leaks and CommonJS output stays valid.

The keep/clear decision is deferred to the parser's `finish()` (the callee is left un-walked so a clear doesn't collide with an import-specifier rewrite; the kept case re-renders the callee as `__rspack_createRequire`). The kept literal `import.meta.url` honors a customized `output.importMetaName`.

Since literal `import.meta.url` is only valid in ESM output, an `Unsupported feature` warning is emitted when a kept `createRequire(import.meta.url)` would land in a CommonJS bundle.

```js
const r = createRequire(import.meta.url);
r("./x");               // bundled (__webpack_require__)
r.resolve("./x");       // preserved, runtime-resolved
r.resolve.paths("./x"); // real Node API (was unsupported/undefined)
export const x = r;     // real created require (was a context-require + warning)
```

### Tests

- `esmOutputCases/create-require/import-meta-url-resolve-disabled` — ESM keep via helper, variable + inline forms, 2-arg resolve, extra-arg side effect; snapshot.
- `configCases/require/create-require-kept-for-access` — value-position use + non-resolve member access keep the **real** created require (no context-require/unsupported rewrite, no warning); invoke still bundled.
- `configCases/require/create-require-no-resolve-no-leak` — used only as invokes → cleared to `undefined`, valid CJS, no warning.
- `configCases/require/create-require-resolve-disabled-cjs` — CommonJS warning + artifact.
- `configCases/require/create-require-resolve-custom-import-meta-name` — kept argument honors `output.importMetaName`.
- `configCases/require/module-require-disable-resolve` — dynamic-argument dependency preservation.

## Related links

<!-- none -->

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

