### PR TITLE
feat: support css entry bundling

### DIFF
--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -153,6 +153,8 @@ pub enum SourceType {
   Runtime,
 }
 
+pub static NO_SOURCE_TYPE_LIST: &[SourceType; 0] = &[];
+
 impl std::fmt::Display for SourceType {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.write_str(self.as_str())

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -15,8 +15,9 @@ use rspack_cacheable::{
 use rspack_core::{
   BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, CodeGenerationDataItem, Compilation,
   CssAutoOrModuleParserOptions, CssBuildInfo, CssExportType, DependencyType, ExportsInfoArtifact,
-  GenerateContext, Module, ModuleGraph, ModuleIdentifier, NormalModule, ParseContext, ParseResult,
-  ParserAndGenerator, ParserOptions, ResolvedModuleOptions, RuntimeSpec, SourceType, UsageState,
+  GenerateContext, Module, ModuleGraph, ModuleIdentifier, NO_SOURCE_TYPE_LIST, NormalModule,
+  ParseContext, ParseResult, ParserAndGenerator, ParserOptions, ResolvedModuleOptions, RuntimeSpec,
+  SourceType, UsageState,
   rspack_sources::{BoxSource, Source},
 };
 pub use rspack_core::{CssExport, CssExports};
@@ -203,19 +204,33 @@ impl ParserAndGenerator for CssParserAndGenerator {
       return CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST;
     }
 
+    let incoming_connections = module_graph
+      .get_incoming_connections(&module.identifier())
+      .collect::<Vec<_>>();
+
     if self.exports_only {
-      return CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST;
+      let is_root_only = !incoming_connections.is_empty()
+        && incoming_connections
+          .iter()
+          .all(|conn| conn.original_module_identifier.is_none());
+      return if is_root_only {
+        NO_SOURCE_TYPE_LIST
+      } else {
+        CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST
+      };
     }
 
-    let no_need_js = module_graph
-      .get_incoming_connections(&module.identifier())
-      .all(|conn| {
-        let dep = module_graph.dependency_by_id(&conn.dependency_id);
-        matches!(
-          dep.dependency_type(),
-          DependencyType::CssImport | DependencyType::EsmImport
-        )
-      });
+    let no_need_js = incoming_connections.iter().all(|conn| {
+      if conn.original_module_identifier.is_none() {
+        return true;
+      }
+
+      let dep = module_graph.dependency_by_id(&conn.dependency_id);
+      matches!(
+        dep.dependency_type(),
+        DependencyType::CssImport | DependencyType::EsmImport
+      )
+    });
 
     if no_need_js {
       CSS_MODULE_SOURCE_TYPE_LIST

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -46,6 +46,8 @@ pub(crate) static CSS_MODULE_AND_JS_SOURCE_TYPE_LIST: &[SourceType; 2] =
 pub(crate) static CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST: &[SourceType; 1] =
   &[SourceType::JavaScript];
 
+pub(crate) static CSS_MODULE_NO_SOURCE_TYPE_LIST: &[SourceType; 0] = &[];
+
 pub type CssExportsRef<'a> = FxIndexMap<&'a str, &'a FxIndexSet<CssExport>>;
 
 #[cacheable]
@@ -204,19 +206,33 @@ impl ParserAndGenerator for CssParserAndGenerator {
       return CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST;
     }
 
+    let incoming_connections = module_graph
+      .get_incoming_connections(&module.identifier())
+      .collect::<Vec<_>>();
+
     if self.exports_only {
-      return CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST;
+      let is_root_only = !incoming_connections.is_empty()
+        && incoming_connections
+          .iter()
+          .all(|conn| conn.original_module_identifier.is_none());
+      return if is_root_only {
+        CSS_MODULE_NO_SOURCE_TYPE_LIST
+      } else {
+        CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST
+      };
     }
 
-    let no_need_js = module_graph
-      .get_incoming_connections(&module.identifier())
-      .all(|conn| {
-        let dep = module_graph.dependency_by_id(&conn.dependency_id);
-        matches!(
-          dep.dependency_type(),
-          DependencyType::CssImport | DependencyType::EsmImport
-        )
-      });
+    let no_need_js = incoming_connections.iter().all(|conn| {
+      if conn.original_module_identifier.is_none() {
+        return true;
+      }
+
+      let dep = module_graph.dependency_by_id(&conn.dependency_id);
+      matches!(
+        dep.dependency_type(),
+        DependencyType::CssImport | DependencyType::EsmImport
+      )
+    });
 
     if no_need_js {
       CSS_MODULE_SOURCE_TYPE_LIST

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -204,6 +204,14 @@ impl ParserAndGenerator for CssParserAndGenerator {
       return CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST;
     }
 
+    if module.build_meta().is_css_module() {
+      return if self.exports_only {
+        CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST
+      } else {
+        CSS_MODULE_AND_JS_SOURCE_TYPE_LIST
+      };
+    }
+
     let module_identifier = module.identifier();
     let mut incoming_connections = module_graph.get_incoming_connections(&module_identifier);
 

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -204,15 +204,14 @@ impl ParserAndGenerator for CssParserAndGenerator {
       return CSS_MODULE_EXPORTS_ONLY_SOURCE_TYPE_LIST;
     }
 
-    let incoming_connections = module_graph
-      .get_incoming_connections(&module.identifier())
-      .collect::<Vec<_>>();
+    let module_identifier = module.identifier();
+    let mut incoming_connections = module_graph.get_incoming_connections(&module_identifier);
 
     if self.exports_only {
-      let is_root_only = !incoming_connections.is_empty()
-        && incoming_connections
-          .iter()
-          .all(|conn| conn.original_module_identifier.is_none());
+      let is_root_only = incoming_connections
+        .next()
+        .is_some_and(|conn| conn.original_module_identifier.is_none())
+        && incoming_connections.all(|conn| conn.original_module_identifier.is_none());
       return if is_root_only {
         NO_SOURCE_TYPE_LIST
       } else {
@@ -220,7 +219,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
       };
     }
 
-    let no_need_js = incoming_connections.iter().all(|conn| {
+    let no_need_js = incoming_connections.all(|conn| {
       if conn.original_module_identifier.is_none() {
         return true;
       }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -4,10 +4,10 @@ use rspack_core::{
   AssetInfo, CachedConstDependencyTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationChunkHash, CompilationContentHash,
   CompilationId, CompilationParams, CompilationRenderManifest, CompilerCompilation,
-  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ManifestAssetType,
-  ModuleGraph, ModuleType, ParserAndGenerator, PathData, Plugin, RenderManifestEntry,
-  RuntimeGlobals, RuntimeModule, RuntimeRequirementsDependencyTemplate, SelfModuleFactory,
-  SourceType, get_js_chunk_filename_template,
+  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ManifestAssetType, ModuleType,
+  ParserAndGenerator, PathData, Plugin, RenderManifestEntry, RuntimeGlobals, RuntimeModule,
+  RuntimeRequirementsDependencyTemplate, SelfModuleFactory, SourceType,
+  get_js_chunk_filename_template,
   rspack_sources::{BoxSource, CachedSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -559,29 +559,13 @@ async fn render_manifest(
     .expect_get(chunk_ukey);
   let runtime_template = compilation.runtime_template.create_chunk_code_template();
   let is_hot_update = matches!(chunk.kind(), ChunkKind::HotUpdate);
-  let is_main_chunk = chunk.groups().iter().any(|group_ukey| {
-    let group = compilation
-      .build_chunk_graph_artifact
-      .chunk_group_by_ukey
-      .expect_get(group_ukey);
-
-    group.is_initial() && group.kind.is_entrypoint() && &group.get_entrypoint_chunk() == chunk_ukey
-  });
   let is_runtime_chunk =
     chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey);
 
-  if !is_hot_update
-    && is_runtime_chunk
-    && !chunk_has_runtime_or_js(
-      chunk_ukey,
-      &compilation.build_chunk_graph_artifact.chunk_graph,
-      compilation.get_module_graph(),
-    )
-  {
+  if !is_hot_update && is_runtime_chunk && !chunk_has_runtime_or_js(chunk_ukey, compilation) {
     return Ok(());
   }
-  if !is_hot_update && !is_main_chunk && !is_runtime_chunk && !chunk_has_js(chunk_ukey, compilation)
-  {
+  if !is_hot_update && !is_runtime_chunk && !chunk_has_js(chunk_ukey, compilation) {
     return Ok(());
   }
   let filename_template = get_js_chunk_filename_template(
@@ -705,15 +689,6 @@ pub struct ExtractedCommentsInfo {
 }
 
 pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
-  if compilation
-    .build_chunk_graph_artifact
-    .chunk_graph
-    .get_number_of_entry_modules(chunk_ukey)
-    > 0
-  {
-    return true;
-  }
-
   compilation
     .build_chunk_graph_artifact
     .chunk_graph
@@ -724,20 +699,35 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
     )
 }
 
-fn chunk_has_runtime_or_js(
-  chunk: &ChunkUkey,
-  chunk_graph: &ChunkGraph,
-  module_graph: &ModuleGraph,
-) -> bool {
+fn chunk_has_runtime_or_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
+  if chunk_has_js(chunk_ukey, compilation) {
+    return true;
+  }
+
+  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   if chunk_graph
-    .get_chunk_runtime_modules_iterable(chunk)
+    .get_chunk_runtime_modules_iterable(chunk_ukey)
     .next()
-    .is_some()
+    .is_none()
   {
-    return true;
+    return false;
   }
-  if chunk_graph.has_chunk_module_by_source_type(chunk, SourceType::JavaScript, module_graph) {
-    return true;
+
+  let chunk = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .expect_get(chunk_ukey);
+  for group_ukey in chunk.groups() {
+    let chunk_group = compilation
+      .build_chunk_graph_artifact
+      .chunk_group_by_ukey
+      .expect_get(group_ukey);
+    for chunk_ukey in &chunk_group.chunks {
+      if chunk_has_js(chunk_ukey, compilation) {
+        return true;
+      }
+    }
   }
+
   false
 }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -4,10 +4,10 @@ use rspack_core::{
   AssetInfo, CachedConstDependencyTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationChunkHash, CompilationContentHash,
   CompilationId, CompilationParams, CompilationRenderManifest, CompilerCompilation,
-  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ManifestAssetType,
-  ModuleGraph, ModuleType, ParserAndGenerator, PathData, Plugin, RenderManifestEntry,
-  RuntimeGlobals, RuntimeModule, RuntimeRequirementsDependencyTemplate, SelfModuleFactory,
-  SourceType, get_js_chunk_filename_template,
+  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ManifestAssetType, ModuleType,
+  ParserAndGenerator, PathData, Plugin, RenderManifestEntry, RuntimeGlobals, RuntimeModule,
+  RuntimeRequirementsDependencyTemplate, SelfModuleFactory, SourceType,
+  get_js_chunk_filename_template,
   rspack_sources::{BoxSource, CachedSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -577,28 +577,50 @@ async fn render_manifest(
   }
   let runtime_template = compilation.runtime_template.create_chunk_code_template();
   let is_hot_update = matches!(chunk.kind(), ChunkKind::HotUpdate);
-  let is_main_chunk = chunk.groups().iter().any(|group_ukey| {
+  let module_graph = compilation.get_module_graph();
+  // ESM optimizations can move both the entry module and its chunk graph entry
+  // connection. The original entrypoint still needs to emit its re-exports.
+  let is_js_entry_chunk = chunk.groups().iter().any(|group_ukey| {
     let group = compilation
       .build_chunk_graph_artifact
       .chunk_group_by_ukey
       .expect_get(group_ukey);
-
-    group.is_initial() && group.kind.is_entrypoint() && &group.get_entrypoint_chunk() == chunk_ukey
+    group.is_initial()
+      && group.kind.is_entrypoint()
+      && group.get_entrypoint_chunk() == *chunk_ukey
+      && group
+        .name()
+        .and_then(|name| compilation.entries.get(name))
+        .is_some_and(|entry| {
+          entry
+            .all_dependencies()
+            .chain(compilation.global_entry.all_dependencies())
+            .filter_map(|dependency| module_graph.module_identifier_by_dependency_id(dependency))
+            .any(|module_identifier| {
+              module_graph
+                .module_by_identifier(module_identifier)
+                .is_some_and(|module| {
+                  module
+                    .source_types(module_graph)
+                    .contains(&SourceType::JavaScript)
+                })
+            })
+        })
   });
   let is_runtime_chunk =
     chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey);
 
   if !is_hot_update
+    && !is_js_entry_chunk
     && is_runtime_chunk
-    && !chunk_has_runtime_or_js(
-      chunk_ukey,
-      &compilation.build_chunk_graph_artifact.chunk_graph,
-      compilation.get_module_graph(),
-    )
+    && !chunk_has_runtime_or_js(chunk_ukey, compilation)
   {
     return Ok(());
   }
-  if !is_hot_update && !is_main_chunk && !is_runtime_chunk && !chunk_has_js(chunk_ukey, compilation)
+  if !is_hot_update
+    && !is_js_entry_chunk
+    && !is_runtime_chunk
+    && !chunk_has_js(chunk_ukey, compilation)
   {
     return Ok(());
   }
@@ -724,39 +746,58 @@ pub struct ExtractedCommentsInfo {
 }
 
 pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
-  if compilation
-    .build_chunk_graph_artifact
-    .chunk_graph
-    .get_number_of_entry_modules(chunk_ukey)
-    > 0
+  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+  let module_graph = compilation.get_module_graph();
+
+  // JavaScript entries still need startup code when their modules move to another chunk.
+  if chunk_graph
+    .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey)
+    .keys()
+    .any(|module_identifier| {
+      module_graph
+        .module_by_identifier(module_identifier)
+        .is_some_and(|module| {
+          module
+            .source_types(module_graph)
+            .contains(&SourceType::JavaScript)
+        })
+    })
   {
     return true;
   }
 
-  compilation
-    .build_chunk_graph_artifact
-    .chunk_graph
-    .has_chunk_module_by_source_type(
-      chunk_ukey,
-      SourceType::JavaScript,
-      compilation.get_module_graph(),
-    )
+  chunk_graph.has_chunk_module_by_source_type(chunk_ukey, SourceType::JavaScript, module_graph)
 }
 
-fn chunk_has_runtime_or_js(
-  chunk: &ChunkUkey,
-  chunk_graph: &ChunkGraph,
-  module_graph: &ModuleGraph,
-) -> bool {
+fn chunk_has_runtime_or_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
+  if chunk_has_js(chunk_ukey, compilation) {
+    return true;
+  }
+
+  let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   if chunk_graph
-    .get_chunk_runtime_modules_iterable(chunk)
+    .get_chunk_runtime_modules_iterable(chunk_ukey)
     .next()
-    .is_some()
+    .is_none()
   {
-    return true;
+    return false;
   }
-  if chunk_graph.has_chunk_module_by_source_type(chunk, SourceType::JavaScript, module_graph) {
-    return true;
+
+  let chunk = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .expect_get(chunk_ukey);
+  for group_ukey in chunk.groups() {
+    let chunk_group = compilation
+      .build_chunk_graph_artifact
+      .chunk_group_by_ukey
+      .expect_get(group_ukey);
+    for chunk_ukey in &chunk_group.chunks {
+      if chunk_has_js(chunk_ukey, compilation) {
+        return true;
+      }
+    }
   }
+
   false
 }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -581,11 +581,8 @@ async fn render_manifest(
     chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey);
 
   if !is_hot_update && !is_js_entry_chunk(chunk_ukey, compilation) {
-    let has_js = if is_runtime_chunk {
-      chunk_has_runtime_or_js(chunk_ukey, compilation)
-    } else {
-      chunk_has_js(chunk_ukey, compilation)
-    };
+    let has_js = chunk_has_js(chunk_ukey, compilation)
+      || (is_runtime_chunk && chunk_has_required_runtime(chunk_ukey, compilation));
     if !has_js {
       return Ok(());
     }
@@ -765,11 +762,7 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
   chunk_graph.has_chunk_module_by_source_type(chunk_ukey, SourceType::JavaScript, module_graph)
 }
 
-fn chunk_has_runtime_or_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
-  if chunk_has_js(chunk_ukey, compilation) {
-    return true;
-  }
-
+fn chunk_has_required_runtime(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   if chunk_graph
     .get_chunk_runtime_modules_iterable(chunk_ukey)

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -4,10 +4,10 @@ use rspack_core::{
   AssetInfo, CachedConstDependencyTemplate, ChunkGraph, ChunkKind, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationChunkHash, CompilationContentHash,
   CompilationId, CompilationParams, CompilationRenderManifest, CompilerCompilation,
-  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ManifestAssetType, ModuleType,
-  ParserAndGenerator, PathData, Plugin, RenderManifestEntry, RuntimeGlobals, RuntimeModule,
-  RuntimeRequirementsDependencyTemplate, SelfModuleFactory, SourceType,
-  get_js_chunk_filename_template,
+  ConstDependencyTemplate, DependencyType, IgnoreErrorModuleFactory, ManifestAssetType,
+  ModuleGraph, ModuleIdentifier, ModuleType, ParserAndGenerator, PathData, Plugin,
+  RenderManifestEntry, RuntimeGlobals, RuntimeModule, RuntimeRequirementsDependencyTemplate,
+  SelfModuleFactory, SourceType, get_js_chunk_filename_template,
   rspack_sources::{BoxSource, CachedSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -577,52 +577,18 @@ async fn render_manifest(
   }
   let runtime_template = compilation.runtime_template.create_chunk_code_template();
   let is_hot_update = matches!(chunk.kind(), ChunkKind::HotUpdate);
-  let module_graph = compilation.get_module_graph();
-  // ESM optimizations can move both the entry module and its chunk graph entry
-  // connection. The original entrypoint still needs to emit its re-exports.
-  let is_js_entry_chunk = chunk.groups().iter().any(|group_ukey| {
-    let group = compilation
-      .build_chunk_graph_artifact
-      .chunk_group_by_ukey
-      .expect_get(group_ukey);
-    group.is_initial()
-      && group.kind.is_entrypoint()
-      && group.get_entrypoint_chunk() == *chunk_ukey
-      && group
-        .name()
-        .and_then(|name| compilation.entries.get(name))
-        .is_some_and(|entry| {
-          entry
-            .all_dependencies()
-            .chain(compilation.global_entry.all_dependencies())
-            .filter_map(|dependency| module_graph.module_identifier_by_dependency_id(dependency))
-            .any(|module_identifier| {
-              module_graph
-                .module_by_identifier(module_identifier)
-                .is_some_and(|module| {
-                  module
-                    .source_types(module_graph)
-                    .contains(&SourceType::JavaScript)
-                })
-            })
-        })
-  });
   let is_runtime_chunk =
     chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey);
 
-  if !is_hot_update
-    && !is_js_entry_chunk
-    && is_runtime_chunk
-    && !chunk_has_runtime_or_js(chunk_ukey, compilation)
-  {
-    return Ok(());
-  }
-  if !is_hot_update
-    && !is_js_entry_chunk
-    && !is_runtime_chunk
-    && !chunk_has_js(chunk_ukey, compilation)
-  {
-    return Ok(());
+  if !is_hot_update && !is_js_entry_chunk(chunk_ukey, compilation) {
+    let has_js = if is_runtime_chunk {
+      chunk_has_runtime_or_js(chunk_ukey, compilation)
+    } else {
+      chunk_has_js(chunk_ukey, compilation)
+    };
+    if !has_js {
+      return Ok(());
+    }
   }
   let mut asset_info = AssetInfo::default().with_asset_type(ManifestAssetType::JavaScript);
   asset_info.set_javascript_module(compilation.options.output.module);
@@ -745,6 +711,44 @@ pub struct ExtractedCommentsInfo {
   pub comments_file_name: String,
 }
 
+fn module_has_js(module_identifier: &ModuleIdentifier, module_graph: &ModuleGraph) -> bool {
+  module_graph
+    .module_by_identifier(module_identifier)
+    .is_some_and(|module| {
+      module
+        .source_types(module_graph)
+        .contains(&SourceType::JavaScript)
+    })
+}
+
+fn is_js_entry_chunk(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
+  let chunk = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .expect_get(chunk_ukey);
+  let module_graph = compilation.get_module_graph();
+  // ESM optimizations can move both the entry module and its chunk graph entry
+  // connection. The original entrypoint still needs to emit its re-exports.
+  chunk.groups().iter().any(|group_ukey| {
+    let group = compilation
+      .build_chunk_graph_artifact
+      .chunk_group_by_ukey
+      .expect_get(group_ukey);
+    group.is_initial()
+      && group.get_entrypoint_chunk() == *chunk_ukey
+      && group
+        .name()
+        .and_then(|name| compilation.entries.get(name))
+        .is_some_and(|entry| {
+          entry
+            .all_dependencies()
+            .chain(compilation.global_entry.all_dependencies())
+            .filter_map(|dependency| module_graph.module_identifier_by_dependency_id(dependency))
+            .any(|module_identifier| module_has_js(module_identifier, module_graph))
+        })
+  })
+}
+
 pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   let module_graph = compilation.get_module_graph();
@@ -753,15 +757,7 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
   if chunk_graph
     .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey)
     .keys()
-    .any(|module_identifier| {
-      module_graph
-        .module_by_identifier(module_identifier)
-        .is_some_and(|module| {
-          module
-            .source_types(module_graph)
-            .contains(&SourceType::JavaScript)
-        })
-    })
+    .any(|module_identifier| module_has_js(module_identifier, module_graph))
   {
     return true;
   }
@@ -792,8 +788,8 @@ fn chunk_has_runtime_or_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) ->
       .build_chunk_graph_artifact
       .chunk_group_by_ukey
       .expect_get(group_ukey);
-    for chunk_ukey in &chunk_group.chunks {
-      if chunk_has_js(chunk_ukey, compilation) {
+    for other_chunk_ukey in &chunk_group.chunks {
+      if other_chunk_ukey != chunk_ukey && chunk_has_js(other_chunk_ukey, compilation) {
         return true;
       }
     }

--- a/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/test.config.js
+++ b/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/test.config.js
@@ -4,19 +4,13 @@ module.exports = {
 
 		switch (i % 4) {
 			case 0:
-				return ["test.js", `${i}/runtime~app.${ext}`];
+				return ["test.js"];
 			case 1:
 				return ["test.js", `${i}/app.${ext}`, `${i}/runtime~app.${ext}`];
 			case 2:
-				return ["test.js", `${i}/app.${ext}`, `${i}/runtime~app.${ext}`];
+				return ["test.js"];
 			case 3:
-				return [
-					"test.js",
-					`${i}/entry1.${ext}`,
-					`${i}/entry2.${ext}`,
-					`${i}/runtime~entry1.${ext}`,
-					`${i}/runtime~entry2.${ext}`
-				];
+				return ["test.js", `${i}/entry2.${ext}`, `${i}/runtime~entry2.${ext}`];
 			default:
 				break;
 		}

--- a/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/test.js
+++ b/tests/rspack-test/configCases/asset-modules/entry-with-runtimeChunk/test.js
@@ -11,4 +11,9 @@ it("should work", () => {
 	);
 	expect(Boolean(assetEntry)).toBe(true);
 
+	if (__STATS_I__ % 4 === 0 || __STATS_I__ % 4 === 2) {
+		expect(
+			stats.assets.filter(a => /\.m?js$/.test(a.name)).map(a => a.name)
+		).toEqual(["test.js"]);
+	}
 });

--- a/tests/rspack-test/configCases/asset-modules/only-entry/test.js
+++ b/tests/rspack-test/configCases/asset-modules/only-entry/test.js
@@ -26,12 +26,12 @@ it("should work", () => {
 			break;
 		}
 		case 2: {
-			expect(stats.assets.length).toBe(4);
+			expect(stats.assets.length).toBe(3);
 
 			const cssEntryInJs = stats.assets.find(
 				a => a.name.endsWith("css-entry.js")
 			);
-			expect(Boolean(cssEntryInJs)).toBe(true);
+			expect(Boolean(cssEntryInJs)).toBe(false);
 
 			const cssEntry = stats.assets.find(
 				a => a.name.endsWith("css-entry.css")
@@ -40,25 +40,6 @@ it("should work", () => {
 			break;
 		}
 		case 3: {
-			expect(stats.assets.length).toBe(5);
-
-			const jsEntry = stats.assets.find(
-				a => a.name.endsWith("js-entry.js")
-			);
-			expect(Boolean(jsEntry)).toBe(true);
-
-			const cssEntryInJs = stats.assets.find(
-				a => a.name.endsWith("css-entry.js")
-			);
-			expect(Boolean(cssEntryInJs)).toBe(true);
-
-			const cssEntry = stats.assets.find(
-				a => a.name.endsWith("css-entry.css")
-			);
-			expect(Boolean(cssEntry)).toBe(true);
-			break;
-		}
-		case 4: {
 			expect(stats.assets.length).toBe(4);
 
 			const jsEntry = stats.assets.find(
@@ -69,7 +50,26 @@ it("should work", () => {
 			const cssEntryInJs = stats.assets.find(
 				a => a.name.endsWith("css-entry.js")
 			);
-			expect(Boolean(cssEntryInJs)).toBe(true);
+			expect(Boolean(cssEntryInJs)).toBe(false);
+
+			const cssEntry = stats.assets.find(
+				a => a.name.endsWith("css-entry.css")
+			);
+			expect(Boolean(cssEntry)).toBe(true);
+			break;
+		}
+		case 4: {
+			expect(stats.assets.length).toBe(3);
+
+			const jsEntry = stats.assets.find(
+				a => a.name.endsWith("js-entry.js")
+			);
+			expect(Boolean(jsEntry)).toBe(true);
+
+			const cssEntryInJs = stats.assets.find(
+				a => a.name.endsWith("css-entry.js")
+			);
+			expect(Boolean(cssEntryInJs)).toBe(false);
 			break;
 		}
 		case 5: {

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/classes-dev.0.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/classes-dev.0.txt
@@ -1,7 +1,7 @@
 Object {
   UsedClassName: my-app-identifiers_module_css-UsedClassName,
   VARS: --my-app-style_module_css-LOCAL-COLOR my-app-style_module_css-VARS undefined my-app-style_module_css-globalVarsUpperCase,
-  __webpack_modules__: 12,
+  __webpack_modules__: 13,
   animation: my-app-style_module_css-animation,
   animationName: my-app-style_module_css-animationName,
   class: my-app-style_module_css-class,

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/classes-prod.1.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/classes-prod.1.txt
@@ -1,7 +1,7 @@
 Object {
   UsedClassName: mrynNF,
   VARS: --_odIAe Ks_BHh undefined m2PA6x,
-  __webpack_modules__: 12,
+  __webpack_modules__: 13,
   animation: _4v9LUE,
   animationName: RI1Z9k,
   class: fcj_Kv,

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/common.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/common.css
@@ -1,0 +1,3 @@
+.class-a {
+	background: red;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/five.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/five.css
@@ -1,0 +1,13 @@
+@import url("https://some/other/external/css");
+@import url("https://some/external/css");
+
+
+.a {
+	color: yellow;
+}
+
+
+
+.b {
+	color: yellow;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/four.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/four.css
@@ -1,0 +1,1 @@
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@500;800&display=swap");

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/one.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/one.css
@@ -1,0 +1,3 @@
+.class-1 {
+	color: red;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/six.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/six.css
@@ -1,0 +1,3 @@
+.class-b {
+	background: blue;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/three.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/three.css
@@ -1,0 +1,6 @@
+@media (prefers-color-scheme: dark){
+body {
+	background: black;
+}
+
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/two.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/__snapshots__/two.css
@@ -1,0 +1,3 @@
+.class-2 {
+	color: blue;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/basic.js
+++ b/tests/rspack-test/configCases/css/multiple-entries/basic.js
@@ -1,0 +1,3 @@
+it("should contain only one module", () => {
+	expect(Object.keys(__webpack_modules__).length).toBe(1);
+});

--- a/tests/rspack-test/configCases/css/multiple-entries/common.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/common.css
@@ -1,0 +1,3 @@
+.class-a {
+	background: red;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/commonjs.js
+++ b/tests/rspack-test/configCases/css/multiple-entries/commonjs.js
@@ -1,0 +1,1 @@
+import "./common.css";

--- a/tests/rspack-test/configCases/css/multiple-entries/dark.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/dark.css
@@ -1,0 +1,3 @@
+body {
+	background: black;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/five-a.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/five-a.css
@@ -1,0 +1,5 @@
+@import url("https://some/other/external/css");
+
+.a {
+	color: yellow;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/five-b.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/five-b.css
@@ -1,0 +1,5 @@
+@import url("https://some/external/css");
+
+.b {
+	color: yellow;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/five.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/five.css
@@ -1,0 +1,2 @@
+@import "./five-a.css";
+@import "./five-b.css";

--- a/tests/rspack-test/configCases/css/multiple-entries/four.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/four.css
@@ -1,0 +1,1 @@
+@import url(https://fonts.googleapis.com/css2?family=Manrope:wght@500;800&display=swap);

--- a/tests/rspack-test/configCases/css/multiple-entries/one.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/one.css
@@ -1,0 +1,3 @@
+.class-1 {
+	color: red;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/rspack.config.js
+++ b/tests/rspack-test/configCases/css/multiple-entries/rspack.config.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  entry: {
+    basic: './basic.js',
+    one: './one.css',
+    two: './two.css',
+    three: './three.css',
+    four: './four.css',
+    five: './five.css',
+    common: './commonjs.js',
+    six: { import: './six.js', dependOn: 'common' },
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
+  },
+  optimization: {
+    chunkIds: 'named',
+  },
+  module: {
+    rules: [{ test: /\.css$/, type: 'css/auto' }],
+  },
+};

--- a/tests/rspack-test/configCases/css/multiple-entries/six-b.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/six-b.css
@@ -1,0 +1,3 @@
+.class-b {
+	background: blue;
+}

--- a/tests/rspack-test/configCases/css/multiple-entries/six.js
+++ b/tests/rspack-test/configCases/css/multiple-entries/six.js
@@ -1,0 +1,1 @@
+import "./six-b.css";

--- a/tests/rspack-test/configCases/css/multiple-entries/test.config.js
+++ b/tests/rspack-test/configCases/css/multiple-entries/test.config.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["basic.js"];
+	},
+	afterExecute(options) {
+		// Sort: readdirSync order is filesystem-dependent (differs on Bun).
+		const files = fs
+			.readdirSync(options.output.path)
+			.filter((item) => !/stats/.test(item))
+			.sort();
+
+		expect(files).toEqual([
+			"basic.js",
+			"common.css",
+			"common.js",
+			"five.css",
+			"four.css",
+			"one.css",
+			"six.css",
+			"six.js",
+			"three.css",
+			"two.css"
+		]);
+
+		for (const file of files.filter((item) => /\.css/.test(item))) {
+			expect(
+				fs.readFileSync(path.join(options.output.path, file), "utf8")
+			).toMatchFileSnapshotSync(path.join(__dirname, "__snapshots__", file));
+		}
+	}
+};

--- a/tests/rspack-test/configCases/css/multiple-entries/three.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/three.css
@@ -1,0 +1,1 @@
+@import "./dark.css" (prefers-color-scheme: dark);

--- a/tests/rspack-test/configCases/css/multiple-entries/two.css
+++ b/tests/rspack-test/configCases/css/multiple-entries/two.css
@@ -1,0 +1,3 @@
+.class-2 {
+	color: blue;
+}

--- a/tests/rspack-test/configCases/css/no-extra-empty-js/index.js
+++ b/tests/rspack-test/configCases/css/no-extra-empty-js/index.js
@@ -1,0 +1,6 @@
+import './style.css' // doesn't has js output
+
+it('should contain no js outupt', () => {
+	// only has index.js
+	expect(Reflect.ownKeys(__webpack_modules__).length).toBe(1)
+})

--- a/tests/rspack-test/configCases/css/no-extra-empty-js/other.css
+++ b/tests/rspack-test/configCases/css/no-extra-empty-js/other.css
@@ -1,0 +1,3 @@
+body {
+	color: white;
+}

--- a/tests/rspack-test/configCases/css/no-extra-empty-js/rspack.config.js
+++ b/tests/rspack-test/configCases/css/no-extra-empty-js/rspack.config.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  module: {
+    rules: [{ test: /\.css$/, type: 'css/auto' }],
+  },
+};

--- a/tests/rspack-test/configCases/css/no-extra-empty-js/style.css
+++ b/tests/rspack-test/configCases/css/no-extra-empty-js/style.css
@@ -1,0 +1,5 @@
+@import './other.css';
+
+body {
+	background-color: red;
+}

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/rspack.config.js
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/rspack.config.js
@@ -69,7 +69,10 @@ module.exports = {
             path.join(__dirname, '__snapshot__', 'g.js.txt'),
             'harmony export should concat, even with bailout reason',
           );
-          expect(assets['h.js']).toBeDefined();
+          expect(assets['h.js']).toBeUndefined();
+          expect(
+            Object.keys(assets).filter((name) => name.endsWith('.png')),
+          ).toHaveLength(1);
         });
       };
       this.hooks.compilation.tap('testcase', handler);

--- a/tests/rspack-test/configCases/loader-import-module/native-css-module/index.js
+++ b/tests/rspack-test/configCases/loader-import-module/native-css-module/index.js
@@ -1,0 +1,6 @@
+it("should return native CSS-module exports from a direct loader import", () => {
+	expect(classes).toEqual({
+		button: "button",
+		title: "title"
+	});
+});

--- a/tests/rspack-test/configCases/loader-import-module/native-css-module/loader.js
+++ b/tests/rspack-test/configCases/loader-import-module/native-css-module/loader.js
@@ -1,0 +1,5 @@
+/** @type {import("@rspack/core").LoaderDefinitionFunction} */
+module.exports = async function (source) {
+	const classes = await this.importModule("./style.module.css");
+	return `const classes = ${JSON.stringify(classes)};\n${source}`;
+};

--- a/tests/rspack-test/configCases/loader-import-module/native-css-module/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-import-module/native-css-module/rspack.config.js
@@ -1,0 +1,21 @@
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = ['css/module', 'css/auto'].flatMap((type) =>
+  [true, false].map((exportsOnly) => ({
+    module: {
+      rules: [
+        {
+          test: /index\.js$/,
+          loader: './loader.js',
+        },
+        {
+          test: /\.module\.css$/,
+          type,
+          generator: {
+            exportsOnly,
+            localIdentName: '[local]',
+          },
+        },
+      ],
+    },
+  })),
+);

--- a/tests/rspack-test/configCases/loader-import-module/native-css-module/style.module.css
+++ b/tests/rspack-test/configCases/loader-import-module/native-css-module/style.module.css
@@ -1,0 +1,7 @@
+.button {
+	color: red;
+}
+
+.title {
+	color: blue;
+}

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/__snapshots__/web/0.snap.txt
@@ -1,0 +1,14 @@
+# Case css-entry-mini-extract: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: css-entry.js
+- Bundle: main.js
+- Bundle: runtime.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/__snapshots__/web/1.snap.txt
@@ -1,0 +1,44 @@
+# Case css-entry-mini-extract: Step 1
+
+## Changed Files
+- entry.css
+
+## Asset Files
+- Bundle: css-entry.js
+- Bundle: main.js
+- Bundle: runtime.js
+- Manifest: runtime.LAST_HASH.hot-update.json, size: 68
+- Update: runtime.LAST_HASH.hot-update.js, size: 184
+
+## Manifest
+
+### runtime.LAST_HASH.hot-update.json
+
+```json
+{"c":["runtime"],"r":[],"m":[],"miniCss":{"c":["styles-entry_css"]}}
+```
+
+
+## Update
+
+
+### runtime.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("runtime", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/__snapshots__/web/2.snap.txt
@@ -1,0 +1,85 @@
+# Case css-entry-mini-extract: Step 2
+
+## Changed Files
+- entry.css
+
+## Asset Files
+- Bundle: css-entry.js
+- Bundle: main.js
+- Bundle: runtime.js
+- Manifest: runtime.LAST_HASH.hot-update.json, size: 68
+- Update: runtime.LAST_HASH.hot-update.js, size: 184
+
+## Manifest
+
+### runtime.LAST_HASH.hot-update.json
+
+```json
+{"c":["runtime"],"r":[],"m":[],"miniCss":{"c":["styles-entry_css"]}}
+```
+
+
+## Update
+
+
+### runtime.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("runtime", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+
+## Runtime
+### Status
+
+```txt
+check => prepare => dispose => apply => idle
+```
+
+
+
+### JavaScript
+
+#### Outdated
+
+Outdated Modules:
+
+
+
+Outdated Dependencies:
+```json
+{}
+```
+
+#### Updated
+
+Updated Modules:
+
+
+Updated Runtime:
+- `__webpack_require__.h`
+
+
+#### Callback
+
+Accepted Callback:
+
+
+Disposed Callback:

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/entry.css
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/entry.css
@@ -1,0 +1,12 @@
+body {
+	color: red;
+}
+---
+body {
+	color: blue;
+}
+---
+body {
+	color: green;
+}
+

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/index.js
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/index.js
@@ -1,0 +1,15 @@
+const getFile = name =>
+	__non_webpack_require__("fs").readFileSync(
+		__non_webpack_require__("path").join(__dirname, name),
+		"utf-8"
+	);
+
+it("should update a CSS entry", async () => {
+	expect(getFile("css-entry.css")).toContain("color: red;");
+
+	await NEXT_HMR();
+	expect(getFile("css-entry.css")).toContain("color: blue;");
+
+	await NEXT_HMR();
+	expect(getFile("css-entry.css")).toContain("color: green;");
+});

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/rspack.config.js
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/rspack.config.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { CssExtractRspackPlugin } = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  entry: {
+    'css-entry': './entry.css',
+    main: './index.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'javascript/auto',
+        use: [
+          {
+            loader: CssExtractRspackPlugin.loader,
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              esModule: true,
+              modules: {
+                namedExport: false,
+                localIdentName: '[name]',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  output: {
+    filename: '[name].js',
+    cssChunkFilename: '[name].css',
+  },
+  optimization: {
+    runtimeChunk: 'single',
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        styles: {
+          type: 'css/mini-extract',
+          enforce: true,
+        },
+      },
+    },
+  },
+  target: 'web',
+  node: {
+    __dirname: false,
+  },
+  plugins: [new CssExtractRspackPlugin({ filename: 'css-entry.css' })],
+};

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/test.config.js
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/test.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "https://test.cases/path/css-entry.css";
+		scope.window.document.head.appendChild(link);
+	},
+	env: "jsdom"
+};

--- a/tests/rspack-test/hotCases/css/css-entry-mini-extract/test.filter.js
+++ b/tests/rspack-test/hotCases/css/css-entry-mini-extract/test.filter.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = (config) => {
+	const [major] = process.versions.node.split(".").map(Number);
+	// TODO: oom
+	return config.target === "web" && major >= 18;
+};

--- a/tests/rspack-test/hotCases/css/css-entry/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-entry/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case css-entry: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: main.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/css/css-entry/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-entry/__snapshots__/web/1.snap.txt
@@ -1,0 +1,75 @@
+# Case css-entry: Step 1
+
+## Changed Files
+- entry.css
+
+## Asset Files
+- Bundle: main.js
+- Manifest: css-entry.LAST_HASH.hot-update.json, size: 59
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: css-entry.LAST_HASH.hot-update.js, size: 186
+- Update: main.LAST_HASH.hot-update.js, size: 181
+
+## Manifest
+
+### css-entry.LAST_HASH.hot-update.json
+
+```json
+{"c":["css-entry"],"r":[],"m":[],"css":{"c":["css-entry"]}}
+```
+
+
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### css-entry.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("css-entry", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("main", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/css/css-entry/__snapshots__/web/2.snap.txt
+++ b/tests/rspack-test/hotCases/css/css-entry/__snapshots__/web/2.snap.txt
@@ -1,0 +1,116 @@
+# Case css-entry: Step 2
+
+## Changed Files
+- entry.css
+
+## Asset Files
+- Bundle: main.js
+- Manifest: css-entry.LAST_HASH.hot-update.json, size: 59
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: css-entry.LAST_HASH.hot-update.js, size: 186
+- Update: main.LAST_HASH.hot-update.js, size: 181
+
+## Manifest
+
+### css-entry.LAST_HASH.hot-update.json
+
+```json
+{"c":["css-entry"],"r":[],"m":[],"css":{"c":["css-entry"]}}
+```
+
+
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### css-entry.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("css-entry", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("main", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+
+## Runtime
+### Status
+
+```txt
+check => prepare => dispose => apply => idle
+```
+
+
+
+### JavaScript
+
+#### Outdated
+
+Outdated Modules:
+
+
+
+Outdated Dependencies:
+```json
+{}
+```
+
+#### Updated
+
+Updated Modules:
+
+
+Updated Runtime:
+- `__webpack_require__.h`
+
+
+#### Callback
+
+Accepted Callback:
+
+
+Disposed Callback:

--- a/tests/rspack-test/hotCases/css/css-entry/entry.css
+++ b/tests/rspack-test/hotCases/css/css-entry/entry.css
@@ -1,0 +1,12 @@
+body {
+	color: red;
+}
+---
+body {
+	color: blue;
+}
+---
+body {
+	color: green;
+}
+

--- a/tests/rspack-test/hotCases/css/css-entry/index.js
+++ b/tests/rspack-test/hotCases/css/css-entry/index.js
@@ -1,0 +1,15 @@
+const getFile = name =>
+	__non_webpack_require__("fs").readFileSync(
+		__non_webpack_require__("path").join(__dirname, name),
+		"utf-8"
+	);
+
+it("should update a CSS entry", async () => {
+	expect(getFile("css-entry.css")).toContain("color: red;");
+
+	await NEXT_HMR();
+	expect(getFile("css-entry.css")).toContain("color: blue;");
+
+	await NEXT_HMR();
+	expect(getFile("css-entry.css")).toContain("color: green;");
+});

--- a/tests/rspack-test/hotCases/css/css-entry/rspack.config.js
+++ b/tests/rspack-test/hotCases/css/css-entry/rspack.config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  entry: {
+    'css-entry': './entry.css',
+    main: './index.js',
+  },
+  output: {
+    filename: '[name].js',
+    cssFilename: '[name].css',
+  },
+  node: {
+    __dirname: false,
+  },
+};

--- a/tests/rspack-test/hotCases/css/css-entry/test.config.js
+++ b/tests/rspack-test/hotCases/css/css-entry/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	env: "jsdom"
+};


### PR DESCRIPTION
## Summary

CSS-only entries previously emitted an unnecessary JavaScript bundle because entry chunks were treated as JavaScript regardless of their modules' source types. This change checks the actual source types and omits JavaScript facades and standalone runtime chunks when the entrypoint has no JavaScript consumer.

JavaScript entries retain the startup code and ESM re-exports they need when their modules move to another chunk. CSS imports that need JavaScript exports, including `text`, `style`, and `CSSStyleSheet` export types, retain their existing behavior. Modules that produce no source use the shared `NO_SOURCE_TYPE_LIST`.

### Example

A project can build a standalone stylesheet with native CSS support:

```js
module.exports = {
  mode: "production",
  entry: {
    styles: "./src/styles.css"
  },
  module: {
    rules: [{ test: /\.css$/i, type: "css/auto" }]
  },
  output: {
    filename: "[name].js",
    cssFilename: "[name].css"
  }
};
```

Before this change, the build emitted both `styles.css` and an unnecessary `styles.js`. It now emits only `styles.css`. With `optimization.runtimeChunk: "single"`, a runtime bundle is also omitted when no JavaScript entry needs it. Mixed CSS and JavaScript entries still emit the JavaScript bundles and runtime they require.

## Test coverage

- Port webpack's `configCases/css/no-extra-empty-js` and `configCases/css/multiple-entries` cases to cover CSS-only and mixed entries.
- Update asset-entry and modern-module library regression expectations.
- Port `hotCases/css/css-entry` and `hotCases/css/css-entry-mini-extract`, adapting the latter to `CssExtractRspackPlugin`. Both verify CSS changing from red to blue to green across two hot updates. Assertions propagate failures, and six snapshots cover the initial builds and update manifests.

## Related links

- webpack regression fix: web-infra-dev/webpack#20454

## Validation

- `pnpm run build:cli:dev` and `pnpm run build:js` passed.
- From `tests/rspack-test`, `pnpm run test --project base HotWeb -t 'css/css-entry'`: 4 tests passed across the default and Rspack runtimes.
- From `tests/rspack-test`, `pnpm run test --project hottest -t 'css/css-entry'`: 2 tests passed with all six snapshots unchanged after removing the unused `experiments.css` option.
- Commit hooks: JavaScript lint and formatting passed.

## Checklist

- [x] Tests updated.
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_