### PR TITLE
fix: execute worker entry modules in modern-module output

### DIFF
--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -66,6 +66,7 @@ impl SymbolRef {
 pub struct ExternalInterop {
   pub module: ModuleIdentifier,
   pub from_module: IdentifierSet,
+  pub set_entry_module_id: bool,
   pub required_symbol: Option<Atom>,
   pub default_access: Option<Atom>,
   pub default_exported: Option<Atom>,
@@ -169,6 +170,15 @@ impl ExternalInterop {
     let name = self.required_symbol.as_ref();
 
     let is_async = ModuleGraph::is_async(&compilation.async_modules_artifact, &self.module);
+    let module_id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, self.module)
+      .unwrap_or_else(|| panic!("should set module id for {:?}", self.module));
+    let mut module_id_expr = rspack_util::json_stringify(module_id.as_str());
+    if self.set_entry_module_id {
+      module_id_expr = format!(
+        "{} = {module_id_expr}",
+        runtime_template.render_runtime_globals(&RuntimeGlobals::ENTRY_MODULE_ID)
+      );
+    }
 
     if let Some(name) = name {
       source.add(RawStringSource::from(format!(
@@ -176,11 +186,7 @@ impl ExternalInterop {
         "const {name} = {}{}({});\n",
         if is_async { "await " } else { "" },
         runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
-        rspack_util::json_stringify(
-          ChunkGraph::get_module_id(&compilation.module_ids_artifact, self.module)
-            .unwrap_or_else(|| panic!("should set module id for {:?}", self.module))
-            .as_str()
-        )
+        module_id_expr
       )));
 
       if let Some(namespace_object) = &self.namespace_object {
@@ -226,11 +232,7 @@ impl ExternalInterop {
         "{}{}({});\n",
         if is_async { "await " } else { "" },
         runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
-        rspack_util::json_stringify(
-          ChunkGraph::get_module_id(&compilation.module_ids_artifact, self.module)
-            .unwrap_or_else(|| panic!("should set module id for {}", self.module))
-            .as_str()
-        )
+        module_id_expr
       )));
     }
 

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -223,7 +223,8 @@ impl ExternalInterop {
       }
     } else {
       source.add(RawStringSource::from(format!(
-        "{}({});\n",
+        "{}{}({});\n",
+        if is_async { "await " } else { "" },
         runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
         rspack_util::json_stringify(
           ChunkGraph::get_module_id(&compilation.module_ids_artifact, self.module)

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -2380,6 +2380,21 @@ var {} = {{}};
             continue;
           }
 
+          // Rslib removes entry hashbangs and directives from the module source
+          // during parsing, so restore them at the top of the async entry chunk.
+          let hashbang = get_module_hashbang(module_graph, entry_module);
+          let directives = get_module_directives(module_graph, entry_module);
+
+          if let Some(hashbang) = &hashbang {
+            let entry_chunk_link = link.get_mut_unwrap(&entry_chunk_ukey);
+            entry_chunk_link.hashbang = Some(format!("{hashbang}\n"));
+          }
+
+          if let Some(directives) = directives {
+            let entry_chunk_link = link.get_mut_unwrap(&entry_chunk_ukey);
+            entry_chunk_link.directives = directives;
+          }
+
           entry_imports.entry(*entry_module).or_default();
 
           if concate_modules_map[entry_module].is_external() {

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1617,6 +1617,7 @@ var {} = {{}};
     let require_info: &mut ExternalInterop = required.entry(m).or_insert(ExternalInterop {
       module: m,
       from_module: Default::default(),
+      set_entry_module_id: false,
       required_symbol: None,
       default_access: None,
       default_exported: None,
@@ -2370,12 +2371,14 @@ var {} = {{}};
           .chunk_graph
           .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey)
         {
-          if module_entrypoint_ukey != entrypoint_ukey
-            || compilation
-              .code_generation_results
-              .get_one(entry_module)
-              .get(&SourceType::JavaScript)
-              .is_none()
+          if module_entrypoint_ukey != entrypoint_ukey {
+            continue;
+          }
+
+          let code_generation_result = compilation.code_generation_results.get_one(entry_module);
+          if code_generation_result
+            .get(&SourceType::JavaScript)
+            .is_none()
           {
             continue;
           }
@@ -2398,13 +2401,16 @@ var {} = {{}};
           entry_imports.entry(*entry_module).or_default();
 
           if concate_modules_map[entry_module].is_external() {
-            Self::add_require(
+            let require_info = Self::add_require(
               *entry_module,
               None,
               None,
               &mut FxHashSet::default(),
               required.entry(*chunk_ukey).or_default(),
             );
+            require_info.set_entry_module_id |= code_generation_result
+              .runtime_requirements
+              .contains(RuntimeGlobals::ENTRY_MODULE_ID);
           }
         }
       }

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -2350,6 +2350,51 @@ var {} = {{}};
       }
     }
 
+    // Async entrypoints such as workers don't expose library exports, but their
+    // entry modules still need to execute when the entry chunk is loaded. The
+    // normal startup runtime is disabled for ESM library output, so explicitly
+    // execute entry modules that couldn't be scope hoisted.
+    for entrypoint_ukey in &compilation.build_chunk_graph_artifact.async_entrypoints {
+      let entrypoint = compilation
+        .build_chunk_graph_artifact
+        .chunk_group_by_ukey
+        .expect_get(entrypoint_ukey);
+      let entry_chunk_ukey = entrypoint.get_entrypoint_chunk();
+      let entry_imports = imports
+        .get_mut(&entry_chunk_ukey)
+        .unwrap_or_else(|| panic!("should set imports for chunk {entry_chunk_ukey:?}"));
+
+      for chunk_ukey in &entrypoint.chunks {
+        for (entry_module, module_entrypoint_ukey) in compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey)
+        {
+          if module_entrypoint_ukey != entrypoint_ukey
+            || compilation
+              .code_generation_results
+              .get_one(entry_module)
+              .get(&SourceType::JavaScript)
+              .is_none()
+          {
+            continue;
+          }
+
+          entry_imports.entry(*entry_module).or_default();
+
+          if concate_modules_map[entry_module].is_external() {
+            Self::add_require(
+              *entry_module,
+              None,
+              None,
+              &mut FxHashSet::default(),
+              required.entry(*chunk_ukey).or_default(),
+            );
+          }
+        }
+      }
+    }
+
     if let Some(root) = &self.preserve_modules {
       let preserve_entry_modules = compilation
         .entries

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -130,7 +130,7 @@ impl EsmLibraryPlugin {
           !is_esm_dep_like(dep)
             && !matches!(
               dep.dependency_type(),
-              DependencyType::Entry | DependencyType::DynamicImport
+              DependencyType::Entry | DependencyType::DynamicImport | DependencyType::NewWorker
             )
         })
       {

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
@@ -1,0 +1,81 @@
+```mjs title=worker.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+__webpack_require__.add({
+"./worker.js"
+/*!*******************!*\
+  !*** ./worker.js ***!
+  \*******************/
+(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+/* export default */ const __rspack_default_export = ('worker');
+
+globalThis.__workerEntryExecuted = true;
+
+
+},
+});
+__webpack_require__("./worker.js");
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
@@ -41,7 +41,204 @@ function createCommonJsWorker() {
   return new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker-cjs"), __webpack_require__.b), { type: "module" });
 }
 
-export { createCommonJsWorker, createWorker };
+function createAsyncWorker() {
+  return new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker-async"), __webpack_require__.b), { type: "module" });
+}
+
+export { createAsyncWorker, createCommonJsWorker, createWorker };
+
+```
+
+```mjs title=worker-async.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+// expose the module cache
+__webpack_require__.c = __webpack_module_cache__;
+
+// webpack/runtime/async_module
+(() => {
+var hasSymbol = typeof Symbol === "function";
+var rspackQueues = hasSymbol ? Symbol("rspack queues") : "__rspack_queues";
+var rspackExports = __webpack_require__.aE = hasSymbol ? Symbol("rspack exports") : "__webpack_exports__";
+var rspackError = hasSymbol ? Symbol("rspack error") : "__rspack_error";
+var rspackDone = hasSymbol ? Symbol("rspack done") : "__rspack_done";
+var rspackDefer = __webpack_require__.zS = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";
+__webpack_require__.zT = (asyncDeps) => {
+	var hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {
+		var cache = __webpack_module_cache__[id];
+		return !cache || cache[rspackDone] === false;
+	});
+	if (hasUnresolvedAsyncSubgraph) {
+		return ({ then(onFulfilled, onRejected) { return Promise.all(asyncDeps.map(__webpack_require__)).then(onFulfilled, onRejected) } });
+	}
+}
+var resolveQueue = (queue) => {
+	if (queue && queue.d < 1) {
+		queue.d = 1;
+	queue.forEach((fn) => (fn.r--));
+		queue.forEach((fn) => (fn.r-- ? fn.r++ : fn()));
+	}
+}
+var wrapDeps = (deps) => {
+	return deps.map((dep) => {
+		if (dep !== null && typeof dep === "object") {
+			if(!dep[rspackQueues] && dep[rspackDefer]) {
+				var asyncDeps = __webpack_require__.zT(dep[rspackDefer]);
+				if (asyncDeps) {
+					var d = dep;
+					dep = {
+						then(onFulfilled, onRejected) {
+							asyncDeps.then(() => (onFulfilled(d)), onRejected);
+						}
+					};
+				} else return dep;
+			}
+			if (dep[rspackQueues]) return dep;
+			if (dep.then) {
+				var queue = [];
+				queue.d = 0;
+				dep.then((r) => {
+					obj[rspackExports] = r;
+					resolveQueue(queue);
+				},(e) => {
+					obj[rspackError] = e;
+					resolveQueue(queue);
+				});
+				var obj = {};
+				obj[rspackDefer] = false;
+				obj[rspackQueues] = (fn) => (fn(queue));
+				return obj;
+			}
+		}
+		var ret = {};
+		ret[rspackQueues] = () => {};
+		ret[rspackExports] = dep;
+		return ret;
+	});
+};
+__webpack_require__.a = (module, body, hasAwait) => {
+	var queue;
+	hasAwait && ((queue = []).d = -1);
+	var depQueues = new Set();
+	var exports = module.exports;
+	var currentDeps;
+	var outerResolve;
+	var reject;
+	var promise = new Promise((resolve, rej) => {
+		reject = rej;
+		outerResolve = resolve;
+	});
+	promise[rspackExports] = exports;
+	promise[rspackQueues] = (fn) => { queue && fn(queue), depQueues.forEach(fn), promise["catch"](() => {}); };
+	module.exports = promise;
+	var handle = (deps) => {
+		currentDeps = wrapDeps(deps);
+		var fn;
+		var getResult = () => {
+			return currentDeps.map((d) => {
+				if(d[rspackDefer]) return d;
+				if (d[rspackError]) throw d[rspackError];
+				return d[rspackExports];
+			});
+		}
+		var promise = new Promise((resolve) => {
+			fn = () => (resolve(getResult));
+			fn.r = 0;
+			var fnQueue = (q) => (q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn))));
+			currentDeps.map((dep) => (dep[rspackDefer] || dep[rspackQueues](fnQueue)));
+		});
+		return fn.r ? promise : getResult();
+	};
+	var done = (err) => ((err ? reject(promise[rspackError] = err) : outerResolve(exports)), resolveQueue(queue), promise[rspackDone] = true);
+	body(handle, done);
+	queue && queue.d < 0 && (queue.d = 0);
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+
+__webpack_require__.add({
+"./worker-async.js"
+/*!*************************!*\
+  !*** ./worker-async.js ***!
+  \*************************/
+(module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.a(module, async function (__rspack_load_async_deps, __rspack_async_done) { try {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+if ((__webpack_require__.c[__webpack_require__.s] === module)) {
+  globalThis.__workerIsMain = true;
+}
+
+await Promise.resolve();
+
+/* export default */ const __rspack_default_export = ('worker-async');
+
+globalThis.__workerAsyncEntryExecuted = true;
+
+__rspack_async_done();
+} catch(e) { __rspack_async_done(e); } }, 1);
+
+},
+});
+await __webpack_require__("./worker-async.js");
+
+export {};
 
 ```
 
@@ -96,9 +293,14 @@ export {};
 ```
 
 ```mjs title=worker.mjs
+#!/usr/bin/env node
+"use client"
 
 
 // ./worker.js
+//
+
+
 /* export default */ const worker = ('worker');
 
 globalThis.__workerEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
@@ -227,6 +227,10 @@ if ((__webpack_require__.c[__webpack_require__.s] === module)) {
 
 await Promise.resolve();
 
+if (!globalThis.__workerIsMain) {
+  throw new Error('worker entry should be the main module');
+}
+
 /* export default */ const __rspack_default_export = ('worker-async');
 
 globalThis.__workerAsyncEntryExecuted = true;
@@ -236,7 +240,7 @@ __rspack_async_done();
 
 },
 });
-await __webpack_require__("./worker-async.js");
+await __webpack_require__(__webpack_require__.s = "./worker-async.js");
 
 export {};
 

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
@@ -1,3 +1,50 @@
+```mjs title=main.mjs
+// The require scope
+var __webpack_require__ = {};
+
+// webpack/runtime/get javascript chunk filename
+(() => {
+// This function allow to reference chunks
+__webpack_require__.u = (chunkId) => {
+  // return url for filenames not based on template
+
+  // return url for filenames based on template
+  return "" + chunkId + ".mjs"
+}
+})();
+// webpack/runtime/public_path
+(() => {
+__webpack_require__.p = "";
+})();
+// webpack/runtime/module_chunk_loading
+(() => {
+__webpack_require__.b = new URL("./", import.meta.url);;
+
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"main": 0,};
+      // no install chunk// no chunk on demand loading
+// no external install chunk
+// no on chunks loaded
+// no HMR
+// no HMR manifest
+
+})();
+
+// ./index.js
+function createWorker() {
+  return new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker"), __webpack_require__.b), { type: "module" });
+}
+
+function createCommonJsWorker() {
+  return new Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("worker-cjs"), __webpack_require__.b), { type: "module" });
+}
+
+export { createCommonJsWorker, createWorker };
+
+```
+
 ```mjs title=worker-cjs.mjs
 
 var __webpack_modules__ = {};

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=worker.mjs
+```mjs title=worker-cjs.mjs
 
 var __webpack_modules__ = {};
 // The module cache
@@ -23,58 +23,38 @@ return module.exports;
 // expose the modules object (__webpack_modules__)
 __webpack_require__.m = __webpack_modules__;
 
-// webpack/runtime/define_property_getters
-(() => {
-__webpack_require__.d = (exports, getters, values) => {
-	var define = (defs, kind) => {
-		for(var key in defs) {
-			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
-				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
-			}
-		}
-	};
-	define(getters, "get");
-	define(values, "value");
-};
-})();
 // webpack/runtime/esm_register_module
 (() => {
 __webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
 
 })();
-// webpack/runtime/has_own_property
-(() => {
-__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
-})();
-// webpack/runtime/make_namespace_object
-(() => {
-// define __esModule on exports
-__webpack_require__.r = (exports) => {
-	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-	}
-	Object.defineProperty(exports, '__esModule', { value: true });
-};
-})();
 
 __webpack_require__.add({
-"./worker.js"
-/*!*******************!*\
-  !*** ./worker.js ***!
-  \*******************/
-(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  "default": () => (__rspack_default_export)
-});
-/* export default */ const __rspack_default_export = ('worker');
+"./worker-cjs.js"
+/*!***********************!*\
+  !*** ./worker-cjs.js ***!
+  \***********************/
+(module) {
+module.exports = 'worker-cjs';
 
-globalThis.__workerEntryExecuted = true;
+globalThis.__workerCommonJsEntryExecuted = true;
 
 
 },
 });
