### PR TITLE
chore: update simd-json and value-trait to fix stringify issue  for CPUs without AVX/SSE4 capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5683,9 +5683,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simd-json"
-version = "0.17.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
 dependencies = [
  "halfbrown",
  "ref-cast",
@@ -7757,9 +7757,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-trait"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
 dependencies = [
  "float-cmp",
  "halfbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ serde_json          = { version = "1.0.150", default-features = false, features 
 sftrace-setup       = { version = "0.1.2", default-features = false }
 sha2                = { version = "0.10.9", default-features = false }
 signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
-simd-json           = { version = "0.17.0", default-features = false, features = ["runtime-detection", "serde_impl"] }
+simd-json           = { version = "0.17.3", default-features = false, features = ["runtime-detection", "serde_impl"] }
 simd-utf16-len      = { version = "0.1.0", default-features = false }
 simdutf8            = { version = "0.1.5", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }


### PR DESCRIPTION
## Summary

- Update the workspace `simd-json` constraint from 0.17.0 to 0.17.3.
- Update the locked `simd-json` package from 0.17.0 to 0.17.3.
- Update the locked transitive `value-trait` package from 0.12.1 to 0.12.2.

## Example

A compilation that parses JSON through `simd-json` now both declares and resolves version 0.17.3, so a fresh dependency resolution receives the same patch release as the checked-in lockfile.

## Validation

- `cargo check --workspace --locked`

---
_by OpenAI Codex_