### PR TITLE
feat: add reroute_specifier parser hook

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -807,6 +807,24 @@ impl<'p: 'a, 'a> JavascriptParserPlugin<'p, 'a> for JavaScriptParserPluginDrive 
     None
   }
 
+  fn reroute_specifier(
+    &self,
+    parser: &JavascriptParser<'p>,
+    imported: Option<&Atom>,
+    request: &Atom,
+  ) -> Option<Atom> {
+    // Thread the request through each plugin so successive plugins observe the
+    // previous plugin's rewrite, mirroring sequential webpack plugin ordering.
+    let mut rerouted: Option<Atom> = None;
+    for plugin in self.plugins_for(JavascriptParserPluginHook::RerouteSpecifier) {
+      let current = rerouted.as_ref().unwrap_or(request);
+      if let Some(next) = plugin.reroute_specifier(parser, imported, current) {
+        rerouted = Some(next);
+      }
+    }
+    rerouted
+  }
+
   fn export_import(
     &self,
     parser: &mut JavascriptParser<'p>,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -156,8 +156,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
       }) {
       let range = DependencyRange::from(statement.span());
       let loc = parser.to_dependency_location(range);
+      let rerouted_source =
+        parser
+          .plugin_drive
+          .clone()
+          .reroute_specifier(parser, ids.first(), &source);
+      let rerouted_source = rerouted_source.unwrap_or(source);
       let mut dep = ESMExportImportedSpecifierDependency::new(
-        source,
+        rerouted_source,
         source_order,
         ids.into_vec(),
         Some(export_name.clone()),
@@ -243,8 +249,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
     } else {
       Some(parser.build_info.all_star_exports.clone())
     };
+    let rerouted_source = parser
+      .plugin_drive
+      .clone()
+      .reroute_specifier(parser, local_id, source)
+      .unwrap_or_else(|| source.clone());
     let mut dep = ESMExportImportedSpecifierDependency::new(
-      source.clone(),
+      rerouted_source,
       parser.last_esm_import_order,
       local_id.map(|id| vec![id.clone()]).unwrap_or_default(),
       export_name.cloned(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -176,8 +176,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     let expr_span = expr.span;
     let range = DependencyRange::from(expr_span);
     let loc = parser.to_dependency_location(range);
+    let rerouted_source =
+      parser
+        .plugin_drive
+        .clone()
+        .reroute_specifier(parser, ids.first(), &source);
+    let rerouted_source = rerouted_source.unwrap_or(source);
     let mut dep = ESMImportSpecifierDependency::new(
-      source,
+      rerouted_source,
       name,
       source_order,
       parser.in_short_hand,
@@ -278,8 +284,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       .cloned();
     let range = DependencyRange::from(ident.span);
     let loc = parser.to_dependency_location(range);
+    let rerouted_source =
+      parser
+        .plugin_drive
+        .clone()
+        .reroute_specifier(parser, settings.ids.first(), &settings.source);
+    let rerouted_source = rerouted_source.unwrap_or(settings.source);
     let dep = ESMImportSpecifierDependency::new(
-      settings.source,
+      rerouted_source,
       settings.name,
       settings.source_order,
       parser.in_short_hand,
@@ -346,8 +358,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
     let direct_import = members.is_empty();
     let range = DependencyRange::from(span);
     let ns_access = settings.namespace_import && !ids.is_empty();
+    let rerouted_source =
+      parser
+        .plugin_drive
+        .clone()
+        .reroute_specifier(parser, ids.first(), &settings.source);
+    let rerouted_source = rerouted_source.unwrap_or(settings.source);
     let mut dep = ESMImportSpecifierDependency::new(
-      settings.source,
+      rerouted_source,
       settings.name,
       settings.source_order,
       false,
@@ -422,8 +440,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       .destructuring_assignment_properties
       .get(&member_expr.span())
       .cloned();
+    let rerouted_source =
+      parser
+        .plugin_drive
+        .clone()
+        .reroute_specifier(parser, ids.first(), &settings.source);
+    let rerouted_source = rerouted_source.unwrap_or(settings.source);
     let dep = ESMImportSpecifierDependency::new(
-      settings.source,
+      rerouted_source,
       settings.name,
       settings.source_order,
       false,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -62,10 +62,11 @@ pub enum JavascriptParserPluginHook {
   Finish,
   IsPure,
   ImportMetaPropertyInDestructuring,
+  RerouteSpecifier,
 }
 
 impl JavascriptParserPluginHook {
-  pub const COUNT: usize = Self::ImportMetaPropertyInDestructuring as usize + 1;
+  pub const COUNT: usize = Self::RerouteSpecifier as usize + 1;
   pub const ALL_MASK: u64 = if Self::COUNT == u64::BITS as usize {
     u64::MAX
   } else {
@@ -127,6 +128,7 @@ impl JavascriptParserPluginHook {
     Self::Finish,
     Self::IsPure,
     Self::ImportMetaPropertyInDestructuring,
+    Self::RerouteSpecifier,
   ];
 
   pub const fn mask(self) -> u64 {
@@ -620,6 +622,22 @@ Please annotate your `impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ...` block
     _export_name: Option<&Atom>,
     _identifier_name: &Atom,
   ) -> Option<bool> {
+    None
+  }
+
+  /// Allows a plugin to reroute an ESM import or re-export specifier to a
+  /// different request before its dependency is constructed. This runs at every
+  /// specifier dependency creation site, receiving the first imported id (the
+  /// name being accessed) and the current request. Return `Some(new_request)`
+  /// to reroute, or `None` to leave the request unchanged. Rerouting recomputes
+  /// the dependency's `resource_identifier`, so a single source import can be
+  /// split across multiple target modules per specifier.
+  fn reroute_specifier(
+    &self,
+    _parser: &JavascriptParser<'p>,
+    _imported: Option<&Atom>,
+    _request: &Atom,
+  ) -> Option<Atom> {
     None
   }
 


### PR DESCRIPTION
## Summary

Adds an opt-in, default no-op `JavascriptParserPlugin::reroute_specifier` hook. It lets a plugin rewrite the request of an individual ESM import or re-export specifier at the point its dependency is constructed. Rerouting recomputes the dependency's `resource_identifier`, so a single source import can be split across multiple target modules per specifier. For example,
`import { A, B } from 'pkg'` can send `A` to one module and `B` to another.

## Motivation

We are building a custom native Rspack plugin in Rust (N-API binding). It redirects individual ESM named imports to per-component shim or wrapper modules:

```js
import { A, B } from 'pkg';
```

`A` must resolve to one target module and `B` to another. This splits a single `import` statement across multiple modules per specifier. It matches the original Webpack implementation we have, which hooks `succeedModule`, walks the harmony import dependencies, and rewrites `dep.request` per specifier keyed on `dep.ids[0]` (the imported name).

## Why this isn't possible today

- The specifier dependencies (`ESMImportSpecifierDependency`, `ESMExportImportedSpecifierDependency`) store `request` in a private field with no setter.
- `resource_identifier` is computed once at construction, and factorization groups specifiers by it. By the time a `NormalModuleFactory` hook runs, the specifiers of one import are already one group and cannot be split.
- `succeedModule` is too late. The deps aren't reachable or mutable there the way they are in Webpack.

The only place rewriting the request has the intended effect (a fresh `resource_identifier`, so factorization treats it as a distinct module) is at dependency construction, inside the ESM import and export parser plugins.

## Why it's needed and how we use it

This is for a custom Rspack Rust binding (N-API), not the standard JS config API. We register a `JavascriptParserPlugin` via the `NormalModuleFactoryParser` hook (same pattern as the built-in `URLPlugin`) and implement `reroute_specifier` to map each imported name to its shim module:

```rust
impl JavascriptParserPlugin for ShimRerouteParserPlugin {
    fn reroute_specifier(
        &self,
        parser: &JavascriptParser,
        imported: Option<&Atom>,
        request: &Atom,
    ) -> Option<Atom> {
        let name = imported?.as_str();               // e.g. "A"
        let pkg = parser.resource_data               // decide by owning package
            .description()
            .and_then(|d| d.json().get("name"))
            .and_then(|v| v.as_str());
        // "A" from "pkg" -> "pkg/shim/A", leaving "B" to resolve elsewhere
        self.lookup(pkg, name, request).map(Atom::from)
    }
}
```

With this, `import { A, B } from 'pkg'` produces two distinct modules and the original `pkg` import is tree-shaken away, matching our Webpack plugin's behavior. Everything the plugin needs to decide (imported name, resource path, owning package) is reachable from the hook arguments and `parser.resource_data`, so no global state or compiler-identity keys are required.

## Change

Adds a parser hook that runs at those construction sites, mirroring patterns already used by other parser hooks:

```rust
fn reroute_specifier(
    &self,
    _parser: &JavascriptParser,
    _imported: Option<&Atom>, // first imported id (ids[0]); the accessed name
    _request: &Atom,          // current request (source specifier)
) -> Option<Atom> {           // Some(new_request) to reroute, None to keep
    None
}
```

- The plugin drive threads the request through each registered plugin, so successive plugins observe the previous plugin's rewrite (mirroring sequential Webpack plugin ordering).
- The 6 ESM specifier construction sites (4 import, 2 re-export) use `reroute_specifier(...).unwrap_or(original)`.

This would:

- Expose a rewrite point that only exists at dependency construction today.
- Avoid any API behavior changes. The default `None` body means every existing `JavascriptParserPlugin` is unaffected, and each call site produces a byte-identical `Atom` unless a plugin overrides the hook.
- Avoid any serialization changes.
- Enable external plugins to split one import across multiple target modules per specifier.
- Leave non-specifier deps (e.g. whole-module side-effect imports) untouched, so tree-shaking drops the now-unused original import as in Webpack.

We currently carry this as a local patch and would love to drop it once supported upstream.

## Related links

## Checklist

- [ ] Tests updated (or not required)
- [ ] Documentation updated (or not required)
