### PR TITLE
fix: preserve worker entrypoints during module deduplication

### DIFF
--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -68,7 +68,7 @@ fn has_non_initial_entry_module(
   })
 }
 
-fn move_empty_non_initial_entrypoints(
+fn move_empty_anonymous_non_initial_entrypoints(
   compilation: &mut Compilation,
   chunks: &[ChunkUkey],
   modules: &[ModuleIdentifier],
@@ -84,6 +84,14 @@ fn move_empty_non_initial_entrypoints(
         .get_number_of_chunk_modules(chunk_ukey)
         != 0
     {
+      continue;
+    }
+
+    let chunk = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .expect_get(chunk_ukey);
+    if chunk.name().is_some() || chunk.filename_template().is_some() {
       continue;
     }
 
@@ -107,39 +115,6 @@ fn move_empty_non_initial_entrypoints(
   }
 
   for (chunk_ukey, module, group) in entrypoints {
-    // The replacement becomes the entrypoint chunk, so it also owns the async entry's output
-    // identity. Clear that identity from the old runtime chunk to avoid `[name]` collisions.
-    let name = {
-      let [Some(new_chunk), Some(old_chunk)] = compilation
-        .build_chunk_graph_artifact
-        .chunk_by_ukey
-        .get_many_mut([&new_chunk_ukey, &chunk_ukey])
-      else {
-        panic!("should have both chunks")
-      };
-
-      let name = old_chunk.name().map(ToOwned::to_owned);
-      let filename_template = old_chunk.filename_template().cloned();
-      if name.is_some() {
-        old_chunk.set_name(None);
-        old_chunk.set_filename_template(None);
-
-        if new_chunk.name().is_none() {
-          new_chunk.set_name(name.clone());
-          new_chunk.set_filename_template(filename_template);
-        }
-      }
-
-      name
-    };
-
-    if let Some(name) = name {
-      compilation
-        .build_chunk_graph_artifact
-        .named_chunks
-        .insert(name, new_chunk_ukey);
-    }
-
     compilation
       .build_chunk_graph_artifact
       .chunk_graph
@@ -320,10 +295,10 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       }
     }
 
-    // Empty async entry chunks are not emitted by module output. Point the entrypoint at the
-    // shared module chunk while keeping its original runtime chunk.
+    // Anonymous entry chunks have no output identity to preserve and may not be emitted by
+    // module output. Named entry chunks stay in place as facades for the shared module chunk.
     if preserve_entry_chunks && compilation.options.output.module {
-      move_empty_non_initial_entrypoints(compilation, &chunks, &modules, new_chunk_ukey);
+      move_empty_anonymous_non_initial_entrypoints(compilation, &chunks, &modules, new_chunk_ukey);
     }
   }
 

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -107,6 +107,39 @@ fn move_empty_non_initial_entrypoints(
   }
 
   for (chunk_ukey, module, group) in entrypoints {
+    // The replacement becomes the entrypoint chunk, so it also owns the async entry's output
+    // identity. Clear that identity from the old runtime chunk to avoid `[name]` collisions.
+    let name = {
+      let [Some(new_chunk), Some(old_chunk)] = compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .get_many_mut([&new_chunk_ukey, &chunk_ukey])
+      else {
+        panic!("should have both chunks")
+      };
+
+      let name = old_chunk.name().map(ToOwned::to_owned);
+      let filename_template = old_chunk.filename_template().cloned();
+      if name.is_some() {
+        old_chunk.set_name(None);
+        old_chunk.set_filename_template(None);
+
+        if new_chunk.name().is_none() {
+          new_chunk.set_name(name.clone());
+          new_chunk.set_filename_template(filename_template);
+        }
+      }
+
+      name
+    };
+
+    if let Some(name) = name {
+      compilation
+        .build_chunk_graph_artifact
+        .named_chunks
+        .insert(name, new_chunk_ukey);
+    }
+
     compilation
       .build_chunk_graph_artifact
       .chunk_graph

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -43,6 +43,86 @@ fn find_reusable_chunk(
   }
 }
 
+fn has_non_initial_entry_module(
+  compilation: &Compilation,
+  chunks: &[ChunkUkey],
+  modules: &[ModuleIdentifier],
+) -> bool {
+  chunks.iter().any(|chunk| {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_entry_modules_with_chunk_group_iterable(chunk)
+      .iter()
+      .any(|(module, group)| {
+        if !modules.contains(module) {
+          return false;
+        }
+
+        let group = compilation
+          .build_chunk_graph_artifact
+          .chunk_group_by_ukey
+          .expect_get(group);
+        group.kind.is_entrypoint() && !group.is_initial()
+      })
+  })
+}
+
+fn move_empty_non_initial_entrypoints(
+  compilation: &mut Compilation,
+  chunks: &[ChunkUkey],
+  modules: &[ModuleIdentifier],
+  new_chunk_ukey: ChunkUkey,
+) {
+  let mut entrypoints = Vec::new();
+
+  for chunk_ukey in chunks {
+    if chunk_ukey == &new_chunk_ukey
+      || compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_number_of_chunk_modules(chunk_ukey)
+        != 0
+    {
+      continue;
+    }
+
+    for (module, group) in compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey)
+    {
+      let chunk_group = compilation
+        .build_chunk_graph_artifact
+        .chunk_group_by_ukey
+        .expect_get(group);
+      if modules.contains(module)
+        && chunk_group.kind.is_entrypoint()
+        && !chunk_group.is_initial()
+        && chunk_group.get_entrypoint_chunk() == *chunk_ukey
+      {
+        entrypoints.push((*chunk_ukey, *module, *group));
+      }
+    }
+  }
+
+  for (chunk_ukey, module, group) in entrypoints {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .disconnect_chunk_and_entry_module(&chunk_ukey, module);
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .connect_chunk_and_entry_module(new_chunk_ukey, module, group);
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_group_by_ukey
+      .expect_get_mut(&group)
+      .set_entrypoint_chunk(new_chunk_ukey);
+  }
+}
+
 #[plugin_hook(CompilationOptimizeChunks for RemoveDuplicateModulesPlugin)]
 async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
   let module_graph = compilation.get_module_graph();
@@ -92,8 +172,17 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       continue;
     }
 
+    let preserve_entry_chunks = has_non_initial_entry_module(compilation, &chunks, &modules);
+
     // split chunks from original chunks and create new chunk
-    let new_chunk_ukey = if let Some(chunk) = find_reusable_chunk(compilation, &chunks, &modules) {
+    // A non-initial entrypoint needs to keep its own runtime/startup chunk. Reusing one of the
+    // existing chunks would make that entrypoint point at a chunk owned by another runtime.
+    let reusable_chunk = if preserve_entry_chunks {
+      None
+    } else {
+      find_reusable_chunk(compilation, &chunks, &modules)
+    };
+    let new_chunk_ukey = if let Some(chunk) = reusable_chunk {
       // we can use this chunk directly
       // all modules are into existing chunk, the chunkMap needs update
 
@@ -151,7 +240,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
       }
     }
 
