### PR TITLE
refactor: record content hash dependencies during rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,7 +4899,6 @@ dependencies = [
  "indexmap",
  "once_cell",
  "rayon",
- "regex",
  "rspack_core",
  "rspack_error",
  "rspack_hash",

--- a/crates/rspack_core/src/artifacts/chunk_render_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/chunk_render_cache_artifact.rs
@@ -6,7 +6,7 @@ use rspack_error::{Diagnostic, Result};
 use rspack_sources::BoxSource;
 
 use crate::{
-  ArtifactExt, Chunk, Compilation, MemoryGCStorage, SourceType,
+  ArtifactExt, Chunk, Compilation, ContentHashDependencies, MemoryGCStorage, SourceType,
   incremental::{Incremental, IncrementalPasses},
 };
 
@@ -14,6 +14,7 @@ use crate::{
 struct ChunkRenderCacheEntry {
   filename: Arc<str>,
   source: BoxSource,
+  content_hash_dependencies: ContentHashDependencies,
 }
 
 #[derive(Debug, Default)]
@@ -48,10 +49,10 @@ impl ChunkRenderCacheArtifact {
     source_type: &SourceType,
     output_path: &str,
     generator: G,
-  ) -> Result<(BoxSource, Vec<Diagnostic>)>
+  ) -> Result<(BoxSource, ContentHashDependencies, Vec<Diagnostic>)>
   where
     G: FnOnce() -> F,
-    F: Future<Output = Result<(BoxSource, Vec<Diagnostic>)>>,
+    F: Future<Output = Result<(BoxSource, ContentHashDependencies, Vec<Diagnostic>)>>,
   {
     let Some(storage) = &self.storage else {
       panic!("ChunkRenderCacheArtifact storage is not set");
@@ -65,7 +66,7 @@ impl ChunkRenderCacheArtifact {
     if let Some(entry) = storage.get(&cache_key)
       && entry.filename.as_ref() == output_path
     {
-      return Ok((entry.source, Vec::new()));
+      return Ok((entry.source, entry.content_hash_dependencies, Vec::new()));
     }
 
     let res = generator().await?;
@@ -74,6 +75,7 @@ impl ChunkRenderCacheArtifact {
       ChunkRenderCacheEntry {
         filename: Arc::from(output_path),
         source: res.0.clone(),
+        content_hash_dependencies: res.1.clone(),
       },
     );
     Ok(res)

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -13,8 +13,9 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use serde::Serialize;
 
 use crate::{
-  ArtifactExt, AssetInfo, BindingCell, ChunkInitFragments, ConcatenationScope, ModuleIdentifier,
-  RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, SourceType, incremental::IncrementalPasses,
+  ArtifactExt, AssetInfo, BindingCell, ChunkInitFragments, ConcatenationScope,
+  ContentHashDependencies, ModuleIdentifier, RuntimeGlobals, RuntimeSpec, RuntimeSpecMap,
+  SourceType, incremental::IncrementalPasses,
 };
 
 #[derive(Clone, Debug)]
@@ -123,6 +124,18 @@ impl Deref for CodeGenerationData {
 impl DerefMut for CodeGenerationData {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.inner
+  }
+}
+
+impl CodeGenerationData {
+  pub fn add_content_hash_dependency(&mut self, hash: impl Into<String>) {
+    if let Some(dependencies) = self.get_mut::<ContentHashDependencies>() {
+      dependencies.insert_hash(hash);
+    } else {
+      let mut dependencies = ContentHashDependencies::default();
+      dependencies.insert_hash(hash);
+      self.insert(dependencies);
+    }
   }
 }
 

--- a/crates/rspack_core/src/artifacts/mod.rs
+++ b/crates/rspack_core/src/artifacts/mod.rs
@@ -17,6 +17,7 @@ mod imported_by_defer_modules_artifact;
 mod module_graph_cache_artifact;
 mod module_ids_artifact;
 mod process_runtime_requirements_cache_artifact;
+mod real_content_hash_artifact;
 mod runtime_proxy_metadata_artifact;
 mod side_effects_do_optimize_artifact;
 mod side_effects_state_artifact;
@@ -103,6 +104,7 @@ pub use imported_by_defer_modules_artifact::ImportedByDeferModulesArtifact;
 pub use module_graph_cache_artifact::*;
 pub use module_ids_artifact::ModuleIdsArtifact;
 pub use process_runtime_requirements_cache_artifact::ProcessRuntimeRequirementsCacheArtifact;
+pub use real_content_hash_artifact::*;
 pub use runtime_proxy_metadata_artifact::{
   RuntimeProxyMetadata, RuntimeProxyMetadataArtifact, render_lexical_declarations,
 };

--- a/crates/rspack_core/src/artifacts/real_content_hash_artifact.rs
+++ b/crates/rspack_core/src/artifacts/real_content_hash_artifact.rs
@@ -1,0 +1,208 @@
+use std::{cell::RefCell, future::Future};
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{ChunkUkey, SourceType};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ContentHashDependency {
+  Chunk(ChunkUkey, SourceType),
+  Hash(String),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ContentHashDependencies(FxHashSet<ContentHashDependency>);
+
+impl ContentHashDependencies {
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
+  pub fn insert_chunk(&mut self, chunk: ChunkUkey, source_type: SourceType) {
+    self
+      .0
+      .insert(ContentHashDependency::Chunk(chunk, source_type));
+  }
+
+  pub fn insert_hash(&mut self, hash: impl Into<String>) {
+    self.0.insert(ContentHashDependency::Hash(hash.into()));
+  }
+
+  pub fn extend(&mut self, other: &Self) {
+    self.0.extend(other.0.iter().cloned());
+  }
+
+  pub fn iter(&self) -> impl Iterator<Item = &ContentHashDependency> {
+    self.0.iter()
+  }
+}
+
+tokio::task_local! {
+  static CURRENT_CONTENT_HASH_DEPENDENCIES: RefCell<ContentHashDependencies>;
+}
+
+pub async fn collect_content_hash_dependencies<F>(
+  enabled: bool,
+  future: F,
+) -> (F::Output, ContentHashDependencies)
+where
+  F: Future,
+{
+  if !enabled {
+    return (future.await, ContentHashDependencies::default());
+  }
+
+  CURRENT_CONTENT_HASH_DEPENDENCIES
+    .scope(
+      RefCell::new(ContentHashDependencies::default()),
+      async move {
+        let output = future.await;
+        let dependencies = CURRENT_CONTENT_HASH_DEPENDENCIES
+          .with(|dependencies| std::mem::take(&mut *dependencies.borrow_mut()));
+        (output, dependencies)
+      },
+    )
+    .await
+}
+
+pub fn record_chunk_content_hash_dependency(chunk: ChunkUkey, source_type: SourceType) {
+  _ = CURRENT_CONTENT_HASH_DEPENDENCIES
+    .try_with(|dependencies| dependencies.borrow_mut().insert_chunk(chunk, source_type));
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RealContentHashAssetRecord {
+  own_hashes: FxHashSet<String>,
+  dependencies: ContentHashDependencies,
+  chunk_source: Option<(ChunkUkey, SourceType)>,
+}
+
+impl RealContentHashAssetRecord {
+  pub fn own_hashes(&self) -> &FxHashSet<String> {
+    &self.own_hashes
+  }
+
+  pub fn dependencies(&self) -> &ContentHashDependencies {
+    &self.dependencies
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct RealContentHashArtifact {
+  asset_records: FxHashMap<String, RealContentHashAssetRecord>,
+  chunk_hashes: FxHashMap<(ChunkUkey, SourceType), FxHashSet<String>>,
+}
+
+impl RealContentHashArtifact {
+  pub fn clear(&mut self) {
+    self.asset_records.clear();
+    self.chunk_hashes.clear();
+  }
+
+  pub fn record_asset(
+    &mut self,
+    asset: String,
+    chunk: ChunkUkey,
+    source_type: Option<SourceType>,
+    own_hashes: impl IntoIterator<Item = String>,
+    dependencies: ContentHashDependencies,
+  ) {
+    let own_hashes = own_hashes.into_iter().collect::<FxHashSet<_>>();
+    let record = self.asset_records.entry(asset).or_default();
+    record.own_hashes.extend(own_hashes.iter().cloned());
+    record.dependencies.extend(&dependencies);
+    record.chunk_source = source_type.map(|source_type| (chunk, source_type));
+
+    if let Some(source_type) = source_type {
+      self
+        .chunk_hashes
+        .entry((chunk, source_type))
+        .or_default()
+        .extend(own_hashes);
+    }
+  }
+
+  pub fn asset_record(&self, asset: &str) -> Option<&RealContentHashAssetRecord> {
+    self.asset_records.get(asset)
+  }
+
+  pub fn add_asset_content_hash(&mut self, asset: &str, hash: String) {
+    let Some(record) = self.asset_records.get_mut(asset) else {
+      return;
+    };
+    record.own_hashes.insert(hash.clone());
+    if let Some(chunk_source) = record.chunk_source {
+      self
+        .chunk_hashes
+        .entry(chunk_source)
+        .or_default()
+        .insert(hash);
+    }
+  }
+
+  pub fn add_asset_content_hash_dependency(&mut self, asset: &str, hash: String) {
+    if let Some(record) = self.asset_records.get_mut(asset) {
+      record.dependencies.insert_hash(hash);
+    }
+  }
+
+  pub fn chunk_hashes(
+    &self,
+    chunk: ChunkUkey,
+    source_type: SourceType,
+  ) -> Option<&FxHashSet<String>> {
+    self.chunk_hashes.get(&(chunk, source_type))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn collects_dependencies_only_inside_enabled_scope() {
+    record_chunk_content_hash_dependency(ChunkUkey::new(), SourceType::JavaScript);
+
+    let (_, disabled) = collect_content_hash_dependencies(false, async {
+      record_chunk_content_hash_dependency(ChunkUkey::new(), SourceType::JavaScript);
+    })
+    .await;
+    assert!(disabled.is_empty());
+
+    let chunk = ChunkUkey::new();
+    let (_, enabled) = collect_content_hash_dependencies(true, async {
+      record_chunk_content_hash_dependency(chunk, SourceType::JavaScript);
+      record_chunk_content_hash_dependency(chunk, SourceType::JavaScript);
+    })
+    .await;
+    assert_eq!(enabled.iter().count(), 1);
+  }
+
+  #[test]
+  fn extends_asset_records_after_chunk_rendering() {
+    let chunk = ChunkUkey::new();
+    let mut artifact = RealContentHashArtifact::default();
+    artifact.record_asset(
+      "main.js".to_string(),
+      chunk,
+      Some(SourceType::JavaScript),
+      ["content-hash".to_string()],
+      ContentHashDependencies::default(),
+    );
+
+    artifact.add_asset_content_hash("main.js", "integrity-hash".to_string());
+    artifact.add_asset_content_hash_dependency("main.js", "referenced-integrity".to_string());
+
+    let record = artifact.asset_record("main.js").expect("recorded asset");
+    assert!(record.own_hashes().contains("integrity-hash"));
+    assert!(record.dependencies().iter().any(
+      |dependency| matches!(dependency, ContentHashDependency::Hash(hash) if hash == "referenced-integrity")
+    ));
+    assert!(
+      artifact
+        .chunk_hashes(chunk, SourceType::JavaScript)
+        .expect("recorded chunk source")
+        .contains("integrity-hash")
+    );
+  }
+}

--- a/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
@@ -32,6 +32,10 @@ pub async fn create_chunk_assets(
   compilation: &mut Compilation,
   plugin_driver: SharedPluginDriver,
 ) -> Result<()> {
+  if compilation.options.optimization.real_content_hash {
+    compilation.real_content_hash_artifact.clear();
+  }
+
   if (compilation.options.output.filename.has_hash_placeholder()
     || compilation
       .options
@@ -163,23 +167,38 @@ pub async fn create_chunk_assets(
     compilation.extend_diagnostics(diagnostics);
 
     for file_manifest in manifests {
-      let filename = file_manifest.filename;
+      let RenderManifestEntry {
+        source,
+        filename,
+        source_type,
+        info,
+        auxiliary,
+        content_hash_dependencies,
+        ..
+      } = file_manifest;
       let current_chunk = compilation
         .build_chunk_graph_artifact
         .chunk_by_ukey
         .expect_get_mut(&chunk_ukey);
 
       current_chunk.set_rendered(true);
-      if file_manifest.auxiliary {
+      if auxiliary {
         current_chunk.add_auxiliary_file(filename.clone());
       } else {
         current_chunk.add_file(filename.clone());
       }
 
-      compilation.emit_asset(
-        filename.clone(),
-        CompilationAsset::new(Some(file_manifest.source), file_manifest.info),
-      );
+      if compilation.options.optimization.real_content_hash {
+        compilation.real_content_hash_artifact.record_asset(
+          filename.clone(),
+          chunk_ukey,
+          source_type,
+          info.content_hash.iter().cloned(),
+          content_hash_dependencies,
+        );
+      }
+
+      compilation.emit_asset(filename.clone(), CompilationAsset::new(Some(source), info));
 
       _ = chunk_asset(compilation, chunk_ukey, &filename, plugin_driver.clone()).await;
     }

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -4,7 +4,8 @@ use rustc_hash::FxHashSet;
 
 use super::*;
 use crate::{
-  ModuleCodeGenerationContext, cache::Cache, compilation::pass::PassExt, logger::Logger,
+  ModuleCodeGenerationContext, cache::Cache, collect_content_hash_dependencies,
+  compilation::pass::PassExt, logger::Logger,
 };
 
 pub struct ChunkHashResult {
@@ -496,13 +497,20 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
               concatenation_scope: None,
               runtime_template: &mut runtime_template,
             };
-            let result = runtime_module
-              .code_generation(&mut code_generation_context)
-              .await?;
+            let (result, content_hash_dependencies) = collect_content_hash_dependencies(
+              compilation.options.optimization.real_content_hash,
+              runtime_module.code_generation(&mut code_generation_context),
+            )
+            .await;
+            let result = result?;
             let source = result
               .get(&SourceType::Runtime)
               .expect("should have source");
-            Ok((*runtime_module_identifier, source.clone()))
+            Ok((
+              *runtime_module_identifier,
+              source.clone(),
+              content_hash_dependencies,
+            ))
           },
         )
       })
@@ -513,12 +521,17 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
   .collect::<Result<Vec<_>>>()?;
 
   let mut runtime_module_sources = IdentifierMap::<BoxSource>::default();
+  let mut runtime_module_dependencies = IdentifierMap::default();
   for result in results {
-    let (runtime_module_identifier, source) = result?;
+    let (runtime_module_identifier, source, dependencies) = result?;
     runtime_module_sources.insert(runtime_module_identifier, source);
+    if !dependencies.is_empty() {
+      runtime_module_dependencies.insert(runtime_module_identifier, dependencies);
+    }
   }
 
   compilation.runtime_modules_code_generation_source = runtime_module_sources;
+  compilation.runtime_modules_content_hash_dependencies = runtime_module_dependencies;
   compilation
     .code_generated_modules
     .extend(compilation.runtime_modules.keys().copied());

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -77,11 +77,12 @@ use crate::{
   ChunkRenderCacheArtifact, ChunkRenderResult, ChunkUkey, CircularModulesInfo,
   CodeGenerateCacheArtifact, CodeGenerationJob, CodeGenerationResult, CodeGenerationResults,
   CompilationLogger, CompilationLogging, CompilerOptions, CompilerPlatform, ConcatenationScope,
-  DependenciesDiagnosticsArtifact, DependencyId, DependencyTemplate, DependencyTemplateType,
-  DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId,
-  ExportsInfoArtifact, Filename, ImportPhase, ImportVarMap, ImportedByDeferModulesArtifact,
-  ModuleFactory, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact,
-  ModuleStaticCache, PathData, ProcessRuntimeRequirementsCacheArtifact, ReferencedExport,
+  ContentHashDependencies, DependenciesDiagnosticsArtifact, DependencyId, DependencyTemplate,
+  DependencyTemplateType, DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint,
+  ExecuteModuleId, ExportsInfoArtifact, Filename, ImportPhase, ImportVarMap,
+  ImportedByDeferModulesArtifact, ModuleFactory, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, ModuleIdsArtifact, ModuleStaticCache, PathData,
+  ProcessRuntimeRequirementsCacheArtifact, RealContentHashArtifact, ReferencedExport,
   ResolverFactory, RuntimeGlobals, RuntimeKeyMap, RuntimeMode, RuntimeModule,
   RuntimeProxyMetadataArtifact, RuntimeSpec, RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver,
   SideEffectsOptimizeArtifact, SideEffectsStateArtifact, SourceType, Stats, StatsContext,
@@ -95,7 +96,7 @@ use crate::{
   compiler::{CompilationRecords, CompilerId},
   get_runtime_key,
   incremental::{self, Incremental, IncrementalPasses, Mutation},
-  is_source_equal, to_identifier,
+  is_source_equal, record_chunk_content_hash_dependency, to_identifier,
 };
 
 define_hook!(CompilationAddEntry: Series(entry_name: Option<&str>, options: &mut EntryOptions));
@@ -229,6 +230,7 @@ pub struct Compilation {
   pub runtime_modules: IdentifierMap<Box<dyn RuntimeModule>>,
   pub runtime_modules_hash: IdentifierMap<RspackHashDigest>,
   pub runtime_modules_code_generation_source: IdentifierMap<BoxSource>,
+  pub runtime_modules_content_hash_dependencies: IdentifierMap<ContentHashDependencies>,
   assets: CompilationAssets,
   assets_related_in: HashMap<String, HashSet<String>>,
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,
@@ -266,6 +268,7 @@ pub struct Compilation {
   pub chunk_hashes_artifact: StealCell<ChunkHashesArtifact>,
   // artifact for create_chunk_assets
   pub chunk_render_artifact: StealCell<ChunkRenderArtifact>,
+  pub real_content_hash_artifact: RealContentHashArtifact,
   // artifact for caching get_mode
   pub module_graph_cache_artifact: StealCell<ModuleGraphCacheArtifact>,
   // transient cache for module static info
@@ -375,6 +378,7 @@ impl Compilation {
       runtime_modules: Default::default(),
       runtime_modules_hash: Default::default(),
       runtime_modules_code_generation_source: Default::default(),
+      runtime_modules_content_hash_dependencies: Default::default(),
       entries: Default::default(),
       global_entry: Default::default(),
       assets: Default::default(),
@@ -402,6 +406,7 @@ impl Compilation {
       runtime_proxy_metadata_artifact: StealCell::new(Default::default()),
       chunk_hashes_artifact: StealCell::new(Default::default()),
       chunk_render_artifact: StealCell::new(Default::default()),
+      real_content_hash_artifact: Default::default(),
       module_graph_cache_artifact: StealCell::new(Default::default()),
       module_static_cache: Default::default(),
       code_generated_modules: Default::default(),
@@ -904,20 +909,42 @@ impl Compilation {
   // repeated full traversals of chunk_by_ukey. This method uses parallel iteration
   // over chunk_by_ukey to reduce traversal frequency and improve performance.
   pub fn par_rename_assets(&mut self, renames: Vec<(String, String)>) {
+    let rename_map = renames
+      .iter()
+      .map(|(old_name, new_name)| (old_name.as_str(), new_name.as_str()))
+      .collect::<HashMap<_, _>>();
     self
       .build_chunk_graph_artifact
       .chunk_by_ukey
       .values_mut()
       .par_bridge()
       .for_each(|chunk| {
-        for (old_name, new_name) in renames.iter() {
-          if chunk.remove_file(old_name) {
-            chunk.add_file(new_name.clone());
-          }
+        let renamed_files = chunk
+          .files()
+          .iter()
+          .filter_map(|old_name| {
+            rename_map
+              .get(old_name.as_str())
+              .map(|new_name| (old_name.clone(), (*new_name).to_string()))
+          })
+          .collect::<Vec<_>>();
+        for (old_name, new_name) in renamed_files {
+          chunk.remove_file(&old_name);
+          chunk.add_file(new_name);
+        }
 
-          if chunk.remove_auxiliary_file(old_name) {
-            chunk.add_auxiliary_file(new_name.clone());
-          }
+        let renamed_auxiliary_files = chunk
+          .auxiliary_files()
+          .iter()
+          .filter_map(|old_name| {
+            rename_map
+              .get(old_name.as_str())
+              .map(|new_name| (old_name.clone(), (*new_name).to_string()))
+          })
+          .collect::<Vec<_>>();
+        for (old_name, new_name) in renamed_auxiliary_files {
+          chunk.remove_auxiliary_file(&old_name);
+          chunk.add_auxiliary_file(new_name);
         }
       });
 
@@ -1189,6 +1216,71 @@ impl Compilation {
       .hash
       .as_ref()
       .map(|hash| hash.rendered(self.options.output.hash_digest_length))
+  }
+
+  pub fn get_chunk_content_hash_by_source_type<'a>(
+    &'a self,
+    chunk: &Chunk,
+    source_type: &SourceType,
+  ) -> Option<&'a RspackHashDigest> {
+    let hash = chunk.content_hash_by_source_type(&self.chunk_hashes_artifact, source_type);
+    if self.options.optimization.real_content_hash && hash.is_some() {
+      record_chunk_content_hash_dependency(chunk.ukey(), *source_type);
+    }
+    hash
+  }
+
+  pub fn get_rendered_chunk_content_hash<'a>(
+    &'a self,
+    chunk: &Chunk,
+    source_type: &SourceType,
+    len: usize,
+  ) -> Option<&'a str> {
+    self
+      .get_chunk_content_hash_by_source_type(chunk, source_type)
+      .map(|hash| hash.rendered(len))
+  }
+
+  pub fn get_chunk_content_hash_dependencies(
+    &self,
+    chunk_ukey: &ChunkUkey,
+  ) -> ContentHashDependencies {
+    let mut dependencies = ContentHashDependencies::default();
+    let chunk = self
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get(chunk_ukey);
+    let module_graph = self.get_module_graph();
+
+    for module in self
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_modules(chunk_ukey, module_graph)
+    {
+      if let Some(module_dependencies) = self
+        .code_generation_results
+        .get(&module.identifier(), Some(chunk.runtime()))
+        .data
+        .get::<ContentHashDependencies>()
+      {
+        dependencies.extend(module_dependencies);
+      }
+    }
+
+    for runtime_module in self
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_runtime_modules_iterable(chunk_ukey)
+    {
+      if let Some(runtime_dependencies) = self
+        .runtime_modules_content_hash_dependencies
+        .get(runtime_module)
+      {
+        dependencies.extend(runtime_dependencies);
+      }
+    }
+
+    dependencies
   }
 
   pub async fn get_path<'b, 'a: 'b>(
@@ -1525,8 +1617,10 @@ pub struct RenderManifestEntry {
   pub source: BoxSource,
   pub filename: String,
   pub has_filename: bool, /* webpack only asset has filename, js/css/wasm has filename template */
+  pub source_type: Option<SourceType>,
   pub info: AssetInfo,
   pub auxiliary: bool,
+  pub content_hash_dependencies: ContentHashDependencies,
 }
 
 #[cacheable]

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -562,6 +562,11 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         } else if parsed_asset_config.is_resource() {
           let contenthash = self.hash_for_source(source, &compilation.options);
           let contenthash = contenthash.rendered(compilation.options.output.hash_digest_length);
+          if compilation.options.optimization.real_content_hash {
+            generate_context
+              .data
+              .add_content_hash_dependency(contenthash);
+          }
 
           let source_file_name = self.get_source_file_name(normal_module, compilation);
           let (original_filename, filename, mut asset_info) = self
@@ -856,8 +861,10 @@ async fn render_manifest(
           source: source.clone(),
           filename: asset_filename.to_owned(),
           has_filename: true,
+          source_type: None,
           info: asset_info,
           auxiliary: true,
+          content_hash_dependencies: Default::default(),
         }
       });
 

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -585,8 +585,8 @@ async fn render_manifest(
           compilation.options.output.hash_digest_length,
         ))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::Css,
           compilation.options.output.hash_digest_length,
         ))
@@ -595,7 +595,7 @@ async fn render_manifest(
     )
     .await?;
 
-  let (source, more_diagnostics) = compilation
+  let (source, mut content_hash_dependencies, more_diagnostics) = compilation
     .chunk_render_cache_artifact
     .use_cache(
       compilation,
@@ -603,28 +603,37 @@ async fn render_manifest(
       &SourceType::Css,
       &output_path,
       || async {
-        let (source, diagnostics) = self
-          .render_chunk(
+        let (result, dependencies) = rspack_core::collect_content_hash_dependencies(
+          compilation.options.optimization.real_content_hash,
+          self.render_chunk(
             compilation,
             module_graph,
             chunk,
             &output_path,
             css_import_modules,
             css_modules,
-          )
-          .await?;
-        Ok((CachedSource::new(source).boxed(), diagnostics))
+          ),
+        )
+        .await;
+        let (source, diagnostics) = result?;
+        Ok((CachedSource::new(source).boxed(), dependencies, diagnostics))
       },
     )
     .await?;
+
+  if compilation.options.optimization.real_content_hash {
+    content_hash_dependencies.extend(&compilation.get_chunk_content_hash_dependencies(chunk_ukey));
+  }
 
   diagnostics.extend(more_diagnostics);
   manifest.push(RenderManifestEntry {
     source: source.boxed(),
     filename: output_path,
     has_filename: false,
+    source_type: Some(SourceType::Css),
     info: asset_info,
     auxiliary: false,
+    content_hash_dependencies,
   });
   Ok(())
 }

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -93,8 +93,8 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
                 compilation.options.output.hash_digest_length,
               ))
               .chunk_name_optional(chunk.name_for_filename_template())
-              .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-                &compilation.chunk_hashes_artifact,
+              .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+                chunk,
                 &SourceType::JavaScript,
                 compilation.options.output.hash_digest_length,
               )),

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -180,8 +180,8 @@ impl EsmLibraryPlugin {
           ))
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_name_optional(chunk.name_for_filename_template())
-          .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-            &compilation.chunk_hashes_artifact,
+          .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+            chunk,
             &SourceType::JavaScript,
             compilation.options.output.hash_digest_length,
           ))

--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -686,8 +686,8 @@ async fn render_manifest(
           compilation.options.output.hash_digest_length,
         ))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SOURCE_TYPE[0],
           compilation.options.output.hash_digest_length,
         )),
