### PR TITLE
fix(watcher): preserve concrete raw events

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -466,6 +466,8 @@ export declare class NativeWatcher {
   constructor(options: NativeWatcherOptions)
   watch(files: [Array<string>, Array<string>], directories: [Array<string>, Array<string>], missing: [Array<string>, Array<string>], startTime: bigint, callback: (err: Error | null, result: NativeWatchResult) => void, callbackUndelayed: (event: NativeWatchUndelayedEvent) => void): void
   triggerEvent(kind: 'change' | 'remove' | 'create', path: string): void
+  takePendingEvents(): NativeWatchResult
+  acknowledgePendingEvents(generation: number): void
   close(): Promise<void>
   pause(): void
 }
@@ -473,6 +475,7 @@ export declare class NativeWatcher {
 export declare class NativeWatchResult {
   changedFiles: Array<string>
   removedFiles: Array<string>
+  generation: number
 }
 
 

--- a/crates/rspack_binding_api/src/native_watcher.rs
+++ b/crates/rspack_binding_api/src/native_watcher.rs
@@ -1,7 +1,6 @@
 use std::{
   boxed::Box,
   path::{Path, PathBuf},
-  sync::Arc,
   time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -10,7 +9,6 @@ use napi_derive::*;
 use rspack_paths::ArcPath;
 use rspack_regex::RspackRegex;
 use rspack_watcher::{FsEventKind, FsWatcher, FsWatcherIgnored, FsWatcherOptions};
-use tokio::sync::Mutex;
 
 type JsWatcherIgnored = Either3<String, Vec<String>, RspackRegex>;
 
@@ -44,6 +42,7 @@ pub struct NativeWatcherOptions {
 pub struct NativeWatchResult {
   pub changed_files: Vec<String>,
   pub removed_files: Vec<String>,
+  pub generation: u32,
 }
 
 /// A single, undelayed file system event delivered to the `callbackUndelayed`
@@ -55,14 +54,10 @@ pub struct NativeWatchUndelayedEvent {
   pub path: String,
 }
 
-struct NativeWatcherState {
-  watcher: Mutex<FsWatcher>,
-  closed: AtomicBool,
-}
-
 #[napi]
 pub struct NativeWatcher {
-  state: Arc<NativeWatcherState>,
+  watcher: FsWatcher,
+  closed: bool,
 }
 
 fn timestamp_to_system_time(millis: u64) -> SystemTime {
@@ -83,10 +78,8 @@ impl NativeWatcher {
     );
 
     Self {
-      state: Arc::new(NativeWatcherState {
-        watcher: Mutex::new(watcher),
-        closed: AtomicBool::new(false),
-      }),
+      watcher,
+      closed: false,
     }
   }
 
@@ -102,7 +95,7 @@ impl NativeWatcher {
     #[napi(ts_arg_type = "(event: NativeWatchUndelayedEvent) => void")]
     callback_undelayed: Function<'static>,
   ) -> napi::Result<()> {
-    if self.state.closed.load(Ordering::Acquire) {
+    if self.closed {
       return Err(napi::Error::from_reason(
         "The native watcher has been closed, cannot watch again.",
       ));
@@ -137,11 +130,25 @@ impl NativeWatcher {
       _ => None,
     } {
       self
-        .state
         .watcher
-        .blocking_lock()
         .trigger_event(&ArcPath::from(AsRef::<Path>::as_ref(&path)), kind);
     }
+  }
+
+  #[napi]
+  pub fn take_pending_events(&self) -> NativeWatchResult {
+    let (changed_files, removed_files, generation) =
+      self.watcher.take_pending_events();
+    NativeWatchResult {
+      changed_files: changed_files.into_iter().collect(),
+      removed_files: removed_files.into_iter().collect(),
+      generation,
+    }
+  }
+
+  #[napi]
+  pub fn acknowledge_pending_events(&self, generation: u32) {
+    self.watcher.acknowledge_pending_events(generation);
   }
 
   #[napi(ts_return_type = "Promise<void>")]
@@ -162,9 +169,7 @@ impl NativeWatcher {
   #[napi]
   pub fn pause(&self) -> napi::Result<()> {
     self
-      .state
       .watcher
-      .blocking_lock()
       .pause()
       .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
@@ -189,7 +194,7 @@ struct JsEventHandler {
     Status,
     true,
     true,
-    1,
+    0,
   >,
 }
 
@@ -198,13 +203,32 @@ impl JsEventHandler {
     let callback = callback
       .build_threadsafe_function::<NativeWatchResult>()
       .callee_handled::<true>()
-      .max_queue_size::<1>()
+      // The executor permits at most one aggregate in flight. An unbounded
+      // TSFN prevents a live callback from dropping that batch on QueueFull.
+      .max_queue_size::<0>()
       .weak::<true>()
       .build_callback(
         move |ctx: napi::threadsafe_function::ThreadSafeCallContext<_>| Ok(ctx.value),
       )?;
 
     Ok(Self { inner: callback })
+  }
+
+  fn deliver(
+    &self,
+    changed_files: rspack_util::fx_hash::FxHashSet<String>,
+    deleted_files: rspack_util::fx_hash::FxHashSet<String>,
+    generation: u32,
+  ) -> bool {
+    let result = NativeWatchResult {
+      changed_files: changed_files.into_iter().collect(),
+      removed_files: deleted_files.into_iter().collect(),
+      generation,
+    };
+    self.inner.call(
+      Ok(result),
+      napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+    ) == Status::Ok
   }
 }
 
@@ -214,16 +238,16 @@ impl rspack_watcher::EventAggregateHandler for JsEventHandler {
     changed_files: rspack_util::fx_hash::FxHashSet<String>,
     deleted_files: rspack_util::fx_hash::FxHashSet<String>,
   ) {
-    let changed_files_vec: Vec<String> = changed_files.into_iter().collect();
-    let deleted_files_vec: Vec<String> = deleted_files.into_iter().collect();
-    let result = NativeWatchResult {
-      changed_files: changed_files_vec,
-      removed_files: deleted_files_vec,
-    };
-    self.inner.call(
-      Ok(result),
-      napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
-    );
+    let _ = self.deliver(changed_files, deleted_files, 0);
+  }
+
+  fn on_event_handle_with_generation(
+    &self,
+    changed_files: rspack_util::fx_hash::FxHashSet<String>,
+    deleted_files: rspack_util::fx_hash::FxHashSet<String>,
+    generation: u32,
+  ) -> bool {
+    self.deliver(changed_files, deleted_files, generation)
   }
 
   fn on_error(&self, error: rspack_error::Error) {
@@ -237,14 +261,16 @@ impl rspack_watcher::EventAggregateHandler for JsEventHandler {
 }
 
 struct JsEventHandlerUndelayed {
-  inner: napi::threadsafe_function::ThreadsafeFunction<
-    NativeWatchUndelayedEvent,
-    napi::Unknown<'static>,
-    NativeWatchUndelayedEvent,
-    Status,
-    false,
-    false,
-    1,
+  inner: Option<
+    napi::threadsafe_function::ThreadsafeFunction<
+      NativeWatchUndelayedEvent,
+      napi::Unknown<'static>,
+      NativeWatchUndelayedEvent,
+      Status,
+      false,
+      false,
+      0,
+    >,
   >,
 }
 
@@ -253,35 +279,60 @@ impl JsEventHandlerUndelayed {
     let callback = callback
       .build_threadsafe_function::<NativeWatchUndelayedEvent>()
       .weak::<false>()
-      .max_queue_size::<1>()
+      // A watch tick can produce a burst of concrete file events. Keep the
+      // raw stream lossless so later children cannot be silently dropped on
+      // QueueFull while the JS thread drains an earlier callback.
+      .max_queue_size::<0>()
       .build_callback(
         move |ctx: napi::threadsafe_function::ThreadSafeCallContext<_>| Ok(ctx.value),
       )?;
 
-    Ok(Self { inner: callback })
+    Ok(Self {
+      inner: Some(callback),
+    })
+  }
+
+  fn deliver(&self, kind: &'static str, path: String) -> rspack_error::Result<()> {
+    let Some(inner) = &self.inner else {
+      return Err(rspack_error::error!(
+        "native watcher raw callback is closed"
+      ));
+    };
+    let status = inner.call(
+      NativeWatchUndelayedEvent {
+        kind: kind.to_string(),
+        path,
+      },
+      napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+    );
+    if status == Status::Ok {
+      Ok(())
+    } else {
+      Err(rspack_error::error!(
+        "native watcher raw callback could not be queued: {status}"
+      ))
+    }
   }
 }
 
 impl rspack_watcher::EventHandler for JsEventHandlerUndelayed {
   fn on_change(&self, changed_file: String) -> rspack_error::Result<()> {
-    self.inner.call(
-      NativeWatchUndelayedEvent {
-        kind: "change".to_string(),
-        path: changed_file,
-      },
-      napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
-    );
-    Ok(())
+    self.deliver("change", changed_file)
   }
 
   fn on_delete(&self, deleted_file: String) -> rspack_error::Result<()> {
-    self.inner.call(
-      NativeWatchUndelayedEvent {
-        kind: "remove".to_string(),
-        path: deleted_file,
-      },
-      napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
-    );
-    Ok(())
+    self.deliver("remove", deleted_file)
+  }
+}
+
+impl Drop for JsEventHandlerUndelayed {
+  fn drop(&mut self) {
+    if let Some(inner) = self.inner.take() {
+      // Releasing a TSFN drains its queue into the previous watch callback.
+      // Abort the obsolete callback so a rewatch cannot receive stale raw
+      // events after the handler generation has been replaced.
+      #[allow(deprecated)]
+      let _ = inner.abort();
+    }
   }
 }

--- a/crates/rspack_watcher/src/executor.rs
+++ b/crates/rspack_watcher/src/executor.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-  Arc,
-  atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, Mutex as SyncMutex, MutexGuard as SyncMutexGuard};
 
 use rspack_util::fx_hash::FxHashSet as HashSet;
 use tokio::sync::{
@@ -14,17 +11,150 @@ use crate::EventBatch;
 
 type ThreadSafetyReceiver<T> = ThreadSafety<UnboundedReceiver<T>>;
 type ThreadSafety<T> = Arc<Mutex<T>>;
+type PendingFiles = Arc<SyncMutex<FilesData>>;
+
+#[derive(Clone)]
+pub(crate) struct PendingEvents {
+  files_data: PendingFiles,
+  exec_aggregate_tx: UnboundedSender<ExecAggregateEvent>,
+}
+
+impl PendingEvents {
+  /// Pauses aggregate delivery. Raw events continue accumulating until resume.
+  pub fn pause(&self) {
+    lock_pending(&self.files_data).paused = true;
+  }
+
+  /// Atomically pauses aggregate delivery and consumes its pending events.
+  /// Consumed events will not be delivered to that handler later.
+  pub fn take(&self) -> (HashSet<String>, HashSet<String>, u32) {
+    let mut files = lock_pending(&self.files_data);
+    files.paused = true;
+    files.aggregate_scheduled = false;
+    let files = files.drain();
+    (files.changed, files.deleted, files.generation)
+  }
+
+  pub fn acknowledge(&self, generation: u32) {
+    let should_aggregate = {
+      let mut files = lock_pending(&self.files_data);
+      if files.acknowledge(generation) {
+        files.aggregate_scheduled = false;
+      }
+      files.schedule_if_needed()
+    };
+    if should_aggregate {
+      let _ = self.exec_aggregate_tx.send(ExecAggregateEvent::Execute);
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+struct AggregatedFiles {
+  changed: HashSet<String>,
+  deleted: HashSet<String>,
+  generation: u32,
+}
+
+impl AggregatedFiles {
+  fn merge(&mut self, changed: HashSet<String>, deleted: HashSet<String>) {
+    for path in changed {
+      self.deleted.remove(&path);
+      self.changed.insert(path);
+    }
+    for path in deleted {
+      self.changed.remove(&path);
+      self.deleted.insert(path);
+    }
+  }
+}
 
 #[derive(Debug, Default)]
 struct FilesData {
   changed: HashSet<String>,
   deleted: HashSet<String>,
+  in_flight: Option<AggregatedFiles>,
+  next_generation: u32,
+  aggregate_scheduled: bool,
+  paused: bool,
 }
 
 impl FilesData {
   fn is_empty(&self) -> bool {
     self.changed.is_empty() && self.deleted.is_empty()
   }
+
+  fn record(&mut self, path: String, kind: FsEventKind) {
+    match kind {
+      FsEventKind::Change | FsEventKind::Create => {
+        self.deleted.remove(&path);
+        self.changed.insert(path);
+      }
+      FsEventKind::Remove => {
+        self.changed.remove(&path);
+        self.deleted.insert(path);
+      }
+    }
+  }
+
+  fn next_generation(&mut self) -> u32 {
+    let generation = self.next_generation;
+    self.next_generation = self.next_generation.wrapping_add(1);
+    generation
+  }
+
+  fn claim(&mut self) -> AggregatedFiles {
+    let files = AggregatedFiles {
+      changed: std::mem::take(&mut self.changed),
+      deleted: std::mem::take(&mut self.deleted),
+      generation: self.next_generation(),
+    };
+    debug_assert!(self.in_flight.is_none());
+    self.in_flight = Some(files.clone());
+    files
+  }
+
+  fn drain(&mut self) -> AggregatedFiles {
+    let generation = self.next_generation();
+    let mut files = self.in_flight.take().unwrap_or_else(|| AggregatedFiles {
+      changed: Default::default(),
+      deleted: Default::default(),
+      generation,
+    });
+    files.generation = generation;
+    files.merge(
+      std::mem::take(&mut self.changed),
+      std::mem::take(&mut self.deleted),
+    );
+    files
+  }
+
+  fn acknowledge(&mut self, generation: u32) -> bool {
+    if self
+      .in_flight
+      .as_ref()
+      .is_some_and(|files| files.generation == generation)
+    {
+      self.in_flight = None;
+      true
+    } else {
+      false
+    }
+  }
+
+  fn schedule_if_needed(&mut self) -> bool {
+    if self.paused || self.aggregate_scheduled || self.in_flight.is_some() || self.is_empty() {
+      return false;
+    }
+    self.aggregate_scheduled = true;
+    true
+  }
+}
+
+fn lock_pending(files: &PendingFiles) -> SyncMutexGuard<'_, FilesData> {
+  files
+    .lock()
+    .expect("pending watcher events mutex should not be poisoned")
 }
 
 /// `WatcherExecutor` is responsible for managing the execution of file system event handlers,
@@ -34,13 +164,11 @@ impl FilesData {
 pub struct Executor {
   aggregate_timeout: u32,
   rx: ThreadSafetyReceiver<EventBatch>,
-  files_data: ThreadSafety<FilesData>,
+  files_data: PendingFiles,
   exec_aggregate_tx: UnboundedSender<ExecAggregateEvent>,
   exec_aggregate_rx: ThreadSafetyReceiver<ExecAggregateEvent>,
   exec_tx: UnboundedSender<ExecEvent>,
   exec_rx: ThreadSafetyReceiver<ExecEvent>,
-  paused: Arc<AtomicBool>,
-  aggregate_running: Arc<AtomicBool>,
   start_waiting: bool,
   execute_handle: Option<tokio::task::JoinHandle<()>>,
   execute_aggregate_handle: Option<tokio::task::JoinHandle<()>>,
@@ -66,20 +194,12 @@ enum ExecEvent {
 
 impl Executor {
   /// Create a new `WatcherExecutor` with the given receiver and optional aggregate timeout.
-  /// `paused` is shared with [`crate::FsWatcher`] so pausing stays a lock-free
-  /// synchronous operation.
-  pub fn new(
-    rx: UnboundedReceiver<EventBatch>,
-    aggregate_timeout: Option<u32>,
-    paused: Arc<AtomicBool>,
-  ) -> Self {
+  pub fn new(rx: UnboundedReceiver<EventBatch>, aggregate_timeout: Option<u32>) -> Self {
     let (exec_aggregate_tx, exec_aggregate_rx) = mpsc::unbounded_channel::<ExecAggregateEvent>();
     let (exec_tx, exec_rx) = mpsc::unbounded_channel::<ExecEvent>();
 
     Self {
       start_waiting: false,
-      aggregate_running: Arc::new(AtomicBool::new(false)),
-      paused,
       rx: Arc::new(Mutex::new(rx)),
       files_data: Default::default(),
       exec_aggregate_tx,
@@ -92,6 +212,12 @@ impl Executor {
     }
   }
 
+  pub(crate) fn pending_events(&self) -> PendingEvents {
+    PendingEvents {
+      files_data: Arc::clone(&self.files_data),
+      exec_aggregate_tx: self.exec_aggregate_tx.clone(),
+    }
+  }
   /// Abort all executor.
   async fn abort(&mut self) {
     if let Some(execute_aggregate_handle) = std::mem::take(&mut self.execute_aggregate_handle) {
@@ -102,7 +228,7 @@ impl Executor {
       if let Err(err) = execute_aggregate_handle.await {
         debug_assert!(err.is_cancelled());
       }
-      self.aggregate_running.store(false, Ordering::Relaxed);
+      lock_pending(&self.files_data).aggregate_scheduled = false;
     }
     if let Some(execute_handle) = std::mem::take(&mut self.execute_handle) {
       execute_handle.abort();
@@ -130,27 +256,18 @@ impl Executor {
       let rx = Arc::clone(&self.rx);
       let exec_aggregate_tx = self.exec_aggregate_tx.clone();
       let exec_tx = self.exec_tx.clone();
-      let paused = Arc::clone(&self.paused);
-      let aggregate_running = Arc::clone(&self.aggregate_running);
 
       let future = async move {
         while let Some(events) = rx.lock().await.recv().await {
-          for event in &events {
-            let path = event.path.to_string_lossy().to_string();
-            match event.kind {
-              FsEventKind::Change => {
-                files_data.lock().await.changed.insert(path);
-              }
-              FsEventKind::Remove => {
-                files_data.lock().await.deleted.insert(path);
-              }
-              FsEventKind::Create => {
-                files_data.lock().await.changed.insert(path);
-              }
+          let should_aggregate = {
+            let mut files_data = lock_pending(&files_data);
+            for event in events.aggregated() {
+              files_data.record(event.path.to_string_lossy().to_string(), event.kind);
             }
-          }
+            files_data.schedule_if_needed()
+          };
 
-          if !paused.load(Ordering::Relaxed) && !aggregate_running.load(Ordering::Relaxed) {
+          if should_aggregate {
             let _ = exec_aggregate_tx.send(ExecAggregateEvent::Execute);
           }
 
@@ -165,7 +282,6 @@ impl Executor {
       self.start_waiting = true;
     }
 
-    self.paused.store(false, Ordering::Relaxed);
     // abort the previous handlers if they exist
     self.abort().await;
 
@@ -176,7 +292,12 @@ impl Executor {
     // indefinitely — the event loop already processed them (added to files_data)
     // but skipped sending Execute because paused was true. No future OS event
     // will re-deliver them, so we must kick the aggregate task ourselves.
-    if !self.files_data.lock().await.is_empty() {
+    let should_aggregate = {
+      let mut files = lock_pending(&self.files_data);
+      files.paused = false;
+      files.schedule_if_needed()
+    };
+    if should_aggregate {
       let _ = self.exec_aggregate_tx.send(ExecAggregateEvent::Execute);
     }
   }
@@ -190,8 +311,8 @@ impl Executor {
       event_aggregate_handler,
       Arc::clone(&self.exec_aggregate_rx),
       Arc::clone(&self.files_data),
+      self.exec_aggregate_tx.clone(),
       self.aggregate_timeout as u64,
-      Arc::clone(&self.aggregate_running),
     ));
 
     self.execute_handle = Some(create_execute_task(
@@ -209,20 +330,26 @@ fn create_execute_task(
     while let Some(exec_event) = exec_rx.lock().await.recv().await {
       match exec_event {
         ExecEvent::Execute(batch_events) => {
-          for event in batch_events {
-            // Handle each event based on its kind
+          let handle_event = |event: crate::FsEvent| {
             let path = event.path.to_string_lossy().to_string();
             match event.kind {
               super::FsEventKind::Change | super::FsEventKind::Create => {
-                if event_handler.on_change(path).is_err() {
+                event_handler.on_change(path)
+              }
+              super::FsEventKind::Remove => event_handler.on_delete(path),
+            }
+          };
+
+          match batch_events {
+            EventBatch::Shared(events) => {
+              for event in events {
+                if handle_event(event).is_err() {
                   break;
                 }
               }
-              super::FsEventKind::Remove => {
-                if event_handler.on_delete(path).is_err() {
-                  break;
-                }
-              }
+            }
+            EventBatch::Split { undelayed, .. } => {
+              let _ = handle_event(undelayed);
             }
           }
         }
@@ -238,9 +365,9 @@ fn create_execute_task(
 fn create_execute_aggregate_task(
   event_handler: Box<dyn EventAggregateHandler + Send>,
   exec_aggregate_rx: ThreadSafetyReceiver<ExecAggregateEvent>,
-  files: ThreadSafety<FilesData>,
+  pending_files: PendingFiles,
+  exec_aggregate_tx: UnboundedSender<ExecAggregateEvent>,
   aggregate_timeout: u64,
-  running: Arc<AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
   let future = async move {
     loop {
@@ -255,23 +382,43 @@ fn create_execute_aggregate_task(
       };
 
       if let ExecAggregateEvent::Execute = aggregate_rx {
-        running.store(true, Ordering::Relaxed);
         // Wait for the aggregate timeout before executing the handler
         tokio::time::sleep(tokio::time::Duration::from_millis(aggregate_timeout)).await;
 
         // Get the files to process
         let files = {
-          let mut files = files.lock().await;
-          if files.is_empty() {
-            running.store(false, Ordering::Relaxed);
+          let mut files = lock_pending(&pending_files);
+          if files.paused {
+            files.aggregate_scheduled = false;
             continue;
           }
-          std::mem::take(&mut *files)
+          // A stale queued Execute must not replace a batch that is still
+          // waiting for the JS consumer to acknowledge or drain it.
+          if files.in_flight.is_some() {
+            continue;
+          }
+          if files.is_empty() {
+            files.aggregate_scheduled = false;
+            continue;
+          }
+          files.claim()
         };
 
         // Call the event handler with the changed and deleted files
-        event_handler.on_event_handle(files.changed, files.deleted);
-        running.store(false, Ordering::Relaxed);
+        let generation = files.generation;
+        let defer_acknowledgement =
+          event_handler.on_event_handle_with_generation(files.changed, files.deleted, generation);
+        if !defer_acknowledgement {
+          let should_aggregate = {
+            let mut files = lock_pending(&pending_files);
+            files.acknowledge(generation);
+            files.aggregate_scheduled = false;
+            files.schedule_if_needed()
+          };
+          if should_aggregate {
+            let _ = exec_aggregate_tx.send(ExecAggregateEvent::Execute);
+          }
+        }
       }
     }
   };

--- a/crates/rspack_watcher/src/lib.rs
+++ b/crates/rspack_watcher/src/lib.rs
@@ -10,16 +10,13 @@ mod trigger;
 use std::{
   future::Future,
   pin::Pin,
-  sync::{
-    Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
-  },
+  sync::{Arc, Mutex},
   time::SystemTime,
 };
 
 use analyzer::{Analyzer, RecommendedAnalyzer};
 use disk_watcher::DiskWatcher;
-use executor::Executor;
+use executor::{Executor, PendingEvents};
 pub use ignored::FsWatcherIgnored;
 use paths::PathManager;
 use rspack_error::Result;
@@ -48,7 +45,28 @@ pub(crate) struct FsEvent {
   pub kind: FsEventKind,
 }
 
-pub(crate) type EventBatch = Vec<FsEvent>;
+pub(crate) enum EventBatch {
+  Shared(Vec<FsEvent>),
+  Split {
+    aggregated: Vec<FsEvent>,
+    undelayed: FsEvent,
+  },
+}
+
+impl EventBatch {
+  pub fn aggregated(&self) -> &[FsEvent] {
+    match self {
+      Self::Shared(events) => events,
+      Self::Split { aggregated, .. } => aggregated,
+    }
+  }
+}
+
+impl From<Vec<FsEvent>> for EventBatch {
+  fn from(events: Vec<FsEvent>) -> Self {
+    Self::Shared(events)
+  }
+}
 
 /// `EventAggregateHandler` is a trait for handling aggregated file system events.
 /// It provides methods to handle changes and deletions of files, as well as errors.
@@ -59,6 +77,18 @@ pub(crate) type EventBatch = Vec<FsEvent>;
 pub trait EventAggregateHandler {
   /// Handle a batch of file system events.
   fn on_event_handle(&self, _changed_files: HashSet<String>, _deleted_files: HashSet<String>);
+
+  /// Handle a versioned batch. Return `true` only when asynchronous delivery was
+  /// successfully queued; the caller must then acknowledge the generation.
+  fn on_event_handle_with_generation(
+    &self,
+    changed_files: HashSet<String>,
+    deleted_files: HashSet<String>,
+    _generation: u32,
+  ) -> bool {
+    self.on_event_handle(changed_files, deleted_files);
+    false
+  }
 
   /// Handle an error that occurs during file system watching.
   fn on_error(&self, _error: rspack_error::Error) {
@@ -112,8 +142,8 @@ enum WatcherOp {
 }
 
 pub struct FsWatcher {
-  paused: Arc<AtomicBool>,
   trigger: Arc<Mutex<Option<Arc<Trigger>>>>,
+  pending_events: PendingEvents,
   op_tx: mpsc::UnboundedSender<WatcherOp>,
 }
 
@@ -138,8 +168,8 @@ impl FsWatcher {
       options.poll_interval,
       trigger.clone(),
     );
-    let paused = Arc::new(AtomicBool::new(false));
-    let executor = Executor::new(rx, options.aggregate_timeout, Arc::clone(&paused));
+    let executor = Executor::new(rx, options.aggregate_timeout);
+    let pending_events = executor.pending_events();
     let scanner = Scanner::new(tx, Arc::clone(&path_manager));
     let trigger = Arc::new(Mutex::new(Some(trigger)));
 
@@ -153,8 +183,8 @@ impl FsWatcher {
     };
 
     Self {
-      paused,
       trigger,
+      pending_events,
       op_tx: spawn_owner_thread(inner),
     }
   }
@@ -228,9 +258,20 @@ impl FsWatcher {
 
   /// Pauses the file system watcher, stopping the execution of the event loop.
   pub fn pause(&self) -> Result<()> {
-    self.paused.store(true, Ordering::Relaxed);
+    self.pending_events.pause();
 
     Ok(())
+  }
+
+  /// Atomically pauses aggregate delivery and consumes its pending events.
+  /// Consumed events will not be delivered to that handler later.
+  pub fn take_pending_events(&self) -> (HashSet<String>, HashSet<String>, u32) {
+    self.pending_events.take()
+  }
+
+  /// Acknowledges asynchronous delivery of an aggregate generation.
+  pub fn acknowledge_pending_events(&self, generation: u32) {
+    self.pending_events.acknowledge(generation);
   }
 }
 

--- a/crates/rspack_watcher/src/scanner.rs
+++ b/crates/rspack_watcher/src/scanner.rs
@@ -110,7 +110,7 @@ fn scan_path_missing(
   if remove_event.is_empty() {
     return true;
   }
-  tx.send(remove_event).is_ok()
+  tx.send(remove_event.into()).is_ok()
 }
 
 fn scan_path_events(
@@ -129,7 +129,7 @@ fn scan_path_events(
   if events.is_empty() {
     return true;
   }
-  tx.send(events).is_ok()
+  tx.send(events.into()).is_ok()
 }
 
 /// Whether `path`'s current on-disk mtime is at or after `start_time`, using
@@ -180,7 +180,7 @@ mod tests {
     let collector = tokio::spawn(async move {
       let mut collected_events = Vec::new();
       while let Some(event) = _rx.recv().await {
-        collected_events.push(event);
+        collected_events.push(event.aggregated().to_vec());
       }
       collected_events
     });
@@ -251,9 +251,9 @@ mod tests {
 
     let mut changed_paths = HashSet::new();
     while let Some(batch) = rx.recv().await {
-      for ev in batch {
+      for ev in batch.aggregated() {
         if ev.kind == FsEventKind::Change {
-          changed_paths.insert(ev.path);
+          changed_paths.insert(ev.path.clone());
         }
       }
     }
@@ -301,8 +301,8 @@ mod tests {
 
     let mut event_paths = HashSet::new();
     while let Some(batch) = rx.recv().await {
-      for ev in batch {
-        event_paths.insert(ev.path);
+      for ev in batch.aggregated() {
+        event_paths.insert(ev.path.clone());
       }
     }
 

--- a/crates/rspack_watcher/src/trigger.rs
+++ b/crates/rspack_watcher/src/trigger.rs
@@ -123,17 +123,22 @@ impl Trigger {
 
     // A watched path that no longer exists on disk is a removal, regardless of
     // how the OS reported the event. macOS FSEvents reports an unlink as a
-    // rename (`ModifyKind::Name` → `Change`), so normalize a `Change` whose
-    // path is gone into a `Remove`, keeping the event kind consistent with
-    // inotify (which already reports `Remove`). Done before the stale-event
-    // filter below, which only applies to `Change`/`Create`.
-    let kind = if kind == FsEventKind::Change && !path.exists() {
+    // rename (`ModifyKind::Name` → `Change`), and a rapid create/delete in a
+    // context may arrive as a delayed `Create` for an unregistered child.
+    // Normalize either event whose path is gone into a `Remove`, keeping the
+    // event kind consistent with inotify (which already reports `Remove`). Do
+    // this before the stale-event filter below.
+    let finder = self.finder();
+    let kind = if (kind == FsEventKind::Change
+      || (kind == FsEventKind::Create && !finder.contains_path(path)))
+      && !path.exists()
+    {
       FsEventKind::Remove
     } else {
       kind
     };
 
-    let is_registered_file = self.path_manager.access().files().0.contains(path);
+    let is_registered_file = finder.files.contains(path);
 
     // Filter stale FSEvents: on macOS, FSEvents can deliver events for files
     // written before the watcher was created. Stat the file and compare mtime
@@ -146,9 +151,23 @@ impl Trigger {
       return;
     }
 
-    let finder = self.finder();
-    let associated_event = finder.find_associated_event(path, kind);
-    self.trigger_events(associated_event);
+    let associated_events = finder.find_associated_event(path, kind);
+    if associated_events.is_empty() {
+      return;
+    }
+
+    // Watchpack emits the concrete filesystem path to its undelayed listener,
+    // while compilation aggregation contains only registered dependencies.
+    // Keep those projections separate so context consumers can incrementally
+    // scan a new child without inflating `modifiedFiles` or duplicating parent
+    // callbacks.
+    self.trigger_events(
+      associated_events,
+      FsEvent {
+        path: path.clone(),
+        kind,
+      },
+    );
   }
   /// Helper to construct a `DependencyFinder` for the current path register state.
   fn finder(&self) -> DependencyFinder<'_> {
@@ -167,15 +186,16 @@ impl Trigger {
 
   /// Sends a group of file system events for the given path and event kind.
   /// If the event is successfully sent, it returns true; otherwise, it returns false.
-  fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>) -> bool {
+  fn trigger_events(&self, events: Vec<(ArcPath, FsEventKind)>, undelayed: FsEvent) -> bool {
     self
       .tx
-      .send(
-        events
+      .send(EventBatch::Split {
+        aggregated: events
           .into_iter()
           .map(|(path, kind)| FsEvent { path, kind })
           .collect(),
-      )
+        undelayed,
+      })
       .is_ok()
   }
 }
@@ -238,5 +258,73 @@ mod tests {
     assert_eq!(associated_events.len(), 2);
     assert!(associated_events.contains(&(dir_0, FsEventKind::Change)));
     assert!(associated_events.contains(&(dir_1, FsEventKind::Change)));
+  }
+
+  #[test]
+  fn test_find_dependency_for_context_file_events() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let context = temp_dir.path().join("context");
+    let child = context.join("child.js");
+    let removed = context.join("removed.js");
+    let unrelated = temp_dir.path().join("unrelated.js");
+    std::fs::create_dir_all(&context).unwrap();
+    std::fs::write(&child, "export default true;").unwrap();
+    std::fs::write(&unrelated, "export default false;").unwrap();
+
+    let files = ArcPathDashSet::default();
+    let directories = ArcPathDashSet::default();
+    let missing = ArcPathDashSet::default();
+    let context = ArcPath::from(context);
+    let child = ArcPath::from(child);
+    let removed = ArcPath::from(removed);
+    let unrelated = ArcPath::from(unrelated);
+    directories.insert(context.clone());
+
+    let finder = DependencyFinder {
+      files: &files,
+      directories: &directories,
+      missing: &missing,
+    };
+    for kind in [
+      FsEventKind::Create,
+      FsEventKind::Change,
+      FsEventKind::Remove,
+    ] {
+      let associated_events = finder.find_associated_event(&child, kind);
+
+      assert_eq!(associated_events.len(), 1);
+      assert!(associated_events.contains(&(context.clone(), FsEventKind::Change)));
+    }
+
+    let associated_events = finder.find_associated_event(&removed, FsEventKind::Remove);
+    assert_eq!(associated_events.len(), 1);
+    assert!(associated_events.contains(&(context, FsEventKind::Change)));
+    assert!(
+      finder
+        .find_associated_event(&unrelated, FsEventKind::Create)
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn test_find_dependency_emits_removed_directory_once() {
+    let files = ArcPathDashSet::default();
+    let directories = ArcPathDashSet::default();
+    let missing = ArcPathDashSet::default();
+    let parent = ArcPath::from(Path::new("/path/a"));
+    let child = ArcPath::from(Path::new("/path/a/removed"));
+    directories.insert(parent.clone());
+    directories.insert(child.clone());
+
+    let finder = DependencyFinder {
+      files: &files,
+      directories: &directories,
+      missing: &missing,
+    };
+    let associated_events = finder.find_associated_event(&child, FsEventKind::Remove);
+
+    assert_eq!(associated_events.len(), 2);
+    assert!(associated_events.contains(&(child, FsEventKind::Remove)));
+    assert!(associated_events.contains(&(parent, FsEventKind::Change)));
   }
 }

--- a/crates/rspack_watcher/tests/pending_events.rs
+++ b/crates/rspack_watcher/tests/pending_events.rs
@@ -1,0 +1,278 @@
+use std::time::SystemTime;
+
+use rspack_paths::ArcPath;
+use rspack_util::fx_hash::FxHashSet;
+use rspack_watcher::{
+  EventAggregateHandler, EventHandler, FsEventKind, FsWatcher, FsWatcherOptions,
+};
+use tempfile::TempDir;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+type Aggregate = (FxHashSet<String>, FxHashSet<String>, u32);
+
+struct AggregateHandler(UnboundedSender<Aggregate>);
+
+impl EventAggregateHandler for AggregateHandler {
+  fn on_event_handle(&self, _changed: FxHashSet<String>, _removed: FxHashSet<String>) {
+    unreachable!("the executor should provide an aggregate generation");
+  }
+
+  fn on_event_handle_with_generation(
+    &self,
+    changed: FxHashSet<String>,
+    removed: FxHashSet<String>,
+    generation: u32,
+  ) -> bool {
+    let _ = self.0.send((changed, removed, generation));
+    true
+  }
+}
+
+struct ClosingDeliveryHandler(UnboundedSender<Aggregate>);
+
+impl EventAggregateHandler for ClosingDeliveryHandler {
+  fn on_event_handle(&self, _changed: FxHashSet<String>, _removed: FxHashSet<String>) {
+    unreachable!("the executor should provide an aggregate generation");
+  }
+
+  fn on_event_handle_with_generation(
+    &self,
+    changed: FxHashSet<String>,
+    removed: FxHashSet<String>,
+    generation: u32,
+  ) -> bool {
+    let _ = self.0.send((changed, removed, generation));
+    false
+  }
+}
+
+struct ChangeHandler(UnboundedSender<(FsEventKind, String)>);
+
+impl EventHandler for ChangeHandler {
+  fn on_change(&self, path: String) -> rspack_error::Result<()> {
+    let _ = self.0.send((FsEventKind::Change, path));
+    Ok(())
+  }
+
+  fn on_delete(&self, path: String) -> rspack_error::Result<()> {
+    let _ = self.0.send((FsEventKind::Remove, path));
+    Ok(())
+  }
+}
+
+fn empty_paths() -> (std::iter::Empty<ArcPath>, std::iter::Empty<ArcPath>) {
+  (std::iter::empty(), std::iter::empty())
+}
+
+fn path_string(path: &ArcPath) -> String {
+  path.as_ref().to_string_lossy().into_owned()
+}
+
+async fn watch(
+  watcher: &mut FsWatcher,
+  paths: &[ArcPath],
+  aggregate_tx: &UnboundedSender<Aggregate>,
+  change_tx: &UnboundedSender<(FsEventKind, String)>,
+) {
+  watcher
+    .watch(
+      empty_paths(),
+      empty_paths(),
+      (paths.iter().cloned(), std::iter::empty()),
+      SystemTime::now(),
+      Box::new(AggregateHandler(aggregate_tx.clone())),
+      Box::new(ChangeHandler(change_tx.clone())),
+    )
+    .await;
+}
+
+async fn receive_changes(
+  receiver: &mut UnboundedReceiver<(FsEventKind, String)>,
+  count: usize,
+) -> Vec<(FsEventKind, String)> {
+  let mut events = Vec::with_capacity(count);
+  for _ in 0..count {
+    let event = tokio::time::timeout(std::time::Duration::from_secs(10), receiver.recv())
+      .await
+      .expect("watcher event should arrive")
+      .expect("watcher event channel should stay open");
+    events.push(event);
+  }
+  events
+}
+
+async fn receive_aggregate(receiver: &mut UnboundedReceiver<Aggregate>) -> Aggregate {
+  tokio::time::timeout(std::time::Duration::from_secs(10), receiver.recv())
+    .await
+    .expect("aggregate should arrive")
+    .expect("aggregate channel should stay open")
+}
+
+#[tokio::test]
+async fn pending_events_are_consumed_once_without_aggregate_replay() {
+  let temp_dir = TempDir::new().expect("temporary directory should be created");
+  let changed_path = ArcPath::from(temp_dir.path().join("changed.js"));
+  let removed_path = ArcPath::from(temp_dir.path().join("removed.js"));
+
+  let mut watcher = FsWatcher::new(
+    FsWatcherOptions {
+      aggregate_timeout: Some(200),
+      ..Default::default()
+    },
+    Default::default(),
+  );
+  let (aggregate_tx, mut aggregate_rx) = unbounded_channel();
+  let (change_tx, mut change_rx) = unbounded_channel();
+  let paths = [changed_path.clone(), removed_path.clone()];
+
+  watch(&mut watcher, &paths, &aggregate_tx, &change_tx).await;
+  watcher.trigger_event(&changed_path, FsEventKind::Create);
+  watcher.trigger_event(&removed_path, FsEventKind::Remove);
+  assert_eq!(
+    receive_changes(&mut change_rx, 2).await,
+    [
+      (FsEventKind::Change, path_string(&changed_path)),
+      (FsEventKind::Remove, path_string(&removed_path)),
+    ],
+  );
+  watcher.pause().expect("watcher should pause");
+
+  let (changes, removals, generation) = watcher.take_pending_events();
+  assert_eq!(changes, FxHashSet::from_iter([path_string(&changed_path)]));
+  assert_eq!(removals, FxHashSet::from_iter([path_string(&removed_path)]));
+  watcher.trigger_event(&removed_path, FsEventKind::Create);
+  assert_eq!(
+    receive_changes(&mut change_rx, 1).await,
+    [(FsEventKind::Change, path_string(&removed_path))],
+  );
+  let (changes, removals, next_generation) = watcher.take_pending_events();
+  assert_eq!(changes, FxHashSet::from_iter([path_string(&removed_path)]));
+  assert!(removals.is_empty());
+  assert!(next_generation > generation);
+  assert!(
+    tokio::time::timeout(std::time::Duration::from_millis(500), aggregate_rx.recv())
+      .await
+      .is_err(),
+    "a scheduled aggregate must not claim events after pause",
+  );
+
+  watch(&mut watcher, &paths, &aggregate_tx, &change_tx).await;
+  assert!(
+    tokio::time::timeout(std::time::Duration::from_millis(500), aggregate_rx.recv())
+      .await
+      .is_err(),
+    "consumed events must not be replayed by the aggregate handler",
+  );
+
+  watcher.trigger_event(&changed_path, FsEventKind::Create);
+  watcher.trigger_event(&changed_path, FsEventKind::Remove);
+  watcher.trigger_event(&changed_path, FsEventKind::Create);
+  assert_eq!(
+    receive_changes(&mut change_rx, 3).await,
+    [
+      (FsEventKind::Change, path_string(&changed_path)),
+      (FsEventKind::Remove, path_string(&changed_path)),
+      (FsEventKind::Change, path_string(&changed_path)),
+    ],
+  );
+
+  let (changes, removals, aggregate_generation) = receive_aggregate(&mut aggregate_rx).await;
+  assert_eq!(changes, FxHashSet::from_iter([path_string(&changed_path)]));
+  assert!(removals.is_empty());
+  watcher.acknowledge_pending_events(aggregate_generation);
+
+  let (changes, removals, drained_generation) = watcher.take_pending_events();
+  assert!(changes.is_empty());
+  assert!(removals.is_empty());
+  assert!(drained_generation > aggregate_generation);
+
+  watch(&mut watcher, &paths, &aggregate_tx, &change_tx).await;
+  watcher.trigger_event(&changed_path, FsEventKind::Create);
+  assert_eq!(
+    receive_changes(&mut change_rx, 1).await,
+    [(FsEventKind::Change, path_string(&changed_path))],
+  );
+  let (changes, removals, aggregate_generation) = receive_aggregate(&mut aggregate_rx).await;
+  assert_eq!(changes, FxHashSet::from_iter([path_string(&changed_path)]));
+  assert!(removals.is_empty());
+
+  watcher.trigger_event(&changed_path, FsEventKind::Remove);
+  watcher.trigger_event(&removed_path, FsEventKind::Create);
+  assert_eq!(
+    receive_changes(&mut change_rx, 2).await,
+    [
+      (FsEventKind::Remove, path_string(&changed_path)),
+      (FsEventKind::Change, path_string(&removed_path)),
+    ],
+  );
+
+  // The aggregate handler queues delivery asynchronously. Until JS acknowledges
+  // it, a synchronous drain must recover that claimed batch and supersede the
+  // late callback generation.
+  let (changes, removals, drained_generation) = watcher.take_pending_events();
+  assert_eq!(changes, FxHashSet::from_iter([path_string(&removed_path)]));
+  assert_eq!(removals, FxHashSet::from_iter([path_string(&changed_path)]));
+  assert!(drained_generation > aggregate_generation);
+  watcher.acknowledge_pending_events(aggregate_generation);
+  assert!(
+    tokio::time::timeout(std::time::Duration::from_millis(500), aggregate_rx.recv())
+      .await
+      .is_err(),
+    "coalesced events should produce one aggregate",
+  );
+
+  watcher.close().await.expect("watcher should close");
+}
+
+#[tokio::test]
+async fn closing_aggregate_delivery_does_not_block_a_restarted_watcher() {
+  let temp_dir = TempDir::new().expect("temporary directory should be created");
+  let changed_path = ArcPath::from(temp_dir.path().join("changed.js"));
+  let paths = [changed_path.clone()];
+  let mut watcher = FsWatcher::new(
+    FsWatcherOptions {
+      aggregate_timeout: Some(10),
+      ..Default::default()
+    },
+    Default::default(),
+  );
+  let (failed_tx, mut failed_rx) = unbounded_channel();
+  let (aggregate_tx, mut aggregate_rx) = unbounded_channel();
+  let (change_tx, mut change_rx) = unbounded_channel();
+
+  watcher
+    .watch(
+      empty_paths(),
+      empty_paths(),
+      (paths.iter().cloned(), std::iter::empty()),
+      SystemTime::now(),
+      Box::new(ClosingDeliveryHandler(failed_tx)),
+      Box::new(ChangeHandler(change_tx.clone())),
+    )
+    .await;
+  watcher.trigger_event(&changed_path, FsEventKind::Create);
+  assert_eq!(
+    receive_changes(&mut change_rx, 1).await,
+    [(FsEventKind::Change, path_string(&changed_path))],
+  );
+  let (changes, removals, failed_generation) = receive_aggregate(&mut failed_rx).await;
+  assert_eq!(changes, FxHashSet::from_iter([path_string(&changed_path)]));
+  assert!(removals.is_empty());
+
+  // The aggregate TSFN is unbounded, so a live callback cannot lose this batch
+  // to QueueFull. A false result models Closing during callback teardown; no
+  // consumer remains for the claimed batch, and the replacement must not wedge.
+  watch(&mut watcher, &paths, &aggregate_tx, &change_tx).await;
+  watcher.trigger_event(&changed_path, FsEventKind::Remove);
+  assert_eq!(
+    receive_changes(&mut change_rx, 1).await,
+    [(FsEventKind::Remove, path_string(&changed_path))],
+  );
+  let (changes, removals, next_generation) = receive_aggregate(&mut aggregate_rx).await;
+  assert!(changes.is_empty());
+  assert_eq!(removals, FxHashSet::from_iter([path_string(&changed_path)]));
+  assert_ne!(next_generation, failed_generation);
+  watcher.acknowledge_pending_events(next_generation);
+
+  watcher.close().await.expect("watcher should close");
+}

--- a/crates/rspack_watcher/tests/watcher.rs
+++ b/crates/rspack_watcher/tests/watcher.rs
@@ -173,3 +173,52 @@ fn should_emit_remove_when_a_watched_file_is_deleted() {
     },
   );
 }
+
+#[test]
+fn should_emit_existing_and_created_files_in_the_same_context_batch() {
+  let mut helper = h!(FsWatcherOptions {
+    aggregate_timeout: Some(100),
+    ..Default::default()
+  });
+  std::fs::create_dir_all(helper.join("assets")).unwrap();
+  helper.file("assets/existing.js");
+
+  let rx = helper.watch(f!("assets/existing.js"), f!("assets"), e!());
+
+  helper.tick(|| {
+    helper.file("assets/existing.js");
+    helper.file("assets/created.js");
+  });
+
+  let existing_events = c!();
+  let created_events = c!();
+  helper.collect_events(
+    rx,
+    |event, _| {
+      if let helpers::ChangedEvent::Changed(path) = event {
+        if path == helper.join("assets/existing.js").as_str() {
+          add!(existing_events);
+        }
+        if path == helper.join("assets/created.js").as_str() {
+          add!(created_events);
+        }
+      }
+    },
+    |changes, abort| {
+      if load!(created_events) == 0 {
+        return;
+      }
+      changes.assert_changed(helper.join("assets"));
+      changes.assert_changed(helper.join("assets/existing.js"));
+      assert!(
+        !changes
+          .changed_files
+          .contains(helper.join("assets/created.js").as_str())
+      );
+      *abort = true;
+    },
+  );
+
+  assert!(load!(existing_events) > 0);
+  assert!(load!(created_events) > 0);
+}

--- a/packages/rspack/src/NativeWatchFileSystem.ts
+++ b/packages/rspack/src/NativeWatchFileSystem.ts
@@ -8,6 +8,13 @@ import type {
   WatchFileSystem,
 } from './util/fs';
 
+// Native generations are uint32. Serial-number arithmetic keeps ordering valid
+// across wraparound while the native watcher has at most one batch in flight.
+const isNewerGeneration = (generation: number, previous: number): boolean => {
+  const distance = (generation - previous) >>> 0;
+  return distance > 0 && distance < 0x80000000;
+};
+
 /**
  * The following code is modified based on
  * https://github.com/webpack/watchpack/blob/332b55016b7c32dab4134f793ca71a5141bd10c1/lib/watchpack.js#L33-L57
@@ -93,6 +100,19 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
     return this.#watcher;
   }
 
+  #purge(changes: Iterable<string>, removals: Iterable<string>): void {
+    const fs = this.#inputFileSystem;
+    if (!fs.purge) {
+      return;
+    }
+    for (const item of changes) {
+      fs.purge(item);
+    }
+    for (const item of removals) {
+      fs.purge(item);
+    }
+  }
+
   watch(
     files: Iterable<string> & {
       added?: Iterable<string>;
@@ -149,10 +169,13 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
     // Fresh shim per cycle (see field comment). Events are emitted to both the
     // long-lived `#events` (the `on`/`once` API) and this cycle's shim (the
     // `.watcher` surface).
-    const watcher = new NativeWatcherShim((kind, path) =>
-      this.#inner?.triggerEvent(kind, path),
-    );
+    const watcher = new NativeWatcherShim((kind, path) => {
+      if (this.#watcher === watcher) {
+        nativeWatcher.triggerEvent(kind, path);
+      }
+    });
     this.#watcher = watcher;
+    let lastDrainedGeneration: number | undefined;
 
     nativeWatcher.watch(
       this.formatWatchDependencies(files),
@@ -160,22 +183,28 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
       this.formatWatchDependencies(missing),
       BigInt(startTime),
       (err: Error | null, result) => {
+        if (this.#watcher !== watcher) {
+          if (!err) {
+            nativeWatcher.acknowledgePendingEvents(result.generation);
+          }
+          return;
+        }
         if (err) {
           callback(err, new Map(), new Map(), new Set(), new Set());
           return;
         }
+        if (
+          lastDrainedGeneration !== undefined &&
+          !isNewerGeneration(result.generation, lastDrainedGeneration)
+        ) {
+          nativeWatcher.acknowledgePendingEvents(result.generation);
+          return;
+        }
         nativeWatcher.pause();
+        nativeWatcher.acknowledgePendingEvents(result.generation);
         const changedFiles = result.changedFiles;
         const removedFiles = result.removedFiles;
-        if (this.#inputFileSystem?.purge) {
-          const fs = this.#inputFileSystem;
-          for (const item of changedFiles) {
-            fs.purge?.(item);
-          }
-          for (const item of removedFiles) {
-            fs.purge?.(item);
-          }
-        }
+        this.#purge(changedFiles, removedFiles);
         // TODO: add fileTimeInfoEntries and contextTimeInfoEntries
         const changes = new Set(changedFiles);
         const removals = new Set(removedFiles);
@@ -190,6 +219,9 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
         callback(err, new Map(), new Map(), changes, removals);
       },
       (event) => {
+        if (this.#watcher !== watcher) {
+          return;
+        }
         if (event.kind === 'change') {
           // The native watcher reports paths without an mtime, so events are
           // stamped with their arrival time.
@@ -211,6 +243,10 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
         // Detach immediately: a closed native watcher rejects further watch()
         // calls, so a later compiler.watch() must get a fresh instance with a
         // full (non-incremental) registration.
+        if (this.#watcher !== watcher) {
+          return;
+        }
+        this.#watcher = undefined;
         if (this.#inner === nativeWatcher) {
           this.#inner = undefined;
           this.#isFirstWatch = true;
@@ -221,15 +257,27 @@ export default class NativeWatchFileSystem implements WatchFileSystem {
       },
 
       pause: () => {
-        nativeWatcher.pause();
+        if (this.#watcher === watcher) {
+          nativeWatcher.pause();
+        }
       },
 
-      getInfo() {
-        // This is a placeholder implementation.
-        // TODO: The actual implementation should return the current state of the watcher.
+      getInfo: () => {
+        if (this.#watcher !== watcher) {
+          return {
+            changes: new Set(),
+            removals: new Set(),
+            fileTimeInfoEntries: new Map(),
+            contextTimeInfoEntries: new Map(),
+          };
+        }
+        const { changedFiles, removedFiles, generation } =
+          nativeWatcher.takePendingEvents();
+        lastDrainedGeneration = generation;
+        this.#purge(changedFiles, removedFiles);
         return {
-          changes: new Set(),
-          removals: new Set(),
+          changes: new Set(changedFiles),
+          removals: new Set(removedFiles),
           fileTimeInfoEntries: new Map(),
           contextTimeInfoEntries: new Map(),
         };

--- a/tests/rspack-test/NativeWatcherGeneration.test.js
+++ b/tests/rspack-test/NativeWatcherGeneration.test.js
@@ -1,0 +1,280 @@
+const { rspack } = require("@rspack/core");
+
+class FakeNativeWatcher {
+	acknowledgements = [];
+	pauses = 0;
+	closes = 0;
+	drains = 0;
+	triggered = [];
+	pendingDrain = {
+		changedFiles: [],
+		removedFiles: [],
+		generation: 0
+	};
+
+	watch(_files, _directories, _missing, _startTime, onAggregate, onRaw) {
+		this.onAggregate = onAggregate;
+		this.onRaw = onRaw;
+	}
+
+	takePendingEvents() {
+		this.drains++;
+		return this.pendingDrain;
+	}
+
+	acknowledgePendingEvents(generation) {
+		this.acknowledgements.push(generation);
+	}
+
+	pause() {
+		this.pauses++;
+	}
+
+	triggerEvent(kind, path) {
+		this.triggered.push([kind, path]);
+	}
+
+	close() {
+		this.closes++;
+		return Promise.resolve();
+	}
+}
+
+const dependencies = () =>
+	Object.assign([], {
+		added: [],
+		removed: []
+	});
+
+function createWatcherHarness(callbackUndelayed = () => {}) {
+	const nativeWatcher = new FakeNativeWatcher();
+	const purged = [];
+	const callbackChanges = [];
+	const compiler = rspack({
+		context: __dirname,
+		entry: __filename,
+		experiments: { nativeWatcher: true }
+	});
+	compiler.inputFileSystem.purge = path => purged.push(path);
+	const watchFileSystem = compiler.watchFileSystem;
+	watchFileSystem.getNativeWatcher = () => nativeWatcher;
+
+	const watcher = watchFileSystem.watch(
+		dependencies(),
+		dependencies(),
+		dependencies(),
+		Date.now(),
+		{},
+		(_error, _fileTimes, _contextTimes, changes) =>
+			callbackChanges.push(changes),
+		callbackUndelayed
+	);
+
+	return { nativeWatcher, purged, callbackChanges, watcher, watchFileSystem };
+}
+
+describe("NativeWatchFileSystem aggregate generations", () => {
+	it("suppresses a callback superseded by a synchronous native drain", () => {
+		const { nativeWatcher, purged, callbackChanges, watcher } =
+			createWatcherHarness();
+
+		nativeWatcher.pendingDrain = {
+			changedFiles: ["/changed"],
+			removedFiles: [],
+			generation: 2
+		};
+		expect(watcher.getInfo().changes).toEqual(new Set(["/changed"]));
+		expect(purged).toEqual(["/changed"]);
+
+		nativeWatcher.onAggregate(null, {
+			changedFiles: ["/changed"],
+			removedFiles: [],
+			generation: 1
+		});
+		expect(nativeWatcher.acknowledgements).toEqual([1]);
+		expect(nativeWatcher.pauses).toBe(0);
+		expect(purged).toEqual(["/changed"]);
+		expect(callbackChanges).toEqual([]);
+
+		nativeWatcher.onAggregate(null, {
+			changedFiles: ["/next"],
+			removedFiles: [],
+			generation: 3
+		});
+		expect(nativeWatcher.acknowledgements).toEqual([1, 3]);
+		expect(nativeWatcher.pauses).toBe(1);
+		expect(purged).toEqual(["/changed", "/next"]);
+		expect(callbackChanges).toEqual([new Set(["/next"])]);
+	});
+
+	it("accepts a newer aggregate after the native generation wraps", () => {
+		const { nativeWatcher, purged, callbackChanges, watcher } =
+			createWatcherHarness();
+
+		nativeWatcher.pendingDrain = {
+			changedFiles: ["/drained"],
+			removedFiles: [],
+			generation: 0xffffffff
+		};
+		expect(watcher.getInfo().changes).toEqual(new Set(["/drained"]));
+
+		nativeWatcher.onAggregate(null, {
+			changedFiles: ["/stale"],
+			removedFiles: [],
+			generation: 0xfffffffe
+		});
+		nativeWatcher.onAggregate(null, {
+			changedFiles: ["/wrapped"],
+			removedFiles: [],
+			generation: 0
+		});
+
+		expect(nativeWatcher.acknowledgements).toEqual([0xfffffffe, 0]);
+		expect(nativeWatcher.pauses).toBe(1);
+		expect(purged).toEqual(["/drained", "/wrapped"]);
+		expect(callbackChanges).toEqual([new Set(["/wrapped"])]);
+	});
+
+	it("ignores a raw callback retained by an earlier watch generation", () => {
+		const stale = [];
+		const fresh = [];
+		const { nativeWatcher, watchFileSystem } = createWatcherHarness(path =>
+			stale.push(path)
+		);
+		const staleRaw = nativeWatcher.onRaw;
+
+		const currentWatcher = watchFileSystem.watch(
+			dependencies(),
+			dependencies(),
+			dependencies(),
+			Date.now(),
+			{},
+			() => {},
+			path => fresh.push(path)
+		);
+
+		staleRaw({ kind: "change", path: "/stale" });
+		nativeWatcher.onRaw({ kind: "change", path: "/fresh" });
+
+		expect(stale).toEqual([]);
+		expect(fresh).toEqual(["/fresh"]);
+
+		currentWatcher.close();
+		nativeWatcher.onRaw({ kind: "change", path: "/after-close" });
+		expect(fresh).toEqual(["/fresh"]);
+	});
+
+	it("forwards concrete child events to long-lived watch-file-system listeners", () => {
+		const events = [];
+		const { nativeWatcher, watchFileSystem } = createWatcherHarness();
+		watchFileSystem.on("change", (file, mtime) =>
+			events.push(["change", file, mtime])
+		);
+		watchFileSystem.on("remove", file => events.push(["remove", file]));
+		const staleRaw = nativeWatcher.onRaw;
+
+		const currentWatcher = watchFileSystem.watch(
+			dependencies(),
+			dependencies(),
+			dependencies(),
+			Date.now(),
+			{},
+			() => {},
+			() => {}
+		);
+
+		staleRaw({ kind: "change", path: "/src/stale.js" });
+		staleRaw({ kind: "remove", path: "/src/stale.js" });
+		nativeWatcher.onRaw({ kind: "change", path: "/src/created.js" });
+		nativeWatcher.onRaw({ kind: "remove", path: "/src/created.js" });
+		expect(events).toEqual([
+			["change", "/src/created.js", expect.any(Number)],
+			["remove", "/src/created.js"]
+		]);
+
+		currentWatcher.close();
+		nativeWatcher.onRaw({ kind: "change", path: "/src/after-close.js" });
+		nativeWatcher.onRaw({ kind: "remove", path: "/src/after-close.js" });
+		expect(events).toHaveLength(2);
+	});
+
+	it("prevents stale watcher handles and callbacks from affecting the live generation", () => {
+		const events = [];
+		const {
+			nativeWatcher,
+			purged,
+			callbackChanges,
+			watcher: staleWatcher,
+			watchFileSystem
+		} = createWatcherHarness();
+		watchFileSystem.on("aggregated", (changes, removals) =>
+			events.push([changes, removals])
+		);
+		const staleAggregate = nativeWatcher.onAggregate;
+		const staleShim = watchFileSystem.watcher;
+
+		const currentChanges = [];
+		const currentWatcher = watchFileSystem.watch(
+			dependencies(),
+			dependencies(),
+			dependencies(),
+			Date.now(),
+			{},
+			(_error, _fileTimes, _contextTimes, changes) =>
+				currentChanges.push(changes),
+			() => {}
+		);
+
+		nativeWatcher.pendingDrain = {
+			changedFiles: ["/src/live.js"],
+			removedFiles: [],
+			generation: 2
+		};
+		staleWatcher.pause();
+		expect(staleWatcher.getInfo()).toEqual({
+			changes: new Set(),
+			removals: new Set(),
+			fileTimeInfoEntries: new Map(),
+			contextTimeInfoEntries: new Map()
+		});
+		staleWatcher.close();
+		staleShim._onChange("/src/stale.js");
+		staleShim._onRemove("/src/stale.js");
+		staleAggregate(null, {
+			changedFiles: ["/src/stale.js"],
+			removedFiles: [],
+			generation: 1
+		});
+
+		expect(nativeWatcher.pauses).toBe(0);
+		expect(nativeWatcher.drains).toBe(0);
+		expect(nativeWatcher.closes).toBe(0);
+		expect(nativeWatcher.triggered).toEqual([]);
+		expect(nativeWatcher.acknowledgements).toEqual([1]);
+		expect(purged).toEqual([]);
+		expect(callbackChanges).toEqual([]);
+		expect(currentChanges).toEqual([]);
+		expect(events).toEqual([]);
+
+		nativeWatcher.onAggregate(null, {
+			changedFiles: ["/src/live.js"],
+			removedFiles: [],
+			generation: 2
+		});
+		expect(nativeWatcher.pauses).toBe(1);
+		expect(nativeWatcher.acknowledgements).toEqual([1, 2]);
+		expect(purged).toEqual(["/src/live.js"]);
+		expect(callbackChanges).toEqual([]);
+		expect(currentChanges).toEqual([new Set(["/src/live.js"])]);
+		expect(events).toEqual([[new Set(["/src/live.js"]), new Set()]]);
+		watchFileSystem.watcher._onChange("/src/live.js");
+		watchFileSystem.watcher._onRemove("/src/live.js");
+		expect(nativeWatcher.triggered).toEqual([
+			["change", "/src/live.js"],
+			["remove", "/src/live.js"]
+		]);
+
+		currentWatcher.close();
+		expect(nativeWatcher.closes).toBe(1);
+	});
+});

--- a/tests/rspack-test/NativeWatcherRawEvents.test.js
+++ b/tests/rspack-test/NativeWatcherRawEvents.test.js
@@ -1,0 +1,150 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { NativeWatcher } = require('@rspack/binding');
+
+describe('NativeWatcher raw context events', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rspack-native-raw-'));
+  const context = path.join(root, 'src');
+  const ignored = path.join(context, 'ignored');
+  const existing = path.join(context, 'existing.js');
+  const created = path.join(context, 'created.js');
+  const ignoredFile = path.join(ignored, 'ignored.js');
+  let watcher;
+
+  beforeAll(() => {
+    fs.mkdirSync(ignored, { recursive: true });
+    fs.writeFileSync(existing, 'export default 1;\n');
+  });
+
+  afterAll(async () => {
+    await watcher?.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('delivers concrete created and removed children without dropping a raw burst', async () => {
+    watcher = new NativeWatcher({
+      aggregateTimeout: 10,
+      ignored: ['**/ignored/**'],
+    });
+    const rawEvents = [];
+    const aggregated = [];
+    const errors = [];
+
+    watcher.watch(
+      [[existing], []],
+      [[context], []],
+      [[], []],
+      BigInt(Date.now()),
+      (error, result) => {
+        if (error) errors.push(error);
+        if (result) {
+          aggregated.push(result);
+          watcher.acknowledgePendingEvents(result.generation);
+        }
+      },
+      (event) => rawEvents.push(event),
+    );
+
+    const waitFor = async (predicate) => {
+      const deadline = Date.now() + 5000;
+      while (!predicate()) {
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `timed out waiting for native raw events: ${JSON.stringify(rawEvents)}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    };
+
+    fs.writeFileSync(existing, 'export default 2;\n');
+    const changedAt = new Date(Date.now() + 2000);
+    fs.utimesSync(existing, changedAt, changedAt);
+    watcher.triggerEvent('change', existing);
+    await waitFor(() => rawEvents.some((event) => event.path === existing));
+    rawEvents.length = 0;
+    aggregated.length = 0;
+
+    fs.writeFileSync(existing, 'export default 3;\n');
+    const nextChangedAt = new Date(Date.now() + 4000);
+    fs.utimesSync(existing, nextChangedAt, nextChangedAt);
+    fs.writeFileSync(created, 'export default true;\n');
+    fs.writeFileSync(ignoredFile, 'export default false;\n');
+    watcher.triggerEvent('change', existing);
+    watcher.triggerEvent('create', created);
+    watcher.triggerEvent('create', ignoredFile);
+
+    await waitFor(
+      () =>
+        rawEvents.some(
+          (event) => event.kind === 'change' && event.path === existing,
+        ) &&
+        rawEvents.some(
+          (event) => event.kind === 'change' && event.path === created,
+        ) &&
+        aggregated.some(
+          (result) =>
+            result.changedFiles.includes(context) &&
+            result.changedFiles.includes(existing),
+        ),
+    );
+    expect(rawEvents.some((event) => event.path === ignoredFile)).toBe(false);
+    expect(
+      aggregated.some((result) => result.changedFiles.includes(ignoredFile)),
+    ).toBe(false);
+    expect(
+      aggregated.some((result) => result.changedFiles.includes(created)),
+    ).toBe(false);
+
+    const burst = Array.from({ length: 128 }, (_, index) =>
+      path.join(context, `created-${index}.js`),
+    );
+    rawEvents.length = 0;
+    aggregated.length = 0;
+    for (const file of burst) {
+      fs.writeFileSync(file, 'export default true;\n');
+      watcher.triggerEvent('create', file);
+    }
+    await waitFor(
+      () =>
+        burst.every((file) =>
+          rawEvents.some(
+            (event) => event.kind === 'change' && event.path === file,
+          ),
+        ) && aggregated.some((result) => result.changedFiles.includes(context)),
+    );
+    expect(
+      aggregated.some((result) =>
+        burst.some((file) => result.changedFiles.includes(file)),
+      ),
+    ).toBe(false);
+
+    rawEvents.length = 0;
+    aggregated.length = 0;
+    fs.rmSync(created);
+    watcher.triggerEvent('remove', created);
+    await waitFor(
+      () =>
+        rawEvents.some(
+          (event) => event.kind === 'remove' && event.path === created,
+        ) && aggregated.some((result) => result.changedFiles.includes(context)),
+    );
+
+    expect(
+      aggregated.some((result) => result.removedFiles.includes(created)),
+    ).toBe(false);
+
+    rawEvents.length = 0;
+    aggregated.length = 0;
+    watcher.triggerEvent('create', created);
+    await waitFor(
+      () =>
+        rawEvents.some(
+          (event) => event.kind === 'remove' && event.path === created,
+        ) && aggregated.some((result) => result.changedFiles.includes(context)),
+    );
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Separate dependency aggregates from concrete filesystem paths delivered to raw listeners.
- Make aggregate delivery lossless across claim, acknowledge, drain, and watcher generation boundaries.
- Add burst, context-child, stale callback, and generation ownership regressions.

## Related links

Source PR: #14772

Closes #14766

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).