### PR TITLE
perf: optimize module concatenation root search

### DIFF
--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -12,8 +12,12 @@ module.exports = async function action({ github, context, limit }) {
 
   let baseCommit;
   let baseSize;
+  let unpublishedBase;
   try {
-    ({ baseCommit, baseSize } = await findBaseCommit(github, context));
+    ({ baseCommit, baseSize, unpublishedBase } = await findBaseCommit(
+      github,
+      context,
+    ));
   } catch (e) {
     if (e instanceof PendingBinaryDataError) {
       await tryComment(
@@ -27,11 +31,11 @@ module.exports = async function action({ github, context, limit }) {
 
   console.log(`Base commit size: ${baseSize}`);
 
-  await tryComment(
-    github,
-    context,
-    compareBinarySize(headSize, baseSize, context, baseCommit),
-  );
+  let comment = compareBinarySize(headSize, baseSize, context, baseCommit);
+  if (unpublishedBase) {
+    comment += stackedBaseNote(unpublishedBase);
+  }
+  await tryComment(github, context, comment);
 
   const increasedSize = headSize - baseSize;
   if (increasedSize > limit) {
@@ -87,11 +91,21 @@ async function findBaseCommit(github, context) {
       if (pendingBase) {
         const data = await fetchDataBySha(github, commit.sha);
         if (data?.size) {
-          console.log(`Fallback reference ${commit.sha}: ${data.size}`);
-          throw new PendingBinaryDataError(pendingBase, {
+          console.log(`Nearest published ancestor ${commit.sha}: ${data.size}`);
+          if (await dataWillBePublished(github, owner, repo, pendingBase.sha)) {
+            throw new PendingBinaryDataError(pendingBase, {
+              baseCommit: commit,
+              baseSize: data.size,
+            });
+          }
+          // The true base commit sits on a branch that never publishes size
+          // data (e.g. this PR is stacked on another PR), so waiting is
+          // pointless; the nearest published ancestor is the best baseline.
+          return {
             baseCommit: commit,
             baseSize: data.size,
-          });
+            unpublishedBase: pendingBase,
+          };
         }
         continue;
       }
@@ -157,6 +171,31 @@ async function triggersBinaryBuild(github, owner, repo, sha) {
 
 function isDocFile(filename) {
   return filename.endsWith('.md') || filename.startsWith('website/');
+}
+
+// Ecosystem-benchmark only uploads size data on pushes to these branches
+// (`on.push.branches` plus the upload step's `if: github.event_name == 'push'`),
+// so data for a commit not reachable from one of them will never appear.
+const DATA_PUBLISHING_BRANCHES = ['main', 'v1.x'];
+
+async function dataWillBePublished(github, owner, repo, sha) {
+  for (const branch of DATA_PUBLISHING_BRANCHES) {
+    try {
+      const { data } = await github.rest.repos.compareCommitsWithBasehead({
+        owner,
+        repo,
+        basehead: `${sha}...${branch}`,
+        per_page: 1,
+      });
+      // "identical"/"ahead" means the branch contains the commit.
+      if (data.status === 'identical' || data.status === 'ahead') {
+        return true;
+      }
+    } catch (e) {
+      if (e.status !== 404) throw e;
+    }
+  }
+  return false;
 }
 
 async function tryComment(github, context, comment) {
@@ -266,6 +305,16 @@ function referenceComparison(headSize, { baseCommit, baseSize }) {
     `([\`${shortSha}\`](${baseCommit.html_url})) for a rough estimate:\n` +
     '>\n' +
     `> ${sizeDiffLine(headSize, baseSize)}`
+  );
+}
+
+function stackedBaseNote(unpublishedBase) {
+  const shortSha = unpublishedBase.sha.slice(0, 7);
+  return (
+    '\n\n> [!NOTE]\n' +
+    `> The base commit [\`${shortSha}\`](${unpublishedBase.html_url}) is not on a ` +
+    'branch that publishes binary-size data, so this compares against its nearest ' +
+    'published ancestor instead.'
   );
 }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1190,8 +1190,15 @@ impl ModuleConcatenationPlugin {
           })
           .collect::<Vec<_>>();
 
+        let incoming_connection_ids = module_graph
+          .module_graph_module_by_identifier(&module_id)
+          .expect("should have mgm")
+          .incoming_connections();
         let mut incomings = IncomingConnections::default();
-        for connection in module_graph.get_incoming_connections(&module_id) {
+        for dependency_id in incoming_connection_ids {
+          let connection = module_graph
+            .connection_by_dependency_id(dependency_id)
+            .expect("should have connection");
           let origin_module = connection.original_module_identifier;
           let connection = CachedIncomingConnection::new(
             connection,
@@ -1437,6 +1444,8 @@ impl ModuleConcatenationPlugin {
         );
       });
 
+    // These lazy warnings inspect the current chunk graph, so materialize them before
+    // creating concatenated modules mutates that graph below.
     let formatted_empty_config_warnings = empty_config_warnings
       .into_par_iter()
       .map(|(current_root, warnings)| {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -57,7 +57,7 @@ enum ConcatenationProblem {
   },
   UnsupportedSyntax {
     module: ModuleIdentifier,
-    modules: Vec<(ModuleIdentifier, Vec<String>)>,
+    modules: Arc<[(ModuleIdentifier, Vec<String>)]>,
   },
 }
 
@@ -858,7 +858,7 @@ impl ModuleConcatenationPlugin {
 
         Warning::Problem(ConcatenationProblem::UnsupportedSyntax {
           module: *module_id,
-          modules,
+          modules: modules.into(),
         })
       };
       state.statistics.incorrect_module_dependency += 1;
@@ -1094,11 +1094,7 @@ impl ModuleConcatenationPlugin {
     ));
 
     let start = logger.time("sort relevant modules");
-    relevant_modules.sort_by(|a, b| {
-      let ad = module_graph.get_depth(a);
-      let bd = module_graph.get_depth(b);
-      ad.cmp(&bd)
-    });
+    relevant_modules.sort_by_cached_key(|module| module_graph.get_depth(module));
 
     logger.time_end(start);
     let mut statistics = Statistics::default();
@@ -1917,6 +1913,7 @@ fn add_concatenated_module(
   // integrate
 
   let module_graph = compilation.get_module_graph_mut();
+  let root_chunks = chunk_graph.get_module_chunks(root_module_id).clone();
 
   for m in modules_set.iter() {
     if *m == root_module_id {
@@ -1926,18 +1923,18 @@ fn add_concatenated_module(
       .module_by_identifier(m)
       .expect("should exist module");
     // TODO: optimize asset module https://github.com/webpack/webpack/pull/15515/files
-    for chunk_ukey in chunk_graph.get_module_chunks(root_module_id).clone() {
+    for chunk_ukey in &root_chunks {
       let source_types =
-        chunk_graph.get_chunk_module_source_types(&chunk_ukey, module, module_graph);
+        chunk_graph.get_chunk_module_source_types(chunk_ukey, module, module_graph);
 
       if source_types.len() == 1 && source_types.contains(&SourceType::JavaScript) {
-        chunk_graph.disconnect_chunk_and_module(&chunk_ukey, *m);
+        chunk_graph.disconnect_chunk_and_module(chunk_ukey, *m);
       } else {
         let new_source_types = source_types
           .into_iter()
           .filter(|source_type| !matches!(source_type, SourceType::JavaScript))
           .collect();
-        chunk_graph.set_chunk_modules_source_types(&chunk_ukey, *m, new_source_types)
+        chunk_graph.set_chunk_modules_source_types(chunk_ukey, *m, new_source_types)
       }
     }
   }

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::only_used_in_recursion)]
-use std::{borrow::Cow, collections::VecDeque, sync::Arc};
+use std::{
+  borrow::Cow,
+  collections::VecDeque,
+  sync::{Arc, OnceLock},
+};
 
 use rayon::prelude::*;
 use rspack_collections::{
@@ -10,7 +14,8 @@ use rspack_core::{
   DependencyType, ExportProvided, ExportsInfoArtifact, ExtendedReferencedExport, GetTargetResult,
   ImportedByDeferModulesArtifact, LibIdentOptions, Logger, ModuleGraph, ModuleGraphCacheArtifact,
   ModuleGraphConnection, ModuleGraphModule, ModuleIdentifier, OptimizationBailoutItem, Plugin,
-  ProvidedExports, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, SourceType,
+  ProvidedExports, RuntimeCondition, RuntimeSpec, RuntimeSpecMap, SideEffectsStateArtifact,
+  SourceType,
   concatenated_module::{
     ConcatenatedInnerModule, ConcatenatedModule, RootModuleContext, is_esm_dep_like,
   },
@@ -20,7 +25,7 @@ use rspack_core::{
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_util::itoa;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashSet as HashSet;
 
 fn format_bailout_reason(msg: &str) -> String {
   format!("ModuleConcatenation bailout: {msg}")
@@ -36,8 +41,7 @@ enum Warning {
 enum ConcatenationProblem {
   MissingChunks {
     module: ModuleIdentifier,
-    missing_chunks: Vec<ChunkUkey>,
-    chunks: Vec<ChunkUkey>,
+    root_chunks: Arc<HashSet<ChunkUkey>>,
   },
   ReferencedFromNonModule {
     module: ModuleIdentifier,
@@ -45,11 +49,11 @@ enum ConcatenationProblem {
   RuntimeDependent {
     module: ModuleIdentifier,
     expected_runtime: RuntimeSpec,
-    modules: Vec<(ModuleIdentifier, RuntimeCondition)>,
+    modules: Arc<[(ModuleIdentifier, RuntimeCondition)]>,
   },
   ReferencedFromDifferentChunks {
     module: ModuleIdentifier,
-    modules: Vec<ModuleIdentifier>,
+    chunk_modules: Arc<DifferentChunkModules>,
   },
   UnsupportedSyntax {
     module: ModuleIdentifier,
@@ -77,11 +81,13 @@ impl ConcatenationProblem {
       } => {
         modules.extend(origin_modules.iter().map(|(module, _)| *module));
       }
-      Self::ReferencedFromDifferentChunks {
-        modules: origin_modules,
-        ..
-      } => {
-        modules.extend(origin_modules.iter().copied());
+      Self::ReferencedFromDifferentChunks { chunk_modules, .. } => {
+        modules.extend(
+          chunk_modules
+            .incoming_modules
+            .iter()
+            .map(|incoming_module| incoming_module.module_identifier),
+        );
       }
       Self::UnsupportedSyntax {
         modules: origin_modules,
@@ -103,14 +109,13 @@ impl ConcatenationProblem {
     );
 
     match self {
-      Self::MissingChunks {
-        missing_chunks,
-        chunks,
-        ..
-      } => {
+      Self::MissingChunks { root_chunks, .. } => {
         let chunk_by_ukey = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
-        let mut missing_chunks = missing_chunks
+        let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+        let module_chunks = chunk_graph.get_module_chunks(module);
+        let mut missing_chunks = root_chunks
           .iter()
+          .filter(|chunk| !module_chunks.contains(*chunk))
           .map(|chunk| {
             chunk_by_ukey
               .expect_get(chunk)
@@ -120,7 +125,7 @@ impl ConcatenationProblem {
           })
           .collect::<Vec<_>>();
         missing_chunks.sort_unstable();
-        let mut chunks = chunks
+        let mut chunks = module_chunks
           .iter()
           .map(|chunk| {
             chunk_by_ukey
@@ -169,12 +174,13 @@ impl ConcatenationProblem {
             .join(", ")
         )
       }
-      Self::ReferencedFromDifferentChunks { modules, .. } => {
-        let mut names: Vec<_> = modules
+      Self::ReferencedFromDifferentChunks { chunk_modules, .. } => {
+        let mut names: Vec<_> = chunk_modules
+          .modules(compilation)
           .iter()
-          .map(|mid| {
+          .map(|module| {
             get_cached_readable_identifier(
-              mid,
+              module,
               module_graph,
               &compilation.module_static_cache,
               &compilation.options.context,
@@ -261,8 +267,8 @@ impl ConcatConfiguration {
     self.warnings.insert(module, problem);
   }
 
-  fn get_warnings_sorted(&self) -> Vec<(ModuleIdentifier, Warning)> {
-    let mut sorted_warnings: Vec<_> = self.warnings.clone().into_iter().collect();
+  fn into_warnings_sorted(self) -> Vec<(ModuleIdentifier, Warning)> {
+    let mut sorted_warnings: Vec<_> = self.warnings.into_iter().collect();
     sorted_warnings.sort_by_key(|(id, _)| *id);
     sorted_warnings
   }
@@ -293,13 +299,59 @@ pub struct ModuleConcatenationPlugin {
 #[derive(Default)]
 pub struct RuntimeIdentifierCache<T> {
   no_runtime_map: IdentifierMap<T>,
-  runtime_map: HashMap<RuntimeSpec, IdentifierMap<T>>,
+  runtime_map: RuntimeSpecMap<IdentifierMap<T>>,
 }
 
 struct ModuleGraphArtifacts<'a> {
   mg_cache: &'a ModuleGraphCacheArtifact,
   side_effects_state_artifact: &'a SideEffectsStateArtifact,
   exports_info_artifact: &'a ExportsInfoArtifact,
+}
+
+struct ConcatenationSearchContext<'a> {
+  compilation: &'a Compilation,
+  root_chunks: &'a Arc<HashSet<ChunkUkey>>,
+  runtime: &'a RuntimeSpec,
+  possible_modules: &'a IdentifierSet,
+  module_cache: &'a IdentifierMap<NoRuntimeModuleCache>,
+}
+
+impl ConcatenationSearchContext<'_> {
+  fn module_graph_artifacts(&self) -> ModuleGraphArtifacts<'_> {
+    ModuleGraphArtifacts {
+      mg_cache: &self.compilation.module_graph_cache_artifact,
+      side_effects_state_artifact: &self
+        .compilation
+        .build_module_graph_artifact
+        .side_effects_state_artifact,
+      exports_info_artifact: &self.compilation.exports_info_artifact,
+    }
+  }
+}
+
+struct ConcatenationSearchState<'a> {
+  candidates: &'a mut IdentifierSet,
+  failure_cache: &'a mut IdentifierMap<Warning>,
+  incoming_modules_cache: &'a mut RuntimeIdentifierCache<IncomingModulesCacheEntry>,
+  statistics: &'a mut Statistics,
+  imports_cache: &'a mut RuntimeIdentifierCache<Arc<[ModuleIdentifier]>>,
+}
+
+#[derive(Default)]
+struct RootSearchScratch {
+  failure_cache: IdentifierMap<Warning>,
+  candidates_visited: IdentifierSet,
+  candidates: VecDeque<ModuleIdentifier>,
+  import_candidates: IdentifierSet,
+}
+
+impl RootSearchScratch {
+  fn reset(&mut self) {
+    self.failure_cache.clear();
+    self.candidates_visited.clear();
+    self.candidates.clear();
+    self.import_candidates.clear();
+  }
 }
 
 impl<T> RuntimeIdentifierCache<T> {
@@ -310,7 +362,7 @@ impl<T> RuntimeIdentifierCache<T> {
       } else {
         let mut map = IdentifierMap::with_capacity_and_hasher(1, Default::default());
         map.insert(module, value);
-        self.runtime_map.insert(runtime.clone(), map);
+        self.runtime_map.set(runtime.clone(), map);
       }
     } else {
       self.no_runtime_map.insert(module, value);
@@ -451,357 +503,370 @@ impl ModuleConcatenationPlugin {
     imports
   }
 
-  #[allow(clippy::too_many_arguments)]
-  fn try_to_add(
-    compilation: &Compilation,
-    config: &mut ConcatConfiguration,
-    root_chunks: &HashSet<ChunkUkey>,
-    module_id: &ModuleIdentifier,
-    runtime: Option<&RuntimeSpec>,
-    active_runtime: Option<&RuntimeSpec>,
-    possible_modules: &IdentifierSet,
-    candidates: &mut IdentifierSet,
-    failure_cache: &mut IdentifierMap<Warning>,
-    success_cache: &mut RuntimeIdentifierCache<Arc<[ModuleIdentifier]>>,
-    avoid_mutate_on_failure: bool,
-    statistics: &mut Statistics,
-    imports_cache: &mut RuntimeIdentifierCache<Arc<[ModuleIdentifier]>>,
-    module_cache: &IdentifierMap<NoRuntimeModuleCache>,
-  ) -> Option<Warning> {
-    statistics
-      .module_visit
-      .entry(*module_id)
-      .and_modify(|count| {
-        *count += 1;
-      })
-      .or_insert(1);
+  fn get_incoming_modules(
+    context: &ConcatenationSearchContext<'_>,
+    state: &mut ConcatenationSearchState<'_>,
+    module_id: ModuleIdentifier,
+    cached: &NoRuntimeModuleCache,
+  ) -> std::result::Result<CachedIncomingModules, RuntimeDependentBailout> {
+    if let Some(incomings) = state
+      .incoming_modules_cache
+      .get(&module_id, Some(context.runtime))
+    {
+      return match incomings {
+        IncomingModulesCacheEntry::Modules(incomings) => Ok(incomings.clone()),
+        IncomingModulesCacheEntry::RuntimeDependent(bailout) => Err(bailout.clone()),
+      };
+    }
 
-    if let Some(cache_entry) = failure_cache.get(module_id) {
-      statistics.cached += 1;
+    let incoming_modules = Self::compute_incoming_modules(context, cached);
+    match &incoming_modules {
+      Ok(incomings) => state.incoming_modules_cache.insert(
+        module_id,
+        Some(context.runtime),
+        IncomingModulesCacheEntry::Modules(incomings.clone()),
+      ),
+      Err(bailout) => state.incoming_modules_cache.insert(
+        module_id,
+        Some(context.runtime),
+        IncomingModulesCacheEntry::RuntimeDependent(bailout.clone()),
+      ),
+    }
+    incoming_modules
+  }
+
+  fn compute_incoming_modules(
+    context: &ConcatenationSearchContext<'_>,
+    cached: &NoRuntimeModuleCache,
+  ) -> std::result::Result<CachedIncomingModules, RuntimeDependentBailout> {
+    let compilation = context.compilation;
+    let runtime = context.runtime;
+    let module_cache = context.module_cache;
+    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+    let chunk_by_ukey = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
+    let module_graph = compilation.get_module_graph();
+    let module_graph_artifacts = context.module_graph_artifacts();
+    let mut modules = Vec::with_capacity(cached.incomings.from_modules.len());
+
+    let needs_runtime_condition = runtime.len() > 1;
+    // Keep the common single-runtime path free of the per-origin connection vectors that the
+    // multi-runtime condition analysis needs.
+    if !needs_runtime_condition {
+      for (origin_module, connections) in &cached.incomings.from_modules {
+        let origin_cache = module_cache.get(origin_module);
+        let number_of_chunks = origin_cache.map_or_else(
+          || chunk_graph.get_number_of_module_chunks(*origin_module),
+          |module| module.number_of_chunks,
+        );
+
+        if number_of_chunks == 0 {
+          continue;
+        }
+
+        let is_intersect = if let Some(origin_runtime) = origin_cache.map(|module| &module.runtime)
+        {
+          !runtime.is_disjoint(origin_runtime)
+        } else {
+          let origin_runtime = RuntimeSpec::from_runtimes(
+            chunk_graph.get_module_runtimes_iter(*origin_module, chunk_by_ukey),
+          );
+          !runtime.is_disjoint(&origin_runtime)
+        };
+
+        if !is_intersect {
+          continue;
+        }
+
+        let mut has_active_connection = false;
+        let mut has_non_esm_connection = false;
+        for connection in connections {
+          if is_connection_active_in_runtime(
+            connection,
+            Some(runtime),
+            &cached.runtime,
+            module_graph,
+            &module_graph_artifacts,
+          ) {
+            has_active_connection = true;
+            has_non_esm_connection |= !connection.is_esm;
+          }
+        }
+
+        if has_active_connection {
+          modules.push(CachedIncomingModule {
+            module_identifier: *origin_module,
+            has_non_esm_connection,
+          });
+        }
+      }
+    } else {
+      let mut incoming_connections_from_modules =
+        Vec::with_capacity(cached.incomings.from_modules.len());
+      for (origin_module, connections) in &cached.incomings.from_modules {
+        let origin_cache = module_cache.get(origin_module);
+        let number_of_chunks = origin_cache.map_or_else(
+          || chunk_graph.get_number_of_module_chunks(*origin_module),
+          |module| module.number_of_chunks,
+        );
+
+        if number_of_chunks == 0 {
+          continue;
+        }
+
+        let is_intersect = if let Some(origin_runtime) = origin_cache.map(|module| &module.runtime)
+        {
+          !runtime.is_disjoint(origin_runtime)
+        } else {
+          let origin_runtime = RuntimeSpec::from_runtimes(
+            chunk_graph.get_module_runtimes_iter(*origin_module, chunk_by_ukey),
+          );
+          !runtime.is_disjoint(&origin_runtime)
+        };
+
+        if !is_intersect {
+          continue;
+        }
+
+        let active_connections = connections
+          .iter()
+          .filter(|connection| {
+            is_connection_active_in_runtime(
+              connection,
+              Some(runtime),
+              &cached.runtime,
+              module_graph,
+              &module_graph_artifacts,
+            )
+          })
+          .collect::<Vec<_>>();
+
+        if !active_connections.is_empty() {
+          modules.push(CachedIncomingModule {
+            module_identifier: *origin_module,
+            has_non_esm_connection: active_connections
+              .iter()
+              .any(|connection| !connection.is_esm),
+          });
+          incoming_connections_from_modules.push((*origin_module, active_connections));
+        }
+      }
+
+      let mut runtime_dependent_modules = Vec::new();
+      'outer: for (origin_module, connections) in &incoming_connections_from_modules {
+        let mut current_runtime_condition = RuntimeCondition::Boolean(false);
+        for connection in connections {
+          let runtime_condition = filter_runtime(Some(runtime), |runtime| {
+            connection.connection.is_target_active(
+              module_graph,
+              runtime,
+              module_graph_artifacts.mg_cache,
+              module_graph_artifacts.side_effects_state_artifact,
+              module_graph_artifacts.exports_info_artifact,
+            )
+          });
+
+          if runtime_condition == RuntimeCondition::Boolean(false) {
+            continue;
+          }
+
+          if runtime_condition == RuntimeCondition::Boolean(true) {
+            continue 'outer;
+          }
+
+          if current_runtime_condition != RuntimeCondition::Boolean(false) {
+            current_runtime_condition
+              .as_spec_mut()
+              .expect("should be spec")
+              .extend(runtime_condition.as_spec().expect("should be spec"));
+          } else {
+            current_runtime_condition = runtime_condition;
+          }
+        }
+
+        if current_runtime_condition != RuntimeCondition::Boolean(false) {
+          runtime_dependent_modules.push((*origin_module, current_runtime_condition));
+        }
+      }
+
+      if !runtime_dependent_modules.is_empty() {
+        return Err(RuntimeDependentBailout {
+          expected_runtime: runtime.clone(),
+          modules: Arc::from(runtime_dependent_modules),
+        });
+      }
+    }
+
+    let modules: Arc<[CachedIncomingModule]> = Arc::from(modules);
+    let mut module_identifiers = modules
+      .iter()
+      .map(|incoming_module| incoming_module.module_identifier)
+      .collect::<Vec<_>>();
+    module_identifiers.sort_unstable();
+    Ok(CachedIncomingModules {
+      modules,
+      module_identifiers: Arc::from(module_identifiers),
+    })
+  }
+
+  fn try_to_add(
+    context: &ConcatenationSearchContext<'_>,
+    state: &mut ConcatenationSearchState<'_>,
+    config: &mut ConcatConfiguration,
+    module_id: &ModuleIdentifier,
+    rollback_on_failure: bool,
+  ) -> Option<Warning> {
+    if let Some(cache_entry) = state.failure_cache.get(module_id) {
+      state.statistics.cached += 1;
       return Some(cache_entry.clone());
     }
 
     if config.has(module_id) {
-      statistics.already_in_config += 1;
+      state.statistics.already_in_config += 1;
       return None;
     }
 
+    let compilation = context.compilation;
+    let runtime = context.runtime;
+    let root_chunks = context.root_chunks;
+    let module_cache = context.module_cache;
     let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-    let chunk_by_ukey = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
     let module_graph = compilation.get_module_graph();
-    let module_graph_cache = &compilation.module_graph_cache_artifact;
-    let side_effects_state_artifact = &compilation
-      .build_module_graph_artifact
-      .side_effects_state_artifact;
-    let module_graph_artifacts = ModuleGraphArtifacts {
-      mg_cache: module_graph_cache,
-      side_effects_state_artifact,
-      exports_info_artifact: &compilation.exports_info_artifact,
-    };
+    let module_graph_artifacts = context.module_graph_artifacts();
 
-    let incoming_modules = if let Some(incomings) = success_cache.get(module_id, runtime) {
-      statistics.cache_hit += 1;
-      Arc::clone(incomings)
-    } else {
-      if !possible_modules.contains(module_id) {
-        statistics.invalid_module += 1;
-        let problem = Warning::Id(*module_id);
-        failure_cache.insert(*module_id, problem.clone());
-        return Some(problem);
-      }
+    if !context.possible_modules.contains(module_id) {
+      state.statistics.invalid_module += 1;
+      let problem = Warning::Id(*module_id);
+      state.failure_cache.insert(*module_id, problem.clone());
+      return Some(problem);
+    }
 
-      let cached = module_cache
-        .get(module_id)
-        .expect("should have module cache");
-      let missing_chunks: Vec<_> = root_chunks
-        .iter()
-        .filter(|chunk| !cached.chunks.contains(chunk))
-        .collect();
+    let cached = module_cache
+      .get(module_id)
+      .expect("should have module cache");
+    if !root_chunks.is_subset(&cached.chunks) {
+      let problem = Warning::Problem(ConcatenationProblem::MissingChunks {
+        module: *module_id,
+        root_chunks: Arc::clone(root_chunks),
+      });
 
-      if !missing_chunks.is_empty() {
-        let problem = Warning::Problem(ConcatenationProblem::MissingChunks {
-          module: *module_id,
-          missing_chunks: missing_chunks.into_iter().copied().collect(),
-          chunks: cached.chunks.iter().copied().collect(),
+      state.statistics.incorrect_chunks += 1;
+      state.failure_cache.insert(*module_id, problem.clone());
+      return Some(problem);
+    }
+
+    let NoRuntimeModuleCache {
+      incomings,
+      runtime: cached_module_runtime,
+      ..
+    } = cached;
+
+    if !incomings.from_non_modules.is_empty() {
+      let has_active_non_modules_connections =
+        incomings.from_non_modules.iter().any(|connection| {
+          is_connection_active_in_runtime(
+            connection,
+            Some(runtime),
+            cached_module_runtime,
+            module_graph,
+            &module_graph_artifacts,
+          )
         });
 
-        statistics.incorrect_chunks += 1;
-        failure_cache.insert(*module_id, problem.clone());
+      // TODO: ADD module connection explanations
+      if has_active_non_modules_connections {
+        let problem =
+          Warning::Problem(ConcatenationProblem::ReferencedFromNonModule { module: *module_id });
+        state.statistics.incorrect_dependency += 1;
+        state.failure_cache.insert(*module_id, problem.clone());
         return Some(problem);
       }
+    }
 
-      let NoRuntimeModuleCache {
-        incomings,
-        runtime: cached_module_runtime,
-        ..
-      } = cached;
-
-      if !incomings.from_non_modules.is_empty() {
-        let has_active_non_modules_connections =
-          incomings.from_non_modules.iter().any(|connection| {
-            is_connection_active_in_runtime(
-              connection,
-              runtime,
-              cached_module_runtime,
-              module_graph,
-              &module_graph_artifacts,
-            )
-          });
-
-        // TODO: ADD module connection explanations
-        if has_active_non_modules_connections {
-          let problem =
-            Warning::Problem(ConcatenationProblem::ReferencedFromNonModule { module: *module_id });
-          statistics.incorrect_dependency += 1;
-          failure_cache.insert(*module_id, problem.clone());
-          return Some(problem);
-        }
+    let incoming_modules = match Self::get_incoming_modules(context, state, *module_id, cached) {
+      Ok(incoming_modules) => incoming_modules,
+      Err(bailout) => {
+        let problem = bailout.warning(*module_id);
+        state.statistics.incorrect_runtime_condition += 1;
+        state.failure_cache.insert(*module_id, problem.clone());
+        return Some(problem);
       }
+    };
 
-      let mut other_chunk_modules = Vec::new();
-      let mut non_esm_modules = Vec::new();
-      let mut incoming_modules = Vec::with_capacity(incomings.from_modules.len());
-
-      let needs_runtime_condition = runtime.is_some_and(|runtime| runtime.len() > 1);
-      if !needs_runtime_condition {
-        for (origin_module, connections) in incomings.from_modules.iter() {
-          let origin_cache = module_cache.get(origin_module);
-          let number_of_chunks = origin_cache.map_or_else(
-            || chunk_graph.get_number_of_module_chunks(*origin_module),
-            |m| m.number_of_chunks,
-          );
-
-          if number_of_chunks == 0 {
-            // Ignore connection from orphan modules
-            continue;
-          }
-
-          let is_intersect = if let Some(runtime) = runtime {
-            if let Some(origin_runtime) = origin_cache.map(|m| &m.runtime) {
-              !runtime.is_disjoint(origin_runtime)
-            } else {
-              let origin_runtime = RuntimeSpec::from_runtimes(
-                chunk_graph.get_module_runtimes_iter(*origin_module, chunk_by_ukey),
-              );
-              !runtime.is_disjoint(&origin_runtime)
-            }
-          } else {
-            false
-          };
-
-          if !is_intersect {
-            continue;
-          }
-
-          let mut has_active_connection = false;
-          let mut has_non_esm_connection = false;
-          for connection in connections {
-            if is_connection_active_in_runtime(
-              connection,
-              runtime,
-              cached_module_runtime,
-              module_graph,
-              &module_graph_artifacts,
-            ) {
-              has_active_connection = true;
-              has_non_esm_connection |= !connection.is_esm;
-            }
-          }
-
-          if has_active_connection {
-            let is_same_chunks = if let Some(origin_cache) = origin_cache {
-              root_chunks.is_subset(&origin_cache.chunks)
-            } else {
-              root_chunks.is_subset(chunk_graph.get_module_chunks(*origin_module))
-            };
-            if !is_same_chunks {
-              other_chunk_modules.push(*origin_module);
-            }
-            if has_non_esm_connection {
-              non_esm_modules.push(*origin_module);
-            }
-            incoming_modules.push(*origin_module);
-          }
-        }
+    let has_other_chunk_module = incoming_modules.modules.iter().any(|incoming_module| {
+      let origin_module = incoming_module.module_identifier;
+      let origin_cache = module_cache.get(&origin_module);
+      if let Some(origin_cache) = origin_cache {
+        !root_chunks.is_subset(&origin_cache.chunks)
       } else {
-        let mut incoming_connections_from_modules =
-          Vec::with_capacity(incomings.from_modules.len());
-        for (origin_module, connections) in incomings.from_modules.iter() {
-          let origin_cache = module_cache.get(origin_module);
-          let number_of_chunks = origin_cache.map_or_else(
-            || chunk_graph.get_number_of_module_chunks(*origin_module),
-            |m| m.number_of_chunks,
-          );
+        !root_chunks.is_subset(chunk_graph.get_module_chunks(origin_module))
+      }
+    });
 
-          if number_of_chunks == 0 {
-            // Ignore connection from orphan modules
-            continue;
-          }
+    if has_other_chunk_module {
+      state.statistics.incorrect_chunks_of_importer += 1;
+      let problem = Warning::Problem(ConcatenationProblem::ReferencedFromDifferentChunks {
+        module: *module_id,
+        chunk_modules: Arc::new(DifferentChunkModules {
+          root_chunks: Arc::clone(root_chunks),
+          incoming_modules: Arc::clone(&incoming_modules.modules),
+          modules: OnceLock::new(),
+        }),
+      });
+      state.failure_cache.insert(*module_id, problem.clone());
+      return Some(problem);
+    }
 
-          let is_intersect = if let Some(runtime) = runtime {
-            if let Some(origin_runtime) = origin_cache.map(|m| &m.runtime) {
-              !runtime.is_disjoint(origin_runtime)
-            } else {
-              let origin_runtime = RuntimeSpec::from_runtimes(
-                chunk_graph.get_module_runtimes_iter(*origin_module, chunk_by_ukey),
-              );
-              !runtime.is_disjoint(&origin_runtime)
-            }
-          } else {
-            false
-          };
+    let non_esm_modules = incoming_modules
+      .modules
+      .iter()
+      .filter_map(|incoming_module| {
+        incoming_module
+          .has_non_esm_connection
+          .then_some(incoming_module.module_identifier)
+      })
+      .collect::<Vec<_>>();
 
-          if !is_intersect {
-            continue;
-          }
-
-          let mut active_connections = Vec::new();
-          for connection in connections {
-            if is_connection_active_in_runtime(
-              connection,
-              runtime,
-              cached_module_runtime,
-              module_graph,
-              &module_graph_artifacts,
-            ) {
-              active_connections.push(connection);
-            }
-          }
-
-          if !active_connections.is_empty() {
-            let is_same_chunks = if let Some(origin_cache) = origin_cache {
-              root_chunks.is_subset(&origin_cache.chunks)
-            } else {
-              root_chunks.is_subset(chunk_graph.get_module_chunks(*origin_module))
-            };
-            if !is_same_chunks {
-              other_chunk_modules.push(*origin_module);
-            }
-            if active_connections
+    if !non_esm_modules.is_empty() {
+      let problem = {
+        let modules = non_esm_modules
+          .iter()
+          .map(|origin_module| {
+            let mut names = incomings
+              .from_modules
+              .get(origin_module)
+              .expect("should have incoming connections")
               .iter()
-              .any(|connection| !connection.is_esm)
-            {
-              non_esm_modules.push(*origin_module);
-            }
-            incoming_modules.push(*origin_module);
-            incoming_connections_from_modules.push((*origin_module, active_connections));
-          }
-        }
-
-        if let Some(runtime) = runtime {
-          let mut other_runtime_connections = Vec::new();
-          'outer: for (origin_module, connections) in &incoming_connections_from_modules {
-            let mut current_runtime_condition = RuntimeCondition::Boolean(false);
-            for connection in connections {
-              let runtime_condition = filter_runtime(Some(runtime), |runtime| {
-                connection.connection.is_target_active(
-                  module_graph,
-                  runtime,
-                  module_graph_cache,
-                  &compilation
-                    .build_module_graph_artifact
-                    .side_effects_state_artifact,
-                  &compilation.exports_info_artifact,
-                )
-              });
-
-              if runtime_condition == RuntimeCondition::Boolean(false) {
-                continue;
-              }
-
-              if runtime_condition == RuntimeCondition::Boolean(true) {
-                continue 'outer;
-              }
-
-              // here two runtime_condition must be `RuntimeCondition::Spec`
-              if current_runtime_condition != RuntimeCondition::Boolean(false) {
-                current_runtime_condition
-                  .as_spec_mut()
-                  .expect("should be spec")
-                  .extend(runtime_condition.as_spec().expect("should be spec"));
-              } else {
-                current_runtime_condition = runtime_condition;
-              }
-            }
-
-            if current_runtime_condition != RuntimeCondition::Boolean(false) {
-              other_runtime_connections.push((origin_module, current_runtime_condition));
-            }
-          }
-
-          if !other_runtime_connections.is_empty() {
-            let problem = Warning::Problem(ConcatenationProblem::RuntimeDependent {
-              module: *module_id,
-              expected_runtime: runtime.clone(),
-              modules: other_runtime_connections
-                .into_iter()
-                .map(|(origin_module, runtime_condition)| (*origin_module, runtime_condition))
-                .collect(),
-            });
-            statistics.incorrect_runtime_condition += 1;
-            failure_cache.insert(*module_id, problem.clone());
-            return Some(problem);
-          }
-        }
-      }
-
-      if !other_chunk_modules.is_empty() {
-        statistics.incorrect_chunks_of_importer += 1;
-        let problem = Warning::Problem(ConcatenationProblem::ReferencedFromDifferentChunks {
-          module: *module_id,
-          modules: other_chunk_modules,
-        });
-        failure_cache.insert(*module_id, problem.clone());
-        return Some(problem);
-      }
-
-      if !non_esm_modules.is_empty() {
-        let problem = {
-          let modules = non_esm_modules
-            .iter()
-            .map(|origin_module| {
-              let mut names = incomings
-                .from_modules
-                .get(origin_module)
-                .expect("should have incoming connections")
-                .iter()
-                .filter(|connection| {
-                  !connection.is_esm
-                    && is_connection_active_in_runtime(
-                      connection,
-                      runtime,
-                      cached_module_runtime,
-                      module_graph,
-                      &module_graph_artifacts,
-                    )
-                })
-                .map(|item| {
-                  let dep = module_graph.dependency_by_id(&item.connection.dependency_id);
-                  dep.dependency_type().to_string()
-                })
-                .collect::<Vec<_>>();
-              names.sort();
-              (*origin_module, names)
-            })
-            .collect::<Vec<_>>();
-
-          Warning::Problem(ConcatenationProblem::UnsupportedSyntax {
-            module: *module_id,
-            modules,
+              .filter(|connection| {
+                !connection.is_esm
+                  && is_connection_active_in_runtime(
+                    connection,
+                    Some(runtime),
+                    cached_module_runtime,
+                    module_graph,
+                    &module_graph_artifacts,
+                  )
+              })
+              .map(|item| {
+                let dep = module_graph.dependency_by_id(&item.connection.dependency_id);
+                dep.dependency_type().to_string()
+              })
+              .collect::<Vec<_>>();
+            names.sort();
+            (*origin_module, names)
           })
-        };
-        statistics.incorrect_module_dependency += 1;
-        failure_cache.insert(*module_id, problem.clone());
-        return Some(problem);
-      }
+          .collect::<Vec<_>>();
 
-      incoming_modules.sort();
-      let incoming_modules: Arc<[ModuleIdentifier]> = Arc::from(incoming_modules);
-      success_cache.insert(*module_id, runtime, Arc::clone(&incoming_modules));
-      incoming_modules
-    };
+        Warning::Problem(ConcatenationProblem::UnsupportedSyntax {
+          module: *module_id,
+          modules,
+        })
+      };
+      state.statistics.incorrect_module_dependency += 1;
+      state.failure_cache.insert(*module_id, problem.clone());
+      return Some(problem);
+    }
 
-    let backup = if avoid_mutate_on_failure {
+    let backup = if rollback_on_failure {
       Some(config.snapshot())
     } else {
       None
@@ -809,28 +874,13 @@ impl ModuleConcatenationPlugin {
 
     config.add(*module_id);
 
-    for origin_module in incoming_modules.iter() {
-      if let Some(problem) = Self::try_to_add(
-        compilation,
-        config,
-        root_chunks,
-        origin_module,
-        runtime,
-        active_runtime,
-        possible_modules,
-        candidates,
-        failure_cache,
-        success_cache,
-        false,
-        statistics,
-        imports_cache,
-        module_cache,
-      ) {
+    for origin_module in incoming_modules.module_identifiers.iter() {
+      if let Some(problem) = Self::try_to_add(context, state, config, origin_module, false) {
         if let Some(backup) = &backup {
           config.rollback(*backup);
         }
-        statistics.importer_failed += 1;
-        failure_cache.insert(*module_id, problem.clone());
+        state.statistics.importer_failed += 1;
+        state.failure_cache.insert(*module_id, problem.clone());
         return Some(problem);
       }
     }
@@ -839,15 +889,15 @@ impl ModuleConcatenationPlugin {
       module_graph,
       &module_graph_artifacts,
       *module_id,
-      runtime,
-      imports_cache,
+      Some(runtime),
+      state.imports_cache,
       module_cache,
     )
     .iter()
     {
-      candidates.insert(*imp);
+      state.candidates.insert(*imp);
     }
-    statistics.added += 1;
+    state.statistics.added += 1;
     None
   }
 
@@ -1002,7 +1052,9 @@ impl ModuleConcatenationPlugin {
           bailout_reason.push("Module is an entry point".into());
         }
 
-        if module_graph.is_deferred(&compilation.imported_by_defer_modules_artifact, &module_id) {
+        if compilation.options.experiments.defer_import
+          && module_graph.is_deferred(&compilation.imported_by_defer_modules_artifact, &module_id)
+        {
           bailout_reason.push("Module is deferred".into());
           can_be_inner = false;
         }
@@ -1059,6 +1111,12 @@ impl ModuleConcatenationPlugin {
     let mut concat_configurations: Vec<ConcatConfiguration> = Vec::new();
     let mut used_as_inner: IdentifierSet = IdentifierSet::default();
     let mut imports_cache = RuntimeIdentifierCache::<Arc<[ModuleIdentifier]>>::default();
+    // Incoming activity depends on runtime, while chunk compatibility remains root-specific.
+    let mut incoming_modules_cache = RuntimeIdentifierCache {
+      no_runtime_map: IdentifierMap::default(),
+      runtime_map: Default::default(),
+    };
+    let mut root_search_scratch = RootSearchScratch::default();
 
     let module_graph = compilation.get_module_graph();
     let module_graph_cache = &compilation.module_graph_cache_artifact;
@@ -1080,11 +1138,13 @@ impl ModuleConcatenationPlugin {
         let module = module_graph
           .module_by_identifier(&module_id)
           .expect("should have module");
-        let chunks = compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .get_module_chunks(module_id)
-          .clone();
+        let chunks = Arc::new(
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .get_module_chunks(module_id)
+            .clone(),
+        );
         let runtime = RuntimeSpec::from_runtimes(chunks.iter().map(|chunk| {
           compilation
             .build_chunk_graph_artifact
@@ -1130,50 +1190,29 @@ impl ModuleConcatenationPlugin {
           })
           .collect::<Vec<_>>();
 
-        let incoming_connections =
-          module_graph.get_incoming_connections_by_origin_module(&module_id);
-        let (incoming_connections_from_non_modules, incoming_connections_from_modules) =
-          incoming_connections.into_parts();
-        let incomings = IncomingConnections {
-          from_non_modules: incoming_connections_from_non_modules
-            .into_iter()
-            .map(|connection| {
-              CachedIncomingConnection::new(
-                connection,
-                &runtime,
-                module_graph,
-                module_graph_cache,
-                &compilation
-                  .build_module_graph_artifact
-                  .side_effects_state_artifact,
-                &compilation.exports_info_artifact,
-              )
-            })
-            .collect(),
-          from_modules: incoming_connections_from_modules
-            .into_iter()
-            .map(|(origin_module, connections)| {
-              (
-                origin_module,
-                connections
-                  .into_iter()
-                  .map(|connection| {
-                    CachedIncomingConnection::new(
-                      connection,
-                      &runtime,
-                      module_graph,
-                      module_graph_cache,
-                      &compilation
-                        .build_module_graph_artifact
-                        .side_effects_state_artifact,
-                      &compilation.exports_info_artifact,
-                    )
-                  })
-                  .collect(),
-              )
-            })
-            .collect(),
-        };
+        let mut incomings = IncomingConnections::default();
+        for connection in module_graph.get_incoming_connections(&module_id) {
+          let origin_module = connection.original_module_identifier;
+          let connection = CachedIncomingConnection::new(
+            connection,
+            &runtime,
+            module_graph,
+            module_graph_cache,
+            &compilation
+              .build_module_graph_artifact
+              .side_effects_state_artifact,
+            &compilation.exports_info_artifact,
+          );
+          if let Some(origin_module) = origin_module {
+            incomings
+              .from_modules
+              .entry(origin_module)
+              .or_default()
+              .push(connection);
+          } else {
+            incomings.from_non_modules.push(connection);
+          }
+        }
         let number_of_chunks = chunks.len();
         (
           module_id,
@@ -1193,7 +1232,6 @@ impl ModuleConcatenationPlugin {
       Default::default(),
     );
     modules_without_runtime_cache.extend(modules_without_runtime_cache_entries);
-
     for current_root in relevant_modules.iter() {
       if used_as_inner.contains(current_root) {
         continue;
@@ -1220,12 +1258,15 @@ impl ModuleConcatenationPlugin {
 
       let mut current_configuration =
         ConcatConfiguration::new(*current_root, active_runtime.clone());
-      let root_chunks = root_chunks.clone();
+      let root_chunks = Arc::clone(root_chunks);
 
-      let mut failure_cache = IdentifierMap::default();
-      let mut success_cache = RuntimeIdentifierCache::default();
-      let mut candidates_visited = IdentifierSet::default();
-      let mut candidates = VecDeque::new();
+      root_search_scratch.reset();
+      let RootSearchScratch {
+        failure_cache,
+        candidates_visited,
+        candidates,
+        import_candidates,
+      } = &mut root_search_scratch;
       let imports = {
         let module_graph_artifacts = ModuleGraphArtifacts {
           mg_cache: module_graph_cache,
@@ -1248,29 +1289,36 @@ impl ModuleConcatenationPlugin {
         candidates.push_back(*import);
       }
 
-      let mut import_candidates = IdentifierSet::default();
+      let search_context = ConcatenationSearchContext {
+        compilation,
+        root_chunks: &root_chunks,
+        runtime,
+        possible_modules: &possible_inners,
+        module_cache: &modules_without_runtime_cache,
+      };
       while let Some(imp) = candidates.pop_front() {
         if candidates_visited.contains(&imp) {
           continue;
         }
         candidates_visited.insert(imp);
         import_candidates.clear();
-        match Self::try_to_add(
-          compilation,
-          &mut current_configuration,
-          &root_chunks,
-          &imp,
-          Some(runtime),
-          active_runtime.as_ref(),
-          &possible_inners,
-          &mut import_candidates,
-          &mut failure_cache,
-          &mut success_cache,
-          true,
-          &mut statistics,
-          &mut imports_cache,
-          &modules_without_runtime_cache,
-        ) {
+        let result = {
+          let mut search_state = ConcatenationSearchState {
+            candidates: import_candidates,
+            failure_cache,
+            incoming_modules_cache: &mut incoming_modules_cache,
+            statistics: &mut statistics,
+            imports_cache: &mut imports_cache,
+          };
+          Self::try_to_add(
+            &search_context,
+            &mut search_state,
+            &mut current_configuration,
+            &imp,
+            true,
+          )
+        };
+        match result {
           Some(problem) => {
             failure_cache.insert(imp, problem.clone());
             current_configuration.add_warning(imp, problem);
@@ -1296,10 +1344,9 @@ impl ModuleConcatenationPlugin {
         concat_configurations.push(current_configuration);
       } else {
         stats_empty_configurations += 1;
-        empty_config_warnings.push((*current_root, current_configuration.get_warnings_sorted()));
+        empty_config_warnings.push((*current_root, current_configuration.into_warnings_sorted()));
       }
     }
-
     logger.time_end(start);
 
     rayon::spawn(move || drop(modules_without_runtime_cache));
@@ -1390,24 +1437,29 @@ impl ModuleConcatenationPlugin {
         );
       });
 
-    for (current_root, warnings) in empty_config_warnings {
-      let module_graph = compilation.get_module_graph();
-      let messages = warnings
-        .iter()
-        .map(|warning| {
-          OptimizationBailoutItem::Message(self.format_bailout_warning(
-            warning.0,
-            &warning.1,
-            module_graph,
-            compilation,
-          ))
-        })
-        .collect::<Vec<_>>();
+    let formatted_empty_config_warnings = empty_config_warnings
+      .into_par_iter()
+      .map(|(current_root, warnings)| {
+        let module_graph = compilation.get_module_graph();
+        let messages = warnings
+          .iter()
+          .map(|warning| {
+            OptimizationBailoutItem::Message(self.format_bailout_warning(
+              warning.0,
+              &warning.1,
+              module_graph,
+              compilation,
+            ))
+          })
+          .collect::<Vec<_>>();
+        (current_root, messages)
+      })
+      .collect::<Vec<_>>();
+    for (current_root, messages) in formatted_empty_config_warnings {
       let module_graph = compilation.get_module_graph_mut();
       let optimization_bailouts = module_graph.get_optimization_bailout_mut(&current_root);
       optimization_bailouts.extend(messages);
     }
-
     let new_modules = rspack_parallel::scope::<_, Result<_>>(|token| {
       batch.into_iter().for_each(|config| {
         let s = unsafe { token.used(&*compilation) };
@@ -1530,8 +1582,6 @@ struct Statistics {
   incorrect_chunks_of_importer: u32,
   incorrect_runtime_condition: u32,
   importer_failed: u32,
-  cache_hit: u32,
-  module_visit: IdentifierMap<usize>,
   added: u32,
 }
 
@@ -1539,6 +1589,65 @@ struct Statistics {
 struct IncomingConnections {
   from_non_modules: Vec<CachedIncomingConnection>,
   from_modules: IdentifierMap<Vec<CachedIncomingConnection>>,
+}
+
+enum IncomingModulesCacheEntry {
+  Modules(CachedIncomingModules),
+  RuntimeDependent(RuntimeDependentBailout),
+}
+
+#[derive(Clone)]
+struct RuntimeDependentBailout {
+  expected_runtime: RuntimeSpec,
+  modules: Arc<[(ModuleIdentifier, RuntimeCondition)]>,
+}
+
+impl RuntimeDependentBailout {
+  fn warning(&self, module: ModuleIdentifier) -> Warning {
+    Warning::Problem(ConcatenationProblem::RuntimeDependent {
+      module,
+      expected_runtime: self.expected_runtime.clone(),
+      modules: Arc::clone(&self.modules),
+    })
+  }
+}
+
+#[derive(Debug, Clone)]
+struct CachedIncomingModules {
+  modules: Arc<[CachedIncomingModule]>,
+  module_identifiers: Arc<[ModuleIdentifier]>,
+}
+
+#[derive(Debug)]
+struct CachedIncomingModule {
+  module_identifier: ModuleIdentifier,
+  has_non_esm_connection: bool,
+}
+
+#[derive(Debug)]
+struct DifferentChunkModules {
+  root_chunks: Arc<HashSet<ChunkUkey>>,
+  incoming_modules: Arc<[CachedIncomingModule]>,
+  modules: OnceLock<Arc<[ModuleIdentifier]>>,
+}
+
+impl DifferentChunkModules {
+  fn modules(&self, compilation: &Compilation) -> &[ModuleIdentifier] {
+    self.modules.get_or_init(|| {
+      let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+      self
+        .incoming_modules
+        .iter()
+        .filter_map(|incoming_module| {
+          (!self
+            .root_chunks
+            .is_subset(chunk_graph.get_module_chunks(incoming_module.module_identifier)))
+          .then_some(incoming_module.module_identifier)
+        })
+        .collect::<Vec<_>>()
+        .into()
+    })
+  }
 }
 
 #[derive(Debug)]
@@ -1583,7 +1692,7 @@ impl CachedIncomingConnection {
 #[derive(Debug)]
 pub struct NoRuntimeModuleCache {
   runtime: RuntimeSpec,
-  chunks: HashSet<ChunkUkey>,
+  chunks: Arc<HashSet<ChunkUkey>>,
   provided_names: bool,
   connections: Vec<CachedOutgoingConnection>,
   incomings: IncomingConnections,

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/a.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/a.js
@@ -12,10 +12,7 @@ it("should keep runtime-specific concatenation results isolated", () => {
 
   const shared = __STATS__.modules.find(module => module.name.endsWith("root-shared.js"));
   expect(shared).toBeDefined();
-  // Runtime-mode compilation exercises the runtime-keyed bailout; the default compilation
-  // exercises the same candidate across incompatible root chunks.
-  const leafWasConcatenated = rootAGroup.modules.some(module => module.name.endsWith("leaf.js"));
-  const expectedBailout = leafWasConcatenated
+  const expectedBailout = globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK
     ? "runtime-dependent referenced"
     : "not in the same chunk(s)";
   expect(shared.optimizationBailout).toEqual(

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/a.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/a.js
@@ -1,0 +1,24 @@
+import { getValue as getRootAValue } from "./root-a";
+import { stable } from "./root-shared";
+
+it("should keep runtime-specific concatenation results isolated", () => {
+  expect(getRootAValue()).toBe(42);
+  expect(stable).toBe(1);
+
+  const rootAGroup = __STATS__.modules.find(module =>
+    module.modules?.some(nested => nested.name.endsWith("root-a.js"))
+  );
+  expect(rootAGroup).toBeDefined();
+
+  const shared = __STATS__.modules.find(module => module.name.endsWith("root-shared.js"));
+  expect(shared).toBeDefined();
+  // Runtime-mode compilation exercises the runtime-keyed bailout; the default compilation
+  // exercises the same candidate across incompatible root chunks.
+  const leafWasConcatenated = rootAGroup.modules.some(module => module.name.endsWith("leaf.js"));
+  const expectedBailout = leafWasConcatenated
+    ? "runtime-dependent referenced"
+    : "not in the same chunk(s)";
+  expect(shared.optimizationBailout).toEqual(
+    expect.arrayContaining([expect.stringContaining(expectedBailout)])
+  );
+});

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/b.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/b.js
@@ -1,0 +1,5 @@
+import { getValue } from "./root-shared";
+
+it("should preserve the runtime-dependent export", () => {
+  expect(getValue()).toBe(42);
+});

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/leaf.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/leaf.js
@@ -1,0 +1,1 @@
+export let value = 42;

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/root-a.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/root-a.js
@@ -1,0 +1,3 @@
+import { value } from "./leaf";
+
+export const getValue = () => value;

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/root-shared.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/root-shared.js
@@ -1,0 +1,4 @@
+import { value } from "./leaf";
+
+export const stable = 1;
+export const getValue = () => value;

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/rspack.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/rspack.config.js
@@ -1,0 +1,42 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  entry: {
+    a: './a.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        sideEffects: false,
+      },
+    ],
+  },
+  optimization: {
+    concatenateModules: true,
+    innerGraph: true,
+    minimize: false,
+    sideEffects: true,
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      cacheGroups: {
+        shared: {
+          enforce: true,
+          name: 'shared',
+          test: /root-shared/,
+        },
+      },
+    },
+    usedExports: true,
+  },
+  stats: {
+    modules: true,
+    nestedModules: true,
+    optimizationBailout: true,
+  },
+};

--- a/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/test.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/runtime-cache-isolation/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle() {
+    return ["shared.js", "a.js", "b.js"];
+  },
+};

--- a/xtask/benchmark/benches/groups/compilation_stages/concatenation_cases.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages/concatenation_cases.rs
@@ -20,11 +20,13 @@ enum ConcatenationBenchmarkTopology {
 enum SharedRootsTopology {
   Standard,
   Bailouts,
+  UnsupportedSyntax,
 }
 
 #[derive(Clone, Copy)]
 pub(super) enum ConcatenationStatistic {
   IncorrectChunksOfImporter,
+  IncorrectModuleDependency,
   ImporterFailed,
 }
 
@@ -32,6 +34,7 @@ impl ConcatenationStatistic {
   pub(super) const fn log_label(self) -> &'static str {
     match self {
       Self::IncorrectChunksOfImporter => "incorrect chunks of importer",
+      Self::IncorrectModuleDependency => "incorrect module dependency",
       Self::ImporterFailed => "importer failed",
     }
   }
@@ -45,7 +48,7 @@ pub(super) struct ConcatenationBenchmarkCase {
   topology: ConcatenationBenchmarkTopology,
 }
 
-pub(super) const CONCATENATION_BENCHMARK_CASES: [ConcatenationBenchmarkCase; 3] = [
+pub(super) const CONCATENATION_BENCHMARK_CASES: [ConcatenationBenchmarkCase; 4] = [
   ConcatenationBenchmarkCase {
     name: "rust@create_concatenate_module",
     setup_label: "create_concatenate_module setup",
@@ -66,6 +69,12 @@ pub(super) const CONCATENATION_BENCHMARK_CASES: [ConcatenationBenchmarkCase; 3] 
       ConcatenationStatistic::ImporterFailed,
     ],
     topology: ConcatenationBenchmarkTopology::SharedRoots(SharedRootsTopology::Bailouts),
+  },
+  ConcatenationBenchmarkCase {
+    name: "rust@create_concatenate_module_unsupported_syntax",
+    setup_label: "create_concatenate_module_unsupported_syntax setup",
+    expected_statistics: &[ConcatenationStatistic::IncorrectModuleDependency],
+    topology: ConcatenationBenchmarkTopology::SharedRoots(SharedRootsTopology::UnsupportedSyntax),
   },
 ];
 
@@ -218,7 +227,7 @@ async fn prepare_shared_concatenation_case(topology: SharedRootsTopology, fs: &M
         }
         imports
       }
-      SharedRootsTopology::Standard => Vec::new(),
+      SharedRootsTopology::Standard | SharedRootsTopology::UnsupportedSyntax => Vec::new(),
     };
 
     let mut imports = vec![format!(
@@ -227,6 +236,9 @@ async fn prepare_shared_concatenation_case(topology: SharedRootsTopology, fs: &M
     )];
     if matches!(topology, SharedRootsTopology::Bailouts) {
       imports.push("import './blocker.js';".to_string());
+    }
+    if matches!(topology, SharedRootsTopology::UnsupportedSyntax) {
+      imports.push("require('./local-0.js');".to_string());
     }
     let mut values = vec!["local".to_string()];
     for offset in 0..CONCAT_SHARED_WINDOW {
@@ -243,7 +255,7 @@ async fn prepare_shared_concatenation_case(topology: SharedRootsTopology, fs: &M
         lazy_panel_imports.join(", "),
         values.join(" + ")
       ),
-      SharedRootsTopology::Standard => format!(
+      SharedRootsTopology::Standard | SharedRootsTopology::UnsupportedSyntax => format!(
         "{}\nexport default {};",
         imports.join("\n"),
         values.join(" + ")


### PR DESCRIPTION
## Summary

`ModuleConcatenationPlugin` repeatedly rebuilt the same incoming-module analysis for every candidate root. This PR:

- caches incoming analysis per `(module, runtime)` for one optimization pass
- keeps root-specific chunk checks and graph mutations outside the shared cache
- reuses root-search allocations and defers bailout formatting
- skips deferred-module lookup when the `deferImport` experiment is disabled
- caches module-depth sort keys and clones the root chunk set once per concatenation
- shares unsupported-syntax bailout payloads instead of deep-cloning them
- uses the shared-root and bailout benchmarks from #14817 and adds runtime-isolation and unsupported-syntax coverage

## Performance

Large synthetic support application:

| Measurement | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Server plugin | 10.47 s | 1.60–1.64 s | ~84.5% |
| Server root search | 9.56 s | 0.86–0.89 s | ~90.9% |
| Profiled server build | 26.1 s | 17.4–17.6 s | ~33% |
| Cold release build | 58.08 s | 29.07 s | 49.95% |

Cold release figures are five-run medians with caches cleared. They compare published `@rspack/core` 2.1.0 with a local 2.1.4 distribution and therefore include intervening `main` changes. The plugin and root-search profiles isolate this PR's target path.

CodSpeed compares this branch with the stacked benchmark base from #14817: shared roots improved from 30.2 ms to 17.6 ms (+71.61%), bailouts from 107.4 ms to 97.7 ms (+9.95%), and the existing case from 14.4 ms to 13.4 ms (+7.77%). The aggregate report improved 20.16%. CodSpeed flags differing runner environments, so local profiles and support-app measurements remain the primary magnitude check. The ecosystem benchmark improved every reported wall-time case by 0.87–6.80%.

The latest follow-up changes were measured against the previous PR head with deterministic Callgrind instruction counts:

| Case | Previous head | Current head | Improvement |
| --- | ---: | ---: | ---: |
| Shared roots | 63,055,803 | 61,785,291 | 2.02% |
| Unsupported syntax | 62,044,869 | 61,740,194 | 0.49% |

## Correctness

- cache entries are runtime-keyed and live for one plugin invocation
- root chunk compatibility, recursive rollback, ESM checks, and `used_as_inner` ownership remain root-local and sequential
- parallel work only formats immutable bailout data; graph writes retain their original order
- browser output remained byte-identical across 2,514 files
- the unsupported-syntax benchmark asserts that the intended non-ESM bailout path executes

Review entry points: `RuntimeIdentifierCache` and `CachedIncomingModules` for cache lifetime; `ConcatenationSearchContext`, `ConcatenationSearchState`, and `try_to_add` for root search; `runtime-cache-isolation` for regression coverage.

## Testing

- `pnpm run build:cli:dev`
- `pnpm run format:rs` and `pnpm run format:js`
- focused `runtime-cache-isolation`: 2 passed
- 51 concatenate-modules cases; 211 scope-hoisting cases; 6 watch cases
- CodSpeed simulation checks for all four concatenation scenarios
- `pnpm run test:unit`: 8,808 passed, 4 skipped; only 3 pre-existing browserslist cleanup failures remain
- cold support-app benchmark: five published and five local runs with cleared caches
- final deslop pass and thermonuclear review: no findings

Workspace all-features Clippy remains blocked by the existing rkyv 0.7/0.8 conflict in `rspack_cacheable`.

## Related links

- #14817

## Checklist

- [x] Tests updated.
- [x] Documentation not required; no public API or behavior change.