-    for m in modules {
+    for &m in &modules {
       let is_entry = entry_modules.contains(&m);
       for chunk_ukey in &chunks {
         if chunk_ukey == &new_chunk_ukey {
@@ -162,7 +251,9 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
           .chunk_graph
           .disconnect_chunk_and_module(chunk_ukey, m);
 
-        if is_entry {
+        // Keep entry-module associations on their original startup chunks when the shared
+        // modules include a non-initial entrypoint. Only the module content moves.
+        if is_entry && !preserve_entry_chunks {
           compilation
             .build_chunk_graph_artifact
             .chunk_graph
@@ -175,7 +266,7 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
         .chunk_graph
         .connect_chunk_and_module(new_chunk_ukey, m);
 
-      if is_entry {
+      if is_entry && !preserve_entry_chunks {
         let chunk = compilation
           .build_chunk_graph_artifact
           .chunk_by_ukey
@@ -194,6 +285,12 @@ async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<
             .connect_chunk_and_entry_module(new_chunk_ukey, m, *group);
         }
       }
+    }
+
+    // Empty async entry chunks are not emitted by module output. Point the entrypoint at the
+    // shared module chunk while keeping its original runtime chunk.
+    if preserve_entry_chunks && compilation.options.output.module {
+      move_empty_non_initial_entrypoints(compilation, &chunks, &modules, new_chunk_ukey);
     }
   }
 

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/esm.snap.txt
@@ -1,56 +1,6 @@
-```mjs title=main.mjs
-export const __rspack_esm_id = "main";
-export const __rspack_esm_ids = ["main"];
-export const __webpack_modules__ = {
-"./index.js"
-/*!******************!*\
-  !*** ./index.js ***!
-  \******************/
-(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.r(__webpack_exports__);
-/* import */ var node_worker_threads__rspack_import_0 = __webpack_require__(/*! node:worker_threads */ "node:worker_threads");
-/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(node_worker_threads__rspack_import_0);
-
-
-it("should preserve a duplicated worker entry name", async () => {
-	const worker = new node_worker_threads__rspack_import_0.Worker(
-		new URL(
-			/* webpackChunkName: "named-worker" */ /* worker import */__webpack_require__.p + __webpack_require__.u("named-worker"), __webpack_require__.b
-		), { type: "module" }
-	);
-	let result;
-
-	try {
-		result = await new Promise((resolve, reject) => {
-			worker.on("message", resolve);
-			worker.on("error", reject);
-			worker.on("exit", code => {
-				reject(new Error(`Worker stopped before responding with exit code ${code}`));
-			});
-		});
-	} finally {
-		await worker.terminate();
-	}
-
-	expect(result).toBe("worker result");
-});
-
-
-},
-
-};
-import { __webpack_require__ } from './runtime.mjs';
-var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId); }
-import * as __rspack_chunk_1 from './node_worker_threads.mjs';
-__webpack_require__.C(__rspack_chunk_1);
-import * as __rspack_chunk_2 from './main.mjs';
-__webpack_require__.C(__rspack_chunk_2);
-var __webpack_exports__ = __webpack_exec__("./index.js");
-```
-
-```mjs title=named-worker.mjs
-export const __rspack_esm_id = "named-worker";
-export const __rspack_esm_ids = ["named-worker"];
+```mjs title=lib_js.mjs
+export const __rspack_esm_id = "lib_js";
+export const __rspack_esm_ids = ["lib_js"];
 export const __webpack_modules__ = {
 "./lib.js"
 /*!****************!*\
@@ -75,13 +25,391 @@ if (node_worker_threads__rspack_import_0.parentPort) node_worker_threads__rspack
 },
 
 };
-import { __webpack_require__ } from './0.mjs';
+
+```
+
+```mjs title=main.mjs
+export const __rspack_esm_id = "main";
+export const __rspack_esm_ids = ["main"];
+export const __webpack_modules__ = {
+"./index.js"
+/*!******************!*\
+  !*** ./index.js ***!
+  \******************/
+(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+/* import */ var node_worker_threads__rspack_import_0 = __webpack_require__(/*! node:worker_threads */ "node:worker_threads");
+/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(node_worker_threads__rspack_import_0);
+
+
+it("should preserve every duplicated worker entry name", async () => {
+	const workers = [
+		new node_worker_threads__rspack_import_0.Worker(
+			new URL(
+				/* webpackChunkName: "named-worker-a" */ /* worker import */__webpack_require__.p + __webpack_require__.u("named-worker-a"), __webpack_require__.b
+			), { type: "module" }
+		),
+		new node_worker_threads__rspack_import_0.Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("named-worker-b"), __webpack_require__.b), Object.assign({}, {
+			name: "named-worker-b"
+		}, { type: "module" }))
+	];
+	let results;
+
+	try {
+		results = await Promise.all(
+			workers.map(
+				worker =>
+					new Promise((resolve, reject) => {
+						worker.on("message", resolve);
+						worker.on("error", reject);
+						worker.on("exit", code => {
+							reject(
+								new Error(
+									`Worker stopped before responding with exit code ${code}`
+								)
+							);
+						});
+					})
+			)
+		);
+	} finally {
+		await Promise.all(workers.map(worker => worker.terminate()));
+	}
+
+	expect(results).toEqual(["worker result", "worker result"]);
+});
+
+
+},
+
+};
+import { __webpack_require__ } from './runtime.mjs';
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId); }
 import * as __rspack_chunk_1 from './node_worker_threads.mjs';
 __webpack_require__.C(__rspack_chunk_1);
-import * as __rspack_chunk_2 from './named-worker.mjs';
+import * as __rspack_chunk_2 from './main.mjs';
 __webpack_require__.C(__rspack_chunk_2);
