### PR TITLE
fix: disable incremental chunk assets for entry fullhash filenames

### DIFF
--- a/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
@@ -32,7 +32,7 @@ pub async fn create_chunk_assets(
   compilation: &mut Compilation,
   plugin_driver: SharedPluginDriver,
 ) -> Result<()> {
-  if (compilation.options.output.filename.has_hash_placeholder()
+  let filename_has_hash_placeholder = compilation.options.output.filename.has_hash_placeholder()
     || compilation
       .options
       .output
@@ -47,7 +47,16 @@ pub async fn create_chunk_assets(
       .options
       .output
       .css_chunk_filename
-      .has_hash_placeholder())
+      .has_hash_placeholder()
+    || compilation.entries.values().any(|entry| {
+      entry
+        .options
+        .filename
+        .as_ref()
+        .is_some_and(|filename| filename.has_hash_placeholder())
+    });
+
+  if filename_has_hash_placeholder
     && let Some(diagnostic) = compilation.incremental.disable_passes(
       IncrementalPasses::CHUNK_ASSET,
       "Chunk filename that dependent on full hash",

--- a/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/0/first.js
+++ b/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/0/first.js
@@ -1,0 +1,1 @@
+import("./lazy");

--- a/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/0/lazy.js
+++ b/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/0/lazy.js
@@ -1,0 +1,1 @@
+console.log("lazy");

--- a/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/0/second.js
+++ b/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/0/second.js
@@ -1,0 +1,1 @@
+console.log("0");

--- a/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/1/second.js
+++ b/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/1/second.js
@@ -1,0 +1,1 @@
+console.log("1");

--- a/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/rspack.config.js
+++ b/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  incremental: true,
+  entry: {
+    first: {
+      import: './first.js',
+      filename: '[name].[fullhash].js',
+    },
+    second: './second.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    runtimeChunk: 'single',
+  },
+};

--- a/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/test.config.js
+++ b/tests/rspack-test/watchCases/hashes/entry-filename-fullhash/test.config.js
@@ -1,0 +1,20 @@
+const fs = require("node:fs");
+
+let outputPath;
+let initialHash;
+
+module.exports = {
+	findBundle(_, config) {
+		outputPath = config.output.path;
+		return [];
+	},
+	checkStats(step, stats) {
+		if (step === "0") {
+			initialHash = stats.hash;
+		} else {
+			expect(stats.hash).not.toBe(initialHash);
+			expect(fs.readdirSync(outputPath)).toContain(`first.${stats.hash}.js`);
+		}
+		return true;
+	}
+};


### PR DESCRIPTION
## Summary

Fix https://github.com/web-infra-dev/rspack/issues/14869

- Detect fullhash placeholders in entry-specific filenames.
- Disable incremental chunk asset passes when those filenames depend on the full hash.
- Add a watch test covering fullhash changes across rebuilds.

## Testing

- Added a watch integration test for entry filenames using `[fullhash]`.
- Not run (not requested).