### PR TITLE
refactor(mf): add structural shared identity keys

### DIFF
--- a/crates/rspack_plugin_mf/src/lib.rs
+++ b/crates/rspack_plugin_mf/src/lib.rs
@@ -4,8 +4,14 @@ mod sharing;
 
 use rspack_hash::{RspackHash, RspackHasher};
 
-#[rspack_cacheable::cacheable]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
+fn push_identifier_component(key: &mut String, value: &str) {
+  key.push_str(&value.len().to_string());
+  key.push(':');
+  key.push_str(value);
+}
+
+#[rspack_cacheable::cacheable(hashable)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum ShareScope {
   Single(String),
@@ -15,8 +21,36 @@ pub enum ShareScope {
 impl ShareScope {
   pub fn key(&self) -> String {
     match self {
-      ShareScope::Single(s) => s.clone(),
-      ShareScope::Multiple(v) => v.join("|"),
+      ShareScope::Single(scope) => scope.clone(),
+      ShareScope::Multiple(scopes) => scopes.join("|"),
+    }
+  }
+
+  /// Stable, collision-free representation for internal module identifiers.
+  /// Runtime and display values must continue to use [`Self::scopes`] or [`Self::key`].
+  pub(crate) fn identifier_key(&self) -> String {
+    let mut key = String::new();
+    match self {
+      ShareScope::Single(scope) => {
+        key.push('s');
+        push_identifier_component(&mut key, scope);
+      }
+      ShareScope::Multiple(scopes) => {
+        key.push('m');
+        key.push_str(&scopes.len().to_string());
+        key.push(':');
+        for scope in scopes {
+          push_identifier_component(&mut key, scope);
+        }
+      }
+    }
+    key
+  }
+
+  pub(crate) fn identifier_fragment(&self) -> String {
+    match self {
+      ShareScope::Single(scope) => format!("({scope})"),
+      ShareScope::Multiple(_) => format!("[{}]", self.identifier_key()),
     }
   }
 
@@ -35,12 +69,74 @@ impl ShareScope {
   }
 }
 
+#[rspack_cacheable::cacheable(hashable)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SharedIdentity {
+  pub(crate) share_scope: ShareScope,
+  pub(crate) share_key: String,
+  pub(crate) layer: Option<String>,
+}
+
+impl SharedIdentity {
+  pub(crate) fn new(share_scope: &ShareScope, share_key: &str, layer: Option<&str>) -> Self {
+    Self {
+      share_scope: share_scope.clone(),
+      share_key: share_key.to_string(),
+      layer: layer.map(str::to_string),
+    }
+  }
+
+  pub(crate) fn identifier_key(&self) -> String {
+    let mut key = String::new();
+    push_identifier_component(&mut key, &self.share_scope.identifier_key());
+    match &self.layer {
+      Some(layer) => {
+        key.push('l');
+        push_identifier_component(&mut key, layer);
+      }
+      None => key.push('n'),
+    }
+    push_identifier_component(&mut key, &self.share_key);
+    key
+  }
+}
+
 impl RspackHash for ShareScope {
   fn hash(&self, state: &mut RspackHasher) {
     match self {
       ShareScope::Single(scope) => scope.hash(state),
       ShareScope::Multiple(scopes) => scopes.hash(state),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{ShareScope, SharedIdentity};
+
+  #[test]
+  fn share_scope_identifier_key_is_collision_free() {
+    let single = ShareScope::Single("a|b".to_string());
+    let multiple = ShareScope::Multiple(vec!["a".to_string(), "b".to_string()]);
+
+    assert_eq!(single.key(), multiple.key());
+    assert_ne!(single.identifier_key(), multiple.identifier_key());
+    assert_ne!(single.identifier_fragment(), multiple.identifier_fragment());
+    assert_ne!(
+      ShareScope::Multiple(vec!["a:".to_string(), "b".to_string()]).identifier_key(),
+      ShareScope::Multiple(vec!["a".to_string(), ":b".to_string()]).identifier_key()
+    );
+  }
+
+  #[test]
+  fn shared_identity_key_is_collision_free() {
+    let scope = ShareScope::Single("default".to_string());
+    let first = SharedIdentity::new(&scope, "c", Some("a) b"));
+    let second = SharedIdentity::new(&scope, "b) c", Some("a"));
+    let unlayered = SharedIdentity::new(&scope, "(a) b) c", None);
+
+    assert_ne!(first.identifier_key(), second.identifier_key());
+    assert_ne!(first.identifier_key(), unlayered.identifier_key());
   }
 }
 

--- a/crates/rspack_plugin_mf/src/sharing/mod.rs
+++ b/crates/rspack_plugin_mf/src/sharing/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use rspack_fs::ReadableFileSystem;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 pub mod collect_shared_entry_plugin;
 pub mod consume_shared_fallback_dependency;
@@ -23,6 +23,53 @@ pub mod shared_container_plugin;
 pub mod shared_container_runtime_module;
 pub mod shared_used_exports_optimizer_plugin;
 pub mod shared_used_exports_optimizer_runtime_module;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RequestMatchKey {
+  request: String,
+  layer: Option<String>,
+}
+
+impl RequestMatchKey {
+  pub(crate) fn new(request: &str, layer: Option<&str>) -> Self {
+    Self {
+      request: request.to_string(),
+      layer: layer.map(str::to_string),
+    }
+  }
+
+  pub(crate) fn request(&self) -> &str {
+    &self.request
+  }
+
+  fn matches_layer(&self, layer: Option<&str>) -> bool {
+    self.layer.is_none() || self.layer.as_deref() == layer
+  }
+}
+
+pub(crate) fn find_exact_match<'a, T>(
+  matches: &'a FxHashMap<RequestMatchKey, T>,
+  request: &str,
+  layer: Option<&str>,
+) -> Option<&'a T> {
+  matches
+    .get(&RequestMatchKey::new(request, layer))
+    .or_else(|| layer.and_then(|_| matches.get(&RequestMatchKey::new(request, None))))
+}
+
+pub(crate) fn find_prefix_match<'rules, 'request, T>(
+  matches: &'rules [(RequestMatchKey, T)],
+  request: &'request str,
+  layer: Option<&str>,
+) -> Option<(&'rules T, &'request str)> {
+  let (key, value) = matches
+    .iter()
+    .enumerate()
+    .filter(|(_, (key, _))| key.matches_layer(layer) && request.starts_with(key.request()))
+    .max_by_key(|(index, (key, _))| (key.request().len(), key.layer.is_some(), *index))?
+    .1;
+  Some((value, request.strip_prefix(key.request())?))
+}
 
 const DESCRIPTION_FILE_NAME: &str = "package.json";
 
