### PR TITLE
fix(rstest): register hoisted mocks before importActual imports

### DIFF
--- a/crates/rspack_plugin_rstest/src/esm_import_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/esm_import_dependency.rs
@@ -116,6 +116,11 @@ fn hoist_new_esm_import_fragments(
       conditional_fragment.content().to_string()
     };
 
+    // Position -1: after the hoisted mock placeholders (-2) so the importActual
+    // subgraph is evaluated with mocks already registered, but before normal
+    // imports (source_order >= 1) so mock factories that spread an importActual
+    // binding observe an initialized value. See the ordering contract in
+    // `mock_method_dependency.rs`.
     let override_fragment = rspack_core::ConditionalInitFragment::new(
       content,
       InitFragmentStage::StageESMImports,

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -192,7 +192,17 @@ impl MockMethodDependencyTemplate {
     }
   }
 
-  /// Add a placeholder init fragment that marks where hoisted code should be inserted
+  /// Add a placeholder init fragment that marks where hoisted code should be inserted.
+  ///
+  /// `StageESMImports` ordering contract (position → fragment):
+  /// - `-3`: the hoisted `@rstest/core` import (see [`Self::hoist_rstest_core_import`])
+  /// - `-2`: this placeholder — mock registrations run before any user module is
+  ///   evaluated, so an `importActual` subgraph still sees mocked transitive deps
+  /// - `-1`: `importActual` imports (see `esm_import_dependency.rs`) — evaluated
+  ///   after mocks are registered (registration does not run mock factories) but
+  ///   before normal imports, so factories that spread an `importActual` binding
+  ///   observe an initialized value once they lazily run
+  /// - `>= 1`: normal ESM imports (`source_order` starts at 1)
   fn add_placeholder_fragment(
     init_fragments: &mut Vec<Box<dyn rspack_core::InitFragment<rspack_core::GenerateContext<'_>>>>,
     flag: &str,
@@ -202,7 +212,7 @@ impl MockMethodDependencyTemplate {
     let init = NormalInitFragment::new(
       format!("/* RSTEST:{flag}:{hoist_id}:{request}:PLACEHOLDER */;"),
       InitFragmentStage::StageESMImports,
-      0,
+      -2,
       InitFragmentKey::Const(format!("rstest mock_hoist {hoist_id}")),
       None,
     );
@@ -234,12 +244,13 @@ impl MockMethodDependencyTemplate {
       return;
     };
 
-    // Create a new fragment with higher priority (position=-1) and insert at the beginning
+    // Create a new fragment with higher priority (position=-3, before the mock
+    // placeholder at -2 and importActual imports at -1) and insert at the beginning
     let content = conditional_fragment.content().to_string();
     let rstest_import = ConditionalInitFragment::new(
       content,
       InitFragmentStage::StageESMImports,
-      -1, // Higher priority than default (0)
+      -3,
       target_key,
       None,
       RuntimeCondition::Boolean(true),

--- a/tests/rspack-test/configCases/rstest/mock/importActualSpreadTransitive.js
+++ b/tests/rspack-test/configCases/rstest/mock/importActualSpreadTransitive.js
@@ -1,0 +1,20 @@
+import * as otherActual from './src/transitive/other' with { rstest: 'importActual' };
+import { tag, viaOther } from './src/transitive/other';
+import { read } from './src/transitive/mid';
+import { rstest } from '@rstest/core';
+
+rstest.mock('./src/transitive/other', () => {
+  return { ...otherActual, tag: 'MOCKED_OTHER' };
+});
+
+rstest.mock('./src/transitive/dep', () => {
+  return { flag: () => 'MOCK' };
+});
+
+it('spreading importActual into a mock factory should keep transitive mocks', () => {
+  // The factory ran and observed the initialized importActual binding.
+  expect(tag).toBe('MOCKED_OTHER');
+  // The spread actual implementation still sees the mocked transitive dep.
+  expect(viaOther()).toBe('MOCK');
+  expect(read()).toBe('MOCK');
+});

--- a/tests/rspack-test/configCases/rstest/mock/importActualTransitive.js
+++ b/tests/rspack-test/configCases/rstest/mock/importActualTransitive.js
@@ -1,0 +1,15 @@
+import * as otherActual from './src/transitive/other' with { rstest: 'importActual' };
+import { read } from './src/transitive/mid';
+import { rstest } from '@rstest/core';
+
+rstest.mock('./src/transitive/dep', () => {
+  return { flag: () => 'MOCK' };
+});
+
+it('mock should apply to transitive deps reachable from an importActual import', () => {
+  // The importActual target itself is the actual module...
+  expect(otherActual.tag).toBe('REAL_OTHER');
+  // ...but its transitive deps still follow mocks (shared module graph).
+  expect(otherActual.viaOther()).toBe('MOCK');
+  expect(read()).toBe('MOCK');
+});

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -37,6 +37,13 @@ Object.keys(originalRequire).forEach(key => {
 });
 
 __webpack_require__.rstest_original_modules = {};
+__webpack_require__.rstest_original_module_factories = {};
+
+const captureOriginalFactory = (id) => {
+  if (!Object.hasOwn(__webpack_require__.rstest_original_module_factories, id)) {
+    __webpack_require__.rstest_original_module_factories[id] = __webpack_modules__[id];
+  }
+};
 
 __webpack_require__.rstest_reset_modules = () => {
   const mockedIds = Object.keys(__webpack_require__.rstest_original_modules)
@@ -49,14 +56,26 @@ __webpack_require__.rstest_reset_modules = () => {
 }
 
 __webpack_require__.rstest_unmock = (id) => {
+  const originalFactory = __webpack_require__.rstest_original_module_factories[id];
+  if (originalFactory) {
+    __webpack_modules__[id] = originalFactory;
+  }
   delete __webpack_module_cache__[id]
 }
 
 __webpack_require__.rstest_require_actual = __webpack_require__.rstest_import_actual = (id) => {
-  const originalModule = __webpack_require__.rstest_original_modules[id];
+  if (Object.hasOwn(__webpack_require__.rstest_original_modules, id)) {
+    return __webpack_require__.rstest_original_modules[id];
+  }
+  const originalFactory = __webpack_require__.rstest_original_module_factories[id];
+  if (originalFactory) {
+    const moduleInstance = { exports: {} };
+    originalFactory(moduleInstance, moduleInstance.exports, __webpack_require__);
+    __webpack_require__.rstest_original_modules[id] = moduleInstance.exports;
+    return moduleInstance.exports;
+  }
   // Use fallback module if the module is not mocked.
-  const fallbackMod = __webpack_require__(id);
-  return originalModule ? originalModule : fallbackMod;
+  return __webpack_require__(id);
 }
 
 __webpack_require__.rstest_exec = async (id, modFactory) => {
@@ -69,14 +88,13 @@ __webpack_require__.rstest_exec = async (id, modFactory) => {
 };
 
 __webpack_require__.rstest_mock = (id, modFactory) => {
-  let requiredModule = undefined
-  try {
-    requiredModule = __webpack_require__(id);
-  } catch {
-    // TODO: non-resolved module
-  } finally {
-    __webpack_require__.rstest_original_modules[id] = requiredModule;
+  // Registering a mock must not eagerly evaluate the real module (and its
+  // transitive deps) — only capture what is already evaluated, plus the
+  // original factory so rstest_import_actual can run it lazily.
+  if (__webpack_module_cache__[id]) {
+    __webpack_require__.rstest_original_modules[id] = __webpack_module_cache__[id].exports;
   }
+  captureOriginalFactory(id);
   if (modFactory && modFactory.mock === true) {
     return;
   } else if (typeof modFactory === 'string' || typeof modFactory === 'number') {
@@ -205,6 +223,8 @@ module.exports = [
   rstestEntry('./directoryManualMock.js'),
   rstestEntry('./importActual.js'),
   rstestEntry('./importActualHoisted.js'),
+  rstestEntry('./importActualTransitive.js'),
+  rstestEntry('./importActualSpreadTransitive.js'),
   rstestEntry('./requireActual.js'),
   rstestEntry('./doMockRequire.js'),
   rstestEntry('./unmockRequire.js'),

--- a/tests/rspack-test/configCases/rstest/mock/src/transitive/dep.js
+++ b/tests/rspack-test/configCases/rstest/mock/src/transitive/dep.js
@@ -1,0 +1,1 @@
+export const flag = () => 'REAL';

--- a/tests/rspack-test/configCases/rstest/mock/src/transitive/mid.js
+++ b/tests/rspack-test/configCases/rstest/mock/src/transitive/mid.js
@@ -1,0 +1,3 @@
+import { flag } from './dep';
+
+export const read = () => flag();

--- a/tests/rspack-test/configCases/rstest/mock/src/transitive/other.js
+++ b/tests/rspack-test/configCases/rstest/mock/src/transitive/other.js
@@ -1,0 +1,4 @@
+import { read } from './mid';
+
+export const viaOther = () => read();
+export const tag = 'REAL_OTHER';


### PR DESCRIPTION
## Summary

Fixes web-infra-dev/rstest#1581: a static `import ... with { rstest: 'importActual' }` in a test file silently prevented `rs.mock` from applying to **transitive** dependencies.

Given `other → mid → dep` with `rs.mock('./dep', factory)` and an `importActual` import of `other` (itself unmocked and unrelated to the mock), `mid` observed the **real** `dep` and the mock factory never ran — while the test file itself still saw the mock, so two views of the same module coexisted with no warning.

### Root cause

#13025 hoists `importActual` ESM imports to `StageESMImports` position `-1`, ahead of the mock-hoist placeholder at `0`. Evaluating the `importActual` import therefore evaluates its whole transitive subgraph (shared with the normal module graph — the attribute only forks the identity of the top-level target) **before** any `rstest_mock` registration runs. `mid` gets cached holding a live binding to the real `dep`, and installing the mock afterwards only clears `dep`'s own cache entry.

### Fix

Registering a mock does not run its factory, so mock registration does not need the `importActual` binding — it only needs to happen before user modules evaluate. Reorder the `StageESMImports` fragments:

| position | fragment |
|---|---|
| `-3` | hoisted `@rstest/core` import (was `-1`) |
| `-2` | mock-hoist placeholder (was `0`) |
| `-1` | `importActual` imports (unchanged) |
| `>= 1` | normal ESM imports (`source_order`, unchanged) |

This keeps the #13025 guarantee (a factory that spreads an `importActual` binding runs lazily at the first normal import, after the binding is initialized — covered by the existing `importActualHoisted` case) while making the `importActual` subgraph observe already-registered mocks, matching the semantics of the dynamic `rstest.importActual()` form.

The test fixture's `RstestSimpleRuntimePlugin.rstest_mock` also eagerly required the original module at registration time, which reproduces the same eager-evaluation poisoning under the new ordering; it now lazily captures the original factory instead, mirroring rstest's real mock runtime.

### Tests

- New `configCases/rstest/mock/importActualTransitive.js`: the issue's minimal repro (unrelated `importActual` import + transitively mocked dep).
- New `configCases/rstest/mock/importActualSpreadTransitive.js`: the documented spread pattern (`rs.mock('./x', () => ({ ...actual }))`) combined with a transitively mocked dep, which was also affected.
- Existing `importActualHoisted.js` (#13025 regression) still passes; all `configCases/rstest/*` cases pass.
- Verified end-to-end against the rstest repo (unchanged rstest runtime + this patch): the issue's repro passes and rstest's full e2e suite passes (809 tests).

## Related links

- web-infra-dev/rstest#1581
- #13025

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).