### PR TITLE
refactor(copy-plugin): cache and order static patterns

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -340,7 +340,7 @@ export declare class JsCompiler {
   /** Build with the given option passed to the constructor */
   build(callback: (err: null | Error) => void): void
   /** Rebuild with the given option passed to the constructor */
-  rebuild(changed_files: string[], removed_files: string[], callback: (err: null | Error) => void): void
+  rebuild(changed_files: string[], removed_files: string[], callback: (err: null | Error) => void, is_lazy_watch_rebuild?: boolean): void
   close(): Promise<void>
   getVirtualFileStore(): VirtualFileStore | null
   getCompilerId(): ExternalObject<CompilerId>

--- a/crates/rspack/tests/compilation_dependencies.rs
+++ b/crates/rspack/tests/compilation_dependencies.rs
@@ -1,0 +1,31 @@
+use rspack::builder::Builder as _;
+use rspack_core::Compiler;
+use rspack_paths::ArcPath;
+use rspack_tasks::within_compiler_context_for_testing_sync;
+
+#[test]
+fn compilation_level_dependencies_stay_in_their_own_added_iterators() {
+  within_compiler_context_for_testing_sync(|| {
+    let mut compiler = Compiler::builder().build().expect("compiler should build");
+    let compilation = &mut compiler.compilation;
+    let file = ArcPath::from("/project/file.tsx");
+    let context = ArcPath::from("/project/context");
+    let missing = ArcPath::from("/project/missing.tsx");
+    let build = ArcPath::from("/project/build.config.js");
+
+    compilation.file_dependencies.insert(file.clone());
+    compilation.context_dependencies.insert(context.clone());
+    compilation.missing_dependencies.insert(missing.clone());
+    compilation.build_dependencies.insert(build.clone());
+
+    let (_, file_added, _, _) = compilation.file_dependencies();
+    let (_, context_added, _, _) = compilation.context_dependencies();
+    let (_, missing_added, _, _) = compilation.missing_dependencies();
+    let (_, build_added, _, _) = compilation.build_dependencies();
+
+    assert_eq!(file_added.cloned().collect::<Vec<_>>(), [file]);
+    assert_eq!(context_added.cloned().collect::<Vec<_>>(), [context]);
+    assert_eq!(missing_added.cloned().collect::<Vec<_>>(), [missing]);
+    assert_eq!(build_added.cloned().collect::<Vec<_>>(), [build]);
+  });
+}

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -390,7 +390,7 @@ impl JsCompiler {
 
   /// Rebuild with the given option passed to the constructor
   #[napi(
-    ts_args_type = "changed_files: string[], removed_files: string[], callback: (err: null | Error) => void"
+    ts_args_type = "changed_files: string[], removed_files: string[], callback: (err: null | Error) => void, is_lazy_watch_rebuild?: boolean"
   )]
   pub fn rebuild(
     &mut self,
@@ -398,6 +398,7 @@ impl JsCompiler {
     changed_files: Vec<String>,
     removed_files: Vec<String>,
     f: Function<'static>,
+    is_lazy_watch_rebuild: Option<bool>,
   ) -> Result<(), ErrorCode> {
     unsafe {
       self.run(reference, |compiler, guard| {
@@ -405,9 +406,10 @@ impl JsCompiler {
           f,
           async move {
             let result = compiler
-              .rebuild(
+              .rebuild_with_invalidation_provenance(
                 changed_files.into_iter().collect::<FxHashSet<_>>(),
                 removed_files.into_iter().collect::<FxHashSet<_>>(),
+                is_lazy_watch_rebuild.unwrap_or(false),
               )
               .await
               .to_napi_result_with_message(|e| {

--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -32,7 +32,7 @@ pub struct BuildChunkGraphArtifact {
   pub(crate) code_splitter: CodeSplitter,
   pub module_idx: IdentifierMap<(u32, u32)>,
   global_include_modules: Vec<ModuleIdentifier>,
-  entry_include_modules: FxIndexMap<String, Vec<ModuleIdentifier>>,
+  entry_include_modules: Vec<(String, Vec<ModuleIdentifier>)>,
 }
 
 impl BuildChunkGraphArtifact {
@@ -230,7 +230,7 @@ impl BuildChunkGraphArtifact {
           .copied()
           .map(DependenciesBlockIdentifier::AsyncDependenciesBlock),
       ) {
-        let outgoings = prepared_connections_by_block
+        let mut outgoings = prepared_connections_by_block
           .remove(&block)
           .unwrap_or_default()
           .into_iter()
@@ -248,7 +248,7 @@ impl BuildChunkGraphArtifact {
             .is_not_false()
           })
           .map(|connection| connection.module)
-          .collect::<Vec<_>>();
+          .peekable();
 
         let mut previous_modules = IdentifierIndexMap::default();
         let mut miss_in_previous = true;
@@ -273,7 +273,7 @@ impl BuildChunkGraphArtifact {
 
         if miss_in_previous
           && !(matches!(block, DependenciesBlockIdentifier::Module(_))
-            && outgoings.is_empty()
+            && outgoings.peek().is_none()
             && self.chunk_graph.try_get_module_chunks(&module).is_some())
         {
           logger.log("new module detected, rebuilding chunk graph");
@@ -374,10 +374,7 @@ fn refresh_async_chunk_group_origins(compilation: &mut Compilation) {
 
 fn collect_entry_include_modules(
   compilation: &Compilation,
-) -> (
-  Vec<ModuleIdentifier>,
-  FxIndexMap<String, Vec<ModuleIdentifier>>,
-) {
+) -> (Vec<ModuleIdentifier>, Vec<(String, Vec<ModuleIdentifier>)>) {
   let module_graph = compilation.get_module_graph();
   let mut global_includes = compilation
     .global_entry
@@ -490,9 +487,10 @@ fn refresh_entrypoint_options(compilation: &mut Compilation) {
     let ChunkGroupKind::Entrypoint { options, .. } = &mut entrypoint.kind else {
       unreachable!("cached entrypoint should have entrypoint options");
     };
-    **options = entry.options.clone();
+    options.filename.clone_from(&entry.options.filename);
+    options.public_path.clone_from(&entry.options.public_path);
 
-    let filename = entry.options.filename.clone();
+    let filename = options.filename.clone();
     requires_full_chunk_assets |= filename
       .as_ref()
       .is_some_and(Filename::has_hash_placeholder);

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -316,6 +316,8 @@ pub struct Compilation {
   ///
   /// Rebuild will include previous compilation data, so persistent cache will not recovery anything
   pub is_rebuild: bool,
+  /// Whether this rebuild was explicitly invalidated by lazy compilation.
+  pub is_lazy_watch_rebuild: bool,
   pub compiler_context: Arc<CompilerContext>,
 }
 
@@ -445,6 +447,7 @@ impl Compilation {
       intermediate_filesystem,
       output_filesystem,
       is_rebuild,
+      is_lazy_watch_rebuild: false,
       compiler_context,
     }
   }
@@ -525,7 +528,7 @@ impl Compilation {
       .build_module_graph_artifact
       .context_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(&self.context_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .context_dependencies
@@ -554,7 +557,7 @@ impl Compilation {
       .build_module_graph_artifact
       .missing_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(&self.missing_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .missing_dependencies
@@ -583,7 +586,7 @@ impl Compilation {
       .build_module_graph_artifact
       .build_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(&self.build_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .build_dependencies

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -21,9 +21,20 @@ impl Compiler {
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
   ) -> Result<()> {
+    self
+      .rebuild_with_invalidation_provenance(changed_files, deleted_files, false)
+      .await
+  }
+
+  pub async fn rebuild_with_invalidation_provenance(
+    &mut self,
+    changed_files: FxHashSet<String>,
+    deleted_files: FxHashSet<String>,
+    is_lazy_watch_rebuild: bool,
+  ) -> Result<()> {
     match within_compiler_context(
       self.compiler_context.clone(),
-      self.rebuild_inner(changed_files, deleted_files),
+      self.rebuild_inner(changed_files, deleted_files, is_lazy_watch_rebuild),
     )
     .await
     {
@@ -50,12 +61,14 @@ impl Compiler {
 
   #[tracing::instrument("Compiler:rebuild", skip_all, fields(
     compiler.changed_files = ?changed_files.iter().cloned().collect::<Vec<_>>(),
-    compiler.deleted_files = ?deleted_files.iter().cloned().collect::<Vec<_>>()
+    compiler.deleted_files = ?deleted_files.iter().cloned().collect::<Vec<_>>(),
+    compiler.is_lazy_watch_rebuild = is_lazy_watch_rebuild
   ))]
   async fn rebuild_inner(
     &mut self,
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
+    is_lazy_watch_rebuild: bool,
   ) -> Result<()> {
     let records = self.last_records.clone();
 
@@ -93,6 +106,7 @@ impl Compiler {
         true,
         self.compiler_context.clone(),
       );
+      next_compilation.is_lazy_watch_rebuild = is_lazy_watch_rebuild;
       next_compilation.hot_index = self.compilation.hot_index + 1;
 
       if next_compilation

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -10,13 +10,14 @@ use std::{
 use cow_utils::CowUtils;
 use derive_more::Debug;
 use fast_glob::glob_match;
-use futures::future::{BoxFuture, join_all};
+use futures::{StreamExt, future::BoxFuture, stream::FuturesOrdered};
 use regex::Regex;
 use rspack_core::{
   AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
   CompilationProcessAssets, Filename, GlobMatchOptions, Logger, PathData, Plugin,
-  escape_glob_pattern, find_files_by_glob,
+  escape_glob_pattern, extract_glob_base_dir, find_files_by_glob,
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
+  unescape_glob_path,
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHashDigest, RspackHasher};
@@ -24,6 +25,10 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
 use sugar_path::SugarPath;
+
+mod pattern_cache;
+
+use pattern_cache::CachedPatternResult;
 
 #[derive(Debug)]
 pub struct CopyRspackPluginOptions {
@@ -119,14 +124,22 @@ pub struct RunPatternResult {
   pub source: BoxSource,
   pub info: Option<Info>,
   pub force: bool,
-  pub priority: i32,
-  pub pattern_index: usize,
 }
 
 #[plugin]
 #[derive(Debug)]
 pub struct CopyRspackPlugin {
   pub patterns: Vec<CopyPattern>,
+  pattern_cache: Mutex<Vec<Option<CachedPatternResult>>>,
+}
+
+struct PendingPattern<'a> {
+  index: usize,
+  pattern: &'a CopyPattern,
+  cacheable: bool,
+  file_dependencies: FxDashSet<PathBuf>,
+  context_dependencies: FxDashSet<PathBuf>,
+  diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
 }
 
 static TEMPLATE_RE: LazyLock<Regex> =
@@ -142,7 +155,16 @@ fn normalize_glob_path_separators(path: &str) -> Cow<'_, str> {
 
 impl CopyRspackPlugin {
   pub fn new(patterns: Vec<CopyPattern>) -> Self {
-    Self::new_inner(patterns)
+    let pattern_cache = Mutex::new(vec![None; patterns.len()]);
+    Self::new_inner(patterns, pattern_cache)
+  }
+
+  fn is_cacheable(pattern: &CopyPattern) -> bool {
+    pattern.transform_fn.is_none()
+      && !matches!(pattern.to, Some(ToOption::Fn(_)))
+      && !pattern.copy_permissions.unwrap_or(false)
+      && !matches!(pattern.to_type, Some(ToType::Template))
+      && !matches!(pattern.to, Some(ToOption::String(ref to)) if TEMPLATE_RE.is_match(to))
   }
 
   fn get_content_hash(
@@ -167,20 +189,11 @@ impl CopyRspackPlugin {
     diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
     compilation: &Compilation,
     logger: &CompilationLogger,
-    pattern_index: usize,
   ) -> Result<Option<RunPatternResult>> {
     // Exclude directories
     if entry.is_dir() {
       return Ok(None);
     }
-    if let Some(ignore) = &pattern.glob_options.ignore
-      && ignore
-        .iter()
-        .any(|ignore| glob_match(ignore.as_bytes(), entry.as_str().as_bytes()))
-    {
-      return Ok(None);
-    }
-
     let from = entry;
 
     logger.debug(format!("found '{from}'"));
@@ -299,11 +312,9 @@ impl CopyRspackPlugin {
       }
     };
 
-    let mut source = RawBufferSource::from(source_vec.clone()).boxed();
-
-    if let Some(transformer) = &pattern.transform_fn {
+    let source = if let Some(transformer) = &pattern.transform_fn {
+      let mut source = RawBufferSource::from(source_vec.clone()).boxed();
       logger.debug(format!("transforming content for '{absolute_filename}'..."));
-      // TODO: support cache in the future.
       handle_transform(
         transformer,
         source_vec,
@@ -311,8 +322,11 @@ impl CopyRspackPlugin {
         &mut source,
         diagnostics,
       )
-      .await
-    }
+      .await;
+      source
+    } else {
+      RawBufferSource::from(source_vec).boxed()
+    };
 
     let filename = if matches!(&to_type, ToType::Template) {
       logger.log(format!(
@@ -344,6 +358,7 @@ impl CopyRspackPlugin {
     } else {
       filename.as_str().normalize().to_string_lossy().to_string()
     };
+    let filename = normalize_glob_path_separators(&filename).into_owned();
 
     Ok(Some(RunPatternResult {
       source_filename,
@@ -352,20 +367,17 @@ impl CopyRspackPlugin {
       source,
       info: pattern.info.clone(),
       force: pattern.force,
-      priority: pattern.priority,
-      pattern_index,
     }))
   }
 
-  async fn run_patter(
+  async fn run_pattern(
     compilation: &Compilation,
     pattern: &CopyPattern,
-    index: usize,
     file_dependencies: &FxDashSet<PathBuf>,
     context_dependencies: &FxDashSet<PathBuf>,
     diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
     logger: &CompilationLogger,
-  ) -> Result<Option<Vec<Option<RunPatternResult>>>> {
+  ) -> Result<Option<Vec<RunPatternResult>>> {
     let orig_from = &pattern.from;
     let normalized_orig_from = Utf8PathBuf::from(orig_from);
 
@@ -413,11 +425,6 @@ impl CopyRspackPlugin {
     // Enable copy files starts with dot
     let mut dot_enable = pattern.glob_options.dot;
 
-    /*
-     * If input is a glob query like `/a/b/**/*.js`, we need to add common directory
-     * to context_dependencies
-     */
-    let mut need_add_context_to_dependency = false;
     let glob_query = match from_type {
       FromType::Dir => {
         logger.debug(format!("added '{abs_from}' as a context dependency"));
@@ -450,7 +457,6 @@ impl CopyRspackPlugin {
         escape_glob_pattern(&from)
       }
       FromType::Glob => {
-        need_add_context_to_dependency = true;
         let mut glob_query = if Path::new(orig_from).is_absolute() {
           orig_from.into()
         } else {
@@ -469,6 +475,11 @@ impl CopyRspackPlugin {
       }
     };
 
+    if matches!(from_type, FromType::Glob) {
+      let glob_base_dir = unescape_glob_path(extract_glob_base_dir(&glob_query));
+      context_dependencies.insert(PathBuf::from(glob_base_dir).normalize().into_owned());
+    }
+
     logger.log(format!("begin globbing '{glob_query}'..."));
 
     let glob_match_options = GlobMatchOptions {
@@ -484,32 +495,14 @@ impl CopyRspackPlugin {
     .await;
 
     match glob_entries {
-      Ok(entries) => {
-        let entries: Vec<_> = entries
-          .into_iter()
-          .filter(|entry| {
-            if let Some(filters) = &pattern.glob_options.ignore {
-              // If filters length is 0, exist is true by default
-              filters
-                .iter()
-                .all(|filter| !glob_match(filter.as_bytes(), entry.as_str().as_bytes()))
-            } else {
-              true
-            }
+      Ok(mut entries) => {
+        entries.retain(|entry| {
+          pattern.glob_options.ignore.as_ref().is_none_or(|filters| {
+            filters
+              .iter()
+              .all(|filter| !glob_match(filter.as_bytes(), entry.as_str().as_bytes()))
           })
-          .collect();
-
-        if need_add_context_to_dependency
-          && let Some(common_dir) = get_closest_common_parent_dir(
-            &entries.iter().map(|it| it.as_path()).collect::<Vec<_>>(),
-          )
-        {
-          // The glob common dir is derived from glob-matched entries, which keep
-          // the pattern's raw shape (e.g. a leading `./`, and `/` separators on
-          // Windows). Normalize it so the registered context dependency matches
-          // the native, normalized paths used everywhere else in the dep graph.
-          context_dependencies.insert(common_dir.into_std_path_buf().normalize().into_owned());
-        }
+        });
 
         if entries.is_empty() {
           if pattern.no_error_on_missing {
@@ -526,28 +519,31 @@ impl CopyRspackPlugin {
               "CopyRspackPlugin Error".into(),
               format!("unable to locate '{glob_query}' glob"),
             ));
+          return Ok(None);
         }
 
         let output_path = &compilation.options.output.path;
 
-        let copied_result = join_all(entries.into_iter().map(|entry| async {
-          Self::analyze_every_entry(
-            entry,
-            pattern,
-            &context,
-            output_path,
-            from_type,
-            file_dependencies,
-            diagnostics.clone(),
-            compilation,
-            logger,
-            index,
-          )
+        let copied_result = entries
+          .into_iter()
+          .map(|entry| {
+            Self::analyze_every_entry(
+              entry,
+              pattern,
+              &context,
+              output_path,
+              from_type,
+              file_dependencies,
+              diagnostics.clone(),
+              compilation,
+              logger,
+            )
+          })
+          .collect::<FuturesOrdered<_>>()
+          .collect::<Vec<_>>()
           .await
-        }))
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>>>()?;
+          .into_iter()
+          .collect::<Result<Vec<_>>>()?;
 
         if copied_result.is_empty() {
           if pattern.no_error_on_missing {
@@ -565,7 +561,7 @@ impl CopyRspackPlugin {
           return Ok(None);
         }
 
-        Ok(Some(copied_result))
+        Ok(Some(copied_result.into_iter().flatten().collect()))
       }
       Err(e) => {
         if pattern.no_error_on_missing {
@@ -597,41 +593,186 @@ impl CopyRspackPlugin {
       }
     }
   }
+
+  fn emit_pattern_results(
+    &self,
+    compilation: &mut Compilation,
+    results_by_pattern: Vec<Option<Vec<RunPatternResult>>>,
+  ) -> Vec<(Utf8PathBuf, Utf8PathBuf)> {
+    let mut ordered_patterns = results_by_pattern
+      .into_iter()
+      .enumerate()
+      .collect::<Vec<_>>();
+    ordered_patterns.sort_unstable_by_key(|(index, _)| (self.patterns[*index].priority, *index));
+
+    let mut permission_copies = Vec::new();
+    for (index, results) in ordered_patterns {
+      let copy_permissions = self.patterns[index].copy_permissions.unwrap_or(false);
+      for result in results.into_iter().flatten() {
+        let permission_copy = copy_permissions.then(|| {
+          (
+            result.absolute_filename.clone(),
+            compilation.options.output.path.join(&result.filename),
+          )
+        });
+
+        if let Some(exist_asset) = compilation.assets_mut().get_mut(&result.filename) {
+          if !result.force {
+            continue;
+          }
+          exist_asset.set_source(Some(Arc::new(result.source)));
+          if let Some(info) = result.info {
+            set_info(&mut exist_asset.info, info);
+          }
+          exist_asset.info.source_filename = Some(result.source_filename.to_string());
+          exist_asset.info.copied = Some(true);
+        } else {
+          let mut asset_info = AssetInfo {
+            source_filename: Some(result.source_filename.to_string()),
+            copied: Some(true),
+            ..Default::default()
+          };
+
+          if let Some(info) = result.info {
+            set_info(&mut asset_info, info);
+          }
+
+          compilation.emit_asset(
+            result.filename,
+            CompilationAsset::new(Some(Arc::new(result.source)), asset_info),
+          );
+        }
+
+        if let Some(permission_copy) = permission_copy {
+          permission_copies.push(permission_copy);
+        }
+      }
+    }
+
+    permission_copies
+  }
 }
 
 #[plugin_hook(CompilationProcessAssets for CopyRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
 async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let logger = compilation.get_logger("rspack.CopyRspackPlugin");
   let start = logger.time("run pattern");
-  let file_dependencies = FxDashSet::default();
-  let context_dependencies = FxDashSet::default();
-  let diagnostics = Arc::new(Mutex::new(Vec::new()));
+  let mut file_dependencies = Vec::new();
+  let mut context_dependencies = Vec::new();
+  let mut diagnostics = Vec::new();
+  let cache_counter = logger.cache("copy pattern cache");
 
-  let mut copied_result: Vec<(i32, RunPatternResult)> =
-    join_all(self.patterns.iter().enumerate().map(|(index, pattern)| {
-      CopyRspackPlugin::run_patter(
-        compilation,
-        pattern,
+  let mut results_by_pattern = vec![None; self.patterns.len()];
+  let mut pending_patterns = Vec::new();
+  {
+    let mut pattern_cache = self
+      .pattern_cache
+      .lock()
+      .expect("failed to obtain lock of `pattern_cache`");
+    pattern_cache.resize_with(self.patterns.len(), || None);
+
+    for (index, pattern) in self.patterns.iter().enumerate() {
+      let cacheable = CopyRspackPlugin::is_cacheable(pattern);
+      let cached = &mut pattern_cache[index];
+
+      if cacheable
+        && (compilation.is_lazy_watch_rebuild
+          || !compilation.modified_files.is_empty()
+          || !compilation.removed_files.is_empty())
+        && let Some(cached) = cached.as_ref()
+        && !cached.is_invalidated(
+          compilation
+            .modified_files
+            .iter()
+            .chain(compilation.removed_files.iter())
+            .map(|changed| changed.as_ref()),
+        )
+      {
+        cache_counter.hit();
+        file_dependencies.extend(cached.file_dependencies.iter().cloned());
+        context_dependencies.extend(cached.context_dependencies.iter().cloned());
+        results_by_pattern[index] = Some(cached.results.clone());
+        continue;
+      }
+
+      cache_counter.miss();
+      *cached = None;
+      pending_patterns.push(PendingPattern {
         index,
-        &file_dependencies,
-        &context_dependencies,
-        diagnostics.clone(),
+        pattern,
+        cacheable,
+        file_dependencies: FxDashSet::default(),
+        context_dependencies: FxDashSet::default(),
+        diagnostics: Arc::new(Mutex::new(Vec::new())),
+      });
+    }
+  }
+  logger.cache_end(cache_counter);
+  let pending_results = pending_patterns
+    .iter()
+    .map(|pending| {
+      CopyRspackPlugin::run_pattern(
+        compilation,
+        pending.pattern,
+        &pending.file_dependencies,
+        &pending.context_dependencies,
+        pending.diagnostics.clone(),
         &logger,
       )
-    }))
-    .await
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?
-    .into_iter()
-    .flatten()
-    .flat_map(|item| {
-      item
-        .into_iter()
-        .flatten()
-        .map(|item| (item.priority, item))
-        .collect::<Vec<_>>()
     })
-    .collect();
+    .collect::<FuturesOrdered<_>>()
+    .collect::<Vec<_>>()
+    .await;
+
+  let mut first_error = None;
+  if !pending_patterns.is_empty() {
+    let mut pattern_cache = self
+      .pattern_cache
+      .lock()
+      .expect("failed to obtain lock of `pattern_cache`");
+    for (pending, results) in pending_patterns.into_iter().zip(pending_results) {
+      let results = match results {
+        Ok(results) => results,
+        Err(error) => {
+          if first_error.is_none() {
+            first_error = Some(error);
+          }
+          continue;
+        }
+      };
+      let pattern_file_dependencies = pending.file_dependencies.into_iter().collect::<Vec<_>>();
+      let pattern_context_dependencies =
+        pending.context_dependencies.into_iter().collect::<Vec<_>>();
+      let pattern_diagnostics = std::mem::take(
+        pending
+          .diagnostics
+          .lock()
+          .expect("failed to obtain lock of `pattern_diagnostics`")
+          .deref_mut(),
+      );
+      let has_diagnostics = !pattern_diagnostics.is_empty();
+      file_dependencies.extend(pattern_file_dependencies.iter().cloned());
+      context_dependencies.extend(pattern_context_dependencies.iter().cloned());
+      diagnostics.extend(pattern_diagnostics);
+
+      if pending.cacheable
+        && !has_diagnostics
+        && let Some(results) = results.as_ref()
+      {
+        pattern_cache[pending.index] = Some(CachedPatternResult {
+          results: results.clone(),
+          file_dependencies: pattern_file_dependencies,
+          context_dependencies: pattern_context_dependencies,
+        });
+      }
+
+      results_by_pattern[pending.index] = results;
+    }
+  }
+  if let Some(error) = first_error {
+    return Err(error);
+  }
+
   logger.time_end(start);
 
   let start = logger.time("emit assets");
@@ -641,60 +782,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   compilation
     .context_dependencies
     .extend(context_dependencies.into_iter().map(Into::into));
-  compilation.extend_diagnostics(std::mem::take(
-    diagnostics
-      .lock()
-      .expect("failed to obtain lock of `diagnostics`")
-      .deref_mut(),
-  ));
+  compilation.extend_diagnostics(diagnostics);
 
-  copied_result.sort_unstable_by_key(|a| a.0);
-
-  // Keep track of source to destination file mappings for permission copying
-  let mut permission_copies = Vec::new();
-
-  copied_result.into_iter().for_each(|(_priority, result)| {
-    let source_path = result.absolute_filename.clone();
-    let dest_path = compilation.options.output.path.join(&result.filename);
-
-    if let Some(exist_asset) = compilation.assets_mut().get_mut(&result.filename) {
-      if !result.force {
-        return;
-      }
-      exist_asset.set_source(Some(Arc::new(result.source)));
-      if let Some(info) = result.info {
-        set_info(&mut exist_asset.info, info);
-      }
-      exist_asset.info.source_filename = Some(result.source_filename.to_string());
-      exist_asset.info.copied = Some(true);
-    } else {
-      let mut asset_info = AssetInfo {
-        source_filename: Some(result.source_filename.to_string()),
-        copied: Some(true),
-        ..Default::default()
-      };
-
-      if let Some(info) = result.info {
-        set_info(&mut asset_info, info);
-      }
-
-      compilation.emit_asset(
-        result.filename,
-        CompilationAsset::new(Some(Arc::new(result.source)), asset_info),
-      );
-    }
-
-    // Store the paths for permission copying along with the pattern index
-    permission_copies.push((result.pattern_index, source_path, dest_path));
-  });
+  let permission_copies = self.emit_pattern_results(compilation, results_by_pattern);
   logger.time_end(start);
 
   // Handle permission copying after all assets are emitted
-  for (pattern_index, source_path, dest_path) in permission_copies.iter() {
-    if let Some(pattern) = self.patterns.get(*pattern_index)
-      && pattern.copy_permissions.unwrap_or(false)
-      && let Ok(Some(permissions)) = compilation.input_filesystem.permissions(source_path).await
-    {
+  for (source_path, dest_path) in permission_copies.iter() {
+    if let Ok(Some(permissions)) = compilation.input_filesystem.permissions(source_path).await {
       // Make sure the output directory exists
       if let Some(parent) = dest_path.parent() {
         compilation
@@ -741,26 +836,6 @@ impl Plugin for CopyRspackPlugin {
       .tap(process_assets::new(self));
     Ok(())
   }
-}
-
-fn get_closest_common_parent_dir(paths: &[&Utf8Path]) -> Option<Utf8PathBuf> {
-  // If there are no matching files, return `None`.
-  if paths.is_empty() {
-    return None;
-  }
-
-  // Get the first file path and use it as the initial value for the common parent directory.
-  let mut parent_dir: Utf8PathBuf = paths[0].parent()?.to_path_buf();
-
-  // Iterate over the remaining file paths, updating the common parent directory as necessary.
-  for path in paths.iter().skip(1) {
-    // Find the common parent directory between the current file path and the previous common parent directory.
-    while !path.starts_with(&parent_dir) {
-      parent_dir = parent_dir.parent()?.into();
-    }
-  }
-
-  Some(parent_dir)
 }
 
 fn set_info(target: &mut AssetInfo, info: Info) {

--- a/crates/rspack_plugin_copy/src/pattern_cache.rs
+++ b/crates/rspack_plugin_copy/src/pattern_cache.rs
@@ -1,0 +1,63 @@
+use std::path::{Path, PathBuf};
+
+use crate::RunPatternResult;
+
+#[derive(Debug, Clone)]
+pub(super) struct CachedPatternResult {
+  pub(super) results: Vec<RunPatternResult>,
+  pub(super) file_dependencies: Vec<PathBuf>,
+  pub(super) context_dependencies: Vec<PathBuf>,
+}
+
+impl CachedPatternResult {
+  pub(super) fn is_invalidated<'a>(
+    &self,
+    mut changed_paths: impl Iterator<Item = &'a Path>,
+  ) -> bool {
+    changed_paths.any(|changed| {
+      self
+        .file_dependencies
+        .iter()
+        .chain(&self.context_dependencies)
+        .any(|dependency| changed.starts_with(dependency) || dependency.starts_with(changed))
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn cached(file_dependencies: &[&str], context_dependencies: &[&str]) -> CachedPatternResult {
+    CachedPatternResult {
+      results: Vec::new(),
+      file_dependencies: file_dependencies.iter().map(PathBuf::from).collect(),
+      context_dependencies: context_dependencies.iter().map(PathBuf::from).collect(),
+    }
+  }
+
+  #[test]
+  fn invalidates_matching_files_and_context_descendants() {
+    let cached = cached(&["/project/assets/file.txt"], &["/project/assets/glob"]);
+
+    assert!(cached.is_invalidated([Path::new("/project/assets/file.txt")].into_iter()));
+    assert!(cached.is_invalidated([Path::new("/project/assets/glob/nested/new.txt")].into_iter()));
+  }
+
+  #[test]
+  fn invalidates_ancestor_directory_events_for_files_and_contexts() {
+    let file = cached(&["/project/assets/nested/file.txt"], &[]);
+    let context = cached(&[], &["/project/assets/nested"]);
+
+    assert!(file.is_invalidated([Path::new("/project/assets")].into_iter()));
+    assert!(context.is_invalidated([Path::new("/project/assets")].into_iter()));
+  }
+
+  #[test]
+  fn reuses_for_empty_and_unrelated_changes() {
+    let cached = cached(&["/project/assets/file.txt"], &["/project/assets/glob"]);
+
+    assert!(!cached.is_invalidated([Path::new("/project/src/index.js")].into_iter()));
+    assert!(!cached.is_invalidated(std::iter::empty()));
+  }
+}

--- a/crates/rspack_watcher/src/analyzer/directories.rs
+++ b/crates/rspack_watcher/src/analyzer/directories.rs
@@ -1,15 +1,15 @@
 #![allow(unused)]
 use rspack_paths::ArcPath;
-use rspack_util::fx_hash::FxHashSet as HashSet;
+use rspack_util::fx_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::{Analyzer, WatchPattern};
 use crate::paths::PathAccessor;
 
 /// `WatcherDirectoriesAnalyzer` analyzes the path register and determines
 ///
-/// which directories should be watched individually (non-recursively).
-/// This is typically used on platforms where recursive watching is not
-/// available or not desired, so each directory is watched separately.
+/// which directories should be watched individually. File parents stay
+/// non-recursive, while registered context directories must be recursive so
+/// changes in pre-existing child directories are observable.
 #[derive(Default)]
 pub struct WatcherDirectoriesAnalyzer;
 
@@ -25,25 +25,47 @@ impl Analyzer for WatcherDirectoriesAnalyzer {
 const DIRECTORY_WATCH_DEPTH: u32 = 2;
 
 impl WatcherDirectoriesAnalyzer {
-  /// Finds all directories that should be watched individually (non-recursively).
+  /// Finds all directories that should be watched individually, keeping the
+  /// strongest required mode when a file parent and context share a path.
   fn find_watch_directories<'a>(&self, path_accessor: PathAccessor<'a>) -> HashSet<WatchPattern> {
-    let mut patterns = HashSet::default();
-    let all = path_accessor.all();
-    for path in all {
+    let mut modes = HashMap::default();
+    let directories = path_accessor.directories().0;
+
+    for path in path_accessor.all() {
       if let Some((dir, deep)) = self.find_exists_path(path) {
-        // Insert the parent directory of the file
-        patterns.insert(WatchPattern {
-          path: dir,
-          mode: if deep >= DIRECTORY_WATCH_DEPTH {
-            notify::RecursiveMode::Recursive
-          } else {
-            notify::RecursiveMode::NonRecursive
-          },
-        });
+        let recursive = deep >= DIRECTORY_WATCH_DEPTH || directories.contains(&dir);
+        modes
+          .entry(dir)
+          .and_modify(|current| *current |= recursive)
+          .or_insert(recursive);
       }
     }
 
-    patterns
+    // A recursive root already covers its descendants. Re-registering a child
+    // non-recursively duplicates inotify work and can downgrade that child's mode.
+    let recursive_roots: HashSet<ArcPath> = modes
+      .iter()
+      .filter_map(|(path, recursive)| recursive.then_some(path.clone()))
+      .collect();
+
+    modes
+      .into_iter()
+      .filter(|(path, _)| {
+        path
+          .as_ref()
+          .ancestors()
+          .skip(1)
+          .all(|parent| !recursive_roots.contains(&ArcPath::from(parent)))
+      })
+      .map(|(path, recursive)| WatchPattern {
+        path,
+        mode: if recursive {
+          notify::RecursiveMode::Recursive
+        } else {
+          notify::RecursiveMode::NonRecursive
+        },
+      })
+      .collect()
   }
 
   /// Finds the deepest existing directory path and its depth.
@@ -101,7 +123,7 @@ mod tests {
     }));
     assert!(watch_patterns.contains(&WatchPattern {
       path: ArcPath::from(current_dir.join("src")),
-      mode: notify::RecursiveMode::NonRecursive
+      mode: notify::RecursiveMode::Recursive
     }));
   }
 
@@ -134,11 +156,7 @@ mod tests {
     let analyzer = WatcherDirectoriesAnalyzer::default();
     let watch_patterns = analyzer.analyze(path_manager.access());
 
-    assert_eq!(watch_patterns.len(), 3);
-    assert!(watch_patterns.contains(&WatchPattern {
-      path: dir_0.clone(),
-      mode: notify::RecursiveMode::NonRecursive,
-    }));
+    assert_eq!(watch_patterns.len(), 2);
     assert!(watch_patterns.contains(&WatchPattern {
       path: dir_0,
       mode: notify::RecursiveMode::Recursive,
@@ -147,5 +165,44 @@ mod tests {
       path: ArcPath::from(current_dir),
       mode: notify::RecursiveMode::NonRecursive,
     }));
+  }
+
+  #[test]
+  fn test_recursive_context_prunes_covered_file_parents() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let base = temp_dir.path().canonicalize().unwrap();
+    let context_a = base.join("a");
+    let context_b = base.join("b");
+    let child = context_a.join("child");
+    let file = child.join("file.txt");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::create_dir_all(&context_b).unwrap();
+    std::fs::write(&file, "file").unwrap();
+
+    let path_manager = PathManager::default();
+    path_manager
+      .update(
+        (std::iter::once(ArcPath::from(file)), std::iter::empty()),
+        (
+          [
+            ArcPath::from(context_a.clone()),
+            ArcPath::from(context_b.clone()),
+          ]
+          .into_iter(),
+          std::iter::empty(),
+        ),
+        (std::iter::empty(), std::iter::empty()),
+      )
+      .unwrap();
+
+    let watch_patterns = WatcherDirectoriesAnalyzer.analyze(path_manager.access());
+
+    assert_eq!(watch_patterns.len(), 2);
+    for context in [context_a, context_b] {
+      assert!(watch_patterns.contains(&WatchPattern {
+        path: ArcPath::from(context),
+        mode: notify::RecursiveMode::Recursive,
+      }));
+    }
   }
 }

--- a/crates/rspack_watcher/src/disk_watcher.rs
+++ b/crates/rspack_watcher/src/disk_watcher.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc, time::Duration};
 
 use notify::{Event, EventKind, RecommendedWatcher, Watcher, event::ModifyKind};
 use rspack_paths::ArcPath;
@@ -85,17 +85,20 @@ impl DiskWatcher {
   ) -> rspack_error::Result<()> {
     let new_patterns: HashSet<WatchPattern> = patterns.collect();
 
-    let new_paths = new_patterns.iter().map(|p| &p.path).collect::<HashSet<_>>();
-
-    // Collect stale paths that are no longer needed, then unwatch and remove them.
-    let stale_paths: HashSet<ArcPath> = self
+    // A changed recursive mode must be unwatched before it is registered again.
+    let stale_patterns: Vec<(ArcPath, bool)> = self
       .watch_patterns
       .iter()
-      .filter(|p| !new_paths.contains(&p.path))
-      .map(|p| p.path.clone())
+      .filter(|p| !new_patterns.contains(*p))
+      .map(|p| {
+        (
+          p.path.clone(),
+          matches!(p.mode, notify::RecursiveMode::Recursive),
+        )
+      })
       .collect();
 
-    for path in &stale_paths {
+    for (path, _) in &stale_patterns {
       if let Some(watcher) = &mut self.inner
         && let Err(e) = watcher.unwatch(path)
         && !matches!(e.kind, notify::ErrorKind::WatchNotFound)
@@ -104,9 +107,24 @@ impl DiskWatcher {
       }
     }
 
-    self
-      .watch_patterns
-      .retain(|p| !stale_paths.contains(&p.path));
+    // notify's inotify backend removes every descendant watch when a recursive
+    // parent is unwatched, so retained children must also be registered again.
+    let stale_paths: HashSet<&Path> = stale_patterns
+      .iter()
+      .map(|(path, _)| path.as_ref())
+      .collect();
+    let stale_recursive_paths: HashSet<&Path> = stale_patterns
+      .iter()
+      .filter_map(|(path, recursive)| recursive.then_some(path.as_ref()))
+      .collect();
+    self.watch_patterns.retain(|p| {
+      !stale_paths.contains(p.path.as_ref())
+        && !p
+          .path
+          .as_ref()
+          .ancestors()
+          .any(|path| stale_recursive_paths.contains(path))
+    });
 
     for pattern in new_patterns {
       if self.watch_patterns.contains(&pattern) {
@@ -133,13 +151,19 @@ impl DiskWatcher {
 
 #[cfg(test)]
 mod tests {
-  use std::sync::Arc;
+  use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+  };
 
   use rspack_paths::ArcPath;
   use tokio::sync::mpsc;
 
   use super::*;
-  use crate::paths::PathManager;
+  use crate::{
+    analyzer::{Analyzer, RecommendedAnalyzer},
+    paths::PathManager,
+  };
 
   fn create_disk_watcher() -> DiskWatcher {
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -206,5 +230,250 @@ mod tests {
     assert!(paths.contains(&ArcPath::from(dir_b)));
     assert!(paths.contains(&ArcPath::from(dir_c)));
     assert!(!paths.contains(&ArcPath::from(dir_a)));
+  }
+
+  #[test]
+  fn test_watch_replaces_recursive_mode_for_existing_path() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let dir = ArcPath::from(temp_dir.path().canonicalize().unwrap());
+    let mut watcher = create_disk_watcher();
+
+    watcher
+      .watch(std::iter::once(WatchPattern {
+        path: dir.clone(),
+        mode: notify::RecursiveMode::NonRecursive,
+      }))
+      .unwrap();
+    watcher
+      .watch(std::iter::once(WatchPattern {
+        path: dir.clone(),
+        mode: notify::RecursiveMode::Recursive,
+      }))
+      .unwrap();
+
+    assert_eq!(watcher.watch_patterns.len(), 1);
+    assert!(watcher.watch_patterns.contains(&WatchPattern {
+      path: dir.clone(),
+      mode: notify::RecursiveMode::Recursive,
+    }));
+
+    watcher
+      .watch(std::iter::once(WatchPattern {
+        path: dir.clone(),
+        mode: notify::RecursiveMode::NonRecursive,
+      }))
+      .unwrap();
+
+    assert_eq!(watcher.watch_patterns.len(), 1);
+    assert!(watcher.watch_patterns.contains(&WatchPattern {
+      path: dir,
+      mode: notify::RecursiveMode::NonRecursive,
+    }));
+  }
+
+  #[test]
+  fn test_many_stale_siblings_keep_retained_children_and_prefix_siblings() {
+    let root = std::path::PathBuf::from("/virtual-project");
+    let recursive_parent = root.join("package-1");
+    let retained_child = recursive_parent.join("retained");
+    let prefix_sibling = root.join("package-10").join("retained");
+    let retained_siblings = (0..1024)
+      .map(|index| root.join(format!("retained-{index}")))
+      .collect::<Vec<_>>();
+    let stale_siblings = (0..1024)
+      .map(|index| root.join(format!("stale-{index}")))
+      .collect::<Vec<_>>();
+
+    let pattern = |path, mode| WatchPattern {
+      path: ArcPath::from(path),
+      mode,
+    };
+    let mut watcher = create_disk_watcher();
+    watcher.inner = None;
+    watcher.watch_patterns =
+      std::iter::once(pattern(recursive_parent, notify::RecursiveMode::Recursive))
+        .chain(std::iter::once(pattern(
+          retained_child.clone(),
+          notify::RecursiveMode::NonRecursive,
+        )))
+        .chain(std::iter::once(pattern(
+          prefix_sibling.clone(),
+          notify::RecursiveMode::NonRecursive,
+        )))
+        .chain(
+          retained_siblings
+            .iter()
+            .cloned()
+            .map(|path| pattern(path, notify::RecursiveMode::NonRecursive)),
+        )
+        .chain(stale_siblings.into_iter().enumerate().map(|(index, path)| {
+          pattern(
+            path,
+            if index % 2 == 0 {
+              notify::RecursiveMode::Recursive
+            } else {
+              notify::RecursiveMode::NonRecursive
+            },
+          )
+        }))
+        .collect();
+
+    let expected: HashSet<WatchPattern> =
+      std::iter::once(pattern(retained_child, notify::RecursiveMode::NonRecursive))
+        .chain(std::iter::once(pattern(
+          prefix_sibling,
+          notify::RecursiveMode::NonRecursive,
+        )))
+        .chain(
+          retained_siblings
+            .into_iter()
+            .map(|path| pattern(path, notify::RecursiveMode::NonRecursive)),
+        )
+        .collect();
+
+    watcher
+      .watch(expected.iter().map(|pattern| WatchPattern {
+        path: pattern.path.clone(),
+        mode: pattern.mode,
+      }))
+      .unwrap();
+
+    assert_eq!(watcher.watch_patterns, expected);
+  }
+
+  #[test]
+  fn test_removing_recursive_parent_keeps_retained_child_observable() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let parent = temp_dir.path().canonicalize().unwrap();
+    let child = parent.join("child");
+    let file = child.join("file.txt");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::write(&file, "before").unwrap();
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let path_manager = Arc::new(PathManager::default());
+    path_manager
+      .update(
+        (
+          std::iter::once(ArcPath::from(file.clone())),
+          std::iter::empty(),
+        ),
+        (std::iter::empty(), std::iter::empty()),
+        (std::iter::empty(), std::iter::empty()),
+      )
+      .unwrap();
+    let trigger = Arc::new(trigger::Trigger::new(path_manager, tx));
+    let mut watcher = DiskWatcher::new(false, None, trigger);
+
+    watcher
+      .watch(
+        [
+          WatchPattern {
+            path: ArcPath::from(parent),
+            mode: notify::RecursiveMode::Recursive,
+          },
+          WatchPattern {
+            path: ArcPath::from(child.clone()),
+            mode: notify::RecursiveMode::NonRecursive,
+          },
+        ]
+        .into_iter(),
+      )
+      .unwrap();
+    watcher
+      .watch(std::iter::once(WatchPattern {
+        path: ArcPath::from(child),
+        mode: notify::RecursiveMode::NonRecursive,
+      }))
+      .unwrap();
+
+    std::thread::sleep(Duration::from_millis(100));
+    while rx.try_recv().is_ok() {}
+    std::fs::write(&file, "after").unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let observed = loop {
+      if let Ok(events) = rx.try_recv()
+        && events
+          .aggregated()
+          .iter()
+          .any(|event| event.path.as_ref() == file)
+      {
+        break true;
+      }
+      if Instant::now() >= deadline {
+        break false;
+      }
+      std::thread::sleep(Duration::from_millis(10));
+    };
+
+    assert!(observed, "retained child was no longer watched");
+  }
+
+  #[test]
+  fn test_recursive_context_observes_file_in_new_grandchild() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let parent = temp_dir.path().canonicalize().unwrap();
+    let child = parent.join("child");
+    let existing = child.join("existing.txt");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::write(&existing, "existing").unwrap();
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let path_manager = Arc::new(PathManager::default());
+    path_manager
+      .update(
+        (std::iter::once(ArcPath::from(existing)), std::iter::empty()),
+        (
+          std::iter::once(ArcPath::from(parent.clone())),
+          std::iter::empty(),
+        ),
+        (std::iter::empty(), std::iter::empty()),
+      )
+      .unwrap();
+    let trigger = Arc::new(trigger::Trigger::new(path_manager.clone(), tx));
+    let mut watcher = DiskWatcher::new(false, None, trigger);
+
+    watcher
+      .watch(std::iter::once(WatchPattern {
+        path: ArcPath::from(parent.clone()),
+        mode: notify::RecursiveMode::Recursive,
+      }))
+      .unwrap();
+    watcher
+      .watch(
+        RecommendedAnalyzer::default()
+          .analyze(path_manager.access())
+          .into_iter(),
+      )
+      .unwrap();
+
+    let grandchild = child.join("new");
+    std::thread::sleep(Duration::from_millis(100));
+    std::fs::create_dir(&grandchild).unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    while rx.try_recv().is_ok() {}
+    std::fs::write(grandchild.join("created.txt"), "created").unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let observed = loop {
+      if let Ok(events) = rx.try_recv()
+        && events
+          .aggregated()
+          .iter()
+          .any(|event| event.path.as_ref() == parent)
+      {
+        break true;
+      }
+      if Instant::now() >= deadline {
+        break false;
+      }
+      std::thread::sleep(Duration::from_millis(10));
+    };
+
+    assert!(
+      observed,
+      "recursive context did not watch the new grandchild"
+    );
   }
 }

--- a/crates/rspack_watcher/tests/watcher.rs
+++ b/crates/rspack_watcher/tests/watcher.rs
@@ -175,6 +175,47 @@ fn should_emit_remove_when_a_watched_file_is_deleted() {
 }
 
 #[test]
+fn should_watch_a_file_created_in_an_existing_context_child() {
+  let mut helper = h!(FsWatcherOptions {
+    aggregate_timeout: Some(100),
+    ..Default::default()
+  });
+  std::fs::create_dir_all(helper.join("assets/empty-child")).unwrap();
+
+  let rx = watch!(dirs @ helper, "assets");
+
+  helper.tick(|| {
+    helper.file("assets/empty-child/created.txt");
+  });
+
+  let created_events = c!();
+  helper.collect_events(
+    rx,
+    |event, _| {
+      if let helpers::ChangedEvent::Changed(path) = event
+        && path == helper.join("assets/empty-child/created.txt").as_str()
+      {
+        add!(created_events);
+      }
+    },
+    |changes, abort| {
+      if load!(created_events) == 0 {
+        return;
+      }
+      changes.assert_changed(helper.join("assets"));
+      assert!(
+        !changes
+          .changed_files
+          .contains(helper.join("assets/empty-child/created.txt").as_str())
+      );
+      *abort = true;
+    },
+  );
+
+  assert!(load!(created_events) > 0);
+}
+
+#[test]
 fn should_emit_existing_and_created_files_in_the_same_context_batch() {
   let mut helper = h!(FsWatcherOptions {
     aggregate_timeout: Some(100),

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -22,6 +22,8 @@ import binding from '@rspack/binding';
 
 export type { AssetInfo } from '@rspack/binding';
 
+export type WatchInvalidationKind = 'lazy' | 'normal';
+
 import * as liteTapable from '@rspack/lite-tapable';
 import type { Source } from 'webpack-sources';
 import type { EntryOptions, EntryPlugin } from './builtin-plugin';
@@ -292,6 +294,11 @@ export class Compilation {
     needAdditionalPass: liteTapable.SyncBailHook<[], boolean>;
   }>;
   name?: string;
+  /**
+   * The invalidation that started this watch compilation. `normal` dominates
+   * mixed or coalesced invalidations; initial and non-watch compilations are undefined.
+   */
+  readonly watchInvalidationKind: WatchInvalidationKind | undefined;
   startTime?: number;
   endTime?: number;
   compiler: Compiler;
@@ -324,6 +331,7 @@ export class Compilation {
   constructor(compiler: Compiler, inner: JsCompilation) {
     this.#inner = inner;
     this.#shutdown = false;
+    this.watchInvalidationKind = compiler.__internal__watchInvalidationKind;
 
     const processAssetsHook = new liteTapable.AsyncSeriesHook<Assets>([
       'assets',

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -21,7 +21,7 @@ import {
 } from './builtin-plugin';
 import { canInherentFromParent } from './builtin-plugin/base';
 import type { Chunk } from './Chunk';
-import type { CompilationParams } from './Compilation';
+import type { CompilationParams, WatchInvalidationKind } from './Compilation';
 import { Compilation } from './Compilation';
 import { ContextModuleFactory } from './ContextModuleFactory';
 import type {
@@ -167,6 +167,9 @@ class Compiler {
   resolverFactory: ResolverFactory;
   infrastructureLogger: any;
   watching?: Watching;
+
+  /** @internal Set by Watching while a watch compilation is being created. */
+  __internal__watchInvalidationKind?: WatchInvalidationKind;
 
   inputFileSystem: InputFileSystem | null;
   intermediateFileSystem: IntermediateFileSystem | null;
@@ -846,6 +849,7 @@ class Compiler {
           Array.from(this.modifiedFiles || []),
           Array.from(this.removedFiles || []),
           callback,
+          this.__internal__watchInvalidationKind === 'lazy',
         );
         return;
       }

--- a/packages/rspack/src/MultiCompiler.ts
+++ b/packages/rspack/src/MultiCompiler.ts
@@ -15,6 +15,7 @@ import type {
   CompilerHooks,
   RspackOptions,
   Stats,
+  WatchInvalidationKind,
 } from '.';
 import type { WatchOptions } from './config';
 import ConcurrentCompilationError from './error/ConcurrentCompilationError';
@@ -34,6 +35,7 @@ interface Node<T> {
   parents: Node<T>[];
   setupResult?: T;
   result?: Stats;
+  parentInvalidationKind?: WatchInvalidationKind;
   state:
     | 'pending'
     | 'blocked'
@@ -321,6 +323,7 @@ export class MultiCompiler {
       compiler: Compiler,
       res: SetupResult,
       done: liteTapable.Callback<Error, Stats>,
+      parentInvalidationKind?: WatchInvalidationKind,
     ) => void,
     callback: liteTapable.Callback<Error, MultiStats>,
   ): SetupResult[] {
@@ -391,7 +394,13 @@ export class MultiCompiler {
       running--;
       if (node.state === 'running') {
         node.state = 'done';
+        const invalidationKind = stats.compilation.watchInvalidationKind;
         for (const child of node.children) {
+          // Dependents consume a newly emitted parent artifact and must take
+          // the normal path even when the parent was explicitly lazy.
+          if (invalidationKind !== undefined) {
+            child.parentInvalidationKind = 'normal';
+          }
           if (child.state === 'blocked') queue.enqueue(child);
         }
       } else if (node.state === 'running-outdated') {
@@ -422,7 +431,12 @@ export class MultiCompiler {
       if (node.state === 'done') {
         node.state = 'pending';
       } else if (node.state === 'running') {
-        node.state = 'running-outdated';
+        // Watching will coalesce its own in-flight invalidation before
+        // delivering `done`; keep the node runnable so that generation can
+        // finish and unblock its already-invalidated dependents.
+        if (!node.compiler.watching?.invalid) {
+          node.state = 'running-outdated';
+        }
       }
       for (const child of node.children) {
         nodeInvalidFromParent(child);
@@ -476,7 +490,9 @@ export class MultiCompiler {
             node.compiler,
             node.setupResult!,
             nodeDone.bind(null, node) as liteTapable.Callback<Error, Stats>,
+            node.parentInvalidationKind,
           );
+          node.parentInvalidationKind = undefined;
           node.state = 'running';
         }
       }
@@ -531,9 +547,13 @@ export class MultiCompiler {
           }
           return watching;
         },
-        (compiler, watching, _done) => {
-          if (compiler.watching !== watching) return;
-          if (!watching.running) watching.invalidate();
+        (compiler, watching, _done, parentInvalidationKind) => {
+          if (compiler.watching !== watching || watching.running) return;
+          if (parentInvalidationKind) {
+            watching.__internal__invalidate(parentInvalidationKind);
+          } else {
+            watching.__internal__resumeFromMultiCompiler();
+          }
         },
         handler,
       );

--- a/packages/rspack/src/MultiWatching.ts
+++ b/packages/rspack/src/MultiWatching.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Callback } from '@rspack/lite-tapable';
+import type { WatchInvalidationKind } from './Compilation';
 import type { MultiCompiler } from './MultiCompiler';
 import asyncLib from './util/asyncLib';
 import type { Watching } from './Watching';
@@ -26,17 +27,25 @@ class MultiWatching {
     this.compiler = compiler;
   }
   invalidate(callback?: Callback<Error, void>) {
+    this.__internal__invalidate('normal', callback);
+  }
+
+  /** @internal Invalidates all child compilers with Rspack provenance. */
+  __internal__invalidate(
+    kind: WatchInvalidationKind,
+    callback?: Callback<Error, void>,
+  ) {
     if (callback) {
       asyncLib.each(
         this.watchings,
-        (watching, callback) => watching.invalidate(callback),
+        (watching, callback) => watching.__internal__invalidate(kind, callback),
         // cannot be resolved without assertion
         // Type 'Error | null | undefined' is not assignable to type 'Error | null'
         callback as (err: Error | null | undefined) => void,
       );
     } else {
       for (const watching of this.watchings) {
-        watching.invalidate();
+        watching.__internal__invalidate(kind);
       }
     }
   }

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -11,10 +11,18 @@ import type { Callback } from '@rspack/lite-tapable';
 
 import type { Compilation, Compiler } from '.';
 import { Stats } from '.';
+import type { WatchInvalidationKind } from './Compilation';
 import type { WatchOptions } from './config';
 import type { FileSystemInfoEntry, Watcher } from './util/fs';
 
 type PendingWatchDelta = { added: Set<string>; removed: Set<string> };
+
+function withWatchDelta(
+  dependencies: Iterable<string>,
+  delta: PendingWatchDelta,
+): Set<string> & PendingWatchDelta {
+  return Object.assign(new Set(dependencies), delta);
+}
 
 // Merge an incremental `(added, removed)` delta into an accumulator, cancelling
 // a path that is added then removed (or vice-versa) across calls.
@@ -53,6 +61,7 @@ export class Watching {
   #closed: boolean;
   #collectedChangedFiles?: Set<string>;
   #collectedRemovedFiles?: Set<string>;
+  #pendingInvalidationKind?: WatchInvalidationKind;
   #pendingWatchDeps?: {
     file: PendingWatchDelta;
     context: PendingWatchDelta;
@@ -131,6 +140,9 @@ export class Watching {
           this.compiler.removedFiles = undefined;
           return this.handler(err);
         }
+        if (changedFiles.size > 0 || removedFiles.size > 0) {
+          this.#recordInvalidation('normal');
+        }
         this.#invalidate(
           fileTimeInfoEntries,
           contextTimeInfoEntries,
@@ -140,6 +152,13 @@ export class Watching {
         this.onChange();
       },
       (fileName, changeTime) => {
+        this.#recordInvalidation('normal');
+        if (this.running) {
+          // The aggregate callback can arrive after an in-flight compilation
+          // finishes. Suppress that stale generation and drain the paused
+          // watcher before starting the coalesced rebuild.
+          this.invalid = true;
+        }
         if (!this.#invalidReported) {
           this.#invalidReported = true;
           this.compiler.hooks.invalid.call(fileName, changeTime);
@@ -159,6 +178,8 @@ export class Watching {
 
     const finalCallback = (err: Error | null) => {
       this.running = false;
+      this.#pendingInvalidationKind = undefined;
+      this.compiler.__internal__watchInvalidationKind = undefined;
       this.compiler.running = false;
       this.compiler.watching = undefined;
       this.compiler.watchMode = false;
@@ -214,14 +235,40 @@ export class Watching {
     }
   }
 
-  invalidate(callback?: Callback<Error, void>) {
-    if (callback) {
-      this.callbacks.push(callback);
-    }
+  #notifyInvalid() {
     if (!this.#invalidReported) {
       this.#invalidReported = true;
       this.compiler.hooks.invalid.call(null, Date.now());
     }
+  }
+
+  #recordInvalidation(kind: WatchInvalidationKind) {
+    if (kind === 'normal' || this.#pendingInvalidationKind === undefined) {
+      this.#pendingInvalidationKind = kind;
+    }
+  }
+
+  invalidate(callback?: Callback<Error, void>) {
+    this.__internal__invalidate('normal', callback);
+  }
+
+  /** @internal Invalidates with provenance supplied by Rspack internals. */
+  __internal__invalidate(
+    kind: WatchInvalidationKind,
+    callback?: Callback<Error, void>,
+  ) {
+    if (callback) {
+      this.callbacks.push(callback);
+    }
+    this.#recordInvalidation(kind);
+    this.#notifyInvalid();
+    this.onChange();
+    this.#invalidate();
+  }
+
+  /** @internal Resume an invalidation already recorded by MultiCompiler. */
+  __internal__resumeFromMultiCompiler() {
+    this.#notifyInvalid();
     this.onChange();
     this.#invalidate();
   }
@@ -237,10 +284,8 @@ export class Watching {
     if (callback) {
       this.callbacks.push(callback);
     }
-    if (!this.#invalidReported) {
-      this.#invalidReported = true;
-      this.compiler.hooks.invalid.call(null, Date.now());
-    }
+    this.#recordInvalidation('normal');
+    this.#notifyInvalid();
     this.onChange();
     this.#invalidate(undefined, undefined, changedFiles, removedFiles);
   }
@@ -255,6 +300,7 @@ export class Watching {
     if (this.suspended || (this.isBlocked() && (this.blocked = true))) {
       return;
     }
+    this.blocked = false;
 
     if (this.running) {
       this.invalid = true;
@@ -300,12 +346,12 @@ export class Watching {
       this.compiler.fileTimestamps = fileTimeInfoEntries;
       this.compiler.contextTimestamps = contextTimeInfoEntries;
     } else if (this.pausedWatcher) {
-      const { changes, removals, fileTimeInfoEntries, contextTimeInfoEntries } =
-        this.pausedWatcher.getInfo();
-      this.#mergeWithCollected(changes, removals);
-      this.compiler.fileTimestamps = fileTimeInfoEntries;
-      this.compiler.contextTimestamps = contextTimeInfoEntries;
+      this.#drainPausedWatcher();
     }
+
+    this.compiler.__internal__watchInvalidationKind =
+      this.#pendingInvalidationKind;
+    this.#pendingInvalidationKind = undefined;
 
     this.compiler.modifiedFiles = this.#collectedChangedFiles;
     this.compiler.removedFiles = this.#collectedRemovedFiles;
@@ -394,6 +440,8 @@ export class Watching {
     };
 
     if (error) {
+      this.#pendingInvalidationKind = undefined;
+      this.compiler.__internal__watchInvalidationKind = undefined;
       return handleError(error);
     }
 
@@ -403,6 +451,21 @@ export class Watching {
 
     stats = new Stats(compilation);
 
+    const watcherStartTime = Date.now();
+    if (
+      !this.invalid &&
+      this.pausedWatcher?.hasPendingEvents?.() !== false &&
+      this.#drainPausedWatcher()
+    ) {
+      // Watchpack continues collecting while paused but does not deliver an
+      // invalid callback. Coalesce those changes before publishing the stale
+      // generation and advance the baseline so they are not replayed.
+      this.lastWatcherStartTime = watcherStartTime;
+      this.invalid = true;
+      this.#notifyInvalid();
+      this.onInvalid();
+    }
+
     if (
       this.invalid &&
       !this.suspended &&
@@ -411,7 +474,10 @@ export class Watching {
     ) {
       // Coalesced rebuild: the `watch()` delivery below is skipped, so carry
       // this build's deltas forward to the next delivered `watch()`. See #12904.
-      if (compilation) this.#accumulateWatchDeps(compilation);
+      this.#accumulateWatchDeps(compilation);
+      if (compilation.watchInvalidationKind) {
+        this.#recordInvalidation(compilation.watchInvalidationKind);
+      }
       this.#go();
       return;
     }
@@ -423,46 +489,33 @@ export class Watching {
     compilation.endTime = Date.now();
     const cbs = this.callbacks;
     this.callbacks = [];
+    this.compiler.__internal__watchInvalidationKind = undefined;
 
     this.compiler.hooks.done.callAsync(stats, (err) => {
       if (err) return handleError(err, cbs);
+
+      // Snapshot this build's watch deltas before user callbacks can invalidate.
+      this.#accumulateWatchDeps(compilation);
+      const pending = this.#pendingWatchDeps!;
+      this.#pendingWatchDeps = undefined;
+
+      const fileDependencies = withWatchDelta(
+        compilation.fileDependencies,
+        pending.file,
+      );
+      const contextDependencies = withWatchDelta(
+        compilation.contextDependencies,
+        pending.context,
+      );
+      const missingDependencies = withWatchDelta(
+        compilation.missingDependencies,
+        pending.missing,
+      );
+
       this.handler(null, stats);
 
       process.nextTick(() => {
         if (!this.#closed) {
-          // Deliver this build's deltas merged with any carried from skipped
-          // coalesced builds, then reset the accumulator.
-          this.#accumulateWatchDeps(compilation);
-          const pending = this.#pendingWatchDeps!;
-          this.#pendingWatchDeps = undefined;
-
-          const fileDependencies = new Set([
-            ...compilation.fileDependencies,
-          ]) as unknown as Iterable<string> & {
-            added?: Iterable<string>;
-            removed?: Iterable<string>;
-          };
-          fileDependencies.added = pending.file.added;
-          fileDependencies.removed = pending.file.removed;
-
-          const contextDependencies = new Set([
-            ...compilation.contextDependencies,
-          ]) as unknown as Iterable<string> & {
-            added?: Iterable<string>;
-            removed?: Iterable<string>;
-          };
-          contextDependencies.added = pending.context.added;
-          contextDependencies.removed = pending.context.removed;
-
-          const missingDependencies = new Set([
-            ...compilation.missingDependencies,
-          ]) as unknown as Iterable<string> & {
-            added?: Iterable<string>;
-            removed?: Iterable<string>;
-          };
-          missingDependencies.added = pending.missing.added;
-          missingDependencies.removed = pending.missing.removed;
-
           this.watch(
             fileDependencies,
             contextDependencies,
@@ -473,6 +526,21 @@ export class Watching {
       for (const cb of cbs) cb(null);
       this.compiler.hooks.afterDone.call(stats);
     });
+  }
+
+  #drainPausedWatcher() {
+    if (!this.pausedWatcher) return false;
+
+    const { changes, removals, fileTimeInfoEntries, contextTimeInfoEntries } =
+      this.pausedWatcher.getInfo();
+    const hasChanges = changes.size > 0 || removals.size > 0;
+    if (hasChanges) {
+      this.#recordInvalidation('normal');
+    }
+    this.#mergeWithCollected(changes, removals);
+    this.compiler.fileTimestamps = fileTimeInfoEntries;
+    this.compiler.contextTimestamps = contextTimeInfoEntries;
+    return hasChanges;
   }
 
   #mergeWithCollected(

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -80,7 +80,9 @@ export const lazyCompilationMiddleware = (
 
     const keys = [...middlewareByCompiler.keys()];
     return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
-      const key = keys.find((key) => req.url?.startsWith(key));
+      const key = keys.find(
+        (key) => req.url === key || req.url?.startsWith(`${key}?`),
+      );
       if (!key) {
         return next?.();
       }
@@ -261,7 +263,7 @@ const lazyCompilationMiddlewareInternal = (
     }
 
     if (moduleActivated.length && compiler.watching) {
-      compiler.watching.invalidate();
+      compiler.watching.__internal__invalidate('lazy');
     }
 
     res.writeHead(200);

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -10,6 +10,7 @@ export type {
   CompilationParams,
   LogEntry,
   PathData,
+  WatchInvalidationKind,
 } from './Compilation';
 export { Compilation } from './Compilation';
 export { Compiler, type CompilerHooks } from './Compiler';

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -189,9 +189,24 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
         "Watcher.getContextTimeInfoEntries is deprecated in favor of Watcher.getInfo since that's more performant.",
         'DEP_WEBPACK_WATCHER_CONTEXT_TIME_INFO_ENTRIES',
       ),
+      hasPendingEvents: () => {
+        const watcher = this.watcher;
+        return Boolean(
+          watcher &&
+          (watcher.aggregatedChanges.size > 0 ||
+            watcher.aggregatedRemovals.size > 0),
+        );
+      },
       getInfo: () => {
-        const removals = this.watcher?.aggregatedRemovals ?? new Set();
-        const changes = this.watcher?.aggregatedChanges ?? new Set();
+        const watcher = this.watcher;
+        const { changes, removals } = watcher
+          ? watcher.paused
+            ? watcher.getAggregated()
+            : {
+                changes: watcher.aggregatedChanges,
+                removals: watcher.aggregatedRemovals,
+              }
+          : { changes: new Set<string>(), removals: new Set<string>() };
         if (this.inputFileSystem?.purge) {
           const fs = this.inputFileSystem;
           if (removals) {

--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -19,6 +19,7 @@ export interface Watcher {
   getAggregatedRemovals?(): Set<string>; // get current aggregated removals that have not yet send to callback
   getFileTimeInfoEntries?(): Map<string, FileSystemInfoEntry | 'ignore'>; // get info about files
   getContextTimeInfoEntries?(): Map<string, FileSystemInfoEntry | 'ignore'>; // get info about directories
+  hasPendingEvents?(): boolean; // cheaply checks for changes collected while paused
   getInfo(): WatcherInfo; // get info about timestamps and changes
 }
 

--- a/tests/rspack-test/CopyPluginCache.test.js
+++ b/tests/rspack-test/CopyPluginCache.test.js
@@ -1,0 +1,692 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+	CopyRspackPlugin,
+	Stats,
+	lazyCompilationMiddleware,
+	rspack
+} = require("@rspack/core");
+
+const fixtureRoot = path.resolve(__dirname, "js/copy-plugin-cache");
+
+function write(root, filename, content) {
+	const file = path.join(root, filename);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+	return file;
+}
+
+function remove(root, filename) {
+	const file = path.join(root, filename);
+	fs.rmSync(file);
+	return file;
+}
+
+function createCompiler(name, patterns, nativeWatcher = false, prepare) {
+	const root = path.join(fixtureRoot, name);
+	fs.rmSync(root, { recursive: true, force: true });
+	write(root, "src/index.js", "module.exports = 'initial';\n");
+	prepare?.(root);
+
+	return {
+		root,
+		compiler: rspack({
+			context: root,
+			mode: "development",
+			target: "node",
+			devtool: false,
+			cache: true,
+			incremental: true,
+			experiments: { nativeWatcher },
+			entry: "./src/index.js",
+			output: { path: path.join(root, "dist"), filename: "main.js" },
+			plugins: [new CopyRspackPlugin({ patterns })]
+		})
+	};
+}
+
+function compile(compiler) {
+	return new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve(compiler._lastCompilation);
+		});
+	});
+}
+
+function rebuild(compiler, modifiedFiles = [], removedFiles = []) {
+	return new Promise((resolve, reject) => {
+		compiler.__internal__rebuild(
+			new Set(modifiedFiles),
+			new Set(removedFiles),
+			error => {
+				if (error) return reject(error);
+				const compilation = compiler._lastCompilation;
+				if (compilation.errors.length > 0) {
+					return reject(
+						new Error(new Stats(compilation).toString({ all: false, errors: true }))
+					);
+				}
+				resolve(compilation);
+			}
+		);
+	});
+}
+
+function rebuildAllowErrors(compiler, modifiedFiles = [], removedFiles = []) {
+	return new Promise((resolve, reject) => {
+		compiler.__internal__rebuild(
+			new Set(modifiedFiles),
+			new Set(removedFiles),
+			error => {
+				if (error) return reject(error);
+				resolve(compiler._lastCompilation);
+			}
+		);
+	});
+}
+
+function watch(compiler) {
+	const builds = [];
+	const waiters = [];
+	const watching = compiler.watch({ aggregateTimeout: 0 }, (error, stats) => {
+		const build = { error, stats };
+		const waiter = waiters.shift();
+		if (waiter) waiter(build);
+		else builds.push(build);
+	});
+
+	return {
+		next(timeoutMs = 5000) {
+			if (builds.length > 0) return Promise.resolve(builds.shift());
+			return new Promise((resolve, reject) => {
+				const timeout = setTimeout(
+					() => reject(new Error("timed out waiting for a copy-plugin rebuild")),
+					timeoutMs
+				);
+				waiters.push(build => {
+					clearTimeout(timeout);
+					resolve(build);
+				});
+			});
+		},
+		close() {
+			return new Promise((resolve, reject) => {
+				watching.close(error => (error ? reject(error) : resolve()));
+			});
+		},
+		invalidate() {
+			watching.invalidate();
+		}
+	};
+}
+
+function asset(compilation, filename) {
+	return compilation.getAsset(filename)?.source.source().toString();
+}
+
+async function nextBuildWithAsset(watching, filename) {
+	const deadline = Date.now() + 5000;
+
+	while (Date.now() < deadline) {
+		const build = await watching.next(deadline - Date.now());
+		if (build.error || asset(build.stats.compilation, filename) !== undefined) {
+			return build;
+		}
+	}
+
+	throw new Error(`timed out waiting for copied asset '${filename}'`);
+}
+
+function reusedPatterns(compilation) {
+	const logging = new Stats(compilation).toJson({
+		all: false,
+		logging: false,
+		loggingDebug: [/CopyRspackPlugin/]
+	}).logging;
+
+	const entries = Object.values(logging || {})
+		.flatMap(group => group.entries || [])
+		.map(entry => entry.message || "");
+	const summary = entries.find(message =>
+		message.startsWith("copy pattern cache: ")
+	);
+	const hits = summary?.match(/\((\d+)\/\d+\)$/);
+	return hits ? Number(hits[1]) : 0;
+}
+
+function foundPatternFiles(compilation, directory) {
+	const logging = new Stats(compilation).toJson({
+		all: false,
+		logging: false,
+		loggingDebug: [/CopyRspackPlugin/]
+	}).logging;
+	const normalizedDirectory = directory.replaceAll("\\", "/");
+
+	return Object.values(logging || {})
+		.flatMap(group => group.entries || [])
+		.map(entry => entry.message || "")
+		.map(message => message.match(/^found '(.+)'$/)?.[1])
+		.filter(filename =>
+			filename?.replaceAll("\\", "/").includes(normalizedDirectory)
+		);
+}
+
+async function close(compiler) {
+	await new Promise((resolve, reject) => {
+		compiler.close(error => (error ? reject(error) : resolve()));
+	});
+}
+
+describe("CopyRspackPlugin pattern cache", () => {
+	afterAll(() => {
+		fs.rmSync(fixtureRoot, { recursive: true, force: true });
+	});
+
+	it.each([
+		["watchpack", false],
+		...(process.env.WASM ? [] : [["native watcher", true]])
+	])(
+		"watches the stable glob base and copies a newly populated sibling with %s",
+		async (watcherName, nativeWatcher) => {
+			const { root, compiler } = createCompiler(
+				`glob-sibling-${watcherName.replace(" ", "-")}`,
+				[{ from: "assets/*/*.txt", to: "copied", toType: "dir" }],
+				nativeWatcher,
+				root => {
+					write(root, "assets/a/one.txt", "one\n");
+					fs.mkdirSync(path.join(root, "assets/b"), { recursive: true });
+				}
+			);
+			const watching = watch(compiler);
+
+			try {
+				const initial = await watching.next();
+				expect(initial.error).toBeNull();
+				expect(initial.stats.hasErrors()).toBe(false);
+				expect([...initial.stats.compilation.contextDependencies]).toContain(
+					path.join(root, "assets")
+				);
+				expect(asset(initial.stats.compilation, "copied/assets/a/one.txt")).toBe(
+					"one\n"
+				);
+
+				await new Promise(resolve => setTimeout(resolve, 200));
+				write(root, "assets/b/two.txt", "two\n");
+				const sibling = await nextBuildWithAsset(
+					watching,
+					"copied/assets/b/two.txt"
+				);
+
+				expect(sibling.error).toBeNull();
+				expect(sibling.stats.hasErrors()).toBe(false);
+				expect(asset(sibling.stats.compilation, "copied/assets/b/two.txt")).toBe(
+					"two\n"
+				);
+
+				write(root, "src/index.js", "module.exports = 'changed';\n");
+				const updated = await watching.next();
+
+				expect(updated.error).toBeNull();
+				expect(updated.stats.hasErrors()).toBe(false);
+				expect(asset(updated.stats.compilation, "copied/assets/a/one.txt")).toBe(
+					"one\n"
+				);
+				expect(asset(updated.stats.compilation, "copied/assets/b/two.txt")).toBe(
+					"two\n"
+				);
+			} finally {
+				await watching.close();
+			}
+		}
+	);
+
+	it.each([
+		["directory", "assets/nested", "copied-dir/one.txt"],
+		["file", "assets/nested/one.txt", "copied-file/one.txt"]
+	])("invalidates a %s pattern for an ancestor-directory event", async (kind, from, emitted) => {
+		const { root, compiler } = createCompiler(`ancestor-${kind}`, [
+			{ from, to: kind === "file" ? "copied-file" : "copied-dir", toType: "dir" }
+		]);
+		write(root, "assets/nested/one.txt", "before\n");
+
+		try {
+			const initial = await compile(compiler);
+			expect(asset(initial, emitted)).toBe("before\n");
+
+			write(root, "assets/nested/one.txt", "after\n");
+			const updated = await rebuild(compiler, [path.join(root, "assets")]);
+
+			expect(asset(updated, emitted)).toBe("after\n");
+			expect(reusedPatterns(updated)).toBe(0);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("invalidates modified and removed children, including removing the last glob match and re-adding it", async () => {
+		const { root, compiler } = createCompiler("glob-add-remove", [
+			{
+				from: "assets/glob/**/*.txt",
+				to: "copied",
+				toType: "dir",
+				noErrorOnMissing: true,
+				globOptions: { ignore: ["**/skip-*.txt"] }
+			}
+		]);
+		const one = write(root, "assets/glob/nested/one.txt", "one\n");
+
+		try {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/assets/glob/nested/one.txt")).toBe("one\n");
+
+			const two = write(root, "assets/glob/nested/two.txt", "two\n");
+			let updated = await rebuild(compiler, [two]);
+			expect(asset(updated, "copied/assets/glob/nested/two.txt")).toBe("two\n");
+
+			write(root, "assets/glob/nested/two.txt", "two-edited\n");
+			updated = await rebuild(compiler, [two]);
+			expect(asset(updated, "copied/assets/glob/nested/two.txt")).toBe("two-edited\n");
+
+			remove(root, "assets/glob/nested/one.txt");
+			remove(root, "assets/glob/nested/two.txt");
+			updated = await rebuild(compiler, [], [one, two]);
+			expect(asset(updated, "copied/assets/glob/nested/one.txt")).toBeUndefined();
+			expect(asset(updated, "copied/assets/glob/nested/two.txt")).toBeUndefined();
+
+			const three = write(root, "assets/glob/other/three.txt", "three\n");
+			const ignored = write(root, "assets/glob/other/skip-three.txt", "ignored\n");
+			updated = await rebuild(compiler, [three, ignored]);
+			expect(asset(updated, "copied/assets/glob/other/three.txt")).toBe("three\n");
+			expect(asset(updated, "copied/assets/glob/other/skip-three.txt")).toBeUndefined();
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("reuses unchanged static patterns but never caches callback, template, or permission patterns", async () => {
+		let transformCalls = 0;
+		let destinationCalls = 0;
+		const { root, compiler } = createCompiler("cache-policy", [
+			{ from: "assets/static", to: "static" },
+			{
+				from: "assets/transform",
+				to: "transform",
+				transform(content) {
+					transformCalls += 1;
+					return content;
+				}
+			},
+			{
+				from: "assets/function",
+				to({ absoluteFilename }) {
+					destinationCalls += 1;
+					return `function/${path.basename(absoluteFilename)}`;
+				}
+			},
+			{ from: "assets/template", to: "template/[name][ext]" },
+			{ from: "assets/nested-template", to: "template-path/[path][name][ext]" },
+			{ from: "assets/permissions", to: "permissions", copyPermissions: true }
+		]);
+		write(root, "assets/static/one.txt", "static\n");
+		write(root, "assets/transform/one.txt", "transform\n");
+		write(root, "assets/function/one.txt", "function\n");
+		write(root, "assets/template/one.txt", "template\n");
+		write(root, "assets/nested-template/deep/two.txt", "nested-template\n");
+		write(root, "assets/permissions/one.txt", "permissions\n");
+
+		try {
+			const initial = await compile(compiler);
+			expect(transformCalls).toBe(1);
+			expect(destinationCalls).toBe(1);
+			expect(asset(initial, "template/one.txt")).toBe("template\n");
+			expect(asset(initial, "template-path/deep/two.txt")).toBe(
+				"nested-template\n"
+			);
+			expect(initial.getAssets().some(({ name }) => name.includes("\\"))).toBe(
+				false
+			);
+
+			const entry = write(root, "src/index.js", "module.exports = 'changed';\n");
+			const updated = await rebuild(compiler, [entry]);
+
+			expect(reusedPatterns(updated)).toBe(1);
+			expect(transformCalls).toBe(2);
+			expect(destinationCalls).toBe(2);
+			expect(asset(updated, "static/one.txt")).toBe("static\n");
+			expect(asset(updated, "transform/one.txt")).toBe("transform\n");
+			expect(asset(updated, "function/one.txt")).toBe("function\n");
+			expect(asset(updated, "template/one.txt")).toBe("template\n");
+			expect(asset(updated, "template-path/deep/two.txt")).toBe(
+				"nested-template\n"
+			);
+			expect(updated.getAssets().some(({ name }) => name.includes("\\"))).toBe(
+				false
+			);
+			expect(asset(updated, "permissions/one.txt")).toBe("permissions\n");
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("does not reuse cached results across compiler.run calls without watcher provenance", async () => {
+		const { root, compiler } = createCompiler("run-twice", [
+			{ from: "assets/source", to: "copied" }
+		]);
+		write(root, "assets/source/one.txt", "before\n");
+
+		try {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/one.txt")).toBe("before\n");
+
+			write(root, "assets/source/one.txt", "after\n");
+			const updated = await compile(compiler);
+
+			expect(asset(updated, "copied/one.txt")).toBe("after\n");
+			expect(reusedPatterns(updated)).toBe(0);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("reuses a 2000-file copy pattern during an empty lazy watch rebuild", async () => {
+		const fileCount = 2000;
+		const root = path.join(fixtureRoot, "lazy-watch-cache-hit");
+		const beforeWatch = new Date(Date.now() - 3000);
+		fs.rmSync(root, { recursive: true, force: true });
+		const entry = write(root, "src/index.js", "export const value = 'lazy';\n");
+		for (let index = 0; index < fileCount; index += 1) {
+			const asset = write(root, `assets/${index}.txt`, `${index}\n`);
+			fs.utimesSync(asset, beforeWatch, beforeWatch);
+		}
+		for (const filename of [
+			path.join(root, "src"),
+			path.join(root, "assets"),
+			entry
+		]) {
+			fs.utimesSync(filename, beforeWatch, beforeWatch);
+		}
+
+		const compiler = rspack({
+			context: root,
+			mode: "development",
+			target: "web",
+			devtool: false,
+			cache: true,
+			incremental: true,
+			entry: "./src/index.js",
+			lazyCompilation: { entries: true, imports: false },
+			output: { path: path.join(root, "dist"), filename: "main.js" },
+			plugins: [
+				new CopyRspackPlugin({ patterns: [{ from: "assets", to: "copied" }] })
+			]
+		});
+		const middleware = lazyCompilationMiddleware(compiler);
+		const watching = watch(compiler);
+
+		try {
+			const initial = await watching.next();
+			expect(initial.error).toBeNull();
+			expect(initial.stats.hasErrors()).toBe(false);
+			expect(
+				initial.stats.compilation
+					.getAssets()
+					.filter(({ name }) => name.startsWith("copied/"))
+			).toHaveLength(fileCount);
+			await new Promise(resolve => setTimeout(resolve, 200));
+
+			const bundle = fs.readFileSync(path.join(root, "dist/main.js"), "utf8");
+			const encoded = bundle.match(/var data = ("(?:[^"\\]|\\.)*")/)?.[1];
+			expect(encoded).toBeDefined();
+			const moduleId = JSON.parse(encoded);
+
+			await new Promise((resolve, reject) => {
+				Promise.resolve(
+					middleware(
+						{
+							body: [moduleId],
+							method: "POST",
+							url: "/_rspack/lazy/trigger"
+						},
+						{
+							end: resolve,
+							write() {},
+							writeHead(status) {
+								expect(status).toBe(200);
+							}
+						},
+						reject
+					)
+				).catch(reject);
+			});
+			const updated = await watching.next();
+
+			expect(updated.error).toBeNull();
+			expect(updated.stats.hasErrors()).toBe(false);
+			expect(updated.stats.compilation.watchInvalidationKind).toBe("lazy");
+			expect(compiler.modifiedFiles).toEqual(new Set());
+			expect(compiler.removedFiles).toEqual(new Set());
+			expect(reusedPatterns(updated.stats.compilation)).toBe(1);
+			expect(
+				updated.stats.compilation
+					.getAssets()
+					.filter(({ name }) => name.startsWith("copied/"))
+			).toHaveLength(fileCount);
+		} finally {
+			await watching.close();
+		}
+	});
+
+	it("does not reuse a copy pattern for an empty normal watch invalidation", async () => {
+		const { root, compiler } = createCompiler("normal-watch-invalidation", [
+			{ from: "assets/source", to: "copied" }
+		]);
+		const source = write(root, "assets/source/one.txt", "before\n");
+		const beforeWatch = new Date(Date.now() - 3000);
+		for (const filename of [
+			path.join(root, "src"),
+			path.join(root, "src/index.js"),
+			path.join(root, "assets"),
+			path.join(root, "assets/source"),
+			source
+		]) {
+			fs.utimesSync(filename, beforeWatch, beforeWatch);
+		}
+		let mutateDuringWatchRun = false;
+		compiler.hooks.watchRun.tap("copy-plugin-cache-test", () => {
+			if (!mutateDuringWatchRun) return;
+			mutateDuringWatchRun = false;
+			const { atime, mtime } = fs.statSync(source);
+			write(root, "assets/source/one.txt", "after\n");
+			fs.utimesSync(source, atime, mtime);
+		});
+		const watching = watch(compiler);
+
+		try {
+			const initial = await watching.next();
+			expect(initial.error).toBeNull();
+			expect(initial.stats.hasErrors()).toBe(false);
+			expect(asset(initial.stats.compilation, "copied/one.txt")).toBe("before\n");
+			await new Promise(resolve => setTimeout(resolve, 200));
+
+			mutateDuringWatchRun = true;
+			watching.invalidate();
+			const updated = await watching.next();
+
+			expect(updated.error).toBeNull();
+			expect(updated.stats.hasErrors()).toBe(false);
+			expect(updated.stats.compilation.watchInvalidationKind).toBe("normal");
+			expect(compiler.modifiedFiles).toEqual(new Set());
+			expect(compiler.removedFiles).toEqual(new Set());
+			expect(asset(updated.stats.compilation, "copied/one.txt")).toBe("after\n");
+			expect(reusedPatterns(updated.stats.compilation)).toBe(0);
+		} finally {
+			await watching.close();
+		}
+	});
+
+	it("preserves equal-priority copy order with interleaved cache hits and misses", async () => {
+		const patternCount = 64;
+		const patterns = Array.from({ length: patternCount }, (_, index) => ({
+			from: `assets/${index}.txt`,
+			to: "copied/value.txt",
+			toType: "file",
+			force: true,
+			priority: index % 5
+		}));
+		const { root, compiler } = createCompiler("mixed-cache-order", patterns);
+		const files = patterns.map((_, index) =>
+			write(root, `assets/${index}.txt`, `${index}\n`)
+		);
+		const winner = Math.floor((patternCount - 5) / 5) * 5 + 4;
+
+		try {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/value.txt")).toBe(`${winner}\n`);
+
+			write(root, "assets/0.txt", "first-edited\n");
+			let updated = await rebuild(compiler, [files[0]]);
+			expect(reusedPatterns(updated)).toBe(patternCount - 1);
+			expect(asset(updated, "copied/value.txt")).toBe(`${winner}\n`);
+
+			write(root, `assets/${winner}.txt`, "last-edited\n");
+			updated = await rebuild(compiler, [files[winner]]);
+			expect(reusedPatterns(updated)).toBe(patternCount - 1);
+			expect(asset(updated, "copied/value.txt")).toBe("last-edited\n");
+
+			const entry = write(root, "src/index.js", "module.exports = 'changed';\n");
+			updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(patternCount);
+			expect(asset(updated, "copied/value.txt")).toBe("last-edited\n");
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("preserves forced glob emission order with interleaved pattern priorities and cache hits", async () => {
+		const interleavedCount = 32;
+		const globFileCount = 64;
+		const patterns = Array.from({ length: interleavedCount }, (_, index) => ({
+			from: `assets/interleaved/${index}.txt`,
+			to: `copied/interleaved-${index}.txt`,
+			toType: "file",
+			force: true,
+			priority: index % 5
+		}));
+		patterns.splice(Math.floor(interleavedCount / 2), 0, {
+			from: "assets/many/*.txt",
+			to: "copied/many.txt",
+			toType: "file",
+			force: true,
+			priority: 2
+		});
+		const { root, compiler } = createCompiler("forced-glob-order", patterns);
+		const interleaved = Array.from({ length: interleavedCount }, (_, index) =>
+			write(root, `assets/interleaved/${index}.txt`, `${index}\n`)
+		);
+		const globFiles = Array.from({ length: globFileCount }, (_, index) =>
+			write(
+				root,
+				`assets/many/${String(index).padStart(4, "0")}.txt`,
+				`${index}\n`
+			)
+		);
+		const expectedWinner = compilation => {
+			const found = foundPatternFiles(compilation, "/assets/many/");
+			expect(found).toHaveLength(globFileCount);
+			return fs.readFileSync(found.at(-1), "utf-8");
+		};
+
+		try {
+			let updated = await compile(compiler);
+			let winner = expectedWinner(updated);
+			expect(asset(updated, "copied/many.txt")).toBe(winner);
+
+			write(root, "assets/interleaved/0.txt", "interleaved-edited\n");
+			updated = await rebuild(compiler, [interleaved[0]]);
+			expect(reusedPatterns(updated)).toBe(patterns.length - 1);
+			expect(asset(updated, "copied/many.txt")).toBe(winner);
+
+			write(root, "assets/many/0000.txt", "glob-edited\n");
+			updated = await rebuild(compiler, [globFiles[0]]);
+			expect(reusedPatterns(updated)).toBe(patterns.length - 1);
+			winner = expectedWinner(updated);
+			expect(asset(updated, "copied/many.txt")).toBe(winner);
+
+			const entry = write(root, "src/index.js", "module.exports = 'changed';\n");
+			updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(patterns.length);
+			expect(asset(updated, "copied/many.txt")).toBe(winner);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("evicts a cached pattern before an errored recomputation and recovers when the source returns", async () => {
+		const { root, compiler } = createCompiler("diagnostic-recovery", [
+			{ from: "assets/source/*.txt", to: "copied", toType: "dir" }
+		]);
+		const source = write(root, "assets/source/one.txt", "before\n");
+
+		try {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/assets/source/one.txt")).toBe("before\n");
+
+			remove(root, "assets/source/one.txt");
+			let failed = await rebuildAllowErrors(compiler, [], [source]);
+			expect(failed.errors.length).toBeGreaterThan(0);
+			expect(
+				failed.errors.filter(error =>
+					String(error.message ?? error).includes("unable to locate")
+				)
+			).toHaveLength(1);
+			expect(reusedPatterns(failed)).toBe(0);
+			expect(asset(failed, "copied/assets/source/one.txt")).toBeUndefined();
+
+			const entry = write(root, "src/index.js", "module.exports = 'changed';\n");
+			failed = await rebuildAllowErrors(compiler, [entry]);
+			expect(failed.errors.length).toBeGreaterThan(0);
+			expect(reusedPatterns(failed)).toBe(0);
+			expect(asset(failed, "copied/assets/source/one.txt")).toBeUndefined();
+
+			write(root, "assets/source/one.txt", "after\n");
+			const recovered = await rebuild(compiler, [source]);
+			expect(asset(recovered, "copied/assets/source/one.txt")).toBe("after\n");
+			expect(reusedPatterns(recovered)).toBe(0);
+		} finally {
+			await close(compiler);
+		}
+	});
+
+	it("keeps a successful sibling cached while a glob recomputation reports an error", async () => {
+		const { root, compiler } = createCompiler("sibling-diagnostic", [
+			{ from: "assets/missing/*.txt", to: "copied", toType: "dir" },
+			{ from: "assets/stable.txt", to: "copied/stable.txt", toType: "file" }
+		]);
+		const missing = write(root, "assets/missing/one.txt", "one\n");
+		const stable = write(root, "assets/stable.txt", "before\n");
+
+		try {
+			await compile(compiler);
+			remove(root, "assets/missing/one.txt");
+			write(root, "assets/stable.txt", "after\n");
+			let failed = await rebuildAllowErrors(compiler, [stable], [missing]);
+
+			expect(failed.errors).toHaveLength(1);
+			expect(asset(failed, "copied/stable.txt")).toBe("after\n");
+			expect(reusedPatterns(failed)).toBe(0);
+
+			const entry = write(root, "src/index.js", "module.exports = 'changed';\n");
+			failed = await rebuildAllowErrors(compiler, [entry]);
+
+			expect(failed.errors).toHaveLength(1);
+			expect(asset(failed, "copied/stable.txt")).toBe("after\n");
+			expect(reusedPatterns(failed)).toBe(1);
+		} finally {
+			await close(compiler);
+		}
+	});
+});

--- a/tests/rspack-test/LazyCompilationArtifactChain.test.js
+++ b/tests/rspack-test/LazyCompilationArtifactChain.test.js
@@ -1,0 +1,381 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+
+const names = ["source", "dependent", "tail", "unrelated"];
+const parent = {
+	source: undefined,
+	dependent: "source",
+	tail: "dependent",
+	unrelated: undefined
+};
+
+async function withTimeout(promise, description) {
+	let timeout;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${description}`)),
+					15000
+				);
+			})
+		]);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+async function waitForPausedChange(watching, compilerName) {
+	const child = watching.watchings.find(
+		watching => watching.compiler.name === compilerName
+	);
+	const deadline = Date.now() + 15000;
+	while (Date.now() < deadline) {
+		if (child?.pausedWatcher?.hasPendingEvents?.()) return;
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for the paused ${compilerName} watcher`);
+}
+
+describe("lazy MultiCompiler artifact provenance", () => {
+	async function runArtifactChain(_watcherName, nativeWatcher) {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "rspack-lazy-chain-"));
+		const sourceFile = path.join(root, "source.js");
+		const coalescedEntry = path.join(root, "coalesced-source.js");
+		const stampFile = name => path.join(root, name, "stamp.txt");
+		const generations = Object.fromEntries(names.map(name => [name, 0]));
+		const events = [];
+		const invalidations = [];
+		let delayedSource;
+		let releaseSource;
+		let resolveFileInvalidation;
+		let server;
+		let watching;
+
+		try {
+			await Promise.all(
+				names.map(name =>
+					fs.writeFile(
+						path.join(root, `${name}.js`),
+						`export const ${name} = "${name}";\n`
+					)
+				)
+			);
+			await fs.writeFile(
+				coalescedEntry,
+				'export const coalesced = "coalesced";\n'
+			);
+			// Keep Watchpack's initial scan from treating fresh fixture files as edits.
+			const beforeWatch = new Date(Date.now() - 3000);
+			await Promise.all(
+				[
+					...names.map(name => path.join(root, `${name}.js`)),
+					coalescedEntry
+				].map(file => fs.utimes(file, beforeWatch, beforeWatch))
+			);
+
+			const config = name => ({
+				context: root,
+				dependencies: parent[name] ? [parent[name]] : [],
+				devtool: false,
+				entry:
+					name === "source"
+						? { main: "./source.js", coalesced: "./coalesced-source.js" }
+						: { main: `./${name}.js` },
+				experiments: { nativeWatcher },
+				lazyCompilation: { entries: true, imports: false },
+				mode: "development",
+				name,
+				output: {
+					chunkFilename: "[name].js",
+					filename: "[name].js",
+					path: path.join(root, name)
+				},
+				plugins: [
+					{
+						apply(compiler) {
+							compiler.hooks.invalid.tap("lazy-artifact-chain", file => {
+								invalidations.push({ name, file });
+								if (name === "source" && path.basename(file ?? "") === "source.js") {
+									resolveFileInvalidation?.();
+								}
+							});
+							compiler.hooks.make.tapPromise(
+								"lazy-artifact-chain",
+								async () => {
+									if (name === "source" && delayedSource) {
+										delayedSource.started();
+										await delayedSource.release;
+									}
+								}
+							);
+							compiler.hooks.thisCompilation.tap(
+								"lazy-artifact-chain",
+								compilation => {
+									compilation.hooks.processAssets.tapPromise(
+										{
+											name: "lazy-artifact-chain",
+											stage:
+												compilation.constructor.PROCESS_ASSETS_STAGE_ADDITIONS
+										},
+										async () => {
+											generations[name] += 1;
+											const upstream = parent[name]
+												? (
+														await fs.readFile(stampFile(parent[name]), "utf8")
+													).trim()
+												: "";
+											const stamp = upstream
+												? `${upstream}>${name}${generations[name]}`
+												: `${name}${generations[name]}`;
+											compilation.emitAsset(
+												"stamp.txt",
+												new rspack.sources.RawSource(`${stamp}\n`)
+											);
+										}
+									);
+								}
+							);
+							compiler.hooks.done.tap("lazy-artifact-chain", stats => {
+								events.push({
+									name,
+									kind: stats.compilation.watchInvalidationKind,
+									changed: [...(compiler.modifiedFiles ?? [])].map(file =>
+										path.basename(file)
+									)
+								});
+							});
+						}
+					}
+				],
+				target: "web"
+			});
+
+			const compiler = rspack.rspack(names.map(config));
+			const middleware = rspack.lazyCompilationMiddleware(compiler);
+			server = http.createServer((request, response) =>
+				middleware(request, response, () => {
+					response.statusCode = 404;
+					response.end();
+				})
+			);
+			await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+			const { port } = server.address();
+
+			const builds = [];
+			const waiters = [];
+			const nextBuild = () =>
+				builds.length
+					? Promise.resolve(builds.shift())
+					: new Promise((resolve, reject) => {
+							const timeout = setTimeout(
+								() => reject(new Error("Timed out waiting for a watch build")),
+								15000
+							);
+							waiters.push(value => {
+								clearTimeout(timeout);
+								resolve(value);
+							});
+						});
+			watching = compiler.watch({ aggregateTimeout: 20 }, (error, stats) => {
+				const value = {
+					error:
+						error ??
+						(stats?.hasErrors()
+							? new Error(stats.toString({ all: false, errors: true }))
+							: undefined),
+					children: stats?.stats ?? [stats]
+				};
+				(waiters.shift() ?? (result => builds.push(result)))(value);
+			});
+
+			const assertBuild = (build, expectedNames, expectedKind) => {
+				assert.equal(build.error, undefined);
+				const children = build.children.filter(Boolean);
+				assert.deepEqual(
+					children.map(child => child.compilation.name).sort(),
+					[...expectedNames].sort()
+				);
+				assert.deepEqual(
+					children.map(child => child.compilation.watchInvalidationKind),
+					children.map(child =>
+						typeof expectedKind === "function"
+							? expectedKind(child.compilation.name)
+							: expectedKind
+					)
+				);
+			};
+			const assertTail = async () => {
+				assert.equal(
+					(await fs.readFile(stampFile("tail"), "utf8")).trim(),
+					`source${generations.source}>dependent${generations.dependent}>tail${generations.tail}`
+				);
+			};
+
+			assertBuild(await nextBuild(), names, undefined);
+			const baseline = { ...generations };
+			await assertTail();
+			const lazyIds = new Map();
+			for (const name of names) {
+				const bundle = await fs.readFile(
+					path.join(root, name, "main.js"),
+					"utf8"
+				);
+				const encoded = bundle.match(/var data = ("(?:[^"\\]|\\.)*")/)?.[1];
+				assert.notEqual(
+					encoded,
+					undefined,
+					`Missing lazy module ID for ${name}`
+				);
+				lazyIds.set(name, JSON.parse(encoded));
+			}
+			const coalescedBundle = await fs.readFile(
+				path.join(root, "source", "coalesced.js"),
+				"utf8"
+			);
+			const coalescedId = coalescedBundle.match(
+				/var data = ("(?:[^"\\]|\\.)*")/
+			)?.[1];
+			assert.notEqual(
+				coalescedId,
+				undefined,
+				"Missing coalesced lazy module ID"
+			);
+			const activate = (name, moduleId = lazyIds.get(name)) =>
+				new Promise((resolve, reject) => {
+					const request = http.request(
+						{
+							host: "127.0.0.1",
+							method: "POST",
+							path: `/_rspack/lazy/trigger__${names.indexOf(name)}`,
+							port
+						},
+						response => {
+							response.resume();
+							response.on("end", () => resolve(response.statusCode));
+						}
+					);
+					request.on("error", reject);
+					request.end(moduleId);
+				});
+
+			const beforeUnrelated = events.length;
+			assert.equal(await activate("unrelated"), 200);
+			assertBuild(await nextBuild(), ["unrelated"], "lazy");
+			assert.deepEqual(
+				events.slice(beforeUnrelated).map(event => event.name),
+				["unrelated"]
+			);
+			assert.equal(generations.source, baseline.source);
+			assert.equal(generations.dependent, baseline.dependent);
+			assert.equal(generations.tail, baseline.tail);
+
+			const beforeLazy = events.length;
+			assert.equal(await activate("source"), 200);
+			assertBuild(await nextBuild(), ["source", "dependent", "tail"], name =>
+				name === "source" ? "lazy" : "normal"
+			);
+			assert.deepEqual(
+				events.slice(beforeLazy).map(event => [event.name, event.kind]),
+				[
+					["source", "lazy"],
+					["dependent", "normal"],
+					["tail", "normal"]
+				]
+			);
+			await assertTail();
+
+			let signalSourceStarted;
+			const sourceStarted = new Promise(resolve => {
+				signalSourceStarted = resolve;
+			});
+			const sourceRelease = new Promise(resolve => {
+				releaseSource = resolve;
+			});
+			const fileInvalidated = new Promise(resolve => {
+				resolveFileInvalidation = resolve;
+			});
+			delayedSource = {
+				started: signalSourceStarted,
+				release: sourceRelease
+			};
+			const beforeCoalesced = events.length;
+			const beforeGenerations = { ...generations };
+			assert.equal(await activate("source", JSON.parse(coalescedId)), 200);
+			await withTimeout(sourceStarted, "the coalesced source build to start");
+			const beforeFileInvalidations = invalidations.length;
+			await fs.writeFile(
+				sourceFile,
+				'export const source = "source";\nexport const edited = "file-edit";\n'
+			);
+			if (nativeWatcher) {
+				await withTimeout(fileInvalidated, "the coalesced source file event");
+			} else {
+				await waitForPausedChange(watching, "source");
+			}
+			releaseSource();
+			assertBuild(await nextBuild(), ["source", "dependent", "tail"], "normal");
+			const coalesced = events.slice(beforeCoalesced);
+			assert.equal(
+				invalidations
+					.slice(beforeFileInvalidations)
+					.filter(event => event.name === "source").length,
+				1,
+				"a coalesced file edit must notify the source compiler exactly once"
+			);
+			assert.equal(
+				coalesced.every(event => event.kind === "normal"),
+				true,
+				`normal must dominate a coalesced file edit: ${JSON.stringify(coalesced)}`
+			);
+			assert.equal(
+				coalesced.some(
+					event =>
+						event.name === "source" && event.changed.includes("source.js")
+				),
+				true,
+				`expected a file-backed source generation: ${JSON.stringify(coalesced)}`
+			);
+			const emittedJavaScript = await Promise.all(
+				(await fs.readdir(path.join(root, "source")))
+					.filter(file => file.endsWith(".js"))
+					.map(file => fs.readFile(path.join(root, "source", file), "utf8"))
+			);
+			assert.equal(
+				emittedJavaScript.some(source => source.includes("file-edit")),
+				true,
+				"the coalesced file edit must reach an emitted JavaScript asset"
+			);
+			assert.ok(generations.source > beforeGenerations.source);
+			assert.equal(generations.dependent, beforeGenerations.dependent + 1);
+			assert.equal(generations.tail, beforeGenerations.tail + 1);
+			assert.equal(generations.unrelated, beforeGenerations.unrelated);
+			await assertTail();
+			const deliveredGenerations = { ...generations };
+			await new Promise(resolve => setTimeout(resolve, 80));
+			assert.deepEqual(generations, deliveredGenerations);
+		} finally {
+			releaseSource?.();
+			if (watching) {
+				await new Promise((resolve, reject) =>
+					watching.close(error => (error ? reject(error) : resolve()))
+				);
+			}
+			if (server) await new Promise(resolve => server.close(resolve));
+			await fs.rm(root, { force: true, recursive: true });
+		}
+	}
+
+	it.each([
+		...(process.env.WASM ? [] : [["native", true]]),
+		["watchpack", false]
+	])(
+		"keeps dependent and coalesced file-backed generations normal with %s watching",
+		runArtifactChain
+	);
+});

--- a/tests/rspack-test/LazyCompilationPrefix.test.js
+++ b/tests/rspack-test/LazyCompilationPrefix.test.js
@@ -1,0 +1,104 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { rspack, lazyCompilationMiddleware } = require("@rspack/core");
+
+describe("lazy MultiCompiler prefix routing", () => {
+	it("activates compiler 10 without matching the compiler 1 prefix", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "rspack-lazy-prefix-"));
+		const names = Array.from({ length: 11 }, (_, index) => `compiler-${index}`);
+		for (const name of names) {
+			fs.writeFileSync(
+				path.join(root, `${name}.js`),
+				`export const name = '${name}';\n`
+			);
+		}
+
+		const builds = [];
+		const waiters = [];
+		const nextBuild = () =>
+			builds.length > 0
+				? Promise.resolve(builds.shift())
+				: new Promise((resolve, reject) => {
+						const timeout = setTimeout(
+							() => reject(new Error("Timed out waiting for a lazy rebuild")),
+							10000
+						);
+						waiters.push(value => {
+							clearTimeout(timeout);
+							resolve(value);
+						});
+					});
+		const compiler = rspack(
+			names.map(name => ({
+				context: root,
+				mode: "development",
+				name,
+				target: "web",
+				devtool: false,
+				entry: `./${name}.js`,
+				lazyCompilation: { entries: true, imports: false },
+				output: {
+					path: path.join(root, name),
+					filename: "main.js",
+					chunkFilename: "[name].js"
+				}
+			}))
+		);
+		const middleware = lazyCompilationMiddleware(compiler);
+		const watching = compiler.watch({}, (error, stats) => {
+			const value = {
+				error:
+					error ??
+					(stats?.hasErrors()
+						? new Error(stats.toString({ all: false, errors: true }))
+						: undefined),
+				stats
+			};
+			(waiters.shift() ?? (build => builds.push(build)))(value);
+		});
+
+		try {
+			const initial = await nextBuild();
+			expect(initial.error).toBeUndefined();
+			const bundle = fs.readFileSync(
+				path.join(root, "compiler-10", "main.js"),
+				"utf8"
+			);
+			const encoded = bundle.match(/var data = ("(?:[^"\\]|\\.)*")/)?.[1];
+			expect(encoded).toBeDefined();
+			const moduleId = JSON.parse(encoded);
+
+			await new Promise((resolve, reject) => {
+				middleware(
+					{
+						body: [moduleId],
+						method: "POST",
+						url: "/_rspack/lazy/trigger__10?source=test"
+					},
+					{
+						end: resolve,
+						write() {},
+						writeHead(status) {
+							expect(status).toBe(200);
+						}
+					},
+					reject
+				).catch(reject);
+			});
+			const updated = await nextBuild();
+			expect(updated.error).toBeUndefined();
+			expect(updated.stats.stats.map(child => child.compilation.name)).toEqual([
+				"compiler-10"
+			]);
+			expect(updated.stats.stats[0].compilation.watchInvalidationKind).toBe(
+				"lazy"
+			);
+		} finally {
+			await new Promise((resolve, reject) =>
+				watching.close(error => (error ? reject(error) : resolve()))
+			);
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/tests/rspack-test/NodeWatcherGetInfo.test.js
+++ b/tests/rspack-test/NodeWatcherGetInfo.test.js
@@ -1,0 +1,52 @@
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { rspack } = require("@rspack/core");
+
+describe("NodeWatchFileSystem getInfo", () => {
+	it("keeps an active aggregate callback and consumes paused changes once", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "rspack-watchpack-"));
+		const entry = path.join(root, "entry.js");
+		await fs.writeFile(entry, "export default 1;\n");
+		const beforeWatch = new Date(Date.now() - 3000);
+		await fs.utimes(entry, beforeWatch, beforeWatch);
+
+		const compiler = rspack({
+			context: root,
+			entry,
+			experiments: { nativeWatcher: false }
+		});
+		const watchFileSystem = compiler.watchFileSystem;
+		const callbackChanges = [];
+		const watcher = watchFileSystem.watch(
+			[entry],
+			[],
+			[],
+			Date.now(),
+			{ aggregateTimeout: 1000 },
+			(_error, _fileTimes, _contextTimes, changes) =>
+				callbackChanges.push(changes),
+			() => {}
+		);
+
+		try {
+			const watchpack = watchFileSystem.watcher;
+			watchpack._onChange(entry, Date.now(), entry, "change");
+			expect(watcher.hasPendingEvents()).toBe(true);
+			expect(watcher.getInfo().changes).toEqual(new Set([entry]));
+			expect(watchpack.aggregateTimer).toBeDefined();
+			watchpack._onTimeout();
+			expect(callbackChanges).toEqual([new Set([entry])]);
+
+			watchpack._onChange(entry, Date.now(), entry, "change");
+			expect(watcher.hasPendingEvents()).toBe(true);
+			expect(watcher.getInfo().changes).toEqual(new Set([entry]));
+			expect(watcher.getInfo().changes).toEqual(new Set());
+			expect(watcher.hasPendingEvents()).toBe(false);
+		} finally {
+			watcher.close();
+			await new Promise(resolve => compiler.close(resolve));
+			await fs.rm(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/tests/rspack-test/WatchingDependencyRegistration.test.js
+++ b/tests/rspack-test/WatchingDependencyRegistration.test.js
@@ -1,0 +1,99 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { rspack } = require("@rspack/core");
+
+describe("Watching dependency registration", () => {
+	it("snapshots completed dependency deltas before the watch handler", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "rspack-watch-deps-"));
+		const entry = path.join(root, "entry.js");
+		const trackedFile = path.join(root, "tracked.js");
+		const trackedContext = path.join(root, "tracked-context");
+		const trackedMissing = path.join(root, "missing.js");
+		fs.writeFileSync(entry, "export default true;\n");
+
+		let registration;
+		let resolveRegistration;
+		const registered = new Promise(resolve => {
+			resolveRegistration = resolve;
+		});
+		const compiler = rspack({
+			context: root,
+			entry: "./entry.js",
+			mode: "development",
+			output: { filename: "bundle.js", path: path.join(root, "dist") },
+			plugins: [
+				{
+					apply(compiler) {
+						compiler.hooks.done.tap("watch-dependency-regression", stats => {
+							for (const [key, value] of [
+								["__internal__addedFileDependencies", trackedFile],
+								["__internal__addedContextDependencies", trackedContext],
+								["__internal__addedMissingDependencies", trackedMissing]
+							]) {
+								Object.defineProperty(stats.compilation, key, {
+									configurable: true,
+									value: [value]
+								});
+							}
+						});
+					}
+				}
+			]
+		});
+		compiler.watchFileSystem = {
+			watch(files, contexts, missing) {
+				registration = {
+					file: [...(files.added ?? [])],
+					context: [...(contexts.added ?? [])],
+					missing: [...(missing.added ?? [])]
+				};
+				resolveRegistration();
+				return {
+					close() {},
+					pause() {},
+					getInfo() {
+						return {
+							changes: new Set(),
+							removals: new Set(),
+							fileTimeInfoEntries: new Map(),
+							contextTimeInfoEntries: new Map()
+						};
+					}
+				};
+			}
+		};
+
+		let watching;
+		try {
+			await new Promise((resolve, reject) => {
+				watching = compiler.watch({}, (error, stats) => {
+					if (error || stats.hasErrors()) {
+						reject(
+							error ?? new Error(stats.toString({ all: false, errors: true }))
+						);
+						return;
+					}
+					for (const key of [
+						"__internal__addedFileDependencies",
+						"__internal__addedContextDependencies",
+						"__internal__addedMissingDependencies"
+					]) {
+						Object.defineProperty(stats.compilation, key, {
+							configurable: true,
+							value: []
+						});
+					}
+					resolve();
+				});
+			});
+			await registered;
+			expect(registration.file).toContain(trackedFile);
+			expect(registration.context).toContain(trackedContext);
+			expect(registration.missing).toContain(trackedMissing);
+		} finally {
+			if (watching) await new Promise(resolve => watching.close(resolve));
+			fs.rmSync(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/tests/rspack-test/compilerCases/watching.js
+++ b/tests/rspack-test/compilerCases/watching.js
@@ -1,4 +1,6 @@
 const { createFsFromVolume, Volume } = require("memfs");
+const { lazyCompilationMiddleware } = require("@rspack/core");
+const path = require("node:path");
 const { start } = require("@rspack/test-tools/helper/legacy/deprecationTracking");
 let tracker = null;
 
@@ -41,6 +43,120 @@ module.exports = [{
           expect(compiler.watchMode).toBeFalsy();
           resolve();
         });
+      });
+    });
+  },
+}, {
+  description: "should snapshot lazy compilation invalidation provenance per watch cycle",
+  options(context) {
+    return {
+      entry: "./c",
+      lazyCompilation: {
+        entries: false,
+        imports: false,
+      },
+    };
+  },
+  async compiler(context, compiler) {
+    compiler.outputFileSystem = createFsFromVolume(new Volume());
+  },
+  async build(context, compiler) {
+    const cycles = [];
+    let coalesceNormalInvalidation = false;
+    let emitNormalFileChange;
+    let watching;
+    compiler.watchFileSystem = {
+      watch(
+        files,
+        dirs,
+        missing,
+        startTime,
+        options,
+        callback,
+        callbackUndelayed,
+      ) {
+        emitNormalFileChange = () => {
+          const file = path.join(compiler.context, "c.js");
+          callbackUndelayed(file, Date.now());
+          callback(null, new Map(), new Map(), new Set([file]), new Set());
+        };
+        return {
+          close() {},
+          getInfo() {
+            return {
+              changes: new Set(),
+              removals: new Set(),
+              fileTimeInfoEntries: new Map(),
+              contextTimeInfoEntries: new Map(),
+            };
+          },
+          pause() {},
+        };
+      },
+    };
+    compiler.hooks.thisCompilation.tap(
+      "test lazy invalidation provenance",
+      compilation => {
+        cycles.push(compilation.watchInvalidationKind);
+      },
+    );
+    compiler.hooks.make.tapAsync(
+      "coalesce normal invalidation",
+      (compilation, callback) => {
+        if (
+          coalesceNormalInvalidation &&
+          compilation.watchInvalidationKind === "lazy"
+        ) {
+          coalesceNormalInvalidation = false;
+          emitNormalFileChange();
+        }
+        callback();
+      },
+    );
+
+    const middleware = lazyCompilationMiddleware(compiler);
+    const activate = module =>
+      new Promise((resolve, reject) => {
+        middleware(
+          {
+            body: [module],
+            method: "POST",
+            url: "/_rspack/lazy/trigger",
+          },
+          {
+            end: resolve,
+            write() {},
+            writeHead(status) {
+              expect(status).toBe(200);
+            },
+          },
+          reject,
+        ).catch(reject);
+      });
+
+    return new Promise((resolve, reject) => {
+      let builds = 0;
+      watching = compiler.watch({}, err => {
+        if (err) return reject(err);
+        builds++;
+        if (builds === 1) {
+          setImmediate(() => activate("first-lazy-module").catch(reject));
+          return;
+        }
+        if (builds === 2) {
+          coalesceNormalInvalidation = true;
+          setImmediate(() => activate("coalesced-lazy-module").catch(reject));
+          return;
+        }
+        if (builds === 3) {
+          try {
+            expect(cycles).toEqual([undefined, "lazy", "lazy", "normal"]);
+          } catch (error) {
+            watching.close(() => reject(error));
+            return;
+          }
+          watching.close(error => (error ? reject(error) : resolve()));
+        }
       });
     });
   },

--- a/tests/rspack-test/multiCompilerCases/invalidate.js
+++ b/tests/rspack-test/multiCompilerCases/invalidate.js
@@ -5,6 +5,7 @@ const path = require("path");
 module.exports = [
   (() => {
     const events = [];
+    const lazyCompilationCycles = [];
     let state = 0;
     return {
       description: "should respect dependencies when using invalidate",
@@ -36,6 +37,11 @@ module.exports = [
           c.hooks.done.tap("test", () => {
             events.push(`${c.name} done`);
           });
+          c.hooks.thisCompilation.tap("test", compilation => {
+            if (c.name === "a") {
+              lazyCompilationCycles.push(compilation.watchInvalidationKind);
+            }
+          });
         });
 
         compiler.watchFileSystem = { watch() { } };
@@ -48,10 +54,9 @@ module.exports = [
               reject(error);
               return;
             }
-            if (state !== 0) return;
-            state++;
-
-            expect(events).toMatchInlineSnapshot(`
+            if (state === 0) {
+              state = 1;
+              expect(events).toMatchInlineSnapshot(`
 				Array [
 				  b run,
 				  b done,
@@ -59,13 +64,13 @@ module.exports = [
 				  a done,
 				]
 			`);
-            events.length = 0;
+              events.length = 0;
 
-            watching.invalidate(err => {
-              try {
-                if (err) return reject(err);
+              watching.__internal__invalidate("lazy", err => {
+                try {
+                  if (err) return reject(err);
 
-                expect(events).toMatchInlineSnapshot(`
+                  expect(events).toMatchInlineSnapshot(`
 					Array [
 					  a invalid,
 					  b invalid,
@@ -75,16 +80,46 @@ module.exports = [
 					  a done,
 					]
 				`);
-                events.length = 0;
-                expect(state).toBe(1);
-                setTimeout(() => {
-                  compiler.close(resolve);
-                }, 1000);
-              } catch (e) {
-                console.error(e);
-                reject(e);
-              }
-            });
+                  // `a` consumes `b`'s lazy artifact, so its dependent
+                  // generation must remain normal and emit fresh output.
+                  expect(lazyCompilationCycles).toEqual([undefined, "normal"]);
+                  events.length = 0;
+                  expect(state).toBe(1);
+                  state = 2;
+                  watching.watchings[0].__internal__invalidate("lazy");
+                  watching.watchings[1].invalidate(error => {
+                    if (error) reject(error);
+                  });
+                } catch (e) {
+                  console.error(e);
+                  reject(e);
+                }
+              });
+              return;
+            }
+
+            if (state !== 2) return;
+            try {
+              expect(events).toMatchInlineSnapshot(`
+				Array [
+				  a invalid,
+				  b invalid,
+				  b run,
+				  b done,
+				  a run,
+				  a done,
+				]
+			`);
+              expect(lazyCompilationCycles).toEqual([
+                undefined,
+                "normal",
+                "normal"
+              ]);
+              state = 3;
+              compiler.close(error => (error ? reject(error) : resolve()));
+            } catch (error) {
+              compiler.close(() => reject(error));
+            }
           });
         });
       }


### PR DESCRIPTION
## Summary

- Cache safe static Copy patterns and invalidate them on overlapping file or context changes.
- Preserve recursive watch registration and lazy invalidation provenance so only empty lazy rebuilds reuse unchanged results.
- Emit patterns deterministically by priority and pattern index, with portable asset keys and focused cache regressions.

## Related links

Source PR: #14772

Closes #14791

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).