### PR TITLE
fix: serialize native watcher lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5401,6 +5401,7 @@ dependencies = [
  "cow-utils",
  "dashmap",
  "fast-glob",
+ "futures",
  "notify",
  "regex",
  "rspack_error",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -466,13 +466,6 @@ export declare class NativeWatcher {
   constructor(options: NativeWatcherOptions)
   watch(files: [Array<string>, Array<string>], directories: [Array<string>, Array<string>], missing: [Array<string>, Array<string>], startTime: bigint, callback: (err: Error | null, result: NativeWatchResult) => void, callbackUndelayed: (event: NativeWatchUndelayedEvent) => void): void
   triggerEvent(kind: 'change' | 'remove' | 'create', path: string): void
-  /**
-   * # Safety
-   *
-   * This function is unsafe because it uses `&mut self` to call the watcher asynchronously.
-   * It's important to ensure that the watcher is not used in any other places before this function is finished.
-   * You must ensure that the watcher not call watch, close or pause in the same time, otherwise it may lead to undefined behavior.
-   */
   close(): Promise<void>
   pause(): void
 }

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -117,7 +117,7 @@ serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 simd-json                              = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot", "sync"] }
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -117,7 +117,7 @@ serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 simd-json                              = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot", "sync"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -1,21 +1,17 @@
 use std::{
   boxed::Box,
-  panic::AssertUnwindSafe,
-  path::{Path, PathBuf},
-  sync::Mutex,
+  path::PathBuf,
   time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use futures::FutureExt;
 use napi::bindgen_prelude::*;
 use napi_derive::*;
 use rspack_paths::ArcPath;
 use rspack_regex::RspackRegex;
 use rspack_watcher::{
-  EventAggregateHandler, EventHandler, FsEventKind, FsWatcher, FsWatcherControl, FsWatcherIgnored,
+  FsEventKind, FsWatcherHandle, FsWatcherHandleError, FsWatcherIgnored, FsWatcherOperation,
   FsWatcherOptions,
 };
-use tokio::sync::{mpsc, watch};
 
 type JsWatcherIgnored = Either3<String, Vec<String>, RspackRegex>;
 
@@ -62,138 +58,25 @@ pub struct NativeWatchUndelayedEvent {
 
 #[napi]
 pub struct NativeWatcher {
-  command_tx: mpsc::UnboundedSender<NativeWatcherCommand>,
-  control: FsWatcherControl,
-  close_state_tx: watch::Sender<NativeWatcherCloseState>,
-  admission: Mutex<()>,
+  watcher: FsWatcherHandle,
 }
 
-enum NativeWatcherCommand {
-  Watch {
-    files: (Vec<String>, Vec<String>),
-    directories: (Vec<String>, Vec<String>),
-    missing: (Vec<String>, Vec<String>),
-    start_time: SystemTime,
-    event_handler: Box<dyn EventAggregateHandler + Send>,
-    event_handler_undelayed: Box<dyn EventHandler + Send>,
-  },
-  Close,
-}
-
-#[derive(Clone)]
-enum NativeWatcherCloseState {
-  Open,
-  Closing,
-  Closed(std::result::Result<(), String>),
-}
-
-const WATCH_AFTER_CLOSE_ERROR: &str = "The native watcher has been closed, cannot watch again.";
-const COMMAND_LOOP_STOPPED_ERROR: &str =
-  "The native watcher command loop stopped before the request could be processed.";
-
-fn publish_close_result(
-  close_state_tx: &watch::Sender<NativeWatcherCloseState>,
-  result: std::result::Result<(), String>,
-) {
-  close_state_tx.send_if_modified(|state| {
-    if matches!(state, NativeWatcherCloseState::Closed(_)) {
-      return false;
+fn to_napi_error(error: FsWatcherHandleError) -> napi::Error {
+  let reason = match error {
+    FsWatcherHandleError::Closed(FsWatcherOperation::Watch) => {
+      "The native watcher has been closed, cannot watch again.".to_string()
     }
-
-    *state = NativeWatcherCloseState::Closed(result);
-    true
-  });
-}
-
-async fn run_native_watcher_actor(
-  mut watcher: FsWatcher,
-  command_rx: &mut mpsc::UnboundedReceiver<NativeWatcherCommand>,
-) -> std::result::Result<(), String> {
-  while let Some(command) = command_rx.recv().await {
-    match command {
-      NativeWatcherCommand::Watch {
-        files,
-        directories,
-        missing,
-        start_time,
-        event_handler,
-        event_handler_undelayed,
-      } => {
-        watcher
-          .watch(
-            to_tuple_path_iterator(files),
-            to_tuple_path_iterator(directories),
-            to_tuple_path_iterator(missing),
-            start_time,
-            event_handler,
-            event_handler_undelayed,
-          )
-          .await;
-      }
-      NativeWatcherCommand::Close => {
-        return watcher.close().await.map_err(|error| error.to_string());
-      }
+    FsWatcherHandleError::Closed(FsWatcherOperation::TriggerEvent) => {
+      "The native watcher has been closed, cannot trigger events.".to_string()
     }
-  }
-
-  watcher.close().await.map_err(|error| error.to_string())
-}
-
-fn spawn_native_watcher_actor(
-  watcher: FsWatcher,
-  mut command_rx: mpsc::UnboundedReceiver<NativeWatcherCommand>,
-  close_state_tx: watch::Sender<NativeWatcherCloseState>,
-) {
-  rspack_napi::runtime::spawn(async move {
-    let result = AssertUnwindSafe(run_native_watcher_actor(watcher, &mut command_rx))
-      .catch_unwind()
-      .await;
-    let result = match result {
-      Ok(result) => result,
-      Err(payload) => Err(rspack_napi::runtime::panic_to_napi_error(payload).reason),
-    };
-    publish_close_result(&close_state_tx, result);
-  });
-}
-
-fn is_open(close_state_tx: &watch::Sender<NativeWatcherCloseState>) -> bool {
-  matches!(*close_state_tx.borrow(), NativeWatcherCloseState::Open)
-}
-
-fn watch_after_close_error() -> napi::Error {
-  napi::Error::from_reason(WATCH_AFTER_CLOSE_ERROR)
-}
-
-fn command_loop_stopped_error() -> napi::Error {
-  napi::Error::from_reason(COMMAND_LOOP_STOPPED_ERROR)
-}
-
-fn admission_error() -> napi::Error {
-  napi::Error::from_reason("The native watcher admission lock is poisoned.")
-}
-
-async fn wait_for_close(
-  mut close_state_rx: watch::Receiver<NativeWatcherCloseState>,
-) -> napi::Result<()> {
-  loop {
-    let result = {
-      let state = close_state_rx.borrow_and_update();
-      match &*state {
-        NativeWatcherCloseState::Closed(result) => Some(result.clone()),
-        NativeWatcherCloseState::Open | NativeWatcherCloseState::Closing => None,
-      }
-    };
-
-    if let Some(result) = result {
-      return result.map_err(napi::Error::from_reason);
+    FsWatcherHandleError::Closed(FsWatcherOperation::Pause) => {
+      "The native watcher has been closed, cannot pause.".to_string()
     }
+    FsWatcherHandleError::Unavailable => "The native watcher is unavailable.".to_string(),
+    FsWatcherHandleError::Internal(error) => error.to_string(),
+  };
 
-    close_state_rx.changed().await.map_err(|_| {
-      napi::Error::from_reason(
-        "The native watcher lifecycle ended before a close result was published.",
-      )
-    })?;
-  }
+  napi::Error::from_reason(reason)
 }
 
 fn timestamp_to_system_time(millis: u64) -> SystemTime {
@@ -204,7 +87,7 @@ fn timestamp_to_system_time(millis: u64) -> SystemTime {
 impl NativeWatcher {
   #[napi(constructor)]
   pub fn new(options: NativeWatcherOptions) -> Self {
-    let watcher = FsWatcher::new(
+    let (watcher, task) = FsWatcherHandle::new(
       FsWatcherOptions {
         follow_symlinks: options.follow_symlinks.unwrap_or(false),
         poll_interval: options.poll_interval,
@@ -212,17 +95,9 @@ impl NativeWatcher {
       },
       to_fs_watcher_ignored(options.ignored),
     );
-    let control = watcher.control();
-    let (command_tx, command_rx) = mpsc::unbounded_channel();
-    let (close_state_tx, _) = watch::channel(NativeWatcherCloseState::Open);
-    spawn_native_watcher_actor(watcher, command_rx, close_state_tx.clone());
+    rspack_napi::runtime::spawn(task);
 
-    Self {
-      command_tx,
-      control,
-      close_state_tx,
-      admission: Mutex::new(()),
-    }
+    Self { watcher }
   }
 
   #[napi]
@@ -238,111 +113,67 @@ impl NativeWatcher {
     #[napi(ts_arg_type = "(event: NativeWatchUndelayedEvent) => void")]
     callback_undelayed: Function<'static>,
   ) -> napi::Result<()> {
-    if !is_open(&self.close_state_tx) {
-      return Err(watch_after_close_error());
-    }
-
     let event_handler = Box::new(JsEventHandler::new(callback)?);
     let event_handler_undelayed = Box::new(JsEventHandlerUndelayed::new(callback_undelayed)?);
-    let command = NativeWatcherCommand::Watch {
-      files,
-      directories,
-      missing,
-      start_time: timestamp_to_system_time(start_time.get_u64().1),
-      event_handler,
-      event_handler_undelayed,
-    };
 
-    let _admission = self.admission.lock().map_err(|_| admission_error())?;
-    if !is_open(&self.close_state_tx) {
-      return Err(watch_after_close_error());
-    }
-
-    if self.command_tx.send(command).is_err() {
-      publish_close_result(
-        &self.close_state_tx,
-        Err(COMMAND_LOOP_STOPPED_ERROR.to_string()),
-      );
-      return Err(command_loop_stopped_error());
-    }
-
-    Ok(())
+    self
+      .watcher
+      .watch(
+        to_tuple_paths(files),
+        to_tuple_paths(directories),
+        to_tuple_paths(missing),
+        timestamp_to_system_time(start_time.get_u64().1),
+        event_handler,
+        event_handler_undelayed,
+      )
+      .map_err(to_napi_error)
   }
 
   #[napi(ts_type = "(kind: 'change' | 'remove' | 'create', path: string): void")]
   pub fn trigger_event(&self, kind: String, path: String) -> napi::Result<()> {
-    let _admission = self.admission.lock().map_err(|_| admission_error())?;
-    if !is_open(&self.close_state_tx) {
-      return Err(napi::Error::from_reason(
-        "The native watcher has been closed, cannot trigger events.",
-      ));
-    }
-
-    if let Some(kind) = match kind.as_str() {
+    let Some(kind) = (match kind.as_str() {
       "change" => Some(FsEventKind::Change),
       "remove" => Some(FsEventKind::Remove),
       "create" => Some(FsEventKind::Create),
       _ => None,
-    } {
-      self
-        .control
-        .trigger_event(&ArcPath::from(AsRef::<Path>::as_ref(&path)), kind);
-    }
+    }) else {
+      return Ok(());
+    };
 
-    Ok(())
+    self
+      .watcher
+      .trigger_event(&ArcPath::from(PathBuf::from(path)), kind)
+      .map_err(to_napi_error)
   }
 
   #[napi(ts_return_type = "Promise<void>")]
   pub fn close<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
-    let close_state_rx = {
-      let _admission = self.admission.lock().map_err(|_| admission_error())?;
-      let close_state_rx = self.close_state_tx.subscribe();
-      let should_send_close = self.close_state_tx.send_if_modified(|state| {
-        if matches!(state, NativeWatcherCloseState::Open) {
-          *state = NativeWatcherCloseState::Closing;
-          true
-        } else {
-          false
-        }
-      });
+    let close = self.watcher.close();
 
-      if should_send_close && self.command_tx.send(NativeWatcherCommand::Close).is_err() {
-        publish_close_result(
-          &self.close_state_tx,
-          Err(COMMAND_LOOP_STOPPED_ERROR.to_string()),
-        );
-      }
-
-      close_state_rx
-    };
-
-    rspack_napi::runtime::promise_from_future(env, wait_for_close(close_state_rx))
+    rspack_napi::runtime::promise_from_future(
+      env,
+      async move { close.await.map_err(to_napi_error) },
+    )
   }
 
   #[napi]
   pub fn pause(&self) -> napi::Result<()> {
-    let _admission = self.admission.lock().map_err(|_| admission_error())?;
-    if !is_open(&self.close_state_tx) {
-      return Err(napi::Error::from_reason(
-        "The native watcher has been closed, cannot pause.",
-      ));
-    }
-
-    self
-      .control
-      .pause()
-      .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-
-    Ok(())
+    self.watcher.pause().map_err(to_napi_error)
   }
 }
 
-fn to_tuple_path_iterator(
-  tuple: (Vec<String>, Vec<String>),
-) -> (impl Iterator<Item = ArcPath>, impl Iterator<Item = ArcPath>) {
+fn to_tuple_paths(tuple: (Vec<String>, Vec<String>)) -> (Vec<ArcPath>, Vec<ArcPath>) {
   (
-    tuple.0.into_iter().map(|s| ArcPath::from(PathBuf::from(s))),
-    tuple.1.into_iter().map(|s| ArcPath::from(PathBuf::from(s))),
+    tuple
+      .0
+      .into_iter()
+      .map(|path| ArcPath::from(PathBuf::from(path)))
+      .collect(),
+    tuple
+      .1
+      .into_iter()
+      .map(|path| ArcPath::from(PathBuf::from(path)))
+      .collect(),
   )
 }
 

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -2,6 +2,7 @@ use std::{
   boxed::Box,
   panic::AssertUnwindSafe,
   path::{Path, PathBuf},
+  sync::Mutex,
   time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -10,7 +11,11 @@ use napi::bindgen_prelude::*;
 use napi_derive::*;
 use rspack_paths::ArcPath;
 use rspack_regex::RspackRegex;
-use rspack_watcher::{FsEventKind, FsWatcher, FsWatcherIgnored, FsWatcherOptions};
+use rspack_watcher::{
+  EventAggregateHandler, EventHandler, FsEventKind, FsWatcher, FsWatcherControl, FsWatcherIgnored,
+  FsWatcherOptions,
+};
+use tokio::sync::{mpsc, watch};
 
 type JsWatcherIgnored = Either3<String, Vec<String>, RspackRegex>;
 
@@ -57,8 +62,138 @@ pub struct NativeWatchUndelayedEvent {
 
 #[napi]
 pub struct NativeWatcher {
+  command_tx: mpsc::UnboundedSender<NativeWatcherCommand>,
+  control: FsWatcherControl,
+  close_state_tx: watch::Sender<NativeWatcherCloseState>,
+  admission: Mutex<()>,
+}
+
+enum NativeWatcherCommand {
+  Watch {
+    files: (Vec<String>, Vec<String>),
+    directories: (Vec<String>, Vec<String>),
+    missing: (Vec<String>, Vec<String>),
+    start_time: SystemTime,
+    event_handler: Box<dyn EventAggregateHandler + Send>,
+    event_handler_undelayed: Box<dyn EventHandler + Send>,
+  },
+  Close,
+}
+
+#[derive(Clone)]
+enum NativeWatcherCloseState {
+  Open,
+  Closing,
+  Closed(std::result::Result<(), String>),
+}
+
+const WATCH_AFTER_CLOSE_ERROR: &str = "The native watcher has been closed, cannot watch again.";
+const COMMAND_LOOP_STOPPED_ERROR: &str =
+  "The native watcher command loop stopped before the request could be processed.";
+
+fn publish_close_result(
+  close_state_tx: &watch::Sender<NativeWatcherCloseState>,
+  result: std::result::Result<(), String>,
+) {
+  close_state_tx.send_if_modified(|state| {
+    if matches!(state, NativeWatcherCloseState::Closed(_)) {
+      return false;
+    }
+
+    *state = NativeWatcherCloseState::Closed(result);
+    true
+  });
+}
+
+async fn run_native_watcher_actor(
+  mut watcher: FsWatcher,
+  command_rx: &mut mpsc::UnboundedReceiver<NativeWatcherCommand>,
+) -> std::result::Result<(), String> {
+  while let Some(command) = command_rx.recv().await {
+    match command {
+      NativeWatcherCommand::Watch {
+        files,
+        directories,
+        missing,
+        start_time,
+        event_handler,
+        event_handler_undelayed,
+      } => {
+        watcher
+          .watch(
+            to_tuple_path_iterator(files),
+            to_tuple_path_iterator(directories),
+            to_tuple_path_iterator(missing),
+            start_time,
+            event_handler,
+            event_handler_undelayed,
+          )
+          .await;
+      }
+      NativeWatcherCommand::Close => {
+        return watcher.close().await.map_err(|error| error.to_string());
+      }
+    }
+  }
+
+  watcher.close().await.map_err(|error| error.to_string())
+}
+
+fn spawn_native_watcher_actor(
   watcher: FsWatcher,
-  closed: bool,
+  mut command_rx: mpsc::UnboundedReceiver<NativeWatcherCommand>,
+  close_state_tx: watch::Sender<NativeWatcherCloseState>,
+) {
+  rspack_napi::runtime::spawn(async move {
+    let result = AssertUnwindSafe(run_native_watcher_actor(watcher, &mut command_rx))
+      .catch_unwind()
+      .await;
+    let result = match result {
+      Ok(result) => result,
+      Err(payload) => Err(rspack_napi::runtime::panic_to_napi_error(payload).reason),
+    };
+    publish_close_result(&close_state_tx, result);
+  });
+}
+
+fn is_open(close_state_tx: &watch::Sender<NativeWatcherCloseState>) -> bool {
+  matches!(*close_state_tx.borrow(), NativeWatcherCloseState::Open)
+}
+
+fn watch_after_close_error() -> napi::Error {
+  napi::Error::from_reason(WATCH_AFTER_CLOSE_ERROR)
+}
+
+fn command_loop_stopped_error() -> napi::Error {
+  napi::Error::from_reason(COMMAND_LOOP_STOPPED_ERROR)
+}
+
+fn admission_error() -> napi::Error {
+  napi::Error::from_reason("The native watcher admission lock is poisoned.")
+}
+
+async fn wait_for_close(
+  mut close_state_rx: watch::Receiver<NativeWatcherCloseState>,
+) -> napi::Result<()> {
+  loop {
+    let result = {
+      let state = close_state_rx.borrow_and_update();
+      match &*state {
+        NativeWatcherCloseState::Closed(result) => Some(result.clone()),
+        NativeWatcherCloseState::Open | NativeWatcherCloseState::Closing => None,
+      }
+    };
+
+    if let Some(result) = result {
+      return result.map_err(napi::Error::from_reason);
+    }
+
+    close_state_rx.changed().await.map_err(|_| {
+      napi::Error::from_reason(
+        "The native watcher lifecycle ended before a close result was published.",
+      )
+    })?;
+  }
 }
 
 fn timestamp_to_system_time(millis: u64) -> SystemTime {
@@ -77,18 +212,23 @@ impl NativeWatcher {
       },
       to_fs_watcher_ignored(options.ignored),
     );
+    let control = watcher.control();
+    let (command_tx, command_rx) = mpsc::unbounded_channel();
+    let (close_state_tx, _) = watch::channel(NativeWatcherCloseState::Open);
+    spawn_native_watcher_actor(watcher, command_rx, close_state_tx.clone());
 
     Self {
-      watcher,
-      closed: false,
+      command_tx,
+      control,
+      close_state_tx,
+      admission: Mutex::new(()),
     }
   }
 
   #[napi]
   #[allow(clippy::too_many_arguments)]
   pub fn watch(
-    &mut self,
-    reference: Reference<NativeWatcher>,
+    &self,
     files: (Vec<String>, Vec<String>),
     directories: (Vec<String>, Vec<String>),
     missing: (Vec<String>, Vec<String>),
@@ -97,41 +237,47 @@ impl NativeWatcher {
     callback: Function<'static>,
     #[napi(ts_arg_type = "(event: NativeWatchUndelayedEvent) => void")]
     callback_undelayed: Function<'static>,
-    env: Env,
   ) -> napi::Result<()> {
-    if self.closed {
-      return Err(napi::Error::from_reason(
-        "The native watcher has been closed, cannot watch again.",
-      ));
+    if !is_open(&self.close_state_tx) {
+      return Err(watch_after_close_error());
     }
 
-    let js_event_handler = JsEventHandler::new(callback)?;
-    let js_event_handler_undelayed = JsEventHandlerUndelayed::new(callback_undelayed)?;
+    let event_handler = Box::new(JsEventHandler::new(callback)?);
+    let event_handler_undelayed = Box::new(JsEventHandlerUndelayed::new(callback_undelayed)?);
+    let command = NativeWatcherCommand::Watch {
+      files,
+      directories,
+      missing,
+      start_time: timestamp_to_system_time(start_time.get_u64().1),
+      event_handler,
+      event_handler_undelayed,
+    };
 
-    let start_time = start_time.get_u64().1;
+    let _admission = self.admission.lock().map_err(|_| admission_error())?;
+    if !is_open(&self.close_state_tx) {
+      return Err(watch_after_close_error());
+    }
 
-    reference.share_with(env, |native_watcher| {
-      rspack_napi::runtime::spawn(async move {
-        native_watcher
-          .watcher
-          .watch(
-            to_tuple_path_iterator(files),
-            to_tuple_path_iterator(directories),
-            to_tuple_path_iterator(missing),
-            timestamp_to_system_time(start_time),
-            Box::new(js_event_handler),
-            Box::new(js_event_handler_undelayed),
-          )
-          .await
-      });
-      Ok(())
-    })?;
+    if self.command_tx.send(command).is_err() {
+      publish_close_result(
+        &self.close_state_tx,
+        Err(COMMAND_LOOP_STOPPED_ERROR.to_string()),
+      );
+      return Err(command_loop_stopped_error());
+    }
 
     Ok(())
   }
 
   #[napi(ts_type = "(kind: 'change' | 'remove' | 'create', path: string): void")]
-  pub fn trigger_event(&self, kind: String, path: String) {
+  pub fn trigger_event(&self, kind: String, path: String) -> napi::Result<()> {
+    let _admission = self.admission.lock().map_err(|_| admission_error())?;
+    if !is_open(&self.close_state_tx) {
+      return Err(napi::Error::from_reason(
+        "The native watcher has been closed, cannot trigger events.",
+      ));
+    }
+
     if let Some(kind) = match kind.as_str() {
       "change" => Some(FsEventKind::Change),
       "remove" => Some(FsEventKind::Remove),
@@ -139,57 +285,51 @@ impl NativeWatcher {
       _ => None,
     } {
       self
-        .watcher
+        .control
         .trigger_event(&ArcPath::from(AsRef::<Path>::as_ref(&path)), kind);
     }
+
+    Ok(())
   }
 
   #[napi(ts_return_type = "Promise<void>")]
-  /// # Safety
-  ///
-  /// This function is unsafe because it uses `&mut self` to call the watcher asynchronously.
-  /// It's important to ensure that the watcher is not used in any other places before this function is finished.
-  /// You must ensure that the watcher not call watch, close or pause in the same time, otherwise it may lead to undefined behavior.
-  pub unsafe fn close<'env>(
-    &mut self,
-    env: &'env Env,
-    reference: Reference<NativeWatcher>,
-  ) -> napi::Result<PromiseRaw<'env, ()>> {
-    let (deferred, promise) = env.create_deferred()?;
-    let mut promise = PromiseRaw::new(env.raw(), promise.raw());
-    let shared_reference = reference.share_with(Env::from_raw(env.raw()), |native_watcher| {
-      rspack_napi::runtime::spawn(async move {
-        let result = AssertUnwindSafe(async {
-          native_watcher
-            .watcher
-            .close()
-            .await
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-          native_watcher.closed = true;
-          Ok(())
-        })
-        .catch_unwind()
-        .await;
-
-        match result {
-          Ok(Ok(())) => deferred.resolve(|_| Ok(())),
-          Ok(Err(error)) => deferred.reject(error),
-          Err(payload) => deferred.reject(rspack_napi::runtime::panic_to_napi_error(payload)),
+  pub fn close<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    let close_state_rx = {
+      let _admission = self.admission.lock().map_err(|_| admission_error())?;
+      let close_state_rx = self.close_state_tx.subscribe();
+      let should_send_close = self.close_state_tx.send_if_modified(|state| {
+        if matches!(state, NativeWatcherCloseState::Open) {
+          *state = NativeWatcherCloseState::Closing;
+          true
+        } else {
+          false
         }
       });
-      Ok(())
-    })?;
 
-    promise.finally(|_env| {
-      drop(shared_reference);
-      Ok(())
-    })
+      if should_send_close && self.command_tx.send(NativeWatcherCommand::Close).is_err() {
+        publish_close_result(
+          &self.close_state_tx,
+          Err(COMMAND_LOOP_STOPPED_ERROR.to_string()),
+        );
+      }
+
+      close_state_rx
+    };
+
+    rspack_napi::runtime::promise_from_future(env, wait_for_close(close_state_rx))
   }
 
   #[napi]
   pub fn pause(&self) -> napi::Result<()> {
+    let _admission = self.admission.lock().map_err(|_| admission_error())?;
+    if !is_open(&self.close_state_tx) {
+      return Err(napi::Error::from_reason(
+        "The native watcher has been closed, cannot pause.",
+      ));
+    }
+
     self
-      .watcher
+      .control
       .pause()
       .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 

--- a/crates/rspack_watcher/Cargo.toml
+++ b/crates/rspack_watcher/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 cow-utils    = { workspace = true }
 dashmap      = { workspace = true }
 fast-glob    = { workspace = true }
+futures      = { workspace = true }
 notify       = { workspace = true, features = ["macos_fsevent"] }
 regex        = { workspace = true }
 rspack_error = { workspace = true }

--- a/crates/rspack_watcher/src/executor.rs
+++ b/crates/rspack_watcher/src/executor.rs
@@ -86,6 +86,10 @@ impl Executor {
     }
   }
 
+  pub(super) fn pause_handle(&self) -> Arc<AtomicBool> {
+    Arc::clone(&self.paused)
+  }
+
   /// Pause the aggregate executor, it will not execute the event handler until resume.
   pub fn pause(&self) {
     self

--- a/crates/rspack_watcher/src/executor.rs
+++ b/crates/rspack_watcher/src/executor.rs
@@ -46,6 +46,17 @@ pub struct Executor {
   execute_aggregate_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
+impl Drop for Executor {
+  fn drop(&mut self) {
+    if let Some(handle) = self.execute_aggregate_handle.take() {
+      handle.abort();
+    }
+    if let Some(handle) = self.execute_handle.take() {
+      handle.abort();
+    }
+  }
+}
+
 const DEFAULT_AGGREGATE_TIMEOUT: u32 = 50; // Default timeout in milliseconds
 
 /// `ExecEvent` represents control events for the watcher executor loop.
@@ -84,10 +95,6 @@ impl Executor {
       execute_handle: None,
       aggregate_timeout: aggregate_timeout.unwrap_or(DEFAULT_AGGREGATE_TIMEOUT),
     }
-  }
-
-  pub(super) fn pause_handle(&self) -> Arc<AtomicBool> {
-    Arc::clone(&self.paused)
   }
 
   /// Pause the aggregate executor, it will not execute the event handler until resume.

--- a/crates/rspack_watcher/src/lib.rs
+++ b/crates/rspack_watcher/src/lib.rs
@@ -2,23 +2,19 @@ mod analyzer;
 mod disk_watcher;
 mod executor;
 mod ignored;
+mod managed;
 mod paths;
 mod scanner;
 mod time_info;
 mod trigger;
 
-use std::{
-  sync::{
-    Arc, Weak,
-    atomic::{AtomicBool, Ordering},
-  },
-  time::SystemTime,
-};
+use std::{sync::Arc, time::SystemTime};
 
 use analyzer::{Analyzer, RecommendedAnalyzer};
 use disk_watcher::DiskWatcher;
 use executor::Executor;
 pub use ignored::FsWatcherIgnored;
+pub use managed::{FsWatcherHandle, FsWatcherHandleError, FsWatcherOperation, FsWatcherTask};
 use paths::PathManager;
 use rspack_error::Result;
 use rspack_paths::ArcPath;
@@ -91,26 +87,6 @@ pub struct FsWatcherOptions {
   pub aggregate_timeout: Option<u32>,
 }
 
-#[derive(Clone)]
-pub struct FsWatcherControl {
-  paused: Arc<AtomicBool>,
-  trigger: Weak<Trigger>,
-}
-
-impl FsWatcherControl {
-  pub fn pause(&self) -> Result<()> {
-    self.paused.store(true, Ordering::Relaxed);
-
-    Ok(())
-  }
-
-  pub fn trigger_event(&self, path: &ArcPath, kind: FsEventKind) {
-    if let Some(trigger) = self.trigger.upgrade() {
-      trigger.on_event(path, kind);
-    }
-  }
-}
-
 pub struct FsWatcher {
   path_manager: Arc<PathManager>,
   disk_watcher: DiskWatcher,
@@ -142,13 +118,6 @@ impl FsWatcher {
       scanner,
       analyzer: RecommendedAnalyzer::default(),
       trigger: Some(trigger),
-    }
-  }
-
-  pub fn control(&self) -> FsWatcherControl {
-    FsWatcherControl {
-      paused: self.executor.pause_handle(),
-      trigger: self.trigger.as_ref().map_or_else(Weak::new, Arc::downgrade),
     }
   }
 

--- a/crates/rspack_watcher/src/lib.rs
+++ b/crates/rspack_watcher/src/lib.rs
@@ -7,7 +7,13 @@ mod scanner;
 mod time_info;
 mod trigger;
 
-use std::{sync::Arc, time::SystemTime};
+use std::{
+  sync::{
+    Arc, Weak,
+    atomic::{AtomicBool, Ordering},
+  },
+  time::SystemTime,
+};
 
 use analyzer::{Analyzer, RecommendedAnalyzer};
 use disk_watcher::DiskWatcher;
@@ -85,6 +91,26 @@ pub struct FsWatcherOptions {
   pub aggregate_timeout: Option<u32>,
 }
 
+#[derive(Clone)]
+pub struct FsWatcherControl {
+  paused: Arc<AtomicBool>,
+  trigger: Weak<Trigger>,
+}
+
+impl FsWatcherControl {
+  pub fn pause(&self) -> Result<()> {
+    self.paused.store(true, Ordering::Relaxed);
+
+    Ok(())
+  }
+
+  pub fn trigger_event(&self, path: &ArcPath, kind: FsEventKind) {
+    if let Some(trigger) = self.trigger.upgrade() {
+      trigger.on_event(path, kind);
+    }
+  }
+}
+
 pub struct FsWatcher {
   path_manager: Arc<PathManager>,
   disk_watcher: DiskWatcher,
@@ -116,6 +142,13 @@ impl FsWatcher {
       scanner,
       analyzer: RecommendedAnalyzer::default(),
       trigger: Some(trigger),
+    }
+  }
+
+  pub fn control(&self) -> FsWatcherControl {
+    FsWatcherControl {
+      paused: self.executor.pause_handle(),
+      trigger: self.trigger.as_ref().map_or_else(Weak::new, Arc::downgrade),
     }
   }
 

--- a/crates/rspack_watcher/src/managed.rs
+++ b/crates/rspack_watcher/src/managed.rs
@@ -1,0 +1,376 @@
+use std::{
+  any::Any,
+  fmt,
+  future::Future,
+  panic::AssertUnwindSafe,
+  pin::Pin,
+  sync::Mutex,
+  task::{Context, Poll},
+  time::SystemTime,
+};
+
+use futures::FutureExt;
+use rspack_error::error;
+use rspack_paths::ArcPath;
+use tokio::sync::{mpsc, watch};
+
+use crate::{
+  EventAggregateHandler, EventHandler, FsEventKind, FsWatcher, FsWatcherIgnored, FsWatcherOptions,
+};
+
+type WatchPaths = (Vec<ArcPath>, Vec<ArcPath>);
+type HandleResult<T> = std::result::Result<T, FsWatcherHandleError>;
+
+enum FsWatcherCommand {
+  Watch {
+    files: WatchPaths,
+    directories: WatchPaths,
+    missing: WatchPaths,
+    start_time: SystemTime,
+    event_handler: Box<dyn EventAggregateHandler + Send>,
+    event_handler_undelayed: Box<dyn EventHandler + Send>,
+  },
+  TriggerEvent {
+    path: ArcPath,
+    kind: FsEventKind,
+  },
+  Pause,
+  Close,
+}
+
+type TaskOutput = (HandleResult<()>, mpsc::UnboundedReceiver<FsWatcherCommand>);
+
+#[derive(Clone)]
+enum FsWatcherCloseState {
+  Open,
+  Closing,
+  Closed(HandleResult<()>),
+}
+
+#[derive(Debug, Clone)]
+pub enum FsWatcherHandleError {
+  Closed(FsWatcherOperation),
+  Unavailable,
+  Internal(rspack_error::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsWatcherOperation {
+  Watch,
+  TriggerEvent,
+  Pause,
+}
+
+impl fmt::Display for FsWatcherHandleError {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Closed(operation) => write!(
+        formatter,
+        "The file watcher cannot {operation} after it has been closed."
+      ),
+      Self::Unavailable => formatter.write_str("The file watcher is unavailable."),
+      Self::Internal(error) => error.fmt(formatter),
+    }
+  }
+}
+
+impl fmt::Display for FsWatcherOperation {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Watch => formatter.write_str("watch"),
+      Self::TriggerEvent => formatter.write_str("trigger events"),
+      Self::Pause => formatter.write_str("pause"),
+    }
+  }
+}
+
+impl std::error::Error for FsWatcherHandleError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      Self::Internal(error) => Some(error),
+      _ => None,
+    }
+  }
+}
+
+/// Drives the exclusively owned file watcher and publishes a terminal result when dropped.
+pub struct FsWatcherTask {
+  future: Option<Pin<Box<dyn Future<Output = TaskOutput> + Send + 'static>>>,
+  close_state_tx: watch::Sender<FsWatcherCloseState>,
+  completed: bool,
+}
+
+impl FsWatcherTask {
+  fn new(
+    future: Pin<Box<dyn Future<Output = TaskOutput> + Send + 'static>>,
+    close_state_tx: watch::Sender<FsWatcherCloseState>,
+  ) -> Self {
+    Self {
+      future: Some(future),
+      close_state_tx,
+      completed: false,
+    }
+  }
+}
+
+impl Future for FsWatcherTask {
+  type Output = ();
+
+  fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+    let (result, command_rx) = match self.future.as_mut() {
+      Some(future) => match future.as_mut().poll(context) {
+        Poll::Ready(output) => output,
+        Poll::Pending => return Poll::Pending,
+      },
+      None => return Poll::Ready(()),
+    };
+
+    self.completed = true;
+    publish_close_result(&self.close_state_tx, result);
+    self.future.take();
+    drop(command_rx);
+
+    Poll::Ready(())
+  }
+}
+
+impl Drop for FsWatcherTask {
+  fn drop(&mut self) {
+    if !self.completed {
+      self.future.take();
+      self.completed = true;
+      publish_close_result(&self.close_state_tx, Err(FsWatcherHandleError::Unavailable));
+    }
+  }
+}
+
+/// Provides concurrent access while a background task exclusively owns the file watcher.
+pub struct FsWatcherHandle {
+  command_tx: mpsc::UnboundedSender<FsWatcherCommand>,
+  close_state_tx: watch::Sender<FsWatcherCloseState>,
+  admission: Mutex<()>,
+}
+
+impl FsWatcherHandle {
+  /// Creates a handle and a background task that the caller must run to drive it.
+  pub fn new(options: FsWatcherOptions, ignored: FsWatcherIgnored) -> (Self, FsWatcherTask) {
+    let watcher = FsWatcher::new(options, ignored);
+    let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+    let (close_state_tx, _) = watch::channel(FsWatcherCloseState::Open);
+
+    let task = FsWatcherTask::new(
+      Box::pin(async move {
+        let result = AssertUnwindSafe(run_fs_watcher_actor(watcher, &mut command_rx))
+          .catch_unwind()
+          .await;
+        let result = match result {
+          Ok(result) => result,
+          Err(payload) => Err(FsWatcherHandleError::Internal(error!(panic_message(
+            payload
+          )))),
+        };
+
+        // The receiver stays alive until FsWatcherTask publishes the exact terminal result.
+        (result, command_rx)
+      }),
+      close_state_tx.clone(),
+    );
+
+    (
+      Self {
+        command_tx,
+        close_state_tx,
+        admission: Mutex::new(()),
+      },
+      task,
+    )
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  pub fn watch(
+    &self,
+    files: (Vec<ArcPath>, Vec<ArcPath>),
+    directories: (Vec<ArcPath>, Vec<ArcPath>),
+    missing: (Vec<ArcPath>, Vec<ArcPath>),
+    start_time: SystemTime,
+    event_handler: Box<dyn EventAggregateHandler + Send>,
+    event_handler_undelayed: Box<dyn EventHandler + Send>,
+  ) -> std::result::Result<(), FsWatcherHandleError> {
+    self.enqueue(
+      FsWatcherCommand::Watch {
+        files,
+        directories,
+        missing,
+        start_time,
+        event_handler,
+        event_handler_undelayed,
+      },
+      FsWatcherOperation::Watch,
+    )
+  }
+
+  pub fn trigger_event(
+    &self,
+    path: &ArcPath,
+    kind: FsEventKind,
+  ) -> std::result::Result<(), FsWatcherHandleError> {
+    self.enqueue(
+      FsWatcherCommand::TriggerEvent {
+        path: path.clone(),
+        kind,
+      },
+      FsWatcherOperation::TriggerEvent,
+    )
+  }
+
+  pub fn pause(&self) -> std::result::Result<(), FsWatcherHandleError> {
+    self.enqueue(FsWatcherCommand::Pause, FsWatcherOperation::Pause)
+  }
+
+  pub fn close(
+    &self,
+  ) -> impl Future<Output = std::result::Result<(), FsWatcherHandleError>> + Send + 'static {
+    let close_state_rx = self.start_close();
+
+    async move {
+      let close_state_rx = close_state_rx?;
+      wait_for_close(close_state_rx).await
+    }
+  }
+
+  fn enqueue(&self, command: FsWatcherCommand, operation: FsWatcherOperation) -> HandleResult<()> {
+    let _admission = self
+      .admission
+      .lock()
+      .map_err(|_| FsWatcherHandleError::Unavailable)?;
+    if !is_open(&self.close_state_tx) {
+      return Err(FsWatcherHandleError::Closed(operation));
+    }
+
+    self
+      .command_tx
+      .send(command)
+      .map_err(|_| FsWatcherHandleError::Unavailable)
+  }
+
+  fn start_close(&self) -> HandleResult<watch::Receiver<FsWatcherCloseState>> {
+    let _admission = self
+      .admission
+      .lock()
+      .map_err(|_| FsWatcherHandleError::Unavailable)?;
+    let close_state_rx = self.close_state_tx.subscribe();
+    let should_send_close = self.close_state_tx.send_if_modified(|state| {
+      if matches!(state, FsWatcherCloseState::Open) {
+        *state = FsWatcherCloseState::Closing;
+        true
+      } else {
+        false
+      }
+    });
+
+    if should_send_close {
+      let _ = self.command_tx.send(FsWatcherCommand::Close);
+    }
+
+    Ok(close_state_rx)
+  }
+}
+
+async fn run_fs_watcher_actor(
+  mut watcher: FsWatcher,
+  command_rx: &mut mpsc::UnboundedReceiver<FsWatcherCommand>,
+) -> HandleResult<()> {
+  while let Some(command) = command_rx.recv().await {
+    match command {
+      FsWatcherCommand::Watch {
+        files,
+        directories,
+        missing,
+        start_time,
+        event_handler,
+        event_handler_undelayed,
+      } => {
+        watcher
+          .watch(
+            into_iterators(files),
+            into_iterators(directories),
+            into_iterators(missing),
+            start_time,
+            event_handler,
+            event_handler_undelayed,
+          )
+          .await;
+      }
+      FsWatcherCommand::TriggerEvent { path, kind } => watcher.trigger_event(&path, kind),
+      FsWatcherCommand::Pause => watcher.pause().map_err(FsWatcherHandleError::Internal)?,
+      FsWatcherCommand::Close => {
+        return watcher
+          .close()
+          .await
+          .map_err(FsWatcherHandleError::Internal);
+      }
+    }
+  }
+
+  watcher
+    .close()
+    .await
+    .map_err(FsWatcherHandleError::Internal)
+}
+
+fn into_iterators(
+  paths: WatchPaths,
+) -> (impl Iterator<Item = ArcPath>, impl Iterator<Item = ArcPath>) {
+  (paths.0.into_iter(), paths.1.into_iter())
+}
+
+fn is_open(close_state_tx: &watch::Sender<FsWatcherCloseState>) -> bool {
+  matches!(*close_state_tx.borrow(), FsWatcherCloseState::Open)
+}
+
+fn publish_close_result(
+  close_state_tx: &watch::Sender<FsWatcherCloseState>,
+  result: HandleResult<()>,
+) {
+  close_state_tx.send_if_modified(|state| {
+    if matches!(state, FsWatcherCloseState::Closed(_)) {
+      return false;
+    }
+
+    *state = FsWatcherCloseState::Closed(result);
+    true
+  });
+}
+
+async fn wait_for_close(
+  mut close_state_rx: watch::Receiver<FsWatcherCloseState>,
+) -> HandleResult<()> {
+  loop {
+    let result = {
+      let state = close_state_rx.borrow_and_update();
+      match &*state {
+        FsWatcherCloseState::Closed(result) => Some(result.clone()),
+        FsWatcherCloseState::Open | FsWatcherCloseState::Closing => None,
+      }
+    };
+
+    if let Some(result) = result {
+      return result;
+    }
+
+    close_state_rx
+      .changed()
+      .await
+      .map_err(|_| FsWatcherHandleError::Unavailable)?;
+  }
+}
+
+fn panic_message(payload: Box<dyn Any + Send + 'static>) -> String {
+  if let Some(message) = payload.downcast_ref::<&str>() {
+    (*message).to_string()
+  } else if let Some(message) = payload.downcast_ref::<String>() {
+    message.clone()
+  } else {
+    "Panic in file watcher task".to_string()
+  }
+}


### PR DESCRIPTION
## Summary

- add `FsWatcherHandle` and `FsWatcherTask` in `rspack_watcher`, where one task exclusively owns `FsWatcher`
- serialize `watch`, `pause`, `triggerEvent`, and `close` through one FIFO with an `Open -> Closing -> Closed` lifecycle
- keep `NativeWatcher` as a thin JS/N-API adapter that converts arguments, maps typed errors, and spawns the watcher task
- make repeated `close()` calls share one terminal result and make task cancellation or JavaScript wrapper GC release callback tasks safely

The panic was caused by multiple detached tasks mutating the same `FsWatcher` through overlapping extended mutable references. On macOS, one task could register FSEvents paths while another closed and released the underlying watcher, leading to use-after-free/data corruption and Objective-C exceptions.

The watcher crate now owns command admission, FIFO ordering, panic capture, close-result publication, and cancellation cleanup. The binding no longer contains queue, locking, or close-state implementation details.

## Validation

- `cargo check -p rspack_watcher -p rspack_binding_api`
- `cargo clippy -p rspack_watcher -p rspack_binding_api --all-targets -- -D warnings`
- `cargo test -p rspack_watcher` — 28 unit and 2 native integration tests passed
- `cargo fmt --all -- --check`
- native addon debug build passed
- original native crash workload — 30/30 iterations passed
- FIFO contract — confirmed `watch`, `pause`, `triggerEvent`, and `close` retain call order
- lifecycle stress — 1,000/1,000 iterations passed, covering 5,000 watches, 1,000 synchronous post-close rejections, and 3,000 resolved close promises
- forced-GC stress — 400/400 abandoned wrappers finalized with natural process exit
- focused NativeWatcher part 3 — 60/60 passed

The complete local NativeWatcher project ran 237 tests: 232 passed, while five CSS/React fixture cases could not resolve local dependencies in the isolated worktree. None failed from watcher lifecycle, panic, callback, close, or hang behavior.

## Related links

- N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
