### PR TITLE
docs: recommend TypeScript 7 for ts-checker-rspack-plugin

### DIFF
--- a/website/docs/en/guide/optimization/profile.mdx
+++ b/website/docs/en/guide/optimization/profile.mdx
@@ -60,6 +60,10 @@ If you need to use some Babel plugins for custom transformations, configure babe
 
 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) performs poorly when generating large numbers of HTML files. The [HtmlRspackPlugin](/plugins/rspack/html-rspack-plugin) implemented in Rust by Rspack can provide better performance.
 
+### ts-checker-rspack-plugin
+
+When using [ts-checker-rspack-plugin](https://github.com/rspack-contrib/ts-checker-rspack-plugin), TypeScript 7 or later is recommended to enable the native type checker and improve type-checking performance on large projects. See the [plugin README](https://github.com/rspack-contrib/ts-checker-rspack-plugin#typescript-7-support) for details.
+
 ## Blocking thread pool size
 
 Rspack internally uses a dedicated thread pool to handle blocking operations such as file system reads and writes, preventing the main thread from being blocked.

--- a/website/docs/zh/guide/optimization/profile.mdx
+++ b/website/docs/zh/guide/optimization/profile.mdx
@@ -62,6 +62,10 @@ RSPACK_PROFILE=ALL rspack build
 
 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 在生成大量 HTML 文件时，性能表现不佳，Rspack 基于 Rust 实现的 [HtmlRspackPlugin](/plugins/rspack/html-rspack-plugin) 可以提供更好的性能。
 
+### ts-checker-rspack-plugin
+
+使用 [ts-checker-rspack-plugin](https://github.com/rspack-contrib/ts-checker-rspack-plugin) 时，推荐使用 TypeScript 7 或更高版本，以启用原生类型检查器并提升大型项目的类型检查性能，详见[插件 README](https://github.com/rspack-contrib/ts-checker-rspack-plugin#typescript-7-support)。
+
 ## 阻塞线程池大小
 
 Rspack 在内部使用一个专门的线程池来执行文件系统读写等阻塞操作，以避免阻塞主线程。


### PR DESCRIPTION
## Summary

This PR updates the performance bottleneck guidance to recommend TypeScript 7+ for `ts-checker-rspack-plugin`, enabling its native type checker to improve type-checking performance on large projects. The guidance is added to both the English and Chinese docs.

## Related links

- https://github.com/rspack-contrib/ts-checker-rspack-plugin#typescript-7-support

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).