### PR TITLE
fix(stats): avoid live chunk access when serializing stale stats

### DIFF
--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -58,7 +58,7 @@ impl Chunk {
         f(compilation, chunk)
       } else {
         Err(napi::Error::from_reason(format!(
-          "Unable to access chunk with id = {:?} now. The module have been removed on the Rust side.",
+          "Unable to access chunk with id = {:?} now. The chunk have been removed on the Rust side.",
           self.chunk_ukey
         )))
       }

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -15,7 +15,6 @@ import type {
   JsStatsError,
   JsStatsModule,
 } from '@rspack/binding';
-import type { Chunk } from '../Chunk';
 import type { LogEntry, NormalizedStatsOptions } from '../Compilation';
 import type { Compiler } from '../Compiler';
 import type { StatsOptions } from '../config';
@@ -1006,24 +1005,15 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
         chunkGroup: entrypoint,
       }));
 
-      const chunks = Array.from(compilation.chunks).reduce<
-        Record<string, Chunk>
-      >((res, chunk) => {
-        res[chunk.id!] = chunk;
-        return res;
-      }, {});
-
       if (entrypoints === 'auto' && !chunkGroups) {
         if (array.length > 5) return;
         if (
           !chunkGroupChildren &&
           array.every(({ chunkGroup }) => {
             if (chunkGroup.chunks.length !== 1) return false;
-            const chunk = chunks[chunkGroup.chunks[0]];
             return (
-              chunk &&
-              chunk.files.size === 1 &&
-              (!chunkGroupAuxiliary || chunk.auxiliaryFiles.size === 0)
+              chunkGroup.assets.length === 1 &&
+              (!chunkGroupAuxiliary || chunkGroup.auxiliaryAssets?.length === 0)
             );
           })
         ) {

--- a/tests/rspack-test/statsAPICases/stale-entrypoints-stats.js
+++ b/tests/rspack-test/statsAPICases/stale-entrypoints-stats.js
@@ -1,0 +1,37 @@
+let entrypoints;
+
+/** @type {import('@rspack/test-tools').TStatsAPICaseConfig} */
+module.exports = {
+  description:
+    'should generate entrypoints from stale stats without accessing live chunks',
+  options(context) {
+    return {
+      context: context.getSource(),
+      entry: {
+        main: './fixtures/a',
+      },
+    };
+  },
+  compiler(_context, compiler) {
+    compiler.hooks.done.tap('EntrypointsWithStaleStatsTest', (stats) => {
+      Object.defineProperty(stats.compilation, 'chunks', {
+        configurable: true,
+        get() {
+          throw new Error('stats must not access live compilation chunks');
+        },
+      });
+      try {
+        entrypoints = stats.toJson({
+          all: false,
+          entrypoints: true,
+        }).entrypoints;
+      } finally {
+        delete stats.compilation.chunks;
+      }
+    });
+  },
+  check() {
+    expect(entrypoints).toHaveProperty('main');
+    expect(entrypoints.main.assets).toHaveLength(1);
+  },
+};


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- avoid traversing live `compilation.chunks` when generating entrypoint stats
- use the `assets` and `auxiliaryAssets` data from the stats snapshot instead
- prevent stale stats from accessing chunk wrappers removed by a subsequent watch compilation
- add a regression test ensuring entrypoint stats do not read live compilation chunks


## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