-__webpack_require__("./worker.js");
+__webpack_require__("./worker-cjs.js");
+
+export {};
+
+```
+
+```mjs title=worker.mjs
+
+
+// ./worker.js
+/* export default */ const worker = ('worker');
+
+globalThis.__workerEntryExecuted = true;
 
 export {};
 

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,81 @@
+```mjs title=worker.mjs
+
+var __rspack_modules = {};
+// The module cache
+var __rspack_module_cache = {};
+// The require function
+function __rspack_require(moduleId) {
+// Check if module is in cache
+var cachedModule = __rspack_module_cache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__rspack_module_cache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+
+// Return the exports of the module
+return module.exports;
+}
+var __rspack_context = {};
+__rspack_context.r = __rspack_require;
+// expose the modules object (__rspack_modules)
+__rspack_context.m = __rspack_modules;
+
+(function() {
+var moduleFactories=__rspack_modules;
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+__rspack_context.d = definePropertyGetters;
+// rspack/runtime/esm_register_module
+moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+// rspack/runtime/make_namespace_object
+// define __esModule on exports
+var makeNamespaceObject = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};;
+__rspack_context.N = makeNamespaceObject;
+
+}).call(this);
+
+__rspack_context.m.add({
+"./worker.js"
+/*!*******************!*\
+  !*** ./worker.js ***!
+  \*******************/
+(__unused_rspack_module, __rspack_exports, __rspack_context) {
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
+  "default": () => (__rspack_default_export)
+});
+/* export default */ const __rspack_default_export = ('worker');
+
+globalThis.__workerEntryExecuted = true;
+
+
+},
+});
+__rspack_context.r("./worker.js");
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -230,6 +230,10 @@ if ((__rspack_context.c[__rspack_context.s] === module)) {
 
 await Promise.resolve();
 
+if (!globalThis.__workerIsMain) {
+  throw new Error('worker entry should be the main module');
+}
+
 /* export default */ const __rspack_default_export = ('worker-async');
 
 globalThis.__workerAsyncEntryExecuted = true;
@@ -239,7 +243,7 @@ __rspack_async_done();
 
 },
 });
-await __rspack_context.r("./worker-async.js");
+await __rspack_context.r(__rspack_context.s = "./worker-async.js");
 
 export {};
 

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -43,7 +43,205 @@ function createCommonJsWorker() {
   return new Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("worker-cjs"), __rspack_context.b), { type: "module" });
 }
 
-export { createCommonJsWorker, createWorker };
+function createAsyncWorker() {
+  return new Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("worker-async"), __rspack_context.b), { type: "module" });
+}
+
+export { createAsyncWorker, createCommonJsWorker, createWorker };
+
+```
+
+```mjs title=worker-async.mjs
+
+var __rspack_modules = {};
+// The module cache
+var __rspack_module_cache = {};
+// The require function
+function __rspack_require(moduleId) {
+// Check if module is in cache
+var cachedModule = __rspack_module_cache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__rspack_module_cache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+
+// Return the exports of the module
+return module.exports;
+}
+var __rspack_context = {};
+__rspack_context.r = __rspack_require;
+// expose the modules object (__rspack_modules)
+__rspack_context.m = __rspack_modules;
+// expose the module cache
+__rspack_context.c = __rspack_module_cache;
+
+(function() {
+var moduleCache=typeof __rspack_module_cache !== "undefined" ? __rspack_module_cache : {}, moduleFactories=__rspack_modules, entryModuleId;
+// rspack/runtime/async_module
+var hasSymbol = typeof Symbol === "function";
+var rspackQueues = hasSymbol ? Symbol("rspack queues") : "__rspack_queues";
+var asyncModuleExportSymbol = hasSymbol ? Symbol("rspack exports") : "__rspack_exports";
+var rspackExports = asyncModuleExportSymbol;
+var rspackError = hasSymbol ? Symbol("rspack error") : "__rspack_error";
+var rspackDone = hasSymbol ? Symbol("rspack done") : "__rspack_done";
+var deferredModulesAsyncTransitiveDependenciesSymbol = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";
+var rspackDefer = deferredModulesAsyncTransitiveDependenciesSymbol;
+var deferredModulesAsyncTransitiveDependencies = (asyncDeps) => {
+	var hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {
+		var cache = __rspack_module_cache[id];
+		return !cache || cache[rspackDone] === false;
+	});
+	if (hasUnresolvedAsyncSubgraph) {
+		return ({ then(onFulfilled, onRejected) { return Promise.all(asyncDeps.map(__rspack_require)).then(onFulfilled, onRejected) } });
+	}
+}
+var resolveQueue = (queue) => {
+	if (queue && queue.d < 1) {
+		queue.d = 1;
+	queue.forEach((fn) => (fn.r--));
+		queue.forEach((fn) => (fn.r-- ? fn.r++ : fn()));
+	}
+}
+var wrapDeps = (deps) => {
+	return deps.map((dep) => {
+		if (dep !== null && typeof dep === "object") {
+			if(!dep[rspackQueues] && dep[rspackDefer]) {
+				var asyncDeps = deferredModulesAsyncTransitiveDependencies(dep[rspackDefer]);
+				if (asyncDeps) {
+					var d = dep;
+					dep = {
+						then(onFulfilled, onRejected) {
+							asyncDeps.then(() => (onFulfilled(d)), onRejected);
+						}
+					};
+				} else return dep;
+			}
+			if (dep[rspackQueues]) return dep;
+			if (dep.then) {
+				var queue = [];
+				queue.d = 0;
+				dep.then((r) => {
+					obj[rspackExports] = r;
+					resolveQueue(queue);
+				},(e) => {
+					obj[rspackError] = e;
+					resolveQueue(queue);
+				});
+				var obj = {};
+				obj[rspackDefer] = false;
+				obj[rspackQueues] = (fn) => (fn(queue));
+				return obj;
+			}
+		}
+		var ret = {};
+		ret[rspackQueues] = () => {};
+		ret[rspackExports] = dep;
+		return ret;
+	});
+};
+var asyncModule = (module, body, hasAwait) => {
+	var queue;
+	hasAwait && ((queue = []).d = -1);
+	var depQueues = new Set();
+	var exports = module.exports;
+	var currentDeps;
+	var outerResolve;
+	var reject;
+	var promise = new Promise((resolve, rej) => {
+		reject = rej;
+		outerResolve = resolve;
+	});
+	promise[rspackExports] = exports;
+	promise[rspackQueues] = (fn) => { queue && fn(queue), depQueues.forEach(fn), promise["catch"](() => {}); };
+	module.exports = promise;
+	var handle = (deps) => {
+		currentDeps = wrapDeps(deps);
+		var fn;
+		var getResult = () => {
+			return currentDeps.map((d) => {
+				if(d[rspackDefer]) return d;
+				if (d[rspackError]) throw d[rspackError];
+				return d[rspackExports];
+			});
+		}
+		var promise = new Promise((resolve) => {
+			fn = () => (resolve(getResult));
+			fn.r = 0;
+			var fnQueue = (q) => (q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn))));
+			currentDeps.map((dep) => (dep[rspackDefer] || dep[rspackQueues](fnQueue)));
+		});
+		return fn.r ? promise : getResult();
+	};
+	var done = (err) => ((err ? reject(promise[rspackError] = err) : outerResolve(exports)), resolveQueue(queue), promise[rspackDone] = true);
+	body(handle, done);
+	queue && queue.d < 0 && (queue.d = 0);
+};
+;
+__rspack_context.a = asyncModule;
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+__rspack_context.d = definePropertyGetters;
+// rspack/runtime/esm_register_module
+moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+// rspack/runtime/make_namespace_object
+// define __esModule on exports
+var makeNamespaceObject = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};;
+__rspack_context.N = makeNamespaceObject;
+
+}).call(this);
+
+__rspack_context.m.add({
+"./worker-async.js"
+/*!*************************!*\
+  !*** ./worker-async.js ***!
+  \*************************/
+(module, __rspack_exports, __rspack_context) {
+__rspack_context.a(module, async function (__rspack_load_async_deps, __rspack_async_done) { try {
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
+  "default": () => (__rspack_default_export)
+});
+if ((__rspack_context.c[__rspack_context.s] === module)) {
+  globalThis.__workerIsMain = true;
+}
+
+await Promise.resolve();
+
+/* export default */ const __rspack_default_export = ('worker-async');
+
+globalThis.__workerAsyncEntryExecuted = true;
+
+__rspack_async_done();
+} catch(e) { __rspack_async_done(e); } }, 1);
+
+},
+});
+await __rspack_context.r("./worker-async.js");
+
+export {};
 
 ```
 