@@ -695,23 +695,32 @@ async fn render_manifest(
     )
     .await?;
 
-  let (source, more_diagnostics) = compilation
+  let (source, mut content_hash_dependencies, more_diagnostics) = compilation
     .chunk_render_cache_artifact
     .use_cache(compilation, chunk, &SOURCE_TYPE[0], &filename, || async {
-      let (source, diagnostics) = self
-        .render_content_asset(chunk, &rendered_modules, &filename, compilation)
-        .await;
-      Ok((CachedSource::new(source).boxed(), diagnostics))
+      let (result, dependencies) = rspack_core::collect_content_hash_dependencies(
+        compilation.options.optimization.real_content_hash,
+        self.render_content_asset(chunk, &rendered_modules, &filename, compilation),
+      )
+      .await;
+      let (source, diagnostics) = result;
+      Ok((CachedSource::new(source).boxed(), dependencies, diagnostics))
     })
     .await?;
+
+  if compilation.options.optimization.real_content_hash {
+    content_hash_dependencies.extend(&compilation.get_chunk_content_hash_dependencies(chunk_ukey));
+  }
 
   diagnostics.extend(more_diagnostics);
   manifest.push(RenderManifestEntry {
     source,
     filename,
     has_filename: false,
+    source_type: Some(SOURCE_TYPE[0]),
     info: asset_info,
     auxiliary: false,
+    content_hash_dependencies,
   });
 
   Ok(())

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -602,8 +602,8 @@ async fn render_manifest(
         ))
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::JavaScript,
           compilation.options.output.hash_digest_length,
         ))
