### PR TITLE
fix(css): preserve inline match resource imports

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -46,6 +46,11 @@ use crate::{
 /// We should make sure that there's no read-write and write-write conflicts for each hook instance by looking up [CssPlugin::get_compilation_hooks_mut]
 type ArcCssModulesPluginHooks = Arc<AtomicRefCell<CssModulesPluginHooks>>;
 
+struct CssModuleRenderSources {
+  source_before_hooks: BoxSource,
+  rendered_source: BoxSource,
+}
+
 static COMPILATION_HOOKS_MAP: LazyLock<FxDashMap<CompilationId, ArcCssModulesPluginHooks>> =
   LazyLock::new(Default::default);
 
@@ -206,12 +211,21 @@ impl CssPlugin {
               };
 
               let chunk_ukey = chunk.as_u32().into();
+              // Module package hooks may add module-specific decorations such as pathinfo.
+              // Deduplicate the undecorated source but emit the rendered source.
+              let source_before_hooks = post_module_container.source.clone();
               hooks
                 .render_module_package
                 .call(compilation, &chunk_ukey, module, &mut post_module_container)
                 .await?;
 
-              Ok((module.identifier(), post_module_container.source))
+              Ok((
+                module.identifier(),
+                CssModuleRenderSources {
+                  source_before_hooks,
+                  rendered_source: post_module_container.source,
+                },
+              ))
             },
           );
         });
