### PR TITLE
refactor(binding): remove compilation pointer from async dependency block

### DIFF
--- a/crates/rspack_binding_api/src/async_dependency_block.rs
+++ b/crates/rspack_binding_api/src/async_dependency_block.rs
@@ -1,60 +1,107 @@
-use std::{cell::RefCell, ptr::NonNull};
+use std::cell::RefCell;
 
 use napi_derive::napi;
-use rspack_core::{DependenciesBlock as _, internal};
+use rspack_core::{Compilation, CompilerId, DependenciesBlock as _, internal};
 use rspack_napi::{OneShotRef, napi::bindgen_prelude::*};
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::dependency::DependencyWrapper;
+use crate::{COMPILER_REFERENCES, dependency::DependencyWrapper};
 
 #[napi]
 pub struct AsyncDependenciesBlock {
   pub(crate) block_id: rspack_core::AsyncDependenciesBlockIdentifier,
-  compilation: NonNull<rspack_core::Compilation>,
+  compiler_id: CompilerId,
+}
+
+impl AsyncDependenciesBlock {
+  fn compiler_garbage_collected_error(&self) -> napi::Error {
+    napi::Error::from_reason(format!(
+      "Unable to access async dependencies block with id = {:?} now. The Compiler has been garbage collected by JavaScript.",
+      self.block_id
+    ))
+  }
+
+  fn block_removed_error(&self) -> napi::Error {
+    napi::Error::from_reason(format!(
+      "Unable to access async dependencies block with id = {:?} now. The block has been removed on the Rust side.",
+      self.block_id
+    ))
+  }
+
+  fn with_compilation<R>(
+    &self,
+    f: impl FnOnce(&Compilation) -> napi::Result<R>,
+  ) -> napi::Result<R> {
+    let compiler_reference = COMPILER_REFERENCES.with(|ref_cell| {
+      let references = ref_cell.borrow();
+      references.get(&self.compiler_id).cloned()
+    });
+
+    let Some(this) = compiler_reference
+      .as_ref()
+      .and_then(|compiler_reference| compiler_reference.get())
+    else {
+      return Err(self.compiler_garbage_collected_error());
+    };
+
+    f(&this.compiler.compilation)
+  }
+
+  fn with_ref<R>(
+    &self,
+    f: impl FnOnce(&Compilation, &rspack_core::AsyncDependenciesBlock) -> napi::Result<R>,
+  ) -> napi::Result<R> {
+    self.with_compilation(|compilation| {
+      let module_graph = compilation.get_module_graph();
+      if let Some(block) = module_graph.block_by_id(&self.block_id) {
+        f(compilation, block)
+      } else {
+        Err(self.block_removed_error())
+      }
+    })
+  }
 }
 
 #[napi]
 impl AsyncDependenciesBlock {
   #[napi(getter, ts_return_type = "Dependency[]")]
-  pub fn dependencies(&mut self) -> Vec<DependencyWrapper> {
-    let compilation = unsafe { self.compilation.as_ref() };
-    let module_graph = compilation.get_module_graph();
-    if let Some(block) = module_graph.block_by_id(&self.block_id) {
-      block
-        .get_dependencies()
-        .iter()
-        .filter_map(|dependency_id| {
-          internal::try_dependency_by_id(module_graph, dependency_id).map(|dep| {
-            DependencyWrapper::new(
-              (&**dep) as &dyn rspack_core::Dependency,
-              compilation.id(),
-              Some(compilation),
-            )
+  pub fn dependencies(&self) -> napi::Result<Vec<DependencyWrapper>> {
+    self.with_ref(|compilation, block| {
+      let module_graph = compilation.get_module_graph();
+      Ok(
+        block
+          .get_dependencies()
+          .iter()
+          .filter_map(|dependency_id| {
+            internal::try_dependency_by_id(module_graph, dependency_id).map(|dep| {
+              DependencyWrapper::new(
+                (&**dep) as &dyn rspack_core::Dependency,
+                compilation.id(),
+                Some(compilation),
+              )
+            })
           })
-        })
-        .collect::<Vec<_>>()
-    } else {
-      vec![]
-    }
+          .collect::<Vec<_>>(),
+      )
+    })
   }
 
   #[napi(getter, ts_return_type = "AsyncDependenciesBlock[]")]
-  pub fn blocks(&mut self) -> Vec<AsyncDependenciesBlockWrapper> {
-    let compilation = unsafe { self.compilation.as_ref() };
-    let module_graph = compilation.get_module_graph();
-    if let Some(block) = module_graph.block_by_id(&self.block_id) {
-      block
-        .get_blocks()
-        .iter()
-        .filter_map(|block_id| {
-          module_graph
-            .block_by_id(block_id)
-            .map(|block| AsyncDependenciesBlockWrapper::new(block, compilation))
-        })
-        .collect::<Vec<_>>()
-    } else {
-      vec![]
-    }
+  pub fn blocks(&self) -> napi::Result<Vec<AsyncDependenciesBlockWrapper>> {
+    self.with_ref(|compilation, block| {
+      let module_graph = compilation.get_module_graph();
+      Ok(
+        block
+          .get_blocks()
+          .iter()
+          .filter_map(|block_id| {
+            module_graph
+              .block_by_id(block_id)
+              .map(|block| AsyncDependenciesBlockWrapper::new(block, compilation))
+          })
+          .collect::<Vec<_>>(),
+      )
+    })
   }
 }
 
@@ -69,7 +116,8 @@ thread_local! {
 
 pub struct AsyncDependenciesBlockWrapper {
   block_id: rspack_core::AsyncDependenciesBlockIdentifier,
-  compilation: NonNull<rspack_core::Compilation>,
+  compilation_id: rspack_core::CompilationId,
+  compiler_id: CompilerId,
 }
 
 impl AsyncDependenciesBlockWrapper {
@@ -79,13 +127,10 @@ impl AsyncDependenciesBlockWrapper {
   ) -> Self {
     let block_id = block.identifier();
 
-    #[allow(clippy::unwrap_used)]
     Self {
       block_id,
-      compilation: NonNull::new(
-        compilation as *const rspack_core::Compilation as *mut rspack_core::Compilation,
-      )
-      .unwrap(),
+      compilation_id: compilation.id(),
+      compiler_id: compilation.compiler_id(),
     }
   }
 
@@ -104,9 +149,8 @@ impl ToNapiValue for AsyncDependenciesBlockWrapper {
   ) -> napi::Result<napi::sys::napi_value> {
     unsafe {
       BLOCK_INSTANCE_REFS.with(|refs| {
-        let compilation = val.compilation.as_ref();
         let mut refs_by_compilation_id = refs.borrow_mut();
-        let entry = refs_by_compilation_id.entry(compilation.id());
+        let entry = refs_by_compilation_id.entry(val.compilation_id);
         let refs = match entry {
           std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
           std::collections::hash_map::Entry::Vacant(entry) => {
@@ -123,7 +167,7 @@ impl ToNapiValue for AsyncDependenciesBlockWrapper {
           std::collections::hash_map::Entry::Vacant(vacant_entry) => {
             let js_block = AsyncDependenciesBlock {
               block_id: val.block_id,
-              compilation: val.compilation,
+              compiler_id: val.compiler_id,
             };
             let r = vacant_entry.insert(OneShotRef::new(env, js_block)?);
             ToNapiValue::to_napi_value(env, r)


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- remove the raw `NonNull<Compilation>` pointer from `AsyncDependenciesBlock`
- store `CompilerId` and resolve the current compilation through `COMPILER_REFERENCES`
- look up async dependency blocks by identifier before accessing their dependencies or child blocks
- preserve JS instance caching with `CompilationId`
- return explicit errors when the compiler has been garbage collected or the block has been removed

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