@@ -615,7 +615,7 @@ async fn render_manifest(
   let hooks = JsPlugin::get_compilation_hooks(compilation.id());
   let hooks = hooks.read().await;
 
-  let (source, _) = compilation
+  let (source, mut content_hash_dependencies, _) = compilation
     .chunk_render_cache_artifact
     .use_cache(
       compilation,
@@ -623,36 +623,48 @@ async fn render_manifest(
       &SourceType::JavaScript,
       &output_path,
       || async {
-        let source = if let Some(source) = hooks
-          .render_chunk_content
-          .call(compilation, chunk_ukey, &mut asset_info, &runtime_template)
-          .await?
-        {
-          source.source
-        } else if is_hot_update {
-          self
-            .render_chunk(compilation, chunk_ukey, &output_path, &runtime_template)
-            .await?
-        } else if is_runtime_chunk {
-          self
-            .render_main(compilation, chunk_ukey, &output_path, &runtime_template)
-            .await?
-        } else {
-          self
-            .render_chunk(compilation, chunk_ukey, &output_path, &runtime_template)
-            .await?
-        };
-        Ok((CachedSource::new(source).boxed(), Vec::new()))
+        let (source, dependencies) = rspack_core::collect_content_hash_dependencies(
+          compilation.options.optimization.real_content_hash,
+          async {
+            if let Some(source) = hooks
+              .render_chunk_content
+              .call(compilation, chunk_ukey, &mut asset_info, &runtime_template)
+              .await?
+            {
+              Ok(source.source)
+            } else if is_hot_update {
+              self
+                .render_chunk(compilation, chunk_ukey, &output_path, &runtime_template)
+                .await
+            } else if is_runtime_chunk {
+              self
+                .render_main(compilation, chunk_ukey, &output_path, &runtime_template)
+                .await
+            } else {
+              self
+                .render_chunk(compilation, chunk_ukey, &output_path, &runtime_template)
+                .await
+            }
+          },
+        )
+        .await;
+        Ok((CachedSource::new(source?).boxed(), dependencies, Vec::new()))
       },
     )
     .await?;
+
+  if compilation.options.optimization.real_content_hash {
+    content_hash_dependencies.extend(&compilation.get_chunk_content_hash_dependencies(chunk_ukey));
+  }
 
   manifest.push(RenderManifestEntry {
     source,
     filename: output_path,
     has_filename: false,
+    source_type: Some(SourceType::JavaScript),
     info: asset_info,
     auxiliary: false,
+    content_hash_dependencies,
   });
   Ok(())
 }

--- a/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
@@ -45,8 +45,8 @@ async fn get_chunk_output_path(compilation: &Compilation, chunk_ukey: ChunkUkey)
         ))
         .chunk_id_optional(chunk.id().map(|id| id.as_str()))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::JavaScript,
           compilation.options.output.hash_digest_length,
         ))

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -144,8 +144,8 @@ async fn render(
             compilation.options.output.hash_digest_length,
           ))
           .chunk_name_optional(chunk.name_for_filename_template())
