### PR TITLE
fix(rslib): avoid worker external facade in bundleless output

### DIFF
--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -29,7 +29,10 @@ use rspack_plugin_javascript::{
   JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
   dependency::ImportDependencyTemplate, parser_and_generator::JavaScriptParserAndGenerator,
 };
-use rspack_plugin_rslib::dyn_import_external::cutout_dyn_import_externals;
+use rspack_plugin_rslib::{
+  dyn_import_external::cutout_dyn_import_externals,
+  worker_external::{ExternalWorkerDependencyTemplate, cutout_worker_externals},
+};
 use rspack_plugin_split_chunks::CacheGroup;
 use rspack_util::{
   atom::Atom,
@@ -273,6 +276,16 @@ async fn compilation(
     ImportDependencyTemplate::template_type(),
     Arc::new(DynamicImportDependencyTemplate {
       dyn_import_ns_map: self.dyn_import_ns_map.clone(),
+    }),
+  );
+  let worker_template = compilation.get_dependency_template(
+    rspack_core::DependencyTemplateType::Dependency(DependencyType::NewWorker),
+  );
+  compilation.set_dependency_template(
+    rspack_core::DependencyTemplateType::Dependency(DependencyType::NewWorker),
+    Arc::new(ExternalWorkerDependencyTemplate {
+      cutout_all_externals: false,
+      template: worker_template,
     }),
   );
   Ok(())
@@ -768,6 +781,11 @@ async fn optimize_dependencies(
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   cutout_dyn_import_externals(
+    false,
+    compilation.options.output.module,
+    build_module_graph_artifact,
+  );
+  cutout_worker_externals(
     false,
     compilation.options.output.module,
     build_module_graph_artifact,

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -24,6 +24,7 @@ pub struct WorkerDependency {
   public_path: String,
   range: DependencyRange,
   range_path: DependencyRange,
+  range_request: Option<DependencyRange>,
   factorize_info: FactorizeInfo,
   need_new_url: bool,
   url_mode: Option<JavascriptParserWorkerUrl>,
@@ -35,6 +36,7 @@ impl WorkerDependency {
     public_path: String,
     range: DependencyRange,
     range_path: DependencyRange,
+    range_request: Option<DependencyRange>,
     need_new_url: bool,
     url_mode: Option<JavascriptParserWorkerUrl>,
   ) -> Self {
@@ -44,6 +46,7 @@ impl WorkerDependency {
       public_path,
       range,
       range_path,
+      range_request,
       factorize_info: Default::default(),
       need_new_url,
       url_mode,
@@ -52,6 +55,21 @@ impl WorkerDependency {
 
   pub fn public_path(&self) -> &str {
     &self.public_path
+  }
+
+  pub fn replace_request(&self, source: &mut TemplateReplaceSource, request: String) {
+    if let Some(range_request) = self.range_request {
+      source.replace(range_request.start, range_request.end, request, None);
+    } else if self.need_new_url {
+      source.insert(
+        self.range_path.start,
+        concat_string!("new URL(", request, ", "),
+        None,
+      );
+      source.insert_static(self.range_path.end, ")", None);
+    } else {
+      source.insert(self.range_path.start, concat_string!(request, ", "), None);
+    }
   }
 }
 
@@ -198,13 +216,12 @@ impl DependencyTemplate for WorkerDependencyTemplate {
     ) && compilation.options.output.module
     {
       code_generatable_context.data.insert(URLStaticMode);
-      concat_string!(
-        rspack_util::json_stringify_str(&concat_string!(
-          WORKER_STATIC_URL_PLACEHOLDER,
-          dep.id.as_u32().to_string()
-        )),
-        ", import.meta.url"
-      )
+      let request = rspack_util::json_stringify_str(&concat_string!(
+        WORKER_STATIC_URL_PLACEHOLDER,
+        dep.id.as_u32().to_string()
+      ));
+      dep.replace_request(source, request);
+      return;
     } else {
       let worker_import_base_url = if !dep.public_path.is_empty() {
         format!("\"{}\"", dep.public_path)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -30,6 +30,7 @@ use crate::{
 #[derive(Debug)]
 struct ParsedNewWorkerPath {
   pub range: (u32, u32),
+  pub range_request: Option<(u32, u32)>,
   pub value: String,
 }
 
@@ -99,6 +100,7 @@ fn add_dependencies(
     output_options.worker_public_path.clone(),
     span.into(),
     parsed_path.range.into(),
+    parsed_path.range_request.map(Into::into),
     need_new_url,
     url_mode,
   ));
@@ -175,8 +177,14 @@ fn handle_worker<'a>(
     let path = if let Some(new_url_expr) = expr_box.as_new()
       && let Some((request, start, end)) = get_url_request(parser, new_url_expr)
     {
+      let range_request = new_url_expr.args.as_ref().and_then(|args| {
+        args
+          .get(1)
+          .map(|_| (args[0].span().real_lo(), args[0].span().real_hi()))
+      });
       ParsedNewWorkerPath {
         range: (start, end),
+        range_request,
         value: request,
       }
     } else if let Some(member_expr) = expr_box.as_member()
@@ -186,6 +194,7 @@ fn handle_worker<'a>(
       let span = member_expr.span();
       ParsedNewWorkerPath {
         range: (span.real_lo(), span.real_hi()),
+        range_request: None,
         value: Url::from_file_path(parser.resource_data.resource())
           .expect("should be a path")
           .to_string(),

--- a/crates/rspack_plugin_rslib/src/lib.rs
+++ b/crates/rspack_plugin_rslib/src/lib.rs
@@ -5,4 +5,5 @@ mod isolated_dts;
 mod parser_plugin;
 mod plugin;
 mod react_directives_parser_plugin;
+pub mod worker_external;
 pub use plugin::*;

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -34,6 +34,7 @@ use crate::{
   isolated_dts::{IsolatedDtsAsset, complete_isolated_dts_outputs},
   parser_plugin::RslibParserPlugin,
   react_directives_parser_plugin::ReactDirectivesParserPlugin,
+  worker_external::{ExternalWorkerDependencyTemplate, cutout_worker_externals},
 };
 
 #[derive(Debug, Clone)]
@@ -224,6 +225,17 @@ async fn compilation(
     }),
   );
 
+  let worker_template = compilation.get_dependency_template(
+    rspack_core::DependencyTemplateType::Dependency(DependencyType::NewWorker),
+  );
+  compilation.set_dependency_template(
+    rspack_core::DependencyTemplateType::Dependency(DependencyType::NewWorker),
+    Arc::new(ExternalWorkerDependencyTemplate {
+      cutout_all_externals: true,
+      template: worker_template,
+    }),
+  );
+
   let export_template = compilation.get_dependency_template(
     rspack_core::DependencyTemplateType::Dependency(DependencyType::EsmExportImportedSpecifier),
   );
@@ -315,6 +327,11 @@ async fn optimize_dependencies(
   _diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<Option<bool>> {
   cutout_dyn_import_externals(
+    true,
+    compilation.options.output.module,
+    build_module_graph_artifact,
+  );
+  cutout_worker_externals(
     true,
     compilation.options.output.module,
     build_module_graph_artifact,

--- a/crates/rspack_plugin_rslib/src/worker_external.rs
+++ b/crates/rspack_plugin_rslib/src/worker_external.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use rspack_core::{
+  BuildModuleGraphArtifact, DependenciesBlock, Dependency, DependencyCodeGeneration,
+  DependencyTemplate, ExternalModule, TemplateContext, TemplateReplaceSource,
+};
+use rspack_plugin_javascript::dependency::WorkerDependency;
+
+fn should_cutout_worker_external(
+  cutout_all_externals: bool,
+  output_module: bool,
+  external_module: &ExternalModule,
+) -> bool {
+  if !output_module {
+    return false;
+  }
+
+  let request = &external_module.get_request().primary;
+  if !request.starts_with("./") && !request.starts_with("../") {
+    return false;
+  }
+
+  cutout_all_externals || matches!(external_module.resolve_external_type(), "import" | "module")
+}
+
+pub fn cutout_worker_externals(
+  cutout_all_externals: bool,
+  output_module: bool,
+  build_module_graph_artifact: &mut BuildModuleGraphArtifact,
+) {
+  let mg = build_module_graph_artifact.get_module_graph();
+  let mut connections_to_disable = Vec::new();
+
+  for (_, module) in mg.modules() {
+    for block_id in module.get_blocks() {
+      let Some(block) = mg.block_by_id(block_id) else {
+        continue;
+      };
+      for block_dep_id in block.get_dependencies() {
+        let dependency = mg.dependency_by_id(block_dep_id);
+        if !dependency.as_any().is::<WorkerDependency>() {
+          continue;
+        }
+
+        let Some(connection) = mg.connection_by_dependency_id(block_dep_id) else {
+          continue;
+        };
+        let Some(module) = mg.module_by_identifier(connection.module_identifier()) else {
+          continue;
+        };
+        let Some(external_module) = module.as_external_module() else {
+          continue;
+        };
+
+        if should_cutout_worker_external(cutout_all_externals, output_module, external_module) {
+          connections_to_disable.push(*block_dep_id);
+        }
+      }
+    }
+  }
+
+  let mg = build_module_graph_artifact.get_module_graph_mut();
+  for dep_id in connections_to_disable {
+    let connection = mg
+      .connection_by_dependency_id_mut(&dep_id)
+      .expect("worker external should have a module graph connection");
+    connection.force_inactive();
+  }
+}
+
+fn render_worker_external_module(
+  worker_dependency: &WorkerDependency,
+  external_module: &ExternalModule,
+  source: &mut TemplateReplaceSource,
+) {
+  let request = rspack_util::json_stringify_str(&external_module.get_request().primary);
+  worker_dependency.replace_request(source, request);
+}
+
+#[derive(Debug)]
+pub struct ExternalWorkerDependencyTemplate {
+  pub cutout_all_externals: bool,
+  pub template: Option<Arc<dyn DependencyTemplate>>,
+}
+
+impl DependencyTemplate for ExternalWorkerDependencyTemplate {
+  fn render(
+    &self,
+    dep: &dyn DependencyCodeGeneration,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    let worker_dependency = dep
+      .as_any()
+      .downcast_ref::<WorkerDependency>()
+      .expect("ExternalWorkerDependencyTemplate should be used for WorkerDependency");
+    let compilation = code_generatable_context.compilation;
+    let module_graph = compilation.get_module_graph();
+    let external_module = module_graph
+      .module_identifier_by_dependency_id(worker_dependency.id())
+      .and_then(|module_id| module_graph.module_by_identifier(module_id))
+      .and_then(|module| module.as_external_module());
+
+    if let Some(external_module) = external_module
+      && should_cutout_worker_external(
+        self.cutout_all_externals,
+        compilation.options.output.module,
+        external_module,
+      )
+    {
+      render_worker_external_module(worker_dependency, external_module, source);
+      return;
+    }
+
+    if let Some(template) = &self.template {
+      template.render(dep, source, code_generatable_context);
+    }
+  }
+}

--- a/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/__snapshots__/esm.snap.txt
@@ -1,0 +1,22 @@
+```mjs title=main.mjs
+// ./index.js
+function createWorker() {
+	return new Worker(
+		/* webpackChunkName: "worker-facade" */ new URL(
+			"./worker-source.mjs",
+			import.meta["url"]
+		), { type: "module" }
+	);
+}
+
+export { createWorker };
+
+```
+
+```mjs title=worker-source.mjs
+// ./worker.js
+const workerValue = 42;
+
+export { workerValue };
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,22 @@
+```mjs title=main.mjs
+// ./index.js
+function createWorker() {
+	return new Worker(
+		/* webpackChunkName: "worker-facade" */ new URL(
+			"./worker-source.mjs",
+			import.meta["url"]
+		), { type: "module" }
+	);
+}
+
+export { createWorker };
+
+```
+
+```mjs title=worker-source.mjs
+// ./worker.js
+const workerValue = 42;
+
+export { workerValue };
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/index.js
@@ -1,0 +1,8 @@
+export function createWorker() {
+	return new Worker(
+		/* webpackChunkName: "worker-facade" */ new URL(
+			"./worker.js",
+			import.meta["url"]
+		)
+	);
+}

--- a/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/rspack.config.js
@@ -1,0 +1,26 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index.js',
+    'worker-source': './worker.js',
+  },
+  externalsType: 'modern-module',
+  externals: [
+    ({ request, contextInfo }, callback) => {
+      if (contextInfo.issuer && request === './worker.js') {
+        callback(undefined, './worker-source.mjs');
+        return;
+      }
+      callback();
+    },
+  ],
+  module: {
+    parser: {
+      javascript: {
+        worker: {
+          url: 'new-url-relative',
+        },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/test.config.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	},
+	afterExecute(options) {
+		const files = fs
+			.readdirSync(options.output.path)
+			.filter(file => file.endsWith(".mjs"))
+			.sort();
+		expect(files).toEqual(["main.mjs", "worker-source.mjs"]);
+
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8"
+		);
+		expect(source).toMatch(
+			/new URL\(\s*["']\.\/worker-source\.mjs["']\s*,\s*import\.meta\["url"\]\s*\)/
+		);
+		expect(source).not.toContain('from "./worker-source.mjs"');
+	},
+};

--- a/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/worker.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-new-url-relative/worker.js
@@ -1,0 +1,1 @@
+export const workerValue = 42;

--- a/tests/rspack-test/esmOutputCases/worker/external-worker-true/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/external-worker-true/__snapshots__/esm.snap.txt
@@ -1,0 +1,22 @@
+```mjs title=main.mjs
+// ./index.js
+function createWorker() {
+	return new Worker(
+		/* webpackChunkName: "worker-facade" */ new URL(
+			"./worker-source.mjs",
+			import.meta.url
+		), { type: "module" }
+	);
+}
+
+export { createWorker };
+
+```
+
+```mjs title=worker-source.mjs
+// ./worker.js
+const workerValue = 42;
+
+export { workerValue };
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/external-worker-true/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/external-worker-true/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,22 @@
+```mjs title=main.mjs
+// ./index.js
+function createWorker() {
+	return new Worker(
+		/* webpackChunkName: "worker-facade" */ new URL(
+			"./worker-source.mjs",
+			import.meta.url
+		), { type: "module" }
+	);
+}
+
+export { createWorker };
+
+```
+
+```mjs title=worker-source.mjs
+// ./worker.js
+const workerValue = 42;
+
+export { workerValue };
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/external-worker-true/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-worker-true/index.js
@@ -1,0 +1,8 @@
+export function createWorker() {
+	return new Worker(
+		/* webpackChunkName: "worker-facade" */ new URL(
+			"./worker.js",
+			import.meta.url
+		)
+	);
+}

--- a/tests/rspack-test/esmOutputCases/worker/external-worker-true/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-worker-true/rspack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    main: './index.js',
+    'worker-source': './worker.js',
+  },
+  externalsType: 'modern-module',
+  externals: [
+    ({ request, contextInfo }, callback) => {
+      if (contextInfo.issuer && request === './worker.js') {
+        callback(undefined, './worker-source.mjs');
+        return;
+      }
+      callback();
+    },
+  ],
+  module: {
+    parser: {
+      javascript: {
+        worker: true,
+      },
+    },
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/external-worker-true/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-worker-true/test.config.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return ["main.mjs"];
+	},
+	afterExecute(options) {
+		const files = fs
+			.readdirSync(options.output.path)
+			.filter(file => file.endsWith(".mjs"))
+			.sort();
+		expect(files).toEqual(["main.mjs", "worker-source.mjs"]);
+
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8"
+		);
+		expect(source).toMatch(
+			/new URL\(\s*["']\.\/worker-source\.mjs["']\s*,\s*import\.meta\.url\s*\)/
+		);
+		expect(source).not.toContain('from "./worker-source.mjs"');
+	},
+};

--- a/tests/rspack-test/esmOutputCases/worker/external-worker-true/worker.js
+++ b/tests/rspack-test/esmOutputCases/worker/external-worker-true/worker.js
@@ -1,0 +1,1 @@
+export const workerValue = 42;


### PR DESCRIPTION
## Summary

- Cut relative externalized Worker dependencies out of the async entry chunk graph.
- Replace only the Worker request while preserving the original `new URL()` base expression; the external template no longer hardcodes `import.meta.url`.
- Share the request replacement path with `worker.url: "new-url-relative"` and cover both that mode and `worker: true` in `esmOutputCases`.

### Root cause

Rslib bundleless externalization converted the Worker target to an external module, but the `WorkerDependency` still remained active as an async entrypoint. Modern-module output therefore emitted an extra facade that imported the already emitted Worker source. Dynamic imports avoid this through external dependency cutout, but Worker dependencies did not have equivalent handling.

### Impact

Bundleless ESM output now points directly at the emitted Worker module without reconstructing the caller's URL base expression. Bare package externals and non-ESM output retain their existing behavior.

### Validation

- `cargo check -p rspack_plugin_javascript -p rspack_plugin_rslib -p rspack_plugin_esm_library`
- `cargo clippy -p rspack_plugin_javascript -p rspack_plugin_rslib -p rspack_plugin_esm_library --all-targets -- -D warnings`
- `corepack pnpm run build:binding:dev`
- Worker and library `new-url-relative` config cases (8 tests)
- `corepack pnpm exec rstest EsmOutput.test.js` (464 tests)

## Related links

N/A

## Checklist

- [x] Tests updated.
- [x] Documentation not required; this fixes emitted output without changing the public API.
