### PR TITLE
feat: support caseSensitive in import.meta.glob

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -198,6 +198,7 @@ pub struct ContextOptions {
   pub referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
   pub glob_import: Option<String>,
   pub glob_exhaustive: bool,
+  pub glob_case_sensitive: bool,
   pub attributes: Option<ImportAttributes>,
   pub phase: Option<ImportPhase>,
 }
@@ -222,6 +223,7 @@ impl Default for ContextOptions {
       referenced_specifiers: None,
       glob_import: None,
       glob_exhaustive: false,
+      glob_case_sensitive: true,
       attributes: None,
       phase: None,
     }
@@ -1435,6 +1437,9 @@ impl Module for ContextModule {
       id += " globExhaustive";
     }
     append_context_identifier(&mut id, &self.options.context_options, " context: ");
+    if !self.options.context_options.glob_case_sensitive {
+      id += " globCaseInsensitive";
+    }
     Some(Cow::Owned(id))
   }
 
@@ -1646,6 +1651,9 @@ fn create_identifier(options: &ContextModuleOptions, resource: Option<&str>) -> 
     id += "|globExhaustive";
   }
   append_context_identifier(&mut id, &options.context_options, "|context: ");
+  if !options.context_options.glob_case_sensitive {
+    id += "|globCaseInsensitive";
+  }
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.context_options.group_options {
     if let Some(chunk_name) = &group.name {

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -491,6 +491,7 @@ async fn visit_dirs(
       if is_import_meta_glob
         && !glob_exhaustive
         && is_non_exhaustive_import_meta_glob_skipped_dir(dirname)
+        && !matcher.should_visit_skipped_dir(path.as_str())
       {
         return false;
       }
@@ -626,6 +627,13 @@ impl<'a> ContextModuleMatcher<'a> {
     } else {
       None
     }
+  }
+
+  fn should_visit_skipped_dir(&self, path: &str) -> bool {
+    self
+      .glob
+      .as_ref()
+      .is_some_and(|glob| glob.should_visit_skipped_dir(path))
   }
 }
 

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -488,6 +488,9 @@ async fn visit_dirs(
     options.context_options.recursive,
     skip_dotfiles,
     &mut |path, dirname| {
+      if is_import_meta_glob && !matcher.should_visit_dir(path.as_str()) {
+        return false;
+      }
       if is_import_meta_glob
         && !glob_exhaustive
         && is_non_exhaustive_import_meta_glob_skipped_dir(dirname)
@@ -634,6 +637,13 @@ impl<'a> ContextModuleMatcher<'a> {
       .glob
       .as_ref()
       .is_some_and(|glob| glob.should_visit_skipped_dir(path))
+  }
+
+  fn should_visit_dir(&self, path: &str) -> bool {
+    self
+      .glob
+      .as_ref()
+      .is_none_or(|glob| glob.should_visit_dir(path))
   }
 }
 

--- a/crates/rspack_core/src/context_module_factory/glob.rs
+++ b/crates/rspack_core/src/context_module_factory/glob.rs
@@ -162,6 +162,7 @@ pub(super) struct ContextModuleGlobMatcher<'a> {
   context: &'a str,
   compiler_context: &'a str,
   exhaustive: bool,
+  case_sensitive: bool,
 }
 
 impl<'a> ContextModuleGlobMatcher<'a> {
@@ -178,6 +179,7 @@ impl<'a> ContextModuleGlobMatcher<'a> {
       context: &context_options.context,
       compiler_context: &context_options.compiler_context,
       exhaustive: context_options.glob_exhaustive,
+      case_sensitive: context_options.glob_case_sensitive,
     })
   }
 
@@ -200,7 +202,8 @@ impl<'a> ContextModuleGlobMatcher<'a> {
           },
           pattern.root_relative,
         );
-        glob_pattern_matches(pattern, &request, self.exhaustive).then_some(request)
+        glob_pattern_matches(pattern, &request, self.exhaustive, self.case_sensitive)
+          .then_some(request)
       })?;
 
     if self
@@ -217,7 +220,7 @@ impl<'a> ContextModuleGlobMatcher<'a> {
           },
           pattern.root_relative,
         );
