### PR TITLE
feat: enable createRequire parser for node targets

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -320,10 +320,12 @@ const applyJavascriptParserOptionsDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    targetProperties,
   }: {
     deferImport?: boolean;
     sourceImport?: boolean;
     outputModule: RspackOptionsNormalized['output']['module'];
+    targetProperties: false | TargetProperties;
   },
 ) => {
   D(parserOptions, 'dynamicImportMode', 'lazy');
@@ -349,7 +351,13 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'deferImport', deferImport);
   D(parserOptions, 'sourceImport', sourceImport);
   D(parserOptions, 'importMetaResolve', false);
-  D(parserOptions, 'createRequire', false);
+  D(
+    parserOptions,
+    'createRequire',
+    targetProperties !== false &&
+      targetProperties.node === true &&
+      parserOptions.requireResolve !== false,
+  );
 };
 
 const applyCssGeneratorOptionsDefaults = (
@@ -463,6 +471,7 @@ const applyModuleDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    targetProperties,
   });
 
   F(module.parser, JSON_MODULE_TYPE, () => ({}));

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1398,7 +1398,7 @@ export type JavascriptParserOptions = {
 
   /**
    * Enable or disable parsing `import { createRequire } from "module"` and evaluating createRequire().
-   * @default false
+   * @default true for Node.js targets unless `requireResolve` is false, otherwise false
    */
   createRequire?: boolean | string;
 

--- a/tests/rspack-test/configCases/require/module-require/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require/rspack.config.js
@@ -50,13 +50,6 @@ module.exports = {
     path: 'node-commonjs path',
   },
   target: 'node',
-  module: {
-    parser: {
-      javascript: {
-        createRequire: true,
-      },
-    },
-  },
   optimization: {
     inlineExports: true,
     moduleIds: 'named',

--- a/tests/rspack-test/defaultsCases/target_/electron-main.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-main.js
@@ -37,6 +37,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/electron-preload.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-preload.js
@@ -35,6 +35,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/node-require-resolve-disabled.js
+++ b/tests/rspack-test/defaultsCases/target_/node-require-resolve-disabled.js
@@ -1,0 +1,22 @@
+/** @type {import('@rspack/test-tools').TDefaultsCaseConfig} */
+module.exports = {
+	description: "target node with requireResolve disabled",
+	options: () => ({
+		target: "node",
+		module: {
+			parser: {
+				javascript: {
+					requireResolve: false
+				}
+			}
+		}
+	}),
+	diff: e => {
+		e.toEqual({
+			value: expect.stringMatching(/\+\s+"requireResolve": false/)
+		});
+		e.toEqual({
+			value: expect.not.stringContaining('"createRequire"')
+		});
+	}
+};

--- a/tests/rspack-test/defaultsCases/target_/node.js
+++ b/tests/rspack-test/defaultsCases/target_/node.js
@@ -32,6 +32,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/nwjs.js
+++ b/tests/rspack-test/defaultsCases/target_/nwjs.js
@@ -31,6 +31,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -667,12 +667,11 @@ export default {
 
 ### javascript.createRequire
 
-<PropertyType
-  type="boolean | string"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
+<PropertyType type="boolean | string" />
 
 Control whether Rspack parses `createRequire()` from Node.js `module` and turns the created `require` function into a statically analyzable dependency context.
+
+This option defaults to `true` for Node.js-compatible targets unless `javascript.requireResolve` is `false`. It defaults to `false` for other targets.
 
 When set to `true`, it is equivalent to `"createRequire from module"`. Rspack recognizes imports from both `module` and `node:module` for this default form.
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -666,12 +666,11 @@ export default {
 
 ### javascript.createRequire
 
-<PropertyType
-  type="boolean | string"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
+<PropertyType type="boolean | string" />
 
 控制 Rspack 是否解析来自 Node.js `module` 的 `createRequire()`，并将创建出的 `require` 函数转换为可静态分析的依赖上下文。
+
+对于兼容 Node.js 的 target，除非将 `javascript.requireResolve` 设置为 `false`，否则该选项默认为 `true`。对于其他 target，该选项默认为 `false`。
 
 当设置为 `true` 时，等价于 `"createRequire from module"`。对于这种默认形式，Rspack 会同时识别来自 `module` 和 `node:module` 的导入。
 


### PR DESCRIPTION
## Summary

- enable `module.parser.javascript.createRequire` by default for Node.js-compatible targets
- keep the automatic default disabled when `javascript.requireResolve` is `false`; explicit `createRequire` configuration still takes precedence
- cover Node.js, Electron, and NW.js defaults, and make the existing `module-require` integration case exercise the default path
- update the public type annotation and English/Chinese documentation for the target-dependent default

Supersedes #14798 with a fresh branch based on the latest `main`.

## Validation

- `corepack pnpm run build:js`
- `CARGO_TARGET_DIR=/Users/bytedance/libs/rspack/target corepack pnpm run build:binding:dev`
- `corepack pnpm run test -- Defaults.test.js --runInBand` (`46` files, `8810` tests passed; the test runner expanded to the complete `rspack-test` suite)
- `corepack pnpm run lint:js`
- Prettier check for all changed files
- `git diff --check`