### PR TITLE
fix(esm-library): support worker entries in modern module output

### DIFF
--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -130,7 +130,7 @@ impl EsmLibraryPlugin {
           !is_esm_dep_like(dep)
             && !matches!(
               dep.dependency_type(),
-              DependencyType::Entry | DependencyType::DynamicImport
+              DependencyType::Entry | DependencyType::DynamicImport | DependencyType::NewWorker
             )
         })
       {
@@ -330,7 +330,7 @@ async fn finish_modules(
         !is_esm_dep_like(dep)
           && !matches!(
             dep.dependency_type(),
-            DependencyType::Entry | DependencyType::DynamicImport
+            DependencyType::Entry | DependencyType::DynamicImport | DependencyType::NewWorker
           )
       })
     {


### PR DESCRIPTION
## Summary

Rslib uses modern-module output to generate clean ESM worker chunks. This PR treats `NewWorker` as an entry dependency, ensuring the worker module is executed when its chunk loads instead of only being registered as a module factory.