### PR TITLE
fix(hmr): preserve disposed module factories

### DIFF
--- a/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
+++ b/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
@@ -304,11 +304,50 @@
 	return internalApply(options);
 }
 
+<%- fn("finalizeModuleFactoryTransaction") %>(moduleFactoryTransaction) {
+	if (moduleFactoryTransaction.finalized) return;
+	moduleFactoryTransaction.finalized = true;
+	var finalizers = moduleFactoryTransaction.finalizers;
+	moduleFactoryTransaction.finalizers = [];
+	finalizers.forEach(function (finalize) {
+		finalize();
+	});
+}
+
 <%- fn("internalApply") %>(options) {
 	options = options || {};
+	if (!options.preserveDisposedModuleFactories) {
+		return internalApplyUpdate(options);
+	}
+
+	var moduleFactoryTransaction = {
+		finalizers: [],
+		finalized: false
+	};
+	var applyResult;
+	try {
+		applyResult = internalApplyUpdate(options, moduleFactoryTransaction);
+	} catch (error) {
+		finalizeModuleFactoryTransaction(moduleFactoryTransaction);
+		throw error;
+	}
+
+	return applyResult.then(
+		function (result) {
+			finalizeModuleFactoryTransaction(moduleFactoryTransaction);
+			return result;
+		},
+		function (error) {
+			finalizeModuleFactoryTransaction(moduleFactoryTransaction);
+			throw error;
+		}
+	);
+}
+
+<%- fn("internalApplyUpdate") %>(options, moduleFactoryTransaction) {
 	applyInvalidatedModules();
 	var results = currentUpdateApplyHandlers.map(function (handler) {
-		return handler(options);
+		return handler(options, moduleFactoryTransaction);
 	});
 	currentUpdateApplyHandlers = undefined;
 	var errors = results
@@ -350,13 +389,16 @@
 
 	return Promise.all([disposePromise, applyPromise]).then(function () {
 		if (error) {
+			if (moduleFactoryTransaction) {
+				finalizeModuleFactoryTransaction(moduleFactoryTransaction);
+			}
 			return setStatus("fail").then(function () {
 				throw error;
 			});
 		}
 
 		if (queuedInvalidatedModules) {
-			return internalApply(options).then(function (list) {
+			return internalApplyUpdate(options, moduleFactoryTransaction).then(function (list) {
 				outdatedModules.forEach(function (moduleId) {
 					if (list.indexOf(moduleId) < 0) list.push(moduleId);
 				});
@@ -364,6 +406,9 @@
 			});
 		}
 
+		if (moduleFactoryTransaction) {
+			finalizeModuleFactoryTransaction(moduleFactoryTransaction);
+		}
 		return setStatus("idle").then(function () {
 			return outdatedModules;
 		});

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
@@ -2,7 +2,7 @@
 <%- var("hotCurrentUpdate") %>;
 <%- var("hotCurrentUpdateRemovedChunks") %>;
 <%- var("hotCurrentUpdateRuntime") %>;
-<%- fn("hotApplyHandler") %>(options) {
+<%- fn("hotApplyHandler") %>(options, moduleFactoryTransaction) {
 	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) delete <%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -269,7 +269,46 @@
 			// insert new code
 			for (var updateModuleId in appliedUpdate) {
 				if (<%- HAS_OWN_PROPERTY %>(appliedUpdate, updateModuleId)) {
-					<%- MODULE_FACTORIES %>[updateModuleId] = appliedUpdate[updateModuleId];
+					var newModuleFactory = appliedUpdate[updateModuleId];
+					var preservedModuleFactories =
+						moduleFactoryTransaction &&
+						moduleFactoryTransaction.javascriptModuleFactories;
+					var hasPreservedModuleFactory =
+						preservedModuleFactories &&
+						<%- HAS_OWN_PROPERTY %>(preservedModuleFactories, updateModuleId);
+					// Keep removed factories usable until the outer apply transaction settles.
+					if (
+						moduleFactoryTransaction &&
+						(newModuleFactory === warnUnexpectedRequire || hasPreservedModuleFactory)
+					) {
+						if (!preservedModuleFactories) {
+							preservedModuleFactories = Object.create(null);
+							moduleFactoryTransaction.javascriptModuleFactories =
+								preservedModuleFactories;
+							moduleFactoryTransaction.finalizers.push(function () {
+								for (var moduleId in preservedModuleFactories) {
+									if (<%- HAS_OWN_PROPERTY %>(preservedModuleFactories, moduleId)) {
+										var module = <%- MODULE_CACHE %>[moduleId];
+										if (module) {
+											module.hot.active = false;
+											for (var i = 0; i < module.children.length; i++) {
+												var child = <%- MODULE_CACHE %>[module.children[i]];
+												if (!child) continue;
+												var idx = child.parents.indexOf(moduleId);
+												if (idx >= 0) child.parents.splice(idx, 1);
+											}
+										}
+										delete <%- MODULE_CACHE %>[moduleId];
+										<%- MODULE_FACTORIES %>[moduleId] =
+											preservedModuleFactories[moduleId];
+									}
+								}
+							});
+						}
+						preservedModuleFactories[updateModuleId] = newModuleFactory;
+					} else {
+						<%- MODULE_FACTORIES %>[updateModuleId] = newModuleFactory;
+					}
 					<% if (_is_hot_test) { %>
 					if (self.__HMR_UPDATED_RUNTIME__) {
 						self.__HMR_UPDATED_RUNTIME__.javascript.updatedModules.push(updateModuleId);

--- a/packages/rspack-test-tools/src/helper/util/expectWarningFactory.js
+++ b/packages/rspack-test-tools/src/helper/util/expectWarningFactory.js
@@ -9,8 +9,12 @@ export function expectWarningFactory() {
   });
 
   afterEach(() => {
-    expectWarning();
-    console.warn = oldWarn;
+    try {
+      expectWarning();
+    } finally {
+      warnings.length = 0;
+      console.warn = oldWarn;
+    }
   });
 
   const expectWarning = (...regexp) => {

--- a/packages/rspack-test-tools/src/runner/web/index.ts
+++ b/packages/rspack-test-tools/src/runner/web/index.ts
@@ -31,8 +31,11 @@ export class WebRunner extends NodeRunner {
   constructor(protected _webOptions: IWebRunnerOptions) {
     super(_webOptions);
 
+    // Hot cases run concurrently and can temporarily replace console methods.
+    // Keep those overrides local to the JSDOM instance while preserving normal output.
+    const scopedConsole = Object.create(console) as Console;
     const virtualConsole = new VirtualConsole({});
-    virtualConsole.sendTo(console, {
+    virtualConsole.sendTo(scopedConsole, {
       omitJSDOMErrors: true,
     });
     this.dom = new JSDOM(
@@ -51,7 +54,7 @@ export class WebRunner extends NodeRunner {
       },
     );
 
-    this.dom.window.console = console;
+    this.dom.window.console = scopedConsole;
     // compat with FakeDocument
     this.dom.window.eval(`
       var linkSheetDescriptor = Object.getOwnPropertyDescriptor(HTMLLinkElement.prototype, "sheet");

--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -104,6 +104,8 @@ declare namespace Rspack {
     ignoreUnaccepted?: boolean;
     ignoreDeclined?: boolean;
     ignoreErrored?: boolean;
+    /** Keep factories for modules removed from the compilation available until the apply transaction settles. */
+    preserveDisposedModuleFactories?: boolean;
     onDeclined?: (event: DeclinedEvent) => void;
     onUnaccepted?: (event: UnacceptedEvent) => void;
     onAccepted?: (event: AcceptedEvent) => void;

--- a/tests/rspack-test/WebRunnerConsoleIsolation.test.js
+++ b/tests/rspack-test/WebRunnerConsoleIsolation.test.js
@@ -1,0 +1,45 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { WebRunner } = require("@rspack/test-tools");
+
+it("keeps concurrent web-runner console overrides isolated", async () => {
+	const root = path.resolve(__dirname, "js/web-runner-console-isolation");
+	const bundle = path.join(root, "bundle.js");
+	fs.mkdirSync(root, { recursive: true });
+	fs.writeFileSync(bundle, "module.exports = console;\n");
+
+	const createRunner = name =>
+		new WebRunner({
+			location: "https://test.cases/path/index.html",
+			env: { expect, it, beforeEach, afterEach },
+			name,
+			testConfig: {},
+			source: root,
+			dist: root,
+			compilerOptions: { target: "web", node: false },
+			runInNewContext: true
+		});
+
+	const originalWarn = console.warn;
+	try {
+		const first = await createRunner("first").run(bundle);
+		const second = await createRunner("second").run(bundle);
+		const firstWarnings = [];
+		const secondWarnings = [];
+		first.warn = warning => firstWarnings.push(warning);
+		second.warn = warning => secondWarnings.push(warning);
+
+		first.warn("first warning");
+		second.warn("second warning");
+
+		expect(first).not.toBe(console);
+		expect(second).not.toBe(console);
+		expect(first).not.toBe(second);
+		expect(firstWarnings).toEqual(["first warning"]);
+		expect(secondWarnings).toEqual(["second warning"]);
+		expect(console.warn).toBe(originalWarn);
+	} finally {
+		console.warn = originalWarn;
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/chunks/update-chunk-loading-runtime/__snapshots__/web/1.snap.txt
@@ -12,7 +12,7 @@
 - Bundle: vendors-node_modules_vendor_js.js
 - Manifest: runtime~main.LAST_HASH.hot-update.json, size: 76
 - Update: main.LAST_HASH.hot-update.js, size: 660
-- Update: runtime~main.LAST_HASH.hot-update.js, size: 19242
+- Update: runtime~main.LAST_HASH.hot-update.js, size: 20922
 - Update: vendors-node_modules_vendor_js.LAST_HASH.hot-update.js, size: 374
 
 ## Manifest
@@ -93,9 +93,9 @@ __webpack_require__.e = (chunkId) => {
 // This function allow to reference chunks
 __webpack_require__.u = (chunkId) => {
   // return url for filenames not based on template
-  
+  if (chunkId === "chunk_js") return "" + chunkId + ".chunk." + __webpack_require__.h() + ".js";
   // return url for filenames based on template
-  return "" + chunkId + ".chunk." + __webpack_require__.h() + ".js"
+  return "" + chunkId + ".js"
 }
 })();
 // webpack/runtime/get_full_hash
@@ -211,7 +211,7 @@ var hotCurrentUpdateChunks;
 var hotCurrentUpdate;
 var hotCurrentUpdateRemovedChunks;
 var hotCurrentUpdateRuntime;
-function hotApplyHandler(options) {
+function hotApplyHandler(options, moduleFactoryTransaction) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -478,7 +478,46 @@ function hotApplyHandler(options) {
 			// insert new code
 			for (var updateModuleId in appliedUpdate) {
 				if (__webpack_require__.o(appliedUpdate, updateModuleId)) {
-					__webpack_require__.m[updateModuleId] = appliedUpdate[updateModuleId];
+					var newModuleFactory = appliedUpdate[updateModuleId];
+					var preservedModuleFactories =
+						moduleFactoryTransaction &&
+						moduleFactoryTransaction.javascriptModuleFactories;
+					var hasPreservedModuleFactory =
+						preservedModuleFactories &&
+						__webpack_require__.o(preservedModuleFactories, updateModuleId);
+					// Keep removed factories usable until the outer apply transaction settles.
+					if (
+						moduleFactoryTransaction &&
+						(newModuleFactory === warnUnexpectedRequire || hasPreservedModuleFactory)
+					) {
+						if (!preservedModuleFactories) {
+							preservedModuleFactories = Object.create(null);
+							moduleFactoryTransaction.javascriptModuleFactories =
+								preservedModuleFactories;
+							moduleFactoryTransaction.finalizers.push(function () {
+								for (var moduleId in preservedModuleFactories) {
+									if (__webpack_require__.o(preservedModuleFactories, moduleId)) {
+										var module = __webpack_require__.c[moduleId];
+										if (module) {
+											module.hot.active = false;
+											for (var i = 0; i < module.children.length; i++) {
+												var child = __webpack_require__.c[module.children[i]];
+												if (!child) continue;
+												var idx = child.parents.indexOf(moduleId);
+												if (idx >= 0) child.parents.splice(idx, 1);
+											}
+										}
+										delete __webpack_require__.c[moduleId];
+										__webpack_require__.m[moduleId] =
+											preservedModuleFactories[moduleId];
+									}
+								}
+							});
+						}
+						preservedModuleFactories[updateModuleId] = newModuleFactory;
+					} else {
+						__webpack_require__.m[updateModuleId] = newModuleFactory;
+					}
 					
 					if (self.__HMR_UPDATED_RUNTIME__) {
 						self.__HMR_UPDATED_RUNTIME__.javascript.updatedModules.push(updateModuleId);

--- a/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/__snapshots__/web/1.snap.txt
@@ -8,7 +8,7 @@
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
 - Manifest: [runtime of chunk2_js].LAST_HASH.hot-update.json, size: 60
 - Manifest: main.LAST_HASH.hot-update.json, size: 41
-- Update: main.LAST_HASH.hot-update.js, size: 18632
+- Update: main.LAST_HASH.hot-update.js, size: 20256
 
 ## Manifest
 
@@ -167,7 +167,7 @@ var hotCurrentUpdateChunks;
 var hotCurrentUpdate;
 var hotCurrentUpdateRemovedChunks;
 var hotCurrentUpdateRuntime;
-function hotApplyHandler(options) {
+function hotApplyHandler(options, moduleFactoryTransaction) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -434,7 +434,46 @@ function hotApplyHandler(options) {
 			// insert new code
 			for (var updateModuleId in appliedUpdate) {
 				if (__webpack_require__.o(appliedUpdate, updateModuleId)) {
-					__webpack_require__.m[updateModuleId] = appliedUpdate[updateModuleId];
+					var newModuleFactory = appliedUpdate[updateModuleId];
+					var preservedModuleFactories =
+						moduleFactoryTransaction &&
+						moduleFactoryTransaction.javascriptModuleFactories;
+					var hasPreservedModuleFactory =
+						preservedModuleFactories &&
+						__webpack_require__.o(preservedModuleFactories, updateModuleId);
+					// Keep removed factories usable until the outer apply transaction settles.
+					if (
+						moduleFactoryTransaction &&
+						(newModuleFactory === warnUnexpectedRequire || hasPreservedModuleFactory)
+					) {
+						if (!preservedModuleFactories) {
+							preservedModuleFactories = Object.create(null);
+							moduleFactoryTransaction.javascriptModuleFactories =
+								preservedModuleFactories;
+							moduleFactoryTransaction.finalizers.push(function () {
+								for (var moduleId in preservedModuleFactories) {
+									if (__webpack_require__.o(preservedModuleFactories, moduleId)) {
+										var module = __webpack_require__.c[moduleId];
+										if (module) {
+											module.hot.active = false;
+											for (var i = 0; i < module.children.length; i++) {
+												var child = __webpack_require__.c[module.children[i]];
+												if (!child) continue;
+												var idx = child.parents.indexOf(moduleId);
+												if (idx >= 0) child.parents.splice(idx, 1);
+											}
+										}
+										delete __webpack_require__.c[moduleId];
+										__webpack_require__.m[moduleId] =
+											preservedModuleFactories[moduleId];
+									}
+								}
+							});
+						}
+						preservedModuleFactories[updateModuleId] = newModuleFactory;
+					} else {
+						__webpack_require__.m[updateModuleId] = newModuleFactory;
+					}
 					
 					if (self.__HMR_UPDATED_RUNTIME__) {
 						self.__HMR_UPDATED_RUNTIME__.javascript.updatedModules.push(updateModuleId);

--- a/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/disposing/runtime-independent-filename/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Bundle: chunk1_js.chunk.CURRENT_HASH.js
-- Update: main.LAST_HASH.hot-update.js, size: 18632
+- Update: main.LAST_HASH.hot-update.js, size: 20256
 
 ## Manifest
 
@@ -151,7 +151,7 @@ var hotCurrentUpdateChunks;
 var hotCurrentUpdate;
 var hotCurrentUpdateRemovedChunks;
 var hotCurrentUpdateRuntime;
-function hotApplyHandler(options) {
+function hotApplyHandler(options, moduleFactoryTransaction) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -418,7 +418,46 @@ function hotApplyHandler(options) {
 			// insert new code
 			for (var updateModuleId in appliedUpdate) {
 				if (__webpack_require__.o(appliedUpdate, updateModuleId)) {
-					__webpack_require__.m[updateModuleId] = appliedUpdate[updateModuleId];
+					var newModuleFactory = appliedUpdate[updateModuleId];
+					var preservedModuleFactories =
+						moduleFactoryTransaction &&
+						moduleFactoryTransaction.javascriptModuleFactories;
+					var hasPreservedModuleFactory =
+						preservedModuleFactories &&
+						__webpack_require__.o(preservedModuleFactories, updateModuleId);
+					// Keep removed factories usable until the outer apply transaction settles.
+					if (
+						moduleFactoryTransaction &&
+						(newModuleFactory === warnUnexpectedRequire || hasPreservedModuleFactory)
+					) {
+						if (!preservedModuleFactories) {
+							preservedModuleFactories = Object.create(null);
+							moduleFactoryTransaction.javascriptModuleFactories =
+								preservedModuleFactories;
+							moduleFactoryTransaction.finalizers.push(function () {
+								for (var moduleId in preservedModuleFactories) {
+									if (__webpack_require__.o(preservedModuleFactories, moduleId)) {
+										var module = __webpack_require__.c[moduleId];
+										if (module) {
+											module.hot.active = false;
+											for (var i = 0; i < module.children.length; i++) {
+												var child = __webpack_require__.c[module.children[i]];
+												if (!child) continue;
+												var idx = child.parents.indexOf(moduleId);
+												if (idx >= 0) child.parents.splice(idx, 1);
+											}
+										}
+										delete __webpack_require__.c[moduleId];
+										__webpack_require__.m[moduleId] =
+											preservedModuleFactories[moduleId];
+									}
+								}
+							});
+						}
+						preservedModuleFactories[updateModuleId] = newModuleFactory;
+					} else {
+						__webpack_require__.m[updateModuleId] = newModuleFactory;
+					}
 					
 					if (self.__HMR_UPDATED_RUNTIME__) {
 						self.__HMR_UPDATED_RUNTIME__.javascript.updatedModules.push(updateModuleId);

--- a/tests/rspack-test/hotCases/module/access-dropped-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/module/access-dropped-module/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 42
-- Update: main.LAST_HASH.hot-update.js, size: 15545
+- Update: main.LAST_HASH.hot-update.js, size: 17169
 
 ## Manifest
 
@@ -101,7 +101,7 @@ var hotCurrentUpdateChunks;
 var hotCurrentUpdate;
 var hotCurrentUpdateRemovedChunks;
 var hotCurrentUpdateRuntime;
-function hotApplyHandler(options) {
+function hotApplyHandler(options, moduleFactoryTransaction) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -368,7 +368,46 @@ function hotApplyHandler(options) {
 			// insert new code
 			for (var updateModuleId in appliedUpdate) {
 				if (__webpack_require__.o(appliedUpdate, updateModuleId)) {
-					__webpack_require__.m[updateModuleId] = appliedUpdate[updateModuleId];
+					var newModuleFactory = appliedUpdate[updateModuleId];
+					var preservedModuleFactories =
+						moduleFactoryTransaction &&
+						moduleFactoryTransaction.javascriptModuleFactories;
+					var hasPreservedModuleFactory =
+						preservedModuleFactories &&
+						__webpack_require__.o(preservedModuleFactories, updateModuleId);
+					// Keep removed factories usable until the outer apply transaction settles.
+					if (
+						moduleFactoryTransaction &&
+						(newModuleFactory === warnUnexpectedRequire || hasPreservedModuleFactory)
+					) {
+						if (!preservedModuleFactories) {
+							preservedModuleFactories = Object.create(null);
+							moduleFactoryTransaction.javascriptModuleFactories =
+								preservedModuleFactories;
+							moduleFactoryTransaction.finalizers.push(function () {
+								for (var moduleId in preservedModuleFactories) {
+									if (__webpack_require__.o(preservedModuleFactories, moduleId)) {
+										var module = __webpack_require__.c[moduleId];
+										if (module) {
+											module.hot.active = false;
+											for (var i = 0; i < module.children.length; i++) {
+												var child = __webpack_require__.c[module.children[i]];
+												if (!child) continue;
+												var idx = child.parents.indexOf(moduleId);
+												if (idx >= 0) child.parents.splice(idx, 1);
+											}
+										}
+										delete __webpack_require__.c[moduleId];
+										__webpack_require__.m[moduleId] =
+											preservedModuleFactories[moduleId];
+									}
+								}
+							});
+						}
+						preservedModuleFactories[updateModuleId] = newModuleFactory;
+					} else {
+						__webpack_require__.m[updateModuleId] = newModuleFactory;
+					}
 					
 					if (self.__HMR_UPDATED_RUNTIME__) {
 						self.__HMR_UPDATED_RUNTIME__.javascript.updatedModules.push(updateModuleId);

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case preserve-disposed-module-factories-error: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/__snapshots__/web/1.snap.txt
@@ -1,0 +1,59 @@
+# Case preserve-disposed-module-factories-error: Step 1
+
+## Changed Files
+- module.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 36
+- Update: main.LAST_HASH.hot-update.js, size: 622
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":["./a.js"]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./b.js
+- ./module.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+self["rspackHotUpdate"]("main", {
+"./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+/* export default */ const __rspack_default_export = ("b");
+
+
+},
+"./module.js"(module, __unused_rspack_exports, __webpack_require__) {
+module.exports = () => (__webpack_require__("./b.js")/* ["default"] */["default"]);
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/a.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/b.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/index.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/index.js
@@ -1,0 +1,21 @@
+const initialRemovedFactory = __webpack_require__.m["./a.js"];
+const readRemovedModule = require("./module");
+
+module.hot.accept("./module", () => {
+	throw new Error("accept failed");
+});
+
+it("should finalize disposed factories when apply rejects", async () => {
+	await expect(
+		NEXT_HMR({ preserveDisposedModuleFactories: true })
+	).rejects.toThrow("accept failed");
+
+	expect(__webpack_require__.m["./a.js"]).not.toBe(initialRemovedFactory);
+	const warn = console.warn;
+	console.warn = () => {};
+	try {
+		expect(readRemovedModule).toThrow("RuntimeError: factory is undefined(./a.js)");
+	} finally {
+		console.warn = warn;
+	}
+});

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/module.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-error/module.js
@@ -1,0 +1,3 @@
+module.exports = () => require("./a").default;
+---
+module.exports = () => require("./b").default;

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case preserve-disposed-module-factories-queued: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/__snapshots__/web/1.snap.txt
@@ -1,0 +1,48 @@
+# Case preserve-disposed-module-factories-queued: Step 1
+
+## Changed Files
+- module.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 36
+- Update: main.LAST_HASH.hot-update.js, size: 232
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":["./a.js"]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./module.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+self["rspackHotUpdate"]("main", {
+"./module.js"(module) {
+module.exports = () => "current";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/a.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/a.js
@@ -1,0 +1,4 @@
+export const value = "a";
+export const invalidate = () => module.hot.invalidate();
+
+module.hot.accept();

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/index.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/index.js
@@ -1,0 +1,19 @@
+const initialRemovedFactory = __webpack_require__.m["./a.js"];
+const readRemovedModule = require("./module");
+const removedModule = readRemovedModule();
+let valueDuringApply;
+
+module.hot.accept("./module", () => {
+	valueDuringApply = removedModule.value;
+	removedModule.invalidate();
+});
+
+it("should finalize after recursively applying queued invalidations", async () => {
+	await NEXT_HMR({
+		ignoreUnaccepted: true,
+		preserveDisposedModuleFactories: true
+	});
+
+	expect(valueDuringApply).toBe("a");
+	expect(__webpack_require__.m["./a.js"]).toBe(initialRemovedFactory);
+});

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/module.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories-queued/module.js
@@ -1,0 +1,3 @@
+module.exports = () => require("./a");
+---
+module.exports = () => "current";

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case preserve-disposed-module-factories: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/__snapshots__/web/1.snap.txt
@@ -1,0 +1,59 @@
+# Case preserve-disposed-module-factories: Step 1
+
+## Changed Files
+- module.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 36
+- Update: main.LAST_HASH.hot-update.js, size: 622
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":["./a.js"]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./b.js
+- ./module.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+self["rspackHotUpdate"]("main", {
+"./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+/* export default */ const __rspack_default_export = ("b");
+
+
+},
+"./module.js"(module, __unused_rspack_exports, __webpack_require__) {
+module.exports = () => (__webpack_require__("./b.js")/* ["default"] */["default"]);
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/__snapshots__/web/2.snap.txt
@@ -1,0 +1,97 @@
+# Case preserve-disposed-module-factories: Step 2
+
+## Changed Files
+- module.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 36
+- Update: main.LAST_HASH.hot-update.js, size: 232
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":["./b.js"]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./module.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+self["rspackHotUpdate"]("main", {
+"./module.js"(module) {
+module.exports = () => "current";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+
+## Runtime
+### Status
+
+```txt
+check => prepare => dispose => apply => idle
+```
+
+
+
+### JavaScript
+
+#### Outdated
+
+Outdated Modules:
+- ./a.js
+- ./b.js
+- ./module.js
+
+
+Outdated Dependencies:
+```json
+{
+  "./index.js": [
+    "./module.js"
+  ]
+}
+```
+
+#### Updated
+
+Updated Modules:
+- ./a.js
+- ./b.js
+- ./module.js
+
+Updated Runtime:
+- `__webpack_require__.h`
+
+
+#### Callback
+
+Accepted Callback:
+- ./module.js
+
+Disposed Callback:

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/a.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/a.js
@@ -1,0 +1,5 @@
+import { getParents } from "./child";
+
+getParents();
+export default "a";
+export const readChildParents = () => require("./child").getParents();

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/b.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/child.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/child.js
@@ -1,0 +1,1 @@
+export const getParents = () => module.parents.slice();

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/index.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/index.js
@@ -1,0 +1,61 @@
+const initialRemovedFactory = __webpack_require__.m["./a.js"];
+const readRemovedModule = require("./module");
+const getChildParents = require("./child").getParents;
+let removedModuleId = "./a.js";
+let factoryDuringApply;
+let factoryAtIdle;
+let valueDuringApply;
+let childParentsDuringApply;
+let readChildParentsAfterApply;
+
+module.hot.accept("./module", () => {
+	factoryDuringApply = __webpack_require__.m[removedModuleId];
+	if (removedModuleId === "./a.js") {
+		valueDuringApply = readRemovedModule();
+		childParentsDuringApply = getChildParents();
+		readChildParentsAfterApply = __webpack_require__("./a.js").readChildParents;
+	}
+});
+
+const checkDisposedFactoryAtIdle = (status) => {
+	if (status !== "idle") return;
+	factoryAtIdle = __webpack_require__.m[removedModuleId];
+};
+module.hot.addStatusHandler(checkDisposedFactoryAtIdle);
+
+it("should preserve disposed factories only for the requested apply transaction", async () => {
+	await NEXT_HMR({ preserveDisposedModuleFactories: true });
+
+	expect(factoryDuringApply).toBe(initialRemovedFactory);
+	expect(valueDuringApply).toBe("a");
+	expect(childParentsDuringApply).toContain("./a.js");
+	expect(getChildParents()).not.toContain("./a.js");
+	expect(factoryAtIdle).not.toBe(initialRemovedFactory);
+	expect(__webpack_require__.m["./a.js"]).toBe(factoryAtIdle);
+	const warnings = [];
+	const warn = console.warn;
+	console.warn = warning => warnings.push(warning);
+	try {
+		expect(readChildParentsAfterApply()).not.toContain("./a.js");
+	} finally {
+		console.warn = warn;
+	}
+	expect(warnings).toEqual([
+		"[HMR] unexpected require(./child.js) from disposed module ./a.js"
+	]);
+	console.warn = () => {};
+	try {
+		expect(readRemovedModule).toThrow("RuntimeError: factory is undefined(./a.js)");
+	} finally {
+		console.warn = warn;
+	}
+
+	module.hot.removeStatusHandler(checkDisposedFactoryAtIdle);
+	require("./module");
+	removedModuleId = "./b.js";
+	const secondRemovedFactory = __webpack_require__.m[removedModuleId];
+	await NEXT_HMR();
+
+	expect(factoryDuringApply).not.toBe(secondRemovedFactory);
+	expect(__webpack_require__.m[removedModuleId]).toBe(factoryDuringApply);
+});

--- a/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/module.js
+++ b/tests/rspack-test/hotCases/runtime/preserve-disposed-module-factories/module.js
@@ -1,0 +1,5 @@
+module.exports = () => require("./a").default;
+---
+module.exports = () => require("./b").default;
+---
+module.exports = () => "current";

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42679
+- Update: main.LAST_HASH.hot-update.js, size: 44303
 
 ## Manifest
 
@@ -777,7 +777,7 @@ var hotCurrentUpdateChunks;
 var hotCurrentUpdate;
 var hotCurrentUpdateRemovedChunks;
 var hotCurrentUpdateRuntime;
-function hotApplyHandler(options) {
+function hotApplyHandler(options, moduleFactoryTransaction) {
 	if (__webpack_require__.f) delete __webpack_require__.f.jsonpHmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {
@@ -1044,7 +1044,46 @@ function hotApplyHandler(options) {
 			// insert new code
 			for (var updateModuleId in appliedUpdate) {
 				if (__webpack_require__.o(appliedUpdate, updateModuleId)) {
-					__webpack_require__.m[updateModuleId] = appliedUpdate[updateModuleId];
+					var newModuleFactory = appliedUpdate[updateModuleId];
+					var preservedModuleFactories =
+						moduleFactoryTransaction &&
+						moduleFactoryTransaction.javascriptModuleFactories;
+					var hasPreservedModuleFactory =
+						preservedModuleFactories &&
+						__webpack_require__.o(preservedModuleFactories, updateModuleId);
+					// Keep removed factories usable until the outer apply transaction settles.
+					if (
+						moduleFactoryTransaction &&
+						(newModuleFactory === warnUnexpectedRequire || hasPreservedModuleFactory)
+					) {
+						if (!preservedModuleFactories) {
+							preservedModuleFactories = Object.create(null);
+							moduleFactoryTransaction.javascriptModuleFactories =
+								preservedModuleFactories;
+							moduleFactoryTransaction.finalizers.push(function () {
+								for (var moduleId in preservedModuleFactories) {
+									if (__webpack_require__.o(preservedModuleFactories, moduleId)) {
+										var module = __webpack_require__.c[moduleId];
+										if (module) {
+											module.hot.active = false;
+											for (var i = 0; i < module.children.length; i++) {
+												var child = __webpack_require__.c[module.children[i]];
+												if (!child) continue;
+												var idx = child.parents.indexOf(moduleId);
+												if (idx >= 0) child.parents.splice(idx, 1);
+											}
+										}
+										delete __webpack_require__.c[moduleId];
+										__webpack_require__.m[moduleId] =
+											preservedModuleFactories[moduleId];
+									}
+								}
+							});
+						}
+						preservedModuleFactories[updateModuleId] = newModuleFactory;
+					} else {
+						__webpack_require__.m[updateModuleId] = newModuleFactory;
+					}
 					
 					if (self.__HMR_UPDATED_RUNTIME__) {
 						self.__HMR_UPDATED_RUNTIME__.javascript.updatedModules.push(updateModuleId);

--- a/website/docs/en/api/runtime-api/hmr.mdx
+++ b/website/docs/en/api/runtime-api/hmr.mdx
@@ -311,6 +311,7 @@ The optional `options` object can include the following properties:
 - `ignoreUnaccepted` (boolean): Ignore changes made to unaccepted modules.
 - `ignoreDeclined` (boolean): Ignore changes made to declined modules.
 - `ignoreErrored` (boolean): Ignore errors thrown in accept handlers, error handlers and while reevaluating module.
+- `preserveDisposedModuleFactories` (boolean): Only keep factories for modules removed from the compilation readable until the current apply transaction settles. Defaults to `false` and is intended for activating modules through lazy compilation.
 - `onDeclined` (function(info)): Notifier for declined modules
 - `onUnaccepted` (function(info)): Notifier for unaccepted modules
 - `onAccepted` (function(info)): Notifier for accepted modules

--- a/website/docs/zh/api/runtime-api/hmr.mdx
+++ b/website/docs/zh/api/runtime-api/hmr.mdx
@@ -311,6 +311,7 @@ import.meta.webpackHot
 - `ignoreUnaccepted`（boolean）：忽略对不可接受的模块所做的更改。
 - `ignoreDeclined`（boolean）：忽略对已拒绝的模块所做的更改。
 - `ignoreErrored`（boolean）：忽略在接受处理程序、错误处理器以及重新评估模块时抛出的错误。
+- `preserveDisposedModuleFactories`（boolean）：仅在当前 apply 事务结束前，保持从 compilation 中移除的模块工厂可读取。默认为 `false`，用于激活通过 lazy compilation 编译的模块。
 - `onDeclined`（function(info)）：拒绝模块的通知者。
 - `onUnaccepted`（function(info)）：不可接受的模块的通知程序。
 - `onAccepted`（function(info)）：可接受模块的通知者。


### PR DESCRIPTION
## Summary

- Keep disposed module factories available until the HMR apply transaction settles, then deactivate and unlink transient modules.
- Isolate concurrent web runner consoles and restore warning hooks reliably.

## Related links

Source PR: #14772

Closes #14792

The full-hash runtime filename and compilation-scoped plugin cache changes were extracted into #14997.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