-var __webpack_exports__ = __webpack_exec__("./lib.js");var __webpack_exports__default = __webpack_exports__["default"];
+var __webpack_exports__ = __webpack_exec__("./index.js");
+```
+
+```mjs title=named-worker-a.mjs
+var __webpack_modules__ = ({});
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/export_webpack_require
+var __webpack_require__temp = __webpack_require__;
+export { __webpack_require__temp as __webpack_require__ };
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+// webpack/runtime/on_chunk_loaded
+(() => {
+var deferred = [];
+__webpack_require__.O = (result, chunkIds, fn, priority) => {
+	if (chunkIds) {
+		priority = priority || 0;
+		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)
+			deferred[i] = deferred[i - 1];
+		deferred[i] = [chunkIds, fn, priority];
+		return;
+	}
+	var notFulfilled = Infinity;
+	for (var i = 0; i < deferred.length; i++) {
+		var [chunkIds, fn, priority] = deferred[i];
+		var fulfilled = true;
+		for (var j = 0; j < chunkIds.length; j++) {
+			if (
+				(priority & (1 === 0) || notFulfilled >= priority) &&
+				Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))
+			) {
+				chunkIds.splice(j--, 1);
+			} else {
+				fulfilled = false;
+				if (priority < notFulfilled) notFulfilled = priority;
+			}
+		}
+		if (fulfilled) {
+			deferred.splice(i--, 1);
+			var r = fn();
+			if (r !== undefined) result = r;
+		}
+	}
+	return result;
+};
+
+})();
+// webpack/runtime/module_chunk_loading
+(() => {
+// no BaseURI
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"named-worker-a": 0,};
+      var moduleInstallChunk = (data) => {
+    var __rspack_esm_ids = data.__rspack_esm_ids;
+    var moreModules = data.__webpack_modules__;
+    var __rspack_esm_runtime = data.__rspack_esm_runtime;
+    // add "modules" to the modules object,
+    // then flag all "ids" as loaded and fire callback
+    var moduleId, chunkId, i = 0;
+    for (moduleId in moreModules) {
+        if (__webpack_require__.o(moreModules, moduleId)) {
+            __webpack_require__.m[moduleId] = moreModules[moduleId];
+        }
+    }
+    if (__rspack_esm_runtime) __rspack_esm_runtime(__webpack_require__);
+    for (; i < __rspack_esm_ids.length; i++) {
+        chunkId = __rspack_esm_ids[i];
+        if (__webpack_require__.o(moduleInstalledChunks, chunkId) && moduleInstalledChunks[chunkId]) {
+            moduleInstalledChunks[chunkId][0]();
+        }
+        moduleInstalledChunks[__rspack_esm_ids[i]] = 0;
+    }
+    __webpack_require__.O();
+};
+// no chunk on demand loading
+
+        __webpack_require__.C = moduleInstallChunk;
+
+        __webpack_require__.O.j = function(chunkId) {
+            return moduleInstalledChunks[chunkId] === 0;
+        }
+        // no HMR
+// no HMR manifest
+
+})();
+import * as __rspack_imports_0 from './node_worker_threads.mjs';
+__webpack_require__.C(__rspack_imports_0);
+import * as __rspack_imports_1 from './lib_js.mjs';
+__webpack_require__.C(__rspack_imports_1);
+// module factories are used so entry inlining is disabled
+// startup
+// Load entry module and return exports
+var __webpack_exports__ = __webpack_require__.O(undefined, ["node_worker_threads", "lib_js"], () => __webpack_require__("./lib.js"));
+__webpack_exports__ = __webpack_require__.O(__webpack_exports__);
+var __webpack_exports__default = __webpack_exports__["default"];
+export { __webpack_exports__default as default };
+
+```
+
+```mjs title=named-worker-b.mjs
+var __webpack_modules__ = ({});
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/export_webpack_require
+var __webpack_require__temp = __webpack_require__;
+export { __webpack_require__temp as __webpack_require__ };
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+})();
+// webpack/runtime/on_chunk_loaded
+(() => {
+var deferred = [];
+__webpack_require__.O = (result, chunkIds, fn, priority) => {
+	if (chunkIds) {
+		priority = priority || 0;
+		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)
+			deferred[i] = deferred[i - 1];
+		deferred[i] = [chunkIds, fn, priority];
+		return;
+	}
+	var notFulfilled = Infinity;
+	for (var i = 0; i < deferred.length; i++) {
+		var [chunkIds, fn, priority] = deferred[i];
+		var fulfilled = true;
+		for (var j = 0; j < chunkIds.length; j++) {
+			if (
+				(priority & (1 === 0) || notFulfilled >= priority) &&
+				Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))
+			) {
+				chunkIds.splice(j--, 1);
+			} else {
+				fulfilled = false;
+				if (priority < notFulfilled) notFulfilled = priority;
+			}
+		}
+		if (fulfilled) {
+			deferred.splice(i--, 1);
+			var r = fn();
+			if (r !== undefined) result = r;
+		}
+	}
+	return result;
+};
+
+})();
+// webpack/runtime/module_chunk_loading
+(() => {
+// no BaseURI
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"named-worker-b": 0,};
+      var moduleInstallChunk = (data) => {
+    var __rspack_esm_ids = data.__rspack_esm_ids;
+    var moreModules = data.__webpack_modules__;
+    var __rspack_esm_runtime = data.__rspack_esm_runtime;
+    // add "modules" to the modules object,
+    // then flag all "ids" as loaded and fire callback
+    var moduleId, chunkId, i = 0;
+    for (moduleId in moreModules) {
+        if (__webpack_require__.o(moreModules, moduleId)) {
+            __webpack_require__.m[moduleId] = moreModules[moduleId];
+        }
+    }
+    if (__rspack_esm_runtime) __rspack_esm_runtime(__webpack_require__);
+    for (; i < __rspack_esm_ids.length; i++) {
+        chunkId = __rspack_esm_ids[i];
+        if (__webpack_require__.o(moduleInstalledChunks, chunkId) && moduleInstalledChunks[chunkId]) {
+            moduleInstalledChunks[chunkId][0]();
+        }
+        moduleInstalledChunks[__rspack_esm_ids[i]] = 0;
+    }
+    __webpack_require__.O();
+};
+// no chunk on demand loading
+
+        __webpack_require__.C = moduleInstallChunk;
+
+        __webpack_require__.O.j = function(chunkId) {
+            return moduleInstalledChunks[chunkId] === 0;
+        }
+        // no HMR
+// no HMR manifest
+
+})();
+import * as __rspack_imports_0 from './node_worker_threads.mjs';
+__webpack_require__.C(__rspack_imports_0);
+import * as __rspack_imports_1 from './lib_js.mjs';
+__webpack_require__.C(__rspack_imports_1);
+// module factories are used so entry inlining is disabled
+// startup
+// Load entry module and return exports
+var __webpack_exports__ = __webpack_require__.O(undefined, ["node_worker_threads", "lib_js"], () => __webpack_require__("./lib.js"));
+__webpack_exports__ = __webpack_require__.O(__webpack_exports__);
+var __webpack_exports__default = __webpack_exports__["default"];
 export { __webpack_exports__default as default };
 
 ```

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/esm.snap.txt
@@ -1,0 +1,87 @@
+```mjs title=main.mjs
+export const __rspack_esm_id = "main";
+export const __rspack_esm_ids = ["main"];
+export const __webpack_modules__ = {
+"./index.js"
+/*!******************!*\
+  !*** ./index.js ***!
+  \******************/
+(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+/* import */ var node_worker_threads__rspack_import_0 = __webpack_require__(/*! node:worker_threads */ "node:worker_threads");
+/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(node_worker_threads__rspack_import_0);
+
+
+it("should preserve a duplicated worker entry name", async () => {
+	const worker = new node_worker_threads__rspack_import_0.Worker(
+		new URL(
+			/* webpackChunkName: "named-worker" */ /* worker import */__webpack_require__.p + __webpack_require__.u("named-worker"), __webpack_require__.b
+		), { type: "module" }
+	);
+	let result;
+
+	try {
+		result = await new Promise((resolve, reject) => {
+			worker.on("message", resolve);
+			worker.on("error", reject);
+			worker.on("exit", code => {
+				reject(new Error(`Worker stopped before responding with exit code ${code}`));
+			});
+		});
+	} finally {
+		await worker.terminate();
+	}
+
+	expect(result).toBe("worker result");
+});
+
+
+},
+
+};
+import { __webpack_require__ } from './runtime.mjs';
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId); }
+import * as __rspack_chunk_1 from './node_worker_threads.mjs';
+__webpack_require__.C(__rspack_chunk_1);
+import * as __rspack_chunk_2 from './main.mjs';
+__webpack_require__.C(__rspack_chunk_2);
+var __webpack_exports__ = __webpack_exec__("./index.js");
+```
+
+```mjs title=named-worker.mjs
+export const __rspack_esm_id = "named-worker";
+export const __rspack_esm_ids = ["named-worker"];
+export const __webpack_modules__ = {
+"./lib.js"
+/*!****************!*\
+  !*** ./lib.js ***!
+  \****************/
+(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": () => (__rspack_default_export)
+});
+/* import */ var node_worker_threads__rspack_import_0 = __webpack_require__(/*! node:worker_threads */ "node:worker_threads");
+/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(node_worker_threads__rspack_import_0);
+
+
+const namedWorkerModuleMarker = "worker result";
+
+if (node_worker_threads__rspack_import_0.parentPort) node_worker_threads__rspack_import_0.parentPort.postMessage(namedWorkerModuleMarker);
+
+/* export default */ const __rspack_default_export = ("lib");
+
+
+},
+
+};
+import { __webpack_require__ } from './0.mjs';
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId); }
+import * as __rspack_chunk_1 from './node_worker_threads.mjs';
+__webpack_require__.C(__rspack_chunk_1);
+import * as __rspack_chunk_2 from './named-worker.mjs';
+__webpack_require__.C(__rspack_chunk_2);
+var __webpack_exports__ = __webpack_exec__("./lib.js");var __webpack_exports__default = __webpack_exports__["default"];
+export { __webpack_exports__default as default };
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,56 +1,6 @@
-```mjs title=main.mjs
-export const __rspack_esm_id = "main";
-export const __rspack_esm_ids = ["main"];
-export const __rspack_modules = {
-"./index.js"
-/*!******************!*\
-  !*** ./index.js ***!
-  \******************/
-(__unused_rspack_module, __rspack_exports, __rspack_context) {
-__rspack_context.N(__rspack_exports);
-/* import */ var node_worker_threads__rspack_import_0 = __rspack_context.r(/*! node:worker_threads */ "node:worker_threads");
-/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__rspack_context.n(node_worker_threads__rspack_import_0);
-
-
-it("should preserve a duplicated worker entry name", async () => {
-	const worker = new node_worker_threads__rspack_import_0.Worker(
-		new URL(
-			/* webpackChunkName: "named-worker" */ /* worker import */__rspack_context.p + __rspack_context.u("named-worker"), __rspack_context.b
-		), { type: "module" }
-	);
-	let result;
-
-	try {
-		result = await new Promise((resolve, reject) => {
-			worker.on("message", resolve);
-			worker.on("error", reject);
-			worker.on("exit", code => {
-				reject(new Error(`Worker stopped before responding with exit code ${code}`));
-			});
-		});
-	} finally {
-		await worker.terminate();
-	}
-
-	expect(result).toBe("worker result");
-});
-
-
-},
-
-};
-import { __rspack_context } from './runtime.mjs';
-var __rspack_exec = function(moduleId) { return __rspack_context.r(__rspack_context.s = moduleId); }
-import * as __rspack_chunk_1 from './node_worker_threads.mjs';
-__rspack_context.C(__rspack_chunk_1);
-import * as __rspack_chunk_2 from './main.mjs';
-__rspack_context.C(__rspack_chunk_2);
-var __rspack_exports = __rspack_exec("./index.js");
-```
-
-```mjs title=named-worker.mjs
-export const __rspack_esm_id = "named-worker";
-export const __rspack_esm_ids = ["named-worker"];
+```mjs title=lib_js.mjs
+export const __rspack_esm_id = "lib_js";
+export const __rspack_esm_ids = ["lib_js"];
 export const __rspack_modules = {
 "./lib.js"
 /*!****************!*\
@@ -75,13 +25,389 @@ if (node_worker_threads__rspack_import_0.parentPort) node_worker_threads__rspack
 },
 
 };
-import { __rspack_context } from './0.mjs';
+
+```
+
+```mjs title=main.mjs
+export const __rspack_esm_id = "main";
+export const __rspack_esm_ids = ["main"];
+export const __rspack_modules = {
+"./index.js"
+/*!******************!*\
+  !*** ./index.js ***!
+  \******************/
+(__unused_rspack_module, __rspack_exports, __rspack_context) {
+__rspack_context.N(__rspack_exports);
+/* import */ var node_worker_threads__rspack_import_0 = __rspack_context.r(/*! node:worker_threads */ "node:worker_threads");
+/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__rspack_context.n(node_worker_threads__rspack_import_0);
+
+
+it("should preserve every duplicated worker entry name", async () => {
+	const workers = [
+		new node_worker_threads__rspack_import_0.Worker(
+			new URL(
+				/* webpackChunkName: "named-worker-a" */ /* worker import */__rspack_context.p + __rspack_context.u("named-worker-a"), __rspack_context.b
+			), { type: "module" }
+		),
+		new node_worker_threads__rspack_import_0.Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("named-worker-b"), __rspack_context.b), Object.assign({}, {
+			name: "named-worker-b"
+		}, { type: "module" }))
+	];
+	let results;
+
+	try {
+		results = await Promise.all(
+			workers.map(
+				worker =>
+					new Promise((resolve, reject) => {
+						worker.on("message", resolve);
+						worker.on("error", reject);
+						worker.on("exit", code => {
+							reject(
+								new Error(
+									`Worker stopped before responding with exit code ${code}`
+								)
+							);
+						});
+					})
+			)
+		);
+	} finally {
+		await Promise.all(workers.map(worker => worker.terminate()));
+	}
+
+	expect(results).toEqual(["worker result", "worker result"]);
+});
+
+
+},
+
+};
+import { __rspack_context } from './runtime.mjs';
 var __rspack_exec = function(moduleId) { return __rspack_context.r(__rspack_context.s = moduleId); }
 import * as __rspack_chunk_1 from './node_worker_threads.mjs';
 __rspack_context.C(__rspack_chunk_1);