-          .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-            &compilation.chunk_hashes_artifact,
+          .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+            chunk,
             &SourceType::JavaScript,
             compilation.options.output.hash_digest_length,
           )),

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -163,8 +163,8 @@ impl AssignLibraryPlugin {
                 compilation.options.output.hash_digest_length,
               ))
               .chunk_name_optional(chunk.name_for_filename_template())
-              .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-                &compilation.chunk_hashes_artifact,
+              .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+                chunk,
                 &SourceType::JavaScript,
                 compilation.options.output.hash_digest_length,
               )),

--- a/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/jsonp_library_plugin.rs
@@ -93,8 +93,8 @@ async fn render(
           compilation.options.output.hash_digest_length,
         ))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::JavaScript,
           compilation.options.output.hash_digest_length,
         )),

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -386,8 +386,8 @@ async fn replace_keys(v: String, chunk: &Chunk, compilation: &Compilation) -> Re
           compilation.options.output.hash_digest_length,
         ))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::JavaScript,
           compilation.options.output.hash_digest_length,
         )),

--- a/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
@@ -97,8 +97,8 @@ chunkMatcher: function(chunkId) {{
           ))
           .chunk_id_optional(chunk.id().map(|id| id.as_str()))
           .chunk_name_optional(chunk.name_for_filename_template())
