### PR TITLE
fix: invalidate module hashes when assigning deterministic and natural ids

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1384,7 +1384,7 @@ impl CompilationBeforeModuleIds for CompilationBeforeModuleIdsTap {
     &self,
     compilation: &Compilation,
     modules: &IdentifierSet,
-    module_ids: &mut ModuleIdsArtifact,
+    preserved_module_ids: &mut ModuleIdsArtifact,
   ) -> rspack_error::Result<()> {
     let arg = JsBeforeModuleIdsArg::new(compilation, modules);
     let result: JsBeforeModuleIdsResult = self.function.call_with_sync(arg).await?;
@@ -1395,7 +1395,7 @@ impl CompilationBeforeModuleIds for CompilationBeforeModuleIdsTap {
         Either::A(s) => ModuleId::from(s),
         Either::B(n) => ModuleId::from(n),
       };
-      ChunkGraph::set_module_id(module_ids, identifier, module_id);
+      ChunkGraph::set_module_id(preserved_module_ids, identifier, module_id);
     }
 
     Ok(())

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -122,9 +122,9 @@ define_hook!(CompilationAfterOptimizeModules: Series(compilation: &Compilation))
 define_hook!(CompilationOptimizeChunks: SeriesBail(compilation: &mut Compilation) -> bool);
 define_hook!(CompilationOptimizeTree: Series(compilation: &Compilation));
 define_hook!(CompilationOptimizeChunkModules: SeriesBail(compilation: &mut Compilation) -> bool);
