### PR TITLE
fix(cache): include builtin plugins in persistent cache version

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -104,7 +104,7 @@ export const getRawOptions = (
     }),
     optimization: options.optimization as Required<Optimization>,
     stats: getRawStats(options.stats),
-    cache: getRawCache(options.cache!),
+    cache: getRawCache(options.cache!, compiler),
     experiments,
     incremental: options.incremental,
     node: getRawNode(options.node),
@@ -114,9 +114,16 @@ export const getRawOptions = (
   };
 };
 
-function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
+function getRawCache(
+  cache: CacheNormalized,
+  compiler: Compiler,
+): RawOptions['cache'] {
   if (cache === false) return false;
   if (cache.type === 'memory') return cache;
+  const version = JSON.stringify([
+    cache.version,
+    compiler.__internal__builtinPlugins.map((plugin) => plugin.name),
+  ]);
   const toRawStorageLimit = (name: string, value: number) => {
     if (value === Infinity) return 0;
     if (!Number.isSafeInteger(value) || value < 1 || value > MAX_U32) {
@@ -128,6 +135,9 @@ function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
   };
   return {
     ...cache,
+    // The persistent cache restores the complete module graph, whose shape
+    // depends on the registered builtin plugins and their application order.
+    version,
     maxAge: toRawStorageLimit('cache.maxAge', cache.maxAge!),
     maxVersions: toRawStorageLimit('cache.maxVersions', cache.maxVersions!),
     storage: {

--- a/tests/rspack-test/cacheCases/mf/issue-14827/__snapshots__/stats-0.txt
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/__snapshots__/stats-0.txt
@@ -1,0 +1,17 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/mf/issue-14827/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/__snapshots__/stats-1.txt
@@ -1,0 +1,11 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/mf/issue-14827/app.js
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/app.js
@@ -1,0 +1,1 @@
+export { double } from './shared';

--- a/tests/rspack-test/cacheCases/mf/issue-14827/index.js
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/index.js
@@ -1,0 +1,16 @@
+it('should apply sharing when the previous build has no shared config', async () => {
+  const { double } = await import('./app');
+  expect(double(2)).toBe(4);
+
+  if (COMPILER_INDEX === 0) {
+    await NEXT_START();
+  }
+
+  if (COMPILER_INDEX === 1) {
+    expect(
+      __STATS__.modules.some((module) =>
+        module.name.startsWith('consume shared module (default) ./shared'),
+      ),
+    ).toBe(true);
+  }
+});

--- a/tests/rspack-test/cacheCases/mf/issue-14827/rspack.config.js
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/rspack.config.js
@@ -1,0 +1,27 @@
+const rspack = require('@rspack/core');
+
+let compilerIndex = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  optimization: {
+    minimize: false,
+  },
+  cache: {
+    type: 'persistent',
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        if (compilerIndex > 0) {
+          compiler.options.cache.readonly = true;
+          new rspack.container.ModuleFederationPlugin({
+            shared: ['./shared'],
+          }).apply(compiler);
+        }
+        compilerIndex++;
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/cacheCases/mf/issue-14827/shared/double.js
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/shared/double.js
@@ -1,0 +1,1 @@
+export const double = (value) => value * 2;

--- a/tests/rspack-test/cacheCases/mf/issue-14827/shared/index.js
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/shared/index.js
@@ -1,0 +1,1 @@
+export { double } from './double';

--- a/tests/rspack-test/cacheCases/mf/issue-14827/unused.js
+++ b/tests/rspack-test/cacheCases/mf/issue-14827/unused.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 2;


### PR DESCRIPTION
## Summary

The persistent cache restores the complete module graph, but its version did not account for the registered builtin plugin pipeline. A build that enabled Module Federation sharing could therefore reuse a graph produced without consume/provide shared plugins, bypassing factorization and leaving barrel-file shared modules in the main graph.

This change includes the ordered builtin plugin names in the internal persistent-cache version. Builds with different builtin plugin sets now use separate cache versions, while builds with the same plugin pipeline continue to reuse cached artifacts.

A regression case covers writing a cache without sharing, then starting a readonly build with sharing enabled for a barrel module.

## Related links

Fixes #14827

## Validation

- `pnpm run build:js`
- `pnpm run lint-ci:js`
- `pnpm exec prettier --check <changed files>`
- `cd tests/rspack-test && pnpm run test Cache.test.js`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).