### PR TITLE
fix(rsc): preserve exports for dynamic client references

### DIFF
--- a/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
+++ b/crates/rspack_plugin_rsc/src/client_reference_dependency.rs
@@ -70,12 +70,13 @@ impl Dependency for ClientReferenceDependency {
     _exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
-    // `*` is an internal sentinel meaning this client reference needs the
-    // whole exports object, not a narrowed list of named exports.
-    if self
-      .referenced_exports
-      .iter()
-      .any(|export_name| export_name == "*")
+    // An empty set and `*` both mean this client reference needs the whole
+    // exports object, not a narrowed list of named exports.
+    if self.referenced_exports.is_empty()
+      || self
+        .referenced_exports
+        .iter()
+        .any(|export_name| export_name == "*")
     {
       return create_exports_object_referenced();
     }

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/rspack.config.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/rspack.config.js
@@ -76,6 +76,9 @@ module.exports = [
     plugins: [
       new ServerPlugin(),
       new rspack.DefinePlugin({
+        DYNAMIC_TODO_PATH: JSON.stringify(
+          path.join(__dirname, 'src/DynamicTodo.js'),
+        ),
         TODOS_PATH: JSON.stringify(path.join(__dirname, 'src/Todos.js')),
       }),
     ],

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/App.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/App.js
@@ -3,10 +3,13 @@
 import { TodoItem, Todos } from './Todos';
 
 export const App = async () => {
+    const { DynamicTodo } = await import('./DynamicTodo');
+
     return (
         <>
             <Todos />
             <TodoItem />
+            <DynamicTodo />
         </>
     );
 };

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/DynamicTodo.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/DynamicTodo.js
@@ -1,0 +1,9 @@
+"use client";
+
+export const DynamicTodo = () => {
+    return <></>;
+};
+
+export const Unused = () => {
+    return <></>;
+};

--- a/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/framework/entry.rsc.js
+++ b/tests/rspack-test/configCases/rsc-plugin/tree-shaking/src/framework/entry.rsc.js
@@ -12,3 +12,11 @@ it('should tree-shake unused exports from "use client" modules', async () => {
     const exports = await loadClientModule(chunkId, moduleId);
     expect(exports.sort()).toEqual(['TodoItem', 'Todos']);
 });
+
+it('should preserve the exports object for dynamically imported client modules', async () => {
+    const { loadClientModule } = require("./static/main.js");
+    const dynamicChunkId = __rspack_rsc_manifest__.clientManifest[DYNAMIC_TODO_PATH].chunks[0];
+    const dynamicModuleId = __rspack_rsc_manifest__.clientManifest[DYNAMIC_TODO_PATH].id;
+    const dynamicExports = await loadClientModule(dynamicChunkId, dynamicModuleId);
+    expect(dynamicExports.sort()).toEqual(['DynamicTodo', 'Unused']);
+});


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Treat empty RSC client referenced exports as a reference to the complete exports object.
- Preserve exports for dynamically imported client components while retaining named-export tree-shaking.
- Add a regression test covering dynamic client modules with empty referenced exports.


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