-import * as __rspack_chunk_2 from './named-worker.mjs';
+import * as __rspack_chunk_2 from './main.mjs';
 __rspack_context.C(__rspack_chunk_2);
-var __rspack_exports = __rspack_exec("./lib.js");var __rspack_exportsdefault = __rspack_exports["default"];
+var __rspack_exports = __rspack_exec("./index.js");
+```
+
+```mjs title=named-worker-a.mjs
+var __rspack_modules = ({});
+// The module cache
+var __rspack_module_cache = {};
+
+var __rspack_context={};
+
+// The require function
+function __rspack_require(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __rspack_module_cache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__rspack_module_cache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+__rspack_context.r = __rspack_require;
+
+// expose the modules object (__rspack_modules)
+__rspack_context.m = __rspack_modules;
+
+var moduleFactories=__rspack_modules, asyncStartup;
+// rspack/runtime/compat_get_default_export
+// getDefaultExport function for compatibility with non-ESM modules
+var compatGetDefaultExport = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	definePropertyGetters(getter, { a: getter });
+	return getter;
+};
+;
+__rspack_context.n = compatGetDefaultExport;
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+__rspack_context.d = definePropertyGetters;
+// rspack/runtime/export_require
+var __rspack_contexttemp = __rspack_context;
+export { __rspack_contexttemp as __rspack_context };
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+// rspack/runtime/make_namespace_object
+// define __esModule on exports
+var makeNamespaceObject = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};;
+__rspack_context.N = makeNamespaceObject;
+// rspack/runtime/on_chunk_loaded
+var deferred = [];
+var onChunksLoaded = (result, chunkIds, fn, priority) => {
+	if (chunkIds) {
+		priority = priority || 0;
+		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)
+			deferred[i] = deferred[i - 1];
+		deferred[i] = [chunkIds, fn, priority];
+		return;
+	}
+	var notFulfilled = Infinity;
+	for (var i = 0; i < deferred.length; i++) {
+		var [chunkIds, fn, priority] = deferred[i];
+		var fulfilled = true;
+		for (var j = 0; j < chunkIds.length; j++) {
+			if (
+				(priority & (1 === 0) || notFulfilled >= priority) &&
+				Object.keys(onChunksLoaded).every((key) => (onChunksLoaded[key](chunkIds[j])))
+			) {
+				chunkIds.splice(j--, 1);
+			} else {
+				fulfilled = false;
+				if (priority < notFulfilled) notFulfilled = priority;
+			}
+		}
+		if (fulfilled) {
+			deferred.splice(i--, 1);
+			var r = fn();
+			if (r !== undefined) result = r;
+		}
+	}
+	return result;
+};
+;
+__rspack_context.O = onChunksLoaded;
+// rspack/runtime/module_chunk_loading
+// no BaseURI
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"named-worker-a": 0,};
+      var moduleInstallChunk = (data) => {
+    var __rspack_esm_ids = data.__rspack_esm_ids;
+    var moreModules = data.__rspack_modules;
+    var __rspack_esm_runtime = data.__rspack_esm_runtime;
+    // add "modules" to the modules object,
+    // then flag all "ids" as loaded and fire callback
+    var moduleId, chunkId, i = 0;
+    for (moduleId in moreModules) {
+        if (hasOwnProperty(moreModules, moduleId)) {
+            moduleFactories[moduleId] = moreModules[moduleId];
+        }
+    }
+    if (__rspack_esm_runtime) __rspack_esm_runtime(__rspack_context);
+    for (; i < __rspack_esm_ids.length; i++) {
+        chunkId = __rspack_esm_ids[i];
+        if (hasOwnProperty(moduleInstalledChunks, chunkId) && moduleInstalledChunks[chunkId]) {
+            moduleInstalledChunks[chunkId][0]();
+        }
+        moduleInstalledChunks[__rspack_esm_ids[i]] = 0;
+    }
+    onChunksLoaded();
+};
+// no chunk on demand loading
+
+        var externalInstallChunk = moduleInstallChunk;
+
+        onChunksLoaded.j = function(chunkId) {
+            return moduleInstalledChunks[chunkId] === 0;
+        }
+        // no HMR
+// no HMR manifest
+;
+__rspack_context.C = externalInstallChunk;
+import * as __rspack_imports_0 from './node_worker_threads.mjs';
+__rspack_context.C(__rspack_imports_0);
+import * as __rspack_imports_1 from './lib_js.mjs';
+__rspack_context.C(__rspack_imports_1);
+// module factories are used so entry inlining is disabled
+// startup
+// Load entry module and return exports
+var __rspack_exports = __rspack_context.O(undefined, ["node_worker_threads", "lib_js"], () => __rspack_context.r("./lib.js"));
+__rspack_exports = __rspack_context.O(__rspack_exports);
+var __rspack_exportsdefault = __rspack_exports["default"];
+export { __rspack_exportsdefault as default };
+
+```
+
+```mjs title=named-worker-b.mjs
+var __rspack_modules = ({});
+// The module cache
+var __rspack_module_cache = {};
+
+var __rspack_context={};
+
+// The require function
+function __rspack_require(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __rspack_module_cache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__rspack_module_cache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+__rspack_context.r = __rspack_require;
+
+// expose the modules object (__rspack_modules)
+__rspack_context.m = __rspack_modules;
+
+var moduleFactories=__rspack_modules, asyncStartup;
+// rspack/runtime/compat_get_default_export
+// getDefaultExport function for compatibility with non-ESM modules
+var compatGetDefaultExport = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	definePropertyGetters(getter, { a: getter });
+	return getter;
+};
+;
+__rspack_context.n = compatGetDefaultExport;
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+__rspack_context.d = definePropertyGetters;
+// rspack/runtime/export_require
+var __rspack_contexttemp = __rspack_context;
+export { __rspack_contexttemp as __rspack_context };
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+// rspack/runtime/make_namespace_object
+// define __esModule on exports
+var makeNamespaceObject = (exports) => {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};;
+__rspack_context.N = makeNamespaceObject;
+// rspack/runtime/on_chunk_loaded
+var deferred = [];
+var onChunksLoaded = (result, chunkIds, fn, priority) => {
+	if (chunkIds) {
+		priority = priority || 0;
+		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)
+			deferred[i] = deferred[i - 1];
+		deferred[i] = [chunkIds, fn, priority];
+		return;
+	}
+	var notFulfilled = Infinity;
+	for (var i = 0; i < deferred.length; i++) {
+		var [chunkIds, fn, priority] = deferred[i];
+		var fulfilled = true;
+		for (var j = 0; j < chunkIds.length; j++) {
+			if (
+				(priority & (1 === 0) || notFulfilled >= priority) &&
+				Object.keys(onChunksLoaded).every((key) => (onChunksLoaded[key](chunkIds[j])))
+			) {
+				chunkIds.splice(j--, 1);
+			} else {
+				fulfilled = false;
+				if (priority < notFulfilled) notFulfilled = priority;
+			}
+		}
+		if (fulfilled) {
+			deferred.splice(i--, 1);
+			var r = fn();
+			if (r !== undefined) result = r;
+		}
+	}
+	return result;
+};
+;
+__rspack_context.O = onChunksLoaded;
+// rspack/runtime/module_chunk_loading
+// no BaseURI
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"named-worker-b": 0,};
+      var moduleInstallChunk = (data) => {
+    var __rspack_esm_ids = data.__rspack_esm_ids;
+    var moreModules = data.__rspack_modules;
+    var __rspack_esm_runtime = data.__rspack_esm_runtime;
+    // add "modules" to the modules object,
+    // then flag all "ids" as loaded and fire callback
+    var moduleId, chunkId, i = 0;
+    for (moduleId in moreModules) {
+        if (hasOwnProperty(moreModules, moduleId)) {
+            moduleFactories[moduleId] = moreModules[moduleId];
+        }
+    }
+    if (__rspack_esm_runtime) __rspack_esm_runtime(__rspack_context);
+    for (; i < __rspack_esm_ids.length; i++) {
+        chunkId = __rspack_esm_ids[i];
+        if (hasOwnProperty(moduleInstalledChunks, chunkId) && moduleInstalledChunks[chunkId]) {
+            moduleInstalledChunks[chunkId][0]();
+        }
+        moduleInstalledChunks[__rspack_esm_ids[i]] = 0;
+    }
+    onChunksLoaded();
+};
+// no chunk on demand loading
+
+        var externalInstallChunk = moduleInstallChunk;
+
+        onChunksLoaded.j = function(chunkId) {
+            return moduleInstalledChunks[chunkId] === 0;
+        }
+        // no HMR
+// no HMR manifest
+;
+__rspack_context.C = externalInstallChunk;
+import * as __rspack_imports_0 from './node_worker_threads.mjs';
+__rspack_context.C(__rspack_imports_0);
+import * as __rspack_imports_1 from './lib_js.mjs';
+__rspack_context.C(__rspack_imports_1);
+// module factories are used so entry inlining is disabled
+// startup
+// Load entry module and return exports
+var __rspack_exports = __rspack_context.O(undefined, ["node_worker_threads", "lib_js"], () => __rspack_context.r("./lib.js"));
+__rspack_exports = __rspack_context.O(__rspack_exports);
+var __rspack_exportsdefault = __rspack_exports["default"];
 export { __rspack_exportsdefault as default };
 
 ```

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,87 @@
+```mjs title=main.mjs
+export const __rspack_esm_id = "main";
+export const __rspack_esm_ids = ["main"];
+export const __rspack_modules = {
+"./index.js"
+/*!******************!*\
+  !*** ./index.js ***!
+  \******************/
+(__unused_rspack_module, __rspack_exports, __rspack_context) {
+__rspack_context.N(__rspack_exports);
+/* import */ var node_worker_threads__rspack_import_0 = __rspack_context.r(/*! node:worker_threads */ "node:worker_threads");
+/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__rspack_context.n(node_worker_threads__rspack_import_0);
+
+
+it("should preserve a duplicated worker entry name", async () => {
+	const worker = new node_worker_threads__rspack_import_0.Worker(
+		new URL(
+			/* webpackChunkName: "named-worker" */ /* worker import */__rspack_context.p + __rspack_context.u("named-worker"), __rspack_context.b
+		), { type: "module" }
+	);
+	let result;
+
+	try {
+		result = await new Promise((resolve, reject) => {
+			worker.on("message", resolve);
+			worker.on("error", reject);
+			worker.on("exit", code => {
+				reject(new Error(`Worker stopped before responding with exit code ${code}`));
+			});
+		});
+	} finally {
+		await worker.terminate();
+	}
+
+	expect(result).toBe("worker result");
+});
+
+
+},
+
+};
+import { __rspack_context } from './runtime.mjs';
+var __rspack_exec = function(moduleId) { return __rspack_context.r(__rspack_context.s = moduleId); }
+import * as __rspack_chunk_1 from './node_worker_threads.mjs';
+__rspack_context.C(__rspack_chunk_1);
+import * as __rspack_chunk_2 from './main.mjs';
+__rspack_context.C(__rspack_chunk_2);
+var __rspack_exports = __rspack_exec("./index.js");
+```
+
+```mjs title=named-worker.mjs
+export const __rspack_esm_id = "named-worker";
+export const __rspack_esm_ids = ["named-worker"];
+export const __rspack_modules = {
+"./lib.js"
+/*!****************!*\
+  !*** ./lib.js ***!
+  \****************/
+(__unused_rspack_module, __rspack_exports, __rspack_context) {
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
+  "default": () => (__rspack_default_export)
+});
+/* import */ var node_worker_threads__rspack_import_0 = __rspack_context.r(/*! node:worker_threads */ "node:worker_threads");
+/* import */ var node_worker_threads__rspack_import_0_default = /*#__PURE__*/__rspack_context.n(node_worker_threads__rspack_import_0);
+
+
+const namedWorkerModuleMarker = "worker result";
+
+if (node_worker_threads__rspack_import_0.parentPort) node_worker_threads__rspack_import_0.parentPort.postMessage(namedWorkerModuleMarker);
+
+/* export default */ const __rspack_default_export = ("lib");
+
+
+},
+
+};
+import { __rspack_context } from './0.mjs';
+var __rspack_exec = function(moduleId) { return __rspack_context.r(__rspack_context.s = moduleId); }
+import * as __rspack_chunk_1 from './node_worker_threads.mjs';
+__rspack_context.C(__rspack_chunk_1);
+import * as __rspack_chunk_2 from './named-worker.mjs';
+__rspack_context.C(__rspack_chunk_2);
+var __rspack_exports = __rspack_exec("./lib.js");var __rspack_exportsdefault = __rspack_exports["default"];
+export { __rspack_exportsdefault as default };
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/index.js
@@ -1,25 +1,39 @@
 import { Worker } from "node:worker_threads";
 
