### PR TITLE
fix(rsc): preserve multiple referenced client exports

### DIFF
--- a/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
@@ -82,11 +82,14 @@ impl Dependency for ClientReferenceDependency {
 
     // Otherwise keep the exact export names so usage analysis can preserve
     // tree-shaking granularity for this client reference.
-    vec![ExtendedReferencedExport::Export(ReferencedExport::new(
-      self.referenced_exports.iter().cloned().collect(),
-      false,
-      false,
-    ))]
+    self
+      .referenced_exports
+      .iter()
+      .cloned()
+      .map(|export_name| {
+        ExtendedReferencedExport::Export(ReferencedExport::new(vec![export_name], false, false))
+      })
+      .collect()
   }
 }
 

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/App.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/App.js
@@ -1,7 +1,12 @@
 "use server-entry";
 
-import { Todos } from './Todos';
+import { TodoItem, Todos } from './Todos';
 
 export const App = async () => {
-    return <Todos />;
+    return (
+        <>
+            <Todos />
+            <TodoItem />
+        </>
+    );
 };

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/Todos.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/Todos.js
@@ -4,6 +4,10 @@ export const Todos = () => {
     return <></>;
 };
 
+export const TodoItem = () => {
+    return <></>;
+};
+
 export const Unused = () => {
     return <></>;
 };

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/framework/entry.rsc.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/framework/entry.rsc.js
@@ -10,5 +10,5 @@ it('should tree-shake unused exports from "use client" modules', async () => {
     const chunkId = __rspack_rsc_manifest__.clientManifest[TODOS_PATH].chunks[0];
     const moduleId = __rspack_rsc_manifest__.clientManifest[TODOS_PATH].id;
     const exports = await loadClientModule(chunkId, moduleId);
-    expect(exports).toEqual(['Todos']);
+    expect(exports.sort()).toEqual(['TodoItem', 'Todos']);
 });


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Fix RSC client references with multiple named exports being incorrectly treated as a nested export path.
- Emit a separate ReferencedExport for each referenced client export while preserving the existing namespace (*) behavior.
- Extend the RSC tree-shaking test to verify that multiple referenced exports are retained and unused exports are still removed.

Fix #14756

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
