### PR TITLE
feat: enable createRequire parser by default for node targets

### DIFF
--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -1070,16 +1070,7 @@ impl CompilerOptionsBuilder {
 
     w!(self.externals_type, {
       if let Some(library) = &output.library {
-        // Keep modern-module libraries on the existing output.module default
-        // for compatibility. `externalsType: "modern-module"` must be enabled
-        // explicitly for now, and will become the default in the next major.
-        if library.library_type != "modern-module" {
-          library.library_type.clone()
-        } else if output.module {
-          "module-import".to_string()
-        } else {
-          "var".to_string()
-        }
+        library.library_type.clone()
       } else if output.module {
         "module-import".to_string()
       } else {

--- a/crates/rspack/tests/defaults.rs
+++ b/crates/rspack/tests/defaults.rs
@@ -40,7 +40,7 @@ async fn default_stats_colors_follows_environment() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn modern_module_library_keeps_module_import_externals_default() {
+async fn modern_module_library_uses_modern_module_externals_default() {
   let mut builder_context = BuilderContext::default();
   CompilerOptionsBuilder::default()
     .mode(Mode::None)
@@ -62,11 +62,11 @@ async fn modern_module_library_keeps_module_import_externals_default() {
 
   let builder_context = format!("{builder_context:?}");
   assert!(
-    builder_context.contains(r#"ExternalsPlugin(("module-import""#),
-    "modern-module libraries should keep the module-import externals default until the next major"
+    builder_context.contains(r#"ExternalsPlugin(("modern-module""#),
+    "modern-module libraries should use modern-module externals by default"
   );
   assert!(
-    !builder_context.contains(r#"ExternalsPlugin(("modern-module""#),
-    "modern-module externals should require an explicit externals_type opt-in"
+    !builder_context.contains(r#"ExternalsPlugin(("module-import""#),
+    "modern-module libraries should not use module-import externals by default"
   );
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -321,10 +321,12 @@ const applyJavascriptParserOptionsDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    isNode,
   }: {
     deferImport?: boolean;
     sourceImport?: boolean;
     outputModule: RspackOptionsNormalized['output']['module'];
+    isNode: boolean;
   },
 ) => {
   D(parserOptions, 'dynamicImportMode', 'lazy');
@@ -350,7 +352,7 @@ const applyJavascriptParserOptionsDefaults = (
   D(parserOptions, 'deferImport', deferImport);
   D(parserOptions, 'sourceImport', sourceImport);
   D(parserOptions, 'importMetaResolve', false);
-  D(parserOptions, 'createRequire', false);
+  D(parserOptions, 'createRequire', isNode);
 };
 
 const applyCssGeneratorOptionsDefaults = (
@@ -464,6 +466,7 @@ const applyModuleDefaults = (
     deferImport,
     sourceImport,
     outputModule,
+    isNode: targetProperties !== false && targetProperties.node === true,
   });
 
   F(module.parser, JSON_MODULE_TYPE, () => ({}));

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -149,13 +149,8 @@ export const applyRspackOptionsDefaults = (
 
   F(options, 'externalsType', () => {
     if (options.output.library?.type) {
-      // Keep modern-module libraries on the existing output.module default for
-      // compatibility. `externalsType: "modern-module"` must be enabled
-      // explicitly for now, and will become the default in the next major.
-      if (options.output.library.type !== 'modern-module') {
-        // loose type 'string', actual type is "commonjs" | "var" | "commonjs2"....
-        return options.output.library.type as any;
-      }
+      // loose type 'string', actual type is "commonjs" | "var" | "commonjs2"....
+      return options.output.library.type as any;
     }
     return options.output.module ? 'module-import' : 'var';
   });

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1403,7 +1403,7 @@ export type JavascriptParserOptions = {
 
   /**
    * Enable or disable parsing `import { createRequire } from "module"` and evaluating createRequire().
-   * @default false
+   * @default true for Node.js-compatible targets, otherwise false
    */
   createRequire?: boolean | string;
 

--- a/tests/rspack-test/configCases/require/module-require/rspack.config.js
+++ b/tests/rspack-test/configCases/require/module-require/rspack.config.js
@@ -50,13 +50,6 @@ module.exports = {
     path: 'node-commonjs path',
   },
   target: 'node',
-  module: {
-    parser: {
-      javascript: {
-        createRequire: true,
-      },
-    },
-  },
   optimization: {
     inlineExports: true,
     moduleIds: 'named',

--- a/tests/rspack-test/defaultsCases/target_/electron-main.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-main.js
@@ -37,6 +37,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/electron-preload.js
+++ b/tests/rspack-test/defaultsCases/target_/electron-preload.js
@@ -35,6 +35,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/node-require-resolve-disabled.js
+++ b/tests/rspack-test/defaultsCases/target_/node-require-resolve-disabled.js
@@ -1,0 +1,22 @@
+/** @type {import('@rspack/test-tools').TDefaultsCaseConfig} */
+module.exports = {
+	description: "target node with requireResolve disabled",
+	options: () => ({
+		target: "node",
+		module: {
+			parser: {
+				javascript: {
+					requireResolve: false
+				}
+			}
+		}
+	}),
+	diff: e => {
+		e.toEqual({
+			value: expect.stringMatching(/\+\s+"requireResolve": false/)
+		});
+		e.toEqual({
+			value: expect.stringMatching(/\+\s+"createRequire": true/)
+		});
+	}
+};

--- a/tests/rspack-test/defaultsCases/target_/node.js
+++ b/tests/rspack-test/defaultsCases/target_/node.js
@@ -32,6 +32,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/defaultsCases/target_/nwjs.js
+++ b/tests/rspack-test/defaultsCases/target_/nwjs.js
@@ -31,6 +31,9 @@ module.exports = {
 			-         "exportsOnly": false,
 			+         "exportsOnly": true,
 			@@ ... @@
+			-         "createRequire": false,
+			+         "createRequire": true,
+			@@ ... @@
 			-     "__dirname": "warn-mock",
 			-     "__filename": "warn-mock",
 			-     "global": "warn",

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve-disabled/rspack.config.js
@@ -2,7 +2,6 @@ module.exports = {
   module: {
     parser: {
       javascript: {
-        createRequire: true,
         requireResolve: false,
       },
     },

--- a/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/create-require/import-meta-url-resolve/rspack.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  module: {
-    parser: {
-      javascript: {
-        createRequire: true,
-      },
-    },
-  },
-};

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-default-node/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-default-node/test.config.js
@@ -21,7 +21,9 @@ module.exports = {
 
 		expect(source).toMatch(/import\s*\{\s*resolve\s*\}\s*from\s*["']path["']/);
 		expect(source).toMatch(/import\s*\(\s*["']os["']\s*\)/);
-		expect(source).toMatch(/from\s*["']fs["']/);
-		expect(source).not.toContain("createRequire");
+		expect(source).toMatch(/createRequire\s+as\s+__rspack_createRequire/);
+		expect(source).toMatch(
+			/__rspack_createRequire_require\s*\(\s*["']fs["']\s*\)/
+		);
 	}
 };

--- a/tests/rspack-test/esmOutputCases/externals/modern-module-default-web/test.config.js
+++ b/tests/rspack-test/esmOutputCases/externals/modern-module-default-web/test.config.js
@@ -21,7 +21,7 @@ module.exports = {
 
 		expect(source).toMatch(/import\s*\{\s*resolve\s*\}\s*from\s*["']path["']/);
 		expect(source).toMatch(/import\s*\(\s*["']os["']\s*\)/);
-		expect(source).toMatch(/from\s*["']fs["']/);
+		expect(source).toMatch(/require\s*\(\s*["']fs["']\s*\)/);
 		expect(source).not.toContain("createRequire");
 	}
 };

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -555,7 +555,7 @@ export default {
 
 Specify the default type of externals as `'modern-module'`.
 
-For compatibility, Rspack does not enable this automatically when [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'` yet. Configure `externalsType: 'modern-module'` explicitly to opt in. This will become the default for `modern-module` libraries in the next major version.
+This is the default when [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`.
 
 For static ESM imports, Rspack renders the external like [`'module'`](#externalstypemodule), using a static `import` statement. For dynamic `import()`, Rspack renders the external like [`'module-import'`](#externalstypemodule-import), using `import()`.
 

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -669,12 +669,11 @@ export default {
 
 ### javascript.createRequire
 
-<PropertyType
-  type="boolean | string"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
+<PropertyType type="boolean | string" />
 
 Control whether Rspack parses `createRequire()` from Node.js `module` and turns the created `require` function into a statically analyzable dependency context.
+
+This option defaults to `true` for Node.js-compatible targets and `false` for other targets.
 
 When set to `true`, it is equivalent to `"createRequire from module"`. Rspack recognizes imports from both `module` and `node:module` for this default form.
 

--- a/website/docs/en/guide/features/esm.mdx
+++ b/website/docs/en/guide/features/esm.mdx
@@ -72,7 +72,7 @@ In other words, the focus has been shifting from "can Rspack emit ESM at all?" t
 Below are the main configuration options related to ESM and their descriptions, which are used when building both applications and libraries.
 
 1. [output.module](/config/output#outputmodule): Set to `true` to generate ESM format output. When this option is enabled, it affects the following configurations:
-   1. Affects [externalsType](/config/externals#externalstype) default value: When `output.module` is `true`, `externalsType` defaults to `'module-import'`. For compatibility, `output.library.type: 'modern-module'` currently keeps this default unless you explicitly configure `externalsType: 'modern-module'`; `modern-module` externals will become the default for `modern-module` libraries in the next major version.
+   1. Affects [externalsType](/config/externals#externalstype) default value: When `output.library.type` is `'modern-module'`, `externalsType` defaults to `'modern-module'`. Otherwise, when `output.module` is `true`, `externalsType` defaults to `'module-import'`.
    2. Affects [output.filename](/config/output#outputfilename) default value: When `output.module` is `true`, the default filename is `'[name].mjs'` instead of `'[name].js'`
    3. Affects [output.chunkFilename](/config/output#outputchunkfilename) default value: When `output.module` is `true`, chunk filename defaults to `'[id].mjs'` instead of `'[id].js'`
    4. Affects [output.hotUpdateChunkFilename](/config/output#outputhotupdatechunkfilename) default value: When `output.module` is `true`, defaults to `'[id].[fullhash].hot-update.mjs'`

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -554,7 +554,7 @@ export default {
 
 将 externals 的默认类型指定为 `'modern-module'`。
 
-出于兼容性考虑，Rspack 暂时不会在 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时自动启用它。请显式配置 `externalsType: 'modern-module'` 来开启。下一个 major 版本中，它会成为 `modern-module` library 的默认值。
+当 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，这是默认值。
 
 对于静态 ESM import，Rspack 会像 [`'module'`](#externalstypemodule) 一样渲染 external，生成静态 `import` 语句。对于动态 `import()`，Rspack 会像 [`'module-import'`](#externalstypemodule-import) 一样渲染 external，生成 `import()`。
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -668,12 +668,11 @@ export default {
 
 ### javascript.createRequire
 
-<PropertyType
-  type="boolean | string"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
+<PropertyType type="boolean | string" />
 
 控制 Rspack 是否解析来自 Node.js `module` 的 `createRequire()`，并将创建出的 `require` 函数转换为可静态分析的依赖上下文。
+
+对于兼容 Node.js 的 target，该选项默认为 `true`。对于其他 target，该选项默认为 `false`。
 
 当设置为 `true` 时，等价于 `"createRequire from module"`。对于这种默认形式，Rspack 会同时识别来自 `module` 和 `node:module` 的导入。
 

--- a/website/docs/zh/guide/features/esm.mdx
+++ b/website/docs/zh/guide/features/esm.mdx
@@ -70,7 +70,7 @@ export default {
 下面列出了与 ESM 相关的主要配置选项及其说明，这些配置在构建应用和库时都会用到。
 
 1. [output.module](/config/output#outputmodule): 设置为 `true`，表示生成 ESM 格式的产物。开启此选项后，会对以下配置产生影响：
-   1. 影响 [externalsType](/config/externals#externalstype) 默认值：当 `output.module` 为 `true` 时，`externalsType` 默认为 `'module-import'`。出于兼容性考虑，`output.library.type: 'modern-module'` 当前仍保持这个默认值，除非显式配置 `externalsType: 'modern-module'`；下一个 major 版本中，`modern-module` externals 会成为 `modern-module` library 的默认值。
+   1. 影响 [externalsType](/config/externals#externalstype) 默认值：当 `output.library.type` 为 `'modern-module'` 时，`externalsType` 默认为 `'modern-module'`。其他情况下，当 `output.module` 为 `true` 时，`externalsType` 默认为 `'module-import'`。
    2. 影响 [output.filename](/config/output#outputfilename) 默认值：当 `output.module` 为 `true` 时，默认文件名为 `'[name].mjs'` 而不是 `'[name].js'`
    3. 影响 [output.chunkFilename](/config/output#outputchunkfilename) 默认值：当 `output.module` 为 `true` 时，chunk 文件名默认为 `'[id].mjs'` 而不是 `'[id].js'`
    4. 影响 [output.hotUpdateChunkFilename](/config/output#outputhotupdatechunkfilename) 默认值：当 `output.module` 为 `true` 时，默认为 `'[id].[fullhash].hot-update.mjs'`


### PR DESCRIPTION
## Summary

- default `module.parser.javascript.createRequire` to `true` when the resolved target is Node.js-compatible, matching webpack's `createRequire = isNode` default
- keep the default independent from `javascript.requireResolve`; explicit `createRequire` configuration still takes precedence
- default `externalsType` to `modern-module` when `output.library.type` is `modern-module`, so each external keeps dependency-specific rendering
- preserve CommonJS externals as `createRequire(...)` calls in modern-module Node output instead of turning them into static ESM namespace imports
- update defaults coverage, ESM output cases, public types, and English/Chinese documentation

This PR is stacked on #14813 and should be retargeted to `main` after #14813 merges.

## Validation

- `corepack pnpm run build:js`
- `CARGO_TARGET_DIR=/Users/bytedance/.codex/worktrees/create-require-parser-delegation/target corepack pnpm run build:binding:dev`
- `corepack pnpm run test -t "esmOutputCases/externals/modern-module"` (12 passed)
- `corepack pnpm run test -t "esmOutputCases/create-require"` (8 passed)
- `corepack pnpm run test -t "defaultsCases/target_"` (6 passed)
- `cargo test -p rspack --test defaults modern_module_library_uses_modern_module_externals_default`
- `corepack pnpm run lint:js`
- `cargo fmt --all --check`
- Prettier check for all changed files
- `git diff --check`