### PR TITLE
feat: warn on unknown import.meta properties

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/walk_data.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/walk_data.rs
@@ -262,9 +262,11 @@ impl WalkData {
         define_record = define_record
           .with_on_evaluate_identifier(Box::new(move |record, parser, _ident, start, end| {
             parser
-              .evaluate(
+              .evaluate_with_range(
                 code_to_string(&record.code, None, None).into_owned(),
                 "DefinePlugin",
+                start,
+                end,
               )
               .map(|mut evaluated| {
                 evaluated.set_range(start, end);
@@ -296,7 +298,7 @@ impl WalkData {
             Cow::Owned(format!("typeof ({code})"))
           };
           parser
-            .evaluate(typeof_code.into_owned(), "DefinePlugin")
+            .evaluate_with_range(typeof_code.into_owned(), "DefinePlugin", start, end)
             .map(|mut evaluated| {
               evaluated.set_range(start, end);
               evaluated
@@ -310,7 +312,7 @@ impl WalkData {
             Cow::Owned(format!("typeof ({code})"))
           };
           parser
-            .evaluate(typeof_code.to_string(), "DefinePlugin")
+            .evaluate_with_range(typeof_code.to_string(), "DefinePlugin", start, end)
             .and_then(|evaluated| {
               if !evaluated.is_string() {
                 return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   DependencyRange, ImportMeta, ImportMetaKnownProperties, ResolvedModuleOptions, RscMeta,
   RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access,
 };
-use rspack_error::{Error, Severity};
+use rspack_error::{Error, Label, Severity};
 use rspack_util::{SpanExt, json_stringify_str};
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
@@ -385,22 +385,23 @@ impl ImportMetaPlugin {
     }
 
     let property = if members.is_empty() {
-      "an unknown property of import.meta".to_string()
+      "<computed>".to_string()
     } else {
-      concat_string!("import.meta.", members.join("."))
+      members.join(".")
     };
-    let mut error = create_traceable_error(
-      "Critical dependency".into(),
-      concat_string!(
-        "Accessing ",
-        property,
-        " is unsupported and will be replaced with undefined"
-      )
-      .into(),
-      parser.source.to_string(),
-      span.into(),
-    );
-    error.severity = Severity::Warning;
+    let range: DependencyRange = span.into();
+    let mut error = Error::warning(concat_string!(
+      "Unknown `import.meta` property `",
+      property,
+      "` replaced with undefined."
+    ));
+    error.src = Some(parser.source.to_string());
+    error.labels = Some(vec![Label {
+      name: None,
+      offset: range.start as usize,
+      len: range.end.saturating_sub(range.start) as usize,
+    }]);
+    error.hide_stack = Some(true);
     parser.add_warning(error.into());
   }
 
@@ -695,7 +696,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push('[');
               content.push_str(&rspack_util::json_stringify_str(&prop.id));
               content.push_str("]: ");
-              content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
+              content.push_str(&self.import_meta_unknown_property(&[prop.id.to_string()]));
             }
           } else if let Some(api) = import_meta_runtime_api_from_property(prop.id.as_ref()) {
             if self.runtime_api_enabled(api)
@@ -706,7 +707,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push('[');
               content.push_str(&rspack_util::json_stringify_str(&prop.id));
               content.push_str("]: ");
-              content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
+              content.push_str(&self.import_meta_unknown_property(&[prop.id.to_string()]));
             }
           } else {
             let members = vec![prop.id.to_string()];

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -411,7 +411,7 @@ impl ImportMetaPlugin {
         })
         .join(".");
       concat_string!(
-        "Accessing unknown property '",
+        "Accessing unknown `import.meta` property '",
         property,
         "' is replaced with undefined."
       )

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -356,22 +356,29 @@ impl ImportMetaPlugin {
     )
   }
 
-  fn import_meta_unknown_property(&self, members: &[String]) -> String {
-    if self.preserve_property(members.first().map(|property| property.as_str())) {
-      concat_string!("import.meta", property_access(members, 0))
+  fn import_meta_unknown_property(&self, members: &[Atom]) -> String {
+    if self.preserve_property(members.first().map(Atom::as_ref)) {
+      concat_string!(
+        "import.meta",
+        property_access(members.iter().map(Atom::as_ref), 0)
+      )
     } else {
       let comment = to_normal_comment(&concat_string!(
         "unsupported import.meta.",
-        members.join(".")
+        members.iter().join(".")
       ));
-      concat_string!(comment, " undefined", property_access(members, 1))
+      concat_string!(
+        comment,
+        " undefined",
+        property_access(members.iter().map(Atom::as_ref), 1)
+      )
     }
   }
 
   fn warn_import_meta_unknown_property(
     &self,
     parser: &mut JavascriptParser,
-    members: &[String],
+    members: &[Atom],
     span: Span,
   ) {
     if !matches!(self.0.as_ref(), ImportMeta::Enabled)
@@ -564,7 +571,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     {
       evaluated = Some("undefined".to_string());
       if Self::known_property_from_name(for_name).is_none() {
-        self.warn_import_meta_unknown_property(parser, &[property.to_string()], member_expr.span());
+        self.warn_import_meta_unknown_property(
+          parser,
+          std::slice::from_ref(&property),
+          member_expr.span(),
+        );
       }
     }
     evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
@@ -606,7 +617,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         let span = member.span();
         let name = concat_string!(expr_name::IMPORT_META, ".", ident.sym);
         if Self::known_property_from_name(&name).is_none() {
-          self.warn_import_meta_unknown_property(parser, &[ident.sym.to_string()], span);
+          self.warn_import_meta_unknown_property(parser, &[Atom::from(ident.sym.as_str())], span);
         }
         return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
@@ -625,7 +636,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         let span = member.span();
         let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
         if Self::known_property_from_name(&name).is_none() {
-          self.warn_import_meta_unknown_property(parser, &[property.to_string()], span);
+          self.warn_import_meta_unknown_property(parser, std::slice::from_ref(&property), span);
         }
         return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
@@ -709,7 +720,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push('[');
               content.push_str(&rspack_util::json_stringify_str(&prop.id));
               content.push_str("]: ");
-              content.push_str(&self.import_meta_unknown_property(&[prop.id.to_string()]));
+              content.push_str(&self.import_meta_unknown_property(std::slice::from_ref(&prop.id)));
             }
           } else if let Some(api) = import_meta_runtime_api_from_property(prop.id.as_ref()) {
             if self.runtime_api_enabled(api)
@@ -720,15 +731,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push('[');
               content.push_str(&rspack_util::json_stringify_str(&prop.id));
               content.push_str("]: ");
-              content.push_str(&self.import_meta_unknown_property(&[prop.id.to_string()]));
+              content.push_str(&self.import_meta_unknown_property(std::slice::from_ref(&prop.id)));
             }
           } else {
-            let members = vec![prop.id.to_string()];
-            self.warn_import_meta_unknown_property(parser, &members, span);
+            let members = std::slice::from_ref(&prop.id);
+            self.warn_import_meta_unknown_property(parser, members, span);
             content.push('[');
             content.push_str(&rspack_util::json_stringify_str(&prop.id));
             content.push_str("]: ");
-            content.push_str(&self.import_meta_unknown_property(&members));
+            content.push_str(&self.import_meta_unknown_property(members));
           }
         }
         content.push_str("})");
@@ -925,15 +936,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             )));
             return Some(true);
           };
-          if self.preserve_property(members.members.first().map(|property| property.as_str())) {
+          if self.preserve_property(members.members.first().map(Atom::as_ref)) {
             return Some(true);
           }
-          let unknown_members = members
-            .members
-            .iter()
-            .map(|member| member.to_string())
-            .collect_vec();
-          self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
+          let unknown_members = members.members.as_slice();
+          self.warn_import_meta_unknown_property(parser, unknown_members, expr.span());
           let dep = if members.members.get(1).is_some()
             && members
               .members_optionals
@@ -944,7 +951,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
           } else {
             ConstDependency::new(
               expr.span().into(),
-              self.import_meta_unknown_property(&unknown_members).into(),
+              self.import_meta_unknown_property(unknown_members).into(),
             )
           };
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -393,29 +393,25 @@ impl ImportMetaPlugin {
       return;
     }
 
-    let message = if members.is_empty() {
-      "Dynamic `import.meta` property access may return undefined.".to_string()
-    } else {
-      let property = members
-        .iter()
-        .map(|member| {
-          let mut escaped = String::with_capacity(member.len());
-          for ch in member.chars() {
-            if ch == '\'' {
-              escaped.push_str("\\'");
-            } else {
-              escaped.extend(ch.escape_debug());
-            }
+    let property = members
+      .iter()
+      .map(|member| {
+        let mut escaped = String::with_capacity(member.len());
+        for ch in member.chars() {
+          if ch == '\'' {
+            escaped.push_str("\\'");
+          } else {
+            escaped.extend(ch.escape_debug());
           }
-          escaped
-        })
-        .join(".");
-      concat_string!(
-        "Accessing unknown `import.meta` property '",
-        property,
-        "' is replaced with undefined."
-      )
-    };
+        }
+        escaped
+      })
+      .join(".");
+    let message = concat_string!(
+      "Accessing unknown `import.meta` property '",
+      property,
+      "' is replaced with undefined."
+    );
     let range = parser
       .evaluated_source_range
       .unwrap_or_else(|| DependencyRange::from(span));
@@ -929,7 +925,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             if self.preserve_property(None) {
               return Some(true);
             }
-            self.warn_import_meta_unknown_property(parser, &[], expr.span());
             parser.add_presentational_dependency(Box::new(ConstDependency::new(
               expr.obj.span().into(),
               "({})".into(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -401,8 +401,8 @@ impl ImportMetaPlugin {
         .map(|member| {
           let mut escaped = String::with_capacity(member.len());
           for ch in member.chars() {
-            if ch == '`' {
-              escaped.push_str("\\`");
+            if ch == '\'' {
+              escaped.push_str("\\'");
             } else {
               escaped.extend(ch.escape_debug());
             }
@@ -411,9 +411,9 @@ impl ImportMetaPlugin {
         })
         .join(".");
       concat_string!(
-        "Unknown `import.meta` property `",
+        "Accessing unknown property '",
         property,
-        "` replaced with undefined."
+        "' is replaced with undefined."
       )
     };
     let range = parser

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -384,17 +384,17 @@ impl ImportMetaPlugin {
       return;
     }
 
-    let property = if members.is_empty() {
-      "<computed>".to_string()
+    let message = if members.is_empty() {
+      "Unknown `import.meta` property replaced with undefined.".to_string()
     } else {
-      members.join(".")
+      concat_string!(
+        "Unknown `import.meta` property `",
+        members.join("."),
+        "` replaced with undefined."
+      )
     };
     let range: DependencyRange = span.into();
-    let mut error = Error::warning(concat_string!(
-      "Unknown `import.meta` property `",
-      property,
-      "` replaced with undefined."
-    ));
+    let mut error = Error::warning(message);
     error.src = Some(parser.source.to_string());
     error.labels = Some(vec![Label {
       name: None,
@@ -522,6 +522,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     for_name: &str,
   ) -> Option<eval::BasicEvaluatedExpression<'a>> {
     let mut evaluated = None;
+    let mut has_unknown_property = false;
     if for_name == expr_name::IMPORT_META {
       evaluated = Some("object".to_string());
     } else if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name)
@@ -557,9 +558,17 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         })
         .unwrap_or(false)
     {
-      evaluated = Some("undefined".to_string())
+      evaluated = Some("undefined".to_string());
+      has_unknown_property = Self::known_property_from_name(for_name).is_none();
     }
-    evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
+    evaluated.map(|e| {
+      let mut evaluated = eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi());
+      if has_unknown_property {
+        // Ensure the original expression is walked so the replacement emits its warning.
+        evaluated.set_side_effects(true);
+      }
+      evaluated
+    })
   }
 
   fn evaluate_identifier(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -35,7 +35,7 @@ use crate::{
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
     RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
-    get_non_optional_member_chain_from_expr,
+    get_non_optional_member_chain_from_expr, member_literal_to_atom,
   },
 };
 
@@ -299,14 +299,6 @@ pub struct ImportMetaPlugin(pub(crate) ArcComputed<ResolvedModuleOptions, Import
 
 impl ImportMetaPlugin {
   fn known_property_from_name(name: &str) -> Option<ImportMetaKnownProperties> {
-    match name {
-      expr_name::IMPORT_META_HOT => return Some(ImportMetaKnownProperties::WEBPACK_HOT),
-      expr_name::IMPORT_META_CONTEXT => {
-        return Some(ImportMetaKnownProperties::WEBPACK_CONTEXT);
-      }
-      expr_name::IMPORT_META_GLOB => return Some(ImportMetaKnownProperties::GLOB),
-      _ => {}
-    }
     if let Some(property) = ImportMetaBuiltinProperty::from_name(name) {
       return Some(property.property);
     }
@@ -386,14 +378,17 @@ impl ImportMetaPlugin {
     if !matches!(self.0.as_ref(), ImportMeta::Enabled)
       || members.first().is_some_and(|property| {
         let name = concat_string!(expr_name::IMPORT_META, ".", property);
-        Self::known_property_from_name(&name).is_some()
+        matches!(
+          name.as_str(),
+          expr_name::IMPORT_META_HOT | expr_name::IMPORT_META_CONTEXT | expr_name::IMPORT_META_GLOB
+        ) || Self::known_property_from_name(&name).is_some()
       })
     {
       return;
     }
 
     let message = if members.is_empty() {
-      "Unknown `import.meta` property replaced with undefined.".to_string()
+      "Dynamic `import.meta` property access may return undefined.".to_string()
     } else {
       concat_string!(
         "Unknown `import.meta` property `",
@@ -410,7 +405,7 @@ impl ImportMetaPlugin {
       len: range.end.saturating_sub(range.start) as usize,
     }]);
     error.hide_stack = Some(true);
-    parser.add_warning(error.into());
+    parser.add_warning_once(error.into());
   }
 
   fn process_import_meta_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr) {
@@ -530,7 +525,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     for_name: &str,
   ) -> Option<eval::BasicEvaluatedExpression<'a>> {
     let mut evaluated = None;
-    let mut has_unknown_property = false;
     if for_name == expr_name::IMPORT_META {
       evaluated = Some("object".to_string());
     } else if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name)
@@ -567,16 +561,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         .unwrap_or(false)
     {
       evaluated = Some("undefined".to_string());
-      has_unknown_property = Self::known_property_from_name(for_name).is_none();
-    }
-    evaluated.map(|e| {
-      let mut evaluated = eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi());
-      if has_unknown_property {
-        // Ensure the original expression is walked so the replacement emits its warning.
-        evaluated.set_side_effects(true);
+      if Self::known_property_from_name(for_name).is_none() {
+        let members = for_name
+          .strip_prefix(expr_name::IMPORT_META_PREFIX)
+          .map(|property| vec![property.to_string()])
+          .unwrap_or_default();
+        self.warn_import_meta_unknown_property(parser, &members, member_expr.span());
       }
-      evaluated
-    })
+    }
+    evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
   }
 
   fn evaluate_identifier(
@@ -613,42 +606,37 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
           return None;
         }
         let span = member.span();
-        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
         let name = concat_string!(expr_name::IMPORT_META, ".", ident.sym);
         if Self::known_property_from_name(&name).is_none() {
-          // Ensure the original expression is walked so the replacement emits its warning.
-          evaluated.set_side_effects(true);
+          self.warn_import_meta_unknown_property(parser, &[ident.sym.to_string()], span);
         }
-        return Some(evaluated);
+        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
       if let Some(computed) = member.prop.as_computed()
         && computed.expr.is_lit()
       {
         // Check for computed properties like import.meta["dirname"]
-        let property = computed
-          .expr
-          .as_lit()
-          .and_then(|lit| lit.as_str())
-          .and_then(|str_lit| str_lit.value.as_str());
-        if property.is_some_and(|value| {
-          ImportMetaBuiltinProperty::from_property(value)
+        let property = computed.expr.as_lit().map(member_literal_to_atom);
+        if property.as_ref().is_some_and(|value| {
+          ImportMetaBuiltinProperty::from_property(value.as_ref())
             .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
-            || import_meta_runtime_api_from_property(value)
+            || import_meta_runtime_api_from_property(value.as_ref())
               .is_some_and(|api| self.runtime_api_enabled(api))
-            || self.preserve_property(Some(value))
+            || self.preserve_property(Some(value.as_ref()))
         }) {
           return None;
         }
         let span = member.span();
-        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
-        if property.is_none_or(|property| {
-          let name = concat_string!(expr_name::IMPORT_META, ".", property);
+        if property.as_ref().is_none_or(|property| {
+          let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
           Self::known_property_from_name(&name).is_none()
         }) {
-          // Ensure the original expression is walked so the replacement emits its warning.
-          evaluated.set_side_effects(true);
+          let members = property
+            .map(|property| vec![property.to_string()])
+            .unwrap_or_default();
+          self.warn_import_meta_unknown_property(parser, &members, span);
         }
-        return Some(evaluated);
+        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
     }
     None
@@ -935,32 +923,38 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               _ => None,
             });
 
-          let dep = if let Some(members) = members {
-            if self.preserve_property(members.members.first().map(|property| property.as_str())) {
+          let Some(members) = members else {
+            if self.preserve_property(None) {
               return Some(true);
             }
-            let unknown_members = members
-              .members
-              .iter()
-              .map(|member| member.to_string())
-              .collect_vec();
-            self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
-            if members.members.get(1).is_some()
-              && members
-                .members_optionals
-                .get(1)
-                .is_some_and(|optional| *optional)
-            {
-              ConstDependency::new(expr.span().into(), "undefined".into())
-            } else {
-              ConstDependency::new(
-                expr.span().into(),
-                self.import_meta_unknown_property(&unknown_members).into(),
-              )
-            }
-          } else {
             self.warn_import_meta_unknown_property(parser, &[], expr.span());
+            parser.add_presentational_dependency(Box::new(ConstDependency::new(
+              expr.obj.span().into(),
+              "({})".into(),
+            )));
+            return Some(true);
+          };
+          if self.preserve_property(members.members.first().map(|property| property.as_str())) {
+            return Some(true);
+          }
+          let unknown_members = members
+            .members
+            .iter()
+            .map(|member| member.to_string())
+            .collect_vec();
+          self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
+          let dep = if members.members.get(1).is_some()
+            && members
+              .members_optionals
+              .get(1)
+              .is_some_and(|optional| *optional)
+          {
             ConstDependency::new(expr.span().into(), "undefined".into())
+          } else {
+            ConstDependency::new(
+              expr.span().into(),
+              self.import_meta_unknown_property(&unknown_members).into(),
+            )
           };
 
           parser.add_presentational_dependency(Box::new(dep));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rspack_core::{
   ArcComputed, ConstDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
   DependencyRange, ImportMeta, ImportMetaKnownProperties, ResolvedModuleOptions, RscMeta,
-  RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access,
+  RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access, to_normal_comment,
 };
 use rspack_error::{Error, Label, Severity};
 use rspack_util::{SpanExt, json_stringify_str};
@@ -35,7 +35,7 @@ use crate::{
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
     RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
-    get_non_optional_member_chain_from_expr, member_literal_to_atom,
+    get_non_optional_member_chain_from_expr, member_property_to_atom,
   },
 };
 
@@ -360,12 +360,11 @@ impl ImportMetaPlugin {
     if self.preserve_property(members.first().map(|property| property.as_str())) {
       concat_string!("import.meta", property_access(members, 0))
     } else {
-      concat_string!(
-        "/* unsupported import.meta.",
-        members.join("."),
-        " */ undefined",
-        property_access(members, 1)
-      )
+      let comment = to_normal_comment(&concat_string!(
+        "unsupported import.meta.",
+        members.join(".")
+      ));
+      concat_string!(comment, " undefined", property_access(members, 1))
     }
   }
 
@@ -390,15 +389,31 @@ impl ImportMetaPlugin {
     let message = if members.is_empty() {
       "Dynamic `import.meta` property access may return undefined.".to_string()
     } else {
+      let property = members
+        .iter()
+        .map(|member| {
+          let mut escaped = String::with_capacity(member.len());
+          for ch in member.chars() {
+            if ch == '`' {
+              escaped.push_str("\\`");
+            } else {
+              escaped.extend(ch.escape_debug());
+            }
+          }
+          escaped
+        })
+        .join(".");
       concat_string!(
         "Unknown `import.meta` property `",
-        members.join("."),
+        property,
         "` replaced with undefined."
       )
     };
-    let range: DependencyRange = span.into();
+    let range = parser
+      .evaluated_source_range
+      .unwrap_or_else(|| DependencyRange::from(span));
     let mut error = Error::warning(message);
-    error.src = Some(parser.source.to_string());
+    error.src = Some(parser.source.to_string().into());
     error.labels = Some(vec![Label {
       name: None,
       offset: range.start as usize,
@@ -540,33 +555,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
       && meta_expr
         .get_root_name()
         .is_some_and(|name| name == expr_name::IMPORT_META)
-      && (match &member_expr.prop {
-        MemberProp::Ident(_) => true,
-        MemberProp::Computed(computed) => computed.expr.is_lit(),
-        _ => false,
+      && let Some(property) = (match &member_expr.prop {
+        MemberProp::Ident(ident) => Some(Atom::from(ident.sym.as_str())),
+        MemberProp::Computed(computed) => member_property_to_atom(&computed.expr),
+        _ => None,
       })
-      && member_expr
-        .prop
-        .as_ident()
-        .map(|ident| !self.preserve_property(Some(ident.sym.as_ref())))
-        .or_else(|| {
-          member_expr
-            .prop
-            .as_computed()
-            .and_then(|computed| computed.expr.as_lit())
-            .and_then(|lit| lit.as_str())
-            .and_then(|str_lit| str_lit.value.as_str())
-            .map(|value| !self.preserve_property(Some(value)))
-        })
-        .unwrap_or(false)
+      && !self.preserve_property(Some(property.as_ref()))
     {
       evaluated = Some("undefined".to_string());
       if Self::known_property_from_name(for_name).is_none() {
-        let members = for_name
-          .strip_prefix(expr_name::IMPORT_META_PREFIX)
-          .map(|property| vec![property.to_string()])
-          .unwrap_or_default();
-        self.warn_import_meta_unknown_property(parser, &members, member_expr.span());
+        self.warn_import_meta_unknown_property(parser, &[property.to_string()], member_expr.span());
       }
     }
     evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
@@ -613,28 +611,21 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
       if let Some(computed) = member.prop.as_computed()
-        && computed.expr.is_lit()
+        && let Some(property) = member_property_to_atom(&computed.expr)
       {
-        // Check for computed properties like import.meta["dirname"]
-        let property = computed.expr.as_lit().map(member_literal_to_atom);
-        if property.as_ref().is_some_and(|value| {
-          ImportMetaBuiltinProperty::from_property(value.as_ref())
-            .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
-            || import_meta_runtime_api_from_property(value.as_ref())
-              .is_some_and(|api| self.runtime_api_enabled(api))
-            || self.preserve_property(Some(value.as_ref()))
-        }) {
+        // Check for computed properties like import.meta["dirname"] and import.meta[`dirname`]
+        if ImportMetaBuiltinProperty::from_property(property.as_ref())
+          .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
+          || import_meta_runtime_api_from_property(property.as_ref())
+            .is_some_and(|api| self.runtime_api_enabled(api))
+          || self.preserve_property(Some(property.as_ref()))
+        {
           return None;
         }
         let span = member.span();
-        if property.as_ref().is_none_or(|property| {
-          let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
-          Self::known_property_from_name(&name).is_none()
-        }) {
-          let members = property
-            .map(|property| vec![property.to_string()])
-            .unwrap_or_default();
-          self.warn_import_meta_unknown_property(parser, &members, span);
+        let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
+        if Self::known_property_from_name(&name).is_none() {
+          self.warn_import_meta_unknown_property(parser, &[property.to_string()], span);
         }
         return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -299,6 +299,14 @@ pub struct ImportMetaPlugin(pub(crate) ArcComputed<ResolvedModuleOptions, Import
 
 impl ImportMetaPlugin {
   fn known_property_from_name(name: &str) -> Option<ImportMetaKnownProperties> {
+    match name {
+      expr_name::IMPORT_META_HOT => return Some(ImportMetaKnownProperties::WEBPACK_HOT),
+      expr_name::IMPORT_META_CONTEXT => {
+        return Some(ImportMetaKnownProperties::WEBPACK_CONTEXT);
+      }
+      expr_name::IMPORT_META_GLOB => return Some(ImportMetaKnownProperties::GLOB),
+      _ => {}
+    }
     if let Some(property) = ImportMetaBuiltinProperty::from_name(name) {
       return Some(property.property);
     }
@@ -605,25 +613,42 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
           return None;
         }
         let span = member.span();
-        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
+        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
+        let name = concat_string!(expr_name::IMPORT_META, ".", ident.sym);
+        if Self::known_property_from_name(&name).is_none() {
+          // Ensure the original expression is walked so the replacement emits its warning.
+          evaluated.set_side_effects(true);
+        }
+        return Some(evaluated);
       }
       if let Some(computed) = member.prop.as_computed()
         && computed.expr.is_lit()
       {
         // Check for computed properties like import.meta["dirname"]
-        if let Some(str_lit) = computed.expr.as_lit().and_then(|lit| lit.as_str())
-          && str_lit.value.as_str().is_some_and(|value| {
-            ImportMetaBuiltinProperty::from_property(value)
-              .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
-              || import_meta_runtime_api_from_property(value)
-                .is_some_and(|api| self.runtime_api_enabled(api))
-              || self.preserve_property(Some(value))
-          })
-        {
+        let property = computed
+          .expr
+          .as_lit()
+          .and_then(|lit| lit.as_str())
+          .and_then(|str_lit| str_lit.value.as_str());
+        if property.is_some_and(|value| {
+          ImportMetaBuiltinProperty::from_property(value)
+            .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
+            || import_meta_runtime_api_from_property(value)
+              .is_some_and(|api| self.runtime_api_enabled(api))
+            || self.preserve_property(Some(value))
+        }) {
           return None;
         }
         let span = member.span();
-        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
+        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
+        if property.is_none_or(|property| {
+          let name = concat_string!(expr_name::IMPORT_META, ".", property);
+          Self::known_property_from_name(&name).is_none()
+        }) {
+          // Ensure the original expression is walked so the replacement emits its warning.
+          evaluated.set_side_effects(true);
+        }
+        return Some(evaluated);
       }
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -356,7 +356,7 @@ impl ImportMetaPlugin {
     )
   }
 
-  fn import_meta_unknown_property(&self, members: &Vec<String>) -> String {
+  fn import_meta_unknown_property(&self, members: &[String]) -> String {
     if self.preserve_property(members.first().map(|property| property.as_str())) {
       concat_string!("import.meta", property_access(members, 0))
     } else {
@@ -367,6 +367,41 @@ impl ImportMetaPlugin {
         property_access(members, 1)
       )
     }
+  }
+
+  fn warn_import_meta_unknown_property(
+    &self,
+    parser: &mut JavascriptParser,
+    members: &[String],
+    span: Span,
+  ) {
+    if !matches!(self.0.as_ref(), ImportMeta::Enabled)
+      || members.first().is_some_and(|property| {
+        let name = concat_string!(expr_name::IMPORT_META, ".", property);
+        Self::known_property_from_name(&name).is_some()
+      })
+    {
+      return;
+    }
+
+    let property = if members.is_empty() {
+      "an unknown property of import.meta".to_string()
+    } else {
+      concat_string!("import.meta.", members.join("."))
+    };
+    let mut error = create_traceable_error(
+      "Critical dependency".into(),
+      concat_string!(
+        "Accessing ",
+        property,
+        " is unsupported and will be replaced with undefined"
+      )
+      .into(),
+      parser.source.to_string(),
+      span.into(),
+    );
+    error.severity = Severity::Warning;
+    parser.add_warning(error.into());
   }
 
   fn process_import_meta_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr) {
@@ -674,10 +709,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
             }
           } else {
+            let members = vec![prop.id.to_string()];
+            self.warn_import_meta_unknown_property(parser, &members, span);
             content.push('[');
             content.push_str(&rspack_util::json_stringify_str(&prop.id));
             content.push_str("]: ");
-            content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
+            content.push_str(&self.import_meta_unknown_property(&members));
           }
         }
         content.push_str("})");
@@ -867,6 +904,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             if self.preserve_property(members.members.first().map(|property| property.as_str())) {
               return Some(true);
             }
+            let unknown_members = members
+              .members
+              .iter()
+              .map(|member| member.to_string())
+              .collect_vec();
+            self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
             if members.members.get(1).is_some()
               && members
                 .members_optionals
@@ -877,14 +920,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             } else {
               ConstDependency::new(
                 expr.span().into(),
-                self
-                  .import_meta_unknown_property(
-                    &members.members.iter().map(|x| x.to_string()).collect_vec(),
-                  )
-                  .into(),
+                self.import_meta_unknown_property(&unknown_members).into(),
               )
             }
           } else {
+            self.warn_import_meta_unknown_property(parser, &[], expr.span());
             ConstDependency::new(expr.span().into(), "undefined".into())
           };
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -34,6 +34,7 @@ use crate::{
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
     RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
+    member_literal_to_atom,
   },
 };
 
@@ -291,14 +292,6 @@ pub struct ImportMetaPlugin(pub(crate) ArcComputed<ResolvedModuleOptions, Import
 
 impl ImportMetaPlugin {
   fn known_property_from_name(name: &str) -> Option<ImportMetaKnownProperties> {
-    match name {
-      expr_name::IMPORT_META_HOT => return Some(ImportMetaKnownProperties::WEBPACK_HOT),
-      expr_name::IMPORT_META_CONTEXT => {
-        return Some(ImportMetaKnownProperties::WEBPACK_CONTEXT);
-      }
-      expr_name::IMPORT_META_GLOB => return Some(ImportMetaKnownProperties::GLOB),
-      _ => {}
-    }
     if let Some(property) = ImportMetaBuiltinProperty::from_name(name) {
       return Some(property.property);
     }
@@ -378,14 +371,17 @@ impl ImportMetaPlugin {
     if !matches!(self.0.as_ref(), ImportMeta::Enabled)
       || members.first().is_some_and(|property| {
         let name = concat_string!(expr_name::IMPORT_META, ".", property);
-        Self::known_property_from_name(&name).is_some()
+        matches!(
+          name.as_str(),
+          expr_name::IMPORT_META_HOT | expr_name::IMPORT_META_CONTEXT | expr_name::IMPORT_META_GLOB
+        ) || Self::known_property_from_name(&name).is_some()
       })
     {
       return;
     }
 
     let message = if members.is_empty() {
-      "Unknown `import.meta` property replaced with undefined.".to_string()
+      "Dynamic `import.meta` property access may return undefined.".to_string()
     } else {
       concat_string!(
         "Unknown `import.meta` property `",
@@ -402,7 +398,7 @@ impl ImportMetaPlugin {
       len: range.end.saturating_sub(range.start) as usize,
     }]);
     error.hide_stack = Some(true);
-    parser.add_warning(error.into());
+    parser.add_warning_once(error.into());
   }
 
   fn process_import_meta_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr) {
@@ -522,7 +518,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     for_name: &str,
   ) -> Option<eval::BasicEvaluatedExpression<'a>> {
     let mut evaluated = None;
-    let mut has_unknown_property = false;
     if for_name == expr_name::IMPORT_META {
       evaluated = Some("object".to_string());
     } else if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name)
@@ -559,16 +554,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         .unwrap_or(false)
     {
       evaluated = Some("undefined".to_string());
-      has_unknown_property = Self::known_property_from_name(for_name).is_none();
-    }
-    evaluated.map(|e| {
-      let mut evaluated = eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi());
-      if has_unknown_property {
-        // Ensure the original expression is walked so the replacement emits its warning.
-        evaluated.set_side_effects(true);
+      if Self::known_property_from_name(for_name).is_none() {
+        let members = for_name
+          .strip_prefix(expr_name::IMPORT_META_PREFIX)
+          .map(|property| vec![property.to_string()])
+          .unwrap_or_default();
+        self.warn_import_meta_unknown_property(parser, &members, member_expr.span());
       }
-      evaluated
-    })
+    }
+    evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
   }
 
   fn evaluate_identifier(
@@ -605,42 +599,37 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
           return None;
         }
         let span = member.span();
-        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
         let name = concat_string!(expr_name::IMPORT_META, ".", ident.sym);
         if Self::known_property_from_name(&name).is_none() {
-          // Ensure the original expression is walked so the replacement emits its warning.
-          evaluated.set_side_effects(true);
+          self.warn_import_meta_unknown_property(parser, &[ident.sym.to_string()], span);
         }
-        return Some(evaluated);
+        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
       if let Some(computed) = member.prop.as_computed()
         && computed.expr.is_lit()
       {
         // Check for computed properties like import.meta["dirname"]
-        let property = computed
-          .expr
-          .as_lit()
-          .and_then(|lit| lit.as_str())
-          .and_then(|str_lit| str_lit.value.as_str());
-        if property.is_some_and(|value| {
-          ImportMetaBuiltinProperty::from_property(value)
+        let property = computed.expr.as_lit().map(member_literal_to_atom);
+        if property.as_ref().is_some_and(|value| {
+          ImportMetaBuiltinProperty::from_property(value.as_ref())
             .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
-            || import_meta_runtime_api_from_property(value)
+            || import_meta_runtime_api_from_property(value.as_ref())
               .is_some_and(|api| self.runtime_api_enabled(api))
-            || self.preserve_property(Some(value))
+            || self.preserve_property(Some(value.as_ref()))
         }) {
           return None;
         }
         let span = member.span();
-        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
-        if property.is_none_or(|property| {
-          let name = concat_string!(expr_name::IMPORT_META, ".", property);
+        if property.as_ref().is_none_or(|property| {
+          let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
           Self::known_property_from_name(&name).is_none()
         }) {
-          // Ensure the original expression is walked so the replacement emits its warning.
-          evaluated.set_side_effects(true);
+          let members = property
+            .map(|property| vec![property.to_string()])
+            .unwrap_or_default();
+          self.warn_import_meta_unknown_property(parser, &members, span);
         }
-        return Some(evaluated);
+        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
     }
     None
@@ -876,32 +865,38 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               _ => None,
             });
 
-          let dep = if let Some(members) = members {
-            if self.preserve_property(members.members.first().map(|property| property.as_str())) {
+          let Some(members) = members else {
+            if self.preserve_property(None) {
               return Some(true);
             }
-            let unknown_members = members
-              .members
-              .iter()
-              .map(|member| member.to_string())
-              .collect_vec();
-            self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
-            if members.members.get(1).is_some()
-              && members
-                .members_optionals
-                .get(1)
-                .is_some_and(|optional| *optional)
-            {
-              ConstDependency::new(expr.span().into(), "undefined".into())
-            } else {
-              ConstDependency::new(
-                expr.span().into(),
-                self.import_meta_unknown_property(&unknown_members).into(),
-              )
-            }
-          } else {
             self.warn_import_meta_unknown_property(parser, &[], expr.span());
+            parser.add_presentational_dependency(Box::new(ConstDependency::new(
+              expr.obj.span().into(),
+              "({})".into(),
+            )));
+            return Some(true);
+          };
+          if self.preserve_property(members.members.first().map(|property| property.as_str())) {
+            return Some(true);
+          }
+          let unknown_members = members
+            .members
+            .iter()
+            .map(|member| member.to_string())
+            .collect_vec();
+          self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
+          let dep = if members.members.get(1).is_some()
+            && members
+              .members_optionals
+              .get(1)
+              .is_some_and(|optional| *optional)
+          {
             ConstDependency::new(expr.span().into(), "undefined".into())
+          } else {
+            ConstDependency::new(
+              expr.span().into(),
+              self.import_meta_unknown_property(&unknown_members).into(),
+            )
           };
 
           parser.add_presentational_dependency(Box::new(dep));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   DependencyRange, ImportMeta, ImportMetaKnownProperties, ResolvedModuleOptions, RscMeta,
   RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access,
 };
-use rspack_error::{Error, Severity};
+use rspack_error::{Error, Label, Severity};
 use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
@@ -377,22 +377,23 @@ impl ImportMetaPlugin {
     }
 
     let property = if members.is_empty() {
-      "an unknown property of import.meta".to_string()
+      "<computed>".to_string()
     } else {
-      concat_string!("import.meta.", members.join("."))
+      members.join(".")
     };
-    let mut error = create_traceable_error(
-      "Critical dependency".into(),
-      concat_string!(
-        "Accessing ",
-        property,
-        " is unsupported and will be replaced with undefined"
-      )
-      .into(),
-      parser.source.to_string(),
-      span.into(),
-    );
-    error.severity = Severity::Warning;
+    let range: DependencyRange = span.into();
+    let mut error = Error::warning(concat_string!(
+      "Unknown `import.meta` property `",
+      property,
+      "` replaced with undefined."
+    ));
+    error.src = Some(parser.source.to_string());
+    error.labels = Some(vec![Label {
+      name: None,
+      offset: range.start as usize,
+      len: range.end.saturating_sub(range.start) as usize,
+    }]);
+    error.hide_stack = Some(true);
     parser.add_warning(error.into());
   }
 
@@ -687,7 +688,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push('[');
               content.push_str(&rspack_util::json_stringify_str(&prop.id));
               content.push_str("]: ");
-              content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
+              content.push_str(&self.import_meta_unknown_property(&[prop.id.to_string()]));
             }
           } else if let Some(api) = import_meta_runtime_api_from_property(prop.id.as_ref()) {
             if self.runtime_api_enabled(api)
@@ -698,7 +699,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push('[');
               content.push_str(&rspack_util::json_stringify_str(&prop.id));
               content.push_str("]: ");
-              content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
+              content.push_str(&self.import_meta_unknown_property(&[prop.id.to_string()]));
             }
           } else {
             let members = vec![prop.id.to_string()];

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -348,7 +348,7 @@ impl ImportMetaPlugin {
     )
   }
 
-  fn import_meta_unknown_property(&self, members: &Vec<String>) -> String {
+  fn import_meta_unknown_property(&self, members: &[String]) -> String {
     if self.preserve_property(members.first().map(|property| property.as_str())) {
       concat_string!("import.meta", property_access(members, 0))
     } else {
@@ -359,6 +359,41 @@ impl ImportMetaPlugin {
         property_access(members, 1)
       )
     }
+  }
+
+  fn warn_import_meta_unknown_property(
+    &self,
+    parser: &mut JavascriptParser,
+    members: &[String],
+    span: Span,
+  ) {
+    if !matches!(self.0.as_ref(), ImportMeta::Enabled)
+      || members.first().is_some_and(|property| {
+        let name = concat_string!(expr_name::IMPORT_META, ".", property);
+        Self::known_property_from_name(&name).is_some()
+      })
+    {
+      return;
+    }
+
+    let property = if members.is_empty() {
+      "an unknown property of import.meta".to_string()
+    } else {
+      concat_string!("import.meta.", members.join("."))
+    };
+    let mut error = create_traceable_error(
+      "Critical dependency".into(),
+      concat_string!(
+        "Accessing ",
+        property,
+        " is unsupported and will be replaced with undefined"
+      )
+      .into(),
+      parser.source.to_string(),
+      span.into(),
+    );
+    error.severity = Severity::Warning;
+    parser.add_warning(error.into());
   }
 
   fn process_import_meta_resolve(&self, parser: &mut JavascriptParser, call_expr: &CallExpr) {
@@ -666,10 +701,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
               content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
             }
           } else {
+            let members = vec![prop.id.to_string()];
+            self.warn_import_meta_unknown_property(parser, &members, span);
             content.push('[');
             content.push_str(&rspack_util::json_stringify_str(&prop.id));
             content.push_str("]: ");
-            content.push_str(&self.import_meta_unknown_property(&vec![prop.id.to_string()]));
+            content.push_str(&self.import_meta_unknown_property(&members));
           }
         }
         content.push_str("})");
@@ -808,6 +845,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             if self.preserve_property(members.members.first().map(|property| property.as_str())) {
               return Some(true);
             }
+            let unknown_members = members
+              .members
+              .iter()
+              .map(|member| member.to_string())
+              .collect_vec();
+            self.warn_import_meta_unknown_property(parser, &unknown_members, expr.span());
             if members.members.get(1).is_some()
               && members
                 .members_optionals
@@ -818,14 +861,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
             } else {
               ConstDependency::new(
                 expr.span().into(),
-                self
-                  .import_meta_unknown_property(
-                    &members.members.iter().map(|x| x.to_string()).collect_vec(),
-                  )
-                  .into(),
+                self.import_meta_unknown_property(&unknown_members).into(),
               )
             }
           } else {
+            self.warn_import_meta_unknown_property(parser, &[], expr.span());
             ConstDependency::new(expr.span().into(), "undefined".into())
           };
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -376,17 +376,17 @@ impl ImportMetaPlugin {
       return;
     }
 
-    let property = if members.is_empty() {
-      "<computed>".to_string()
+    let message = if members.is_empty() {
+      "Unknown `import.meta` property replaced with undefined.".to_string()
     } else {
-      members.join(".")
+      concat_string!(
+        "Unknown `import.meta` property `",
+        members.join("."),
+        "` replaced with undefined."
+      )
     };
     let range: DependencyRange = span.into();
-    let mut error = Error::warning(concat_string!(
-      "Unknown `import.meta` property `",
-      property,
-      "` replaced with undefined."
-    ));
+    let mut error = Error::warning(message);
     error.src = Some(parser.source.to_string());
     error.labels = Some(vec![Label {
       name: None,
@@ -514,6 +514,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
     for_name: &str,
   ) -> Option<eval::BasicEvaluatedExpression<'a>> {
     let mut evaluated = None;
+    let mut has_unknown_property = false;
     if for_name == expr_name::IMPORT_META {
       evaluated = Some("object".to_string());
     } else if let Some(property) = ImportMetaBuiltinProperty::from_name(for_name)
@@ -549,9 +550,17 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         })
         .unwrap_or(false)
     {
-      evaluated = Some("undefined".to_string())
+      evaluated = Some("undefined".to_string());
+      has_unknown_property = Self::known_property_from_name(for_name).is_none();
     }
-    evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
+    evaluated.map(|e| {
+      let mut evaluated = eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi());
+      if has_unknown_property {
+        // Ensure the original expression is walked so the replacement emits its warning.
+        evaluated.set_side_effects(true);
+      }
+      evaluated
+    })
   }
 
   fn evaluate_identifier(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use rspack_core::{
   ArcComputed, ConstDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
   DependencyRange, ImportMeta, ImportMetaKnownProperties, ResolvedModuleOptions, RscMeta,
-  RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access,
+  RscModuleType, RuntimeGlobals, RuntimeRequirementsDependency, property_access, to_normal_comment,
 };
 use rspack_error::{Error, Label, Severity};
 use rspack_util::SpanExt;
@@ -34,7 +34,7 @@ use crate::{
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
     RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
-    member_literal_to_atom,
+    member_property_to_atom,
   },
 };
 
@@ -353,12 +353,11 @@ impl ImportMetaPlugin {
     if self.preserve_property(members.first().map(|property| property.as_str())) {
       concat_string!("import.meta", property_access(members, 0))
     } else {
-      concat_string!(
-        "/* unsupported import.meta.",
-        members.join("."),
-        " */ undefined",
-        property_access(members, 1)
-      )
+      let comment = to_normal_comment(&concat_string!(
+        "unsupported import.meta.",
+        members.join(".")
+      ));
+      concat_string!(comment, " undefined", property_access(members, 1))
     }
   }
 
@@ -383,13 +382,29 @@ impl ImportMetaPlugin {
     let message = if members.is_empty() {
       "Dynamic `import.meta` property access may return undefined.".to_string()
     } else {
+      let property = members
+        .iter()
+        .map(|member| {
+          let mut escaped = String::with_capacity(member.len());
+          for ch in member.chars() {
+            if ch == '`' {
+              escaped.push_str("\\`");
+            } else {
+              escaped.extend(ch.escape_debug());
+            }
+          }
+          escaped
+        })
+        .join(".");
       concat_string!(
         "Unknown `import.meta` property `",
-        members.join("."),
+        property,
         "` replaced with undefined."
       )
     };
-    let range: DependencyRange = span.into();
+    let range = parser
+      .evaluated_source_range
+      .unwrap_or_else(|| DependencyRange::from(span));
     let mut error = Error::warning(message);
     error.src = Some(parser.source.to_string());
     error.labels = Some(vec![Label {
@@ -533,33 +548,16 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
       && meta_expr
         .get_root_name()
         .is_some_and(|name| name == expr_name::IMPORT_META)
-      && (match &member_expr.prop {
-        MemberProp::Ident(_) => true,
-        MemberProp::Computed(computed) => computed.expr.is_lit(),
-        _ => false,
+      && let Some(property) = (match &member_expr.prop {
+        MemberProp::Ident(ident) => Some(Atom::from(ident.sym.as_str())),
+        MemberProp::Computed(computed) => member_property_to_atom(&computed.expr),
+        _ => None,
       })
-      && member_expr
-        .prop
-        .as_ident()
-        .map(|ident| !self.preserve_property(Some(ident.sym.as_ref())))
-        .or_else(|| {
-          member_expr
-            .prop
-            .as_computed()
-            .and_then(|computed| computed.expr.as_lit())
-            .and_then(|lit| lit.as_str())
-            .and_then(|str_lit| str_lit.value.as_str())
-            .map(|value| !self.preserve_property(Some(value)))
-        })
-        .unwrap_or(false)
+      && !self.preserve_property(Some(property.as_ref()))
     {
       evaluated = Some("undefined".to_string());
       if Self::known_property_from_name(for_name).is_none() {
-        let members = for_name
-          .strip_prefix(expr_name::IMPORT_META_PREFIX)
-          .map(|property| vec![property.to_string()])
-          .unwrap_or_default();
-        self.warn_import_meta_unknown_property(parser, &members, member_expr.span());
+        self.warn_import_meta_unknown_property(parser, &[property.to_string()], member_expr.span());
       }
     }
     evaluated.map(|e| eval::evaluate_to_string(e, expr.span.real_lo(), expr.span.real_hi()))
@@ -606,28 +604,21 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
         return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }
       if let Some(computed) = member.prop.as_computed()
-        && computed.expr.is_lit()
+        && let Some(property) = member_property_to_atom(&computed.expr)
       {
-        // Check for computed properties like import.meta["dirname"]
-        let property = computed.expr.as_lit().map(member_literal_to_atom);
-        if property.as_ref().is_some_and(|value| {
-          ImportMetaBuiltinProperty::from_property(value.as_ref())
-            .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
-            || import_meta_runtime_api_from_property(value.as_ref())
-              .is_some_and(|api| self.runtime_api_enabled(api))
-            || self.preserve_property(Some(value.as_ref()))
-        }) {
+        // Check for computed properties like import.meta["dirname"] and import.meta[`dirname`]
+        if ImportMetaBuiltinProperty::from_property(property.as_ref())
+          .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
+          || import_meta_runtime_api_from_property(property.as_ref())
+            .is_some_and(|api| self.runtime_api_enabled(api))
+          || self.preserve_property(Some(property.as_ref()))
+        {
           return None;
         }
         let span = member.span();
-        if property.as_ref().is_none_or(|property| {
-          let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
-          Self::known_property_from_name(&name).is_none()
-        }) {
-          let members = property
-            .map(|property| vec![property.to_string()])
-            .unwrap_or_default();
-          self.warn_import_meta_unknown_property(parser, &members, span);
+        let name = concat_string!(expr_name::IMPORT_META, ".", property.as_ref());
+        if Self::known_property_from_name(&name).is_none() {
+          self.warn_import_meta_unknown_property(parser, &[property.to_string()], span);
         }
         return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -291,6 +291,14 @@ pub struct ImportMetaPlugin(pub(crate) ArcComputed<ResolvedModuleOptions, Import
 
 impl ImportMetaPlugin {
   fn known_property_from_name(name: &str) -> Option<ImportMetaKnownProperties> {
+    match name {
+      expr_name::IMPORT_META_HOT => return Some(ImportMetaKnownProperties::WEBPACK_HOT),
+      expr_name::IMPORT_META_CONTEXT => {
+        return Some(ImportMetaKnownProperties::WEBPACK_CONTEXT);
+      }
+      expr_name::IMPORT_META_GLOB => return Some(ImportMetaKnownProperties::GLOB),
+      _ => {}
+    }
     if let Some(property) = ImportMetaBuiltinProperty::from_name(name) {
       return Some(property.property);
     }
@@ -597,25 +605,42 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
           return None;
         }
         let span = member.span();
-        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
+        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
+        let name = concat_string!(expr_name::IMPORT_META, ".", ident.sym);
+        if Self::known_property_from_name(&name).is_none() {
+          // Ensure the original expression is walked so the replacement emits its warning.
+          evaluated.set_side_effects(true);
+        }
+        return Some(evaluated);
       }
       if let Some(computed) = member.prop.as_computed()
         && computed.expr.is_lit()
       {
         // Check for computed properties like import.meta["dirname"]
-        if let Some(str_lit) = computed.expr.as_lit().and_then(|lit| lit.as_str())
-          && str_lit.value.as_str().is_some_and(|value| {
-            ImportMetaBuiltinProperty::from_property(value)
-              .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
-              || import_meta_runtime_api_from_property(value)
-                .is_some_and(|api| self.runtime_api_enabled(api))
-              || self.preserve_property(Some(value))
-          })
-        {
+        let property = computed
+          .expr
+          .as_lit()
+          .and_then(|lit| lit.as_str())
+          .and_then(|str_lit| str_lit.value.as_str());
+        if property.is_some_and(|value| {
+          ImportMetaBuiltinProperty::from_property(value)
+            .is_some_and(|property| property.skip_undefined_evaluation(self, parser))
+            || import_meta_runtime_api_from_property(value)
+              .is_some_and(|api| self.runtime_api_enabled(api))
+            || self.preserve_property(Some(value))
+        }) {
           return None;
         }
         let span = member.span();
-        return Some(eval::evaluate_to_undefined(span.real_lo(), span.real_hi()));
+        let mut evaluated = eval::evaluate_to_undefined(span.real_lo(), span.real_hi());
+        if property.is_none_or(|property| {
+          let name = concat_string!(expr_name::IMPORT_META, ".", property);
+          Self::known_property_from_name(&name).is_none()
+        }) {
+          // Ensure the original expression is walked so the replacement emits its warning.
+          evaluated.set_side_effects(true);
+        }
+        return Some(evaluated);
       }
     }
     None

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -13,7 +13,7 @@ use swc_experimental_allocator::Allocator;
 use swc_experimental_ecma_ast::{Comments, Program};
 use swc_experimental_ecma_semantic::resolver::Semantic;
 
-pub(crate) use self::parser::{StatementPath, member_literal_to_atom};
+pub(crate) use self::parser::{StatementPath, member_property_to_atom};
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
   parser::{

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -13,7 +13,7 @@ use swc_experimental_allocator::Allocator;
 use swc_experimental_ecma_ast::{Comments, Program};
 use swc_experimental_ecma_semantic::resolver::Semantic;
 
-pub(crate) use self::parser::StatementPath;
+pub(crate) use self::parser::{StatementPath, member_literal_to_atom};
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
   parser::{

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -13,7 +13,7 @@ use swc_experimental_allocator::Allocator;
 use swc_experimental_ecma_ast::{Comments, Program};
 use swc_experimental_ecma_semantic::resolver::Semantic;
 
-pub(crate) use self::parser::member_literal_to_atom;
+pub(crate) use self::parser::member_property_to_atom;
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
   parser::{

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -13,6 +13,7 @@ use swc_experimental_allocator::Allocator;
 use swc_experimental_ecma_ast::{Comments, Program};
 use swc_experimental_ecma_semantic::resolver::Semantic;
 
+pub(crate) use self::parser::member_literal_to_atom;
 pub use self::{
   context_dependency_helper::{ContextModuleScanResult, create_context_dependency},
   parser::{

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -72,6 +72,17 @@ fn atom_from_wtf8(value: swc_experimental_allocator::atom::Wtf8Atom<'_>) -> Atom
   Atom::from(value.as_wtf8().to_string_lossy().as_ref())
 }
 
+pub(crate) fn member_literal_to_atom(lit: &Lit) -> Atom {
+  match lit {
+    Lit::Str(s) => atom_from_wtf8(s.value),
+    Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
+    Lit::Null(_) => Atom::from("null"),
+    Lit::Num(n) => Atom::from(n.value.to_string().as_str()),
+    Lit::BigInt(i) => Atom::from(i.value.as_str()),
+    Lit::Regex(r) => Atom::from(r.exp.as_str()),
+  }
+}
+
 impl GetSpan for estree::Statement<'_> {
   fn span(&self) -> Span {
     self.span()
@@ -754,6 +765,27 @@ impl<'parser> JavascriptParser<'parser> {
     self.warning_diagnostics.push(warning);
   }
 
+  pub fn add_warning_once(&mut self, warning: Diagnostic) {
+    let is_duplicate = self.warning_diagnostics.iter().any(|existing| {
+      existing.message == warning.message
+        && match (&existing.labels, &warning.labels) {
+          (Some(existing), Some(incoming)) => {
+            existing.len() == incoming.len()
+              && existing.iter().zip(incoming).all(|(existing, incoming)| {
+                existing.name == incoming.name
+                  && existing.offset == incoming.offset
+                  && existing.len == incoming.len
+              })
+          }
+          (None, None) => true,
+          _ => false,
+        }
+    });
+    if !is_duplicate {
+      self.warning_diagnostics.push(warning);
+    }
+  }
+
   pub fn add_warnings(&mut self, warnings: impl IntoIterator<Item = Diagnostic>) {
     self.warning_diagnostics.extend(warnings);
   }
@@ -1190,14 +1222,7 @@ impl<'parser> JavascriptParser<'parser> {
             let Expr::Lit(lit) = &computed.expr else {
               break;
             };
-            let value = match &**lit {
-              Lit::Str(s) => atom_from_wtf8(s.value),
-              Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
-              Lit::Null(_) => Atom::from("null"),
-              Lit::Num(n) => Atom::from(n.value.to_string().as_str()),
-              Lit::BigInt(i) => Atom::from(i.value.as_str()),
-              Lit::Regex(r) => Atom::from(r.exp.as_str()),
-            };
+            let value = member_literal_to_atom(lit);
             // Since members are not used across rspack javascript parser plugin,
             // we directly makes it atom here
             members.push(value);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -72,14 +72,34 @@ fn atom_from_wtf8(value: swc_experimental_allocator::atom::Wtf8Atom<'_>) -> Atom
   Atom::from(value.as_wtf8().to_string_lossy().as_ref())
 }
 
-pub(crate) fn member_literal_to_atom(lit: &Lit) -> Atom {
-  match lit {
-    Lit::Str(s) => atom_from_wtf8(s.value),
-    Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
-    Lit::Null(_) => Atom::from("null"),
-    Lit::Num(n) => Atom::from(n.value.to_string().as_str()),
-    Lit::BigInt(i) => Atom::from(i.value.as_str()),
-    Lit::Regex(r) => Atom::from(r.exp.as_str()),
+pub(crate) fn member_property_to_atom(expr: &Expr) -> Option<Atom> {
+  match expr {
+    Expr::Lit(lit) => Some(match &**lit {
+      Lit::Str(s) => atom_from_wtf8(s.value),
+      Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
+      Lit::Null(_) => Atom::from("null"),
+      Lit::Num(n) => Atom::from(rspack_util::ryu_js::Buffer::new().format(n.value)),
+      Lit::BigInt(i) => Atom::from(i.value.as_str()),
+      Lit::Regex(r) => {
+        let mut flags = r.flags.as_str().chars().collect::<Vec<_>>();
+        flags.sort_unstable();
+        let mut property = String::with_capacity(r.exp.len() + flags.len() + 2);
+        property.push('/');
+        property.push_str(r.exp.as_str());
+        property.push('/');
+        property.extend(flags);
+        Atom::from(property)
+      }
+    }),
+    Expr::Tpl(tpl) if tpl.exprs.is_empty() && tpl.quasis.len() == 1 => {
+      let quasi = tpl.quasis.first()?;
+      Some(
+        quasi
+          .cooked
+          .map_or_else(|| Atom::from(quasi.raw.as_str()), atom_from_wtf8),
+      )
+    }
+    _ => None,
   }
 }
 
@@ -421,6 +441,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) in_short_hand: bool,
   pub(crate) in_tagged_template_tag: bool,
   pub(crate) member_expr_in_optional_chain: bool,
+  pub(crate) evaluated_source_range: Option<DependencyRange>,
   pub(crate) semicolons: &'parser mut FxHashSet<u32>,
   pub(crate) statement_path: Vec<StatementPath>,
   pub(crate) prev_statement: Option<StatementPath>,
@@ -608,6 +629,7 @@ impl<'parser> JavascriptParser<'parser> {
       worker_index: 0,
       module_identifier,
       member_expr_in_optional_chain: false,
+      evaluated_source_range: None,
       destructuring_assignment_properties: Default::default(),
       dynamic_import_references: Default::default(),
       common_js_require_references: Default::default(),
@@ -1219,10 +1241,9 @@ impl<'parser> JavascriptParser<'parser> {
       match object {
         ExprRef::Member(expr) => {
           if let Some(computed) = expr.prop.as_computed() {
-            let Expr::Lit(lit) = &computed.expr else {
+            let Some(value) = member_property_to_atom(&computed.expr) else {
               break;
             };
-            let value = member_literal_to_atom(lit);
             // Since members are not used across rspack javascript parser plugin,
             // we directly makes it atom here
             members.push(value);
@@ -1527,6 +1548,20 @@ impl<'parser> JavascriptParser<'parser> {
     error_title: T,
   ) -> Option<BasicEvaluatedExpression<'parser>> {
     eval::eval_source(self, source, error_title.to_string())
+  }
+
+  pub fn evaluate_with_range<T: Display>(
+    &mut self,
+    source: String,
+    error_title: T,
+    start: u32,
+    end: u32,
+  ) -> Option<BasicEvaluatedExpression<'parser>> {
+    let previous_range = self.evaluated_source_range;
+    self.evaluated_source_range = previous_range.or(Some(DependencyRange::new(start, end)));
+    let evaluated = eval::eval_source(self, source, error_title.to_string());
+    self.evaluated_source_range = previous_range;
+    evaluated
   }
 
   // same as `JavascriptParser._initializeEvaluating` in webpack

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -71,14 +71,34 @@ fn atom_from_wtf8(value: swc_experimental_allocator::atom::Wtf8Atom<'_>) -> Atom
   Atom::from(value.as_wtf8().to_string_lossy().as_ref())
 }
 
-pub(crate) fn member_literal_to_atom(lit: &Lit) -> Atom {
-  match lit {
-    Lit::Str(s) => atom_from_wtf8(s.value),
-    Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
-    Lit::Null(_) => Atom::from("null"),
-    Lit::Num(n) => Atom::from(n.value.to_string().as_str()),
-    Lit::BigInt(i) => Atom::from(i.value.as_str()),
-    Lit::Regex(r) => Atom::from(r.exp.as_str()),
+pub(crate) fn member_property_to_atom(expr: &Expr) -> Option<Atom> {
+  match expr {
+    Expr::Lit(lit) => Some(match &**lit {
+      Lit::Str(s) => atom_from_wtf8(s.value),
+      Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
+      Lit::Null(_) => Atom::from("null"),
+      Lit::Num(n) => Atom::from(rspack_util::ryu_js::Buffer::new().format(n.value)),
+      Lit::BigInt(i) => Atom::from(i.value.as_str()),
+      Lit::Regex(r) => {
+        let mut flags = r.flags.as_str().chars().collect::<Vec<_>>();
+        flags.sort_unstable();
+        let mut property = String::with_capacity(r.exp.len() + flags.len() + 2);
+        property.push('/');
+        property.push_str(r.exp.as_str());
+        property.push('/');
+        property.extend(flags);
+        Atom::from(property)
+      }
+    }),
+    Expr::Tpl(tpl) if tpl.exprs.is_empty() && tpl.quasis.len() == 1 => {
+      let quasi = tpl.quasis.first()?;
+      Some(
+        quasi
+          .cooked
+          .map_or_else(|| Atom::from(quasi.raw.as_str()), atom_from_wtf8),
+      )
+    }
+    _ => None,
   }
 }
 
@@ -420,6 +440,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) in_short_hand: bool,
   pub(crate) in_tagged_template_tag: bool,
   pub(crate) member_expr_in_optional_chain: bool,
+  pub(crate) evaluated_source_range: Option<DependencyRange>,
   pub(crate) semicolons: &'parser mut FxHashSet<u32>,
   pub(crate) statement_path: Vec<StatementPath>,
   pub(crate) prev_statement: Option<StatementPath>,
@@ -606,6 +627,7 @@ impl<'parser> JavascriptParser<'parser> {
       worker_index: 0,
       module_identifier,
       member_expr_in_optional_chain: false,
+      evaluated_source_range: None,
       destructuring_assignment_properties: Default::default(),
       dynamic_import_references: Default::default(),
       common_js_require_references: Default::default(),
@@ -1210,10 +1232,9 @@ impl<'parser> JavascriptParser<'parser> {
       match object {
         ExprRef::Member(expr) => {
           if let Some(computed) = expr.prop.as_computed() {
-            let Expr::Lit(lit) = &computed.expr else {
+            let Some(value) = member_property_to_atom(&computed.expr) else {
               break;
             };
-            let value = member_literal_to_atom(lit);
             // Since members are not used across rspack javascript parser plugin,
             // we directly makes it atom here
             members.push(value);
@@ -1518,6 +1539,20 @@ impl<'parser> JavascriptParser<'parser> {
     error_title: T,
   ) -> Option<BasicEvaluatedExpression<'parser>> {
     eval::eval_source(self, source, error_title.to_string())
+  }
+
+  pub fn evaluate_with_range<T: Display>(
+    &mut self,
+    source: String,
+    error_title: T,
+    start: u32,
+    end: u32,
+  ) -> Option<BasicEvaluatedExpression<'parser>> {
+    let previous_range = self.evaluated_source_range;
+    self.evaluated_source_range = previous_range.or(Some(DependencyRange::new(start, end)));
+    let evaluated = eval::eval_source(self, source, error_title.to_string());
+    self.evaluated_source_range = previous_range;
+    evaluated
   }
 
   // same as `JavascriptParser._initializeEvaluating` in webpack

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -71,6 +71,17 @@ fn atom_from_wtf8(value: swc_experimental_allocator::atom::Wtf8Atom<'_>) -> Atom
   Atom::from(value.as_wtf8().to_string_lossy().as_ref())
 }
 
+pub(crate) fn member_literal_to_atom(lit: &Lit) -> Atom {
+  match lit {
+    Lit::Str(s) => atom_from_wtf8(s.value),
+    Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
+    Lit::Null(_) => Atom::from("null"),
+    Lit::Num(n) => Atom::from(n.value.to_string().as_str()),
+    Lit::BigInt(i) => Atom::from(i.value.as_str()),
+    Lit::Regex(r) => Atom::from(r.exp.as_str()),
+  }
+}
+
 impl GetSpan for estree::Statement<'_> {
   fn span(&self) -> Span {
     self.span()
@@ -751,6 +762,27 @@ impl<'parser> JavascriptParser<'parser> {
     self.warning_diagnostics.push(warning);
   }
 
+  pub fn add_warning_once(&mut self, warning: Diagnostic) {
+    let is_duplicate = self.warning_diagnostics.iter().any(|existing| {
+      existing.message == warning.message
+        && match (&existing.labels, &warning.labels) {
+          (Some(existing), Some(incoming)) => {
+            existing.len() == incoming.len()
+              && existing.iter().zip(incoming).all(|(existing, incoming)| {
+                existing.name == incoming.name
+                  && existing.offset == incoming.offset
+                  && existing.len == incoming.len
+              })
+          }
+          (None, None) => true,
+          _ => false,
+        }
+    });
+    if !is_duplicate {
+      self.warning_diagnostics.push(warning);
+    }
+  }
+
   pub fn add_warnings(&mut self, warnings: impl IntoIterator<Item = Diagnostic>) {
     self.warning_diagnostics.extend(warnings);
   }
@@ -1181,14 +1213,7 @@ impl<'parser> JavascriptParser<'parser> {
             let Expr::Lit(lit) = &computed.expr else {
               break;
             };
-            let value = match &**lit {
-              Lit::Str(s) => atom_from_wtf8(s.value),
-              Lit::Bool(b) => Atom::from(if b.value { "true" } else { "false" }),
-              Lit::Null(_) => Atom::from("null"),
-              Lit::Num(n) => Atom::from(n.value.to_string().as_str()),
-              Lit::BigInt(i) => Atom::from(i.value.as_str()),
-              Lit::Regex(r) => Atom::from(r.exp.as_str()),
-            };
+            let value = member_literal_to_atom(lit);
             // Since members are not used across rspack javascript parser plugin,
             // we directly makes it atom here
             members.push(value);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1224,6 +1224,21 @@ impl JavascriptParser<'_> {
       }
     }
 
+    if expr.obj.is_meta_prop()
+      && let Some(root_name) = expr.obj.get_root_name()
+    {
+      let root_info = ExportedVariableInfo::Name(root_name);
+      if drive
+        .unhandled_expression_member_chain(self, &root_info, expr)
+        .unwrap_or_default()
+      {
+        if let MemberProp::Computed(computed) = &expr.prop {
+          self.walk_expression(&computed.expr);
+        }
+        return;
+      }
+    }
+
     // (await import(...)).a.b
     if let Some((call, members, await_expr)) = self.extract_await_import_member(expr) {
       if self.is_top_level_scope() {

--- a/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/index.js
@@ -1,0 +1,1 @@
+export default import.meta.environment;

--- a/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/rspack.config.js
+++ b/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  output: {
+    module: false,
+  },
+  module: {
+    parser: {
+      javascript: {
+        importMeta: {
+          environment: false,
+        },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/test.config.js
+++ b/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	noTests: true
+};

--- a/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/warnings.js
+++ b/tests/rspack-test/configCases/module/import-meta-disabled-unknown-property/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
@@ -9,11 +9,19 @@ if (!import.meta.UNKNOWN_PROPERTY) {
 	import.meta.UNKNOWN_PROPERTY = "runtime";
 }
 
+let computedAccesses = 0;
+const getUnknownProperty = () => {
+	computedAccesses++;
+	return "UNKNOWN_PROPERTY";
+};
+
 const { UNKNOWN_PROPERTY, url, webpack } = import.meta;
 
 export default {
 	sourceUrl,
 	unknown: UNKNOWN_PROPERTY,
+	computedUnknown: import.meta[getUnknownProperty()],
+	computedAccesses,
 	unknownOptional: import.meta.UNKNOWN_PROPERTY?.length,
 	missingOptional: import.meta.MISSING_PROPERTY?.length,
 	url,

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/empty-options.js
@@ -21,6 +21,7 @@ export default {
 	sourceUrl,
 	unknown: UNKNOWN_PROPERTY,
 	computedUnknown: import.meta[getUnknownProperty()],
+	templateUnknown: import.meta[`UNKNOWN_PROPERTY`],
 	computedAccesses,
 	unknownOptional: import.meta.UNKNOWN_PROPERTY?.length,
 	missingOptional: import.meta.MISSING_PROPERTY?.length,

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -2,12 +2,26 @@ import disabledFields from "./disabled-fields";
 import emptyOptions from "./empty-options";
 const fs = require("fs");
 
+let preservedComputedAccesses = 0;
+const getPreservedProperty = () => {
+	preservedComputedAccesses++;
+	return "url";
+};
+const preservedComputedUrl = import.meta[getPreservedProperty()];
+
 it("should treat an empty importMeta object like preserve-unknown", () => {
 	expect(emptyOptions.url).toBe(emptyOptions.sourceUrl);
 	expect(emptyOptions.webpack).toBe(5);
 	expect(emptyOptions.unknown).toBe("runtime");
+	expect(emptyOptions.computedUnknown).toBe("runtime");
+	expect(emptyOptions.computedAccesses).toBe(1);
 	expect(emptyOptions.unknownOptional).toBe("runtime".length);
 	expect(emptyOptions.missingOptional).toBeUndefined();
+});
+
+it("should preserve computed import.meta properties for runtime evaluation", () => {
+	expect(preservedComputedUrl).toBeTypeOf("string");
+	expect(preservedComputedAccesses).toBe(1);
 });
 
 it("should preserve disabled import.meta fields for runtime evaluation", () => {

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -2,6 +2,8 @@ import disabledFields from "./disabled-fields";
 import emptyOptions from "./empty-options";
 const fs = require("fs");
 
+import.meta.UNKNOWN_PROPERTY = "runtime";
+const preservedUnknownProperty = import.meta.UNKNOWN_PROPERTY;
 let preservedComputedAccesses = 0;
 const getPreservedProperty = () => {
 	preservedComputedAccesses++;
@@ -20,7 +22,8 @@ it("should treat an empty importMeta object like preserve-unknown", () => {
 	expect(emptyOptions.missingOptional).toBeUndefined();
 });
 
-it("should preserve computed import.meta properties for runtime evaluation", () => {
+it("should default to preserve-unknown for output modules", () => {
+	expect(preservedUnknownProperty).toBe("runtime");
 	expect(preservedComputedUrl).toBeTypeOf("string");
 	expect(preservedComputedAccesses).toBe(1);
 });

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -14,6 +14,7 @@ it("should treat an empty importMeta object like preserve-unknown", () => {
 	expect(emptyOptions.webpack).toBe(5);
 	expect(emptyOptions.unknown).toBe("runtime");
 	expect(emptyOptions.computedUnknown).toBe("runtime");
+	expect(emptyOptions.templateUnknown).toBe("runtime");
 	expect(emptyOptions.computedAccesses).toBe(1);
 	expect(emptyOptions.unknownOptional).toBe("runtime".length);
 	expect(emptyOptions.missingOptional).toBeUndefined();

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/warnings.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/tests/rspack-test/configCases/parsing/import-meta-hot-prod/index.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-hot-prod/index.js
@@ -1,4 +1,8 @@
 it('should transform import.meta.webpackHot to false', () => {
+	expect(import.meta.webpackHot).toBeUndefined();
+	expect(import.meta["webpackHot"]).toBeUndefined();
+	expect(typeof import.meta.webpackHot).toBe("undefined");
+
 	let hot = false;
 	if (import.meta.webpackHot) {
 		hot = true;

--- a/tests/rspack-test/configCases/parsing/import-meta-hot-prod/index.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-hot-prod/index.js
@@ -1,6 +1,7 @@
 it('should transform import.meta.webpackHot to false', () => {
 	expect(import.meta.webpackHot).toBeUndefined();
 	expect(import.meta["webpackHot"]).toBeUndefined();
+	expect(import.meta[`webpackHot`]).toBeUndefined();
 	expect(typeof import.meta.webpackHot).toBe("undefined");
 
 	let hot = false;

--- a/tests/rspack-test/configCases/parsing/import-meta-hot-prod/warnings.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-hot-prod/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/index.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/index.js
@@ -4,6 +4,10 @@ it("should not have import.meta.env", function() {
 	expect(_env).toBe(undefined);
 });
 
+it("should not warn for import.meta defined by DefinePlugin", function() {
+	expect(import.meta.MY_ENV).toBe("canary");
+});
+
 if (FOO) {
 	require("fail");
 }

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/index.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/index.js
@@ -3,3 +3,7 @@ it("should not have import.meta.env", function() {
 	(_env = import.meta.env) === null || _env === void 0 ? void 0 : _env.production;
 	expect(_env).toBe(undefined);
 });
+
+if (FOO) {
+	require("fail");
+}

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/rspack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   plugins: [
     new DefinePlugin({
       'import.meta.env.MODE': '"production"',
+      FOO: 'import.meta.unknownProperty',
     }),
   ],
 };

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/rspack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   plugins: [
     new DefinePlugin({
       'import.meta.env.MODE': '"production"',
+      'import.meta.MY_ENV': JSON.stringify('canary'),
       FOO: 'import.meta.unknownProperty',
     }),
   ],

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Unknown `import.meta` property `env` replaced with undefined\./]
+];

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
@@ -1,9 +1,9 @@
 module.exports = [
-	[/Accessing unknown property 'env' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property 'env' is replaced with undefined\./],
 	[
 		{
 			message:
-				/Accessing unknown property 'unknownProperty' is replaced with undefined\.[\s\S]*if \(FOO\)/
+				/Accessing unknown `import.meta` property 'unknownProperty' is replaced with undefined\.[\s\S]*if \(FOO\)/
 		}
 	]
 ];

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
@@ -1,9 +1,9 @@
 module.exports = [
-	[/Unknown `import.meta` property `env` replaced with undefined\./],
+	[/Accessing unknown property 'env' is replaced with undefined\./],
 	[
 		{
 			message:
-				/Unknown `import.meta` property `unknownProperty` replaced with undefined\.[\s\S]*if \(FOO\)/
+				/Accessing unknown property 'unknownProperty' is replaced with undefined\.[\s\S]*if \(FOO\)/
 		}
 	]
 ];

--- a/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
+++ b/tests/rspack-test/configCases/plugins/define-plugin-import-meta/warnings.js
@@ -1,3 +1,9 @@
 module.exports = [
-	[/Unknown `import.meta` property `env` replaced with undefined\./]
+	[/Unknown `import.meta` property `env` replaced with undefined\./],
+	[
+		{
+			message:
+				/Unknown `import.meta` property `unknownProperty` replaced with undefined\.[\s\S]*if \(FOO\)/
+		}
+	]
 ];

--- a/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
@@ -1,26 +1,26 @@
 module.exports = [
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined\./
+		/Accessing unknown property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined\./
+		/Accessing unknown property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined\./
+		/Accessing unknown property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined\./
+		/Accessing unknown property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `kkk.env.X` replaced with undefined\./
+		/Accessing unknown property 'kkk.env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `kkk.env.X` replaced with undefined\./
+		/Accessing unknown property 'kkk.env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `ttt.env.X` replaced with undefined\./
+		/Accessing unknown property 'ttt.env.X' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `ttt.env.X` replaced with undefined\./
+		/Accessing unknown property 'ttt.env.X' is replaced with undefined\./
 	]
 ];

--- a/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
@@ -1,26 +1,26 @@
 module.exports = [
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined./
+		/Unknown `import.meta` property `env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined./
+		/Unknown `import.meta` property `env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined./
+		/Unknown `import.meta` property `env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `env.X` replaced with undefined./
+		/Unknown `import.meta` property `env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `kkk.env.X` replaced with undefined./
+		/Unknown `import.meta` property `kkk.env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `kkk.env.X` replaced with undefined./
+		/Unknown `import.meta` property `kkk.env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `ttt.env.X` replaced with undefined./
+		/Unknown `import.meta` property `ttt.env.X` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `ttt.env.X` replaced with undefined./
+		/Unknown `import.meta` property `ttt.env.X` replaced with undefined\./
 	]
 ];

--- a/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
@@ -1,26 +1,26 @@
 module.exports = [
 	[
-		/Accessing unknown property 'env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'kkk.env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'kkk.env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'kkk.env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'kkk.env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'ttt.env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'ttt.env.X' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'ttt.env.X' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'ttt.env.X' is replaced with undefined\./
 	]
 ];

--- a/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
@@ -1,0 +1,26 @@
+module.exports = [
+	[
+		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.kkk.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.kkk.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.ttt.env.X is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.ttt.env.X is unsupported and will be replaced with undefined/
+	]
+];

--- a/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta-property/warnings.js
@@ -1,26 +1,26 @@
 module.exports = [
 	[
-		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.kkk.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `kkk.env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.kkk.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `kkk.env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.ttt.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `ttt.env.X` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.ttt.env.X is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `ttt.env.X` replaced with undefined./
 	]
 ];

--- a/tests/rspack-test/normalCases/esm/import-meta/index.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/index.js
@@ -47,6 +47,14 @@ it("should return undefined for unknown property", () => {
 	expect(typeof import.meta["computed-other"]).toBe("undefined");
 	if (import.meta.condition) require("fail");
 	if (import.meta["computed-condition"]) require("fail");
+	expect(import.meta[0]).toBeUndefined();
+	let computedAccesses = 0;
+	const getUnknownProperty = () => {
+		computedAccesses++;
+		return "unknown";
+	};
+	expect(import.meta[getUnknownProperty()]).toBeUndefined();
+	expect(computedAccesses).toBe(1);
 	expect(() => import.meta.other.other.other).toThrowError();
 });
 

--- a/tests/rspack-test/normalCases/esm/import-meta/index.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/index.js
@@ -28,6 +28,7 @@ it('typeof import.meta.webpack === "number"', () => {
 it("should return correct import.meta.url", () => {
 	expect(import.meta.url).toBe(url);
 	expect(import.meta["url"]).toBe(url);
+	expect(import.meta[`url`]).toBe(url);
 	expect("my" + import.meta.url).toBe("my" + url);
 	if (import.meta.url.indexOf("index.js") === -1) require("fail");
 });
@@ -45,9 +46,17 @@ it("should return undefined for unknown property", () => {
 	expect(import.meta.other).toBe(undefined);
 	if (typeof import.meta.other !== "undefined") require("fail");
 	expect(typeof import.meta["computed-other"]).toBe("undefined");
+	expect(import.meta[`template-other`]).toBeUndefined();
+	expect(typeof import.meta[`template-typeof-other`]).toBe("undefined");
+	if (typeof import.meta[`template-condition`] !== "undefined") require("fail");
 	if (import.meta.condition) require("fail");
 	if (import.meta["computed-condition"]) require("fail");
 	expect(import.meta[0]).toBeUndefined();
+	expect(import.meta[1e-7]).toBeUndefined();
+	expect(import.meta[/url/mi]).toBeUndefined();
+	expect(import.meta["line\nbreak"]).toBeUndefined();
+	expect(import.meta["tick`mark"]).toBeUndefined();
+	expect(import.meta["*/"]).toBeUndefined();
 	let computedAccesses = 0;
 	const getUnknownProperty = () => {
 		computedAccesses++;
@@ -61,6 +70,8 @@ it("should return undefined for unknown property", () => {
 it("should not warn for known context properties", () => {
 	expect(typeof import.meta.glob).toBe("undefined");
 	expect(typeof import.meta.webpackContext).toBe("undefined");
+	expect(typeof import.meta[`glob`]).toBe("undefined");
+	expect(typeof import.meta[`webpackContext`]).toBe("undefined");
 	const { glob, webpackContext } = import.meta;
 	expect(glob).toBeUndefined();
 	expect(webpackContext).toBeUndefined();

--- a/tests/rspack-test/normalCases/esm/import-meta/index.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/index.js
@@ -44,6 +44,7 @@ it("should return correct import.meta.webpack", () => {
 it("should return undefined for unknown property", () => {
 	expect(import.meta.other).toBe(undefined);
 	if (typeof import.meta.other !== "undefined") require("fail");
+	expect(typeof import.meta["computed-other"]).toBe("undefined");
 	expect(() => import.meta.other.other.other).toThrowError();
 });
 

--- a/tests/rspack-test/normalCases/esm/import-meta/index.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/index.js
@@ -56,6 +56,7 @@ it("should return undefined for unknown property", () => {
 	expect(import.meta[/url/mi]).toBeUndefined();
 	expect(import.meta["line\nbreak"]).toBeUndefined();
 	expect(import.meta["tick`mark"]).toBeUndefined();
+	expect(import.meta["quote'mark"]).toBeUndefined();
 	expect(import.meta["*/"]).toBeUndefined();
 	let computedAccesses = 0;
 	const getUnknownProperty = () => {

--- a/tests/rspack-test/normalCases/esm/import-meta/index.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/index.js
@@ -45,7 +45,17 @@ it("should return undefined for unknown property", () => {
 	expect(import.meta.other).toBe(undefined);
 	if (typeof import.meta.other !== "undefined") require("fail");
 	expect(typeof import.meta["computed-other"]).toBe("undefined");
+	if (import.meta.condition) require("fail");
+	if (import.meta["computed-condition"]) require("fail");
 	expect(() => import.meta.other.other.other).toThrowError();
+});
+
+it("should not warn for known context properties", () => {
+	expect(typeof import.meta.glob).toBe("undefined");
+	expect(typeof import.meta.webpackContext).toBe("undefined");
+	const { glob, webpackContext } = import.meta;
+	expect(glob).toBeUndefined();
+	expect(webpackContext).toBeUndefined();
 });
 
 it("should add warning on direct import.meta usage", () => {

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -1,21 +1,27 @@
 module.exports = [
 	[
-		/Unknown `import.meta` property `other` replaced with undefined./
+		/Unknown `import.meta` property `other` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `other` replaced with undefined./
+		/Unknown `import.meta` property `other` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `computed-other` replaced with undefined./
+		/Unknown `import.meta` property `computed-other` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `other.other.other` replaced with undefined./
+		/Unknown `import.meta` property `condition` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `c` replaced with undefined./
+		/Unknown `import.meta` property `computed-condition` replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `d` replaced with undefined./
+		/Unknown `import.meta` property `other.other.other` replaced with undefined\./
+	],
+	[
+		/Unknown `import.meta` property `c` replaced with undefined\./
+	],
+	[
+		/Unknown `import.meta` property `d` replaced with undefined\./
 	],
 	[
 		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -9,12 +9,26 @@ module.exports = [
 		/Unknown `import.meta` property `computed-other` replaced with undefined\./
 	],
 	[
+		/Unknown `import.meta` property `template-other` replaced with undefined\./
+	],
+	[
+		/Unknown `import.meta` property `template-typeof-other` replaced with undefined\./
+	],
+	[
+		/Unknown `import.meta` property `template-condition` replaced with undefined\./
+	],
+	[
 		/Unknown `import.meta` property `condition` replaced with undefined\./
 	],
 	[
 		/Unknown `import.meta` property `computed-condition` replaced with undefined\./
 	],
 	[/Unknown `import.meta` property `0` replaced with undefined\./],
+	[/Unknown `import.meta` property `1e-7` replaced with undefined\./],
+	[/Unknown `import.meta` property `\/url\/im` replaced with undefined\./],
+	[/Unknown `import.meta` property `line\\nbreak` replaced with undefined\./],
+	[/Unknown `import.meta` property `tick\\`mark` replaced with undefined\./],
+	[/Unknown `import.meta` property `\*\/` replaced with undefined\./],
 	[/Dynamic `import.meta` property access may return undefined\./],
 	[
 		/Unknown `import.meta` property `other.other.other` replaced with undefined\./

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -1,5 +1,17 @@
 module.exports = [
 	[
+		/Accessing import.meta.other is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.other.other.other is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.c is unsupported and will be replaced with undefined/
+	],
+	[
+		/Accessing import.meta.d is unsupported and will be replaced with undefined/
+	],
+	[
 		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/
 	]
 ];

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -1,43 +1,44 @@
 module.exports = [
 	[
-		/Unknown `import.meta` property `other` replaced with undefined\./
+		/Accessing unknown property 'other' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `other` replaced with undefined\./
+		/Accessing unknown property 'other' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `computed-other` replaced with undefined\./
+		/Accessing unknown property 'computed-other' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `template-other` replaced with undefined\./
+		/Accessing unknown property 'template-other' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `template-typeof-other` replaced with undefined\./
+		/Accessing unknown property 'template-typeof-other' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `template-condition` replaced with undefined\./
+		/Accessing unknown property 'template-condition' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `condition` replaced with undefined\./
+		/Accessing unknown property 'condition' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `computed-condition` replaced with undefined\./
+		/Accessing unknown property 'computed-condition' is replaced with undefined\./
 	],
-	[/Unknown `import.meta` property `0` replaced with undefined\./],
-	[/Unknown `import.meta` property `1e-7` replaced with undefined\./],
-	[/Unknown `import.meta` property `\/url\/im` replaced with undefined\./],
-	[/Unknown `import.meta` property `line\\nbreak` replaced with undefined\./],
-	[/Unknown `import.meta` property `tick\\`mark` replaced with undefined\./],
-	[/Unknown `import.meta` property `\*\/` replaced with undefined\./],
+	[/Accessing unknown property '0' is replaced with undefined\./],
+	[/Accessing unknown property '1e-7' is replaced with undefined\./],
+	[/Accessing unknown property '\/url\/im' is replaced with undefined\./],
+	[/Accessing unknown property 'line\\nbreak' is replaced with undefined\./],
+	[/Accessing unknown property 'tick`mark' is replaced with undefined\./],
+	[/Accessing unknown property 'quote\\'mark' is replaced with undefined\./],
+	[/Accessing unknown property '\*\/' is replaced with undefined\./],
 	[/Dynamic `import.meta` property access may return undefined\./],
 	[
-		/Unknown `import.meta` property `other.other.other` replaced with undefined\./
+		/Accessing unknown property 'other.other.other' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `c` replaced with undefined\./
+		/Accessing unknown property 'c' is replaced with undefined\./
 	],
 	[
-		/Unknown `import.meta` property `d` replaced with undefined\./
+		/Accessing unknown property 'd' is replaced with undefined\./
 	],
 	[
 		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -3,6 +3,12 @@ module.exports = [
 		/Unknown `import.meta` property `other` replaced with undefined./
 	],
 	[
+		/Unknown `import.meta` property `other` replaced with undefined./
+	],
+	[
+		/Unknown `import.meta` property `computed-other` replaced with undefined./
+	],
+	[
 		/Unknown `import.meta` property `other.other.other` replaced with undefined./
 	],
 	[

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -1,15 +1,15 @@
 module.exports = [
 	[
-		/Accessing import.meta.other is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `other` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.other.other.other is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `other.other.other` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.c is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `c` replaced with undefined./
 	],
 	[
-		/Accessing import.meta.d is unsupported and will be replaced with undefined/
+		/Unknown `import.meta` property `d` replaced with undefined./
 	],
 	[
 		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -1,44 +1,44 @@
 module.exports = [
 	[
-		/Accessing unknown property 'other' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'other' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'other' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'other' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'computed-other' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'computed-other' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'template-other' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'template-other' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'template-typeof-other' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'template-typeof-other' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'template-condition' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'template-condition' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'condition' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'condition' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'computed-condition' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'computed-condition' is replaced with undefined\./
 	],
-	[/Accessing unknown property '0' is replaced with undefined\./],
-	[/Accessing unknown property '1e-7' is replaced with undefined\./],
-	[/Accessing unknown property '\/url\/im' is replaced with undefined\./],
-	[/Accessing unknown property 'line\\nbreak' is replaced with undefined\./],
-	[/Accessing unknown property 'tick`mark' is replaced with undefined\./],
-	[/Accessing unknown property 'quote\\'mark' is replaced with undefined\./],
-	[/Accessing unknown property '\*\/' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property '0' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property '1e-7' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property '\/url\/im' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property 'line\\nbreak' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property 'tick`mark' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property 'quote\\'mark' is replaced with undefined\./],
+	[/Accessing unknown `import.meta` property '\*\/' is replaced with undefined\./],
 	[/Dynamic `import.meta` property access may return undefined\./],
 	[
-		/Accessing unknown property 'other.other.other' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'other.other.other' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'c' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'c' is replaced with undefined\./
 	],
 	[
-		/Accessing unknown property 'd' is replaced with undefined\./
+		/Accessing unknown `import.meta` property 'd' is replaced with undefined\./
 	],
 	[
 		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -30,7 +30,6 @@ module.exports = [
 	[/Accessing unknown `import.meta` property 'tick`mark' is replaced with undefined\./],
 	[/Accessing unknown `import.meta` property 'quote\\'mark' is replaced with undefined\./],
 	[/Accessing unknown `import.meta` property '\*\/' is replaced with undefined\./],
-	[/Dynamic `import.meta` property access may return undefined\./],
 	[
 		/Accessing unknown `import.meta` property 'other.other.other' is replaced with undefined\./
 	],

--- a/tests/rspack-test/normalCases/esm/import-meta/warnings.js
+++ b/tests/rspack-test/normalCases/esm/import-meta/warnings.js
@@ -14,6 +14,8 @@ module.exports = [
 	[
 		/Unknown `import.meta` property `computed-condition` replaced with undefined\./
 	],
+	[/Unknown `import.meta` property `0` replaced with undefined\./],
+	[/Dynamic `import.meta` property access may return undefined\./],
 	[
 		/Unknown `import.meta` property `other.other.other` replaced with undefined\./
 	],

--- a/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
@@ -1,1 +1,13 @@
-Rspack x.x.x compiled successfully in X s
+WARNING in ./index.js
+  ⚠ Module parse warning:
+  ╰─▶   ⚠ Unknown `import.meta` property `hot` replaced with undefined.
+           ╭─[468:24]
+       466 │             return routeModule;
+       467 │         } catch (error) {
+       468 │             if (test && import.meta.hot) {
+           ·                         ───────────────
+       469 │                 require("fail36");
+       470 │             }
+           ╰────
+
+Rspack x.x.x compiled with 1 warning in X s

--- a/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
@@ -1,6 +1,6 @@
 WARNING in ./index.js
   ⚠ Module parse warning:
-  ╰─▶   ⚠ Unknown `import.meta` property `hot` replaced with undefined.
+  ╰─▶   ⚠ Accessing unknown property 'hot' is replaced with undefined.
            ╭─[468:24]
        466 │             return routeModule;
        467 │         } catch (error) {

--- a/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
@@ -1,6 +1,6 @@
 WARNING in ./index.js
   ⚠ Module parse warning:
-  ╰─▶   ⚠ Accessing unknown property 'hot' is replaced with undefined.
+  ╰─▶   ⚠ Accessing unknown `import.meta` property 'hot' is replaced with undefined.
            ╭─[468:24]
        466 │             return routeModule;
        467 │         } catch (error) {


### PR DESCRIPTION
## Summary

- Add a traceable warning when a statically known, unknown `import.meta` property is replaced with `undefined` while `parser.javascript.importMeta` is `true`.
- Keep the existing transformation result unchanged.
- Cover identifier access, static computed properties, member chains, optional chains, `typeof`, and destructuring.
- Do not warn for dynamic computed-property access because the property name cannot be determined statically; preserve evaluation of the key expression.
- Do not warn when unknown properties are preserved, including the `output.module: true` default and granular `importMeta` options.
- Keep known properties and exact `DefinePlugin` replacements unchanged.
- Reuse parser `Atom` values when rendering unknown property access to avoid intermediate string allocations.

## Why

Rspack already replaces unsupported, unknown `import.meta` properties with `undefined`. This PR adds diagnostics for statically analyzable accesses so configuration mistakes are visible, without changing the generated runtime behavior.

For example:

```js
console.log(import.meta.environment);
```

With `parser.javascript.importMeta: true`, the expression continues to be replaced with `undefined` and now produces an actionable warning:

```text
Accessing unknown `import.meta` property 'environment' is replaced with undefined.
```

Dynamic access does not warn because its property name cannot be determined statically:

```js
import.meta[getPropertyName()];
```

The key expression is still evaluated exactly once.

Preserved unknown properties also do not warn. Output modules default to `"preserve-unknown"`:

```js
module.exports = {
  experiments: {
    outputModule: true,
  },
  output: {
    module: true,
  },
};
```

Granular parser options can also preserve an unknown property without warning, including with non-module output:

```js
module.exports = {
  output: {
    module: false,
  },
  module: {
    parser: {
      javascript: {
        importMeta: {
          environment: false,
        },
      },
    },
  },
};
```

An exact `DefinePlugin` key is handled before `ImportMetaPlugin` and does not produce an unknown-property warning:

```js
new DefinePlugin({
  'import.meta.MY_ENV': JSON.stringify('canary'),
});

console.log(import.meta.MY_ENV); // "canary"
```

## Related links

N/A

## Validation

- `cargo check -p rspack_plugin_javascript`
- `cargo fmt --all --check`
- `pnpm run build:js`
- `pnpm run build:binding:dev`
- `pnpm run test -t "normalCases/esm/import-meta"`
- `pnpm run test -t "configCases/module/import-meta-parser-options"`
- `pnpm run test -t "configCases/module/import-meta-disabled-unknown-property"`
- `pnpm run test -t "configCases/plugins/define-plugin-import-meta"`
- `pnpm run test -t "statsOutputCases/track-returned"`
- Commit hooks: Rust formatting, Prettier, and JavaScript lint

## Checklist

- [x] Tests updated.
- [x] Documentation not required.

---
_by OpenAI Codex_