### PR TITLE
fix(hmr): keep extracted CSS reload single-owned

### DIFF
--- a/packages/rspack/src/builtin-plugin/css-extract/loader.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/loader.ts
@@ -39,6 +39,8 @@ export function hotLoader(
   },
 ): string {
   const localsJsonString = JSON.stringify(JSON.stringify(context.locals));
+  // The extracted-CSS runtime owns stylesheet replacement when present; keep
+  // the loader reload only as the fallback for `CssExtractRspackPlugin({ runtime: false })`.
   return `${content}
     if(module.hot) {
       (function() {
@@ -60,7 +62,9 @@ export function hotLoader(
         }
         module.hot.dispose(function(data) {
           data.value = localsJsonString;
-          cssReload();
+          if (!__webpack_require__.hmrC || !__webpack_require__.hmrC.miniCss) {
+            cssReload();
+          }
         });
       })();
     }

--- a/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/index.test.ts
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/index.test.ts
@@ -1,9 +1,6 @@
 import { test, expect } from '@/fixtures';
 
-// The hot-update lists both the `style` and `main` chunks while the fixed
-// `filename` maps them to one stylesheet. Without de-duplication the handler
-// re-fetched it once per chunk and leaked one <link> per update.
-test('should keep a single stylesheet link when several updated chunks share it', async ({
+test('keeps the loader CSS reload fallback when the extracted runtime is disabled', async ({
   page,
   fileAction,
 }) => {
@@ -33,8 +30,6 @@ test('should keep a single stylesheet link when several updated chunks share it'
     await expect(links).toHaveCount(1);
   }
 
-  // The loader-level reload is debounced, so repeated edits expose a second
-  // owner even when a transient two-link state has already settled.
   expect(responses).toHaveLength(colors.length - 1);
   expect(new Set(responses).size).toBe(colors.length - 1);
   expect(responses.every((url) => url.includes('?'))).toBe(true);

--- a/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/rspack.config.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/rspack.config.js
@@ -1,0 +1,44 @@
+const { rspack } = require('@rspack/core');
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+  context: __dirname,
+  mode: 'development',
+  entry: {
+    main: ['./src/index.css', './src/index.js'],
+  },
+  devServer: {
+    hot: true,
+  },
+  plugins: [
+    new rspack.HtmlRspackPlugin({
+      template: './src/index.html',
+      inject: 'body',
+    }),
+    new rspack.CssExtractRspackPlugin({
+      filename: 'static/style.css',
+      runtime: false,
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'javascript/auto',
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        style: {
+          name: 'style',
+          test: /\.css$/,
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+};

--- a/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/src/index.css
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/src/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: rgb(10, 20, 30);
+}

--- a/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/src/index.html
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body></body>
+</html>

--- a/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/src/index.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup-runtime-false/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+module.hot.accept();

--- a/tests/rspack-test/hotCases/css/recovery-cacheable/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/recovery-cacheable/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 993
+- Update: main.hot-update.js, size: 1087
 
 ## Manifest
 
@@ -52,7 +52,9 @@ __webpack_require__.r(__webpack_exports__);
         }
         module.hot.dispose(function(data) {
           data.value = localsJsonString;
-          cssReload();
+          if (!__webpack_require__.hmrC || !__webpack_require__.hmrC.miniCss) {
+            cssReload();
+          }
         });
       })();
     }

--- a/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.hot-update.js, size: 6038
+- Update: main.hot-update.js, size: 6132
 
 ## Manifest
 
@@ -54,7 +54,9 @@ __webpack_require__.r(__webpack_exports__);
         }
         module.hot.dispose(function(data) {
           data.value = localsJsonString;
-          cssReload();
+          if (!__webpack_require__.hmrC || !__webpack_require__.hmrC.miniCss) {
+            cssReload();
+          }
         });
       })();
     }


### PR DESCRIPTION
## Summary

- Let the native miniCss HMR handler own extracted stylesheet replacement when it is present.
- Retain the loader reload fallback when the extracted runtime is disabled.
- Cover repeated edits, request counts, single-link ownership, and the runtime-disabled fallback.

## Related links

Source PR: #14772

Closes #14793

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).