### PR TITLE
refactor(hmr): limit incremental asset processing

### DIFF
--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -11,7 +11,8 @@ use rspack_core::{
   ModuleId, ModuleIdentifier, ModuleType, NormalModuleFactoryParser, NormalModuleLoader,
   ParserAndGenerator, ParserOptions, PathData, Plugin, RunnerContext, RuntimeGlobals,
   RuntimeModule, RuntimeModuleExt, RuntimeSpec,
-  chunk_graph_chunk::{ChunkId, ChunkIdSet},
+  chunk_graph_chunk::{ChunkId, ChunkIdMap, ChunkIdSet},
+  incremental::{IncrementalPasses, Mutation},
   rspack_sources::{RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -105,31 +106,44 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .iter()
     .map(|(k, v)| (v.clone(), *k))
     .collect();
-  let mut completely_removed_modules: HashSet<ModuleId> = Default::default();
+  let current_chunk_ukeys: ChunkIdMap<ChunkUkey> = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .iter()
+    .map(|(ukey, chunk)| (chunk.expect_id().clone(), *ukey))
+    .collect();
+  let completely_removed_modules: HashSet<ModuleId> = old_all_modules
+    .iter()
+    .filter(|(module_id, chunks)| !chunks.is_empty() && !all_module_ids.contains_key(*module_id))
+    .map(|(module_id, _)| module_id.clone())
+    .collect();
+  let changed_chunks = compilation
+    .incremental
+    .mutations_read(IncrementalPasses::CHUNK_ASSET)
+    .map(|mutations| {
+      mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+          Mutation::ChunkSetHashes { chunk } => Some(*chunk),
+          _ => None,
+        })
+        .collect::<HashSet<_>>()
+    });
 
   for (chunk_id, (old_runtime, old_module_ids)) in old_chunks {
-    let mut remaining_modules: HashSet<ModuleId> = Default::default();
-    for old_module_id in old_module_ids {
-      if !all_module_ids.contains_key(old_module_id) {
-        completely_removed_modules.insert(old_module_id.clone());
-      } else {
-        remaining_modules.insert(old_module_id.clone());
-      }
-    }
-
     let mut new_modules = vec![];
     let mut new_runtime_modules = vec![];
     let chunk_id = chunk_id.clone();
     let new_runtime: RuntimeSpec;
     let removed_from_runtime: RuntimeSpec;
 
-    let current_chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .iter()
-      .find(|(_, chunk)| chunk.expect_id().eq(&chunk_id))
-      .map(|(_, chunk)| chunk);
-    let current_chunk_ukey = current_chunk.map(|c| c.ukey());
+    let current_chunk_ukey = current_chunk_ukeys.get(&chunk_id).copied();
+    let current_chunk = current_chunk_ukey.and_then(|ukey| {
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .get(&ukey)
+    });
 
     if let Some(current_chunk) = current_chunk {
       new_runtime = current_chunk
@@ -139,6 +153,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         .collect();
 
       if new_runtime.is_empty() {
+        continue;
+      }
+
+      if old_runtime == &new_runtime
+        && changed_chunks
+          .as_ref()
+          .is_some_and(|chunks| !chunks.contains(&current_chunk.ukey()))
+      {
         continue;
       }
 
@@ -183,12 +205,23 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       }
     }
 