-define_hook!(CompilationReviveModules: Series(compilation: &Compilation, modules: &IdentifierSet, module_ids: &mut ModuleIdsArtifact));
-define_hook!(CompilationBeforeModuleIds: Series(compilation: &Compilation, modules: &IdentifierSet, module_ids: &mut ModuleIdsArtifact));
-define_hook!(CompilationModuleIds: Series(compilation: &Compilation, module_ids: &mut ModuleIdsArtifact, diagnostics: &mut Vec<Diagnostic>));
+define_hook!(CompilationReviveModules: Series(compilation: &Compilation, modules: &IdentifierSet, preserved_module_ids: &mut ModuleIdsArtifact));
+define_hook!(CompilationBeforeModuleIds: Series(compilation: &Compilation, modules: &IdentifierSet, preserved_module_ids: &mut ModuleIdsArtifact));
+define_hook!(CompilationModuleIds: Series(compilation: &Compilation, module_ids: &mut ModuleIdsArtifact, preserved_module_ids: &ModuleIdsArtifact, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationRecordModules: Series(compilation: &Compilation, module_ids: &ModuleIdsArtifact));
 define_hook!(CompilationChunkIds: Series(compilation: &Compilation, chunk_by_ukey: &mut ChunkByUkey, named_chunk_ids_artifact: &mut ChunkNamedIdArtifact, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationRuntimeModule: Series(compilation: &Compilation, module: &ModuleIdentifier, chunk: &ChunkUkey, runtime_modules: &mut IdentifierMap<Box<dyn RuntimeModule>>));

--- a/crates/rspack_core/src/compilation/module_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/module_ids/mod.rs
@@ -98,11 +98,26 @@ impl PassExt for ModuleIdsPass {
         .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.beforeModuleIds"))?;
     }
 
-    // Put the recovered artifact back before moduleIds plugins merge preserved IDs.
+    // Put the recovered artifact back before preserved IDs are merged.
     compilation.module_ids_artifact = module_ids_artifact.into();
 
     let mut diagnostics = vec![];
     let mut module_ids_artifact = compilation.module_ids_artifact.steal();
+
+    // Merge IDs assigned by reviveModules and beforeModuleIds before running module ID plugins,
+    // so every plugin sees them as reserved IDs. Plugins that reset global IDs retain this
+    // preserved subset.
+    {
+      let mut mutations = compilation.incremental.mutations_write();
+      for (module, id) in preserved_module_ids_artifact.iter() {
+        if ChunkGraph::set_module_id(&mut module_ids_artifact, *module, id.clone())
+          && let Some(mutations) = &mut mutations
+        {
+          mutations.add(Mutation::ModuleSetId { module: *module });
+        }
+      }
+    }
+
     compilation
       .plugin_driver
       .clone()
@@ -116,6 +131,7 @@ impl PassExt for ModuleIdsPass {
       )
       .await
       .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.moduleIds"))?;
+
     if !compilation
       .plugin_driver
       .compilation_hooks

--- a/crates/rspack_core/src/compilation/module_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/module_ids/mod.rs
@@ -49,7 +49,8 @@ impl PassExt for ModuleIdsPass {
       compilation.module_ids_artifact.clear();
     }
 
-    let mut module_ids_artifact = compilation.module_ids_artifact.steal();
+    let module_ids_artifact = compilation.module_ids_artifact.steal();
+    let mut preserved_module_ids_artifact = ModuleIdsArtifact::default();
 
     // Call reviveModules hook - allows plugins to restore IDs from records
     if !compilation
@@ -58,13 +59,18 @@ impl PassExt for ModuleIdsPass {
       .revive_modules
       .is_empty()
     {
-      let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
+      let modules_needing_ids =
+        get_modules_needing_ids(compilation, &preserved_module_ids_artifact);
       compilation
         .plugin_driver
         .clone()
         .compilation_hooks
         .revive_modules
-        .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
+        .call(
+          compilation,
+          &modules_needing_ids,
+          &mut preserved_module_ids_artifact,
+        )
         .await
         .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.reviveModules"))?;
     }
@@ -76,19 +82,23 @@ impl PassExt for ModuleIdsPass {
       .before_module_ids
       .is_empty()
     {
-      let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
+      let modules_needing_ids =
+        get_modules_needing_ids(compilation, &preserved_module_ids_artifact);
       compilation
         .plugin_driver
         .clone()
         .compilation_hooks
         .before_module_ids
-        .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
+        .call(
+          compilation,
+          &modules_needing_ids,
+          &mut preserved_module_ids_artifact,
+        )
         .await
         .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.beforeModuleIds"))?;
     }
 
-    // Put artifact back so moduleIds plugins can see custom IDs from beforeModuleIds
-    // when they call get_used_module_ids_and_modules
+    // Put the recovered artifact back before moduleIds plugins merge preserved IDs.
     compilation.module_ids_artifact = module_ids_artifact.into();
 
     let mut diagnostics = vec![];
@@ -98,7 +108,12 @@ impl PassExt for ModuleIdsPass {
       .clone()
       .compilation_hooks
       .module_ids
-      .call(compilation, &mut module_ids_artifact, &mut diagnostics)
+      .call(
+        compilation,
+        &mut module_ids_artifact,
+        &preserved_module_ids_artifact,
+        &mut diagnostics,
+      )
       .await
       .map_err(|e| e.wrap_err("caused by plugins in Compilation.hooks.moduleIds"))?;
     if !compilation

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -33,7 +33,7 @@ async fn chunk_ids(
   diagnostics: &mut Vec<Diagnostic>,
 ) -> rspack_error::Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
-    IncrementalPasses::CHUNK_IDS,
+    IncrementalPasses::CHUNK_IDS | IncrementalPasses::MODULES_HASHES,
     "DeterministicChunkIdsPlugin (optimization.chunkIds = \"deterministic\")",
     "it requires calculating the id of all the chunks, which is a global effect",
   ) && let Some(diagnostic) = diagnostic

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -74,13 +74,8 @@ async fn module_ids(
     if let Some(diagnostic) = diagnostic {
       diagnostics.push(diagnostic);
     }
-    module_ids.clear();
+    module_ids.retain(|module, _| preserved_module_ids.contains_key(module));
   }
-  module_ids.extend(
-    preserved_module_ids
-      .iter()
-      .map(|(module, id)| (*module, id.clone())),
-  );
 
   // Use the sync path when no async test filter is provided (the common case),
   // avoiding unnecessary async overhead on the hot path.

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -63,10 +63,11 @@ async fn module_ids(
   &self,
   compilation: &Compilation,
   module_ids: &mut ModuleIdsArtifact,
+  preserved_module_ids: &ModuleIdsArtifact,
   diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
-    IncrementalPasses::MODULE_IDS,
+    IncrementalPasses::MODULE_IDS | IncrementalPasses::MODULES_HASHES,
     "DeterministicModuleIdsPlugin (optimization.moduleIds = \"deterministic\")",
     "it requires calculating the id of all the modules, which is a global effect",
   ) {
@@ -75,6 +76,11 @@ async fn module_ids(
     }
     module_ids.clear();
   }
+  module_ids.extend(
+    preserved_module_ids
+      .iter()
+      .map(|(module, id)| (*module, id.clone())),
+  );
 
   // Use the sync path when no async test filter is provided (the common case),
   // avoiding unnecessary async overhead on the hot path.

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -67,13 +67,8 @@ async fn module_ids(
     if let Some(diagnostic) = diagnostic {
       diagnostics.push(diagnostic);
     }
-    module_ids.clear();
+    module_ids.retain(|module, _| preserved_module_ids.contains_key(module));
   }
-  module_ids.extend(
-    preserved_module_ids
-      .iter()
-      .map(|(module, id)| (*module, id.clone())),
-  );
 
   let context = self
     .context

--- a/crates/rspack_ids/src/hashed_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/hashed_module_ids_plugin.rs
@@ -56,10 +56,11 @@ async fn module_ids(
   &self,
   compilation: &Compilation,
   module_ids: &mut ModuleIdsArtifact,
+  preserved_module_ids: &ModuleIdsArtifact,
   diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
-    IncrementalPasses::MODULE_IDS,
+    IncrementalPasses::MODULE_IDS | IncrementalPasses::MODULES_HASHES,
     "HashedModuleIdsPlugin",
     "it requires calculating the id of all the modules, which is a global effect",
   ) {
@@ -68,6 +69,11 @@ async fn module_ids(
     }
     module_ids.clear();
   }
+  module_ids.extend(
+    preserved_module_ids
+      .iter()
+      .map(|(module, id)| (*module, id.clone())),
+  );
 
   let context = self
     .context

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -191,8 +191,14 @@ async fn module_ids(
   &self,
   compilation: &rspack_core::Compilation,
   module_ids_artifact: &mut ModuleIdsArtifact,
+  preserved_module_ids: &ModuleIdsArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
+  module_ids_artifact.extend(
+    preserved_module_ids
+      .iter()
+      .map(|(module, id)| (*module, id.clone())),
+  );
   let mut module_ids = std::mem::take(module_ids_artifact);
   let mut used_ids: ModuleIdMap<ModuleIdentifier> = module_ids
     .iter()

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -191,20 +191,16 @@ async fn module_ids(
   &self,
   compilation: &rspack_core::Compilation,
   module_ids_artifact: &mut ModuleIdsArtifact,
-  preserved_module_ids: &ModuleIdsArtifact,
+  _preserved_module_ids: &ModuleIdsArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
-  module_ids_artifact.extend(
-    preserved_module_ids
-      .iter()
-      .map(|(module, id)| (*module, id.clone())),
-  );
   let mut module_ids = std::mem::take(module_ids_artifact);
   let mut used_ids: ModuleIdMap<ModuleIdentifier> = module_ids
     .iter()
     .map(|(&module, id)| (id.clone(), module))
     .collect();
   let module_graph = compilation.get_module_graph();
+  let mut existing_module_set_id_mutations_len = 0;
   if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::MODULE_IDS)
@@ -224,6 +220,9 @@ async fn module_ids(
             used_ids.remove(id);
           }
           module_ids.remove(module);
+        }
+        Mutation::ModuleSetId { .. } => {
+          existing_module_set_id_mutations_len += 1;
         }
         _ => {}
       }
@@ -298,7 +297,7 @@ async fn module_ids(
     ));
     logger.log(format!(
       "{} modules are updated by set_module_id, with {} unnamed modules",
-      mutations.len(),
+      mutations.len() + existing_module_set_id_mutations_len,
       unnamed_modules_len,
     ));
   }

--- a/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_chunk_ids_plugin.rs
@@ -23,7 +23,7 @@ async fn chunk_ids(
   diagnostics: &mut Vec<Diagnostic>,
 ) -> rspack_error::Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
-    IncrementalPasses::CHUNK_IDS,
+    IncrementalPasses::CHUNK_IDS | IncrementalPasses::MODULES_HASHES,
     "NaturalChunkIdsPlugin (optimization.chunkIds = \"natural\")",
     "it requires calculating the id of all the chunks, which is a global effect",
   ) && let Some(diagnostic) = diagnostic