-it("should preserve a duplicated worker entry name", async () => {
-	const worker = new Worker(
-		new URL(
-			/* webpackChunkName: "named-worker" */ "./lib.js",
-			import.meta.url
-		)
-	);
-	let result;
+it("should preserve every duplicated worker entry name", async () => {
+	const workers = [
+		new Worker(
+			new URL(
+				/* webpackChunkName: "named-worker-a" */ "./lib.js",
+				import.meta.url
+			)
+		),
+		new Worker(new URL("./lib.js", import.meta.url), {
+			name: "named-worker-b"
+		})
+	];
+	let results;
 
 	try {
-		result = await new Promise((resolve, reject) => {
-			worker.on("message", resolve);
-			worker.on("error", reject);
-			worker.on("exit", code => {
-				reject(new Error(`Worker stopped before responding with exit code ${code}`));
-			});
-		});
+		results = await Promise.all(
+			workers.map(
+				worker =>
+					new Promise((resolve, reject) => {
+						worker.on("message", resolve);
+						worker.on("error", reject);
+						worker.on("exit", code => {
+							reject(
+								new Error(
+									`Worker stopped before responding with exit code ${code}`
+								)
+							);
+						});
+					})
+			)
+		);
 	} finally {
-		await worker.terminate();
+		await Promise.all(workers.map(worker => worker.terminate()));
 	}
 
-	expect(result).toBe("worker result");
+	expect(results).toEqual(["worker result", "worker result"]);
 });

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/index.js
@@ -1,0 +1,25 @@
+import { Worker } from "node:worker_threads";
+
+it("should preserve a duplicated worker entry name", async () => {
+	const worker = new Worker(
+		new URL(
+			/* webpackChunkName: "named-worker" */ "./lib.js",
+			import.meta.url
+		)
+	);
+	let result;
+
+	try {
+		result = await new Promise((resolve, reject) => {
+			worker.on("message", resolve);
+			worker.on("error", reject);
+			worker.on("exit", code => {
+				reject(new Error(`Worker stopped before responding with exit code ${code}`));
+			});
+		});
+	} finally {
+		await worker.terminate();
+	}
+
+	expect(result).toBe("worker result");
+});

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/lib.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/lib.js
@@ -1,0 +1,7 @@
+import { parentPort } from "node:worker_threads";
+
+const namedWorkerModuleMarker = "worker result";
+
+if (parentPort) parentPort.postMessage(namedWorkerModuleMarker);
+
+export default "lib";

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/rspack.config.js
@@ -1,0 +1,22 @@
+const rspack = require('@rspack/core');
+
+module.exports = {
+  mode: 'development',
+  entry: {
+    main: './index.js',
+    worker: './lib.js',
+  },
+  output: {
+    filename: '[name].mjs',
+    chunkFilename: '[name].mjs',
+    library: {
+      type: 'module',
+    },
+  },
+  optimization: {
+    runtimeChunk: 'single',
+    mergeDuplicateChunks: false,
+    removeAvailableModules: false,
+  },
+  plugins: [new rspack.experiments.RemoveDuplicateModulesPlugin()],
+};

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/test.config.js
@@ -3,7 +3,12 @@ const path = require("path");
 
 module.exports = {
 	snapshotFileFilter(file) {
-		return file.endsWith("main.mjs") || file.endsWith("named-worker.mjs");
+		return (
+			file.endsWith("main.mjs") ||
+			file.endsWith("lib_js.mjs") ||
+			file.endsWith("named-worker-a.mjs") ||
+			file.endsWith("named-worker-b.mjs")
+		);
 	},
 	snapshotContent(content) {
 		return content.replace(/[ \t]+$/gm, "");
@@ -18,7 +23,8 @@ module.exports = {
 				.includes("namedWorkerModuleMarker")
 		);
 
-		expect(outputFiles).toContain("named-worker.mjs");
-		expect(filesWithWorkerModule).toEqual(["named-worker.mjs"]);
+		expect(outputFiles).toContain("named-worker-a.mjs");
+		expect(outputFiles).toContain("named-worker-b.mjs");
+		expect(filesWithWorkerModule).toHaveLength(1);
 	}
 };

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules-chunk-name/test.config.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	snapshotFileFilter(file) {
+		return file.endsWith("main.mjs") || file.endsWith("named-worker.mjs");
+	},
+	snapshotContent(content) {
+		return content.replace(/[ \t]+$/gm, "");
+	},
+	afterExecute(options) {
+		const outputFiles = fs
+			.readdirSync(options.output.path)
+			.filter(file => file.endsWith(".mjs"));
+		const filesWithWorkerModule = outputFiles.filter(file =>
+			fs
+				.readFileSync(path.join(options.output.path, file), "utf-8")
+				.includes("namedWorkerModuleMarker")
+		);
+
+		expect(outputFiles).toContain("named-worker.mjs");
+		expect(filesWithWorkerModule).toEqual(["named-worker.mjs"]);
+	}
+};

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/__snapshots__/esm.snap.txt
@@ -1,0 +1,98 @@
+```mjs title=lib_js.mjs
+import { external_node_worker_threads_namespaceObject } from "./node_worker_threads.mjs";
+
+// ./lib.js
+
+
+const workerModuleMarker = "worker result";
+
+if (external_node_worker_threads_namespaceObject.parentPort) external_node_worker_threads_namespaceObject.parentPort.postMessage(workerModuleMarker);
+
+/* export default */ const lib = ("lib");
+
+export default lib;
+
+```
+
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime0.mjs";
+import { external_node_worker_threads_namespaceObject } from "./node_worker_threads.mjs";
+
+// ./index.js
+
+
+it("should keep a duplicated worker entry executable", async () => {
+	const worker = new external_node_worker_threads_namespaceObject.Worker(new URL(/* worker import */__webpack_require__.p + __webpack_require__.u("lib_js"), __webpack_require__.b), { type: "module" });
+	let result;
+
+	try {
+		result = await new Promise((resolve, reject) => {
+			worker.on("message", resolve);
+			worker.on("error", reject);
+			worker.on("exit", code => {
+				reject(new Error(`Worker stopped before responding with exit code ${code}`));
+			});
+		});
+	} finally {
+		await worker.terminate();
+	}
+
+	expect(result).toBe("worker result");
+});
+
+export {};
+
+```
+
+```mjs title=node_worker_threads.mjs
+import { createRequire as __rspack_createRequire } from "node:module";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+// node:worker_threads
+const external_node_worker_threads_namespaceObject = __rspack_createRequire_require("node:worker_threads");
+export { external_node_worker_threads_namespaceObject };
+
+```
+
+```mjs title=runtime0.mjs
+// The require scope
+var __webpack_require__ = {};
+
+// webpack/runtime/get javascript chunk filename
+(() => {
+// This function allow to reference chunks
+__webpack_require__.u = (chunkId) => {
+  // return url for filenames not based on template
+
+  // return url for filenames based on template
+  return "" + chunkId + ".mjs"
+}
+})();
+// webpack/runtime/public_path
+(() => {
+__webpack_require__.p = "";
+})();
+// webpack/runtime/module_chunk_loading
+(() => {
+__webpack_require__.b = new URL("./", import.meta.url);;
+
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"runtime0": 0,};
+      // no install chunk// no chunk on demand loading
+// no external install chunk
+// no on chunks loaded
+// no HMR
+// no HMR manifest
+
+})();
+
+export { __webpack_require__ };
+
+```
+
+```mjs title=worker.mjs
+
+export { default } from "./lib_js.mjs";
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,97 @@
+```mjs title=lib_js.mjs
+import { external_node_worker_threads_namespaceObject } from "./node_worker_threads.mjs";
+
+// ./lib.js
+
+
+const workerModuleMarker = "worker result";
+
+if (external_node_worker_threads_namespaceObject.parentPort) external_node_worker_threads_namespaceObject.parentPort.postMessage(workerModuleMarker);
+
+/* export default */ const lib = ("lib");
+
+export default lib;
+
+```
+
+```mjs title=main.mjs
+import { __rspack_context } from "./runtime0.mjs";
+import { external_node_worker_threads_namespaceObject } from "./node_worker_threads.mjs";
+
+// ./index.js
+
+
+it("should keep a duplicated worker entry executable", async () => {
+	const worker = new external_node_worker_threads_namespaceObject.Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("lib_js"), __rspack_context.b), { type: "module" });
+	let result;
+
+	try {
+		result = await new Promise((resolve, reject) => {
+			worker.on("message", resolve);
+			worker.on("error", reject);
+			worker.on("exit", code => {
+				reject(new Error(`Worker stopped before responding with exit code ${code}`));
+			});
+		});
+	} finally {
+		await worker.terminate();
+	}
+
+	expect(result).toBe("worker result");
+});
+
+export {};
+
+```
+
+```mjs title=node_worker_threads.mjs
+import { createRequire as __rspack_createRequire } from "node:module";
+const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
+// node:worker_threads
+const external_node_worker_threads_namespaceObject = __rspack_createRequire_require("node:worker_threads");
+export { external_node_worker_threads_namespaceObject };
+
+```
+
+```mjs title=runtime0.mjs
+// The require scope
+var __rspack_require = {};
+var __rspack_context = {};
+
+var publicPath, hasOwnProperty, baseUri;
+// rspack/runtime/get javascript chunk filename
+// This function allow to reference chunks
+var getChunkScriptFilename = (chunkId) => {
+  // return url for filenames not based on template
+
+  // return url for filenames based on template
+  return "" + chunkId + ".mjs"
+};
+__rspack_context.u = getChunkScriptFilename;
+// rspack/runtime/public_path
+var publicPath = "";;
+__rspack_context.p = publicPath;
+// rspack/runtime/module_chunk_loading
+baseUri = new URL("./", import.meta.url);;
+
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, Promise] = chunk loading, 0 = chunk loaded
+      var moduleInstalledChunks = {"runtime0": 0,};
+      // no install chunk// no chunk on demand loading
+// no external install chunk
+// no on chunks loaded
+// no HMR
+// no HMR manifest
+;
+__rspack_context.b = baseUri;
+
+export { __rspack_context };
+
+```
+
+```mjs title=worker.mjs
+
+export { default } from "./lib_js.mjs";
+
+```

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -15,14 +15,14 @@ export default lib;
 ```
 
 ```mjs title=main.mjs
