### PR TITLE
fix(worker): add module type when options are omitted in module output

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -146,6 +146,12 @@ fn add_dependencies(
       )
       .into(),
     )));
+  } else if options_range.is_none() && output_module {
+    let insert_position = first_arg.span().real_hi();
+    parser.add_presentational_dependency(Box::new(ConstDependency::new(
+      (insert_position, insert_position).into(),
+      ", { type: \"module\" }".into(),
+    )));
   }
 }
 

--- a/tests/rspack-test/configCases/worker/new-url-relative/index.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/index.js
@@ -1,3 +1,28 @@
 new Worker(
 	/* webpackChunkName: "worker" */ new URL("./worker.js", import.meta.url)
 );
+
+new Worker(
+	/* webpackChunkName: "trailing-comma" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+);
+
+const classicOptions = { type: "classic" };
+
+new Worker(
+	/* webpackChunkName: "spread-options" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	{ type: "module", ...classicOptions }
+);
+
+new Worker(
+	/* webpackChunkName: "duplicate-type" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	{ type: "module", type: "classic" }
+);

--- a/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { execFileSync } = require("child_process");
 
 const cases = [
 	{
@@ -51,6 +52,21 @@ module.exports = {
 				);
 			} else {
 				expect(workerUrl).toBe(testCase.url);
+				const output = execFileSync(
+					process.execPath,
+					[
+						"--input-type=module",
+						"--eval",
+						`const types = []; globalThis.Worker = class { constructor(_url, options) { types.push(options.type); } }; ${source}; console.log(JSON.stringify(types));`
+					],
+					{ encoding: "utf8" }
+				);
+				expect(JSON.parse(output)).toEqual([
+					"module",
+					"module",
+					"module",
+					"module"
+				]);
 			}
 
 			expect(


### PR DESCRIPTION
## Summary

When `output.module` is enabled, Worker chunks are emitted as ESM.

Previously, when `new Worker()` had a second argument, Rspack appended `{ type: "module" }`:

```js
new Worker(url, options);

// ↓

new Worker(url, Object.assign({}, options, { type: "module" }));
```

However, when the second argument was omitted, Rspack left it unchanged:

```js
new Worker(url);

// ↓

new Worker(url);
```

This caused the browser to create a classic Worker for an ESM chunk. This PR adds `{ type: "module" }` when the second argument is omitted as well.