--- a/crates/rspack_ids/src/natural_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_module_ids_plugin.rs
@@ -18,10 +18,11 @@ async fn module_ids(
   &self,
   compilation: &Compilation,
   module_ids: &mut ModuleIdsArtifact,
+  preserved_module_ids: &ModuleIdsArtifact,
   diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
-    IncrementalPasses::MODULE_IDS,
+    IncrementalPasses::MODULE_IDS | IncrementalPasses::MODULES_HASHES,
     "NaturalModuleIdsPlugin (optimization.moduleIds = \"natural\")",
     "it requires calculating the id of all the modules, which is a global effect",
   ) {
@@ -30,6 +31,11 @@ async fn module_ids(
     }
     module_ids.clear();
   }
+  module_ids.extend(
+    preserved_module_ids
+      .iter()
+      .map(|(module, id)| (*module, id.clone())),
+  );
 
   let (used_ids, mut modules_in_natural_order) =
     get_used_module_ids_and_modules_with_artifact(compilation, module_ids, None);

--- a/crates/rspack_ids/src/natural_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/natural_module_ids_plugin.rs
@@ -29,13 +29,8 @@ async fn module_ids(
     if let Some(diagnostic) = diagnostic {
       diagnostics.push(diagnostic);
     }
-    module_ids.clear();
+    module_ids.retain(|module, _| preserved_module_ids.contains_key(module));
   }
