### PR TITLE
chore: release version 2.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "rspack"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "bitflags 2.11.1",
  "derive_more",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_allocator"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "mimalloc",
  "sftrace-setup",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_benchmark"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_api"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3807,21 +3807,21 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_build"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "napi-build",
 ]
 
 [[package]]
 name = "rspack_binding_builder"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_binding_api",
 ]
 
 [[package]]
 name = "rspack_binding_builder_macros"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_builder_testing"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "napi",
  "napi-derive",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_browserslist"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "browserslist-rs",
  "lightningcss",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "camino",
  "dashmap",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_macros"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_test"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "camino",
  "dashmap",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_collections"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "dashmap",
  "hashlink",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_core"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anymap3",
  "async-recursion",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_error"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anyhow",
  "miette",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_fs"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hash"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "base64-simd 0.8.0",
  "itoa",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hook"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_error",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_ids"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "derive_more",
  "futures",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_javascript_compiler"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_lightningcss"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_preact_refresh"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_react_refresh"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_runner"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_swc"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "either",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_testing"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_location"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "itoa",
  "memchr",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros_test"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "napi",
  "oneshot",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi_macros"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_node"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "napi-derive",
  "rspack_binding_api",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_parallel"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rayon",
  "rspack_tasks",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_paths"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "camino",
  "dashmap",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_asset"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "mime_guess",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_banner"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "futures",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_case_sensitive"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "itertools 0.14.0",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_circular_dependencies"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_copy"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4431,7 +4431,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css_chunking"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "indexmap",
  "rspack_collections",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_devtool"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dll"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dynamic_entry"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "atomic_refcell",
  "derive_more",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ensure_chunk_conditions"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_entry"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_esm_library"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_externals"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "regex",
  "rspack_core",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_extract_css"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_hmr"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_html"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anyhow",
  "atomic_refcell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ignore"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "derive_more",
  "futures",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_javascript"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_json"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lazy_compilation"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_library"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "futures",
  "regex",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lightning_css_minimizer"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "lightningcss",
  "parcel_sourcemap",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_limit_chunk_count"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_merge_duplicate_chunks"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rayon",
  "rspack_core",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_mf"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "camino",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_info_header"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_cacheable",
  "rspack_core",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_replacement"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "derive_more",
  "futures",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_no_emit_on_errors"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_progress"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "futures",
  "indicatif",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_real_content_hash"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "aho-corasick",
  "atomic_refcell",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_duplicate_modules"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rayon",
  "rspack_collections",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_empty_chunks"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsc"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsdoctor"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "atomic_refcell",
  "futures",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rslib"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rstest"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "camino",
  "cow-utils",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime_chunk"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "futures",
  "rspack_core",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_schemes"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_size_limits"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "derive_more",
  "futures",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_split_chunks"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "derive_more",
  "futures",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_sri"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_swc_js_minimizer"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "once_cell",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_wasm"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_worker"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_regex"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "napi",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "memchr",
  "regex",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_storage"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_import"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "heck",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_ts_collector"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "glob",
  "insta",