-import { __rspack_context } from "./runtime0.mjs";
+import { rspackRequire, publicPath, getChunkScriptFilename, baseUri } from "./runtime0.mjs";
 import { external_node_worker_threads_namespaceObject } from "./node_worker_threads.mjs";
 
 // ./index.js
 
 
 it("should keep a duplicated worker entry executable", async () => {
-	const worker = new external_node_worker_threads_namespaceObject.Worker(new URL(/* worker import */__rspack_context.p + __rspack_context.u("lib_js"), __rspack_context.b), { type: "module" });
+	const worker = new external_node_worker_threads_namespaceObject.Worker(new URL(/* worker import */publicPath + getChunkScriptFilename("lib_js"), baseUri), { type: "module" });
 	let result;
 
 	try {
@@ -55,10 +55,10 @@ export { external_node_worker_threads_namespaceObject };
 
 ```mjs title=runtime0.mjs
 // The require scope
-var __rspack_require = {};
-var __rspack_context = {};
+var rspackRequire = {};
+export { rspackRequire };
 
-var publicPath, hasOwnProperty, baseUri;
+var hasOwnProperty, baseUri;
 // rspack/runtime/get javascript chunk filename
 // This function allow to reference chunks
 var getChunkScriptFilename = (chunkId) => {
@@ -67,10 +67,10 @@ var getChunkScriptFilename = (chunkId) => {
   // return url for filenames based on template
   return "" + chunkId + ".mjs"
 };
-__rspack_context.u = getChunkScriptFilename;
+export { getChunkScriptFilename };
 // rspack/runtime/public_path
 var publicPath = "";;
-__rspack_context.p = publicPath;
+export { publicPath };
 // rspack/runtime/module_chunk_loading
 baseUri = new URL("./", import.meta.url);;
 
@@ -84,9 +84,8 @@ baseUri = new URL("./", import.meta.url);;
 // no HMR
 // no HMR manifest
 ;
-__rspack_context.b = baseUri;
+export { baseUri };
 
-export { __rspack_context };
 
 ```
 

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/index.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/index.js
@@ -1,0 +1,20 @@
+import { Worker } from "node:worker_threads";
+
+it("should keep a duplicated worker entry executable", async () => {
+	const worker = new Worker(new URL("./lib.js", import.meta.url));
+	let result;
+
+	try {
+		result = await new Promise((resolve, reject) => {
+			worker.on("message", resolve);
+			worker.on("error", reject);
+			worker.on("exit", code => {
+				reject(new Error(`Worker stopped before responding with exit code ${code}`));
+			});
+		});
+	} finally {
+		await worker.terminate();
+	}
+
+	expect(result).toBe("worker result");
+});

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/lib.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/lib.js
@@ -1,0 +1,7 @@
+import { parentPort } from "node:worker_threads";
+
+const workerModuleMarker = "worker result";
+
+if (parentPort) parentPort.postMessage(workerModuleMarker);
+
+export default "lib";

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/rspack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  mode: 'development',
+  entry: {
+    main: './index.js',
+    worker: './lib.js',
+  },
+  optimization: {
+    runtimeChunk: false,
+  },
+};

--- a/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/test.config.js
+++ b/tests/rspack-test/esmOutputCases/worker/remove-duplicate-modules/test.config.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	snapshotContent(content) {
+		return content.replace(/[ \t]+$/gm, "");
+	},
+	afterExecute(options) {
+		const filesWithWorkerModule = fs
+			.readdirSync(options.output.path)
+			.filter(file => file.endsWith(".mjs"))
+			.filter(file =>
+				fs
+					.readFileSync(path.join(options.output.path, file), "utf-8")
+					.includes("workerModuleMarker")
+			);
+
+		expect(filesWithWorkerModule).toHaveLength(1);
+	}
+};


### PR DESCRIPTION
## Summary

- force duplicated modules that include a non-initial entry module into a fresh shared chunk
- preserve entry/runtime ownership while keeping module content deduplicated
- add an `esmOutputCases` Worker regression with complete normal/runtime-mode snapshots and actual Worker execution

## Root cause

`RemoveDuplicateModulesPlugin` could reuse one of the existing chunks when the same module was both an explicit entry and a Worker async entry. During the move, the module was disconnected from the Worker entry chunk, while entry-module associations were only rebuilt for initial entrypoints. The non-initial Worker entrypoint could therefore keep pointing at an empty chunk; with module output that chunk is not emitted, so the generated Worker URL is broken.

When the duplicated set contains a non-initial entry module, this change always creates a fresh shared chunk. Module content moves to that chunk, while original startup/runtime ownership is preserved. For module output, an empty non-initial entrypoint is retargeted to the shared chunk while retaining its original runtime chunk. This preserves the plugin's forced deduplication guarantee.

The snapshot makes the resulting graph explicit:

- `main.mjs` starts the Worker with `lib_js.mjs`
- `lib_js.mjs` contains the Worker module exactly once
- `worker.mjs` remains the explicit-entry facade and re-exports from `lib_js.mjs`

## Validation

- `corepack pnpm run build:binding:dev`
- `corepack pnpm exec rstest EsmOutput.test.js -t "worker/remove-duplicate-modules" -u` (2 passed)
- `corepack pnpm exec rstest EsmOutput.test.js` (472 passed)
- `cargo test -p rspack_plugin_remove_duplicate_modules --lib`
- `cargo clippy -p rspack_plugin_remove_duplicate_modules --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- targeted Prettier check and `git diff --check`

## Related links

- [Playground reproduction](https://playground.rspack.rs/#eyJyc3BhY2tWZXJzaW9uIjoiMi4xLjUiLCJpbnB1dEZpbGVzIjpbeyJmaWxlbmFtZSI6InJzcGFjay5jb25maWcuanMiLCJ0ZXh0IjoiaW1wb3J0ICogYXMgcnNwYWNrIGZyb20gXCJAcnNwYWNrL2NvcmVcIjtcblxuY2xhc3MgQXNzZXJ0TmFtZWRXb3JrZXJGYWNhZGVzUGx1Z2luIHtcbiAgYXBwbHkoY29tcGlsZXIpIHtcbiAgICBjb21waWxlci5ob29rcy50aGlzQ29tcGlsYXRpb24udGFwKFxuICAgICAgXCJBc3NlcnROYW1lZFdvcmtlckZhY2FkZXNQbHVnaW5cIixcbiAgICAgIGNvbXBpbGF0aW9uID0+IHtcbiAgICAgICAgY29tcGlsYXRpb24uaG9va3MucHJvY2Vzc0Fzc2V0cy50YXAoXG4gICAgICAgICAgXCJBc3NlcnROYW1lZFdvcmtlckZhY2FkZXNQbHVnaW5cIixcbiAgICAgICAgICBhc3NldHMgPT4ge1xuICAgICAgICAgICAgZm9yIChjb25zdCBmaWxlbmFtZSBvZiBbXG4gICAgICAgICAgICAgIFwibmFtZWQtd29ya2VyLWEubWpzXCIsXG4gICAgICAgICAgICAgIFwibmFtZWQtd29ya2VyLWIubWpzXCIsXG4gICAgICAgICAgICBdKSB7XG4gICAgICAgICAgICAgIGNvbnN0IHNvdXJjZSA9IGFzc2V0c1tmaWxlbmFtZV0/LnNvdXJjZSgpLnRvU3RyaW5nKCkgfHwgXCJcIjtcbiAgICAgICAgICAgICAgaWYgKCFzb3VyY2UuaW5jbHVkZXMoJ19fd2VicGFja19yZXF1aXJlX18oXCIuL2xpYi5qc1wiKScpKSB7XG4gICAgICAgICAgICAgICAgY29tcGlsYXRpb24uZXJyb3JzLnB1c2goXG4gICAgICAgICAgICAgICAgICBuZXcgRXJyb3IoZmlsZW5hbWUgKyBcIiBkb2VzIG5vdCBleGVjdXRlIGxpYi5qc1wiKSxcbiAgICAgICAgICAgICAgICApO1xuICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG4gICAgICAgICAgfSxcbiAgICAgICAgKTtcbiAgICAgIH0sXG4gICAgKTtcbiAgfVxufVxuXG5leHBvcnQgZGVmYXVsdCB7XG4gIG1vZGU6IFwiZGV2ZWxvcG1lbnRcIixcbiAgdGFyZ2V0OiBcImFzeW5jLW5vZGVcIixcbiAgZGV2dG9vbDogZmFsc2UsXG4gIGVudHJ5OiB7XG4gICAgbWFpbjogXCIuL2luZGV4LmpzXCIsXG4gIH0sXG4gIGV4cGVyaW1lbnRzOiB7XG4gICAgb3V0cHV0TW9kdWxlOiB0cnVlLFxuICB9LFxuICBvdXRwdXQ6IHtcbiAgICBmaWxlbmFtZTogXCJbbmFtZV0ubWpzXCIsXG4gICAgY2h1bmtGaWxlbmFtZTogXCJbbmFtZV0ubWpzXCIsXG4gICAgbGlicmFyeToge1xuICAgICAgdHlwZTogXCJtb2R1bGVcIixcbiAgICB9LFxuICB9LFxuICBvcHRpbWl6YXRpb246IHtcbiAgICBtb2R1bGVJZHM6IFwibmFtZWRcIixcbiAgICBjaHVua0lkczogXCJuYW1lZFwiLFxuICAgIHJ1bnRpbWVDaHVuazogXCJzaW5nbGVcIixcbiAgICBtZXJnZUR1cGxpY2F0ZUNodW5rczogZmFsc2UsXG4gICAgcmVtb3ZlQXZhaWxhYmxlTW9kdWxlczogZmFsc2UsXG4gIH0sXG4gIHBsdWdpbnM6IFtcbiAgICBuZXcgcnNwYWNrLmV4cGVyaW1lbnRzLlJlbW92ZUR1cGxpY2F0ZU1vZHVsZXNQbHVnaW4oKSxcbiAgICBuZXcgQXNzZXJ0TmFtZWRXb3JrZXJGYWNhZGVzUGx1Z2luKCksXG4gIF0sXG59O1xuIn0seyJmaWxlbmFtZSI6ImluZGV4LmpzIiwidGV4dCI6ImltcG9ydCB7IFdvcmtlciB9IGZyb20gXCJub2RlOndvcmtlcl90aHJlYWRzXCI7XG5cbm5ldyBXb3JrZXIoXG4gIG5ldyBVUkwoXG4gICAgLyogd2VicGFja0NodW5rTmFtZTogXCJuYW1lZC13b3JrZXItYVwiICovIFwiLi9saWIuanNcIixcbiAgICBpbXBvcnQubWV0YS51cmwsXG4gICksXG4pO1xuXG5uZXcgV29ya2VyKG5ldyBVUkwoXCIuL2xpYi5qc1wiLCBpbXBvcnQubWV0YS51cmwpLCB7XG4gIG5hbWU6IFwibmFtZWQtd29ya2VyLWJcIixcbn0pO1xuIn0seyJmaWxlbmFtZSI6ImxpYi5qcyIsInRleHQiOiJpbXBvcnQgeyBwYXJlbnRQb3J0IH0gZnJvbSBcIm5vZGU6d29ya2VyX3RocmVhZHNcIjtcblxuaWYgKHBhcmVudFBvcnQpIHBhcmVudFBvcnQucG9zdE1lc3NhZ2UoXCJ3b3JrZXIgcmVzdWx0XCIpO1xuXG5leHBvcnQgZGVmYXVsdCBcImxpYlwiO1xuIn1dfQ==) — on v2.1.5 it reports `named-worker-b.mjs does not execute lib.js`.

