### PR TITLE
fix: short-circuit optional import.meta calls

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -9,7 +9,8 @@ use rspack_error::{Error, Severity};
 use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
-  AssignExpr, CallExpr, Expr, GetSpan, MemberExpr, MemberProp, MetaPropKind, Span, UnaryExpr,
+  AssignExpr, CallExpr, Expr, GetSpan, MemberExpr, MemberProp, MetaPropKind, OptChainBase,
+  OptChainExpr, Span, UnaryExpr,
 };
 use url::Url;
 
@@ -34,6 +35,7 @@ use crate::{
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
     RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
+    get_non_optional_member_chain_from_expr,
   },
 };
 
@@ -783,6 +785,55 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
       parser.walk_expression(&expr.right);
     }
     handled
+  }
+
+  fn optional_chaining(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    expr: &OptChainExpr,
+  ) -> Option<bool> {
+    let OptChainBase::Call(call_expr) = &expr.base else {
+      return None;
+    };
+    let info = parser
+      .get_member_expression_info_from_expr(&call_expr.callee, AllowedMemberTypes::Expression)?;
+    let MemberExpressionInfo::Expression(info) = info else {
+      return None;
+    };
+    let ExportedVariableInfo::Name(root) = &info.root_info else {
+      return None;
+    };
+    if root.as_str() != expr_name::IMPORT_META {
+      return None;
+    }
+
+    let first_property = info.members.first()?;
+    if self.preserve_property(Some(first_property.as_str())) {
+      return None;
+    }
+
+    let optional_after_first_property = info
+      .members_optionals
+      .get(1)
+      .is_some_and(|optional| *optional);
+    if !optional_after_first_property {
+      return None;
+    }
+
+    let first_property_expr =
+      get_non_optional_member_chain_from_expr(&call_expr.callee, (info.members.len() - 1) as i32);
+    if !parser
+      .evaluate_expression(first_property_expr)
+      .is_undefined()
+    {
+      return None;
+    }
+
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      expr.span().into(),
+      "undefined".into(),
+    )));
+    Some(true)
   }
 
   fn unhandled_expression_member_chain(

--- a/tests/rspack-test/configCases/parsing/import-meta-hot-prod/index.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-hot-prod/index.js
@@ -7,3 +7,16 @@ it('should transform import.meta.webpackHot to false', () => {
 
 	expect(hot).toBe(false);
 })
+
+it("should short-circuit optional calls on import.meta.webpackHot", () => {
+	let callbackArgumentEvaluated = false;
+	const createCallback = () => {
+		callbackArgumentEvaluated = true;
+		return () => {};
+	};
+
+	expect(
+		import.meta.webpackHot?.dispose(createCallback())
+	).toBeUndefined();
+	expect(callbackArgumentEvaluated).toBe(false);
+});

--- a/tests/rspack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/module.js
+++ b/tests/rspack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/module.js
@@ -2,4 +2,4 @@ import {value} from "dep1";
 
 export const val = value;
 
-import.meta.webpackHot.accept("dep1");
+import.meta.webpackHot?.accept("dep1");

--- a/tests/rspack-test/normalCases/esm/import-meta-property/index.js
+++ b/tests/rspack-test/normalCases/esm/import-meta-property/index.js
@@ -9,6 +9,10 @@ it("import.meta.url.xxx", () => {
 	);
 });
 
+it("should preserve optional calls on supported import.meta properties", () => {
+	expect(import.meta.url?.toString()).toBe(url);
+});
+
 it('import.meta?.env?.X', () => {
 	expect(import.meta?.env?.X).toBeUndefined();
 	expect(typeof import.meta?.env?.X).toBe("undefined");


### PR DESCRIPTION
## Summary

- Fix optional calls such as `import.meta.webpackHot?.dispose(callback)` when HMR does not provide `webpackHot`.
- Replace the complete optional-chain span with `undefined` only when the first `import.meta` property evaluates to `undefined`, preserving argument short-circuiting.
- Preserve supported properties such as `import.meta.url` and HMR-enabled `import.meta.webpackHot`.
- Add regression coverage for disabled HMR, enabled HMR, and supported `import.meta` properties.

The parser previously replaced only the optional member callee span, leaving the enclosing call in the generated output as `undefined(callback)`.

### Verification

- `pnpm run build:binding:dev`
- `pnpm run test -t "configCases/parsing/import-meta-hot-prod"`
- `pnpm run test -t "normalCases/esm/import-meta-property"`
- `pnpm run test:hot -t "esm-dependency-import/import-meta-webpack-hot"`
- `pnpm run test -t "configCases/module/import-meta-parser-options"`
- `cargo fmt --all --check`
- Prettier and pre-commit lint checks

## Related links

Closes #14695

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required).