### PR TITLE
fix(cache): release compilation-scoped plugin state on rebuild

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -633,4 +633,8 @@ impl Plugin for CssPlugin {
 
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_HOOKS_MAP.remove(&id);
+  }
 }

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -702,5 +702,9 @@ impl Plugin for RsdoctorPlugin {
 
   fn clear_cache(&self, id: CompilationId) {
     COMPILATION_HOOKS_MAP.remove(&id);
+    MODULE_UKEY_MAP.remove(&id);
+    ENTRYPOINT_UKEY_MAP.remove(&id);
+    JSON_MODULE_SIZE_MAP.remove(&id);
+    ACTIVE_EXPORT_USAGE_DEPENDENCY_MAP.remove(&id);
   }
 }

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -221,4 +221,9 @@ impl Plugin for SubresourceIntegrityPlugin {
       .tap(handle_runtime::new(self));
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_INTEGRITY_MAP.remove(&id);
+    COMPILATION_CONTEXT_MAP.remove(&id);
+  }
 }


### PR DESCRIPTION
## Summary

Release compilation-scoped plugin maps when a watch rebuild replaces the preceding compilation.

The native CSS, SRI, and Rsdoctor plugins retain several maps keyed by monotonically increasing `CompilationId`; the corresponding entries were not fully removed from `clear_cache(old_id)`. Repeated rebuilds can therefore retain hooks, integrity/context state, or diagnostic/module metadata for every prior generation.

This change uses the existing plugin lifecycle hook and only removes state for the completed compilation:

- CSS: `COMPILATION_HOOKS_MAP`;
- SRI: `COMPILATION_INTEGRITY_MAP` and `COMPILATION_CONTEXT_MAP`;
- Rsdoctor: module, entrypoint, JSON-size, and active-export-usage maps alongside the existing hook-map cleanup.

No public API, option, or compilation behavior changes.

## Validation

- Source audit/regression confirms every compilation-keyed map in these three plugins has a matching removal (**8/8** entries cleared; seven were previously missing).
- An optimized native-binding watch smoke enables native CSS, SRI, Rsdoctor, and HMR, performs repeated edits, and verifies emitted updates and diagnostics remain correct.
- `rustfmt --edition 2024 --check crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs crates/rspack_plugin_sri/src/lib.rs crates/rspack_plugin_rsdoctor/src/plugin.rs` and `git diff --check` pass.

This is independent of the `ModuleGraphConnectionWrapper` lifecycle fix in #14772.