-          .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-            &compilation.chunk_hashes_artifact,
+          .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+            chunk,
             &SourceType::JavaScript,
             compilation.options.output.hash_digest_length,
           ))

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -14,7 +14,6 @@ derive_more     = { workspace = true, features = ["debug"] }
 indexmap        = { workspace = true }
 once_cell       = { workspace = true }
 rayon           = { workspace = true }
-regex           = { workspace = true }
 rspack_core     = { workspace = true }
 rspack_error    = { workspace = true }
 rspack_hash     = { workspace = true }

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -11,10 +11,10 @@ use derive_more::Debug;
 pub use drive::*;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
-use regex::Regex;
 use rspack_core::{
-  AssetInfo, BindingCell, Compilation, CompilationId, CompilationProcessAssets, Logger, Plugin,
-  rspack_sources::{BoxSource, RawStringSource, SourceExt, SourceValue},
+  AssetInfo, Compilation, CompilationId, CompilationProcessAssets, ContentHashDependency, Logger,
+  Plugin, RealContentHashArtifact,
+  rspack_sources::{BoxSource, ReplaceSource, SourceExt, SourceValue},
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_hash::RspackHasher;
@@ -23,9 +23,6 @@ use rspack_util::fx_hash::FxDashMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 type IndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
-
-pub static QUOTE_META: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"[-\[\]\\/{}()*+?.^$|]").expect("Invalid regex"));
 
 /// Safety with [atomic_refcell::AtomicRefCell]:
 ///
@@ -103,16 +100,16 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   // use LeftmostLongest here:
   // e.g. 4afc|4afcbe match xxx.4afcbe-4afc.js -> xxx.[4afc]be-[4afc].js
   //      4afcbe|4afc match xxx.4afcbe-4afc.js -> xxx.[4afcbe]-[4afc].js
-  // force the DFA: hex hash patterns defeat the literal prefilters, leaving
-  // the default automaton scanning with the slower contiguous NFA. Total
-  // pattern bytes bound the DFA size; beyond the cap fall back to the default
-  // automaton so pathological hash counts don't pay the DFA build cost
   const DFA_PATTERN_BYTES_CAP: usize = 128 * 1024;
   let total_pattern_bytes: usize = hash_to_asset_names.keys().map(|s| s.len()).sum();
