### PR TITLE
refactor(core): reuse existing leaf chunk graphs

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -271,7 +271,11 @@ impl BuildChunkGraphArtifact {
           }
         }
 
-        if miss_in_previous {
+        if miss_in_previous
+          && !(matches!(block, DependenciesBlockIdentifier::Module(_))
+            && outgoings.is_empty()
+            && self.chunk_graph.try_get_module_chunks(&module).is_some())
+        {
           logger.log("new module detected, rebuilding chunk graph");
           return false;
         }

--- a/tests/rspack-test/ChunkGraphEntryOptions.test.js
+++ b/tests/rspack-test/ChunkGraphEntryOptions.test.js
@@ -271,6 +271,65 @@ describe("incremental chunk graph entry roots", () => {
 		}
 	});
 
+	it("reuses an unchanged chunk graph when a global and named entry share a root", async () => {
+		const root = path.join(fixtureRoot, "duplicate-root");
+		fs.rmSync(root, { force: true, recursive: true });
+		write(
+			root,
+			"src/a.js",
+			"import './a-child'; globalThis.order.push('A');\n",
+		);
+		write(root, "src/a-child.js", "export const value = 'a';\n");
+		write(root, "src/leaf.js", "export const value = 'before';\n");
+		const compiler = rspack({
+			context: root,
+			mode: "development",
+			target: "node",
+			devtool: false,
+			cache: true,
+			incremental: true,
+			entry: {
+				keeper: { import: "./src/leaf.js" },
+				main: { import: "./src/a.js" },
+			},
+			output: { path: path.join(root, "dist"), filename: "[name].js" },
+			optimization: { minimize: false, splitChunks: false },
+			plugins: [
+				{
+					apply(compiler) {
+						compiler.hooks.make.tapPromise(
+							"duplicate-root-regression",
+							compilation => {
+								return new Promise((resolve, reject) => {
+									compilation.addEntry(
+										compiler.context,
+										rspack.EntryPlugin.createDependency("./src/a.js"),
+										{},
+										error => (error ? reject(error) : resolve()),
+									);
+								});
+							},
+						);
+					},
+				},
+			],
+		});
+
+		try {
+			await run(compiler);
+			const leaf = write(
+				root,
+				"src/leaf.js",
+				"export const value = 'after';\n",
+			);
+			const updated = await rebuild(compiler, [leaf]);
+
+			expect(codeSplittingMessages(updated)).toEqual([]);
+		} finally {
+			await close(compiler);
+		}
+	});
+
 	it.each([
 		["named", { name: "main" }],
 		["global", {}]

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-outgoings/0/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-outgoings/0/index.js
@@ -2,7 +2,11 @@ import { value, load, sync } from "./route";
 
 it("should preserve sync and async outgoings across rebuilds", async () => {
   expect(value).toBe(
-    WATCH_STEP === "0" ? "before:stable" : "after:stable",
+    WATCH_STEP === "0"
+      ? "before:stable"
+      : WATCH_STEP === "7"
+        ? "after:stable-updated"
+        : "after:stable",
   );
   expect(sync).toBe("first:second");
   expect(globalThis.__codesplit_side_effect__).toBe(true);

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-outgoings/7/terminal.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-outgoings/7/terminal.js
@@ -1,0 +1,1 @@
+export const suffix = "stable-updated";

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-outgoings/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-outgoings/test.config.js
@@ -33,6 +33,15 @@ module.exports = {
       assert(rebuild, "inserting an async edge must rebuild the chunk graph");
     } else if (stepName === "6") {
       assert(rebuild, "removing an async edge must rebuild the chunk graph");
+    } else if (stepName === "7") {
+      assert(
+        !rebuild,
+        "editing a module with no outgoing edges must reuse the chunk graph",
+      );
+      assert(
+        !stats.includes("new module detected"),
+        "an existing terminal module must not be treated as a new module",
+      );
     } else {
       throw new Error(`Unexpected watch step: ${stepName}`);
     }

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
@@ -6,4 +6,9 @@ module.exports = {
   incremental: {
     buildChunkGraph: true,
   },
+  stats: {
+    preset: 'verbose',
+    logging: 'verbose',
+    loggingDebug: [/codeSplittingCache/, /incremental/],
+  },
 };

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.config.js
@@ -1,0 +1,26 @@
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+module.exports = {
+  checkStats(stepName, _, stats) {
+    if (stepName === "0") {
+      assert(
+        stats.includes("<t> rebuild chunk graph"),
+        "cold build must build the chunk graph",
+      );
+    } else if (stepName === "1") {
+      assert(
+        !stats.includes("<t> rebuild chunk graph"),
+        "editing an existing leaf must reuse the chunk graph",
+      );
+      assert(
+        !stats.includes("new module detected"),
+        "an existing leaf must not be treated as a new module",
+      );
+    } else {
+      throw new Error(`Unexpected watch step: ${stepName}`);
+    }
+    return true;
+  },
+};

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";


### PR DESCRIPTION
## Summary

- Extend the incremental chunk graph fast path to terminal modules that already exist in the recovered graph.
- Preserve conservative fallback behavior when a leaf is new or topology changes.
- Cover terminal edits, duplicate roots, pre-order indices, and affected-module recovery.

## Related links

Source PR: #14772

Closes #14768

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).