-  module_ids.extend(
-    preserved_module_ids
-      .iter()
-      .map(|(module, id)| (*module, id.clone())),
-  );
 
   let (used_ids, mut modules_in_natural_order) =
     get_used_module_ids_and_modules_with_artifact(compilation, module_ids, None);

--- a/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/occurrence_chunk_ids_plugin.rs
@@ -37,7 +37,7 @@ async fn chunk_ids(
   diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
   if let Some(diagnostic) = compilation.incremental.disable_passes(
-    IncrementalPasses::CHUNK_IDS,
+    IncrementalPasses::CHUNK_IDS | IncrementalPasses::MODULES_HASHES,
     "OccurrenceChunkIdsPlugin (optimization.chunkIds = \"size\")",
     "it requires calculating the id of all the chunks, which is a global effect",
   ) && let Some(diagnostic) = diagnostic

--- a/crates/rspack_ids/src/sync_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/sync_module_ids_plugin.rs
@@ -102,7 +102,7 @@ async fn revive_modules(
   &self,
   compilation: &Compilation,
   modules: &rspack_collections::IdentifierSet,
-  module_ids: &mut ModuleIdsArtifact,
+  preserved_module_ids: &mut ModuleIdsArtifact,
 ) -> Result<()> {
   if !self.need_read() {
     return Ok(());
@@ -123,7 +123,7 @@ async fn revive_modules(
   };
 
   let module_graph = compilation.get_module_graph();
-  let mut used_ids = module_ids
+  let mut used_ids = preserved_module_ids
     .iter()
     .map(|(module_identifier, id)| (id.clone(), *module_identifier))
     .collect::<BTreeMap<_, _>>();
@@ -155,10 +155,10 @@ async fn revive_modules(
         id, self.path
       ));
     }
-    if let Some(old_id) = ChunkGraph::get_module_id(module_ids, module.identifier()) {
+    if let Some(old_id) = ChunkGraph::get_module_id(preserved_module_ids, module.identifier()) {
       used_ids.remove(old_id);
     }
-    ChunkGraph::set_module_id(module_ids, module.identifier(), id.clone());
+    ChunkGraph::set_module_id(preserved_module_ids, module.identifier(), id.clone());
     used_ids.insert(id, module.identifier());
   }
 

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -507,6 +507,7 @@ async fn module_ids(
   &self,
   _compilation: &Compilation,
   _module_ids: &mut ModuleIdsArtifact,
+  _preserved_module_ids: &ModuleIdsArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
   self.sealing_hooks_report("assign module ids", 16).await

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -519,6 +519,7 @@ async fn module_ids(
   &self,
   compilation: &Compilation,
   module_ids: &mut ModuleIdsArtifact,
+  _preserved_module_ids: &ModuleIdsArtifact,
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<()> {
   if !self.has_module_graph_feature(RsdoctorPluginModuleGraphFeature::ModuleIds) {

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/0/chunk77.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/0/chunk77.js
@@ -1,0 +1,1 @@
+export default 'target';

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/0/index.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/0/index.js
@@ -1,0 +1,15 @@
+it('should invalidate cached code generation when global chunk ids change', async () => {
+  const targetChunk = __STATS__.chunks.find((chunk) =>
+    chunk.modules?.some((module) => module.name === './chunk77.js'),
+  );
+  expect(targetChunk).toBeTruthy();
+
+  if (WATCH_STEP === '0') {
+    STATE.targetChunkId = targetChunk.id;
+  } else {
+    expect(targetChunk.id).not.toBe(STATE.targetChunkId);
+  }
+
+  const value = await import('./chunk77.js');
+  expect(value.default).toBe('target');
+});

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/0/trigger.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/0/trigger.js
@@ -1,0 +1,1 @@
+export default 0;

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/1/chunk20.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/1/chunk20.js
@@ -1,0 +1,1 @@
+export default 'collision';

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/1/trigger.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/1/trigger.js
@@ -1,0 +1,3 @@
+import('./chunk20.js');
+
+export default 1;

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/rspack.config.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/rspack.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  entry: ['./index.js', './trigger.js'],
+  cache: { type: 'memory' },
+  optimization: {
+    moduleIds: 'named',
+    chunkIds: 'deterministic',
+    concatenateModules: false,
+    inlineExports: false,
+  },
+  incremental: true,
+};

--- a/tests/rspack-test/watchCases/chunk-ids/global-reassignment/warnings.js
+++ b/tests/rspack-test/watchCases/chunk-ids/global-reassignment/warnings.js
@@ -1,0 +1,5 @@
+module.exports = process.env.RSPACK_INCREMENTAL_WATCH_TEST
+  ? [
+      /DeterministicChunkIdsPlugin .* For this rebuild incremental\.chunkIds, incremental\.modulesHashes are fallback to non-incremental/,
+    ]
+  : [];

--- a/tests/rspack-test/watchCases/module-ids/before-module-ids-disabled/0/index.js
+++ b/tests/rspack-test/watchCases/module-ids/before-module-ids-disabled/0/index.js
@@ -1,0 +1,4 @@
+it('should keep the module id assigned by beforeModuleIds', () => {
+  expect(module.id).toBe('custom-entry-id');
+  expect(WATCH_STEP).toBe('0');
+});

--- a/tests/rspack-test/watchCases/module-ids/before-module-ids-disabled/1/index.js
+++ b/tests/rspack-test/watchCases/module-ids/before-module-ids-disabled/1/index.js
@@ -1,0 +1,4 @@
+it('should keep the module id assigned by beforeModuleIds', () => {
+  expect(module.id).toBe('custom-entry-id');
+  expect(WATCH_STEP).toBe('1');
+});

--- a/tests/rspack-test/watchCases/module-ids/before-module-ids-disabled/rspack.config.js
+++ b/tests/rspack-test/watchCases/module-ids/before-module-ids-disabled/rspack.config.js
@@ -1,0 +1,28 @@
+class CustomModuleIdPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('CustomModuleIdPlugin', (compilation) => {
+      compilation.hooks.beforeModuleIds.tap(
+        'CustomModuleIdPlugin',
+        (modules) => {
+          for (const module of modules) {
+            if (module.identifier.includes('index.js')) {
+              module.id = 'custom-entry-id';
+            }
+          }
+        },
+      );
+    });
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  cache: { type: 'memory' },
+  optimization: {
+    moduleIds: false,
+    concatenateModules: false,
+    inlineExports: false,
+  },
+  plugins: [new CustomModuleIdPlugin()],
+  incremental: true,
+};

--- a/tests/rspack-test/watchCases/module-ids/before-module-ids/0/index.js
+++ b/tests/rspack-test/watchCases/module-ids/before-module-ids/0/index.js
@@ -1,0 +1,4 @@
+it("should keep the module id assigned by beforeModuleIds", () => {
+	expect(module.id).toBe("custom-entry-id");
+	expect(WATCH_STEP).toBe("0");
+});

--- a/tests/rspack-test/watchCases/module-ids/before-module-ids/1/index.js
+++ b/tests/rspack-test/watchCases/module-ids/before-module-ids/1/index.js
@@ -1,0 +1,4 @@
+it("should keep the module id assigned by beforeModuleIds", () => {
+	expect(module.id).toBe("custom-entry-id");
+	expect(WATCH_STEP).toBe("1");
+});

--- a/tests/rspack-test/watchCases/module-ids/before-module-ids/rspack.config.js
+++ b/tests/rspack-test/watchCases/module-ids/before-module-ids/rspack.config.js
@@ -1,0 +1,28 @@
+class CustomModuleIdPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('CustomModuleIdPlugin', (compilation) => {
+      compilation.hooks.beforeModuleIds.tap(
+        'CustomModuleIdPlugin',
+        (modules) => {
+          for (const module of modules) {
+            if (module.identifier.includes('index.js')) {
+              module.id = 'custom-entry-id';
+            }
+          }
+        },
+      );
+    });
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  cache: { type: 'memory' },
+  optimization: {
+    moduleIds: 'deterministic',
+    concatenateModules: false,
+    inlineExports: false,
+  },
+  plugins: [new CustomModuleIdPlugin()],
+  incremental: true,
+};

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/0/index.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/0/index.js
@@ -1,0 +1,17 @@
+import './trigger.js';
+import targetModuleId from './module7.js';
+
+it('should invalidate cached code generation when global module ids change', () => {
+  const targetModule = __STATS__.modules.find(
+    (module) => module.name === './module7.js',
+  );
+  expect(targetModule).toBeTruthy();
+
+  if (WATCH_STEP === '0') {
+    STATE.targetModuleId = targetModule.id;
+  } else {
+    expect(targetModule.id).not.toBe(STATE.targetModuleId);
+  }
+
+  expect(targetModuleId).toBe(targetModule.id);
+});

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/0/module7.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/0/module7.js
@@ -1,0 +1,1 @@
+export default module.id;

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/0/trigger.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/0/trigger.js
@@ -1,0 +1,1 @@
+export default 0;

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/1/module83.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/1/module83.js
@@ -1,0 +1,1 @@
+export default 'collision';

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/1/trigger.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/1/trigger.js
@@ -1,0 +1,3 @@
+import './module83.js';
+
+export default 1;

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/rspack.config.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  cache: { type: 'memory' },
+  optimization: {
+    moduleIds: 'deterministic',
+    chunkIds: 'named',
+    concatenateModules: false,
+    inlineExports: false,
+  },
+  incremental: true,
+};

--- a/tests/rspack-test/watchCases/module-ids/global-reassignment/warnings.js
+++ b/tests/rspack-test/watchCases/module-ids/global-reassignment/warnings.js
@@ -1,0 +1,5 @@
+module.exports = process.env.RSPACK_INCREMENTAL_WATCH_TEST
+  ? [
+      /DeterministicModuleIdsPlugin .* For this rebuild incremental\.moduleIds, incremental\.modulesHashes are fallback to non-incremental/,
+    ]
+  : [];

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -1399,21 +1399,31 @@ fn get_modules_needing_ids(
 
 async fn run_module_ids_hook(compilation: &mut Compilation) -> Result<()> {
   let mut module_ids_artifact = compilation.module_ids_artifact.steal();
+  let mut preserved_module_ids_artifact = ModuleIdsArtifact::default();
   if !compilation
     .plugin_driver
     .compilation_hooks
     .before_module_ids
     .is_empty()
   {
-    let modules_needing_ids = get_modules_needing_ids(compilation, &module_ids_artifact);
+    let modules_needing_ids = get_modules_needing_ids(compilation, &preserved_module_ids_artifact);
     compilation
       .plugin_driver
       .clone()
       .compilation_hooks
       .before_module_ids
-      .call(compilation, &modules_needing_ids, &mut module_ids_artifact)
+      .call(
+        compilation,
+        &modules_needing_ids,
+        &mut preserved_module_ids_artifact,
+      )
       .await?;
   }
+  module_ids_artifact.extend(
+    preserved_module_ids_artifact
+      .iter()
+      .map(|(module, id)| (*module, id.clone())),
+  );
   compilation.module_ids_artifact = module_ids_artifact.into();
 
   let mut diagnostics = vec![];
@@ -1423,7 +1433,12 @@ async fn run_module_ids_hook(compilation: &mut Compilation) -> Result<()> {
     .clone()
     .compilation_hooks
     .module_ids
-    .call(compilation, &mut module_ids_artifact, &mut diagnostics)
+    .call(
+      compilation,
+      &mut module_ids_artifact,
+      &preserved_module_ids_artifact,
+      &mut diagnostics,
+    )
     .await?;
   compilation.module_ids_artifact = module_ids_artifact.into();
   assert!(


### PR DESCRIPTION
## Summary

Fix https://github.com/web-infra-dev/rspack/issues/14872
Fix https://github.com/web-infra-dev/rspack/issues/14871

- Disable incremental module-hash passes whenever ID plugins perform global module or chunk ID assignment.
- Add watch-mode regression tests covering module and deterministic chunk ID reassignment.

## Testing

- Added watch-case coverage for invalidating cached code generation when global IDs change.
- Not run (not requested).