@@ -234,7 +248,7 @@ impl CssPlugin {
 
   fn render_ordered_css_sources(
     ordered_css_modules: &[&dyn Module],
-    module_sources: &HashMap<ModuleIdentifier, BoxSource>,
+    module_sources: &HashMap<ModuleIdentifier, CssModuleRenderSources>,
   ) -> BoxSource {
     let mut non_import_css_sources = HashMap::<_, Vec<_>>::default();
     for module in ordered_css_modules
@@ -248,7 +262,7 @@ impl CssPlugin {
         non_import_css_sources
           .entry(resource)
           .or_default()
-          .push(source);
+          .push(&source.source_before_hooks);
       }
     }
 
@@ -260,9 +274,10 @@ impl CssPlugin {
         && let Some(resource) = css_module_resource(*module)
         && let Some(source) = module_sources.get(&identifier)
         && non_import_css_sources.get(resource).is_some_and(|sources| {
-          sources
-            .iter()
-            .any(|other| is_source_equal(source.as_ref(), (*other).as_ref()))
+          sources.iter().any(|other| {
+            source.source_before_hooks.size() == other.size()
+              && is_source_equal(source.source_before_hooks.as_ref(), (*other).as_ref())
+          })
         })
       {
         if css_module_has_charset(*module) {
@@ -275,7 +290,7 @@ impl CssPlugin {
         if css_module_has_charset(*module) {
           builder.set_has_charset();
         }
-        builder.push_css_source(source.clone(), &[], false);
+        builder.push_css_source(source.rendered_source.clone(), &[], false);
       }
     }
 

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   ModuleIdentifier, ModuleType, NormalModuleCreateData, NormalModuleFactoryAfterResolve,
   NormalModuleFactoryModule, ParserAndGenerator, PathData, Plugin, PublicPath, RenderManifestEntry,
   RuntimeGlobals, RuntimeModule, RuntimeModuleExt, SelfModuleFactory, SourceType,
-  css_module_render_conditions_identifier, get_css_chunk_filename_template,
+  css_module_render_conditions_identifier, get_css_chunk_filename_template, is_source_equal,
   rspack_sources::{BoxSource, CachedSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::{Diagnostic, Result, ToStringResultToRspackResultExt};
@@ -236,24 +236,41 @@ impl CssPlugin {
     ordered_css_modules: &[&dyn Module],
     module_sources: &HashMap<ModuleIdentifier, BoxSource>,
   ) -> BoxSource {
-    let non_import_css_resources = ordered_css_modules
+    let mut non_import_css_sources = HashMap::<_, Vec<_>>::default();
+    for module in ordered_css_modules
       .iter()
       .filter(|module| !css_module_is_import_dependency(**module))
-      .filter(|module| module_sources.contains_key(&module.identifier()))
-      .filter_map(|module| css_module_resource(*module))
-      .collect::<HashSet<_>>();
+    {
+      let identifier = module.identifier();
+      if let Some(resource) = css_module_resource(*module)
+        && let Some(source) = module_sources.get(&identifier)
+      {
+        non_import_css_sources
+          .entry(resource)
+          .or_default()
+          .push(source);
+      }
+    }
 
     let mut builder = CssSourceBuilder::new(false, true, Default::default());
     for module in ordered_css_modules {
+      let identifier = module.identifier();
       if css_module_is_import_dependency(*module)
         && css_render_conditions_from_module(*module).is_empty()
         && let Some(resource) = css_module_resource(*module)
-        && non_import_css_resources.contains(resource)
+        && let Some(source) = module_sources.get(&identifier)
+        && non_import_css_sources.get(resource).is_some_and(|sources| {
+          sources
+            .iter()
+            .any(|other| is_source_equal(source.as_ref(), (*other).as_ref()))
+        })
       {
+        if css_module_has_charset(*module) {
+          builder.set_has_charset();
+        }
         continue;
       }
 
-      let identifier = module.identifier();
       if let Some(source) = module_sources.get(&identifier) {
         if css_module_has_charset(*module) {
           builder.set_has_charset();

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/App.vue
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/App.vue
@@ -1,0 +1,1 @@
+.hello { width: 143px; color: rebeccapurple; }

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/Charset.vue
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/Charset.vue
@@ -1,0 +1,1 @@
+.charset-carrier { width: 271px; color: darkslateblue; }

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/charset-pitcher.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/charset-pitcher.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports.pitch = function () {
+	const request = this.utils.contextify(
+		this.context,
+		`${this.resourcePath}.css!=!-!${path.resolve(
+			__dirname,
+			"charset-style-loader.js"
+		)}!${this.resourcePath}`
+	);
+	const source = fs.readFileSync(this.resourcePath, "utf-8");
+
+	return `@import ${JSON.stringify(request)};${source}`;
+};

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/charset-style-loader.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/charset-style-loader.js
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+	return `@charset "UTF-8";\n${source}`;
+};

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/index.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/index.js
@@ -1,4 +1,5 @@
 import "./App.vue.css!=!./pitcher.js!./App.vue";
+import "./Charset.vue.css!=!./charset-pitcher.js!./Charset.vue";
 
 it("should include CSS imported through an inline match resource", () => {
 	const css = getLinkSheet(document.querySelector("link"));
@@ -6,4 +7,12 @@ it("should include CSS imported through an inline match resource", () => {
 	expect(css).toContain(".hello");
 	expect(css).toContain("143px");
 	expect(css).toContain("rebeccapurple");
+});
+
+it("should preserve charset from a deduplicated inline match resource import", () => {
+	const css = getLinkSheet(document.querySelector("link"));
+
+	expect(css.match(/\.charset-carrier/g)).toEqual([".charset-carrier"]);
+	expect(css.match(/@charset/g)).toEqual(["@charset"]);
+	expect(css.startsWith('@charset "UTF-8";\n')).toBe(true);
 });

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/index.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/index.js
@@ -1,0 +1,9 @@
+import "./App.vue.css!=!./pitcher.js!./App.vue";
+
+it("should include CSS imported through an inline match resource", () => {
+	const css = getLinkSheet(document.querySelector("link"));
+
+	expect(css).toContain(".hello");
+	expect(css).toContain("143px");
+	expect(css).toContain("rebeccapurple");
+});

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/pitcher.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/pitcher.js
@@ -1,0 +1,13 @@
+const path = require("path");
+
+module.exports.pitch = function () {
+	const request = this.utils.contextify(
+		this.context,
+		`${this.resourcePath}.css!=!-!${path.resolve(
+			__dirname,
+			"style-loader.js"
+		)}!${this.resourcePath}`
+	);
+
+	return `@import ${JSON.stringify(request)};`;
+};

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/rspack.config.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  mode: 'development',
+  experiments: {
+    css: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/rspack.config.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/rspack.config.js
@@ -2,6 +2,9 @@
 module.exports = {
   target: 'web',
   mode: 'development',
+  output: {
+    pathinfo: true,
+  },
   experiments: {
     css: true,
   },

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/style-loader.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/style-loader.js
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+	return source;
+};

--- a/tests/rspack-test/configCases/css/inline-match-resource-import/test.config.js
+++ b/tests/rspack-test/configCases/css/inline-match-resource-import/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};


### PR DESCRIPTION
## Summary

- preserve native CSS imports that share an inline match resource but render different content
- deduplicate only byte-identical rendered sources and carry charset metadata from skipped modules
- add focused regression coverage for differing sources and charset-preserving deduplication

## Related links

- Fixes #14802

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).