### PR TITLE
refactor: parse import.meta context options with a serde AST deserializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4696,6 +4696,7 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash",
+ "serde",
  "serde_json",
  "slotmap",
  "smallvec",

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -190,6 +190,7 @@ pub struct ContextOptions {
   pub referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
   pub glob_import: Option<String>,
   pub glob_exhaustive: bool,
+  pub glob_case_sensitive: bool,
   pub attributes: Option<ImportAttributes>,
   pub phase: Option<ImportPhase>,
 }
@@ -213,6 +214,7 @@ impl Default for ContextOptions {
       referenced_specifiers: None,
       glob_import: None,
       glob_exhaustive: false,
+      glob_case_sensitive: true,
       attributes: None,
       phase: None,
     }
@@ -1400,6 +1402,9 @@ impl Module for ContextModule {
     if self.options.context_options.glob_exhaustive {
       id += " globExhaustive";
     }
+    if !self.options.context_options.glob_case_sensitive {
+      id += " globCaseInsensitive";
+    }
     Some(Cow::Owned(id))
   }
 
@@ -1609,6 +1614,9 @@ fn create_identifier(options: &ContextModuleOptions, resource: Option<&str>) -> 
   }
   if options.context_options.glob_exhaustive {
     id += "|globExhaustive";
+  }
+  if !options.context_options.glob_case_sensitive {
+    id += "|globCaseInsensitive";
   }
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.context_options.group_options {

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -464,6 +464,7 @@ async fn visit_dirs(
     };
   let is_import_meta_glob = resolved_glob_patterns.is_some();
   let glob_exhaustive = options.context_options.glob_exhaustive;
+  let glob_case_sensitive = options.context_options.glob_case_sensitive;
 
   walk_dir(
     dir,
@@ -511,7 +512,8 @@ async fn visit_dirs(
         // Keep import.meta.glob Vite-compatible: expose only filesystem-matched
         // paths, not resolver alternative requests like extensionless aliases.
         // Revisit this branch if import.meta.glob compatibility changes.
-        if let Some(user_request) = glob_user_request(patterns, path_str, glob_exhaustive)
+        if let Some(user_request) =
+          glob_user_request(patterns, path_str, glob_exhaustive, glob_case_sensitive)
           && !dependencies.iter().any(|d| d.user_request == user_request)
         {
           push_context_element_dependency(dependencies, options, &relative_path, &user_request);
@@ -658,17 +660,18 @@ fn glob_user_request(
   patterns: &[ResolvedContextModuleGlobPattern],
   path: &str,
   exhaustive: bool,
+  case_sensitive: bool,
 ) -> Option<String> {
   let normalized_path = normalize_path_separators_for_path(path);
   let matched = patterns
     .iter()
     .filter(|pattern| !pattern.negative)
-    .find(|pattern| glob_pattern_matches(pattern, &normalized_path, exhaustive))?;
+    .find(|pattern| glob_pattern_matches(pattern, &normalized_path, exhaustive, case_sensitive))?;
 
   if patterns
     .iter()
     .filter(|pattern| pattern.negative)
-    .any(|pattern| glob_pattern_matches(pattern, &normalized_path, exhaustive))
+    .any(|pattern| glob_pattern_matches(pattern, &normalized_path, exhaustive, case_sensitive))
   {
     return None;
   }
@@ -688,14 +691,15 @@ fn glob_pattern_matches(
   pattern: &ResolvedContextModuleGlobPattern,
   normalized_path: &str,
   exhaustive: bool,
+  case_sensitive: bool,
 ) -> bool {
   glob_match_normalized_with_explicit_dot(
     &pattern.absolute_pattern,
     normalized_path,
     &pattern.absolute_base,
     &GlobMatchOptions {
+      case_sensitive,
       require_literal_leading_dot: !exhaustive,
-      ..Default::default()
     },
   )
 }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -15,7 +15,7 @@ cow-utils                             = { workspace = true }
 either                                = { workspace = true }
 fast-glob                             = { workspace = true }
 form_urlencoded                       = { workspace = true }
-indexmap                              = { workspace = true }
+indexmap                              = { workspace = true, features = ["serde"] }
 itertools                             = { workspace = true }
 memchr                                = { workspace = true }
 num-bigint                            = { workspace = true }
@@ -36,6 +36,7 @@ rspack_paths                          = { workspace = true }
 rspack_regex                          = { workspace = true }
 rspack_util                           = { workspace = true }
 rustc-hash                            = { workspace = true }
+serde                                 = { workspace = true, features = ["std"] }
 serde_json                            = { workspace = true }
 slotmap                               = { workspace = true }
 smallvec                              = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
@@ -82,6 +82,11 @@ fn create_resource_identifier_for_context_dependency(
   } else {
     ""
   };
+  let glob_case_sensitive = if options.glob_case_sensitive {
+    ""
+  } else {
+    "globCaseInsensitive"
+  };
   let mut group_options = String::new();
 
   if let Some(GroupOptions::ChunkGroup(group)) = &options.group_options {
@@ -102,7 +107,7 @@ fn create_resource_identifier_for_context_dependency(
   }
 
   let id = format!(
-    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import} {glob_exhaustive}",
+    "context{context}|ctx request{request} {recursive} {pattern} {include} {exclude} {mode} {group_options} {referenced_exports} {glob_import} {glob_exhaustive} {glob_case_sensitive}",
   );
   id.into()
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -367,6 +367,10 @@ fn create_import_meta_glob_dependency(
     .and_then(static_string_from_expr);
   let glob_exhaustive = glob_options
     .is_some_and(|obj| get_bool_by_obj_prop(obj, "exhaustive").is_some_and(|b| b.value));
+  let glob_case_sensitive = glob_options
+    .and_then(|obj| get_value_by_obj_prop(obj, "caseSensitive"))
+    .and_then(|value| parser.evaluate_expression(value).as_bool())
+    .unwrap_or(true);
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),
     parser.compiler_options.context.as_str(),
@@ -415,6 +419,7 @@ fn create_import_meta_glob_dependency(
     referenced_specifiers,
     glob_import,
     glob_exhaustive,
+    glob_case_sensitive,
     ..Default::default()
   };
   Some(ImportMetaContextDependency::new_glob(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -4,12 +4,13 @@ use rspack_core::{
   ReferencedSpecifier, escape_glob_pattern, extract_glob_base_dir, get_context,
   normalize_path_separators, normalize_path_separators_for_path, unescape_glob_path,
 };
+use rspack_error::{Error, Severity};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_regex::RspackRegex;
 use rspack_util::{SpanExt, identifier::relative_path_to_request, node_path::NodePath};
 use sugar_path::SugarPath;
 use swc_atoms::Atom;
-use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan, Lit, PropName};
+use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan, Lit, ObjectLit, PropName};
 
 use super::JavascriptParserPlugin;
 use crate::{
@@ -22,10 +23,35 @@ use crate::{
     },
   },
   visitors::{
-    JavascriptParser, clean_regexp_in_context_module, default_context_reg_exp, expr_name,
-    static_string_from_expr,
+    JavascriptParser, clean_regexp_in_context_module, create_traceable_error,
+    default_context_reg_exp, expr_name, static_string_from_expr,
   },
 };
+
+fn parse_import_meta_glob_case_sensitive(
+  glob_options: Option<&ObjectLit>,
+  parser: &mut JavascriptParser,
+) -> bool {
+  let Some(value) = glob_options.and_then(|obj| get_value_by_obj_prop(obj, "caseSensitive")) else {
+    return true;
+  };
+
+  let evaluated = parser.evaluate_expression(value);
+  if evaluated.is_bool() {
+    return evaluated.bool();
+  }
+
+  let mut error: Error = create_traceable_error(
+    "Invalid import.meta.glob option".into(),
+    "import.meta.glob() 'caseSensitive' option must be a constant boolean (true or false), defaulting to true".into(),
+    parser.source.to_string(),
+    value.span().into(),
+  );
+  error.severity = Severity::Warning;
+  error.hide_stack = Some(true);
+  parser.add_warning(error.into());
+  true
+}
 
 fn static_glob_patterns_from_expr(expr: &Expr) -> Option<Vec<String>> {
   if let Some(pattern) = static_string_from_expr(expr) {
@@ -367,13 +393,7 @@ fn create_import_meta_glob_dependency(
     .and_then(static_string_from_expr);
   let glob_exhaustive = glob_options
     .is_some_and(|obj| get_bool_by_obj_prop(obj, "exhaustive").is_some_and(|b| b.value));
-  let glob_case_sensitive = glob_options
-    .and_then(|obj| get_value_by_obj_prop(obj, "caseSensitive"))
-    .and_then(|value| {
-      let evaluated = parser.evaluate_expression(value);
-      evaluated.is_bool().then(|| evaluated.bool())
-    })
-    .unwrap_or(true);
+  let glob_case_sensitive = parse_import_meta_glob_case_sensitive(glob_options, parser);
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),
     parser.compiler_options.context.as_str(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -369,7 +369,10 @@ fn create_import_meta_glob_dependency(
     .is_some_and(|obj| get_bool_by_obj_prop(obj, "exhaustive").is_some_and(|b| b.value));
   let glob_case_sensitive = glob_options
     .and_then(|obj| get_value_by_obj_prop(obj, "caseSensitive"))
-    .and_then(|value| parser.evaluate_expression(value).as_bool())
+    .and_then(|value| {
+      let evaluated = parser.evaluate_expression(value);
+      evaluated.is_bool().then(|| evaluated.bool())
+    })
     .unwrap_or(true);
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -1,4 +1,5 @@
 use concat_string::concat_string;
+use indexmap::IndexMap;
 use rspack_core::{
   ContextMode, ContextModulePattern, ContextNameSpaceObject, ContextOptions, DependencyCategory,
   ReferencedSpecifier, escape_glob_pattern, extract_glob_base_dir, get_context,
@@ -8,25 +9,117 @@ use rspack_error::{Error, Severity};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_regex::RspackRegex;
 use rspack_util::{SpanExt, identifier::relative_path_to_request, node_path::NodePath};
+use rustc_hash::FxBuildHasher;
+use serde::Deserialize;
 use sugar_path::SugarPath;
 use swc_atoms::Atom;
-use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan, Lit, ObjectLit, PropName};
+use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan, ObjectLit};
 
 use super::JavascriptParserPlugin;
 use crate::{
   dependency::ImportMetaContextDependency,
   utils::{
+    ast_deserializer::{self, AstRegex, lenient},
     eval::{self, BasicEvaluatedExpression},
-    object_properties::{
-      get_bool_by_obj_prop, get_literal_str_by_obj_prop, get_regex_by_obj_prop,
-      get_value_by_obj_prop,
-    },
+    object_properties::get_value_by_obj_prop,
   },
   visitors::{
     JavascriptParser, clean_regexp_in_context_module, create_traceable_error,
     default_context_reg_exp, expr_name, static_string_from_expr,
   },
 };
+
+/// Options of `import.meta.webpackContext(request, options)`, mirroring the
+/// TypeScript declaration in `packages/rspack/module.d.ts`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct ImportMetaWebpackContextOptions {
+  #[serde(deserialize_with = "lenient")]
+  reg_exp: Option<AstRegex>,
+  #[serde(deserialize_with = "lenient")]
+  include: Option<AstRegex>,
+  #[serde(deserialize_with = "lenient")]
+  exclude: Option<AstRegex>,
+  #[serde(deserialize_with = "lenient")]
+  mode: Option<String>,
+  /// Absent or unrecognized means `true`.
+  #[serde(deserialize_with = "lenient")]
+  recursive: Option<bool>,
+}
+
+/// Options of `import.meta.glob(pattern, options)`, mirroring
+/// `Rspack.ImportMetaGlobOptions` in `packages/rspack/module.d.ts`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct ImportMetaGlobOptions {
+  #[serde(deserialize_with = "lenient")]
+  eager: bool,
+  #[serde(deserialize_with = "lenient")]
+  import: Option<String>,
+  #[serde(deserialize_with = "lenient")]
+  query: Option<ImportMetaGlobQuery>,
+  #[serde(deserialize_with = "lenient")]
+  base: Option<String>,
+  #[serde(deserialize_with = "lenient")]
+  exhaustive: bool,
+  /// Requires expression evaluation and emits a warning on invalid values,
+  /// so it is still parsed manually; see
+  /// `parse_import_meta_glob_case_sensitive`.
+  #[serde(skip, default = "default_case_sensitive")]
+  case_sensitive: bool,
+}
+
+impl Default for ImportMetaGlobOptions {
+  fn default() -> Self {
+    Self {
+      eager: false,
+      import: None,
+      query: None,
+      base: None,
+      exhaustive: false,
+      case_sensitive: default_case_sensitive(),
+    }
+  }
+}
+
+fn default_case_sensitive() -> bool {
+  true
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ImportMetaGlobQuery {
+  String(String),
+  Record(IndexMap<String, ImportMetaGlobQueryValue, FxBuildHasher>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ImportMetaGlobQueryValue {
+  String(String),
+  Number(f64),
+  Bool(bool),
+}
+
+impl ImportMetaGlobQuery {
+  fn into_query_string(self) -> String {
+    match self {
+      Self::String(query) => normalize_import_meta_glob_query(query),
+      Self::Record(entries) => {
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in entries {
+          let value = match value {
+            ImportMetaGlobQueryValue::String(value) => value,
+            ImportMetaGlobQueryValue::Number(value) => value.to_string(),
+            ImportMetaGlobQueryValue::Bool(value) => value.to_string(),
+          };
+          serializer.append_pair(&key, &value);
+        }
+        normalize_import_meta_glob_query(serializer.finish())
+      }
+    }
+  }
+}
 
 fn parse_import_meta_glob_case_sensitive(
   glob_options: Option<&ObjectLit>,
@@ -77,54 +170,6 @@ fn normalize_import_meta_glob_query(query: String) -> String {
     query
   } else {
     concat_string!("?", query)
-  }
-}
-
-fn static_import_meta_glob_query_from_expr(expr: &Expr) -> Option<String> {
-  if let Some(query) = static_string_from_expr(expr) {
-    return Some(normalize_import_meta_glob_query(query));
-  }
-
-  let query = expr.as_object()?;
-  let mut serializer = form_urlencoded::Serializer::new(String::new());
-  for prop in &query.props {
-    let kv = prop.as_prop().and_then(|prop| prop.as_key_value())?;
-    let key = static_import_meta_glob_query_key_from_prop_name(&kv.key)?;
-    let value = if let Some(value) = static_string_from_expr(&kv.value) {
-      value
-    } else {
-      match kv.value.as_lit()? {
-        Lit::Bool(bool) => bool.value.to_string(),
-        Lit::Num(num) => num.value.to_string(),
-        _ => return None,
-      }
-    };
-    serializer.append_pair(&key, &value);
-  }
-
-  Some(normalize_import_meta_glob_query(serializer.finish()))
-}
-
-fn static_import_meta_glob_query_key_from_prop_name(prop_name: &PropName) -> Option<String> {
-  match prop_name {
-    PropName::Ident(ident) => Some(ident.sym.to_string()),
-    PropName::Str(str) => Some(str.value.to_string_lossy().into_owned()),
-    PropName::Num(num) => Some(num.value.to_string()),
-    PropName::Computed(computed) => static_import_meta_glob_query_key_from_expr(&computed.expr),
-    _ => None,
-  }
-}
-
-fn static_import_meta_glob_query_key_from_expr(expr: &Expr) -> Option<String> {
-  if let Some(key) = static_string_from_expr(expr) {
-    return Some(key);
-  }
-
-  match expr.as_lit()? {
-    Lit::Num(num) => Some(num.value.to_string()),
-    Lit::Bool(bool) => Some(bool.value.to_string()),
-    Lit::Null(_) => Some("null".to_string()),
-    _ => None,
   }
 }
 
@@ -311,49 +356,42 @@ fn create_import_meta_context_dependency(
   }
   // TODO: should've used expression evaluation to handle cases like `abc${"efg"}`, etc.
   let context = static_string_from_expr(&dyn_imported.expr)?;
-  let context_options = if let Some(obj) = node.args.get(1).and_then(|arg| arg.expr.as_object()) {
-    let regexp = get_regex_by_obj_prop(obj, "regExp");
-    let regexp_span = regexp.map(|r| r.span().into());
-    let regexp = regexp.map_or_else(default_context_reg_exp, |regexp| {
-      RspackRegex::with_flags(regexp.exp.as_str(), regexp.flags.as_str()).expect("reg failed")
+  let options = node
+    .args
+    .get(1)
+    .map(|arg| {
+      ast_deserializer::from_expr::<ImportMetaWebpackContextOptions>(&arg.expr).unwrap_or_default()
+    })
+    .unwrap_or_default();
+  let regexp_span = options.reg_exp.as_ref().map(|regex| regex.span.into());
+  let regexp = options
+    .reg_exp
+    .map_or_else(default_context_reg_exp, |regex| {
+      RspackRegex::with_flags(regex.exp.as_str(), regex.flags.as_str()).expect("reg failed")
     });
-    let include = get_regex_by_obj_prop(obj, "include").map(|regexp| {
-      RspackRegex::with_flags(regexp.exp.as_str(), regexp.flags.as_str()).expect("reg failed")
-    });
-    let exclude = get_regex_by_obj_prop(obj, "exclude").map(|regexp| {
-      RspackRegex::with_flags(regexp.exp.as_str(), regexp.flags.as_str()).expect("reg failed")
-    });
-    let mode = get_literal_str_by_obj_prop(obj, "mode").map_or(ContextMode::Sync, |s| {
-      s.value.to_string_lossy().as_ref().into()
-    });
-    let recursive = get_bool_by_obj_prop(obj, "recursive").is_none_or(|bool| bool.value);
-    let span = node.span;
-    ContextOptions {
-      pattern: clean_regexp_in_context_module(regexp, regexp_span, parser).into(),
-      include,
-      exclude,
-      recursive,
-      category: DependencyCategory::Esm,
-      request: context.clone(),
-      context,
-      mode,
-      start: span.real_lo(),
-      end: span.real_hi(),
-      ..Default::default()
-    }
-  } else {
-    let span = node.span;
-    ContextOptions {
-      recursive: true,
-      mode: ContextMode::Sync,
-      pattern: clean_regexp_in_context_module(default_context_reg_exp(), None, parser).into(),
-      category: DependencyCategory::Esm,
-      request: context.clone(),
-      context,
-      start: span.real_lo(),
-      end: span.real_hi(),
-      ..Default::default()
-    }
+  let include = options.include.map(|regex| {
+    RspackRegex::with_flags(regex.exp.as_str(), regex.flags.as_str()).expect("reg failed")
+  });
+  let exclude = options.exclude.map(|regex| {
+    RspackRegex::with_flags(regex.exp.as_str(), regex.flags.as_str()).expect("reg failed")
+  });
+  let mode = options
+    .mode
+    .map_or(ContextMode::Sync, |mode| mode.as_str().into());
+  let recursive = options.recursive.is_none_or(|recursive| recursive);
+  let span = node.span;
+  let context_options = ContextOptions {
+    pattern: clean_regexp_in_context_module(regexp, regexp_span, parser).into(),
+    include,
+    exclude,
+    recursive,
+    category: DependencyCategory::Esm,
+    request: context.clone(),
+    context,
+    mode,
+    start: span.real_lo(),
+    end: span.real_hi(),
+    ..Default::default()
   };
   Some(ImportMetaContextDependency::new(
     context_options,
@@ -374,26 +412,24 @@ fn create_import_meta_glob_dependency(
   let raw_glob_patterns = static_glob_patterns_from_expr(&dyn_imported.expr)?;
   let importer_context = get_context(parser.resource_data);
   let glob_options = node.args.get(1).and_then(|arg| arg.expr.as_object());
-  let mode = glob_options.map_or(ContextMode::Lazy, |obj| {
-    if get_bool_by_obj_prop(obj, "eager").is_some_and(|b| b.value) {
-      ContextMode::Sync
-    } else {
-      ContextMode::Lazy
-    }
-  });
-  let glob_import = glob_options
-    .and_then(|obj| get_literal_str_by_obj_prop(obj, "import"))
-    .map(|s| s.value.to_string_lossy().into_owned());
-  let glob_query = glob_options
-    .and_then(|obj| get_value_by_obj_prop(obj, "query"))
-    .and_then(static_import_meta_glob_query_from_expr)
+  let mut options = node
+    .args
+    .get(1)
+    .map(|arg| ast_deserializer::from_expr::<ImportMetaGlobOptions>(&arg.expr).unwrap_or_default())
     .unwrap_or_default();
-  let base = glob_options
-    .and_then(|obj| get_value_by_obj_prop(obj, "base"))
-    .and_then(static_string_from_expr);
-  let glob_exhaustive = glob_options
-    .is_some_and(|obj| get_bool_by_obj_prop(obj, "exhaustive").is_some_and(|b| b.value));
-  let glob_case_sensitive = parse_import_meta_glob_case_sensitive(glob_options, parser);
+  options.case_sensitive = parse_import_meta_glob_case_sensitive(glob_options, parser);
+  let mode = if options.eager {
+    ContextMode::Sync
+  } else {
+    ContextMode::Lazy
+  };
+  let glob_import = options.import;
+  let glob_query = options
+    .query
+    .map_or_else(String::new, ImportMetaGlobQuery::into_query_string);
+  let base = options.base;
+  let glob_exhaustive = options.exhaustive;
+  let glob_case_sensitive = options.case_sensitive;
   let context = resolve_import_meta_glob_context(
     importer_context.as_str(),
     parser.compiler_options.context.as_str(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -502,6 +502,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           referenced_specifiers: None,
           glob_import: None,
           glob_exhaustive: false,
+          glob_case_sensitive: true,
           attributes,
           phase: Some(phase),
         },

--- a/crates/rspack_plugin_javascript/src/utils/ast_deserializer.rs
+++ b/crates/rspack_plugin_javascript/src/utils/ast_deserializer.rs
@@ -1,0 +1,514 @@
+//! A serde [`Deserializer`] over swc AST expressions.
+//!
+//! Parser plugins frequently need to read options objects from call
+//! expressions (e.g. `import.meta.glob(pattern, options)`). Instead of
+//! hand-rolling property lookups for every option, the options can be
+//! declared as a plain `#[derive(Deserialize)]` struct and extracted with
+//! [`from_expr`], similar to validating with zod in TypeScript:
+//!
+//! ```ignore
+//! #[derive(Debug, Default, Deserialize)]
+//! #[serde(rename_all = "camelCase", default)]
+//! struct GlobOptions {
+//!   #[serde(deserialize_with = "lenient")]
+//!   eager: bool,
+//!   #[serde(deserialize_with = "lenient")]
+//!   import: Option<String>,
+//! }
+//!
+//! let options = from_expr::<GlobOptions>(&arg.expr).unwrap_or_default();
+//! ```
+//!
+//! The semantics intentionally match the previous hand-rolled behavior:
+//! - only statically resolvable values are recognized: string/bool/number
+//!   literals, template literals without substitutions, regex literals and
+//!   nested object literals; anything else is invisible to the schema;
+//! - object properties whose key is not statically resolvable are skipped;
+//! - with the [`lenient`] field attribute, an unrecognized value falls back
+//!   to the field's default instead of failing the whole options object.
+
+use std::{fmt, marker::PhantomData, slice};
+
+use serde::{
+  Deserialize, Deserializer,
+  de::{
+    self, DeserializeSeed, Error, MapAccess, Visitor,
+    value::{BorrowedStrDeserializer, StringDeserializer, U32Deserializer},
+  },
+  forward_to_deserialize_any,
+};
+use swc_experimental_ecma_ast::{Expr, Lit, ObjectLit, PropName, PropOrSpread, Regex, Span};
+
+use crate::visitors::static_string_from_expr;
+
+/// Error type of [`ExprDeserializer`].
+#[derive(Debug)]
+pub struct AstDeError {
+  message: String,
+}
+
+impl fmt::Display for AstDeError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "failed to deserialize options object: {}", self.message)
+  }
+}
+
+impl std::error::Error for AstDeError {}
+
+impl de::Error for AstDeError {
+  fn custom<T: fmt::Display>(msg: T) -> Self {
+    Self {
+      message: msg.to_string(),
+    }
+  }
+}
+
+/// Deserialize `T` from an AST expression, typically the options argument of
+/// a call expression. Returns an error if the expression is not statically
+/// deserializable as `T`; call sites usually apply `.unwrap_or_default()` to
+/// fall back to the default options, matching the previous behavior where a
+/// non-object argument was simply ignored.
+pub fn from_expr<'de, 'a, T>(expr: &'de Expr<'a>) -> Result<T, AstDeError>
+where
+  T: Deserialize<'de>,
+{
+  T::deserialize(ExprDeserializer {
+    expr,
+    _ast: PhantomData,
+  })
+}
+
+/// A `deserialize_with` helper for options fields: an unrecognized value
+/// falls back to `T::default()` instead of failing the whole options object,
+/// matching the previous behavior where unmatched properties were ignored.
+pub fn lenient<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+  D: Deserializer<'de>,
+  T: Deserialize<'de> + Default,
+{
+  Ok(T::deserialize(deserializer).unwrap_or_default())
+}
+
+struct ExprDeserializer<'de, 'a> {
+  expr: &'de Expr<'a>,
+  _ast: PhantomData<&'a ()>,
+}
+
+impl<'de, 'a> Deserializer<'de> for ExprDeserializer<'de, 'a> {
+  type Error = AstDeError;
+
+  fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: Visitor<'de>,
+  {
+    let expr = self.expr;
+    if let Some(lit) = expr.as_lit() {
+      return match lit {
+        Lit::Bool(bool) => visitor.visit_bool(bool.value),
+        Lit::Str(str) => visitor.visit_string(str.value.to_string_lossy().into_owned()),
+        Lit::Num(num) => visitor.visit_f64(num.value),
+        Lit::Null(_) => visitor.visit_unit(),
+        Lit::Regex(regex) => visitor.visit_map(RegexMapAccess::new(regex)),
+        Lit::BigInt(_) => Err(Error::custom("bigint literals are not supported")),
+      };
+    }
+    if let Some(obj) = expr.as_object() {
+      return visitor.visit_map(PropsAccess::new(obj));
+    }
+    if let Some(tpl) = expr.as_tpl()
+      && tpl.exprs.is_empty()
+      && tpl.quasis.len() == 1
+      && let Some(el) = tpl.quasis.first()
+    {
+      return visitor.visit_string(el.raw.to_string());
+    }
+    if is_undefined(expr) {
+      return visitor.visit_unit();
+    }
+    Err(Error::custom("expression is not statically deserializable"))
+  }
+
+  fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: Visitor<'de>,
+  {
+    if is_undefined(self.expr) || matches!(self.expr.as_lit(), Some(Lit::Null(_))) {
+      visitor.visit_none()
+    } else {
+      visitor.visit_some(self)
+    }
+  }
+
+  fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+  where
+    V: Visitor<'de>,
+  {
+    if let Some(obj) = self.expr.as_object() {
+      visitor.visit_map(PropsAccess::new(obj))
+    } else {
+      Err(Error::custom("expected an object literal"))
+    }
+  }
+
+  fn deserialize_struct<V>(
+    self,
+    _name: &'static str,
+    _fields: &'static [&'static str],
+    visitor: V,
+  ) -> Result<V::Value, Self::Error>
+  where
+    V: Visitor<'de>,
+  {
+    self.deserialize_map(visitor)
+  }
+
+  forward_to_deserialize_any! {
+    bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes byte_buf
+    unit unit_struct newtype_struct seq tuple tuple_struct enum identifier
+    ignored_any
+  }
+}
+
+fn is_undefined(expr: &Expr) -> bool {
+  expr
+    .as_ident()
+    .is_some_and(|ident| ident.sym == "undefined")
+}
+
+struct PropsAccess<'de, 'a> {
+  props: slice::Iter<'de, PropOrSpread<'a>>,
+  pending_value: Option<&'de Expr<'a>>,
+}
+
+impl<'de, 'a> PropsAccess<'de, 'a> {
+  fn new(obj: &'de ObjectLit<'a>) -> Self {
+    Self {
+      props: obj.props.iter(),
+      pending_value: None,
+    }
+  }
+}
+
+impl<'de, 'a> MapAccess<'de> for PropsAccess<'de, 'a> {
+  type Error = AstDeError;
+
+  fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+  where
+    K: DeserializeSeed<'de>,
+  {
+    for prop in self.props.by_ref() {
+      // Spread, shorthand, getter/setter and method properties are not
+      // options entries.
+      let Some(kv) = prop.as_prop().and_then(|prop| prop.as_key_value()) else {
+        continue;
+      };
+      // Properties whose key is not statically resolvable are invisible.
+      let Some(key) = static_prop_name(&kv.key) else {
+        continue;
+      };
+      self.pending_value = Some(&kv.value);
+      return seed
+        .deserialize(StringDeserializer::<AstDeError>::new(key))
+        .map(Some);
+    }
+    Ok(None)
+  }
+
+  fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+  where
+    V: DeserializeSeed<'de>,
+  {
+    let value = self
+      .pending_value
+      .take()
+      .expect("next_value_seed called before next_key_seed");
+    seed.deserialize(ExprDeserializer {
+      expr: value,
+      _ast: PhantomData,
+    })
+  }
+}
+
+/// Statically resolve an object literal property name, mirroring the key
+/// handling of the previous hand-rolled options parsing.
+fn static_prop_name(key: &PropName) -> Option<String> {
+  match key {
+    PropName::Ident(ident) => Some(ident.sym.to_string()),
+    PropName::Str(str) => Some(str.value.to_string_lossy().into_owned()),
+    PropName::Num(num) => Some(num.value.to_string()),
+    PropName::Computed(computed) => {
+      if let Some(key) = static_string_from_expr(&computed.expr) {
+        return Some(key);
+      }
+      match computed.expr.as_lit()? {
+        Lit::Num(num) => Some(num.value.to_string()),
+        Lit::Bool(bool) => Some(bool.value.to_string()),
+        Lit::Null(_) => Some("null".to_string()),
+        _ => None,
+      }
+    }
+    PropName::BigInt(_) => None,
+  }
+}
+
+/// A regex literal extracted from an options object, with its source span
+/// preserved for later diagnostics.
+#[derive(Debug)]
+pub struct AstRegex {
+  pub exp: String,
+  pub flags: String,
+  pub span: Span,
+}
+
+impl<'de> Deserialize<'de> for AstRegex {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_any(AstRegexVisitor)
+  }
+}
+
+struct AstRegexVisitor;
+
+impl<'de> Visitor<'de> for AstRegexVisitor {
+  type Value = AstRegex;
+
+  fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    formatter.write_str("a regex literal")
+  }
+
+  fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+  where
+    A: MapAccess<'de>,
+  {
+    let mut exp = None;
+    let mut flags = None;
+    let mut start = None;
+    let mut end = None;
+    while let Some(key) = map.next_key::<String>()? {
+      match key.as_str() {
+        "exp" => exp = Some(map.next_value::<String>()?),
+        "flags" => flags = Some(map.next_value::<String>()?),
+        "start" => start = Some(map.next_value::<u32>()?),
+        "end" => end = Some(map.next_value::<u32>()?),
+        _ => {
+          map.next_value::<de::IgnoredAny>()?;
+        }
+      }
+    }
+    Ok(AstRegex {
+      exp: exp.ok_or_else(|| de::Error::missing_field("exp"))?,
+      flags: flags.ok_or_else(|| de::Error::missing_field("flags"))?,
+      span: Span::new(
+        start.ok_or_else(|| de::Error::missing_field("start"))?,
+        end.ok_or_else(|| de::Error::missing_field("end"))?,
+      ),
+    })
+  }
+}
+
+/// A [`MapAccess`] that presents a regex literal as a synthesized map of
+/// `exp`/`flags`/`start`/`end`, so that [`AstRegex`] can be deserialized
+/// through the regular serde data model.
+struct RegexMapAccess<'de, 'a> {
+  regex: &'de Regex<'a>,
+  pending: Option<u8>,
+  index: u8,
+}
+
+impl<'de, 'a> RegexMapAccess<'de, 'a> {
+  const KEYS: [&'static str; 4] = ["exp", "flags", "start", "end"];
+
+  fn new(regex: &'de Regex<'a>) -> Self {
+    Self {
+      regex,
+      pending: None,
+      index: 0,
+    }
+  }
+}
+
+impl<'de, 'a> MapAccess<'de> for RegexMapAccess<'de, 'a> {
+  type Error = AstDeError;
+
+  fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+  where
+    K: DeserializeSeed<'de>,
+  {
+    let Some(&key) = Self::KEYS.get(self.index as usize) else {
+      return Ok(None);
+    };
+    self.pending = Some(self.index);
+    self.index += 1;
+    seed
+      .deserialize(BorrowedStrDeserializer::<AstDeError>::new(key))
+      .map(Some)
+  }
+
+  fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+  where
+    V: DeserializeSeed<'de>,
+  {
+    match self.pending.take() {
+      Some(0) => seed.deserialize(StringDeserializer::<AstDeError>::new(
+        self.regex.exp.to_string(),
+      )),
+      Some(1) => seed.deserialize(StringDeserializer::<AstDeError>::new(
+        self.regex.flags.to_string(),
+      )),
+      Some(2) => seed.deserialize(U32Deserializer::<AstDeError>::new(self.regex.span.start)),
+      Some(3) => seed.deserialize(U32Deserializer::<AstDeError>::new(self.regex.span.end)),
+      _ => unreachable!("next_value_seed called before next_key_seed"),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use indexmap::IndexMap;
+  use rustc_hash::FxBuildHasher;
+  use serde::Deserialize;
+  use swc_experimental_allocator::Allocator;
+  use swc_experimental_ecma_ast::EsVersion;
+  use swc_experimental_ecma_parser::{
+    EsSyntax, Lexer, Parser, StringSource, Syntax, unstable::Capturing,
+  };
+
+  use super::*;
+
+  fn parse_expr<'a>(allocator: &'a Allocator, source: &'a str) -> Expr<'a> {
+    let lexer = Lexer::new(
+      allocator,
+      Syntax::Es(EsSyntax::default()),
+      EsVersion::EsNext,
+      StringSource::new(source),
+      None,
+    );
+    let lexer = Capturing::new(lexer);
+    let mut parser = Parser::new_from(allocator, lexer);
+    parser
+      .parse_expr()
+      .expect("failed to parse test expression")
+  }
+
+  #[derive(Debug, Default, PartialEq, Deserialize)]
+  #[serde(rename_all = "camelCase", default)]
+  struct TestOptions {
+    #[serde(deserialize_with = "lenient")]
+    eager: bool,
+    #[serde(deserialize_with = "lenient")]
+    case_sensitive: Option<bool>,
+    #[serde(deserialize_with = "lenient")]
+    import: Option<String>,
+  }
+
+  #[test]
+  fn deserializes_camel_case_fields_and_defaults() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ eager: true, caseSensitive: false }");
+    let options = from_expr::<TestOptions>(&expr).unwrap();
+    assert_eq!(
+      options,
+      TestOptions {
+        eager: true,
+        case_sensitive: Some(false),
+        import: None,
+      }
+    );
+
+    let expr = parse_expr(&allocator, "{}");
+    assert_eq!(
+      from_expr::<TestOptions>(&expr).unwrap(),
+      TestOptions::default()
+    );
+  }
+
+  #[test]
+  fn unrecognized_values_fall_back_to_default() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ eager: \"yes\", import: 1 }");
+    assert_eq!(
+      from_expr::<TestOptions>(&expr).unwrap(),
+      TestOptions::default()
+    );
+
+    let expr = parse_expr(&allocator, "true");
+    assert!(from_expr::<TestOptions>(&expr).is_err());
+  }
+
+  #[test]
+  fn resolves_template_literal_and_static_computed_keys() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ import: `default` }");
+    assert_eq!(
+      from_expr::<TestOptions>(&expr).unwrap().import,
+      Some("default".to_string())
+    );
+
+    let expr = parse_expr(&allocator, "{ [\"eager\"]: true }");
+    assert!(from_expr::<TestOptions>(&expr).unwrap().eager);
+  }
+
+  #[test]
+  fn undefined_and_null_mean_absent() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ import: undefined, caseSensitive: null }");
+    let options = from_expr::<TestOptions>(&expr).unwrap();
+    assert_eq!(options.import, None);
+    assert_eq!(options.case_sensitive, None);
+  }
+
+  #[test]
+  fn skips_properties_with_unresolvable_keys() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ [Symbol()]: 1, eager: true }");
+    assert!(from_expr::<TestOptions>(&expr).unwrap().eager);
+  }
+
+  #[derive(Debug, Deserialize)]
+  #[serde(untagged)]
+  enum TestScalar {
+    String(String),
+    Number(f64),
+    Bool(bool),
+  }
+
+  #[test]
+  fn record_preserves_source_order() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ b: 1, a: 'x', c: true }");
+    let record = from_expr::<IndexMap<String, TestScalar, FxBuildHasher>>(&expr).unwrap();
+    let keys = record.keys().collect::<Vec<_>>();
+    assert_eq!(keys, ["b", "a", "c"]);
+    assert!(matches!(record["b"], TestScalar::Number(1.0)));
+    assert!(matches!(&record["a"], TestScalar::String(value) if value == "x"));
+    assert!(matches!(record["c"], TestScalar::Bool(true)));
+  }
+
+  #[derive(Debug, Default, Deserialize)]
+  #[serde(rename_all = "camelCase", default)]
+  struct TestRegexOptions {
+    #[serde(deserialize_with = "lenient")]
+    reg_exp: Option<AstRegex>,
+  }
+
+  #[test]
+  fn deserializes_regex_literals_with_span() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(&allocator, "{ regExp: /abc/gi }");
+    let options = from_expr::<TestRegexOptions>(&expr).unwrap();
+    let regex = options.reg_exp.expect("expected a regex");
+    assert_eq!(regex.exp, "abc");
+    assert_eq!(regex.flags, "gi");
+    assert_eq!(regex.span.end - regex.span.start, "/abc/gi".len() as u32);
+
+    let expr = parse_expr(&allocator, "{ regExp: \"nope\" }");
+    assert!(
+      from_expr::<TestRegexOptions>(&expr)
+        .unwrap()
+        .reg_exp
+        .is_none()
+    );
+  }
+}