+  let hash_patterns = hash_to_asset_names
+    .keys()
+    .map(|hash| (*hash).to_string())
+    .collect::<Vec<_>>();
   let hash_ac = AhoCorasick::builder()
     .match_kind(MatchKind::LeftmostLongest)
     .kind((total_pattern_bytes <= DFA_PATTERN_BYTES_CAP).then_some(AhoCorasickKind::DFA))
-    .build(hash_to_asset_names.keys().map(|s| s.as_bytes()))
+    .build(hash_patterns.iter().map(|s| s.as_bytes()))
     .expect("Invalid patterns");
   logger.time_end(start);
 
@@ -122,9 +119,21 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
     .par_iter()
     .filter_map(|(name, asset)| {
       asset.get_source().map(|source| {
+        let recorded_dependencies = get_recorded_dependencies(
+          name,
+          asset.get_info(),
+          &compilation.real_content_hash_artifact,
+          &hash_to_asset_names,
+        );
         (
           name.as_str(),
-          AssetData::new(source.clone(), asset.get_info(), &hash_ac),
+          AssetData::new(
+            source.clone(),
+            asset.get_info(),
+            recorded_dependencies,
+            &hash_ac,
+            &hash_patterns,
+          ),
         )
       })
     })
@@ -180,8 +189,12 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
     let batch_sources = batch_source_tasks
       .into_par_iter()
       .map(|(hash, name, data)| {
-        let new_source =
-          data.compute_new_source(data.own_hashes.contains(hash), &hash_to_new_hash, &hash_ac);
+        let new_source = data.compute_new_source(
+          data.own_hashes.contains(hash),
+          &hash_to_new_hash,
+          &hash_ac,
+          &hash_patterns,
+        );
         ((hash, name), new_source)
       })
       .collect::<HashMap<_, _>>();
@@ -248,16 +261,20 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   let updates: Vec<_> = assets_data
     .into_par_iter()
     .filter_map(|(name, data)| {
-      let new_source = data.compute_new_source(false, &hash_to_new_hash, &hash_ac);
-      let mut new_name = String::with_capacity(name.len());
-      hash_ac.replace_all_with(name, &mut new_name, |_, hash, dst| {
-        let replace_to = hash_to_new_hash
-          .get(hash)
-          .expect("RealContentHashPlugin: should have new hash");
-        dst.push_str(replace_to);
-        true
-      });
-      let new_name = (name != new_name).then_some(new_name);
+      let new_source = data.compute_new_source(false, &hash_to_new_hash, &hash_ac, &hash_patterns);
+      let new_name = if data.has_recorded_dependencies {
+        replace_asset_name(name, &data.own_hashes, &hash_to_new_hash)
+      } else {
+        let mut new_name = String::with_capacity(name.len());
+        hash_ac.replace_all_with(name, &mut new_name, |_, hash, dst| {
+          let replace_to = hash_to_new_hash
+            .get(hash)
+            .expect("RealContentHashPlugin: should have new hash");
+          dst.push_str(replace_to);
+          true
+        });
+        (name != new_name).then_some(new_name)
+      };
       Some((name.to_owned(), new_source, new_name))
     })
     .collect();
@@ -266,23 +283,23 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   let start = logger.time("update assets");
   let mut asset_renames = Vec::with_capacity(updates.len());
   for (name, new_source, new_name) in updates {
-    compilation.update_asset(&name, |_, old_info| {
-      let new_hashes: HashSet<_> = old_info
-        .content_hash
-        .iter()
-        .map(|old_hash| {
-          hash_to_new_hash
-            .get(old_hash.as_str())
-            .expect("should have new hash")
-            .to_owned()
-        })
-        .collect();
-      let info_update = (*old_info).clone();
-      Ok((
-        new_source.clone(),
-        BindingCell::from(info_update.with_content_hashes(new_hashes)),
-      ))
-    })?;
+    let asset = compilation
+      .assets_mut()
+      .get_mut(&name)
+      .expect("RealContentHashPlugin: asset should exist");
+    asset.set_source(Some(new_source));
+    let new_hashes = asset
+      .get_info()
+      .content_hash
+      .iter()
+      .map(|old_hash| {
+        hash_to_new_hash
+          .get(old_hash.as_str())
+          .expect("should have new hash")
+          .to_owned()
+      })
+      .collect();
+    asset.get_info_mut().content_hash = new_hashes;
     if let Some(new_name) = new_name {
       asset_renames.push((name, new_name));
     }
@@ -295,49 +312,171 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
+fn get_recorded_dependencies(
+  name: &str,
+  info: &AssetInfo,
+  artifact: &RealContentHashArtifact,
+  hash_to_asset_names: &HashMap<&str, Vec<&str>>,
+) -> Option<RecordedContentHashDependencies> {
+  let record = artifact.asset_record(name)?;
+  if record.own_hashes() != &info.content_hash {
+    return None;
+  }
+
+  let mut dependencies = HashSet::default();
+  let mut may_contain_own_hash = info.related.source_map.is_some();
+  for dependency in record.dependencies().iter() {
+    match dependency {
+      ContentHashDependency::Chunk(chunk, source_type) => {
+        if let Some(hashes) = artifact.chunk_hashes(*chunk, *source_type) {
+          for hash in hashes {
+            if info.content_hash.contains(hash) {
+              may_contain_own_hash = true;
+            } else if hash_to_asset_names.contains_key(hash.as_str()) {
+              dependencies.insert(hash.clone());
+            }
+          }
+        }
+      }
+      ContentHashDependency::Hash(hash) => {
+        if info.content_hash.contains(hash) {
+          may_contain_own_hash = true;
+        } else if hash_to_asset_names.contains_key(hash.as_str()) {
+          dependencies.insert(hash.clone());
+        }
+      }
+    }
+  }
+  Some(RecordedContentHashDependencies {
+    referenced_hashes: dependencies,
+    may_contain_own_hash,
+  })
+}
+
+struct RecordedContentHashDependencies {
+  referenced_hashes: HashSet<String>,
+  may_contain_own_hash: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ContentHashMatch {
+  start: u32,
+  end: u32,
+  pattern: usize,
+}
+
+fn replace_asset_name(
+  name: &str,
+  own_hashes: &HashSet<String>,
+  hash_to_new_hash: &HashMap<String, String>,
+) -> Option<String> {
+  let mut matches = own_hashes
+    .iter()
+    .flat_map(|hash| {
+      name
+        .match_indices(hash)
+        .map(move |(start, matched)| (start, start + matched.len(), hash))
+    })
+    .collect::<Vec<_>>();
+  if matches.is_empty() {
+    return None;
+  }
+  matches.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| b.1.cmp(&a.1)));
+
+  let mut output = String::with_capacity(name.len());
+  let mut last = 0;
+  for (start, end, hash) in matches {
+    if start < last {
+      continue;
+    }
+    output.push_str(&name[last..start]);
+    output.push_str(
+      hash_to_new_hash
+        .get(hash)
+        .expect("RealContentHashPlugin: should have new hash"),
+    );
+    last = end;
+  }
+  output.push_str(&name[last..]);
+  (name != output).then_some(output)
+}
+
+fn find_content_hash_matches(source: &BoxSource, hash_ac: &AhoCorasick) -> Vec<ContentHashMatch> {
+  let SourceValue::String(content) = source.source() else {
+    return Vec::new();
+  };
+  hash_ac
+    .find_iter(content.as_ref())
+    .map(|matched| ContentHashMatch {
+      start: matched
+        .start()
+        .try_into()
+        .expect("source size should fit in u32"),
+      end: matched
+        .end()
+        .try_into()
+        .expect("source size should fit in u32"),
+      pattern: matched.pattern().as_usize(),
+    })
+    .collect()
+}
+
 #[derive(Debug)]
 struct AssetData {
   own_hashes: HashSet<String>,
   referenced_hashes: HashSet<String>,
+  may_contain_own_hash: bool,
+  has_recorded_dependencies: bool,
   #[debug(skip)]
   old_source: BoxSource,
   #[debug(skip)]
-  content: AssetDataContent,
+  content_hash_matches: OnceCell<Vec<ContentHashMatch>>,
   #[debug(skip)]
   new_source: OnceCell<BoxSource>,
   #[debug(skip)]
   new_source_without_own: OnceCell<BoxSource>,
 }
 
