### PR TITLE
chore: update Rsdoctor diff action version

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -96,7 +96,7 @@ jobs:
         run: RSDOCTOR=true CI=true pnpm run build:cases
 
       - name: Report Compressed Size
-        uses: web-infra-dev/rsdoctor-action@96c3d1f7e1d2abf41c1203c3486364c9c4561b60 # v1.1.2
+        uses: web-infra-dev/rsdoctor-action@bce0934b887cddb56986d16c34a445bcce9a7d65 # v1.1.3
         env:
           AI_TOKEN: ${{ secrets.AI_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
chore: update Rsdoctor diff action version
v1.1.3 release note: https://github.com/web-infra-dev/rsdoctor-action/releases/tag/v1.1.3
<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