@@ -5313,14 +5313,14 @@ dependencies = [
 
 [[package]]
 name = "rspack_tasks"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rspack_tools"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "clap",
  "itertools 0.14.0",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "chrono",
  "rspack_tracing_perfetto",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing_perfetto"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "bytes",
  "micromegas-perfetto",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_util"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "anyhow",
  "base64-simd 0.8.0",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_watcher"
-version = "0.101.4"
+version = "0.101.5"
 dependencies = [
  "cow-utils",
  "dashmap",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_workspace"
-version = "0.101.4"
+version = "0.101.5"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition       = "2024"
 homepage      = "https://rspack.rs/"
 license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
-version       = "0.101.4"
+version       = "0.101.5"
 
 [workspace.metadata.dylint]
 libraries = [{ path = "linting/*" }]
@@ -159,92 +159,92 @@ wasmtime      = { version = "36.0.10", default-features = false }
 
 
 # all rspack workspace dependencies
-rspack                                 = { version = "=0.101.4", path = "crates/rspack", default-features = false }
-rspack_allocator                       = { version = "=0.101.4", path = "crates/rspack_allocator", default-features = false }
-rspack_binding_api                     = { version = "=0.101.4", path = "crates/rspack_binding_api", default-features = false }
-rspack_binding_build                   = { version = "=0.101.4", path = "crates/rspack_binding_build", default-features = false }
-rspack_binding_builder                 = { version = "=0.101.4", path = "crates/rspack_binding_builder", default-features = false }
-rspack_binding_builder_macros          = { version = "=0.101.4", path = "crates/rspack_binding_builder_macros", default-features = false }
-rspack_browserslist                    = { version = "=0.101.4", path = "crates/rspack_browserslist", default-features = false }
-rspack_cacheable                       = { version = "=0.101.4", path = "crates/rspack_cacheable", default-features = false }
-rspack_cacheable_macros                = { version = "=0.101.4", path = "crates/rspack_cacheable_macros", default-features = false }
-rspack_collections                     = { version = "=0.101.4", path = "crates/rspack_collections", default-features = false }
-rspack_core                            = { version = "=0.101.4", path = "crates/rspack_core", default-features = false }
-rspack_error                           = { version = "=0.101.4", path = "crates/rspack_error", default-features = false }
-rspack_fs                              = { version = "=0.101.4", path = "crates/rspack_fs", default-features = false }
-rspack_hash                            = { version = "=0.101.4", path = "crates/rspack_hash", default-features = false }
-rspack_hook                            = { version = "=0.101.4", path = "crates/rspack_hook", default-features = false }
-rspack_ids                             = { version = "=0.101.4", path = "crates/rspack_ids", default-features = false }
-rspack_javascript_compiler             = { version = "=0.101.4", path = "crates/rspack_javascript_compiler", default-features = false }
-rspack_loader_lightningcss             = { version = "=0.101.4", path = "crates/rspack_loader_lightningcss", default-features = false }
-rspack_loader_preact_refresh           = { version = "=0.101.4", path = "crates/rspack_loader_preact_refresh", default-features = false }
-rspack_loader_react_refresh            = { version = "=0.101.4", path = "crates/rspack_loader_react_refresh", default-features = false }
-rspack_loader_runner                   = { version = "=0.101.4", path = "crates/rspack_loader_runner", default-features = false }
-rspack_loader_swc                      = { version = "=0.101.4", path = "crates/rspack_loader_swc", default-features = false }
-rspack_loader_testing                  = { version = "=0.101.4", path = "crates/rspack_loader_testing", default-features = false }
-rspack_location                        = { version = "=0.101.4", path = "crates/rspack_location", default-features = false }
-rspack_macros                          = { version = "=0.101.4", path = "crates/rspack_macros", default-features = false }
-rspack_napi                            = { version = "=0.101.4", path = "crates/rspack_napi", default-features = false }
-rspack_napi_macros                     = { version = "=0.101.4", path = "crates/rspack_napi_macros", default-features = false }
-rspack_parallel                        = { version = "=0.101.4", path = "crates/rspack_parallel", default-features = false }
-rspack_paths                           = { version = "=0.101.4", path = "crates/rspack_paths", default-features = false }
-rspack_plugin_asset                    = { version = "=0.101.4", path = "crates/rspack_plugin_asset", default-features = false }
-rspack_plugin_banner                   = { version = "=0.101.4", path = "crates/rspack_plugin_banner", default-features = false }
-rspack_plugin_case_sensitive           = { version = "=0.101.4", path = "crates/rspack_plugin_case_sensitive", default-features = false }
-rspack_plugin_circular_dependencies    = { version = "=0.101.4", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
-rspack_plugin_copy                     = { version = "=0.101.4", path = "crates/rspack_plugin_copy", default-features = false }
-rspack_plugin_css                      = { version = "=0.101.4", path = "crates/rspack_plugin_css", default-features = false }
-rspack_plugin_css_chunking             = { version = "=0.101.4", path = "crates/rspack_plugin_css_chunking", default-features = false }
-rspack_plugin_devtool                  = { version = "=0.101.4", path = "crates/rspack_plugin_devtool", default-features = false }
-rspack_plugin_dll                      = { version = "=0.101.4", path = "crates/rspack_plugin_dll", default-features = false }
-rspack_plugin_dynamic_entry            = { version = "=0.101.4", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
-rspack_plugin_ensure_chunk_conditions  = { version = "=0.101.4", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
-rspack_plugin_entry                    = { version = "=0.101.4", path = "crates/rspack_plugin_entry", default-features = false }
-rspack_plugin_esm_library              = { version = "=0.101.4", path = "crates/rspack_plugin_esm_library", default-features = false }
-rspack_plugin_externals                = { version = "=0.101.4", path = "crates/rspack_plugin_externals", default-features = false }
-rspack_plugin_extract_css              = { version = "=0.101.4", path = "crates/rspack_plugin_extract_css", default-features = false }
-rspack_plugin_hmr                      = { version = "=0.101.4", path = "crates/rspack_plugin_hmr", default-features = false }
-rspack_plugin_html                     = { version = "=0.101.4", path = "crates/rspack_plugin_html", default-features = false }
-rspack_plugin_ignore                   = { version = "=0.101.4", path = "crates/rspack_plugin_ignore", default-features = false }
-rspack_plugin_javascript               = { version = "=0.101.4", path = "crates/rspack_plugin_javascript", default-features = false }
-rspack_plugin_json                     = { version = "=0.101.4", path = "crates/rspack_plugin_json", default-features = false }
-rspack_plugin_lazy_compilation         = { version = "=0.101.4", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
-rspack_plugin_library                  = { version = "=0.101.4", path = "crates/rspack_plugin_library", default-features = false }
-rspack_plugin_lightning_css_minimizer  = { version = "=0.101.4", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
-rspack_plugin_limit_chunk_count        = { version = "=0.101.4", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
-rspack_plugin_merge_duplicate_chunks   = { version = "=0.101.4", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
-rspack_plugin_mf                       = { version = "=0.101.4", path = "crates/rspack_plugin_mf", default-features = false }
-rspack_plugin_module_info_header       = { version = "=0.101.4", path = "crates/rspack_plugin_module_info_header", default-features = false }
-rspack_plugin_module_replacement       = { version = "=0.101.4", path = "crates/rspack_plugin_module_replacement", default-features = false }
-rspack_plugin_no_emit_on_errors        = { version = "=0.101.4", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
-rspack_plugin_progress                 = { version = "=0.101.4", path = "crates/rspack_plugin_progress", default-features = false }
-rspack_plugin_real_content_hash        = { version = "=0.101.4", path = "crates/rspack_plugin_real_content_hash", default-features = false }
-rspack_plugin_remove_duplicate_modules = { version = "=0.101.4", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
-rspack_plugin_remove_empty_chunks      = { version = "=0.101.4", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
-rspack_plugin_rsc                      = { version = "=0.101.4", path = "crates/rspack_plugin_rsc", default-features = false }
-rspack_plugin_rsdoctor                 = { version = "=0.101.4", path = "crates/rspack_plugin_rsdoctor", default-features = false }
-rspack_plugin_rslib                    = { version = "=0.101.4", path = "crates/rspack_plugin_rslib", default-features = false }
-rspack_plugin_rstest                   = { version = "=0.101.4", path = "crates/rspack_plugin_rstest", default-features = false }
-rspack_plugin_runtime                  = { version = "=0.101.4", path = "crates/rspack_plugin_runtime", default-features = false }
-rspack_plugin_runtime_chunk            = { version = "=0.101.4", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
-rspack_plugin_schemes                  = { version = "=0.101.4", path = "crates/rspack_plugin_schemes", default-features = false }
-rspack_plugin_size_limits              = { version = "=0.101.4", path = "crates/rspack_plugin_size_limits", default-features = false }
-rspack_plugin_split_chunks             = { version = "=0.101.4", path = "crates/rspack_plugin_split_chunks", default-features = false }
-rspack_plugin_sri                      = { version = "=0.101.4", path = "crates/rspack_plugin_sri", default-features = false }
-rspack_plugin_swc_js_minimizer         = { version = "=0.101.4", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
-rspack_plugin_wasm                     = { version = "=0.101.4", path = "crates/rspack_plugin_wasm", default-features = false }
-rspack_plugin_worker                   = { version = "=0.101.4", path = "crates/rspack_plugin_worker", default-features = false }
-rspack_regex                           = { version = "=0.101.4", path = "crates/rspack_regex", default-features = false }
-rspack_sources                         = { version = "=0.101.4", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
-rspack_storage                         = { version = "=0.101.4", path = "crates/rspack_storage", default-features = false }
-rspack_swc_plugin_import               = { version = "=0.101.4", path = "crates/swc_plugin_import", default-features = false }
-rspack_swc_plugin_ts_collector         = { version = "=0.101.4", path = "crates/swc_plugin_ts_collector", default-features = false }
-rspack_tasks                           = { version = "=0.101.4", path = "crates/rspack_tasks", default-features = false }
-rspack_tracing                         = { version = "=0.101.4", path = "crates/rspack_tracing", default-features = false }
-rspack_tracing_perfetto                = { version = "=0.101.4", path = "crates/rspack_tracing_perfetto", default-features = false }
-rspack_util                            = { version = "=0.101.4", path = "crates/rspack_util", default-features = false }
-rspack_watcher                         = { version = "=0.101.4", path = "crates/rspack_watcher", default-features = false }
-rspack_workspace                       = { version = "=0.101.4", path = "crates/rspack_workspace", default-features = false }
+rspack                                 = { version = "=0.101.5", path = "crates/rspack", default-features = false }
+rspack_allocator                       = { version = "=0.101.5", path = "crates/rspack_allocator", default-features = false }
+rspack_binding_api                     = { version = "=0.101.5", path = "crates/rspack_binding_api", default-features = false }
+rspack_binding_build                   = { version = "=0.101.5", path = "crates/rspack_binding_build", default-features = false }
+rspack_binding_builder                 = { version = "=0.101.5", path = "crates/rspack_binding_builder", default-features = false }
+rspack_binding_builder_macros          = { version = "=0.101.5", path = "crates/rspack_binding_builder_macros", default-features = false }
+rspack_browserslist                    = { version = "=0.101.5", path = "crates/rspack_browserslist", default-features = false }
+rspack_cacheable                       = { version = "=0.101.5", path = "crates/rspack_cacheable", default-features = false }
+rspack_cacheable_macros                = { version = "=0.101.5", path = "crates/rspack_cacheable_macros", default-features = false }
+rspack_collections                     = { version = "=0.101.5", path = "crates/rspack_collections", default-features = false }
+rspack_core                            = { version = "=0.101.5", path = "crates/rspack_core", default-features = false }
+rspack_error                           = { version = "=0.101.5", path = "crates/rspack_error", default-features = false }
+rspack_fs                              = { version = "=0.101.5", path = "crates/rspack_fs", default-features = false }
+rspack_hash                            = { version = "=0.101.5", path = "crates/rspack_hash", default-features = false }
+rspack_hook                            = { version = "=0.101.5", path = "crates/rspack_hook", default-features = false }
+rspack_ids                             = { version = "=0.101.5", path = "crates/rspack_ids", default-features = false }
+rspack_javascript_compiler             = { version = "=0.101.5", path = "crates/rspack_javascript_compiler", default-features = false }
+rspack_loader_lightningcss             = { version = "=0.101.5", path = "crates/rspack_loader_lightningcss", default-features = false }
+rspack_loader_preact_refresh           = { version = "=0.101.5", path = "crates/rspack_loader_preact_refresh", default-features = false }
+rspack_loader_react_refresh            = { version = "=0.101.5", path = "crates/rspack_loader_react_refresh", default-features = false }
+rspack_loader_runner                   = { version = "=0.101.5", path = "crates/rspack_loader_runner", default-features = false }
+rspack_loader_swc                      = { version = "=0.101.5", path = "crates/rspack_loader_swc", default-features = false }
+rspack_loader_testing                  = { version = "=0.101.5", path = "crates/rspack_loader_testing", default-features = false }
+rspack_location                        = { version = "=0.101.5", path = "crates/rspack_location", default-features = false }
+rspack_macros                          = { version = "=0.101.5", path = "crates/rspack_macros", default-features = false }
+rspack_napi                            = { version = "=0.101.5", path = "crates/rspack_napi", default-features = false }
+rspack_napi_macros                     = { version = "=0.101.5", path = "crates/rspack_napi_macros", default-features = false }
+rspack_parallel                        = { version = "=0.101.5", path = "crates/rspack_parallel", default-features = false }
+rspack_paths                           = { version = "=0.101.5", path = "crates/rspack_paths", default-features = false }
+rspack_plugin_asset                    = { version = "=0.101.5", path = "crates/rspack_plugin_asset", default-features = false }
+rspack_plugin_banner                   = { version = "=0.101.5", path = "crates/rspack_plugin_banner", default-features = false }
+rspack_plugin_case_sensitive           = { version = "=0.101.5", path = "crates/rspack_plugin_case_sensitive", default-features = false }
+rspack_plugin_circular_dependencies    = { version = "=0.101.5", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
+rspack_plugin_copy                     = { version = "=0.101.5", path = "crates/rspack_plugin_copy", default-features = false }
+rspack_plugin_css                      = { version = "=0.101.5", path = "crates/rspack_plugin_css", default-features = false }
+rspack_plugin_css_chunking             = { version = "=0.101.5", path = "crates/rspack_plugin_css_chunking", default-features = false }
+rspack_plugin_devtool                  = { version = "=0.101.5", path = "crates/rspack_plugin_devtool", default-features = false }
+rspack_plugin_dll                      = { version = "=0.101.5", path = "crates/rspack_plugin_dll", default-features = false }
+rspack_plugin_dynamic_entry            = { version = "=0.101.5", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
+rspack_plugin_ensure_chunk_conditions  = { version = "=0.101.5", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
+rspack_plugin_entry                    = { version = "=0.101.5", path = "crates/rspack_plugin_entry", default-features = false }
+rspack_plugin_esm_library              = { version = "=0.101.5", path = "crates/rspack_plugin_esm_library", default-features = false }
+rspack_plugin_externals                = { version = "=0.101.5", path = "crates/rspack_plugin_externals", default-features = false }
+rspack_plugin_extract_css              = { version = "=0.101.5", path = "crates/rspack_plugin_extract_css", default-features = false }
+rspack_plugin_hmr                      = { version = "=0.101.5", path = "crates/rspack_plugin_hmr", default-features = false }
+rspack_plugin_html                     = { version = "=0.101.5", path = "crates/rspack_plugin_html", default-features = false }
+rspack_plugin_ignore                   = { version = "=0.101.5", path = "crates/rspack_plugin_ignore", default-features = false }
+rspack_plugin_javascript               = { version = "=0.101.5", path = "crates/rspack_plugin_javascript", default-features = false }
+rspack_plugin_json                     = { version = "=0.101.5", path = "crates/rspack_plugin_json", default-features = false }
+rspack_plugin_lazy_compilation         = { version = "=0.101.5", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
+rspack_plugin_library                  = { version = "=0.101.5", path = "crates/rspack_plugin_library", default-features = false }
+rspack_plugin_lightning_css_minimizer  = { version = "=0.101.5", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
+rspack_plugin_limit_chunk_count        = { version = "=0.101.5", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
+rspack_plugin_merge_duplicate_chunks   = { version = "=0.101.5", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
+rspack_plugin_mf                       = { version = "=0.101.5", path = "crates/rspack_plugin_mf", default-features = false }
+rspack_plugin_module_info_header       = { version = "=0.101.5", path = "crates/rspack_plugin_module_info_header", default-features = false }
+rspack_plugin_module_replacement       = { version = "=0.101.5", path = "crates/rspack_plugin_module_replacement", default-features = false }
+rspack_plugin_no_emit_on_errors        = { version = "=0.101.5", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
+rspack_plugin_progress                 = { version = "=0.101.5", path = "crates/rspack_plugin_progress", default-features = false }
+rspack_plugin_real_content_hash        = { version = "=0.101.5", path = "crates/rspack_plugin_real_content_hash", default-features = false }
+rspack_plugin_remove_duplicate_modules = { version = "=0.101.5", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
+rspack_plugin_remove_empty_chunks      = { version = "=0.101.5", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
+rspack_plugin_rsc                      = { version = "=0.101.5", path = "crates/rspack_plugin_rsc", default-features = false }
+rspack_plugin_rsdoctor                 = { version = "=0.101.5", path = "crates/rspack_plugin_rsdoctor", default-features = false }
+rspack_plugin_rslib                    = { version = "=0.101.5", path = "crates/rspack_plugin_rslib", default-features = false }
+rspack_plugin_rstest                   = { version = "=0.101.5", path = "crates/rspack_plugin_rstest", default-features = false }
+rspack_plugin_runtime                  = { version = "=0.101.5", path = "crates/rspack_plugin_runtime", default-features = false }
+rspack_plugin_runtime_chunk            = { version = "=0.101.5", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
+rspack_plugin_schemes                  = { version = "=0.101.5", path = "crates/rspack_plugin_schemes", default-features = false }
+rspack_plugin_size_limits              = { version = "=0.101.5", path = "crates/rspack_plugin_size_limits", default-features = false }
+rspack_plugin_split_chunks             = { version = "=0.101.5", path = "crates/rspack_plugin_split_chunks", default-features = false }
+rspack_plugin_sri                      = { version = "=0.101.5", path = "crates/rspack_plugin_sri", default-features = false }
+rspack_plugin_swc_js_minimizer         = { version = "=0.101.5", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
+rspack_plugin_wasm                     = { version = "=0.101.5", path = "crates/rspack_plugin_wasm", default-features = false }
+rspack_plugin_worker                   = { version = "=0.101.5", path = "crates/rspack_plugin_worker", default-features = false }
+rspack_regex                           = { version = "=0.101.5", path = "crates/rspack_regex", default-features = false }
+rspack_sources                         = { version = "=0.101.5", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
+rspack_storage                         = { version = "=0.101.5", path = "crates/rspack_storage", default-features = false }
+rspack_swc_plugin_import               = { version = "=0.101.5", path = "crates/swc_plugin_import", default-features = false }
+rspack_swc_plugin_ts_collector         = { version = "=0.101.5", path = "crates/swc_plugin_ts_collector", default-features = false }
+rspack_tasks                           = { version = "=0.101.5", path = "crates/rspack_tasks", default-features = false }
+rspack_tracing                         = { version = "=0.101.5", path = "crates/rspack_tracing", default-features = false }
+rspack_tracing_perfetto                = { version = "=0.101.5", path = "crates/rspack_tracing_perfetto", default-features = false }
+rspack_util                            = { version = "=0.101.5", path = "crates/rspack_util", default-features = false }
+rspack_watcher                         = { version = "=0.101.5", path = "crates/rspack_watcher", default-features = false }
+rspack_workspace                       = { version = "=0.101.5", path = "crates/rspack_workspace", default-features = false }
 
 
 [workspace.metadata.release]

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -6,10 +6,10 @@ pub const fn rspack_swc_core_version() -> &'static str {
 
 /// The version of the JavaScript `@rspack/core` package.
 pub const fn rspack_pkg_version() -> &'static str {
-  "2.1.4"
+  "2.1.5"
 }
 
 /// The version of the Rust workspace in the root `Cargo.toml` of the repository.
 pub const fn rspack_workspace_version() -> &'static str {
-  "0.101.4"
+  "0.101.5"
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-gnu",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-gnu.node",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-musl",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-musl.node",

--- a/npm/linux-riscv64-gnu/package.json
+++ b/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-riscv64-gnu",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-riscv64-gnu.node",

--- a/npm/linux-riscv64-musl/package.json
+++ b/npm/linux-riscv64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-riscv64-musl",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-riscv64-musl.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-musl",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-musl.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-arm64-msvc",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-arm64-msvc.node",

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-ia32-msvc",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-ia32-msvc.node",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/browser",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Rspack for running in the browser. This is still in early stage and may not follow the semver.",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Test tools for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",


### PR DESCRIPTION
## Release Information

- Released By: intellild
- Release Date: 2026-07-21
- JavaScript Packages Version: 2.1.5
- Rust Crates Version: 0.101.5

## Example

This release updates published JavaScript packages from 2.1.4 to 2.1.5 and Rust crates from 0.101.4 to 0.101.5, keeping the package and crate versions aligned for downstream consumers.

---
_by OpenAI Codex_