@@ -97,4 +144,59 @@ async fn get_description_file(
   checked_file_paths.sort_unstable();
 
   (None, Some(checked_file_paths))
+}
+
+#[cfg(test)]
+mod tests {
+  use rustc_hash::FxHashMap;
+
+  use super::{RequestMatchKey, find_exact_match, find_prefix_match};
+
+  #[test]
+  fn request_match_keys_do_not_parse_layer_delimiters() {
+    let mut matches = FxHashMap::default();
+    matches.insert(RequestMatchKey::new("b)c", Some("a")), 1);
+    matches.insert(RequestMatchKey::new("c", Some("a)b")), 2);
+
+    assert_eq!(find_exact_match(&matches, "b)c", Some("a")), Some(&1));
+    assert_eq!(find_exact_match(&matches, "c", Some("a)b")), Some(&2));
+  }
+
+  #[test]
+  fn exact_match_prefers_layer_then_falls_back() {
+    let mut matches = FxHashMap::default();
+    matches.insert(RequestMatchKey::new("pkg", None), "fallback");
+    matches.insert(RequestMatchKey::new("pkg", Some("rsc")), "layered");
+
+    assert_eq!(
+      find_exact_match(&matches, "pkg", Some("rsc")),
+      Some(&"layered")
+    );
+    assert_eq!(
+      find_exact_match(&matches, "pkg", Some("client")),
+      Some(&"fallback")
+    );
+  }
+
+  #[test]
+  fn prefix_match_is_longest_then_layer_specific() {
+    let matches = vec![
+      (RequestMatchKey::new("pkg/", Some("rsc")), "layered"),
+      (RequestMatchKey::new("pkg/", None), "fallback"),
+      (RequestMatchKey::new("pkg/feature/", None), "feature"),
+    ];
+
+    assert_eq!(
+      find_prefix_match(&matches, "pkg/component", Some("rsc")),
+      Some((&"layered", "component"))
+    );
+    assert_eq!(
+      find_prefix_match(&matches, "pkg/component", Some("client")),
+      Some((&"fallback", "component"))
+    );
+    assert_eq!(
+      find_prefix_match(&matches, "pkg/feature/button", Some("rsc")),
+      Some((&"feature", "button"))
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Add collision-safe structural identity keys for share scopes, shared modules, and request/layer matches.
- Keep legacy display strings separate from internal identity keys.
- Add unit coverage for delimiter collisions, exact matches, fallback matches, and prefix matches.

## Related links

- Split from #12977
- Stack 1/5
- Base: `main`
- Next: #12977

## Testing

- `cargo check -p rspack_plugin_mf --quiet`
- `cargo test -p rspack_plugin_mf --lib --quiet` (13 passed)

## Checklist

- [x] Tests updated.
- [x] Documentation not required; internal identity refactor.