-    for old_module_id in remaining_modules {
-      let module_identifier = all_module_ids
-        .get(&old_module_id)
-        .expect("should have module");
+    for old_module_id in old_module_ids {
+      let Some(module_identifier) = all_module_ids.get(old_module_id) else {
+        continue;
+      };
+      if removed_from_runtime.is_empty()
+        && current_chunk_ukey.is_some_and(|ukey| {
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .is_module_in_chunk(module_identifier, ukey)
+        })
+      {
+        continue;
+      }
+
       let old_hashes = old_all_modules
-        .get(&old_module_id)
+        .get(old_module_id)
         .expect("should have module");
       let old_hash = old_hashes.get(&chunk_id);
       let runtimes = compilation

--- a/tests/rspack-test/HmrProcessAssets.test.js
+++ b/tests/rspack-test/HmrProcessAssets.test.js
@@ -1,0 +1,284 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { rspack } = require("@rspack/core");
+
+const fixtureRoot = path.resolve(__dirname, "js/hmr-process-assets");
+
+function write(root, filename, content) {
+	const file = path.join(root, filename);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+	return file;
+}
+
+function createCompiler(
+	name,
+	files,
+	optimization = { splitChunks: false },
+	incremental = true
+) {
+	const root = path.join(fixtureRoot, name);
+	fs.rmSync(root, { recursive: true, force: true });
+	for (const [filename, content] of Object.entries(files)) {
+		write(root, filename, content);
+	}
+
+	return {
+		root,
+		compiler: rspack({
+			context: root,
+			mode: "development",
+			target: "web",
+			devtool: false,
+			cache: true,
+			incremental,
+			entry: { a: "./src/a.js", b: "./src/b.js" },
+			output: {
+				path: path.join(root, "dist"),
+				filename: "[name].js",
+				chunkFilename: "[name].js"
+			},
+			optimization,
+			plugins: [new rspack.HotModuleReplacementPlugin()]
+		})
+	};
+}
+
+function run(compiler) {
+	return new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve(stats.compilation);
+		});
+	});
+}
+
+function rebuild(compiler, modifiedFiles) {
+	return new Promise((resolve, reject) => {
+		compiler.__internal__rebuild(new Set(modifiedFiles), new Set(), error => {
+			if (error) return reject(error);
+			const compilation = compiler._lastCompilation;
+			if (compilation.errors.length > 0) {
+				return reject(new Error(compilation.errors.join("\n")));
+			}
+			resolve(compilation);
+		});
+	});
+}
+
+function hotAssets(compilation) {
+	return compilation
+		.getAssets()
+		.filter(({ name }) => name.includes("hot-update"));
+}
+
+function hotManifests(compilation) {
+	return hotAssets(compilation)
+		.filter(({ name }) => name.endsWith(".json"))
+		.map(({ name, source }) => ({
+			name,
+			...JSON.parse(source.source().toString())
+		}));
+}
+
+async function close(compiler) {
+	await new Promise((resolve, reject) => {
+		compiler.close(error => (error ? reject(error) : resolve()));
+	});
+}
+
+describe("HotModuleReplacementPlugin process assets", () => {
+	afterAll(() => {
+		fs.rmSync(fixtureRoot, { recursive: true, force: true });
+	});
+
+	it("emits a changed shared module for every stable runtime", async () => {
+		const entry = name =>
+			`import { value } from './leaf'; globalThis.${name} = value; if (module.hot) module.hot.accept('./leaf');\n`;
+		const { root, compiler } = createCompiler("stable-runtimes", {
+			"src/a.js": entry("a"),
+			"src/b.js": entry("b"),
+			"src/leaf.js": "export const value = 'before';\n"
+		});
+
+		try {
+			await run(compiler);
+			const leaf = write(
+				root,
+				"src/leaf.js",
+				"export const value = 'after';\n"
+			);
+			const updated = await rebuild(compiler, [leaf]);
+			const manifests = hotManifests(updated);
+			const hotJavaScript = hotAssets(updated).filter(({ name }) =>
+				name.endsWith(".js")
+			);
+
+			expect(manifests).toHaveLength(2);
+			expect(manifests.every(({ c }) => c.length > 0)).toBe(true);
+			expect(
+				manifests.every(({ r, m }) => r.length === 0 && m.length === 0)
+			).toBe(true);
+			expect(hotJavaScript).toHaveLength(2);
+			expect(
+				hotJavaScript.every(({ source }) =>
+					source.source().toString().includes("after")
+				)
+			).toBe(true);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("preserves a shared async chunk until its final runtime is removed", async () => {
+		const entry = (name, includeShared) =>
+			`${
+				includeShared
+					? `import(/* webpackChunkName: 'shared' */ './shared').then(({ value }) => { globalThis.${name} = value; });`
+					: `globalThis.${name} = 'removed';`
+			}\nif (module.hot) module.hot.accept();\n`;
+		const { root, compiler } = createCompiler("removed-runtime", {
+			"src/a.js": entry("a", true),
+			"src/b.js": entry("b", true),
+			"src/shared.js": "export const value = 'shared';\n"
+		});
+
+		try {
+			await run(compiler);
+			const a = write(root, "src/a.js", entry("a", false));
+			const first = await rebuild(compiler, [a]);
+			const firstManifests = hotManifests(first);
+			const removedManifest = firstManifests.find(({ name }) =>
+				name.startsWith("a.")
+			);
+			const activeManifest = firstManifests.find(({ name }) =>
+				name.startsWith("b.")
+			);
+			expect(firstManifests).toHaveLength(2);
+			expect(first.getAsset("shared.js")).toBeDefined();
+			expect(removedManifest).toBeDefined();
+			expect(removedManifest.r).toContain("shared");
+			expect(removedManifest.m).toContain("./src/shared.js");
+			expect(activeManifest).toBeDefined();
+			expect(activeManifest.r).not.toContain("shared");
+			expect(activeManifest.m).not.toContain("./src/shared.js");
+
+			const b = write(root, "src/b.js", entry("b", false));
+			const last = await rebuild(compiler, [b]);
+			const manifests = hotManifests(last);
+
+			expect(last.getAsset("shared.js")).toBeUndefined();
+			expect(manifests.some(({ r }) => r.includes("shared"))).toBe(true);
+			expect(manifests.some(({ m }) => m.includes("./src/shared.js"))).toBe(
+				true
+			);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("updates an installed chunk when an edited module moves within a stable runtime", async () => {
+		const entry = (name, includeMoving) =>
+			`import { anchor } from './shared/anchor';\n${
+				includeMoving ? "import { moving } from './shared/moving';\n" : ""
+			}globalThis.${name} = anchor${includeMoving ? " + moving" : ""};\nif (module.hot) module.hot.accept();\n`;
+		const { root, compiler } = createCompiler(
+			"moved-module",
+			{
+				"src/a.js": entry("a", true),
+				"src/b.js": entry("b", true),
+				"src/shared/anchor.js": "export const anchor = 'anchor';\n",
+				"src/shared/moving.js": "export const moving = 'moving-before';\n"
+			},
+			{
+				runtimeChunk: "single",
+				splitChunks: {
+					chunks: "all",
+					minSize: 0,
+					cacheGroups: {
+						shared: {
+							test: /[\\/]shared[\\/]/,
+							name: "shared",
+							minChunks: 2,
+							enforce: true
+						}
+					}
+				}
+			}
+		);
+
+		try {
+			const initial = await run(compiler);
+			expect(
+				initial.getAsset("shared.js").source.source().toString()
+			).toContain("moving-before");
+
+			const b = write(root, "src/b.js", entry("b", false));
+			const moving = write(
+				root,
+				"src/shared/moving.js",
+				"export const moving = 'moving-after';\n"
+			);
+			const updated = await rebuild(compiler, [b, moving]);
+			expect(updated.getAsset("a.js").source.source().toString()).toContain(
+				"moving-after"
+			);
+			expect(
+				updated.getAsset("shared.js").source.source().toString()
+			).not.toContain("moving-after");
+
+			const hotWithMarker = hotAssets(updated)
+				.filter(
+					({ name, source }) =>
+						name.endsWith(".js") &&
+						source.source().toString().includes("moving-after")
+				)
+				.map(({ name }) => name);
+			expect(hotWithMarker.some(name => name.startsWith("a."))).toBe(true);
+			expect(hotWithMarker.some(name => name.startsWith("shared."))).toBe(true);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("falls back to a full HMR scan when incremental chunk assets are disabled", async () => {
+		const entry = name =>
+			`import { value } from './leaf'; globalThis.${name} = value; if (module.hot) module.hot.accept('./leaf');\n`;
+		const { root, compiler } = createCompiler(
+			"chunk-asset-disabled",
+			{
+				"src/a.js": entry("a"),
+				"src/b.js": entry("b"),
+				"src/leaf.js": "export const value = 'before';\n"
+			},
+			{ splitChunks: false },
+			{ chunkAsset: false }
+		);
+
+		try {
+			await run(compiler);
+			const leaf = write(
+				root,
+				"src/leaf.js",
+				"export const value = 'after';\n"
+			);
+			const updated = await rebuild(compiler, [leaf]);
+			const hotJavaScript = hotAssets(updated).filter(({ name }) =>
+				name.endsWith(".js")
+			);
+
+			expect(hotManifests(updated)).toHaveLength(2);
+			expect(hotJavaScript).toHaveLength(2);
+			expect(
+				hotJavaScript.every(({ source }) =>
+					source.source().toString().includes("after")
+				)
+			).toBe(true);
+		} finally {
+			await close(compiler);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Index current chunks by ID and use changed-chunk mutations to avoid rescanning stable HMR chunks.
- Preserve removed-module, removed-runtime, and full-scan fallback behavior.
- Add focused regressions for unchanged chunks, hash changes, removals, and missing mutation provenance.

## Related links

Source PR: #14772

Closes #14767

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).