### PR TITLE
bench(module-concat): add shared-root scenarios

### DIFF
--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
+mod concatenation_cases;
+
 use std::{
   cell::{Cell, RefCell},
   collections::HashMap,
@@ -36,13 +38,15 @@ use rspack_plugin_split_chunks::{
 use rustc_hash::FxHashMap;
 use tokio::runtime::Runtime;
 
+use self::concatenation_cases::{
+  CONCATENATION_BENCHMARK_CASES, ConcatenationBenchmarkCase, ConcatenationStatistic,
+  prepare_concatenation_benchmark_case, prepare_default_concatenation_case,
+};
 use crate::groups::{
   build_chunk_graph::prepare_large_code_splitting_case, diagnostics::assert_no_compilation_errors,
 };
 
 const GENERAL_STAGE_NUM_MODULES: usize = 3000;
-const CONCAT_GROUPS: usize = 160;
-const CONCAT_MODULES_PER_GROUP: usize = 12;
 const SPLIT_CHUNKS_ENTRY_COUNT: usize = 48;
 const SPLIT_CHUNKS_SHARED_MODULES: usize = 192;
 const SPLIT_CHUNKS_WINDOW: usize = 20;
@@ -856,15 +860,26 @@ pub(crate) fn real_content_hash_benchmark(c: &mut Criterion, rt: &Runtime) {
 }
 
 pub(crate) fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &Runtime) {
-  let fs = Arc::new(MemoryFileSystem::default());
-  let mut compiler = create_concatenate_stage_compiler(fs.clone());
+  for case in CONCATENATION_BENCHMARK_CASES {
+    let fs = Arc::new(MemoryFileSystem::default());
+    let mut compiler = create_concatenate_stage_compiler(fs.clone());
 
-  rt.block_on(async {
-    prepare_large_concatenation_case(CONCAT_GROUPS, CONCAT_MODULES_PER_GROUP, &fs).await;
-    prepare_for_concatenate_module(&mut compiler).await.unwrap();
-  });
+    rt.block_on(async {
+      prepare_concatenation_benchmark_case(case, &fs).await;
+      prepare_for_concatenate_module(&mut compiler).await.unwrap();
+    });
 
-  assert_no_compilation_errors(&compiler.compilation, "create_concatenate_module setup");
+    register_create_concatenate_module_benchmark(c, rt, compiler, case);
+  }
+}
+
+fn register_create_concatenate_module_benchmark(
+  c: &mut Criterion,
+  rt: &Runtime,
+  mut compiler: Compiler,
+  case: ConcatenationBenchmarkCase,
+) {
+  assert_no_compilation_errors(&compiler.compilation, case.setup_label);
   compiler
     .compilation
     .build_module_graph_artifact
@@ -891,6 +906,15 @@ pub(crate) fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &Runtim
     statistics_fingerprint > 0,
     "create_concatenate_module setup should produce module concatenation statistics"
   );
+  for &statistic in case.expected_statistics {
+    assert!(
+      concatenation_statistic_count(&compiler.compilation, statistic)
+        .is_some_and(|count| count > 0),
+      "{} should exercise {}",
+      case.setup_label,
+      statistic.log_label()
+    );
+  }
   compiler
     .compilation
     .build_module_graph_artifact
@@ -905,7 +929,7 @@ pub(crate) fn create_concatenate_module_benchmark(c: &mut Criterion, rt: &Runtim
 
   let compiler = RefCell::new(compiler);
   let should_reset = Cell::new(false);
-  c.bench_function("rust@create_concatenate_module", |b| {
+  c.bench_function(case.name, |b| {
     b.iter_batched_ref(
       || {
         let mut compiler = compiler.borrow_mut();
@@ -949,7 +973,7 @@ pub(crate) fn concatenate_module_code_generation_benchmark(c: &mut Criterion, rt
   let mut compiler = create_concatenate_stage_compiler(fs.clone());
 
   rt.block_on(async {
-    prepare_large_concatenation_case(CONCAT_GROUPS, CONCAT_MODULES_PER_GROUP, &fs).await;
+    prepare_default_concatenation_case(&fs).await;
     compiler.build().await.unwrap();
   });
 
@@ -1779,70 +1803,6 @@ async fn compute_concatenated_module_codegen(
   Ok(generated)
 }
 
-async fn prepare_large_concatenation_case(
-  groups: usize,
-  modules_per_group: usize,
-  fs: &MemoryFileSystem,
-) {
-  fs.create_dir_all("/src".into()).await.unwrap();
-  let mut root_imports = Vec::with_capacity(groups);
-  let mut root_values = Vec::with_capacity(groups);
-
-  for group in 0..groups {
-    let group_dir = format!("/src/group-{group}");
-    fs.create_dir_all(group_dir.as_str().into()).await.unwrap();
-
-    let mut group_imports = Vec::with_capacity(modules_per_group);
-    let mut group_values = Vec::with_capacity(modules_per_group);
-
-    for module in 0..modules_per_group {
-      let file = format!("/src/group-{group}/module-{module}.js");
-      let code = if module == 0 {
-        format!("export const value = {group};")
-      } else {
-        format!(
-          "import {{ value as prev }} from './module-{}.js'; export const value = prev + {};",
-          module - 1,
-          module
-        )
-      };
-      fs.write(file.as_str().into(), code.as_bytes())
-        .await
-        .unwrap();
-      group_imports.push(format!(
-        "import {{ value as v{module} }} from './module-{module}.js';"
-      ));
-      group_values.push(format!("v{module}"));
-    }
-
-    let group_entry = format!(
-      "{}\nexport default {};",
-      group_imports.join("\n"),
-      group_values.join(" + ")
-    );
-    fs.write(
-      format!("/src/group-{group}/entry.js").as_str().into(),
-      group_entry.as_bytes(),
-    )
-    .await
-    .unwrap();
-
-    root_imports.push(format!(
-      "import g{group} from '/src/group-{group}/entry.js';"
-    ));
-    root_values.push(format!("g{group}"));
-  }
-
-  let entry = format!(
-    "{}\nconsole.log({});",
-    root_imports.join("\n"),
-    root_values.join(" + ")
-  );
-  fs.write("/src/index.js".into(), entry.as_bytes())
-    .await
-    .unwrap();
-}
-
 async fn prepare_large_split_chunks_case(
   entry_count: usize,
   shared_modules: usize,
@@ -1926,6 +1886,29 @@ fn concatenation_statistics_fingerprint(compilation: &Compilation) -> usize {
     })
     .map(|message| message.bytes().map(usize::from).sum::<usize>())
     .sum()
+}
+
+fn concatenation_statistic_count(
+  compilation: &Compilation,
+  statistic: ConcatenationStatistic,
+) -> Option<usize> {
+  let logs = compilation
+    .get_logging()
+    .get("rspack.ModuleConcatenationPlugin")?;
+
+  logs.iter().find_map(|log| {
+    let message = match log {
+      LogType::Debug { message } | LogType::Log { message } => message,
+      _ => return None,
+    };
+    let (_, statistics) = message.split_once("candidates were considered for adding (")?;
+    let statistics = statistics.strip_suffix(')')?;
+    statistics.split(", ").find_map(|item| {
+      item
+        .strip_suffix(statistic.log_label())
+        .and_then(|count| count.trim().parse().ok())
+    })
+  })
 }
 
 fn count_assigned_export_used_names(compilation: &Compilation) -> usize {

--- a/xtask/benchmark/benches/groups/compilation_stages/concatenation_cases.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages/concatenation_cases.rs
@@ -1,0 +1,268 @@
+#![allow(clippy::unwrap_used)]
+
+use rspack_fs::{MemoryFileSystem, WritableFileSystem};
+
+const CONCAT_GROUPS: usize = 160;
+const CONCAT_MODULES_PER_GROUP: usize = 12;
+const CONCAT_SHARED_ROOTS: usize = 192;
+const CONCAT_SHARED_MODULES: usize = 128;
+const CONCAT_SHARED_WINDOW: usize = 16;
+const CONCAT_LOCAL_MODULES_PER_ROOT: usize = 8;
+const CONCAT_LAZY_PANELS_PER_ROOT: usize = 3;
+
+#[derive(Clone, Copy)]
+enum ConcatenationBenchmarkTopology {
+  DisjointGroups,
+  SharedRoots(SharedRootsTopology),
+}
+
+#[derive(Clone, Copy)]
+enum SharedRootsTopology {
+  Standard,
+  Bailouts,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum ConcatenationStatistic {
+  IncorrectChunksOfImporter,
+  ImporterFailed,
+}
+
+impl ConcatenationStatistic {
+  pub(super) const fn log_label(self) -> &'static str {
+    match self {
+      Self::IncorrectChunksOfImporter => "incorrect chunks of importer",
+      Self::ImporterFailed => "importer failed",
+    }
+  }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ConcatenationBenchmarkCase {
+  pub(super) name: &'static str,
+  pub(super) setup_label: &'static str,
+  pub(super) expected_statistics: &'static [ConcatenationStatistic],
+  topology: ConcatenationBenchmarkTopology,
+}
+
+pub(super) const CONCATENATION_BENCHMARK_CASES: [ConcatenationBenchmarkCase; 3] = [
+  ConcatenationBenchmarkCase {
+    name: "rust@create_concatenate_module",
+    setup_label: "create_concatenate_module setup",
+    expected_statistics: &[],
+    topology: ConcatenationBenchmarkTopology::DisjointGroups,
+  },
+  ConcatenationBenchmarkCase {
+    name: "rust@create_concatenate_module_shared_roots",
+    setup_label: "create_concatenate_module_shared_roots setup",
+    expected_statistics: &[ConcatenationStatistic::IncorrectChunksOfImporter],
+    topology: ConcatenationBenchmarkTopology::SharedRoots(SharedRootsTopology::Standard),
+  },
+  ConcatenationBenchmarkCase {
+    name: "rust@create_concatenate_module_bailouts",
+    setup_label: "create_concatenate_module_bailouts setup",
+    expected_statistics: &[
+      ConcatenationStatistic::IncorrectChunksOfImporter,
+      ConcatenationStatistic::ImporterFailed,
+    ],
+    topology: ConcatenationBenchmarkTopology::SharedRoots(SharedRootsTopology::Bailouts),
+  },
+];
+
+pub(super) async fn prepare_concatenation_benchmark_case(
+  case: ConcatenationBenchmarkCase,
+  fs: &MemoryFileSystem,
+) {
+  match case.topology {
+    ConcatenationBenchmarkTopology::DisjointGroups => {
+      prepare_large_concatenation_case(CONCAT_GROUPS, CONCAT_MODULES_PER_GROUP, fs).await;
+    }
+    ConcatenationBenchmarkTopology::SharedRoots(topology) => {
+      prepare_shared_concatenation_case(topology, fs).await;
+    }
+  }
+}
+
+pub(super) async fn prepare_default_concatenation_case(fs: &MemoryFileSystem) {
+  prepare_large_concatenation_case(CONCAT_GROUPS, CONCAT_MODULES_PER_GROUP, fs).await;
+}
+
+async fn prepare_large_concatenation_case(
+  groups: usize,
+  modules_per_group: usize,
+  fs: &MemoryFileSystem,
+) {
+  fs.create_dir_all("/src".into()).await.unwrap();
+  let mut root_imports = Vec::with_capacity(groups);
+  let mut root_values = Vec::with_capacity(groups);
+
+  for group in 0..groups {
+    let group_dir = format!("/src/group-{group}");
+    fs.create_dir_all(group_dir.as_str().into()).await.unwrap();
+
+    let mut group_imports = Vec::with_capacity(modules_per_group);
+    let mut group_values = Vec::with_capacity(modules_per_group);
+
+    for module in 0..modules_per_group {
+      let file = format!("/src/group-{group}/module-{module}.js");
+      let code = if module == 0 {
+        format!("export const value = {group};")
+      } else {
+        format!(
+          "import {{ value as prev }} from './module-{}.js'; export const value = prev + {};",
+          module - 1,
+          module
+        )
+      };
+      fs.write(file.as_str().into(), code.as_bytes())
+        .await
+        .unwrap();
+      group_imports.push(format!(
+        "import {{ value as v{module} }} from './module-{module}.js';"
+      ));
+      group_values.push(format!("v{module}"));
+    }
+
+    let group_entry = format!(
+      "{}\nexport default {};",
+      group_imports.join("\n"),
+      group_values.join(" + ")
+    );
+    fs.write(
+      format!("/src/group-{group}/entry.js").as_str().into(),
+      group_entry.as_bytes(),
+    )
+    .await
+    .unwrap();
+
+    root_imports.push(format!(
+      "import g{group} from '/src/group-{group}/entry.js';"
+    ));
+    root_values.push(format!("g{group}"));
+  }
+
+  let entry = format!(
+    "{}\nconsole.log({});",
+    root_imports.join("\n"),
+    root_values.join(" + ")
+  );
+  fs.write("/src/index.js".into(), entry.as_bytes())
+    .await
+    .unwrap();
+}
+
+async fn prepare_shared_concatenation_case(topology: SharedRootsTopology, fs: &MemoryFileSystem) {
+  fs.create_dir_all("/src/shared".into()).await.unwrap();
+  fs.create_dir_all("/src/routes".into()).await.unwrap();
+
+  for module in 0..CONCAT_SHARED_MODULES {
+    let source = format!("export default {module};");
+    fs.write(
+      format!("/src/shared/shared-{module}.js").as_str().into(),
+      source.as_bytes(),
+    )
+    .await
+    .unwrap();
+  }
+
+  let mut route_imports = Vec::with_capacity(CONCAT_SHARED_ROOTS);
+  for root in 0..CONCAT_SHARED_ROOTS {
+    let route_dir = format!("/src/routes/route-{root}");
+    fs.create_dir_all(route_dir.as_str().into()).await.unwrap();
+
+    for module in 0..CONCAT_LOCAL_MODULES_PER_ROOT {
+      let source = if module == 0 {
+        format!("export default {root};")
+      } else {
+        format!(
+          "import value from './local-{}.js'; export default value + {};",
+          module - 1,
+          module
+        )
+      };
+      fs.write(
+        format!("{route_dir}/local-{module}.js").as_str().into(),
+        source.as_bytes(),
+      )
+      .await
+      .unwrap();
+    }
+
+    let lazy_panel_imports = match topology {
+      SharedRootsTopology::Bailouts => {
+        let blocker_source = format!(
+          "import value from './local-{}.js'; eval(''); console.log(value);",
+          CONCAT_LOCAL_MODULES_PER_ROOT - 1
+        );
+        fs.write(
+          format!("{route_dir}/blocker.js").as_str().into(),
+          blocker_source.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        let mut imports = Vec::with_capacity(CONCAT_LAZY_PANELS_PER_ROOT);
+        for panel in 0..CONCAT_LAZY_PANELS_PER_ROOT {
+          let left = panel % CONCAT_LOCAL_MODULES_PER_ROOT;
+          let right = (panel + 1) % CONCAT_LOCAL_MODULES_PER_ROOT;
+          let source = format!(
+            "import left from './local-{left}.js'; import right from './local-{right}.js'; export default left + right;"
+          );
+          fs.write(
+            format!("{route_dir}/panel-{panel}.js").as_str().into(),
+            source.as_bytes(),
+          )
+          .await
+          .unwrap();
+          imports.push(format!("import('./panel-{panel}.js')"));
+        }
+        imports
+      }
+      SharedRootsTopology::Standard => Vec::new(),
+    };
+
+    let mut imports = vec![format!(
+      "import local from './local-{}.js';",
+      CONCAT_LOCAL_MODULES_PER_ROOT - 1
+    )];
+    if matches!(topology, SharedRootsTopology::Bailouts) {
+      imports.push("import './blocker.js';".to_string());
+    }
+    let mut values = vec!["local".to_string()];
+    for offset in 0..CONCAT_SHARED_WINDOW {
+      let module = (root + offset) % CONCAT_SHARED_MODULES;
+      imports.push(format!(
+        "import shared_{module} from '/src/shared/shared-{module}.js';"
+      ));
+      values.push(format!("shared_{module}"));
+    }
+    let source = match topology {
+      SharedRootsTopology::Bailouts => format!(
+        "{}\nexport const panels = Promise.all([{}]);\nexport default {};",
+        imports.join("\n"),
+        lazy_panel_imports.join(", "),
+        values.join(" + ")
+      ),
+      SharedRootsTopology::Standard => format!(
+        "{}\nexport default {};",
+        imports.join("\n"),
+        values.join(" + ")
+      ),
+    };
+    fs.write(
+      format!("{route_dir}/entry.js").as_str().into(),
+      source.as_bytes(),
+    )
+    .await
+    .unwrap();
+    route_imports.push(format!("import('/src/routes/route-{root}/entry.js')"));
+  }
+
+  let entry = format!(
+    "Promise.all([{}]).then(routes => console.log(routes));",
+    route_imports.join(",\n")
+  );
+  fs.write("/src/index.js".into(), entry.as_bytes())
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## Summary

Add CodSpeed scenarios for `ModuleConcatenationPlugin`:

- retain the disjoint-root case
- add a shared-root workload that repeatedly visits common modules
- add cross-chunk and recursive importer-bailout coverage
- keep fixture generation in typed scenario helpers

This benchmark-only PR is the base of #14815 so CodSpeed can measure the optimization against identical fixtures.

## Testing

- `cargo check -p rspack_benchmark --benches`

## Related links

- #14815

## Checklist

- [x] Tests updated.
- [x] Documentation not required; no public API change.