-#[derive(Debug)]
-enum AssetDataContent {
-  Buffer,
-  String(String),
-}
-
 impl AssetData {
-  pub fn new(source: BoxSource, info: &AssetInfo, hash_ac: &AhoCorasick) -> Self {
-    let mut own_hashes = HashSet::default();
-    let mut referenced_hashes = HashSet::default();
-    let content = if let SourceValue::String(content) = source.source() {
-      for hash in hash_ac.find_iter(content.as_ref()) {
-        let hash = &content[hash.range()];
-        if info.content_hash.contains(hash) {
-          own_hashes.insert(hash.to_string());
-          continue;
-        }
-        referenced_hashes.insert(hash.to_string());
-      }
-      AssetDataContent::String(content.into_owned())
-    } else {
-      AssetDataContent::Buffer
-    };
+  pub fn new(
+    source: BoxSource,
+    info: &AssetInfo,
+    recorded_dependencies: Option<RecordedContentHashDependencies>,
+    hash_ac: &AhoCorasick,
+    hash_patterns: &[String],
+  ) -> Self {
+    let own_hashes = info.content_hash.iter().cloned().collect::<HashSet<_>>();
+    let content_hash_matches = OnceCell::new();
+    let has_recorded_dependencies = recorded_dependencies.is_some();
+    let (referenced_hashes, may_contain_own_hash) =
+      if let Some(recorded_dependencies) = recorded_dependencies {
+        (
+          recorded_dependencies.referenced_hashes,
+          recorded_dependencies.may_contain_own_hash,
+        )
+      } else {
+        let matches = find_content_hash_matches(&source, hash_ac);
+        let may_contain_own_hash = matches
+          .iter()
+          .any(|matched| own_hashes.contains(&hash_patterns[matched.pattern]));
+        let referenced_hashes = matches
+          .iter()
+          .map(|matched| hash_patterns[matched.pattern].clone())
+          .filter(|hash| !own_hashes.contains(hash))
+          .collect();
+        content_hash_matches
+          .set(matches)
+          .expect("content hash matches should only be initialized once");
+        (referenced_hashes, may_contain_own_hash)
+      };
 
     Self {
       own_hashes,
       referenced_hashes,
+      may_contain_own_hash,
+      has_recorded_dependencies,
       old_source: source,
-      content,
+      content_hash_matches,
       new_source: OnceCell::new(),
       new_source_without_own: OnceCell::new(),
     }
@@ -348,6 +487,7 @@ impl AssetData {
     without_own: bool,
     hash_to_new_hash: &HashMap<String, String>,
     hash_ac: &AhoCorasick,
+    hash_patterns: &[String],
   ) -> BoxSource {
     (if without_own {
       &self.new_source_without_own
@@ -355,28 +495,47 @@ impl AssetData {
       &self.new_source
     })
     .get_or_init(|| {
-      if let AssetDataContent::String(content) = &self.content
-        && (!self.own_hashes.is_empty()
+      let own_hash_may_change = self.may_contain_own_hash
+        && (without_own
           || self
-            .referenced_hashes
+            .own_hashes
             .iter()
-            .any(|hash| matches!(hash_to_new_hash.get(hash.as_str()), Some(h) if h != hash)))
-      {
-        let mut new_content = String::with_capacity(content.len());
-        hash_ac.replace_all_with(content, &mut new_content, |_, hash, dst| {
-          let replace_to = if without_own && self.own_hashes.contains(hash) {
-            ""
-          } else {
-            hash_to_new_hash
-              .get(hash)
-              .expect("RealContentHashPlugin: should have new hash")
-          };
-          dst.push_str(replace_to);
-          true
-        });
-        return RawStringSource::from(new_content).boxed();
+            .any(|hash| matches!(hash_to_new_hash.get(hash), Some(new_hash) if new_hash != hash)));
+      let referenced_hash_may_change = self
+        .referenced_hashes
+        .iter()
+        .any(|hash| matches!(hash_to_new_hash.get(hash), Some(new_hash) if new_hash != hash));
+      if !own_hash_may_change && !referenced_hash_may_change {
+        return self.old_source.clone();
       }
-      self.old_source.clone()
+
+      let matches = self
+        .content_hash_matches
+        .get_or_init(|| find_content_hash_matches(&self.old_source, hash_ac));
+      let mut replace_source = ReplaceSource::new(self.old_source.clone());
+      let mut changed = false;
+
+      for matched in matches {
+        let old_hash = &hash_patterns[matched.pattern];
+        let replacement = if without_own && self.own_hashes.contains(old_hash) {
+          Some("")
+        } else {
+          hash_to_new_hash
+            .get(old_hash)
+            .filter(|new_hash| *new_hash != old_hash)
+            .map(String::as_str)
+        };
+        if let Some(replacement) = replacement {
+          replace_source.replace(matched.start, matched.end, replacement.to_string(), None);
+          changed = true;
+        }
+      }
+
+      if changed {
+        replace_source.boxed()
+      } else {
+        self.old_source.clone()
+      }
     })
     .clone()
   }

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -380,8 +380,8 @@ pub async fn get_chunk_output_name(chunk: &Chunk, compilation: &Compilation) -> 
           compilation.options.output.hash_digest_length,
         ))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::JavaScript,
           compilation.options.output.hash_digest_length,
         ))

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -53,8 +53,8 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
             compilation.options.output.hash_digest_length,
           ))
           .chunk_name_optional(chunk.name_for_filename_template())
