### PR TITLE
fix(watcher): serialize native watcher lifecycle

### DIFF
--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -10,6 +10,7 @@ use napi_derive::*;
 use rspack_paths::ArcPath;
 use rspack_regex::RspackRegex;
 use rspack_watcher::{FsEventKind, FsWatcher, FsWatcherIgnored, FsWatcherOptions};
+use tokio::sync::Mutex;
 
 type JsWatcherIgnored = Either3<String, Vec<String>, RspackRegex>;
 
@@ -54,10 +55,14 @@ pub struct NativeWatchUndelayedEvent {
   pub path: String,
 }
 
+struct NativeWatcherState {
+  watcher: Mutex<FsWatcher>,
+  closed: AtomicBool,
+}
+
 #[napi]
 pub struct NativeWatcher {
-  watcher: FsWatcher,
-  closed: bool,
+  state: Arc<NativeWatcherState>,
 }
 
 fn timestamp_to_system_time(millis: u64) -> SystemTime {
@@ -78,8 +83,10 @@ impl NativeWatcher {
     );
 
     Self {
-      watcher,
-      closed: false,
+      state: Arc::new(NativeWatcherState {
+        watcher: Mutex::new(watcher),
+        closed: AtomicBool::new(false),
+      }),
     }
   }
 
@@ -95,7 +102,7 @@ impl NativeWatcher {
     #[napi(ts_arg_type = "(event: NativeWatchUndelayedEvent) => void")]
     callback_undelayed: Function<'static>,
   ) -> napi::Result<()> {
-    if self.closed {
+    if self.state.closed.load(Ordering::Acquire) {
       return Err(napi::Error::from_reason(
         "The native watcher has been closed, cannot watch again.",
       ));
@@ -105,7 +112,6 @@ impl NativeWatcher {
     let js_event_handler_undelayed = JsEventHandlerUndelayed::new(callback_undelayed)?;
 
     let start_time = start_time.get_u64().1;
-
     // `FsWatcher::watch` has already enqueued the request by the time it
     // returns; the future only signals "applied", so dropping it cancels
     // nothing.
@@ -131,7 +137,9 @@ impl NativeWatcher {
       _ => None,
     } {
       self
+        .state
         .watcher
+        .blocking_lock()
         .trigger_event(&ArcPath::from(AsRef::<Path>::as_ref(&path)), kind);
     }
   }
@@ -154,7 +162,9 @@ impl NativeWatcher {
   #[napi]
   pub fn pause(&self) -> napi::Result<()> {
     self
+      .state
       .watcher
+      .blocking_lock()
       .pause()
       .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1089,6 +1089,9 @@ importers:
       '@prefresh/utils':
         specifier: 'catalog:'
         version: 1.2.1
+      '@rspack/binding':
+        specifier: workspace:*
+        version: link:../../crates/node_binding
       '@rspack/binding-testing':
         specifier: workspace:*
         version: link:../../crates/rspack_binding_builder_testing

--- a/tests/rspack-test/NativeWatcherLifecycle.test.js
+++ b/tests/rspack-test/NativeWatcherLifecycle.test.js
@@ -1,0 +1,123 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { NativeWatcher } = require("@rspack/binding");
+const { rspack } = require("@rspack/core");
+
+describe("NativeWatcher lifecycle", () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "rspack-native-lifecycle-"));
+	const files = Array.from({ length: 40 }, (_, index) => {
+		const file = path.join(root, `file-${index}.txt`);
+		fs.writeFileSync(file, `${index}\n`);
+		return file;
+	});
+	const raceDirectories = Array.from({ length: 20 }, (_, index) => {
+		const directory = path.join(root, `sub-${index}`);
+		fs.mkdirSync(directory, { recursive: true });
+		return directory;
+	});
+	const raceFiles = Array.from({ length: 400 }, (_, index) => {
+		const file = path.join(
+			raceDirectories[index % raceDirectories.length],
+			`file-${index}.txt`,
+		);
+		fs.writeFileSync(file, `${index}\n`);
+		return file;
+	});
+	const startWatch = (watcher, watchedFiles, directories) =>
+		watcher.watch(
+			[watchedFiles, []],
+			[directories, []],
+			[[], []],
+			BigInt(Date.now()),
+			() => {},
+			() => {},
+		);
+
+	afterAll(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("serializes immediate and repeated close with watch and pause", async () => {
+		for (let index = 0; index < 1000; index++) {
+			const watcher = new NativeWatcher({ aggregateTimeout: 0 });
+			const watch = () => startWatch(watcher, files, [root]);
+
+			watch();
+			watch();
+			watcher.pause();
+			await Promise.all([watcher.close(), watcher.close()]);
+
+			expect(watch).toThrow("The native watcher has been closed");
+		}
+	});
+
+	it("serializes immediate close with overlapping watches on a large dependency set", async () => {
+		for (let index = 0; index < 30; index++) {
+			const watcher = new NativeWatcher({ aggregateTimeout: 1 });
+			const watch = () =>
+				startWatch(watcher, raceFiles, [root, ...raceDirectories]);
+
+			for (let count = 0; count < 5; count++) {
+				watch();
+			}
+			await watcher.close();
+
+			expect(watch).toThrow("The native watcher has been closed");
+		}
+	});
+
+	it("recreates a closed native watcher with its complete dependency set", async () => {
+		const compiler = rspack({
+			context: root,
+			entry: files[0],
+			experiments: { nativeWatcher: true },
+		});
+		const watchFileSystem = compiler.watchFileSystem;
+		const dependencies = values =>
+			Object.assign(values, { added: [], removed: [] });
+		const watch = callback =>
+			watchFileSystem.watch(
+				dependencies(files),
+				dependencies([root]),
+				dependencies([]),
+				Date.now(),
+				{ aggregateTimeout: 0 },
+				callback,
+				() => {},
+			);
+
+		const firstNativeWatcher = watchFileSystem.getNativeWatcher({});
+		const first = watch(() => {});
+		first.close();
+
+		const secondNativeWatcher = watchFileSystem.getNativeWatcher({});
+		expect(secondNativeWatcher).not.toBe(firstNativeWatcher);
+
+		let second;
+		try {
+			const changes = await new Promise((resolve, reject) => {
+				const timeout = setTimeout(
+					() => reject(new Error("timed out waiting for recreated native watcher")),
+					5000,
+				);
+				second = watch((_error, _fileTimes, _contextTimes, changes) => {
+					clearTimeout(timeout);
+					resolve(changes);
+				});
+				fs.writeFileSync(files[0], "changed\n");
+				const changedAt = new Date(Date.now() + 2000);
+				fs.utimesSync(files[0], changedAt, changedAt);
+				watchFileSystem.triggerEvent("change", files[0]);
+			});
+
+			expect([...changes]).toContain(files[0]);
+		} finally {
+			second?.close();
+			await Promise.all([
+				firstNativeWatcher.close(),
+				secondNativeWatcher.close(),
+			]);
+		}
+	});
+});

--- a/tests/rspack-test/package.json
+++ b/tests/rspack-test/package.json
@@ -18,6 +18,7 @@
     "@module-federation/runtime-tools": "catalog:",
     "@prefresh/core": "catalog:",
     "@prefresh/utils": "catalog:",
+    "@rspack/binding": "workspace:*",
     "@rspack/binding-testing": "workspace:*",
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",


### PR DESCRIPTION
## Summary

- Serialize native watch, pause, trigger, and close operations through a shared lifecycle state.
- Release closed JavaScript handles immediately so stale operations cannot reach replacement watchers.
- Add stress coverage for immediate close, repeated close, and overlapping watch and pause operations.

## Related links

Source PR: #14772

Closes #14790

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).