--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod ast_deserializer;
 pub mod eval;
 pub mod mangle_exports;
 pub mod object_properties;

--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -179,6 +179,7 @@ declare namespace Rspack {
     query?: ImportMetaGlobQuery;
     exhaustive?: boolean;
     base?: string;
+    caseSensitive?: boolean;
   };
 
   interface Module {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/case-test/alpha.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/case-test/alpha.js
@@ -1,0 +1,1 @@
+export default 'alpha'

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -106,6 +106,11 @@ const filteredDefaultModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], {
 const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], {
   import: 'named',
 })
+const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
+const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: false,
+})
 const quotedModules = import.meta.glob("./quoted/*.js", { eager: true })
 const escapeModules = import.meta.glob('./escape/**/glob.js', { eager: true })
 
@@ -313,6 +318,12 @@ it('should parse glob calls with comments in the argument list', async () => {
 it('should work when glob results are wrapped with Object.keys and Object.values', () => {
   expect(objectKeyModules.sort()).toEqual(dirKeys)
   expect(objectValueModules.map(mod => mod.default).sort()).toEqual(['bar', 'foo'])
+})
+
+it('should match case-insensitively only when caseSensitive is false', () => {
+  expect(Object.keys(caseSensitiveModules)).toEqual([])
+  expect(Object.keys(caseInsensitiveModules)).toEqual(['./case-test/alpha.js'])
+  expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
 })
 
 it('should handle matched paths containing single quotes', () => {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -109,7 +109,7 @@ const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], 
 const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
 const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,
-  caseSensitive: !true,
+  caseSensitive: false,
 })
 const numberCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,

--- a/tests/rspack-test/normalCases/context/import-meta-glob/index.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/index.js
@@ -109,7 +109,15 @@ const lazyFilteredNamedModules = import.meta.glob(['./dir/*.js', '!**/bar.js'], 
 const caseSensitiveModules = import.meta.glob('./case-test/*.JS', { eager: true })
 const caseInsensitiveModules = import.meta.glob('./case-test/*.JS', {
   eager: true,
-  caseSensitive: false,
+  caseSensitive: !true,
+})
+const numberCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: 0,
+})
+const stringCaseSensitiveModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: '',
 })
 const quotedModules = import.meta.glob("./quoted/*.js", { eager: true })
 const escapeModules = import.meta.glob('./escape/**/glob.js', { eager: true })