-          .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-            &compilation.chunk_hashes_artifact,
+          .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+            chunk,
             &SourceType::JavaScript,
             compilation.options.output.hash_digest_length,
           )),

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -260,15 +260,16 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
       );
       let content_hash = stringify_dynamic_chunk_map(
         |c| {
-          c.rendered_content_hash_by_source_type(
-            &compilation.chunk_hashes_artifact,
-            &self.source_type,
-            compilation.options.output.hash_digest_length,
-          )
-          .map(|hash| match hash_len_map.get("[contenthash]") {
-            Some(hash_len) => hash[..*hash_len].to_string(),
-            None => hash.to_string(),
-          })
+          compilation
+            .get_rendered_chunk_content_hash(
+              c,
+              &self.source_type,
+              compilation.options.output.hash_digest_length,
+            )
+            .map(|hash| match hash_len_map.get("[contenthash]") {
+              Some(hash_len) => hash[..*hash_len].to_string(),
+              None => hash.to_string(),
+            })
         },
         &chunks,
         &chunk_map,
@@ -343,9 +344,8 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
               None => hash,
             }
           });
-        let content_hash = chunk
-          .content_hash(&compilation.chunk_hashes_artifact)
-          .and_then(|content_hash| content_hash.get(&self.source_type))
+        let content_hash = compilation
+          .get_chunk_content_hash_by_source_type(chunk, &self.source_type)
           .map(|i| {
             let hash = unquoted_stringify(
               chunk.id(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -66,8 +66,8 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
               compilation.options.output.hash_digest_length,
             ))
             .chunk_name_optional(chunk.name_for_filename_template())
-            .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-              &compilation.chunk_hashes_artifact,
+            .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+              chunk,
               &SourceType::JavaScript,
               compilation.options.output.hash_digest_length,
             ))

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -67,8 +67,8 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
               compilation.options.output.hash_digest_length,
             ))
             .chunk_name_optional(chunk.name_for_filename_template())
-            .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-              &compilation.chunk_hashes_artifact,
+            .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+              chunk,
               &SourceType::JavaScript,
               compilation.options.output.hash_digest_length,
             ))

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -106,8 +106,8 @@ pub async fn get_output_dir(
           compilation.options.output.hash_digest_length,
         ))
         .chunk_name_optional(chunk.name_for_filename_template())
-        .content_hash_optional(chunk.rendered_content_hash_by_source_type(
-          &compilation.chunk_hashes_artifact,
+        .content_hash_optional(compilation.get_rendered_chunk_content_hash(
+          chunk,
           &SourceType::JavaScript,
           compilation.options.output.hash_digest_length,
         )),

--- a/crates/rspack_plugin_sri/src/asset.rs
+++ b/crates/rspack_plugin_sri/src/asset.rs
@@ -27,6 +27,7 @@ struct ProcessChunkResult {
   pub warnings: Vec<String>,
   pub placeholder: Option<String>,
   pub integrity: Option<String>,
+  pub content_hash_dependencies: Vec<String>,
 }
 
 fn process_chunks(
@@ -96,6 +97,7 @@ See https://w3c.github.io/webappsec-subresource-integrity/#cross-origin-data-lea
             warnings: vec![format!("No asset found for source path '{}'", file)],
             placeholder: None,
             integrity: None,
+            content_hash_dependencies: Vec::new(),
           }
         }
       })
@@ -120,6 +122,16 @@ See https://w3c.github.io/webappsec-subresource-integrity/#cross-origin-data-lea
       }
 
       let real_content_hash = compilation.options.optimization.real_content_hash;
+      if real_content_hash {
+        compilation
+          .real_content_hash_artifact
+          .add_asset_content_hash(&result.file, integrity.clone());
+        for dependency in result.content_hash_dependencies {
+          compilation
+            .real_content_hash_artifact
+            .add_asset_content_hash_dependency(&result.file, dependency);
+        }
+      }
 
       if let Some(source) = result.source
         && let Some(error) = compilation
@@ -165,6 +177,7 @@ fn process_chunk_source(
 ) -> ProcessChunkResult {
   // generate new source
   let mut new_source = ReplaceSource::new(source.clone());
+  let mut content_hash_dependencies = Vec::new();
 
   let mut warnings = vec![];
   let source_content = source.source().into_string_lossy();
@@ -175,10 +188,12 @@ fn process_chunk_source(
   // replace placeholders with integrity hash
   for caps in PLACEHOLDER_REGEX.captures_iter(&source_content) {
     if let Some(m) = caps.get(0) {
-      let replacement = hash_by_placeholders
-        .get(m.as_str())
-        .map_or(m.as_str(), |i| i.as_str())
-        .to_string();
+      let replacement = if let Some(integrity) = hash_by_placeholders.get(m.as_str()) {
+        content_hash_dependencies.push(integrity.clone());
+        integrity.clone()
+      } else {
+        m.as_str().to_string()
+      };
       new_source.replace(m.start() as u32, m.end() as u32, replacement, None);
     }
   }
@@ -193,6 +208,7 @@ fn process_chunk_source(
     warnings,
     placeholder,
     integrity: Some(integrity),
+    content_hash_dependencies,
   }
 }
 

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -79,8 +79,10 @@ async fn render_manifest(
       source: source.clone(),
       filename: output_path,
       has_filename: true,
+      source_type: Some(SourceType::Wasm),
       info: asset_info,
       auxiliary: false,
+      content_hash_dependencies: Default::default(),
     })
   }
 

--- a/tests/rspack-test/configCases/css-extract/with-contenthash/rspack.config.js
+++ b/tests/rspack-test/configCases/css-extract/with-contenthash/rspack.config.js
@@ -9,6 +9,9 @@ module.exports = {
   node: {
     __filename: false,
   },
+  optimization: {
+    realContentHash: true,
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
## Summary

This refactors real content hash processing to record semantic hash dependencies while module, runtime-module, chunk source, and filename data are generated.

The previous implementation inferred the dependency graph by scanning post-processed asset strings. That work was expensive and fragile around minification, source maps, duplicated values, and later source transforms. The new artifact records chunk/source-type and raw-hash dependencies at the point where content hashes are read, caches those dependencies with rendered chunks, and lets `RealContentHashPlugin` build its topology without parsing built-in chunk source.

Final substitutions use `ReplaceSource` so existing source maps are preserved. Untracked custom assets retain the compatibility fallback. Asset modules, JavaScript, CSS, extracted CSS, runtime modules, library output, WebAssembly, Module Federation, and SRI are covered. Dependency collection is gated by `optimization.realContentHash`.

### Performance

Measured locally against `origin/main` with isolated worktrees and identical Criterion parameters:

- `rust@real_content_hash`: 7.663 ms → 5.352 ms (30.2% lower latency, about 43.2% higher throughput)
- `rust@create_chunk_assets` with real content hash disabled: 1.260 ms → 1.251 ms (no measurable regression)

## Related links

- Reworks #14226

## Validation

- `pnpm --filter @rspack/binding run build:dev`
- `pnpm run test:unit` — 8,815 passed, 4 skipped
- Rust workspace tests, compile tests, and doctests
- Focused real-content-hash, asset, source-map, SRI, CSS extract, dynamic CSS, and runtime-mode cases
- `cargo clippy --workspace --all-targets --tests --locked -- -D warnings`
- Affected crates with `--all-targets --all-features --no-deps -- -D warnings`
- Rustfmt, Prettier, Taplo, and staged-file lint checks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).