### PR TITLE
fix: propagate asset emit errors

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -382,7 +382,7 @@ impl Compiler {
       .incremental
       .passes_enabled(IncrementalPasses::EMIT_ASSETS);
 
-    rspack_parallel::scope(|token| {
+    let emit_results = rspack_parallel::scope(|token| {
       self
         .compilation
         .assets()
@@ -410,6 +410,10 @@ impl Compiler {
         })
     })
     .await;
+
+    for result in emit_results {
+      result.map_err(|error| rspack_error::error!("Emit asset task failed: {error}"))??;
+    }
 
     self.emitted_asset_versions = new_emitted_asset_versions;
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -412,7 +412,7 @@ impl Compiler {
     .await;
 
     for result in emit_results {
-      result.map_err(|error| rspack_error::error!("Emit asset task failed: {error}"))??;
+      result.map_err(|error| rspack_error::error!("Emit asset failed: {error}"))??;
     }
 
     self.emitted_asset_versions = new_emitted_asset_versions;

--- a/tests/rspack-test/compilerCases/after-done-hook.js
+++ b/tests/rspack-test/compilerCases/after-done-hook.js
@@ -111,9 +111,13 @@ module.exports = [(() => {
     options(context) {
       return {
         entry: "./c",
+        output: {
+          path: context.getDist()
+        }
       };
     },
-    compilerCallback() {
+    compilerCallback(error) {
+      expect(error).toBeFalsy();
       expect(doneHookCb).toHaveBeenCalled();
       expect(afterDoneHookCb).toHaveBeenCalled();
     },

--- a/tests/rspack-test/compilerCases/emit-assets-emfile.js
+++ b/tests/rspack-test/compilerCases/emit-assets-emfile.js
@@ -1,0 +1,62 @@
+const path = require("path");
+const { createFsFromVolume, Volume } = require("memfs");
+
+let buildError;
+let buildStats;
+let injectedError;
+let outputFileSystem;
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should report EMFILE from the output file system during emit",
+	options(context) {
+		return {
+			entry: "./a",
+			output: {
+				path: context.getDist(),
+				filename: "main.js"
+			}
+		};
+	},
+	compiler(context, compiler) {
+		buildError = undefined;
+		buildStats = undefined;
+		injectedError = undefined;
+		outputFileSystem = createFsFromVolume(new Volume());
+		const writeFile = outputFileSystem.writeFile.bind(outputFileSystem);
+
+		outputFileSystem.writeFile = (filename, content, callback) => {
+			if (!injectedError && filename.endsWith("main.js")) {
+				injectedError = new Error(
+					`EMFILE: too many open files, open '${filename}'`
+				);
+				injectedError.code = "EMFILE";
+				process.nextTick(() => callback(injectedError));
+				return;
+			}
+
+			writeFile(filename, content, callback);
+		};
+
+		compiler.outputFileSystem = outputFileSystem;
+	},
+	build(context, compiler) {
+		return new Promise(resolve => {
+			compiler.run((error, stats) => {
+				buildError = error;
+				buildStats = stats;
+				resolve();
+			});
+		});
+	},
+	check({ context }) {
+		expect(buildError).toBeTruthy();
+		expect(buildError.message).toContain("EMFILE");
+		expect(injectedError).toBeTruthy();
+		expect(injectedError.code).toBe("EMFILE");
+		expect(buildStats).toBeFalsy();
+		expect(
+			outputFileSystem.existsSync(path.join(context.getDist(), "main.js"))
+		).toBe(false);
+	}
+};


### PR DESCRIPTION
## Summary

Propagate failures from parallel asset emit tasks back to the compiler.

The emit scope returns both task join results and the result of each asset write, but those results were previously discarded. A filesystem failure such as `EMFILE` could therefore leave an asset missing while the compiler still reported success.

This change:
- returns asset write failures and task failures from `emitAssets`
- updates emitted asset versions and runs `afterEmit` only after every emit task succeeds
- adds a regression case that injects `EMFILE` from the output file system

## Related links

Related to #14889 , not sure this PR can solve it or not

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).