@@ -324,6 +332,11 @@ it('should match case-insensitively only when caseSensitive is false', () => {
   expect(Object.keys(caseSensitiveModules)).toEqual([])
   expect(Object.keys(caseInsensitiveModules)).toEqual(['./case-test/alpha.js'])
   expect(caseInsensitiveModules['./case-test/alpha.js'].default).toBe('alpha')
+})
+
+it('should use case-sensitive matching for non-boolean caseSensitive values', () => {
+  expect(Object.keys(numberCaseSensitiveModules)).toEqual([])
+  expect(Object.keys(stringCaseSensitiveModules)).toEqual([])
 })
 
 it('should handle matched paths containing single quotes', () => {

--- a/tests/rspack-test/normalCases/context/import-meta-glob/warnings.js
+++ b/tests/rspack-test/normalCases/context/import-meta-glob/warnings.js
@@ -1,0 +1,8 @@
+module.exports = [
+  [
+    /import\.meta\.glob\(\) 'caseSensitive' option must be a constant boolean \(true or false\), defaulting to true/,
+  ],
+  [
+    /import\.meta\.glob\(\) 'caseSensitive' option must be a constant boolean \(true or false\), defaulting to true/,
+  ],
+]

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/case-test/alpha.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/case-test/alpha.js
@@ -1,0 +1,1 @@
+export default 'alpha'

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
@@ -2,7 +2,17 @@ const modules = import.meta.glob('./*.JS', {
   eager: true,
   caseSensitive: 'yes',
 })
+const staticallyEvaluatedModules = import.meta.glob('./case-test/*.JS', {
+  eager: true,
+  caseSensitive: !true,
+})
 
 it('should warn and default to case-sensitive matching for an invalid value', () => {
   expect(Object.keys(modules)).toEqual([])
+})
+
+it('should evaluate a static boolean caseSensitive expression', () => {
+  expect(Object.keys(staticallyEvaluatedModules)).toEqual([
+    './case-test/alpha.js',
+  ])
 })

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/index.js
@@ -1,0 +1,8 @@
+const modules = import.meta.glob('./*.JS', {
+  eager: true,
+  caseSensitive: 'yes',
+})
+
+it('should warn and default to case-sensitive matching for an invalid value', () => {
+  expect(Object.keys(modules)).toEqual([])
+})

--- a/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/warnings.js
+++ b/tests/rspack-test/normalCases/parsing/import-meta-glob-case-sensitive/warnings.js
@@ -1,0 +1,5 @@
+module.exports = [
+  [
+    /import\.meta\.glob\(\) 'caseSensitive' option must be a constant boolean \(true or false\), defaulting to true/,
+  ],
+]

--- a/tests/type-tests/resolution-bundler/index.ts
+++ b/tests/type-tests/resolution-bundler/index.ts
@@ -69,6 +69,7 @@ const multiGlobModules = import.meta.glob<GlobModule>(
     },
     base: './base',
     exhaustive: true,
+    caseSensitive: false,
   },
 );
 multiGlobModules['./dir/foo.js'].default.toUpperCase();

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -236,6 +236,12 @@ interface ImportMetaGlobOptions<Eager extends boolean = boolean> {
    * Base path for resolving relative glob patterns and returned keys.
    */
   base?: string;
+  /**
+   * Match file paths case-sensitively.
+   *
+   * @default true
+   */
+  caseSensitive?: boolean;
 }
 
 function glob(
@@ -262,6 +268,7 @@ function glob(
   - `options.query`: Append a query to each matched module request. It can be a query string such as `'?raw'`, or an object that is serialized as a URL query string. The keys returned from `import.meta.glob()` do not include the query.
   - `options.exhaustive`: Search files inside `node_modules` and hidden paths. This is disabled by default because it can increase build time.
   - `options.base`: Base path for resolving relative glob patterns and returned keys. Absolute glob patterns are still resolved from the project root, while returned keys are made relative to `base`.
+  - `options.caseSensitive`: Whether to match file paths case-sensitively. When set to `false`, matching ignores case, while returned object keys preserve the filesystem's original casing. Defaults to `true`.
 
 - **Example:**
 

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -236,6 +236,12 @@ interface ImportMetaGlobOptions<Eager extends boolean = boolean> {
    * 用于解析相对 glob 模式和返回 key 的 base 路径。
    */
   base?: string;
+  /**
+   * 是否区分文件路径大小写。
+   *
+   * @default true
+   */
+  caseSensitive?: boolean;
 }
 
 function glob(
@@ -262,6 +268,7 @@ function glob(
   - `options.query`：为每个匹配模块请求追加 query。可以是 `'?raw'` 这样的 query 字符串，也可以是会序列化为 URL query 字符串的对象。`import.meta.glob()` 返回对象中的 key 不包含 query。
   - `options.exhaustive`：搜索 `node_modules` 和隐藏路径中的文件。默认关闭，因为可能增加构建时间。
   - `options.base`：用于解析相对 glob 模式和返回 key 的 base 路径。绝对 glob 模式仍从项目根目录解析，但返回 key 会相对于 `base`。
+  - `options.caseSensitive`：是否区分文件路径大小写。设置为 `false` 时忽略大小写匹配，返回对象的 key 保留文件系统原始大小写。默认为 `true`。
 
 - **示例：**
 


### PR DESCRIPTION
## Summary

Replaces the hand-rolled object-literal options parsing in the import.meta
context dependency parser (`import.meta.glob()` and
`import.meta.webpackContext()`) with a serde `Deserializer` over the swc AST,
similar to declaring a zod schema in TypeScript.

- Adds `utils/ast_deserializer.rs`: a serde `Deserializer` for AST
  expressions. Options objects are now declared as plain
  `#[derive(Deserialize)]` structs mirroring the TypeScript declarations in
  `packages/rspack/module.d.ts`, instead of per-property
  `get_*_by_obj_prop` lookups.
- Supports string/bool/number literals, template literals without
  substitutions, nested objects, regex literals (with span preserved for
  diagnostics), `undefined`/`null` as absent, and statically resolved
  (computed) property names. Records deserialize into `IndexMap`/`HashMap`,
  which the future partially-known `import(..., { with })` attributes can
  also build on (struct + `#[serde(flatten)]`).
- A `lenient` field attribute falls back to the field default on
  unrecognized values, preserving the previous "ignore invalid values"
  semantics. `caseSensitive` stays manual because it needs expression
  evaluation and a per-field warning.
- Collapses the duplicated default branches of
  `create_import_meta_context_dependency` into a single parse.

Behavior notes (edge cases only, all aligned with JS runtime semantics):
no-substitution template strings are now accepted for all string options,
statically resolvable computed keys can match known options, unresolvable
keys in `query` records are skipped instead of poisoning the whole query,
and duplicate keys are now last-wins.

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).