### PR TITLE
refactor(core): improve referenced export data struct

### DIFF
--- a/crates/rspack_core/src/artifacts/exports_info_artifact.rs
+++ b/crates/rspack_core/src/artifacts/exports_info_artifact.rs
@@ -25,6 +25,14 @@ impl ArtifactExt for ExportsInfoArtifact {
 }
 
 impl ExportsInfoArtifact {
+  pub fn len(&self) -> usize {
+    self.exports_info_map.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.exports_info_map.is_empty()
+  }
+
   pub fn new_exports_info(&mut self, module_identifier: ModuleIdentifier) {
     let info = ExportsInfoData::default();
     let id = info.id();

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -79,13 +79,13 @@ use crate::{
   CompilationLogger, CompilationLogging, CompilerOptions, CompilerPlatform, ConcatenationScope,
   DependenciesDiagnosticsArtifact, DependencyId, DependencyTemplate, DependencyTemplateType,
   DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId,
-  ExportsInfoArtifact, ExtendedReferencedExport, Filename, ImportPhase, ImportVarMap,
-  ImportedByDeferModulesArtifact, MemoryGCStorage, ModuleFactory, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact, ModuleStaticCache, PathData,
-  ProcessRuntimeRequirementsCacheArtifact, ResolverFactory, RuntimeGlobals, RuntimeKeyMap,
-  RuntimeMode, RuntimeModule, RuntimeProxyMetadataArtifact, RuntimeSpec, RuntimeSpecMap,
-  RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SideEffectsStateArtifact,
-  SourceType, Stats, StatsContext, StealCell, ValueCacheVersions,
+  ExportsInfoArtifact, Filename, ImportPhase, ImportVarMap, ImportedByDeferModulesArtifact,
+  MemoryGCStorage, ModuleFactory, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
+  ModuleIdsArtifact, ModuleStaticCache, PathData, ProcessRuntimeRequirementsCacheArtifact,
+  ReferencedExport, ResolverFactory, RuntimeGlobals, RuntimeKeyMap, RuntimeMode, RuntimeModule,
+  RuntimeProxyMetadataArtifact, RuntimeSpec, RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver,
+  SideEffectsOptimizeArtifact, SideEffectsStateArtifact, SourceType, Stats, StatsContext,
+  StealCell, ValueCacheVersions,
   cache::persistent::occasion::{
     devtool::SourceMapDevToolPluginCacheArtifact, minimize::MinimizePersistentCacheArtifact,
   },
@@ -110,7 +110,7 @@ define_hook!(CompilationSeal: Series(compilation: &Compilation, diagnostics: &mu
 define_hook!(CompilationDependencyReferencedExports: Sync(
   compilation: &Compilation,
   dependency: &DependencyId,
-  referenced_exports: &Option<Vec<ExtendedReferencedExport>>,
+  referenced_exports: &Option<Vec<ReferencedExport>>,
   runtime: Option<&RuntimeSpec>,
   module_graph: Option<&ModuleGraph>
 ));

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -8,8 +8,8 @@ use super::{AffectType, FactorizeInfo};
 use crate::{
   AsContextDependency, AsDependencyCodeGeneration, Context, ContextMode, ContextNameSpaceObject,
   ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType,
-  ExportsInfoArtifact, ExtendedReferencedExport, ImportAttributes, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleLayer, ReferencedSpecifier, ResourceIdentifier, RuntimeSpec,
+  ExportsInfoArtifact, ImportAttributes, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleLayer, ReferencedExport, ReferencedSpecifier, ResourceIdentifier, RuntimeSpec,
   create_exports_object_referenced, create_referenced_exports_by_referenced_specifiers,
 };
 
@@ -82,7 +82,7 @@ impl Dependency for ContextElementDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let Some(parent_module) = module_graph
         .get_parent_module(&self.id)

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -12,9 +12,9 @@ use super::{
   dependency_template::AsDependencyCodeGeneration, module_dependency::*,
 };
 use crate::{
-  AsContextDependency, ConnectionState, Context, ExportsInfoArtifact, ExtendedReferencedExport,
-  ForwardId, ImportAttributes, ImportPhase, LazyUntil, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleLayer, RuntimeSpec, SideEffectsStateArtifact, create_exports_object_referenced,
+  AsContextDependency, ConnectionState, Context, ExportsInfoArtifact, ForwardId, ImportAttributes,
+  ImportPhase, LazyUntil, ModuleGraph, ModuleGraphCacheArtifact, ModuleLayer, ReferencedExport,
+  RuntimeSpec, SideEffectsStateArtifact, create_exports_object_referenced,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -114,7 +114,7 @@ pub trait Dependency:
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     create_exports_object_referenced()
   }
 

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -52,12 +52,6 @@ use crate::{
   SideEffectsStateArtifact, create_exports_object_referenced,
 };
 
-#[derive(Debug, Clone)]
-pub enum ProcessModuleReferencedExports {
-  Map(FxHashMap<String, ReferencedExport>),
-  ExtendRef(Vec<ReferencedExport>),
-}
-
 #[derive(Debug, Default)]
 pub struct ExportSpec {
   pub name: Atom,

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -350,7 +350,11 @@ pub fn create_referenced_exports_by_referenced_specifiers(
       // remove last one
       names = &names[..names.len().saturating_sub(1)];
     }
-    refs.push(ReferencedExport::new(names.iter().cloned(), false, false));
+    refs.push(
+      ReferencedExport::from(names)
+        .with_can_mangle(false)
+        .with_can_inline(false),
+    );
   }
   refs
 }

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -47,16 +47,15 @@ pub use static_exports_dependency::{StaticExportsDependency, StaticExportsSpec};
 use swc_core::ecma::atoms::Atom;
 
 use crate::{
-  ConnectionState, EvaluatedInlinableValue, ExportsInfoArtifact, ExportsType,
-  ExtendedReferencedExport, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, ReferencedExport, RuntimeSpec, SideEffectsStateArtifact,
-  create_exports_object_referenced,
+  ConnectionState, EvaluatedInlinableValue, ExportsInfoArtifact, ExportsType, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ReferencedExport, RuntimeSpec,
+  SideEffectsStateArtifact, create_exports_object_referenced,
 };
 
 #[derive(Debug, Clone)]
 pub enum ProcessModuleReferencedExports {
-  Map(FxHashMap<String, ExtendedReferencedExport>),
-  ExtendRef(Vec<ExtendedReferencedExport>),
+  Map(FxHashMap<String, ReferencedExport>),
+  ExtendRef(Vec<ReferencedExport>),
 }
 
 #[derive(Debug, Default)]
@@ -312,7 +311,7 @@ pub fn create_referenced_exports_by_referenced_specifiers(
   referenced_specifiers: &[ReferencedSpecifier],
   exports_type: ExportsType,
   is_json: bool,
-) -> Vec<ExtendedReferencedExport> {
+) -> Vec<ReferencedExport> {
   let mut refs = vec![];
   for ReferencedSpecifier {
     names,
@@ -357,11 +356,7 @@ pub fn create_referenced_exports_by_referenced_specifiers(
       // remove last one
       names = &names[..names.len().saturating_sub(1)];
     }
-    refs.push(ExtendedReferencedExport::Export(ReferencedExport::new(
-      names.to_vec(),
-      false,
-      false,
-    )));
+    refs.push(ReferencedExport::new(names.iter().cloned(), false, false));
   }
   refs
 }

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -105,11 +105,6 @@ impl ReferencedExport {
   pub fn ns_access(&self) -> bool {
     self.flags.contains(ReferencedExportFlags::NS_ACCESS)
   }
-
-  #[inline]
-  pub fn merge_flags(&mut self, other: ReferencedExportFlags) {
-    self.flags.merge(other);
-  }
 }
 
 pub fn collect_referenced_export_items<'a>(

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -1,68 +1,111 @@
+use bitflags::bitflags;
 use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 
 use crate::{ExportInfo, ExportInfoData, ExportsInfoArtifact, RuntimeSpec, UsageState};
 
-/// refer https://github.com/webpack/webpack/blob/d15c73469fd71cf98734685225250148b68ddc79/lib/FlagDependencyUsagePlugin.js#L64
-#[derive(Clone, Debug)]
-pub enum ExtendedReferencedExport {
-  Array(Vec<Atom>),
-  Export(ReferencedExport),
-}
+pub type ReferencedExportPath = SmallVec<[Atom; 2]>;
 
-pub fn is_no_exports_referenced(exports: &[ExtendedReferencedExport]) -> bool {
-  exports.is_empty()
-}
-
-pub fn is_exports_object_referenced(exports: &[ExtendedReferencedExport]) -> bool {
-  matches!(exports[..], [ExtendedReferencedExport::Array(ref arr)] if arr.is_empty())
-}
-
-pub fn create_no_exports_referenced() -> Vec<ExtendedReferencedExport> {
-  vec![]
-}
-
-pub fn create_exports_object_referenced() -> Vec<ExtendedReferencedExport> {
-  vec![ExtendedReferencedExport::Array(vec![])]
-}
-
-impl From<Vec<Atom>> for ExtendedReferencedExport {
-  fn from(value: Vec<Atom>) -> Self {
-    ExtendedReferencedExport::Array(value)
+bitflags! {
+  #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+  pub struct ReferencedExportFlags: u8 {
+    const CAN_MANGLE = 1 << 0;
+    const CAN_INLINE = 1 << 1;
+    const NS_ACCESS = 1 << 2;
   }
 }
-impl From<ReferencedExport> for ExtendedReferencedExport {
-  fn from(value: ReferencedExport) -> Self {
-    ExtendedReferencedExport::Export(value)
+
+impl Default for ReferencedExportFlags {
+  fn default() -> Self {
+    Self::CAN_MANGLE | Self::CAN_INLINE
   }
 }
 
 #[derive(Clone, Debug)]
 pub struct ReferencedExport {
-  pub name: Vec<Atom>,
-  pub can_mangle: bool,
-  pub can_inline: bool,
-  pub ns_access: bool,
+  pub name: ReferencedExportPath,
+  pub flags: ReferencedExportFlags,
+}
+
+pub fn is_no_exports_referenced(exports: &[ReferencedExport]) -> bool {
+  exports.is_empty()
+}
+
+pub fn is_exports_object_referenced(exports: &[ReferencedExport]) -> bool {
+  matches!(exports, [export] if export.name.is_empty())
+}
+
+pub fn create_no_exports_referenced() -> Vec<ReferencedExport> {
+  vec![]
+}
+
+pub fn create_exports_object_referenced() -> Vec<ReferencedExport> {
+  vec![ReferencedExport::default()]
+}
+
+impl From<Vec<Atom>> for ReferencedExport {
+  fn from(value: Vec<Atom>) -> Self {
+    Self::from_path(value)
+  }
 }
 
 impl ReferencedExport {
-  pub fn new(name: Vec<Atom>, can_mangle: bool, can_inline: bool) -> Self {
+  pub fn from_path(name: impl IntoIterator<Item = Atom>) -> Self {
     Self {
-      name,
-      can_mangle,
-      can_inline,
-      ns_access: false,
+      name: name.into_iter().collect(),
+      flags: ReferencedExportFlags::default(),
     }
+  }
+
+  pub fn new(name: impl IntoIterator<Item = Atom>, can_mangle: bool, can_inline: bool) -> Self {
+    let mut flags = ReferencedExportFlags::empty();
+    flags.set(ReferencedExportFlags::CAN_MANGLE, can_mangle);
+    flags.set(ReferencedExportFlags::CAN_INLINE, can_inline);
+    Self {
+      name: name.into_iter().collect(),
+      flags,
+    }
+  }
+
+  pub fn with_ns_access(mut self, ns_access: bool) -> Self {
+    self.flags.set(ReferencedExportFlags::NS_ACCESS, ns_access);
+    self
+  }
+
+  pub fn can_mangle(&self) -> bool {
+    self.flags.contains(ReferencedExportFlags::CAN_MANGLE)
+  }
+
+  pub fn can_inline(&self) -> bool {
+    self.flags.contains(ReferencedExportFlags::CAN_INLINE)
+  }
+
+  pub fn ns_access(&self) -> bool {
+    self.flags.contains(ReferencedExportFlags::NS_ACCESS)
+  }
+
+  pub fn merge_flags(&mut self, other: ReferencedExportFlags) {
+    self.flags.set(
+      ReferencedExportFlags::CAN_MANGLE,
+      self.can_mangle() && other.contains(ReferencedExportFlags::CAN_MANGLE),
+    );
+    self.flags.set(
+      ReferencedExportFlags::CAN_INLINE,
+      self.can_inline() && other.contains(ReferencedExportFlags::CAN_INLINE),
+    );
+    self.flags.set(
+      ReferencedExportFlags::NS_ACCESS,
+      self.ns_access() || other.contains(ReferencedExportFlags::NS_ACCESS),
+    );
   }
 }
 
 impl Default for ReferencedExport {
   fn default() -> Self {
     Self {
-      name: vec![],
-      can_mangle: true,
-      can_inline: true,
-      ns_access: false,
+      name: SmallVec::new(),
+      flags: ReferencedExportFlags::default(),
     }
   }
 }

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -22,7 +22,25 @@ impl Default for ReferencedExportFlags {
   }
 }
 
-#[derive(Clone, Debug)]
+impl ReferencedExportFlags {
+  #[inline]
+  pub fn merge(&mut self, other: Self) {
+    self.set(
+      Self::CAN_MANGLE,
+      self.contains(Self::CAN_MANGLE) && other.contains(Self::CAN_MANGLE),
+    );
+    self.set(
+      Self::CAN_INLINE,
+      self.contains(Self::CAN_INLINE) && other.contains(Self::CAN_INLINE),
+    );
+    self.set(
+      Self::NS_ACCESS,
+      self.contains(Self::NS_ACCESS) || other.contains(Self::NS_ACCESS),
+    );
+  }
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct ReferencedExport {
   pub name: ReferencedExportPath,
   pub flags: ReferencedExportFlags,
@@ -73,40 +91,24 @@ impl ReferencedExport {
     self
   }
 
+  #[inline]
   pub fn can_mangle(&self) -> bool {
     self.flags.contains(ReferencedExportFlags::CAN_MANGLE)
   }
 
+  #[inline]
   pub fn can_inline(&self) -> bool {
     self.flags.contains(ReferencedExportFlags::CAN_INLINE)
   }
 
+  #[inline]
   pub fn ns_access(&self) -> bool {
     self.flags.contains(ReferencedExportFlags::NS_ACCESS)
   }
 
+  #[inline]
   pub fn merge_flags(&mut self, other: ReferencedExportFlags) {
-    self.flags.set(
-      ReferencedExportFlags::CAN_MANGLE,
-      self.can_mangle() && other.contains(ReferencedExportFlags::CAN_MANGLE),
-    );
-    self.flags.set(
-      ReferencedExportFlags::CAN_INLINE,
-      self.can_inline() && other.contains(ReferencedExportFlags::CAN_INLINE),
-    );
-    self.flags.set(
-      ReferencedExportFlags::NS_ACCESS,
-      self.ns_access() || other.contains(ReferencedExportFlags::NS_ACCESS),
-    );
-  }
-}
-
-impl Default for ReferencedExport {
-  fn default() -> Self {
-    Self {
-      name: SmallVec::new(),
-      flags: ReferencedExportFlags::default(),
-    }
+    self.flags.merge(other);
   }
 }
 

--- a/crates/rspack_core/src/exports/referenced_export.rs
+++ b/crates/rspack_core/src/exports/referenced_export.rs
@@ -63,29 +63,70 @@ pub fn create_exports_object_referenced() -> Vec<ReferencedExport> {
 }
 
 impl From<Vec<Atom>> for ReferencedExport {
+  #[inline]
   fn from(value: Vec<Atom>) -> Self {
-    Self::from_path(value)
+    Self::from(ReferencedExportPath::from_vec(value))
+  }
+}
+
+impl From<Vec<&Atom>> for ReferencedExport {
+  #[inline]
+  fn from(value: Vec<&Atom>) -> Self {
+    Self::from(value.into_iter().cloned().collect::<ReferencedExportPath>())
+  }
+}
+
+impl From<&[Atom]> for ReferencedExport {
+  #[inline]
+  fn from(value: &[Atom]) -> Self {
+    Self::from(ReferencedExportPath::from(value))
+  }
+}
+
+impl From<ReferencedExportPath> for ReferencedExport {
+  #[inline]
+  fn from(name: ReferencedExportPath) -> Self {
+    Self {
+      name,
+      flags: ReferencedExportFlags::default(),
+    }
+  }
+}
+
+impl From<Atom> for ReferencedExport {
+  #[inline]
+  fn from(value: Atom) -> Self {
+    let mut path = ReferencedExportPath::new();
+    path.push(value);
+    Self::from(path)
+  }
+}
+
+impl From<&Atom> for ReferencedExport {
+  #[inline]
+  fn from(value: &Atom) -> Self {
+    Self::from(value.clone())
   }
 }
 
 impl ReferencedExport {
-  pub fn from_path(name: impl IntoIterator<Item = Atom>) -> Self {
-    Self {
-      name: name.into_iter().collect(),
-      flags: ReferencedExportFlags::default(),
-    }
+  #[inline]
+  pub fn with_can_mangle(mut self, can_mangle: bool) -> Self {
+    self
+      .flags
+      .set(ReferencedExportFlags::CAN_MANGLE, can_mangle);
+    self
   }
 
-  pub fn new(name: impl IntoIterator<Item = Atom>, can_mangle: bool, can_inline: bool) -> Self {
-    let mut flags = ReferencedExportFlags::empty();
-    flags.set(ReferencedExportFlags::CAN_MANGLE, can_mangle);
-    flags.set(ReferencedExportFlags::CAN_INLINE, can_inline);
-    Self {
-      name: name.into_iter().collect(),
-      flags,
-    }
+  #[inline]
+  pub fn with_can_inline(mut self, can_inline: bool) -> Self {
+    self
+      .flags
+      .set(ReferencedExportFlags::CAN_INLINE, can_inline);
+    self
   }
 
+  #[inline]
   pub fn with_ns_access(mut self, ns_access: bool) -> Self {
     self.flags.set(ReferencedExportFlags::NS_ACCESS, ns_access);
     self

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -82,11 +82,7 @@ impl Dependency for CssComposeDependency {
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ReferencedExport> {
-    self
-      .names
-      .iter()
-      .map(|n| ReferencedExport::from_path([n.clone()]))
-      .collect()
+    self.names.iter().map(ReferencedExport::from).collect()
   }
 }
 

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsContextDependency, AsDependencyCodeGeneration, CssExportType, Dependency, DependencyCategory,
-  DependencyId, DependencyRange, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport,
-  FactorizeInfo, ModuleDependency, RuntimeSpec,
+  DependencyId, DependencyRange, DependencyType, ExportsInfoArtifact, FactorizeInfo,
+  ModuleDependency, ReferencedExport, RuntimeSpec,
 };
 use rspack_util::atom::Atom;
 
@@ -81,11 +81,11 @@ impl Dependency for CssComposeDependency {
     _module_graph_cache: &rspack_core::ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     self
       .names
       .iter()
-      .map(|n| ExtendedReferencedExport::Array(vec![n.clone()]))
+      .map(|n| ReferencedExport::from_path([n.clone()]))
       .collect()
   }
 }

--- a/crates/rspack_plugin_css/src/dependency/self_reference.rs
+++ b/crates/rspack_plugin_css/src/dependency/self_reference.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, RuntimeSpec, TemplateContext,
+  FactorizeInfo, ModuleDependency, ReferencedExport, RuntimeSpec, TemplateContext,
   TemplateReplaceSource,
 };
 use rspack_util::atom::Atom;
@@ -64,11 +64,11 @@ impl Dependency for CssSelfReferenceLocalIdentDependency {
     _module_graph_cache: &rspack_core::ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     self
       .names
       .iter()
-      .map(|n| ExtendedReferencedExport::Array(vec![Atom::from(n.as_str())]))
+      .map(|n| ReferencedExport::from_path([Atom::from(n.as_str())]))
       .collect()
   }
 }

--- a/crates/rspack_plugin_css/src/dependency/self_reference.rs
+++ b/crates/rspack_plugin_css/src/dependency/self_reference.rs
@@ -68,7 +68,7 @@ impl Dependency for CssSelfReferenceLocalIdentDependency {
     self
       .names
       .iter()
-      .map(|n| ReferencedExport::from_path([Atom::from(n.as_str())]))
+      .map(|n| ReferencedExport::from(Atom::from(n.as_str())))
       .collect()
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -7,11 +7,10 @@ use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportNameOrSpec,
   ExportProvided, ExportSpec, ExportsInfoArtifact, ExportsOfExportsSpec, ExportsSpec, ExportsType,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleIdentifier, Nullable, ReferencedExport, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource, UsageState, UsedName, collect_referenced_export_items,
-  create_exports_object_referenced, create_no_exports_referenced, property_access,
-  to_normal_comment,
+  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
+  Nullable, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState,
+  UsedName, collect_referenced_export_items, create_exports_object_referenced,
+  create_no_exports_referenced, property_access, to_normal_comment,
 };
 use rustc_hash::FxHashSet;
 use swc_atoms::Atom;
@@ -304,19 +303,18 @@ impl Dependency for CommonJsExportRequireDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     let ids = self.get_ids(mg);
     let get_full_result = || {
       if ids.is_empty() {
         create_exports_object_referenced()
       } else {
-        vec![ExtendedReferencedExport::Export(ReferencedExport {
-          name: ids.to_vec(),
+        vec![ReferencedExport::new(
+          ids.iter().cloned(),
           // `module.exports = require("./m")` can't be mangled
-          can_mangle: !self.is_all_exported_by_module_exports(),
-          can_inline: false,
-          ns_access: false,
-        })]
+          !self.is_all_exported_by_module_exports(),
+          false,
+        )]
       }
     };
     if self.result_used {
@@ -374,13 +372,12 @@ impl Dependency for CommonJsExportRequireDependency {
     referenced_exports
       .into_iter()
       .map(|name| {
-        ExtendedReferencedExport::Export(ReferencedExport {
-          name: name.into_iter().map(|i| i.to_owned()).collect_vec(),
+        ReferencedExport::new(
+          name.into_iter().cloned(),
           // `module.exports = require("./m")` can't be mangled
-          can_mangle: !self.is_all_exported_by_module_exports(),
-          can_inline: false,
-          ns_access: false,
-        })
+          !self.is_all_exported_by_module_exports(),
+          false,
+        )
       })
       .collect_vec()
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -309,12 +309,12 @@ impl Dependency for CommonJsExportRequireDependency {
       if ids.is_empty() {
         create_exports_object_referenced()
       } else {
-        vec![ReferencedExport::new(
-          ids.iter().cloned(),
-          // `module.exports = require("./m")` can't be mangled
-          !self.is_all_exported_by_module_exports(),
-          false,
-        )]
+        vec![
+          ReferencedExport::from(ids)
+            // `module.exports = require("./m")` can't be mangled
+            .with_can_mangle(!self.is_all_exported_by_module_exports())
+            .with_can_inline(false),
+        ]
       }
     };
     if self.result_used {
@@ -372,12 +372,10 @@ impl Dependency for CommonJsExportRequireDependency {
     referenced_exports
       .into_iter()
       .map(|name| {
-        ReferencedExport::new(
-          name.into_iter().cloned(),
+        ReferencedExport::from(name)
           // `module.exports = require("./m")` can't be mangled
-          !self.is_all_exported_by_module_exports(),
-          false,
-        )
+          .with_can_mangle(!self.is_all_exported_by_module_exports())
+          .with_can_inline(false)
       })
       .collect_vec()
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -5,8 +5,8 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportsInfoArtifact, ExportsType, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
-  ModuleGraph, ModuleGraphCacheArtifact, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  ExportsInfoArtifact, ExportsType, FactorizeInfo, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ReferencedExport, RuntimeGlobals, RuntimeSpec, TemplateContext,
   TemplateReplaceSource, UsedName, create_exports_object_referenced, property_access,
   to_normal_comment,
 };
@@ -84,7 +84,7 @@ impl Dependency for CommonJsFullRequireDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     let mut namespace_object_as_context = self.namespace_object_as_context;
 
     let module = module_graph
@@ -111,11 +111,13 @@ impl Dependency for CommonJsFullRequireDependency {
       if self.names.is_empty() {
         return create_exports_object_referenced();
       }
-      return vec![ExtendedReferencedExport::Array(
-        self.names[0..self.names.len().saturating_sub(1)].to_vec(),
+      return vec![ReferencedExport::from_path(
+        self.names[0..self.names.len().saturating_sub(1)]
+          .iter()
+          .cloned(),
       )];
     }
-    vec![ExtendedReferencedExport::Array(self.names.clone())]
+    vec![ReferencedExport::from_path(self.names.iter().cloned())]
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -111,13 +111,11 @@ impl Dependency for CommonJsFullRequireDependency {
       if self.names.is_empty() {
         return create_exports_object_referenced();
       }
-      return vec![ReferencedExport::from_path(
-        self.names[0..self.names.len().saturating_sub(1)]
-          .iter()
-          .cloned(),
+      return vec![ReferencedExport::from(
+        &self.names[..self.names.len().saturating_sub(1)],
       )];
     }
-    vec![ReferencedExport::from_path(self.names.iter().cloned())]
+    vec![ReferencedExport::from(self.names.as_slice())]
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -5,10 +5,10 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Context, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyCondition, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport,
-  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ReferencedSpecifier,
-  ResourceIdentifier, RuntimeSpec, TemplateContext, TemplateReplaceSource,
-  create_exports_object_referenced, create_referenced_exports_by_referenced_specifiers,
+  DependencyTemplateType, DependencyType, ExportsInfoArtifact, FactorizeInfo, ModuleDependency,
+  ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, ReferencedSpecifier, ResourceIdentifier,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource, create_exports_object_referenced,
+  create_referenced_exports_by_referenced_specifiers,
 };
 
 use super::create_resource_identifier_for_contextual_commonjs_dependency;
@@ -133,7 +133,7 @@ impl Dependency for CommonJsRequireDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -5,7 +5,7 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport,
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, property_access_with_optional,
 };
 use swc_atoms::Atom;
@@ -73,17 +73,17 @@ impl Dependency for CommonJsSelfReferenceDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     if self.is_call {
       if self.names.is_empty() {
-        vec![ExtendedReferencedExport::Array(vec![])]
+        vec![ReferencedExport::default()]
       } else {
-        vec![ExtendedReferencedExport::Array(
-          self.names[0..self.names.len() - 1].to_vec(),
+        vec![ReferencedExport::from_path(
+          self.names[0..self.names.len() - 1].iter().cloned(),
         )]
       }
     } else {
-      vec![ExtendedReferencedExport::Array(self.names.clone())]
+      vec![ReferencedExport::from_path(self.names.iter().cloned())]
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -78,12 +78,10 @@ impl Dependency for CommonJsSelfReferenceDependency {
       if self.names.is_empty() {
         vec![ReferencedExport::default()]
       } else {
-        vec![ReferencedExport::from_path(
-          self.names[0..self.names.len() - 1].iter().cloned(),
-        )]
+        vec![ReferencedExport::from(&self.names[0..self.names.len() - 1])]
       }
     } else {
-      vec![ReferencedExport::from_path(self.names.iter().cloned())]
+      vec![ReferencedExport::from(self.names.as_slice())]
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -83,7 +83,7 @@ impl Dependency for ModuleDecoratorDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
-  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+  ) -> Vec<rspack_core::ReferencedExport> {
     if self.allow_exports_access {
       create_exports_object_referenced()
     } else {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -2,9 +2,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Context, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ResourceIdentifier, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  ExportsInfoArtifact, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ReferencedExport, ResourceIdentifier, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 use super::create_resource_identifier_for_contextual_commonjs_dependency;
@@ -92,7 +91,7 @@ impl Dependency for RequireResolveDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -15,15 +15,15 @@ use rspack_core::{
   ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
   ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
-  ExportsInfoData, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
-  FactorizeInfo, ForwardId, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, JavascriptParserOptions, LazyUntil, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, NormalInitFragment, NormalReexportItem,
-  ResourceIdentifier, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
-  StarReexportsInfo, TemplateContext, TemplateReplaceSource, UsageState, UsedName,
-  collect_referenced_export_items, create_exports_object_referenced, create_no_exports_referenced,
-  filter_runtime, get_exports_type, get_runtime_key, get_terminal_binding, property_access,
-  property_name, render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
+  ExportsInfoData, ExportsOfExportsSpec, ExportsSpec, ExportsType, FactorizeInfo, ForwardId,
+  ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  JavascriptParserOptions, LazyUntil, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, NormalInitFragment, NormalReexportItem, ReferencedExport, ResourceIdentifier,
+  RuntimeCondition, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, StarReexportsInfo,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedName, collect_referenced_export_items,
+  create_exports_object_referenced, create_no_exports_referenced, filter_runtime, get_exports_type,
+  get_runtime_key, get_terminal_binding, property_access, property_name,
+  render_make_deferred_namespace_mode_from_exports_type, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_hash::{RspackHash, RspackHasher};
@@ -1466,7 +1466,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     let mode = self.get_mode(
       module_graph,
       runtime,
@@ -1506,7 +1506,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         );
         referenced_exports
           .into_iter()
-          .map(|i| ExtendedReferencedExport::Array(i.into_iter().map(|i| i.to_owned()).collect()))
+          .map(|i| ReferencedExport::from_path(i.into_iter().cloned()))
           .collect::<Vec<_>>()
       }
       ExportMode::NormalReexport(mode) => {
@@ -1527,7 +1527,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         }
         referenced_exports
           .into_iter()
-          .map(|i| ExtendedReferencedExport::Array(i.into_iter().map(|i| i.to_owned()).collect()))
+          .map(|i| ReferencedExport::from_path(i.into_iter().cloned()))
           .collect::<Vec<_>>()
       }
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -1506,7 +1506,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         );
         referenced_exports
           .into_iter()
-          .map(|i| ReferencedExport::from_path(i.into_iter().cloned()))
+          .map(ReferencedExport::from)
           .collect::<Vec<_>>()
       }
       ExportMode::NormalReexport(mode) => {
@@ -1527,7 +1527,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         }
         referenced_exports
           .into_iter()
-          .map(|i| ReferencedExport::from_path(i.into_iter().cloned()))
+          .map(ReferencedExport::from)
           .collect::<Vec<_>>()
       }
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -5,11 +5,11 @@ use rspack_core::{
   ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
   DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportProvided, ExportsInfoArtifact, ExportsType, ExtendedReferencedExport, FactorizeInfo,
-  ForwardId, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage,
-  LazyUntil, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  ProvidedExports, ResourceIdentifier, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact,
-  SourceType, TemplateContext, TemplateReplaceSource, TypeReexportPresenceMode, filter_runtime,
+  ExportProvided, ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId, ImportAttributes,
+  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LazyUntil, ModuleDependency,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ProvidedExports, ReferencedExport,
+  ResourceIdentifier, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, SourceType,
+  TemplateContext, TemplateReplaceSource, TypeReexportPresenceMode, filter_runtime,
 };
 use rspack_error::{Diagnostic, Error, Severity};
 use swc_atoms::Atom;
@@ -597,7 +597,7 @@ impl Dependency for ESMImportSideEffectDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -142,17 +142,18 @@ impl ESMImportSpecifierDependency {
       refs
         .into_iter()
         // Do not inline if there are any places where used as destructuring
-        .map(|name| ReferencedExport::new(name, true, false).with_ns_access(self.ns_access))
+        .map(|name| {
+          ReferencedExport::from(name)
+            .with_can_inline(false)
+            .with_ns_access(self.ns_access)
+        })
         .collect::<Vec<_>>()
     } else if let Some(v) = ids {
       vec![
-        ReferencedExport::new(
-          v.iter().cloned(),
-          true,
+        ReferencedExport::from(v)
           // Need access the export value to trigger side effects for deferred module
-          !self.phase.is_defer(),
-        )
-        .with_ns_access(self.ns_access),
+          .with_can_inline(!self.phase.is_defer())
+          .with_ns_access(self.ns_access),
       ]
     } else {
       create_exports_object_referenced()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -331,14 +331,7 @@ impl Dependency for ESMImportSpecifierDependency {
       // remove last one
       ids = &ids[..ids.len().saturating_sub(1)];
     }
-    let referenced_exports = self.get_referenced_exports_in_destructuring(Some(ids));
-    if self.request.contains("referenced-export-smallvec-case") {
-      println!(
-        "[ReferencedExport SmallVec ESM case] request={:?}, referenced_exports={referenced_exports:?}",
-        self.request
-      );
-    }
-    referenced_exports
+    self.get_referenced_exports_in_destructuring(Some(ids))
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -7,12 +7,11 @@ use rspack_core::{
   AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyCondition, DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange,
   DependencyTemplate, DependencyTemplateType, DependencyType, ExportPresenceMode, ExportProvided,
-  ExportsInfoArtifact, ExportsType, ExtendedReferencedExport, FactorizeInfo, ForwardId,
-  ImportAttributes, ImportPhase, JavascriptParserOptions, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport,
-  ResourceIdentifier, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
-  TemplateReplaceSource, UsedByExports, UsedName, create_exports_object_referenced,
-  property_access, to_normal_comment,
+  ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId, ImportAttributes, ImportPhase,
+  JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport, ResourceIdentifier, RuntimeSpec,
+  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedByExports, UsedName,
+  create_exports_object_referenced, property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHasher};
@@ -127,7 +126,7 @@ impl ESMImportSpecifierDependency {
   pub fn get_referenced_exports_in_destructuring(
     &self,
     ids: Option<&[Atom]>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     if let Some(referenced_properties) = &self.referenced_properties_in_destructuring {
       let mut refs = Vec::new();
       referenced_properties.traverse_on_leaf(&mut |stack| {
@@ -143,23 +142,18 @@ impl ESMImportSpecifierDependency {
       refs
         .into_iter()
         // Do not inline if there are any places where used as destructuring
-        .map(|name| {
-          ExtendedReferencedExport::Export(ReferencedExport {
-            name,
-            can_mangle: true,
-            can_inline: false,
-            ns_access: self.ns_access,
-          })
-        })
+        .map(|name| ReferencedExport::new(name, true, false).with_ns_access(self.ns_access))
         .collect::<Vec<_>>()
     } else if let Some(v) = ids {
-      vec![ExtendedReferencedExport::Export(ReferencedExport {
-        name: v.to_vec(),
-        can_mangle: true,
-        // Need access the export value to trigger side effects for deferred module
-        can_inline: !self.phase.is_defer(),
-        ns_access: self.ns_access,
-      })]
+      vec![
+        ReferencedExport::new(
+          v.iter().cloned(),
+          true,
+          // Need access the export value to trigger side effects for deferred module
+          !self.phase.is_defer(),
+        )
+        .with_ns_access(self.ns_access),
+      ]
     } else {
       create_exports_object_referenced()
     }
@@ -277,7 +271,7 @@ impl Dependency for ESMImportSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     let mut ids = self.get_ids(module_graph);
     // namespace import
     if ids.is_empty() {
@@ -337,7 +331,14 @@ impl Dependency for ESMImportSpecifierDependency {
       // remove last one
       ids = &ids[..ids.len().saturating_sub(1)];
     }
-    self.get_referenced_exports_in_destructuring(Some(ids))
+    let referenced_exports = self.get_referenced_exports_in_destructuring(Some(ids));
+    if self.request.contains("referenced-export-smallvec-case") {
+      println!(
+        "[ReferencedExport SmallVec ESM case] request={:?}, referenced_exports={referenced_exports:?}",
+        self.request
+      );
+    }
+    referenced_exports
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -118,7 +118,7 @@ impl Dependency for ImportDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
-  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+  ) -> Vec<rspack_core::ReferencedExport> {
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -100,7 +100,7 @@ impl Dependency for ImportEagerDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
-  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+  ) -> Vec<rspack_core::ReferencedExport> {
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_resolve_dependency.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport,
   RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
@@ -52,7 +52,7 @@ impl Dependency for ImportMetaResolveDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_meta_rsc_dependency.rs
@@ -2,8 +2,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, NormalInitFragment, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  ExportsInfoArtifact, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  NormalInitFragment, ReferencedExport, RuntimeGlobals, RuntimeSpec, TemplateContext,
   TemplateReplaceSource, create_exports_object_referenced,
 };
 use rspack_hash::{RspackHash, RspackHasher};
@@ -76,7 +76,7 @@ impl Dependency for ImportMetaRscDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     create_exports_object_referenced()
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
@@ -105,7 +105,7 @@ impl Dependency for ImportWeakDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
-  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+  ) -> Vec<rspack_core::ReferencedExport> {
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -5,8 +5,8 @@ use rspack_cacheable::{
 use rspack_core::{
   AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, InitFragmentKey,
-  InitFragmentStage, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment,
+  DependencyType, ExportsInfoArtifact, FactorizeInfo, InitFragmentKey, InitFragmentStage,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, NormalInitFragment, ReferencedExport,
   RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName, create_exports_object_referenced,
   property_access, to_normal_comment,
 };
@@ -71,11 +71,11 @@ impl Dependency for ProvideDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     if self.ids.is_empty() {
       create_exports_object_referenced()
     } else {
-      vec![ExtendedReferencedExport::Array(self.ids.clone())]
+      vec![ReferencedExport::from_path(self.ids.iter().cloned())]
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -75,7 +75,7 @@ impl Dependency for ProvideDependency {
     if self.ids.is_empty() {
       create_exports_object_referenced()
     } else {
-      vec![ReferencedExport::from_path(self.ids.iter().cloned())]
+      vec![ReferencedExport::from(self.ids.as_slice())]
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -1,9 +1,9 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCodeGeneration, DependencyId, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact, FactorizeInfo,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource,
 };
 
 #[cacheable]
@@ -48,7 +48,7 @@ impl Dependency for IsIncludeDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -10,9 +10,9 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Compilation, Dependency, DependencyCategory, DependencyCodeGeneration,
   DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, JavascriptParserWorkerUrl,
-  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, RuntimeGlobals, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource, URLStaticMode,
+  ExportsInfoArtifact, FactorizeInfo, JavascriptParserWorkerUrl, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ReferencedExport, RuntimeGlobals, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource, URLStaticMode,
 };
 use rspack_hash::{RspackHash, RspackHasher};
 
@@ -89,7 +89,7 @@ impl Dependency for WorkerDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -5,19 +5,19 @@ use rspack_collections::IdentifierMap;
 use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, CanInlineUse, Compilation,
   CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId, ExportsInfo,
-  ExportsInfoArtifact, ExportsInfoData, ExtendedReferencedExport, GroupOptions, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, Plugin, ReferencedExport, RuntimeSpec,
+  ExportsInfoArtifact, ExportsInfoData, GroupOptions, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, Plugin, ReferencedExport, ReferencedExportPath, RuntimeSpec,
   SideEffectsOptimizeArtifact, SideEffectsStateArtifact, UsageState,
   build_module_graph::BuildModuleGraphArtifact, get_entry_runtime, incremental::IncrementalPasses,
   is_exports_object_referenced, is_no_exports_referenced, module_declared_side_effect_free,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::{atom::Atom, queue::Queue};
+use rspack_util::queue::Queue;
 use rustc_hash::FxHashMap as HashMap;
 
 type ProcessBlockTask = (ModuleOrAsyncDependenciesBlock, Option<RuntimeSpec>, bool);
-type NonNestedTask = (Option<RuntimeSpec>, bool, Vec<ExtendedReferencedExport>);
+type NonNestedTask = (Option<RuntimeSpec>, bool, Vec<ReferencedExport>);
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum ModuleOrAsyncDependenciesBlock {
@@ -27,8 +27,8 @@ enum ModuleOrAsyncDependenciesBlock {
 
 #[derive(Debug, Clone)]
 enum ProcessModuleReferencedExports {
-  Map(HashMap<Vec<Atom>, ExtendedReferencedExport>),
-  ExtendRef(Vec<ExtendedReferencedExport>),
+  Map(HashMap<ReferencedExportPath, ReferencedExport>),
+  ExtendRef(Vec<ReferencedExport>),
 }
 #[allow(unused)]
 pub struct FlagDependencyUsagePluginProxy<'a> {
@@ -175,10 +175,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               let mut non_nested_tasks = Vec::with_capacity(referenced_exports.len());
               for (module_id, exports) in referenced_exports {
                 let exports_info = self.exports_info_artifact.get_exports_info_data(&module_id);
-                let has_nested = exports.iter().any(|e| match e {
-                  ExtendedReferencedExport::Array(arr) => arr.len() > 1,
-                  ExtendedReferencedExport::Export(export) => export.name.len() > 1,
-                });
+                let has_nested = exports.iter().any(|export| export.name.len() > 1);
                 if has_nested {
                   nested_tasks.push((
                     runtime.clone(),
@@ -309,7 +306,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     force_side_effects: bool,
     global: bool,
   ) -> (
-    Vec<(ModuleIdentifier, Vec<ExtendedReferencedExport>)>,
+    Vec<(ModuleIdentifier, Vec<ReferencedExport>)>,
     Vec<ProcessBlockTask>,
   ) {
     let compilation = self.compilation;
@@ -426,7 +423,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     &mut self,
     mgm_exports_info: ExportsInfo,
     module_id: ModuleIdentifier,
-    used_exports: Vec<ExtendedReferencedExport>,
+    used_exports: Vec<ReferencedExport>,
     runtime: Option<RuntimeSpec>,
     force_side_effects: bool,
     side_effects_state_artifact: &SideEffectsStateArtifact,
@@ -457,15 +454,10 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       }
 
       for used_export_info in used_exports {
-        let (used_exports, can_mangle, can_inline, ns_access) = match used_export_info {
-          ExtendedReferencedExport::Array(used_exports) => (used_exports, true, true, false),
-          ExtendedReferencedExport::Export(export) => (
-            export.name,
-            export.can_mangle,
-            export.can_inline,
-            export.ns_access,
-          ),
-        };
+        let can_mangle = used_export_info.can_mangle();
+        let can_inline = used_export_info.can_inline();
+        let ns_access = used_export_info.ns_access();
+        let used_exports = used_export_info.name;
         if used_exports.is_empty() {
           let flag = mgm_exports_info
             .as_data_mut(self.exports_info_artifact)
@@ -629,7 +621,7 @@ impl Plugin for FlagDependencyUsagePlugin {
 
 fn merge_referenced_exports(
   old_referenced_exports: Option<ProcessModuleReferencedExports>,
-  referenced_exports: Vec<ExtendedReferencedExport>,
+  referenced_exports: Vec<ReferencedExport>,
 ) -> Option<ProcessModuleReferencedExports> {
   if old_referenced_exports.is_none()
     || matches!(old_referenced_exports, Some(ProcessModuleReferencedExports::ExtendRef(ref v)) if is_no_exports_referenced(v))
@@ -647,52 +639,22 @@ fn merge_referenced_exports(
       ProcessModuleReferencedExports::Map(map) => map,
       ProcessModuleReferencedExports::ExtendRef(ref_items) => ref_items
         .into_iter()
-        .map(|item| {
-          let key = referenced_export_key(&item);
-          (key, item)
-        })
+        .map(|item| (item.name.clone(), item))
         .collect::<HashMap<_, _>>(),
     };
 
-    for mut item in referenced_exports {
-      let key = referenced_export_key(&item);
-      match item {
-        ExtendedReferencedExport::Array(_) => {
-          exports_map.entry(key).or_insert(item);
+    for item in referenced_exports {
+      let key = item.name.clone();
+      match exports_map.entry(key) {
+        Entry::Occupied(mut occ) => occ.get_mut().merge_flags(item.flags),
+        Entry::Vacant(vac) => {
+          vac.insert(item);
         }
-        ExtendedReferencedExport::Export(ref mut export) => match exports_map.entry(key) {
-          Entry::Occupied(mut occ) => {
-            let old_item = occ.get();
-            match old_item {
-              ExtendedReferencedExport::Array(_) => {
-                occ.insert(item);
-              }
-              ExtendedReferencedExport::Export(old_item) => {
-                occ.insert(ExtendedReferencedExport::Export(ReferencedExport {
-                  name: std::mem::take(&mut export.name),
-                  can_mangle: export.can_mangle && old_item.can_mangle,
-                  can_inline: export.can_inline && old_item.can_inline,
-                  ns_access: export.ns_access || old_item.ns_access,
-                }));
-              }
-            }
-          }
-          Entry::Vacant(vac) => {
-            vac.insert(item);
-          }
-        },
       }
     }
     return Some(ProcessModuleReferencedExports::Map(exports_map));
   }
   None
-}
-
-fn referenced_export_key(item: &ExtendedReferencedExport) -> Vec<Atom> {
-  match item {
-    ExtendedReferencedExport::Array(arr) => arr.clone(),
-    ExtendedReferencedExport::Export(export) => export.name.clone(),
-  }
 }
 
 fn collect_active_dependencies(
@@ -779,7 +741,7 @@ fn get_dependency_referenced_exports(
   module_graph_cache: &ModuleGraphCacheArtifact,
   exports_info_artifact: &ExportsInfoArtifact,
   runtime: Option<&RuntimeSpec>,
-) -> Option<Vec<ExtendedReferencedExport>> {
+) -> Option<Vec<ReferencedExport>> {
   let dep = module_graph.dependency_by_id(&dep_id);
 
   if let Some(md) = dep.as_module_dependency() {
@@ -790,7 +752,7 @@ fn get_dependency_referenced_exports(
       runtime,
     ))
   } else if dep.as_context_dependency().is_some() {
-    Some(vec![ExtendedReferencedExport::Array(vec![])])
+    Some(vec![ReferencedExport::default()])
   } else {
     None
   }
@@ -801,7 +763,7 @@ fn process_referenced_module_without_nested(
   is_exports_type_unset: bool,
   is_side_effect_free: bool,
   exports_info: &mut ExportsInfoData,
-  used_exports: Vec<ExtendedReferencedExport>,
+  used_exports: Vec<ReferencedExport>,
   runtime: Option<RuntimeSpec>,
   force_side_effects: bool,
 ) -> Vec<ProcessBlockTask> {
@@ -820,15 +782,10 @@ fn process_referenced_module_without_nested(
     }
 
     for used_export_info in used_exports {
-      let (used_exports, can_mangle, can_inline, ns_access) = match used_export_info {
-        ExtendedReferencedExport::Array(used_exports) => (used_exports, true, true, false),
-        ExtendedReferencedExport::Export(export) => (
-          export.name,
-          export.can_mangle,
-          export.can_inline,
-          export.ns_access,
-        ),
-      };
+      let can_mangle = used_export_info.can_mangle();
+      let can_inline = used_export_info.can_inline();
+      let ns_access = used_export_info.ns_access();
+      let used_exports = used_export_info.name;
       if used_exports.is_empty() {
         let flag = exports_info.set_used_in_unknown_way(runtime.as_ref());
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -6,8 +6,8 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, BuildMetaExportsType, CanInlineUse, Compilation,
   CompilationOptimizeDependencies, ConnectionState, DependenciesBlock, DependencyId, ExportsInfo,
   ExportsInfoArtifact, ExportsInfoData, GroupOptions, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleIdentifier, Plugin, ReferencedExport, ReferencedExportPath, RuntimeSpec,
-  SideEffectsOptimizeArtifact, SideEffectsStateArtifact, UsageState,
+  ModuleIdentifier, Plugin, ReferencedExport, ReferencedExportFlags, ReferencedExportPath,
+  RuntimeSpec, SideEffectsOptimizeArtifact, SideEffectsStateArtifact, UsageState,
   build_module_graph::BuildModuleGraphArtifact, get_entry_runtime, incremental::IncrementalPasses,
   is_exports_object_referenced, is_no_exports_referenced, module_declared_side_effect_free,
 };
@@ -27,7 +27,7 @@ enum ModuleOrAsyncDependenciesBlock {
 
 #[derive(Debug, Clone)]
 enum ProcessModuleReferencedExports {
-  Map(HashMap<ReferencedExportPath, ReferencedExport>),
+  Map(HashMap<ReferencedExportPath, ReferencedExportFlags>),
   ExtendRef(Vec<ReferencedExport>),
 }
 #[allow(unused)]
@@ -379,7 +379,10 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           (
             module_id,
             match referenced_exports {
-              ProcessModuleReferencedExports::Map(map) => map.into_values().collect::<Vec<_>>(),
+              ProcessModuleReferencedExports::Map(map) => map
+                .into_iter()
+                .map(|(name, flags)| ReferencedExport { name, flags })
+                .collect::<Vec<_>>(),
               ProcessModuleReferencedExports::ExtendRef(extend_ref) => extend_ref,
             },
           )
@@ -639,16 +642,15 @@ fn merge_referenced_exports(
       ProcessModuleReferencedExports::Map(map) => map,
       ProcessModuleReferencedExports::ExtendRef(ref_items) => ref_items
         .into_iter()
-        .map(|item| (item.name.clone(), item))
+        .map(|item| (item.name, item.flags))
         .collect::<HashMap<_, _>>(),
     };
 
     for item in referenced_exports {
-      let key = item.name.clone();
-      match exports_map.entry(key) {
-        Entry::Occupied(mut occ) => occ.get_mut().merge_flags(item.flags),
+      match exports_map.entry(item.name) {
+        Entry::Occupied(mut occ) => occ.get_mut().merge(item.flags),
         Entry::Vacant(vac) => {
-          vac.insert(item);
+          vac.insert(item.flags);
         }
       }
     }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -30,6 +30,7 @@ enum ProcessModuleReferencedExports {
   Map(HashMap<ReferencedExportPath, ReferencedExportFlags>),
   ExtendRef(Vec<ReferencedExport>),
 }
+
 #[allow(unused)]
 pub struct FlagDependencyUsagePluginProxy<'a> {
   global: bool,

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -158,7 +158,8 @@ async fn optimize_code_generation(
     })
     .collect_vec();
 
-  let mut exports_info_cache = FxHashMap::with_capacity_and_hasher(q.len(), Default::default());
+  let mut exports_info_cache =
+    FxHashMap::with_capacity_and_hasher(exports_info_artifact.len(), Default::default());
 
   while !q.is_empty() {
     let items = std::mem::take(&mut q);

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -7,7 +7,7 @@ use rspack_collections::{
 };
 use rspack_core::{
   BoxDependency, BoxModule, ChunkUkey, Compilation, CompilationOptimizeChunkModules, DependencyId,
-  DependencyType, ExportProvided, ExportsInfoArtifact, ExtendedReferencedExport, GetTargetResult,
+  DependencyType, ExportProvided, ExportsInfoArtifact, GetTargetResult,
   ImportedByDeferModulesArtifact, LibIdentOptions, Logger, ModuleGraph, ModuleGraphCacheArtifact,
   ModuleGraphConnection, ModuleGraphModule, ModuleIdentifier, OptimizationBailoutItem, Plugin,
   ProvidedExports, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, SourceType,
@@ -1113,10 +1113,7 @@ impl ModuleConcatenationPlugin {
             Some(CachedOutgoingConnection {
               connection: con.clone(),
               module_identifier: *con.module_identifier(),
-              has_imported_names: imported_names.iter().all(|item| match item {
-                ExtendedReferencedExport::Array(arr) => !arr.is_empty(),
-                ExtendedReferencedExport::Export(export) => !export.name.is_empty(),
-              }),
+              has_imported_names: imported_names.iter().all(|item| !item.name.is_empty()),
               active: con.is_target_active(
                 module_graph,
                 Some(&runtime),

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
@@ -4,8 +4,8 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationDependencyReferencedExports,
   CompilationOptimizeDependencies, CompilationProcessAssets, DependenciesBlock, Dependency,
-  DependencyId, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, Module, ModuleGraph,
-  ModuleIdentifier, Plugin, RuntimeGlobals, RuntimeModule, RuntimeModuleExt, RuntimeSpec,
+  DependencyId, DependencyType, ExportsInfoArtifact, Module, ModuleGraph, ModuleIdentifier, Plugin,
+  ReferencedExport, RuntimeGlobals, RuntimeModule, RuntimeModuleExt, RuntimeSpec,
   SideEffectsOptimizeArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   module_declared_side_effect_free,
@@ -385,7 +385,7 @@ fn dependency_referenced_exports(
   &self,
   compilation: &Compilation,
   dependency_id: &DependencyId,
-  referenced_exports: &Option<Vec<ExtendedReferencedExport>>,
+  referenced_exports: &Option<Vec<ReferencedExport>>,
   _runtime: Option<&RuntimeSpec>,
   module_graph: Option<&ModuleGraph>,
 ) -> Result<()> {
@@ -413,10 +413,7 @@ fn dependency_referenced_exports(
 
   // If it's an import dependency and referenced exports indicate "exports object referenced",
   // clear any recorded shared referenced exports for this share key and stop here.
-  let is_exports_object = matches!(
-    final_exports.as_slice(),
-    [ExtendedReferencedExport::Array(arr)] if arr.is_empty()
-  );
+  let is_exports_object = matches!(final_exports.as_slice(), [export] if export.name.is_empty());
   if dependency
     .as_any()
     .downcast_ref::<ImportDependency>()
@@ -464,21 +461,12 @@ fn dependency_referenced_exports(
       .entry(share_key.to_string())
       .or_default();
 
-    for referenced_export in &final_exports {
-      match referenced_export {
-        ExtendedReferencedExport::Array(exports_array) => {
-          for export in exports_array {
-            export_set.insert(export.to_string());
-          }
-        }
-        ExtendedReferencedExport::Export(referenced) => {
-          if referenced.name.is_empty() {
-            continue;
-          }
-          for atom in &referenced.name {
-            export_set.insert(atom.to_string());
-          }
-        }
+    for referenced in &final_exports {
+      if referenced.name.is_empty() {
+        continue;
+      }
+      for atom in &referenced.name {
+        export_set.insert(atom.to_string());
       }
     }
   }

--- a/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
@@ -4,8 +4,8 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo, ModuleDependency,
-  ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, ResourceIdentifier, RuntimeSpec,
+  DependencyType, ExportsInfoArtifact, FactorizeInfo, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ReferencedExport, ResourceIdentifier, RuntimeSpec,
   create_exports_object_referenced,
 };
 use rspack_util::fx_hash::FxIndexSet;
@@ -69,7 +69,7 @@ impl Dependency for ClientReferenceDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     // `*` is an internal sentinel meaning this client reference needs the
     // whole exports object, not a narrowed list of named exports.
     if self
@@ -86,9 +86,7 @@ impl Dependency for ClientReferenceDependency {
       .referenced_exports
       .iter()
       .cloned()
-      .map(|export_name| {
-        ExtendedReferencedExport::Export(ReferencedExport::new(vec![export_name], false, false))
-      })
+      .map(|export_name| ReferencedExport::new([export_name], false, false))
       .collect()
   }
 }

--- a/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
@@ -85,8 +85,11 @@ impl Dependency for ClientReferenceDependency {
     self
       .referenced_exports
       .iter()
-      .cloned()
-      .map(|export_name| ReferencedExport::new([export_name], false, false))
+      .map(|export_name| {
+        ReferencedExport::from(export_name)
+          .with_can_mangle(false)
+          .with_can_inline(false)
+      })
       .collect()
   }
 }

--- a/crates/rspack_plugin_rsdoctor/src/module_graph.rs
+++ b/crates/rspack_plugin_rsdoctor/src/module_graph.rs
@@ -4,10 +4,10 @@ use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
 use rspack_collections::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_core::{
   BoxModule, ChunkGraph, Compilation, Context, Dependency, DependencyId, DependencyType,
-  ExportInfoData, ExportMode, ExportProvided, ExportsInfoArtifact, ExtendedReferencedExport,
-  Module, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdsArtifact, ModuleType,
-  OptimizationBailoutItem, SideEffectsStateArtifact, UsageState, UsedByExports,
-  UsedByExportsCondition, collect_referenced_export_items,
+  ExportInfoData, ExportMode, ExportProvided, ExportsInfoArtifact, Module, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdsArtifact, ModuleType, OptimizationBailoutItem,
+  SideEffectsStateArtifact, UsageState, UsedByExports, UsedByExportsCondition,
+  collect_referenced_export_items,
   rspack_sources::{MapOptions, ObjectPool},
 };
 use rspack_paths::Utf8PathBuf;
@@ -338,10 +338,7 @@ fn get_esm_import_specifier_target_exports(
       None,
     )
     .into_iter()
-    .map(|referenced_export| match referenced_export {
-      ExtendedReferencedExport::Array(ids) => ids,
-      ExtendedReferencedExport::Export(export) => export.name,
-    })
+    .map(|referenced_export| referenced_export.name)
     .map(|ids| {
       if ids.is_empty() {
         None

--- a/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_module_id_dependency.rs
@@ -2,7 +2,7 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_core::{
   AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
   DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ExtendedReferencedExport, FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  FactorizeInfo, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport,
   RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
@@ -83,7 +83,7 @@ impl Dependency for MockModuleIdDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
+  ) -> Vec<ReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsPreset};
 use rspack_core::{
   AsContextDependency, AsDependencyCodeGeneration, Dependency, DependencyCategory, DependencyId,
-  DependencyRange, DependencyType, ExportsInfoArtifact, ExtendedReferencedExport, FactorizeInfo,
-  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, RuntimeSpec,
+  DependencyRange, DependencyType, ExportsInfoArtifact, FactorizeInfo, ModuleDependency,
+  ModuleGraph, ModuleGraphCacheArtifact, ReferencedExport, RuntimeSpec,
 };
 use swc_core::ecma::atoms::Atom;
 
@@ -56,8 +56,8 @@ impl Dependency for WasmImportDependency {
     _module_graph_cache: &ModuleGraphCacheArtifact,
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
-    vec![ExtendedReferencedExport::Array(vec![self.name.clone()])]
+  ) -> Vec<ReferencedExport> {
+    vec![ReferencedExport::from_path([self.name.clone()])]
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {

--- a/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
@@ -57,7 +57,7 @@ impl Dependency for WasmImportDependency {
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ReferencedExport> {
-    vec![ReferencedExport::from_path([self.name.clone()])]
+    vec![ReferencedExport::from(&self.name)]
   }
 
   fn could_affect_referencing_module(&self) -> rspack_core::AffectType {


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Remove `ExtendedReferencedExport` and use a single `ReferencedExport { name, flags }` representation across dependency producers and consumers.
- Store common short export paths inline with `SmallVec<[Atom; 2]>`, reducing heap allocations for referenced export paths.
- Pack `can_mangle`, `can_inline`, and `ns_access` into `ReferencedExportFlags`.
- Simplify referenced-export construction by accepting iterators, avoiding temporary `Vec<Atom>` allocations at call sites.
- Store only `ReferencedExportFlags` as the value of the referenced-export merge map, avoiding duplicate path ownership and cloning between the map key and value.
- Preserve the existing exports-object, mangling, inlining, namespace-access, and flag-merging semantics.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
