### PR TITLE
feat: enable createRequire parser for node targets

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -320,10 +320,12 @@ const applyJavascriptParserOptionsDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    targetProperties,
   }: {
     deferImport?: boolean;
     sourceImport?: boolean;
     outputModule: RspackOptionsNormalized['output']['module'];
+    targetProperties: false | TargetProperties;
   },
 ) => {
   D(parserOptions, 'dynamicImportMode', 'lazy');
@@ -349,7 +351,13 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'deferImport', deferImport);
   D(parserOptions, 'sourceImport', sourceImport);
   D(parserOptions, 'importMetaResolve', false);
-  D(parserOptions, 'createRequire', false);
+  D(
+    parserOptions,
+    'createRequire',
+    targetProperties !== false &&
+      targetProperties.node === true &&
+      parserOptions.requireResolve !== false,
+  );
 };
 
 const applyCssGeneratorOptionsDefaults = (
@@ -463,6 +471,7 @@ const applyModuleDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    targetProperties,
   });
 
   F(module.parser, JSON_MODULE_TYPE, () => ({}));

--- a/tests/rspack-test/configCases/require/module-require/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require/rspack.config.js
@@ -50,13 +50,6 @@ module.exports = {
     path: 'node-commonjs path',
   },
   target: 'node',
-  module: {
-    parser: {
-      javascript: {
-        createRequire: true,
-      },
-    },
-  },
   optimization: {
     inlineExports: true,
     moduleIds: 'named',

--- a/tests/rspack-test/defaultsCases/target_/electron-main.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-main.js
@@ -37,6 +37,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/electron-preload.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-preload.js
@@ -35,6 +35,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/node-require-resolve-disabled.js
+++ b/tests/rspack-test/defaultsCases/target_/node-require-resolve-disabled.js
@@ -1,0 +1,22 @@
+/** @type {import('@rspack/test-tools').TDefaultsCaseConfig} */
+module.exports = {
+	description: "target node with requireResolve disabled",
+	options: () => ({
+		target: "node",
+		module: {
+			parser: {
+				javascript: {
+					requireResolve: false
+				}
+			}
+		}
+	}),
+	diff: e => {
+		e.toEqual({
+			value: expect.stringMatching(/\+\s+"requireResolve": false/)
+		});
+		e.toEqual({
+			value: expect.not.stringContaining('"createRequire"')
+		});
+	}
+};

--- a/tests/rspack-test/defaultsCases/target_/node.js
+++ b/tests/rspack-test/defaultsCases/target_/node.js
@@ -32,6 +32,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/nwjs.js
+++ b/tests/rspack-test/defaultsCases/target_/nwjs.js
@@ -31,6 +31,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",


### PR DESCRIPTION
## Summary

Enable `module.parser.javascript.createRequire` by default when the resolved target is explicitly Node-compatible. Web and mixed/unknown targets remain disabled, and explicit parser configuration continues to take precedence.

The existing `module-require` config case now runs without an explicit `createRequire: true`, while defaults snapshots cover Node, Electron, and NW.js targets.

## Related links

- Follow-up to #14491

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).