-        glob_pattern_matches(pattern, &request, self.exhaustive)
+        glob_pattern_matches(pattern, &request, self.exhaustive, self.case_sensitive)
       })
     {
       return None;
@@ -241,14 +244,15 @@ fn glob_pattern_matches(
   pattern: &ContextModuleGlobPattern,
   normalized_path: &str,
   exhaustive: bool,
+  case_sensitive: bool,
 ) -> bool {
   glob_match_normalized_with_explicit_dot(
     &pattern.pattern,
     normalized_path,
     &pattern.pattern_base,
     &GlobMatchOptions {
+      case_sensitive,
       require_literal_leading_dot: !exhaustive,
-      ..Default::default()
     },
   )
 }

--- a/crates/rspack_core/src/context_module_factory/glob.rs
+++ b/crates/rspack_core/src/context_module_factory/glob.rs
@@ -216,6 +216,7 @@ fn parse_context_module_glob_pattern(pattern: &str) -> ContextModuleGlobPattern 
 
 pub(super) struct ContextModuleGlobMatcher<'a> {
   patterns: Vec<ContextModuleGlobPattern>,
+  positive_pattern_bases: Vec<String>,
   context: &'a str,
   compiler_context: &'a str,
   exhaustive: bool,
@@ -230,9 +231,25 @@ impl<'a> ContextModuleGlobMatcher<'a> {
       .glob_patterns()?
       .iter()
       .map(|pattern| parse_context_module_glob_pattern(pattern))
-      .collect();
+      .collect::<Vec<_>>();
+    let positive_pattern_bases = if context_options.glob_case_sensitive {
+      Vec::new()
+    } else {
+      patterns
+        .iter()
+        .filter(|pattern| !pattern.negative)
+        .map(|pattern| {
+          absolute_context_module_glob_pattern_base(
+            pattern,
+            &context_options.context,
+            &context_options.compiler_context,
+          )
+        })
+        .collect()
+    };
     Some(Self {
       patterns,
+      positive_pattern_bases,
       context: &context_options.context,
       compiler_context: &context_options.compiler_context,
       exhaustive: context_options.glob_exhaustive,
@@ -286,35 +303,67 @@ impl<'a> ContextModuleGlobMatcher<'a> {
     Some(user_request)
   }
 
+  pub(super) fn should_visit_dir(&self, path: &str) -> bool {
+    if self.case_sensitive {
+      return true;
+    }
+
+    let path = normalize_case_insensitive_path(path);
+    self.positive_pattern_bases.iter().any(|pattern_base| {
+      is_same_or_descendant(pattern_base, &path) || is_same_or_descendant(&path, pattern_base)
+    })
+  }
+
   pub(super) fn should_visit_skipped_dir(&self, path: &str) -> bool {
     if self.case_sensitive {
       return false;
     }
 
+    let path = normalize_case_insensitive_path(path);
     self
-      .patterns
+      .positive_pattern_bases
       .iter()
-      .filter(|pattern| !pattern.negative)
-      .any(|pattern| {
-        let context = if pattern.root_relative {
-          self.compiler_context
-        } else {
-          self.context
-        };
-        let pattern_base = pattern
-          .pattern_base
-          .strip_prefix('/')
-          .unwrap_or(&pattern.pattern_base);
-        let pattern_base = Utf8Path::new(&normalize_path_separators_for_path(context))
-          .node_join_posix(pattern_base)
-          .node_normalize_posix()
-          .to_string();
-        let normalized_path = normalize_path_separators_for_path(path);
-        let path = normalized_path.trim_end_matches('/').cow_to_lowercase();
-        let pattern_base = pattern_base.trim_end_matches('/').cow_to_lowercase();
-        pattern_base == path || pattern_base.starts_with(&format!("{path}/"))
-      })
+      .any(|pattern_base| is_same_or_descendant(pattern_base, &path))
   }
+}
+
+fn absolute_context_module_glob_pattern_base(
+  pattern: &ContextModuleGlobPattern,
+  context: &str,
+  compiler_context: &str,
+) -> String {
+  let context = if pattern.root_relative {
+    compiler_context
+  } else {
+    context
+  };
+  let pattern_base = pattern
+    .pattern_base
+    .strip_prefix('/')
+    .unwrap_or(&pattern.pattern_base);
+  let pattern_base = Utf8Path::new(&normalize_path_separators_for_path(context))
+    .node_join_posix(pattern_base)
+    .node_normalize_posix()
+    .to_string();
+  normalize_case_insensitive_path(&pattern_base)
+}
+
+fn normalize_case_insensitive_path(path: &str) -> String {
+  let normalized_path = normalize_path_separators_for_path(path);
+  let path = normalized_path.trim_end_matches('/');
+  if path.is_empty() {
+    "/".to_string()
+  } else {
+    path.cow_to_lowercase().into_owned()
+  }
+}
+
+fn is_same_or_descendant(path: &str, base: &str) -> bool {
+  path == base
+    || (base == "/" && path.starts_with('/'))
+    || path
+      .strip_prefix(base)
+      .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn context_relative_glob_request(path: &str, context: &str, root_relative: bool) -> String {

--- a/crates/rspack_core/src/context_module_factory/glob.rs
+++ b/crates/rspack_core/src/context_module_factory/glob.rs
@@ -196,6 +196,14 @@ fn parse_context_module_glob_pattern(pattern: &str) -> ContextModuleGlobPattern 
   } else {
     relative_path_to_request(&pattern).into_owned()
   };
+  let matcher_pattern = Utf8Path::new(&matcher_pattern)
+    .node_normalize_posix()
+    .to_string();
+  let matcher_pattern = if root_relative {
+    matcher_pattern
+  } else {
+    relative_path_to_request(&matcher_pattern).into_owned()
+  };
   let pattern_base = unescape_glob_path(extract_glob_base_dir(&matcher_pattern));
 
   ContextModuleGlobPattern {
@@ -288,21 +296,23 @@ impl<'a> ContextModuleGlobMatcher<'a> {
       .iter()
       .filter(|pattern| !pattern.negative)
       .any(|pattern| {
-        let request = context_relative_glob_request(
-          path,
-          if pattern.root_relative {
-            self.compiler_context
-          } else {
-            self.context
-          },
-          pattern.root_relative,
-        );
-        let request = request.trim_end_matches('/').cow_to_lowercase();
+        let context = if pattern.root_relative {
+          self.compiler_context
+        } else {
+          self.context
+        };
         let pattern_base = pattern
           .pattern_base
-          .trim_end_matches('/')
-          .cow_to_lowercase();
-        pattern_base == request || pattern_base.starts_with(&format!("{request}/"))
+          .strip_prefix('/')
+          .unwrap_or(&pattern.pattern_base);
+        let pattern_base = Utf8Path::new(&normalize_path_separators_for_path(context))
+          .node_join_posix(pattern_base)
+          .node_normalize_posix()
+          .to_string();
+        let normalized_path = normalize_path_separators_for_path(path);
+        let path = normalized_path.trim_end_matches('/').cow_to_lowercase();
+        let pattern_base = pattern_base.trim_end_matches('/').cow_to_lowercase();
+        pattern_base == path || pattern_base.starts_with(&format!("{path}/"))
       })
   }
 }
@@ -323,12 +333,27 @@ fn glob_pattern_matches(
   exhaustive: bool,
   case_sensitive: bool,
 ) -> bool {
+  if !case_sensitive {
+    let pattern_value = pattern.pattern.cow_to_lowercase();
+    let path = normalized_path.cow_to_lowercase();
+    let pattern_base = pattern.pattern_base.cow_to_lowercase();
+    return glob_match_normalized_with_explicit_dot(
+      &pattern_value,
+      &path,
+      &pattern_base,
+      &GlobMatchOptions {
+        case_sensitive: true,
+        require_literal_leading_dot: !exhaustive,
+      },
+    );
+  }
+
   glob_match_normalized_with_explicit_dot(
     &pattern.pattern,
     normalized_path,
     &pattern.pattern_base,
     &GlobMatchOptions {
-      case_sensitive,
+      case_sensitive: true,
       require_literal_leading_dot: !exhaustive,
     },
   )

--- a/crates/rspack_core/src/context_module_factory/glob.rs
+++ b/crates/rspack_core/src/context_module_factory/glob.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use rspack_loader_runner::parse_resource;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::{identifier::relative_path_to_request, node_path::NodePath};
@@ -36,6 +37,7 @@ pub fn compile_context_module_glob_request(
   context: &str,
   compiler_context: &str,
   fallback_recursive: bool,
+  case_sensitive: bool,
 ) -> CompiledContextModuleGlobRequest {
   let Some(parsed_request) = parse_resource(request) else {
     return CompiledContextModuleGlobRequest {
@@ -47,7 +49,12 @@ pub fn compile_context_module_glob_request(
     .iter()
     .map(|pattern| resolve_context_module_glob_pattern(pattern, context, compiler_context))
     .collect::<Vec<_>>();
-  let Some(common_base) = common_context_module_glob_base(&resolved_patterns) else {
+  let common_base = if case_sensitive {
+    common_context_module_glob_base(&resolved_patterns)
+  } else {
+    case_insensitive_context_module_glob_base(patterns, context, compiler_context)
+  };
+  let Some(common_base) = common_base else {
     return CompiledContextModuleGlobRequest {
       request: request.to_string(),
       recursive: fallback_recursive,
@@ -68,19 +75,60 @@ pub fn compile_context_module_glob_request(
   CompiledContextModuleGlobRequest { request, recursive }
 }
 
-fn common_context_module_glob_base(
-  patterns: &[ResolvedContextModuleGlobPattern],
+fn case_insensitive_context_module_glob_base(
+  patterns: &[String],
+  context: &str,
+  compiler_context: &str,
 ) -> Option<Utf8PathBuf> {
-  let mut positive_patterns = patterns.iter().filter(|pattern| !pattern.negative);
-  let first = positive_patterns.next()?;
-  let mut common_base = Utf8PathBuf::from(first.absolute_base.as_str());
-  for pattern in positive_patterns {
-    let base = Utf8Path::new(pattern.absolute_base.as_str());
-    while !base.starts_with(&common_base) {
+  let roots = patterns
+    .iter()
+    .map(|pattern| parse_context_module_glob_pattern(pattern))
+    .filter(|pattern| !pattern.negative)
+    .map(|pattern| {
+      let (base, pattern) = if pattern.root_relative {
+        (
+          compiler_context,
+          pattern
+            .pattern
+            .strip_prefix('/')
+            .unwrap_or(&pattern.pattern),
+        )
+      } else {
+        (context, pattern.pattern.as_str())
+      };
+      let stable_prefix = pattern
+        .split('/')
+        .take_while(|segment| segment.is_empty() || *segment == "." || *segment == "..")
+        .collect::<Vec<_>>()
+        .join("/");
+      Utf8Path::new(&normalize_path_separators_for_path(base))
+        .node_join_posix(&stable_prefix)
+        .node_normalize_posix()
+    })
+    .collect::<Vec<_>>();
+
+  common_path_base(roots.iter().map(Utf8PathBuf::as_path))
+}
+
+fn common_path_base<'a>(mut paths: impl Iterator<Item = &'a Utf8Path>) -> Option<Utf8PathBuf> {
+  let mut common_base = paths.next()?.to_path_buf();
+  for path in paths {
+    while !path.starts_with(&common_base) {
       common_base = common_base.parent()?.to_path_buf();
     }
   }
   Some(common_base)
+}
+
+fn common_context_module_glob_base(
+  patterns: &[ResolvedContextModuleGlobPattern],
+) -> Option<Utf8PathBuf> {
+  common_path_base(
+    patterns
+      .iter()
+      .filter(|pattern| !pattern.negative)
+      .map(|pattern| Utf8Path::new(pattern.absolute_base.as_str())),
+  )
 }
 
 fn resolve_context_module_glob_pattern(
@@ -227,6 +275,34 @@ impl<'a> ContextModuleGlobMatcher<'a> {
     }
 
     Some(user_request)
+  }
+
+  pub(super) fn should_visit_skipped_dir(&self, path: &str) -> bool {
+    if self.case_sensitive {
+      return false;
+    }
+
+    self
+      .patterns
+      .iter()
+      .filter(|pattern| !pattern.negative)
+      .any(|pattern| {
+        let request = context_relative_glob_request(
+          path,
+          if pattern.root_relative {
+            self.compiler_context
+          } else {
+            self.context
+          },
+          pattern.root_relative,
+        );
+        let request = request.trim_end_matches('/').cow_to_lowercase();
+        let pattern_base = pattern
+          .pattern_base
+          .trim_end_matches('/')
+          .cow_to_lowercase();
+        pattern_base == request || pattern_base.starts_with(&format!("{request}/"))
+      })
   }
 }
 

--- a/crates/rspack_core/src/context_module_factory/glob.rs
+++ b/crates/rspack_core/src/context_module_factory/glob.rs
@@ -96,7 +96,8 @@ fn case_insensitive_context_module_glob_base(
       } else {
         (context, pattern.pattern.as_str())
       };
-      let stable_prefix = pattern
+      let normalized_pattern = Utf8Path::new(pattern).node_normalize_posix().to_string();
+      let stable_prefix = normalized_pattern
         .split('/')
         .take_while(|segment| segment.is_empty() || *segment == "." || *segment == "..")
         .collect::<Vec<_>>()

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -54,7 +54,11 @@ impl ImportMetaContextDependency {
     optional: bool,
     kind: ImportMetaContextDependencyKind,
   ) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
+    let context = match kind {
+      ImportMetaContextDependencyKind::WebpackContext => None,
+      ImportMetaContextDependencyKind::Glob => Some(options.context.as_str()),
+    };
+    let resource_identifier = create_resource_identifier_for_context_dependency(context, &options);
     Self {
       options,
       range,

--- a/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
@@ -85,6 +85,11 @@ fn create_resource_identifier_for_context_dependency(
   } else {
     ""
   };
+  let glob_case_sensitive = if options.glob_case_sensitive {
+    ""
+  } else {
+    "globCaseInsensitive"
+  };
   let mut group_options = String::new();
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.group_options {
@@ -105,7 +110,7 @@ fn create_resource_identifier_for_context_dependency(
   }
 
   let id = format!(
-    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import} {glob_exhaustive}",
+    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import} {glob_exhaustive} {glob_case_sensitive}",
   );
   id.into()
 }

--- a/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
@@ -37,9 +37,8 @@ fn create_resource_identifier_for_context_dependency(
   options: &ContextOptions,
 ) -> ResourceIdentifier {
   let context = context
-    .filter(|context| !context.is_empty())
-    .unwrap_or(&options.context);
-  let context = context_identifier(&options.compiler_context, context).unwrap_or_default();
+    .and_then(|context| context_identifier(&options.compiler_context, context))
+    .unwrap_or_default();
   let request = &options.request;
   let recursive = options.recursive.to_string();
   let pattern = match &options.pattern {
@@ -88,7 +87,7 @@ fn create_resource_identifier_for_context_dependency(
   let glob_case_sensitive = if options.glob_case_sensitive {
     ""
   } else {
-    "globCaseInsensitive"
+    " globCaseInsensitive"
   };
   let mut group_options = String::new();
 
@@ -110,7 +109,7 @@ fn create_resource_identifier_for_context_dependency(
   }
 
   let id = format!(
-    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import} {glob_exhaustive} {glob_case_sensitive}",
+    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import} {glob_exhaustive}{glob_case_sensitive}",
   );
   id.into()
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -521,11 +521,4 @@ mod tests {
     assert_eq!(context_options.glob_import.as_deref(), Some("default"));
     assert!(context_options.glob_exhaustive);
   }
-  #[test]
-  fn import_meta_glob_fs_path_normalizes_windows_base_before_parent_join() {
-    assert_eq!(
-      join_import_meta_glob_fs_path(r"D:\repo\context\nested", ".."),
-      "D:/repo/context"
-    );
-  }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -11,7 +11,7 @@ use rspack_regex::RspackRegex;
 use rspack_util::{SpanExt, identifier::relative_path_to_request, node_path::NodePath};
 use sugar_path::SugarPath;
 use swc_atoms::Atom;
-use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan};
+use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan, ObjectLit};
 
 use super::JavascriptParserPlugin;
 use crate::{
@@ -21,8 +21,8 @@ use crate::{
     object_properties::{FromAstExpr, get_from_object},
   },
   visitors::{
-    JavascriptParser, clean_regexp_in_context_module, default_context_reg_exp, expr_name,
-    static_string_from_expr,
+    JavascriptParser, clean_regexp_in_context_module, create_traceable_error,
+    default_context_reg_exp, expr_name, static_string_from_expr,
   },
 };
 
@@ -141,6 +141,32 @@ impl ImportMetaGlobQuery {
       }
     }
   }
+}
+
+fn parse_import_meta_glob_case_sensitive(
+  glob_options: Option<&ObjectLit>,
+  parser: &mut JavascriptParser,
+) -> bool {
+  let Some(value) = glob_options.and_then(|object| get_from_object(object, &["caseSensitive"]))
+  else {
+    return true;
+  };
+
+  let evaluated = parser.evaluate_expression(value);
+  if evaluated.is_bool() {
+    return evaluated.bool();
+  }
+
+  let mut error: Error = create_traceable_error(
+    "Invalid import.meta.glob option".into(),
+    "import.meta.glob() 'caseSensitive' option must be a constant boolean (true or false), defaulting to true".into(),
+    parser.source.to_string(),
+    value.span().into(),
+  );
+  error.severity = Severity::Warning;
+  error.hide_stack = Some(true);
+  parser.add_warning(error.into());
+  true
 }
 
 fn static_glob_patterns_from_expr(expr: &Expr) -> Option<Vec<String>> {
@@ -347,13 +373,7 @@ fn create_import_meta_glob_dependency(
     .as_ref()
     .map_or_else(String::new, ImportMetaGlobQuery::to_query_string);
   let base = options.base.as_deref();
-  let glob_case_sensitive = glob_options
-    .and_then(|object| get_from_object(object, &["caseSensitive"]))
-    .and_then(|value| {
-      let evaluated = parser.evaluate_expression(value);
-      evaluated.is_bool().then(|| evaluated.bool())
-    })
-    .unwrap_or(true);
+  let glob_case_sensitive = parse_import_meta_glob_case_sensitive(glob_options, parser);
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),
     parser.compiler_options.context.as_str(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -330,7 +330,8 @@ fn create_import_meta_glob_dependency(
   }
   let raw_glob_patterns = static_glob_patterns_from_expr(&dyn_imported.expr)?;
   let importer_context = get_context(parser.resource_data);
-  let options = match node.args.get(1).and_then(|arg| arg.expr.as_object()) {
+  let glob_options = node.args.get(1).and_then(|arg| arg.expr.as_object());
+  let options = match glob_options {
     Some(raw_options) => {
       let (options, diagnostics) =
         ImportMetaGlobOptions::from_ast_object_with_diagnostics(raw_options);
@@ -346,6 +347,10 @@ fn create_import_meta_glob_dependency(
     .as_ref()
     .map_or_else(String::new, ImportMetaGlobQuery::to_query_string);
   let base = options.base.as_deref();
+  let glob_case_sensitive = glob_options
+    .and_then(|object| get_from_object(object, &["caseSensitive"]))
+    .and_then(|value| parser.evaluate_expression(value).as_bool())
+    .unwrap_or(true);
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),
     parser.compiler_options.context.as_str(),
@@ -388,6 +393,7 @@ fn create_import_meta_glob_dependency(
     start: span.real_lo(),
     end: span.real_hi(),
     referenced_specifiers,
+    glob_case_sensitive,
     ..ContextOptions::from(&options)
   };
   Some(ImportMetaContextDependency::new_glob(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -391,6 +391,7 @@ fn create_import_meta_glob_dependency(
     context.as_str(),
     parser.compiler_options.context.as_str(),
     true,
+    glob_case_sensitive,
   );
 
   let referenced_specifiers = options

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -218,8 +218,9 @@ fn join_import_meta_glob_path(base: &str, path: &str) -> String {
 }
 
 fn join_import_meta_glob_fs_path(base: &str, path: &str) -> String {
+  let base = normalize_path_separators_for_path(base);
   normalize_path_separators_for_path(
-    Utf8Path::new(base)
+    Utf8Path::new(&base)
       .node_join_posix(path)
       .node_normalize_posix()
       .as_ref(),
@@ -519,5 +520,12 @@ mod tests {
     assert_eq!(context_options.mode, ContextMode::Lazy);
     assert_eq!(context_options.glob_import.as_deref(), Some("default"));
     assert!(context_options.glob_exhaustive);
+  }
+  #[test]
+  fn import_meta_glob_fs_path_normalizes_windows_base_before_parent_join() {
+    assert_eq!(
+      join_import_meta_glob_fs_path(r"D:\repo\context\nested", ".."),
+      "D:/repo/context"
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -349,7 +349,10 @@ fn create_import_meta_glob_dependency(
   let base = options.base.as_deref();
   let glob_case_sensitive = glob_options
     .and_then(|object| get_from_object(object, &["caseSensitive"]))
-    .and_then(|value| parser.evaluate_expression(value).as_bool())
+    .and_then(|value| {
+      let evaluated = parser.evaluate_expression(value);
+      evaluated.is_bool().then(|| evaluated.bool())
+    })
     .unwrap_or(true);
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -503,6 +503,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           referenced_specifiers: None,
           glob_import: None,
           glob_exhaustive: false,
+          glob_case_sensitive: true,
           attributes,
           phase: Some(phase),
         },

--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -179,6 +179,7 @@ declare namespace Rspack {
     query?: ImportMetaGlobQuery;
     exhaustive?: boolean;
     base?: string;
+    caseSensitive?: boolean;
   };
 
   interface Module {

--- a/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/index.js
+++ b/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/index.js
@@ -1,0 +1,9 @@
+const modules = import.meta.glob("./SRC/COMPONENTS/*.JS", {
+	caseSensitive: false,
+	eager: true
+});
+
+it("should only visit directories related to the literal glob prefix", () => {
+	expect(Object.keys(modules)).toEqual(["./src/components/alpha.js"]);
+	expect(modules["./src/components/alpha.js"].default).toBe("alpha");
+});

--- a/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/rspack.config.js
+++ b/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/rspack.config.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert');
+
+const normalizePath = (value) => value.replace(/\\/g, '/').replace(/\/+$/, '');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  plugins: [
+    {
+      apply(compiler) {
+        const originalInputFileSystem = compiler.inputFileSystem;
+        const inputFileSystem = Object.create(originalInputFileSystem);
+        let visitedUnrelatedDirectory = false;
+
+        inputFileSystem.readdir = (dirPath, callback) => {
+          if (normalizePath(dirPath).endsWith('/src/unrelated')) {
+            visitedUnrelatedDirectory = true;
+          }
+          return originalInputFileSystem.readdir(dirPath, callback);
+        };
+
+        compiler.inputFileSystem = inputFileSystem;
+        compiler.hooks.beforeCompile.tap(
+          'ImportMetaGlobCaseInsensitivePruning',
+          () => {
+            compiler.inputFileSystem = inputFileSystem;
+          },
+        );
+        compiler.hooks.afterCompile.tap(
+          'ImportMetaGlobCaseInsensitivePruning',
+          () => {
+            assert.strictEqual(
+              visitedUnrelatedDirectory,
+              false,
+              'case-insensitive glob should not scan unrelated directories',
+            );
+          },
+        );
+      },
+    },
+  ],
+  experiments: {
+    useInputFileSystem: [/import-meta-glob-case-insensitive-pruning/],
+  },
+};

--- a/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/src/components/alpha.js
+++ b/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/src/components/alpha.js
@@ -1,0 +1,1 @@
+export default "alpha";

--- a/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/src/unrelated/unused.js
+++ b/tests/rspack-test/configCases/context/import-meta-glob-case-insensitive-pruning/src/unrelated/unused.js
@@ -1,0 +1,1 @@
+export default "unused";

--- a/tests/rspack-test/normalCases/context/import-meta-glob/case-test/alpha.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/case-test/alpha.js
@@ -1,0 +1,1 @@
+export default 'alpha'

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -106,6 +106,11 @@ const filteredDefaultModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], {
 const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], {
   import: 'named',
 })
+const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
+const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: false,
+})
 const quotedModules = import.meta.glob("./quoted/*.js", { eager: true })
 const escapeModules = import.meta.glob('./escape/**/glob.js', { eager: true })
 
@@ -313,6 +318,12 @@ it('should parse glob calls with comments in the argument list', async () => {
 it('should work when glob results are wrapped with Object.keys and Object.values', () => {
   expect(objectKeyModules.sort()).toEqual(dirKeys)
   expect(objectValueModules.map(mod => mod.default).sort()).toEqual(['bar', 'foo'])
+})
+
+it('should match case-insensitively only when caseSensitive is false', () => {
+  expect(Object.keys(caseSensitiveModules)).toEqual([])
+  expect(Object.keys(caseInsensitiveModules)).toEqual(['./case-test/alpha.js'])
+  expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
 })
 
 it('should handle matched paths containing single quotes', () => {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -1,3 +1,5 @@
+import { internalDotDotModules } from './nested/internal-dot-dot'
+
 // Lazy (default): each value is a thunk () => Promise<module>
 const lazyModules = import.meta.glob('./dir/*.js')
 const wildcardModules = import.meta.glob('./dir/*')
@@ -348,6 +350,8 @@ it('should match case-insensitively only when caseSensitive is false', () => {
   expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
   expect(Object.keys(caseInsensitiveDirectoryModules)).toEqual(['./case-test/alpha.js'])
   expect(caseInsensitiveDirectoryModules['./case-test/alpha.js'].default).toBe('alpha')
+  expect(Object.keys(internalDotDotModules)).toEqual(['../case-test/alpha.js'])
+  expect(internalDotDotModules['../case-test/alpha.js'].default).toBe('alpha')
 })
 
 it('should use case-sensitive matching for non-boolean caseSensitive values', () => {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -109,7 +109,7 @@ const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], 
 const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
 const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,
-  caseSensitive: !true,
+  caseSensitive: false,
 })
 const numberCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -12,6 +12,10 @@ const eagerNamespaceModules = import.meta.glob('./dir/*.js', {
 const explicitNodeModulesModules = import.meta.glob('./dir/node_modules/*.js', {
   eager: true,
 })
+const caseInsensitiveExplicitNodeModulesModules = import.meta.glob('./DIR/NODE_MODULES/*.JS', {
+  eager: true,
+  caseSensitive: false,
+})
 const skippedExhaustiveModules = import.meta.glob(
   ['./dot/.*.js', './.foo/*.js', './dir/node_modules/**'],
   { eager: true },
@@ -111,6 +115,10 @@ const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,
   caseSensitive: false,
 })
+const caseInsensitiveDirectoryModules = import.meta.glob('./CASE-TEST/*.JS', {
+  eager: true,
+  caseSensitive: false,
+})
 const numberCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,
   caseSensitive: 0,
@@ -191,6 +199,12 @@ it('should allow explicit glob roots inside node_modules', () => {
   expect(explicitNodeModulesModules['./dir/node_modules/hoge.js'].default).toBe(
     'hoge',
   )
+  expect(Object.keys(caseInsensitiveExplicitNodeModulesModules)).toEqual([
+    './dir/node_modules/hoge.js',
+  ])
+  expect(
+    caseInsensitiveExplicitNodeModulesModules['./dir/node_modules/hoge.js'].default,
+  ).toBe('hoge')
 })
 
 it('should only search hidden directories and node_modules in exhaustive mode', () => {
@@ -332,6 +346,8 @@ it('should match case-insensitively only when caseSensitive is false', () => {
   expect(Object.keys(caseSensitiveModules)).toEqual([])
   expect(Object.keys(caseInsensitiveModules)).toEqual(['./case-test/alpha.js'])
   expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
+  expect(Object.keys(caseInsensitiveDirectoryModules)).toEqual(['./case-test/alpha.js'])
+  expect(caseInsensitiveDirectoryModules['./case-test/alpha.js'].default).toBe('alpha')
 })
 
 it('should use case-sensitive matching for non-boolean caseSensitive values', () => {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -109,7 +109,15 @@ const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], 
 const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
 const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,
-  caseSensitive: false,
+  caseSensitive: !true,
+})
+const numberCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: 0,
+})
+const stringCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: '',
 })
 const quotedModules = import.meta.glob("./quoted/*.js", { eager: true })
 const escapeModules = import.meta.glob('./escape/**/glob.js', { eager: true })
@@ -324,6 +332,11 @@ it('should match case-insensitively only when caseSensitive is false', () => {
   expect(Object.keys(caseSensitiveModules)).toEqual([])
   expect(Object.keys(caseInsensitiveModules)).toEqual(['./case-test/alpha.js'])
   expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
+})
+
+it('should use case-sensitive matching for non-boolean caseSensitive values', () => {
+  expect(Object.keys(numberCaseSensitiveModules)).toEqual([])
+  expect(Object.keys(stringCaseSensitiveModules)).toEqual([])
 })
 
 it('should handle matched paths containing single quotes', () => {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/nested/internal-dot-dot.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/nested/internal-dot-dot.js
@@ -1,0 +1,4 @@
+export const internalDotDotModules = import.meta.glob('./tmp/../../CASE-TEST/*.JS', {
+  eager: true,
+  caseSensitive: false,
+})

--- a/tests/rspack-test/normalCases/context/import-meta-glob/warnings.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/warnings.js
@@ -1,0 +1,8 @@
+module.exports = [
+  [
+    /import\.meta\.glob\(\) 'caseSensitive' option must be a constant boolean \(true or false\), defaulting to true/,
+  ],
+  [
+    /import\.meta\.glob\(\) 'caseSensitive' option must be a constant boolean \(true or false\), defaulting to true/,
+  ],
+]

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/case-test/alpha.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/case-test/alpha.js
@@ -1,0 +1,1 @@
+export default 'alpha'

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
@@ -2,7 +2,17 @@ const modules = import.meta.glob('./*.JS', {
   eager: true,
   caseSensitive: 'yes',
 })
+const staticallyEvaluatedModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: !true,
+})
 
 it('should warn and default to case-sensitive matching for an invalid value', () => {
   expect(Object.keys(modules)).toEqual([])
+})
+
+it('should evaluate a static boolean caseSensitive expression', () => {
+  expect(Object.keys(staticallyEvaluatedModules)).toEqual([
+    './case-test/alpha.js',
+  ])
 })

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
@@ -1,0 +1,8 @@
+const modules = import.meta.glob('./*.JS', {
+  eager: true,
+  caseSensitive: 'yes',
+})
+
+it('should warn and default to case-sensitive matching for an invalid value', () => {
+  expect(Object.keys(modules)).toEqual([])
+})

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/warnings.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/warnings.js
@@ -1,0 +1,5 @@
+module.exports = [
+  [
+    /import\.meta\.glob\(\) 'caseSensitive' option must be a constant boolean \(true or false\), defaulting to true/,
+  ],
+]

--- a/tests/type-tests/resolution-bundler/index.ts
+++ b/tests/type-tests/resolution-bundler/index.ts
@@ -69,6 +69,7 @@ const multiGlobModules = import.meta.glob<GlobModule>(
     },
     base: './base',
     exhaustive: true,
+    caseSensitive: false,
   },
 );
 multiGlobModules['./dir/foo.js'].default.toUpperCase();

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -236,6 +236,12 @@ interface ImportMetaGlobOptions<Eager extends boolean = boolean> {
    * Base path for resolving relative glob patterns and returned keys.
    */
   base?: string;
+  /**
+   * Match file paths case-sensitively.
+   *
+   * @default true
+   */
+  caseSensitive?: boolean;
 }
 
 function glob(
@@ -262,6 +268,7 @@ function glob(
   - `options.query`: Append a query to each matched module request. It can be a query string such as `'?raw'`, or an object that is serialized as a URL query string. The keys returned from `import.meta.glob()` do not include the query.
   - `options.exhaustive`: Search files inside `node_modules` and hidden paths. This is disabled by default because it can increase build time.
   - `options.base`: Base path for resolving relative glob patterns and returned keys. Absolute glob patterns are still resolved from the project root, while returned keys are made relative to `base`.
+  - `options.caseSensitive`: Whether to match file paths case-sensitively. When set to `false`, matching ignores case, while returned object keys preserve the filesystem's original casing. Defaults to `true`.
 
 - **Example:**
 

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -236,6 +236,12 @@ interface ImportMetaGlobOptions<Eager extends boolean = boolean> {
    * 用于解析相对 glob 模式和返回 key 的 base 路径。
    */
   base?: string;
+  /**
+   * 是否区分文件路径大小写。
+   *
+   * @default true
+   */
+  caseSensitive?: boolean;
 }
 
 function glob(
@@ -262,6 +268,7 @@ function glob(
   - `options.query`：为每个匹配模块请求追加 query。可以是 `'?raw'` 这样的 query 字符串，也可以是会序列化为 URL query 字符串的对象。`import.meta.glob()` 返回对象中的 key 不包含 query。
   - `options.exhaustive`：搜索 `node_modules` 和隐藏路径中的文件。默认关闭，因为可能增加构建时间。
   - `options.base`：用于解析相对 glob 模式和返回 key 的 base 路径。绝对 glob 模式仍从项目根目录解析，但返回 key 会相对于 `base`。
+  - `options.caseSensitive`：是否区分文件路径大小写。设置为 `false` 时忽略大小写匹配，返回对象的 key 保留文件系统原始大小写。默认为 `true`。
 
 - **示例：**
 


### PR DESCRIPTION
## Summary

- add `import.meta.glob` support for the `caseSensitive` option
- default to case-sensitive matching and allow `caseSensitive: false` for case-insensitive positive and negative glob patterns
- preserve filesystem path casing in returned object keys
- warn once and fall back to `true` when the option is not a statically evaluated boolean
- expose the option in public types and document it in English and Chinese

## PR order

Review and merge these PRs in order:

1. [#14897 — clarify context module resolution contexts](https://github.com/web-infra-dev/rspack/pull/14897)
2. [#14886 — extract parser options with `AstObject` derive](https://github.com/web-infra-dev/rspack/pull/14886)
3. **[#14811 — support `caseSensitive` in `import.meta.glob`](https://github.com/web-infra-dev/rspack/pull/14811) — this PR**

This PR targets `codex/ast-options-macro-reuse`.

## Example

```js
const modules = import.meta.glob("./components/*.JS", {
  eager: true,
  caseSensitive: false,
});
```

For example, this can match `./components/button.js` even though the pattern uses `.JS`. The returned key remains `./components/button.js`, preserving the filesystem spelling. Omitting the option keeps the existing case-sensitive behavior.

The matching mode is included in context dependency and module identity so otherwise identical glob calls cannot incorrectly reuse modules across different case-sensitivity settings.

## Related links

- Related to #14556

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rspack_plugin_javascript --lib`
- `cargo test -p rspack_macros --lib`
- `cargo clippy -p rspack_macros -p rspack_plugin_javascript --all-targets --tests --locked -- -D warnings`
- `pnpm run build:cli:dev`
- `pnpm --dir tests/rspack-test run test -t "normalCases/parsing/import-meta-glob-case-sensitive"`
- `pnpm --dir tests/rspack-test run test -t "normalCases/context/import-meta-glob"`
- `pnpm --dir tests/rspack-test run test -t "configCases/builtins/define-destructuring"`
- normalized webpack content diff: no remaining `caseSensitive` test-content gaps

## Checklist

- [x] Tests updated.
- [x] Documentation updated.

---
_by OpenAI Codex_