@@ -102,9 +300,14 @@ export {};
 ```
 
 ```mjs title=worker.mjs
+#!/usr/bin/env node
+"use client"
 
 
 // ./worker.js
+//
+
+
 /* export default */ const worker = ('worker');
 
 globalThis.__workerEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,4 +1,4 @@
-```mjs title=worker.mjs
+```mjs title=worker-cjs.mjs
 
 var __rspack_modules = {};
 // The module cache
@@ -27,54 +27,38 @@ __rspack_context.m = __rspack_modules;
 
 (function() {
 var moduleFactories=__rspack_modules;
-// rspack/runtime/define_property_getters
-var definePropertyGetters = (exports, getters, values) => {
-	var define = (defs, kind) => {
-		for(var key in defs) {
-			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
-				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
-			}
-		}
-	};
-	define(getters, "get");
-	define(values, "value");
-};;
-__rspack_context.d = definePropertyGetters;
 // rspack/runtime/esm_register_module
 moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
 ;
-// rspack/runtime/has_own_property
-var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
-// rspack/runtime/make_namespace_object
-// define __esModule on exports
-var makeNamespaceObject = (exports) => {
-	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-	}
-	Object.defineProperty(exports, '__esModule', { value: true });
-};;
-__rspack_context.N = makeNamespaceObject;
 
 }).call(this);
 
 __rspack_context.m.add({
-"./worker.js"
-/*!*******************!*\
-  !*** ./worker.js ***!
-  \*******************/
-(__unused_rspack_module, __rspack_exports, __rspack_context) {
-__rspack_context.N(__rspack_exports);
-__rspack_context.d(__rspack_exports, {
-  "default": () => (__rspack_default_export)
-});
-/* export default */ const __rspack_default_export = ('worker');
+"./worker-cjs.js"
+/*!***********************!*\
+  !*** ./worker-cjs.js ***!
+  \***********************/
+(module) {
+module.exports = 'worker-cjs';
 
-globalThis.__workerEntryExecuted = true;
+globalThis.__workerCommonJsEntryExecuted = true;
 
 
 },
 });
-__rspack_context.r("./worker.js");
+__rspack_context.r("./worker-cjs.js");
+
+export {};
+
+```
+
+```mjs title=worker.mjs
+
+
+// ./worker.js
+/* export default */ const worker = ('worker');
+
+globalThis.__workerEntryExecuted = true;
 
 export {};
 

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,3 +1,52 @@
+```mjs title=main.mjs
+// The require scope
+var __rspack_require = {};
+var __rspack_context = {};
+
+(function() {
+var publicPath, hasOwnProperty, baseUri;
+// rspack/runtime/get javascript chunk filename
+// This function allow to reference chunks
+var getChunkScriptFilename = (chunkId) => {
+  // return url for filenames not based on template
+
+  // return url for filenames based on template
+  return "" + chunkId + ".mjs"
+};
+__rspack_context.u = getChunkScriptFilename;
+// rspack/runtime/public_path
+var publicPath = "";;
+__rspack_context.p = publicPath;
+// rspack/runtime/module_chunk_loading
+baseUri = new URL("./", import.meta.url);;
+
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"main": 0,};
+      // no install chunk// no chunk on demand loading
+// no external install chunk
+// no on chunks loaded
+// no HMR
+// no HMR manifest
+;
+__rspack_context.b = baseUri;
+
+}).call(this);
+
+// ./index.js
+function createWorker() {
+  return new Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("worker"), __rspack_context.b), { type: "module" });
+}
+
+function createCommonJsWorker() {
+  return new Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("worker-cjs"), __rspack_context.b), { type: "module" });
+}
+
+export { createCommonJsWorker, createWorker };
+
+```
+
 ```mjs title=worker-cjs.mjs
 
 var __rspack_modules = {};

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/index.js
@@ -1,3 +1,7 @@
 export function createWorker() {
   return new Worker(new URL('./worker.js', import.meta.url));
 }
+
+export function createCommonJsWorker() {
+  return new Worker(new URL('./worker-cjs.js', import.meta.url));
+}

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/index.js
@@ -5,3 +5,7 @@ export function createWorker() {
 export function createCommonJsWorker() {
   return new Worker(new URL('./worker-cjs.js', import.meta.url));
 }
+
+export function createAsyncWorker() {
+  return new Worker(new URL('./worker-async.js', import.meta.url));
+}

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/index.js
@@ -1,0 +1,3 @@
+export function createWorker() {
+  return new Worker(new URL('./worker.js', import.meta.url));
+}

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/rspack.config.js
@@ -1,6 +1,9 @@
+const rspack = require('@rspack/core');
+
 module.exports = {
   mode: 'development',
   optimization: {
     runtimeChunk: false,
   },
+  plugins: [new rspack.experiments.RslibPlugin()],
 };

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/rspack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  mode: 'development',
+  optimization: {
+    runtimeChunk: false,
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 module.exports = {
   snapshotContent(content) {
@@ -36,10 +37,14 @@ module.exports = {
     );
 
     expect(asyncSource).toMatch(
-      /await (?:__webpack_require__|__rspack_context\.r)\("\.\/worker-async\.js"\);/,
+      /await (?:__webpack_require__\(__webpack_require__\.s|__rspack_context\.r\(__rspack_context\.s) = "\.\/worker-async\.js"\);/,
     );
     expect(asyncSource).toContain(
       'globalThis.__workerAsyncEntryExecuted = true;',
     );
+
+    execFileSync(process.execPath, [
+      path.join(options.output.path, 'worker-async.mjs'),
+    ]);
   },
 };

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  snapshotFileFilter(file) {
-    return file === 'worker.mjs' || file === 'worker-cjs.mjs';
+  snapshotContent(content) {
+    return content.replace(/[ \t]+$/gm, '');
   },
   afterExecute(options) {
     const esmSource = fs.readFileSync(

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  snapshotFileFilter(file) {
+    return file === 'worker.mjs';
+  },
+  afterExecute(options) {
+    const source = fs.readFileSync(
+      path.join(options.output.path, 'worker.mjs'),
+      'utf-8',
+    );
+
+    expect(source).toMatch(
+      /(?:__webpack_require__|__rspack_context\.r)\("\.\/worker\.js"\);/,
+    );
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
@@ -3,16 +3,30 @@ const path = require('path');
 
 module.exports = {
   snapshotFileFilter(file) {
-    return file === 'worker.mjs';
+    return file === 'worker.mjs' || file === 'worker-cjs.mjs';
   },
   afterExecute(options) {
-    const source = fs.readFileSync(
+    const esmSource = fs.readFileSync(
       path.join(options.output.path, 'worker.mjs'),
       'utf-8',
     );
 
-    expect(source).toMatch(
+    expect(esmSource).not.toContain('registerModules');
+    expect(esmSource).not.toMatch(
       /(?:__webpack_require__|__rspack_context\.r)\("\.\/worker\.js"\);/,
+    );
+    expect(esmSource).toContain('globalThis.__workerEntryExecuted = true;');
+
+    const commonJsSource = fs.readFileSync(
+      path.join(options.output.path, 'worker-cjs.mjs'),
+      'utf-8',
+    );
+
+    expect(commonJsSource).toMatch(
+      /(?:__webpack_require__|__rspack_context\.r)\("\.\/worker-cjs\.js"\);/,
+    );
+    expect(commonJsSource).toContain(
+      'globalThis.__workerCommonJsEntryExecuted = true;',
     );
   },
 };

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/test.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = {
   snapshotContent(content) {
-    return content.replace(/[ \t]+$/gm, '');
+    return content.replace(/[ \t]+$/gm, '').replace(/ +\t/g, '\t');
   },
   afterExecute(options) {
     const esmSource = fs.readFileSync(
@@ -15,6 +15,7 @@ module.exports = {
     expect(esmSource).not.toMatch(
       /(?:__webpack_require__|__rspack_context\.r)\("\.\/worker\.js"\);/,
     );
+    expect(esmSource).toMatch(/^#!\/usr\/bin\/env node\n"use client"\n/);
     expect(esmSource).toContain('globalThis.__workerEntryExecuted = true;');
 
     const commonJsSource = fs.readFileSync(
@@ -27,6 +28,18 @@ module.exports = {
     );
     expect(commonJsSource).toContain(
       'globalThis.__workerCommonJsEntryExecuted = true;',
+    );
+
+    const asyncSource = fs.readFileSync(
+      path.join(options.output.path, 'worker-async.mjs'),
+      'utf-8',
+    );
+
+    expect(asyncSource).toMatch(
+      /await (?:__webpack_require__|__rspack_context\.r)\("\.\/worker-async\.js"\);/,
+    );
+    expect(asyncSource).toContain(
+      'globalThis.__workerAsyncEntryExecuted = true;',
     );
   },
 };

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker-async.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker-async.js
@@ -4,6 +4,10 @@ if (import.meta.main) {
 
 await Promise.resolve();
 
+if (!globalThis.__workerIsMain) {
+  throw new Error('worker entry should be the main module');
+}
+
 export default 'worker-async';
 
 globalThis.__workerAsyncEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker-async.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker-async.js
@@ -1,0 +1,9 @@
+if (import.meta.main) {
+  globalThis.__workerIsMain = true;
+}
+
+await Promise.resolve();
+
+export default 'worker-async';
+
+globalThis.__workerAsyncEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker-cjs.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker-cjs.js
@@ -1,0 +1,3 @@
+module.exports = 'worker-cjs';
+
+globalThis.__workerCommonJsEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker.js
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+'use client';
+
 export default 'worker';
 
 globalThis.__workerEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker.js
+++ b/tests/rspack-test/esmOutputCases/worker/entry-module-execution/worker.js
@@ -1,0 +1,3 @@
+export default 'worker';
+
+globalThis.__workerEntryExecuted = true;

--- a/tests/rspack-test/esmOutputCases/worker/new-url-relative/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/new-url-relative/__snapshots__/esm.snap.txt
@@ -1,0 +1,25 @@
+```mjs title=main.mjs
+
+
+// ./index.js
+function createWorker() {
+  return new Worker(
+    /* webpackChunkName: "worker" */ new URL("./worker.mjs", import.meta.url), { type: "module" },
+  );
+}
+
+export { createWorker };
+
+```
+
+```mjs title=worker.mjs
+
+
+// ./worker.js
+/* export default */ const worker = ('worker');
+
+globalThis.__workerEntryExecuted = true;
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/new-url-relative/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/new-url-relative/index.js
@@ -1,0 +1,5 @@
+export function createWorker() {
+  return new Worker(
+    /* webpackChunkName: "worker" */ new URL('./worker.js', import.meta.url),
+  );
+}

--- a/tests/rspack-test/esmOutputCases/worker/new-url-relative/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/new-url-relative/rspack.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  mode: 'development',
+  module: {
+    parser: {
+      javascript: {
+        worker: {
+          url: 'new-url-relative',
+        },
+      },
+    },
+  },
+  optimization: {
+    runtimeChunk: false,
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/new-url-relative/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/new-url-relative/test.config.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  afterExecute(options) {
+    const mainSource = fs.readFileSync(
+      path.join(options.output.path, 'main.mjs'),
+      'utf-8',
+    );
+
+    expect(mainSource).toContain(
+      'new URL("./worker.mjs", import.meta.url)',
+    );
+
+    const workerSource = fs.readFileSync(
+      path.join(options.output.path, 'worker.mjs'),
+      'utf-8',
+    );
+
+    expect(workerSource).not.toContain('registerModules');
+    expect(workerSource).not.toMatch(
+      /(?:__webpack_require__|__rspack_context\.r)\("\.\/worker\.js"\);/,
+    );
+    expect(workerSource).toContain('globalThis.__workerEntryExecuted = true;');
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/new-url-relative/worker.js
+++ b/tests/rspack-test/esmOutputCases/worker/new-url-relative/worker.js
@@ -1,0 +1,3 @@
+export default 'worker';
+
+globalThis.__workerEntryExecuted = true;


### PR DESCRIPTION
## Summary

- scope hoist ESM Worker entry modules by treating `NewWorker` as an entry-like dependency
- explicitly execute Worker entries that cannot be scope hoisted
- cover both scope-hoisted ESM and wrapped CommonJS Worker roots in standard and runtime-mode output

## Root cause

There were two related gaps in the `modern-module` path:

1. Scope-hoisting eligibility allowed `Entry` and `DynamicImport` dependencies but rejected `NewWorker` as a non-ESM reference. This forced the Worker root and its descendants into runtime wrappers.
2. `EsmLibraryPlugin` disables the default startup runtime, while the linker previously handled only regular entrypoints. Wrapped Worker entries live in `async_entrypoints`, so their module factories were registered but never invoked.

## Impact

ESM Worker roots now render directly as top-level ESM without a module registry or startup `require`. Worker roots that genuinely cannot be scope hoisted, such as CommonJS entries, continue to use the runtime wrapper and are explicitly executed.

## Related links

- [Rspack Playground reproduction](https://playground.rspack.rs/#eyJyc3BhY2tWZXJzaW9uIjoiMi4xLjQiLCJpbnB1dEZpbGVzIjpbeyJmaWxlbmFtZSI6InJzcGFjay5jb25maWcuanMiLCJ0ZXh0IjoiaW1wb3J0ICogYXMgcnNwYWNrIGZyb20gXCJAcnNwYWNrL2NvcmVcIlxuXG5leHBvcnQgZGVmYXVsdCB7XG4gIG1vZGU6IFwiZGV2ZWxvcG1lbnRcIixcbiAgZGV2dG9vbDogZmFsc2UsXG5cdGVudHJ5OiB7XG5cdFx0bWFpbjogXCIuL2luZGV4LmpzXCJcblx0fSxcbiAgb3V0cHV0OiB7XG4gICAgbGlicmFyeToge1xuICAgICAgdHlwZTogXCJtb2Rlcm4tbW9kdWxlXCIsXG4gICAgfVxuICB9LFxuICBwbHVnaW5zOiBbXG4gICAgbmV3IHJzcGFjay5leHBlcmltZW50cy5Sc2xpYlBsdWdpbigpLFxuICBdLFxufTsifSx7ImZpbGVuYW1lIjoiaW5kZXguanMiLCJ0ZXh0IjoiXG5uZXcgV29ya2VyKG5ldyBVUkwoJy4vbGliLmpzJywgaW1wb3J0Lm1ldGEudXJsKSlcblxubW9kdWxlOyJ9LHsiZmlsZW5hbWUiOiJsaWIuanMiLCJ0ZXh0IjoiZXhwb3J0IGRlZmF1bHQgXCJsaWJcIjtcblxuY2FsbCgnaGVsbG8nKSJ9XX0=)

## Testing

- `corepack pnpm run build:js`
- `corepack pnpm run build:binding:dev`
- `corepack pnpm exec rstest EsmOutput.test.js` (460 tests)
- `cargo clippy -p rspack_plugin_esm_library --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- Prettier check for the Worker fixture
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Tests updated.
- [x] Documentation not required.