### PR TITLE
fix: compare async block values in code splitting cache

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -1,19 +1,31 @@
 use std::mem;
 
 use futures::Future;
-use rspack_collections::{IdentifierIndexMap, IdentifierMap};
+use rspack_collections::IdentifierMap;
 use rspack_error::Result;
 use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::FxHashMap as HashMap;
 use tracing::instrument;
 
 use crate::{
-  ArtifactExt, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
-  Logger, ModuleIdentifier,
-  build_chunk_graph::code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
+  ArtifactExt, AsyncDependenciesBlockIdentifier, ChunkByUkey, ChunkGraph, ChunkGroupByUkey,
+  ChunkGroupUkey, ChunkUkey, Compilation, DependencyLocation, Logger, ModuleIdentifier,
+  build_chunk_graph::code_splitter::CodeSplitter,
   fast_set,
   incremental::{IncrementalPasses, Mutation},
 };
+
+struct ChunkGroupOriginUpdate {
+  block: AsyncDependenciesBlockIdentifier,
+  module: ModuleIdentifier,
+  loc: Option<DependencyLocation>,
+  request: Option<String>,
+}
+
+#[derive(Default)]
+struct CodeSplittingReusePlan {
+  origin_updates: Vec<ChunkGroupOriginUpdate>,
+}
 
 #[derive(Debug, Default)]
 pub struct BuildChunkGraphArtifact {
@@ -33,15 +45,10 @@ impl BuildChunkGraphArtifact {
     fast_set(&mut self.code_splitter, code_splitter);
   }
 
-  // we can skip rebuilding chunk graph if none of modules
-  // has changed its outgoings
-  // we don't need to check if module has changed its incomings
-  // if it changes, the incoming module changes its outgoings as well
-  fn can_skip_rebuilding(&self, this_compilation: &Compilation) -> bool {
-    self.can_skip_rebuilding_legacy(this_compilation)
-  }
-
-  fn can_skip_rebuilding_legacy(&self, this_compilation: &Compilation) -> bool {
+  fn plan_code_splitting_reuse(
+    &self,
+    this_compilation: &Compilation,
+  ) -> Option<CodeSplittingReusePlan> {
     let logger = this_compilation.get_logger("rspack.Compilation.codeSplittingCache");
 
     if !this_compilation.entries.keys().eq(
@@ -51,7 +58,7 @@ impl BuildChunkGraphArtifact {
         .keys(),
     ) {
       logger.log("entrypoints change detected, rebuilding chunk graph");
-      return false;
+      return None;
     }
 
     let Some(mutations) = this_compilation
@@ -60,122 +67,116 @@ impl BuildChunkGraphArtifact {
     else {
       logger.log("incremental for build module graph disabled, rebuilding chunk graph");
       // if disable incremental for build module graph phase, we can't skip rebuilding
-      return false;
+      return None;
     };
 
-    // if we have module removal, we can't skip rebuilding
     if mutations
       .iter()
       .any(|mutation| matches!(mutation, Mutation::ModuleRemove { .. }))
     {
       logger.log("module removal detected, rebuilding chunk graph");
-      return false;
+      return None;
     }
 
     let module_graph = this_compilation.get_module_graph();
-    let module_graph_cache = &this_compilation.module_graph_cache_artifact;
-    let affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
-    let previous_modules_map = &this_compilation
-      .build_chunk_graph_artifact
-      .code_splitter
-      .block_modules_runtime_map;
+    let affected_modules = mutations
+      .get_affected_modules_with_module_graph(module_graph)
+      .into_iter()
+      .collect::<Vec<_>>();
+    let previous_splitter = &self.code_splitter;
 
-    if previous_modules_map.is_empty() {
+    if previous_splitter.ordinal_by_module.is_empty() {
       logger.log("no cache detected, rebuilding chunk graph");
-      return false;
+      return None;
     }
 
+    if affected_modules
+      .iter()
+      .any(|module| !previous_splitter.ordinal_by_module.contains_key(module))
+    {
+      logger.log("new module detected, rebuilding chunk graph");
+      return None;
+    }
+
+    let mut current_splitter = CodeSplitter::default();
+    if current_splitter
+      .prepare(&affected_modules, this_compilation)
+      .is_err()
+    {
+      logger.log("failed to prepare current block values, rebuilding chunk graph");
+      return None;
+    }
+
+    let mut plan = CodeSplittingReusePlan::default();
     for module in affected_modules {
-      let outgoings: Vec<ModuleIdentifier> = {
-        let mut res = vec![];
-        let mut active_modules = IdentifierIndexMap::<Vec<_>>::default();
-        let module = module_graph
-          .module_graph_module_by_identifier(&module)
-          .expect("should have module");
-        module
-          .all_dependencies()
-          .iter()
-          .filter(|dep_id| {
-            module_graph
-              .dependency_by_id(dep_id)
-              .as_module_dependency()
-              .is_none_or(|module_dep| !module_dep.weak())
-          })
-          .filter_map(|dep| module_graph.connection_by_dependency_id(dep))
-          .for_each(|conn| {
-            let m = *conn.module_identifier();
-            active_modules.entry(m).or_default().push(conn);
-          });
-
-        'outer: for (m, connections) in active_modules {
-          let side_effects_state_artifact = &this_compilation
-            .build_module_graph_artifact
-            .side_effects_state_artifact;
-          for conn in connections {
-            if conn
-              .active_state(
-                module_graph,
-                None,
-                module_graph_cache,
-                side_effects_state_artifact,
-                &this_compilation.exports_info_artifact,
-              )
-              .is_not_false()
-            {
-              res.push(m);
-              continue 'outer;
-            }
-          }
-        }
-
-        res
-      };
-
-      // get outgoings from all runtimes in the previous compilation
-      let mut previous_modules = IdentifierIndexMap::default();
-      let all_runtimes = previous_modules_map.values();
-      let mut miss_in_previous = true;
-
-      all_runtimes.for_each(|modules| {
-        let Some(outgoings) = modules.get(&DependenciesBlockIdentifier::Module(module)) else {
-          return;
-        };
-        miss_in_previous = false;
-
-        for (outgoing, state, _) in outgoings.iter() {
-          // we must insert module even if state is false
-          // because we need to keep the import order
-          previous_modules
-            .entry(*outgoing)
-            .and_modify(|v| {
-              if state.is_not_false() {
-                *v = *state;
-              }
-            })
-            .or_insert(*state);
-        }
-      });
-
-      if miss_in_previous {
-        logger.log("new module detected, rebuilding chunk graph");
-        return false;
+      if !previous_splitter.module_code_splitting_value_equal(
+        &mut current_splitter,
+        module,
+        this_compilation,
+      ) {
+        logger.log(format!(
+          "module code splitting value changed: {module}, rebuilding chunk graph"
+        ));
+        return None;
       }
 
-      if previous_modules
-        .iter()
-        .filter(|(_, conn_state)| conn_state.is_not_false())
-        .map(|(m, _)| *m)
-        .collect::<Vec<_>>()
-        != outgoings.clone()
-      {
-        // we find one module's outgoings has changed
-        // we cannot skip rebuilding
-        logger.log(format!("module outgoings change detected: {module}"));
-        return false;
+      let module = module_graph
+        .module_by_identifier(&module)
+        .expect("affected module should exist");
+      for block_id in module.get_blocks() {
+        let Some(origin_index) = previous_splitter.block_origin_indices.get(block_id) else {
+          continue;
+        };
+        let Some(chunk_group_ukey) = self
+          .chunk_graph
+          .block_to_chunk_group_ukey
+          .get(block_id)
+          .copied()
+        else {
+          logger.log("cached block chunk group is missing, rebuilding chunk graph");
+          return None;
+        };
+        let chunk_group = self.chunk_group_by_ukey.expect_get(&chunk_group_ukey);
+        if chunk_group.origins().get(*origin_index).is_none() {
+          logger.log("cached block origin is missing, rebuilding chunk graph");
+          return None;
+        }
+
+        let block = module_graph.block_by_id_expect(block_id);
+        plan.origin_updates.push(ChunkGroupOriginUpdate {
+          block: *block_id,
+          module: *block.parent(),
+          loc: block.loc(),
+          request: block.request().clone(),
+        });
       }
     }
 
-    true
+    Some(plan)
+  }
+
+  fn apply_code_splitting_reuse(&mut self, plan: CodeSplittingReusePlan) {
+    for update in plan.origin_updates {
+      let chunk_group_ukey = *self
+        .chunk_graph
+        .block_to_chunk_group_ukey
+        .get(&update.block)
+        .expect("validated block chunk group should exist");
+      let origin_index = *self
+        .code_splitter
+        .block_origin_indices
+        .get(&update.block)
+        .expect("validated block origin should exist");
+      self
+        .chunk_group_by_ukey
+        .expect_get_mut(&chunk_group_ukey)
+        .update_origin(
+          origin_index,
+          Some(update.module),
+          update.loc,
+          update.request,
+        );
+    }
   }
 
   /// Reset cached chunks back to the initial render state.
@@ -224,12 +225,19 @@ where
   let incremental_code_splitting = compilation
     .incremental
     .passes_enabled(IncrementalPasses::BUILD_CHUNK_GRAPH);
-  let no_change = incremental_code_splitting
-    && compilation
-      .build_chunk_graph_artifact
-      .can_skip_rebuilding(compilation);
+  let reuse_plan = incremental_code_splitting
+    .then(|| {
+      compilation
+        .build_chunk_graph_artifact
+        .plan_code_splitting_reuse(compilation)
+    })
+    .flatten();
 
-  if no_change {
+  if let Some(reuse_plan) = reuse_plan {
+    compilation
+      .build_chunk_graph_artifact
+      .apply_code_splitting_reuse(reuse_plan);
+
     let module_idx = &compilation.build_chunk_graph_artifact.module_idx;
     let module_graph = compilation
       .build_module_graph_artifact

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -307,12 +307,30 @@ impl ChunkGroup {
     module_id: Option<ModuleIdentifier>,
     loc: Option<DependencyLocation>,
     request: Option<String>,
-  ) {
+  ) -> usize {
+    let index = self.origins.len();
     self.origins.push(OriginRecord {
       module: module_id,
       loc,
       request,
     });
+    index
+  }
+
+  pub(crate) fn update_origin(
+    &mut self,
+    index: usize,
+    module: Option<ModuleIdentifier>,
+    loc: Option<DependencyLocation>,
+    request: Option<String>,
+  ) {
+    let origin = self
+      .origins
+      .get_mut(index)
+      .expect("origin index should be valid");
+    origin.module = module;
+    origin.loc = loc;
+    origin.request = request;
   }
 
   pub fn origins(&self) -> &[OriginRecord] {

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -310,12 +310,30 @@ impl ChunkGroup {
     module_id: Option<ModuleIdentifier>,
     loc: Option<DependencyLocation>,
     request: Option<String>,
-  ) {
+  ) -> usize {
+    let index = self.origins.len();
     self.origins.push(OriginRecord {
       module: module_id,
       loc,
       request,
     });
+    index
+  }
+
+  pub(crate) fn update_origin(
+    &mut self,
+    index: usize,
+    module: Option<ModuleIdentifier>,
+    loc: Option<DependencyLocation>,
+    request: Option<String>,
+  ) {
+    let origin = self
+      .origins
+      .get_mut(index)
+      .expect("origin index should be valid");
+    origin.module = module;
+    origin.loc = loc;
+    origin.request = request;
   }
 
   pub fn origins(&self) -> &[OriginRecord] {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -41,6 +41,36 @@ type BlockConnectionMap = DependenciesBlockIdentifierMap<Arc<BlockModules>>;
 
 static EMPTY_BLOCK_MODULES: LazyLock<Arc<BlockModules>> = LazyLock::new(|| Arc::new(Vec::new()));
 
+fn block_modules_equal(a: &BlockModules, b: &BlockModules) -> bool {
+  a.len() == b.len()
+    && a
+      .iter()
+      .zip(b)
+      .all(|((a_module, a_state, _), (b_module, b_state, _))| {
+        a_module == b_module && a_state == b_state
+      })
+}
+
+fn prepared_block_targets_equal(
+  a: Option<&PreparedBlockConnectionMap>,
+  a_block: DependenciesBlockIdentifier,
+  b: Option<&PreparedBlockConnectionMap>,
+  b_block: DependenciesBlockIdentifier,
+) -> bool {
+  a.map(Vec::as_slice)
+    .unwrap_or_default()
+    .iter()
+    .filter(|connection| connection.block == a_block)
+    .map(|connection| connection.module)
+    .eq(
+      b.map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .filter(|connection| connection.block == b_block)
+        .map(|connection| connection.module),
+    )
+}
+
 #[derive(Debug, Clone)]
 struct PreparedBlockConnection {
   block: DependenciesBlockIdentifier,
@@ -280,6 +310,7 @@ pub(crate) struct CodeSplitter {
   pub(crate) named_chunk_groups: HashMap<String, CgiUkey>,
   pub(crate) named_async_entrypoints: HashMap<String, CgiUkey>,
   pub(crate) block_modules_runtime_map: BlockModulesRuntimeMap,
+  pub(crate) block_origin_indices: AsyncDependenciesBlockIdentifierMap<usize>,
   pub(crate) ordinal_by_module: IdentifierMap<u64>,
   pub(crate) mask_by_chunk: HashMap<ChunkUkey, BigUint>,
 
@@ -308,6 +339,7 @@ pub(crate) struct CodeSplitter {
   prepared_connection_map: IdentifierMap<PreparedBlockConnectionMap>,
 
   prepared_blocks_map: DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
+  prepared_block_group_options: AsyncDependenciesBlockIdentifierMap<Option<GroupOptions>>,
 }
 
 fn add_chunk_in_group(
@@ -315,7 +347,7 @@ fn add_chunk_in_group(
   module_id: ModuleIdentifier,
   loc: Option<DependencyLocation>,
   request: Option<String>,
-) -> ChunkGroup {
+) -> (ChunkGroup, usize) {
   let options = ChunkGroupOptions::new(
     group_options
       .and_then(|x| x.name())
@@ -332,8 +364,8 @@ fn add_chunk_in_group(
   );
   let kind = ChunkGroupKind::Normal { options };
   let mut chunk_group = ChunkGroup::new(kind);
-  chunk_group.add_origin(Some(module_id), loc, request);
-  chunk_group
+  let origin_index = chunk_group.add_origin(Some(module_id), loc, request);
+  (chunk_group, origin_index)
 }
 
 fn get_active_state_of_connections(
@@ -1651,11 +1683,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           chunk_name.and_then(|name| self.named_async_entrypoints.get(name).copied())
         {
           let cgi_chunk_group = self.chunk_group_info(&cgi).chunk_group;
-          compilation
+          let origin_index = compilation
             .build_chunk_graph_artifact
             .chunk_group_by_ukey
             .expect_get_mut(&cgi_chunk_group)
             .add_origin(Some(module_id), loc, request);
+          self.block_origin_indices.insert(block_id, origin_index);
 
           compilation
             .build_chunk_graph_artifact
@@ -1764,11 +1797,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           chunk_group = item_chunk_group;
         }
 
-        compilation
+        let origin_index = compilation
           .build_chunk_graph_artifact
           .chunk_group_by_ukey
           .expect_get_mut(&chunk_group)
           .add_origin(Some(module_id), loc, request);
+        self.block_origin_indices.insert(block_id, origin_index);
 
         compilation
           .build_chunk_graph_artifact
@@ -1777,12 +1811,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         c = Some(chunk_group);
         cgi
       } else {
-        let mut chunk_group = add_chunk_in_group(
+        let (mut chunk_group, origin_index) = add_chunk_in_group(
           block.get_group_options(),
           module_id,
           block.loc(),
           block.request().clone(),
         );
+        self.block_origin_indices.insert(block_id, origin_index);
         let chunk_group_ukey = chunk_group.ukey;
         let chunk = compilation
           .build_chunk_graph_artifact
@@ -1865,6 +1900,90 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         DependenciesBlockIdentifier::AsyncDependenciesBlock(block_id),
       );
     }
+  }
+
+  /// Compares the part of a module's dependency blocks that can affect code
+  /// splitting. Block identifiers only select the corresponding value on each
+  /// side; identifier equality is deliberately not part of the comparison.
+  pub(crate) fn module_code_splitting_value_equal(
+    &self,
+    current: &mut CodeSplitter,
+    module: ModuleIdentifier,
+    compilation: &Compilation,
+  ) -> bool {
+    let old_connections = self.prepared_connection_map.get(&module);
+    let current_connections = current.prepared_connection_map.get(&module);
+    let module_block = DependenciesBlockIdentifier::Module(module);
+
+    if !prepared_block_targets_equal(
+      old_connections,
+      module_block,
+      current_connections,
+      module_block,
+    ) {
+      return false;
+    }
+
+    let old_blocks = self
+      .prepared_blocks_map
+      .get(&module_block)
+      .cloned()
+      .unwrap_or_default();
+    let current_blocks = current
+      .prepared_blocks_map
+      .get(&module_block)
+      .cloned()
+      .unwrap_or_default();
+
+    if old_blocks.len() != current_blocks.len() {
+      return false;
+    }
+
+    for (old_block, current_block) in old_blocks.iter().zip(&current_blocks) {
+      if self.prepared_block_group_options.get(old_block)
+        != current.prepared_block_group_options.get(current_block)
+        || !prepared_block_targets_equal(
+          old_connections,
+          (*old_block).into(),
+          current_connections,
+          (*current_block).into(),
+        )
+      {
+        return false;
+      }
+    }
+
+    let mut has_old_runtime_snapshot = false;
+    for (runtime, old_runtime_map) in &self.block_modules_runtime_map {
+      let Some(old_modules) = old_runtime_map.get(&module_block) else {
+        continue;
+      };
+      has_old_runtime_snapshot = true;
+      let current_modules = current.get_block_modules(module_block, runtime.clone(), compilation);
+      if !block_modules_equal(old_modules, &current_modules) {
+        return false;
+      }
+
+      let current_runtime_map = current
+        .block_modules_runtime_map
+        .get(runtime)
+        .expect("current runtime map should be prepared");
+      for (old_block, current_block) in old_blocks.iter().zip(&current_blocks) {
+        let old_block = DependenciesBlockIdentifier::AsyncDependenciesBlock(*old_block);
+        let current_block = DependenciesBlockIdentifier::AsyncDependenciesBlock(*current_block);
+        let Some(old_modules) = old_runtime_map.get(&old_block) else {
+          return false;
+        };
+        let Some(current_modules) = current_runtime_map.get(&current_block) else {
+          return false;
+        };
+        if !block_modules_equal(old_modules, current_modules) {
+          return false;
+        }
+      }
+    }
+
+    has_old_runtime_snapshot
   }
 
   #[allow(clippy::rc_buffer)]
@@ -2455,6 +2574,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     >::with_capacity_and_hasher(
       all_modules.len(), Default::default()
     );
+    let mut prepared_block_group_options = AsyncDependenciesBlockIdentifierMap::default();
+    let mut blocks_to_prepare = Vec::new();
 
     for module in all_modules {
       let blocks = compilation
@@ -2465,18 +2586,26 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
       if !blocks.is_empty() {
         prepared_blocks_map.insert((*module).into(), blocks.to_vec());
+        blocks_to_prepare.extend(blocks.iter().copied());
       }
     }
 
-    for (block_id, block) in mg.blocks() {
+    while let Some(block_id) = blocks_to_prepare.pop() {
+      if prepared_block_group_options.contains_key(&block_id) {
+        continue;
+      }
+      let block = mg.block_by_id_expect(&block_id);
+      prepared_block_group_options.insert(block_id, block.get_group_options().cloned());
       let blocks = block.get_blocks();
 
       if !blocks.is_empty() {
-        prepared_blocks_map.insert((*block_id).into(), blocks.to_vec());
+        prepared_blocks_map.insert(block_id.into(), blocks.to_vec());
+        blocks_to_prepare.extend(blocks.iter().copied());
       }
     }
 
     self.prepared_blocks_map = prepared_blocks_map;
+    self.prepared_block_group_options = prepared_block_group_options;
 
     Ok(())
   }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -41,6 +41,36 @@ type BlockConnectionMap = DependenciesBlockIdentifierMap<Arc<BlockModules>>;
 
 static EMPTY_BLOCK_MODULES: LazyLock<Arc<BlockModules>> = LazyLock::new(|| Arc::new(Vec::new()));
 
+fn block_modules_equal(a: &BlockModules, b: &BlockModules) -> bool {
+  a.len() == b.len()
+    && a
+      .iter()
+      .zip(b)
+      .all(|((a_module, a_state, _), (b_module, b_state, _))| {
+        a_module == b_module && a_state == b_state
+      })
+}
+
+fn prepared_block_targets_equal(
+  a: Option<&PreparedBlockConnectionMap>,
+  a_block: DependenciesBlockIdentifier,
+  b: Option<&PreparedBlockConnectionMap>,
+  b_block: DependenciesBlockIdentifier,
+) -> bool {
+  a.map(Vec::as_slice)
+    .unwrap_or_default()
+    .iter()
+    .filter(|connection| connection.block == a_block)
+    .map(|connection| connection.module)
+    .eq(
+      b.map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .filter(|connection| connection.block == b_block)
+        .map(|connection| connection.module),
+    )
+}
+
 #[derive(Debug, Clone)]
 struct PreparedBlockConnection {
   block: DependenciesBlockIdentifier,
@@ -280,6 +310,7 @@ pub(crate) struct CodeSplitter {
   pub(crate) named_chunk_groups: HashMap<String, CgiUkey>,
   pub(crate) named_async_entrypoints: HashMap<String, CgiUkey>,
   pub(crate) block_modules_runtime_map: BlockModulesRuntimeMap,
+  pub(crate) block_origin_indices: AsyncDependenciesBlockIdentifierMap<usize>,
   pub(crate) ordinal_by_module: IdentifierMap<u64>,
   pub(crate) mask_by_chunk: HashMap<ChunkUkey, BigUint>,
 
@@ -308,6 +339,7 @@ pub(crate) struct CodeSplitter {
   prepared_connection_map: IdentifierMap<PreparedBlockConnectionMap>,
 
   prepared_blocks_map: DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
+  prepared_block_group_options: AsyncDependenciesBlockIdentifierMap<Option<GroupOptions>>,
 }
 
 fn add_chunk_in_group(
@@ -315,7 +347,7 @@ fn add_chunk_in_group(
   module_id: ModuleIdentifier,
   loc: Option<DependencyLocation>,
   request: Option<String>,
-) -> ChunkGroup {
+) -> (ChunkGroup, usize) {
   let options = ChunkGroupOptions::new(
     group_options
       .and_then(|x| x.name())
@@ -332,8 +364,8 @@ fn add_chunk_in_group(
   );
   let kind = ChunkGroupKind::Normal { options };
   let mut chunk_group = ChunkGroup::new(kind);
-  chunk_group.add_origin(Some(module_id), loc, request);
-  chunk_group
+  let origin_index = chunk_group.add_origin(Some(module_id), loc, request);
+  (chunk_group, origin_index)
 }
 
 fn get_active_state_of_connections(
@@ -1641,11 +1673,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           chunk_name.and_then(|name| self.named_async_entrypoints.get(name).copied())
         {
           let cgi_chunk_group = self.chunk_group_info(&cgi).chunk_group;
-          compilation
+          let origin_index = compilation
             .build_chunk_graph_artifact
             .chunk_group_by_ukey
             .expect_get_mut(&cgi_chunk_group)
             .add_origin(Some(module_id), loc, request);
+          self.block_origin_indices.insert(block_id, origin_index);
 
           compilation
             .build_chunk_graph_artifact
@@ -1754,11 +1787,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           chunk_group = item_chunk_group;
         }
 
-        compilation
+        let origin_index = compilation
           .build_chunk_graph_artifact
           .chunk_group_by_ukey
           .expect_get_mut(&chunk_group)
           .add_origin(Some(module_id), loc, request);
+        self.block_origin_indices.insert(block_id, origin_index);
 
         compilation
           .build_chunk_graph_artifact
@@ -1767,12 +1801,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         c = Some(chunk_group);
         cgi
       } else {
-        let mut chunk_group = add_chunk_in_group(
+        let (mut chunk_group, origin_index) = add_chunk_in_group(
           block.get_group_options(),
           module_id,
           block.loc(),
           block.request().clone(),
         );
+        self.block_origin_indices.insert(block_id, origin_index);
         let chunk_group_ukey = chunk_group.ukey;
         let chunk = compilation
           .build_chunk_graph_artifact
@@ -1855,6 +1890,88 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         DependenciesBlockIdentifier::AsyncDependenciesBlock(block_id),
       );
     }
+  }
+
+  /// Compares the part of a module's dependency blocks that can affect code
+  /// splitting. Block identifiers only select the corresponding value on each
+  /// side; identifier equality is deliberately not part of the comparison.
+  pub(crate) fn module_code_splitting_value_equal(
+    &self,
+    current: &mut CodeSplitter,
+    module: ModuleIdentifier,
+    compilation: &Compilation,
+  ) -> bool {
+    let old_connections = self.prepared_connection_map.get(&module);
+    let current_connections = current.prepared_connection_map.get(&module);
+    let module_block = DependenciesBlockIdentifier::Module(module);
+
+    if !prepared_block_targets_equal(
+      old_connections,
+      module_block,
+      current_connections,
+      module_block,
+    ) {
+      return false;
+    }
+
+    let old_blocks = self
+      .prepared_blocks_map
+      .get(&module_block)
+      .cloned()
+      .unwrap_or_default();
+    let current_blocks = current
+      .prepared_blocks_map
+      .get(&module_block)
+      .cloned()
+      .unwrap_or_default();
+
+    if old_blocks.len() != current_blocks.len() {
+      return false;
+    }
+
+    for (old_block, current_block) in old_blocks.iter().zip(&current_blocks) {
+      if self.prepared_block_group_options.get(old_block)
+        != current.prepared_block_group_options.get(current_block)
+        || !prepared_block_targets_equal(
+          old_connections,
+          (*old_block).into(),
+          current_connections,
+          (*current_block).into(),
+        )
+      {
+        return false;
+      }
+    }
+
+    for (runtime, old_runtime_map) in &self.block_modules_runtime_map {
+      let Some(old_modules) = old_runtime_map.get(&module_block) else {
+        continue;
+      };
+      let current_modules = current.get_block_modules(module_block, runtime.clone(), compilation);
+      if !block_modules_equal(old_modules, &current_modules) {
+        return false;
+      }
+
+      let current_runtime_map = current
+        .block_modules_runtime_map
+        .get(runtime)
+        .expect("current runtime map should be prepared");
+      for (old_block, current_block) in old_blocks.iter().zip(&current_blocks) {
+        let old_block = DependenciesBlockIdentifier::AsyncDependenciesBlock(*old_block);
+        let current_block = DependenciesBlockIdentifier::AsyncDependenciesBlock(*current_block);
+        let Some(old_modules) = old_runtime_map.get(&old_block) else {
+          return false;
+        };
+        let Some(current_modules) = current_runtime_map.get(&current_block) else {
+          return false;
+        };
+        if !block_modules_equal(old_modules, current_modules) {
+          return false;
+        }
+      }
+    }
+
+    true
   }
 
   #[allow(clippy::rc_buffer)]
@@ -2445,6 +2562,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     >::with_capacity_and_hasher(
       all_modules.len(), Default::default()
     );
+    let mut prepared_block_group_options = AsyncDependenciesBlockIdentifierMap::default();
+    let mut blocks_to_prepare = Vec::new();
 
     for module in all_modules {
       let blocks = compilation
@@ -2455,18 +2574,26 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
       if !blocks.is_empty() {
         prepared_blocks_map.insert((*module).into(), blocks.to_vec());
+        blocks_to_prepare.extend(blocks.iter().copied());
       }
     }
 
-    for (block_id, block) in mg.blocks() {
+    while let Some(block_id) = blocks_to_prepare.pop() {
+      if prepared_block_group_options.contains_key(&block_id) {
+        continue;
+      }
+      let block = mg.block_by_id_expect(&block_id);
+      prepared_block_group_options.insert(block_id, block.get_group_options().cloned());
       let blocks = block.get_blocks();
 
       if !blocks.is_empty() {
-        prepared_blocks_map.insert((*block_id).into(), blocks.to_vec());
+        prepared_blocks_map.insert(block_id.into(), blocks.to_vec());
+        blocks_to_prepare.extend(blocks.iter().copied());
       }
     }
 
     self.prepared_blocks_map = prepared_blocks_map;
+    self.prepared_block_group_options = prepared_block_group_options;
 
     Ok(())
   }

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1459,8 +1459,8 @@ impl Module for ContextModule {
       ));
       let mut block = AsyncDependenciesBlock::new(
         (*self.identifier).into(),
+        blocks.len(),
         Some(loc),
-        None,
         context_element_dependencies
           .into_iter()
           .map(|dep| Box::new(dep) as Box<dyn Dependency>)
@@ -1505,8 +1505,8 @@ impl Module for ContextModule {
         let fetch_priority = group_options.and_then(|o| o.fetch_priority);
         let mut block = AsyncDependenciesBlock::new(
           (*self.identifier).into(),
+          blocks.len(),
           None,
-          Some(&context_element_dependency.user_request.clone()),
           vec![Box::new(context_element_dependency)],
           Some(self.options.context_options.request.clone()),
         );

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1426,8 +1426,8 @@ impl Module for ContextModule {
       ));
       let mut block = AsyncDependenciesBlock::new(
         (*self.identifier).into(),
+        blocks.len(),
         Some(loc),
-        None,
         context_element_dependencies
           .into_iter()
           .map(|dep| Box::new(dep) as Box<dyn Dependency>)
@@ -1472,8 +1472,8 @@ impl Module for ContextModule {
         let fetch_priority = group_options.and_then(|o| o.fetch_priority);
         let mut block = AsyncDependenciesBlock::new(
           (*self.identifier).into(),
+          blocks.len(),
           None,
-          Some(&context_element_dependency.user_request.clone()),
           vec![Box::new(context_element_dependency)],
           Some(self.options.context_options.request.clone()),
         );

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write as _, hash::BuildHasherDefault};
+use std::hash::BuildHasherDefault;
 
 use rspack_cacheable::cacheable;
 use rspack_collections::{Identifier, IdentifierHasher};
@@ -90,41 +90,17 @@ pub struct AsyncDependenciesBlock {
 }
 
 impl AsyncDependenciesBlock {
-  /// modifier should be Dependency.span in most of time
+  /// `block_index` is this block's ordinal within its parent module. Location,
+  /// request and dependency data are deliberately excluded from the identity.
   pub fn new(
     parent: ModuleIdentifier,
+    block_index: usize,
     loc: Option<DependencyLocation>,
-    modifier: Option<&str>,
     dependencies: Vec<BoxDependency>,
     request: Option<String>,
   ) -> Self {
-    let dependencies_resource_identifier_len = dependencies
-      .iter()
-      .filter_map(|dep| dep.resource_identifier())
-      .map(str::len)
-      .sum::<usize>();
-    let modifier_len = modifier.map_or(0, |modifier| "|modifier=".len() + modifier.len());
-    let mut id = String::with_capacity(
-      parent.len() + "|dep=".len() + dependencies_resource_identifier_len + modifier_len,
-    );
-    id.push_str(parent.as_str());
-    id.push_str("|dep=");
-
-    let mut dependency_ids = Vec::with_capacity(dependencies.len());
-    for dep in &dependencies {
-      if let Some(resource_identifier) = dep.resource_identifier() {
-        id.push_str(resource_identifier);
-      }
-      dependency_ids.push(*dep.id());
-    }
-
-    if let Some(loc) = loc.as_ref() {
-      write!(id, "|loc={loc}").expect("write to String should not fail");
-    }
-    if let Some(modifier) = modifier {
-      id.push_str("|modifier=");
-      id.push_str(modifier);
-    }
+    let id = format!("{parent}|block={block_index}");
+    let dependency_ids = dependencies.iter().map(|dep| *dep.id()).collect();
 
     Self {
       id: id.into(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -302,10 +302,11 @@ impl AMDRequireDependenciesBlockParserPlugin {
         result = self.process_array(parser, &mut block_deps, call_expr, &param);
       });
       if result.is_some_and(|x| x) {
+        let block_index = parser.next_block_idx();
         let dep_block = Box::new(AsyncDependenciesBlock::new(
           *parser.module_identifier,
+          block_index,
           block_loc,
-          None,
           block_deps,
           self.process_array_for_request_string(&param),
         ));
@@ -350,10 +351,11 @@ impl AMDRequireDependenciesBlockParserPlugin {
       }
 
       block_deps.insert(0, dep);
+      let block_index = parser.next_block_idx();
       let dep_block = Box::new(AsyncDependenciesBlock::new(
         *parser.module_identifier,
+        block_index,
         block_loc,
-        None,
         block_deps,
         self.process_array_for_request_string(&param),
       ));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -305,10 +305,11 @@ impl AMDRequireDependenciesBlockParserPlugin {
         result = self.process_array(parser, &mut block_deps, call_expr, &param);
       });
       if result.is_some_and(|x| x) {
+        let block_index = parser.next_block_idx();
         let dep_block = Box::new(AsyncDependenciesBlock::new(
           *parser.module_identifier,
+          block_index,
           block_loc,
-          None,
           block_deps,
           self.process_array_for_request_string(&param),
         ));
@@ -353,10 +354,11 @@ impl AMDRequireDependenciesBlockParserPlugin {
       }
 
       block_deps.insert(0, dep);
+      let block_index = parser.next_block_idx();
       let dep_block = Box::new(AsyncDependenciesBlock::new(
         *parser.module_identifier,
+        block_index,
         block_loc,
-        None,
         block_deps,
         self.process_array_for_request_string(&param),
       ));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -438,10 +438,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         }
         let range = DependencyRange::from(import_call_span);
         let loc = parser.to_dependency_location(range);
+        let block_idx = parser.next_block_idx();
         let mut block = AsyncDependenciesBlock::new(
           *parser.module_identifier,
+          block_idx,
           loc,
-          None,
           vec![Box::new(dep)],
           Some(param.string().clone()),
         );
@@ -451,7 +452,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           chunk_prefetch,
           fetch_priority,
         )));
-        let block_idx = parser.next_block_idx();
         parser.add_block(Box::new(block));
         ImportDependencyLocator {
           block_idx: Some(block_idx),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -141,7 +141,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RequireEnsureDependenciesBlockPa
 
     let range = DependencyRange::from(expr.span);
     let loc = parser.to_dependency_location(range);
-    let mut block = AsyncDependenciesBlock::new(*parser.module_identifier, loc, None, deps, None);
+    let mut block = AsyncDependenciesBlock::new(
+      *parser.module_identifier,
+      parser.next_block_idx(),
+      loc,
+      deps,
+      None,
+    );
     block.set_group_options(GroupOptions::ChunkGroup(
       ChunkGroupOptions::default().name_optional(chunk_name),
     ));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -150,8 +150,13 @@ fn add_dependencies(
   ));
   let range = DependencyRange::from(span);
   let loc = parser.to_dependency_location(range);
-  let mut block =
-    AsyncDependenciesBlock::new(*parser.module_identifier, loc, None, vec![dep], None);
+  let mut block = AsyncDependenciesBlock::new(
+    *parser.module_identifier,
+    parser.next_block_idx(),
+    loc,
+    vec![dep],
+    None,
+  );
   block.set_group_options(GroupOptions::Entrypoint(Box::new(EntryOptions {
     name,
     runtime: Some(runtime.into()),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -104,8 +104,13 @@ fn add_dependencies(
   ));
   let range = DependencyRange::from(span);
   let loc = parser.to_dependency_location(range);
-  let mut block =
-    AsyncDependenciesBlock::new(*parser.module_identifier, loc, None, vec![dep], None);
+  let mut block = AsyncDependenciesBlock::new(
+    *parser.module_identifier,
+    parser.next_block_idx(),
+    loc,
+    vec![dep],
+    None,
+  );
   block.set_group_options(GroupOptions::Entrypoint(Box::new(EntryOptions {
     name,
     runtime: Some(runtime.into()),

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -207,7 +207,7 @@ impl Module for LazyCompilationProxyModule {
 
       blocks.push(Box::new(AsyncDependenciesBlock::new(
         self.identifier,
-        None,
+        blocks.len(),
         None,
         vec![Box::new(dep)],
         None,

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -213,8 +213,8 @@ impl Module for ContainerEntryModule {
       for (name, options) in &self.exposes {
         let mut block = AsyncDependenciesBlock::new(
           self.identifier,
+          blocks.len(),
           None,
-          Some(name),
           options
             .import
             .iter()

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -212,8 +212,8 @@ impl Module for ContainerEntryModule {
       for (name, options) in &self.exposes {
         let mut block = AsyncDependenciesBlock::new(
           self.identifier,
+          blocks.len(),
           None,
-          Some(name),
           options
             .import
             .iter()

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -183,7 +183,8 @@ impl Module for ConsumeSharedModule {
       if self.options.eager {
         dependencies.push(dep as BoxDependency);
       } else {
-        let block = AsyncDependenciesBlock::new(self.identifier, None, None, vec![dep], None);
+        let block =
+          AsyncDependenciesBlock::new(self.identifier, blocks.len(), None, vec![dep], None);
         blocks.push(Box::new(block));
       }
     }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -175,7 +175,7 @@ impl Module for ProvideSharedModule {
     if self.eager {
       dependencies.push(dep as BoxDependency);
     } else {
-      let block = AsyncDependenciesBlock::new(self.identifier, None, None, vec![dep], None);
+      let block = AsyncDependenciesBlock::new(self.identifier, blocks.len(), None, vec![dep], None);
       blocks.push(Box::new(block));
     }
 

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -324,11 +324,10 @@ impl Module for RscEntryModule {
           continue;
         }
 
-        let block_modifier = format!("server-entry={server_entry}");
         let block = AsyncDependenciesBlock::new(
           self.identifier,
+          blocks.len(),
           None,
-          Some(&block_modifier),
           block_dependencies,
           Some(server_entry.clone()),
         );
@@ -350,7 +349,7 @@ impl Module for RscEntryModule {
 
         let block = AsyncDependenciesBlock::new(
           self.identifier,
-          None,
+          blocks.len(),
           None,
           dependencies,
           Some(format!("{}#root-client", self.name)),
@@ -366,7 +365,7 @@ impl Module for RscEntryModule {
         );
         let block = AsyncDependenciesBlock::new(
           self.identifier,
-          None,
+          blocks.len(),
           None,
           vec![Box::new(dep) as Box<dyn Dependency>],
           Some(client_module.request.clone()),

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -256,8 +256,8 @@ impl RstestParserPlugin {
           let loc = parser.to_dependency_location(range);
           let block = AsyncDependenciesBlock::new(
             *parser.module_identifier,
+            parser.next_block_idx(),
             loc,
-            None,
             vec![dep],
             Some(lit.value.to_string_lossy().to_string()),
           );
@@ -596,8 +596,8 @@ impl RstestParserPlugin {
                 let loc = parser.to_dependency_location(range);
                 let block = AsyncDependenciesBlock::new(
                   *parser.module_identifier,
+                  parser.next_block_idx(),
                   loc,
-                  None,
                   vec![dep],
                   Some(mocked_target.to_string()),
                 );

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -239,8 +239,8 @@ impl RstestParserPlugin {
           let loc = parser.to_dependency_location(range);
           let block = AsyncDependenciesBlock::new(
             *parser.module_identifier,
+            parser.next_block_idx(),
             loc,
-            None,
             vec![dep],
             Some(lit.value.to_string_lossy().to_string()),
           );
@@ -573,8 +573,8 @@ impl RstestParserPlugin {
                 let loc = parser.to_dependency_location(range);
                 let block = AsyncDependenciesBlock::new(
                   *parser.module_identifier,
+                  parser.next_block_idx(),
                   loc,
-                  None,
                   vec![dep],
                   Some(mocked_target.to_string()),
                 );

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/0/a.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/0/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/0/b.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/0/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/0/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/0/index.js
@@ -1,0 +1,8 @@
+export function load(value) {
+	return value ? import("./a") : import("./b");
+}
+
+it("should load the expected async module", async () => {
+	expect((await load(true)).default).toBe("a");
+	expect((await load(false)).default).toBe("b");
+});

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/1/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/1/index.js
@@ -1,0 +1,10 @@
+export function load(value) {
+
+
+	return value ? import("./a") : import("./b");
+}
+
+it("should load the expected async module", async () => {
+	expect((await load(true)).default).toBe("a");
+	expect((await load(false)).default).toBe("b");
+});

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/2/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/2/index.js
@@ -1,0 +1,10 @@
+export function load(value) {
+
+
+	return value ? import("./b") : import("./a");
+}
+
+it("should load the expected async module", async () => {
+	expect((await load(true)).default).toBe("b");
+	expect((await load(false)).default).toBe("a");
+});

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/rspack.config.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const PLUGIN_NAME = 'CheckAsyncBlockOriginsPlugin';
+
+class CheckAsyncBlockOriginsPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
+        const source = fs.readFileSync(
+          path.join(compilation.options.context, 'index.js'),
+          'utf-8',
+        );
+        const expectedLines = new Map(
+          ['./a', './b'].map((request) => {
+            const offset = source.indexOf(`import("${request}")`);
+            expect(offset).toBeGreaterThanOrEqual(0);
+            return [request, source.slice(0, offset).split('\n').length];
+          }),
+        );
+        const asyncOrigins = compilation.chunkGroups
+          .flatMap((chunkGroup) => chunkGroup.origins)
+          .filter((origin) => expectedLines.has(origin.request));
+
+        expect(asyncOrigins).toHaveLength(2);
+        for (const origin of asyncOrigins) {
+          expect(origin.loc.start.line).toBe(expectedLines.get(origin.request));
+        }
+      });
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    splitChunks: false,
+  },
+  plugins: [new CheckAsyncBlockOriginsPlugin()],
+};

--- a/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/async-block-value/test.config.js
@@ -1,0 +1,42 @@
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Assertion failed for ${message}`);
+  }
+}
+
+function shouldRebuild(stats) {
+  return stats.includes('<t> rebuild chunk graph');
+}
+
+module.exports = {
+  checkStats(stepName, _, stats) {
+    switch (stepName) {
+      case '0':
+        assert(
+          shouldRebuild(stats),
+          'initial compilation should build chunk graph',
+        );
+        break;
+      case '1':
+        assert(
+          !shouldRebuild(stats),
+          'loc-only change should reuse chunk graph',
+        );
+        break;
+      case '2':
+        assert(
+          shouldRebuild(stats),
+          'async block target change should rebuild chunk graph',
+        );
+        assert(
+          stats.includes('module code splitting value changed'),
+          'async block value comparison should detect the target change',
+        );
+        break;
+      default:
+        throw new Error(`Unexpected step ${stepName}`);
+    }
+
+    return true;
+  },
+};


### PR DESCRIPTION
## Summary

- generate `AsyncDependenciesBlockIdentifier` from the parent module and the block's module-local index
- validate code-splitting cache reuse from each block's actual value: group options, ordered target modules, and per-runtime connection states
- rebuild the chunk graph when an affected module has no previous runtime snapshot to compare
- refresh cached chunk-group origin metadata when code splitting is reused
- add a watch regression covering loc-only changes and async-block target changes

## Why

Async block identity previously included dependency resource data and source location. A loc-only edit could therefore change the block key even when its code-splitting topology was unchanged.

Identity is now a stable module-local slot used for graph lookup. Cache reuse is decided separately from the block's code-splitting value. When the value is unchanged, the cached chunk graph is reused and its origin `module`, `loc`, and `request` are updated. When a block points to different modules, changes its group/runtime behavior, or has no previous runtime snapshot that can prove equivalence, the chunk graph is rebuilt.

This keeps loc-only rebuilds on the fast path without allowing stale chunk topology or origin metadata.

