### PR TITLE
refactor(runtime): collect runtime module variables from templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,6 +3941,7 @@ dependencies = [
  "hex",
  "indexmap",
  "indoc",
+ "inventory",
  "itertools 0.14.0",
  "json",
  "mime_guess",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -24,6 +24,7 @@ heck                       = { workspace = true }
 hex                        = { workspace = true }
 indexmap                   = { workspace = true, features = ["rayon"] }
 indoc                      = { workspace = true }
+inventory                  = { workspace = true }
 itertools                  = { workspace = true }
 json                       = { workspace = true }
 mime_guess                 = { workspace = true }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -106,6 +106,7 @@ pub use rspack_location::{
 };
 pub mod concatenated_module;
 pub mod reserved_names;
+pub use inventory;
 use rspack_cacheable::{cacheable, with::AsPreset};
 use rspack_hash::{RspackHash, RspackHasher};
 pub use rspack_loader_runner::{

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -247,6 +247,14 @@ pub trait RuntimeModule:
   fn template(&self) -> Vec<(String, String)> {
     vec![]
   }
+  /// Names that this runtime module may declare in the surrounding chunk scope.
+  ///
+  /// Runtime modules backed by EJS templates should derive these names from top-level `var()` and
+  /// `fn()` declarations. `#[impl_runtime_module]` registers the provider so the names can be
+  /// reserved before runtime module instances are created.
+  fn runtime_module_variables() -> &'static [&'static str]
+  where
+    Self: Sized;
   async fn generate(
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
@@ -264,6 +272,18 @@ pub trait RuntimeModule:
   fn runtime_requirements(&self, _compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
     Default::default()
   }
+}
+
+pub struct RuntimeModuleVariableProvider {
+  pub variables: fn() -> &'static [&'static str],
+}
+
+inventory::collect!(RuntimeModuleVariableProvider);
+
+pub fn all_runtime_module_variables() -> impl Iterator<Item = &'static str> {
+  inventory::iter::<RuntimeModuleVariableProvider>
+    .into_iter()
+    .flat_map(|provider| (provider.variables)().iter().copied())
 }
 
 pub trait AttachableRuntimeModule {

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -181,6 +181,7 @@ impl RuntimeTemplate {
     let render_mode = RuntimeTemplateRenderMode::from(compiler_options.experiments.runtime_mode);
     let runtime_globals = get_runtime_globals_render_map(render_mode.runtime_module_render_mode());
     let mut dojang = Dojang::new();
+    register_runtime_module_declaration_functions(&mut dojang);
 
     let runtime_globals_cloned = runtime_globals.clone();
     let compiler_options_cloned = compiler_options.clone();
@@ -509,6 +510,21 @@ fn dojang_empty_function(compiler_options: &Arc<CompilerOptions>) -> Operand {
   } else {
     Operand::Value(Value::from("function() {}"))
   }
+}
+
+fn register_runtime_module_declaration_functions(dojang: &mut Dojang) {
+  dojang.functions.insert(
+    "var".into(),
+    FunctionContainer::F1(Box::new(|name: Operand| {
+      Operand::Value(Value::from(format!("var {}", String::from(name))))
+    })),
+  );
+  dojang.functions.insert(
+    "fn".into(),
+    FunctionContainer::F1(Box::new(|name: Operand| {
+      Operand::Value(Value::from(format!("function {}", String::from(name))))
+    })),
+  );
 }
 
 fn dojang_array_destructure(

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -2,14 +2,24 @@ use quote::quote;
 use syn::{ItemStruct, parse::Parser, parse_macro_input};
 
 pub fn impl_runtime_module(
-  _args: proc_macro::TokenStream,
+  args: proc_macro::TokenStream,
   tokens: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
+  parse_macro_input!(args as syn::parse::Nothing);
   let mut input = parse_macro_input!(tokens as ItemStruct);
   let name = &input.ident;
   let generics = &input.generics;
   let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
   let origin_fields = input.fields.clone();
+  let runtime_module_variable_provider = generics.params.is_empty().then(|| {
+    quote! {
+      ::rspack_core::inventory::submit! {
+        ::rspack_core::RuntimeModuleVariableProvider {
+          variables: <#name as ::rspack_core::RuntimeModule>::runtime_module_variables,
+        }
+      }
+    }
+  });
 
   if let syn::Fields::Named(ref mut fields) = input.fields {
     fields.named.push(
@@ -120,6 +130,8 @@ pub fn impl_runtime_module(
         unreachable!()
       }
     }
+
+    #runtime_module_variable_provider
 
     #[rspack_cacheable::cacheable_dyn]
     #[async_trait::async_trait]

--- a/crates/rspack_macros_test/tests/runtime_module.rs
+++ b/crates/rspack_macros_test/tests/runtime_module.rs
@@ -14,6 +14,10 @@ fn with_generic() {
 
   #[async_trait::async_trait]
   impl<T: std::fmt::Debug + Send + Sync + Eq + 'static> RuntimeModule for Foo<T> {
+    fn runtime_module_variables() -> &'static [&'static str] {
+      &[]
+    }
+
     async fn generate(&self, _: &RuntimeModuleGenerateContext<'_>) -> rspack_error::Result<String> {
       todo!()
     }

--- a/crates/rspack_plugin_css/src/runtime/css_loading.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading.ejs
@@ -1,5 +1,5 @@
-var cssLoadingUniqueName = "<%- _unique_name %>";
-function handleCssComposes(exports, composes) {
+<%- var("cssLoadingUniqueName") %> = "<%- _unique_name %>";
+<%- fn("handleCssComposes") %>(exports, composes) {
 	for (var i = 0; i < composes.length; i += 3) {
 		var moduleId = composes[i];
 		var composeFrom = composes[i + 1];
@@ -8,8 +8,8 @@ function handleCssComposes(exports, composes) {
 		exports[moduleId] = exports[moduleId] + " " + composedId
 	}
 }
-var loadingAttribute = "data-rspack-loading";
-var cssLoadStylesheet = <%- basicFunction("chunkId, url, done, hmr, fetchPriority") %> {
+<%- var("loadingAttribute") %> = "data-rspack-loading";
+<%- var("cssLoadStylesheet") %> = <%- basicFunction("chunkId, url, done, hmr, fetchPriority") %> {
 	var link,
 		needAttach,
 		key = "chunk-" + chunkId;

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_hmr.ejs
@@ -1,6 +1,6 @@
-var cssOldTags = [];
-var cssNewTags = [];
-var cssApplyHandler = <%- basicFunction("options") %> {
+<%- var("cssOldTags") %> = [];
+<%- var("cssNewTags") %> = [];
+<%- var("cssApplyHandler") %> = <%- basicFunction("options") %> {
 	return {
 		dispose: <%- basicFunction("") %> { },
 		apply: <%- basicFunction("") %> {
@@ -17,7 +17,7 @@ var cssApplyHandler = <%- basicFunction("options") %> {
 		}
 	};
 };
-var cssTextKeyOfLink = <%- basicFunction("link") %> {
+<%- var("cssTextKeyOfLink") %> = <%- basicFunction("link") %> {
 	return Array.from(link.sheet.cssRules, <%- returningFunction("r.cssText", "r") %>).join();
 };
 <%- HMR_DOWNLOAD_UPDATE_HANDLERS %>.css = <%- basicFunction("chunkIds, removedChunks, removedModules, promises, applyHandlers, updatedModulesList") %> {

--- a/crates/rspack_plugin_css/src/runtime/css_loading_with_style.ejs
+++ b/crates/rspack_plugin_css/src/runtime/css_loading_with_style.ejs
@@ -1,20 +1,20 @@
-var dataRspackPrefix = <%- _data_rspack_prefix %>;
+<%- var("dataRspackPrefix") %> = <%- _data_rspack_prefix %>;
 
-function getDataRspackId(identifier) {
+<%- fn("getDataRspackId") %>(identifier) {
 	return dataRspackPrefix + identifier;
 }
 
-function applyStyle(styleElement, css) {
+<%- fn("applyStyle") %>(styleElement, css) {
 	styleElement.textContent = css;
 }
 
-function removeStyleElement(styleElement) {
+<%- fn("removeStyleElement") %>(styleElement) {
 	if (styleElement.parentNode) {
 		styleElement.parentNode.removeChild(styleElement);
 	}
 }
 
-function findStyleElement(identifier) {
+<%- fn("findStyleElement") %>(identifier) {
 	var elements = document.getElementsByTagName("style");
 	for (var i = 0; i < elements.length; i++) {
 		var el = elements[i];
@@ -25,7 +25,7 @@ function findStyleElement(identifier) {
 	return null;
 }
 
-function insertStyleElement(key) {
+<%- fn("insertStyleElement") %>(key) {
 	<%- _create_style %>
 	document.head.appendChild(style);
 	return style;

--- a/crates/rspack_plugin_css/src/runtime/mod.rs
+++ b/crates/rspack_plugin_css/src/runtime/mod.rs
@@ -8,7 +8,8 @@ use rspack_core::{
 };
 use rspack_plugin_runtime::{
   CreateLinkData, LinkPrefetchData, LinkPreloadData, RuntimePlugin, chunk_has_css,
-  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements, stringify_chunks,
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+  get_chunk_runtime_requirements, stringify_chunks,
 };
 use rspack_util::json_stringify;
 
@@ -53,6 +54,22 @@ static CSS_LOADING_WITH_STYLE_SHEET_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
 > = LazyLock::new(|| RuntimeModuleRuntimeRequirements {
   ..extract_runtime_globals_from_ejs(CSS_LOADING_WITH_STYLE_SHEET_TEMPLATE)
+});
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    CSS_LOADING_TEMPLATE,
+    CSS_LOADING_CREATE_LINK_TEMPLATE,
+    CSS_LOADING_WITH_HMR_TEMPLATE,
+    CSS_LOADING_WITH_LOADING_TEMPLATE,
+    CSS_LOADING_WITH_PREFETCH_TEMPLATE,
+    CSS_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
+    CSS_LOADING_WITH_PRELOAD_TEMPLATE,
+    CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
+    CSS_LOADING_WITH_STYLE_TEMPLATE,
+    CSS_LOADING_WITH_STYLE_SHEET_TEMPLATE,
+  ]);
+  variables.push("cssInstalledChunks");
+  variables
 });
 
 #[impl_runtime_module]
@@ -121,6 +138,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for CssLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_esm_library/src/runtime.rs
+++ b/crates/rspack_plugin_esm_library/src/runtime.rs
@@ -5,6 +5,8 @@ use rspack_core::{
 use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 use rspack_util::json_stringify_str;
 
+const ESM_CHUNK_LOADING_RUNTIME_MODULE_VARIABLES: &[&str] = &["esmInstalledChunks", "esmChunkMap"];
+
 #[impl_runtime_module]
 #[derive(Debug)]
 pub(crate) struct EsmRegisterModuleRuntimeModule {}
@@ -17,6 +19,10 @@ impl EsmRegisterModuleRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for EsmRegisterModuleRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,
@@ -59,6 +65,10 @@ impl EsmEnsureChunkRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for EsmEnsureChunkRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   async fn generate(
     &self,
     context: &RuntimeModuleGenerateContext<'_>,
@@ -107,6 +117,10 @@ impl EsmChunkLoadingRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for EsmChunkLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    ESM_CHUNK_LOADING_RUNTIME_MODULE_VARIABLES
+  }
+
   async fn generate(
     &self,
     context: &RuntimeModuleGenerateContext<'_>,

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -9,7 +9,8 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_plugin_runtime::{
   CreateLinkData, LinkPrefetchData, LinkPreloadData, RuntimePlugin,
-  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+  get_chunk_runtime_requirements,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -29,6 +30,18 @@ static CSS_LOADING_WITH_PRELOAD_TEMPLATE: &str =
   include_str!("./runtime/css_loading_with_preload.ejs");
 static CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE: &str =
   include_str!("./runtime/css_loading_with_preload_link.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  extract_runtime_module_variables_from_ejs(&[
+    CSS_LOADING_TEMPLATE,
+    CSS_LOADING_CREATE_LINK_TEMPLATE,
+    CSS_LOADING_WITH_HMR_TEMPLATE,
+    CSS_LOADING_WITH_LOADING_TEMPLATE,
+    CSS_LOADING_WITH_PREFETCH_TEMPLATE,
+    CSS_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
+    CSS_LOADING_WITH_PRELOAD_TEMPLATE,
+    CSS_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
+  ])
+});
 
 static CSS_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(CSS_LOADING_TEMPLATE));
@@ -138,6 +151,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for CssLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Attach
   }

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading.ejs
@@ -1,5 +1,5 @@
 if (typeof document === "undefined") return;
-var extractCssCreateStylesheet = function (
+<%- var("extractCssCreateStylesheet") %> = function (
 	chunkId, fullhref, oldTag, resolve, reject, fetchPriority
 ) {
 	<%- _create_link %>
@@ -23,7 +23,7 @@ var extractCssCreateStylesheet = function (
 	<%- _insert %>
 	return linkTag;
 }
-var extractCssFindStylesheet = function (href, fullhref) {
+<%- var("extractCssFindStylesheet") %> = function (href, fullhref) {
 	var existingLinkTags = document.getElementsByTagName("link");
 	for (var i = 0; i < existingLinkTags.length; i++) {
 		var tag = existingLinkTags[i];
@@ -42,7 +42,7 @@ var extractCssFindStylesheet = function (href, fullhref) {
 	}
 }
 
-var extractCssLoadStylesheet = function (chunkId, fetchPriority) {
+<%- var("extractCssLoadStylesheet") %> = function (chunkId, fetchPriority) {
 	return new Promise(function (resolve, reject) {
 		var href = <%- REQUIRE_SCOPE %>.miniCssF(chunkId);
 		var fullhref = <%- PUBLIC_PATH %> + href;

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_hmr.ejs
@@ -1,9 +1,9 @@
-var extractCssOldTags = [];
-var extractCssNewTags = [];
-var extractCssTextKey = function (link) {
+<%- var("extractCssOldTags") %> = [];
+<%- var("extractCssNewTags") %> = [];
+<%- var("extractCssTextKey") %> = function (link) {
 	return Array.from(link.sheet.cssRules, function (r) { return r.cssText; }).join();
 }
-var extractCssApplyHandler = function (options) {
+<%- var("extractCssApplyHandler") %> = function (options) {
 	return {
 		dispose: function () {},
 		apply: function () {

--- a/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_loading.ejs
+++ b/crates/rspack_plugin_extract_css/src/runtime/css_loading_with_loading.ejs
@@ -1,5 +1,5 @@
 // object to store loaded CSS chunks
-var installedCssChunks = {
+<%- var("installedCssChunks") %> = {
 	<%- _installed_chunks %>
 };
 

--- a/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
+++ b/crates/rspack_plugin_hmr/src/hot_module_replacement.rs
@@ -5,7 +5,9 @@ use rspack_core::{
   RuntimeModuleRuntimeRequirements, RuntimeTemplate, impl_runtime_module,
   runtime_mode::RuntimeMode,
 };
-use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
+use rspack_plugin_runtime::{
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+};
 use rspack_util::test::is_hot_test;
 
 static HOT_MODULE_REPLACEMENT_TEMPLATE: &str = include_str!("runtime/hot_module_replacement.ejs");
@@ -17,6 +19,8 @@ static HOT_MODULE_REPLACEMENT_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntim
       .insert(RuntimeGlobals::INTERCEPT_MODULE_EXECUTION);
     requirements
   });
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[HOT_MODULE_REPLACEMENT_TEMPLATE]));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -30,6 +34,10 @@ impl HotModuleReplacementRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for HotModuleReplacementRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
+++ b/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.ejs
@@ -1,21 +1,21 @@
-var currentModuleData = {};
-var hmrInstalledModules = <%- MODULE_CACHE %>;
+<%- var("currentModuleData") %> = {};
+<%- var("hmrInstalledModules") %> = <%- MODULE_CACHE %>;
 
 // module and require creation
-var currentChildModule;
-var currentParents = [];
+<%- var("currentChildModule") %>;
+<%- var("currentParents") %> = [];
 
 // status
-var registeredStatusHandlers = [];
-var currentStatus = "idle";
+<%- var("registeredStatusHandlers") %> = [];
+<%- var("currentStatus") %> = "idle";
 
 // while downloading
-var blockingPromises = 0;
-var blockingPromisesWaiting = [];
+<%- var("blockingPromises") %> = 0;
+<%- var("blockingPromisesWaiting") %> = [];
 
 // The update info
-var currentUpdateApplyHandlers;
-var queuedInvalidatedModules;
+<%- var("currentUpdateApplyHandlers") %>;
+<%- var("queuedInvalidatedModules") %>;
 
 <%- define(HMR_MODULE_DATA) %> = currentModuleData;
 <% if (_is_rspack_runtime_mode) { %><%- define(INTERCEPT_MODULE_EXECUTION) %> = [];
@@ -34,7 +34,7 @@ var queuedInvalidatedModules;
 <%- define(HMR_DOWNLOAD_UPDATE_HANDLERS) %> = {};
 <%- define(HMR_INVALIDATE_MODULE_HANDLERS) %> = {};
 
-function createRequire(require, moduleId<% if (_is_rspack_runtime_mode) { %>, context<% } %>) {
+<%- fn("createRequire") %>(require, moduleId<% if (_is_rspack_runtime_mode) { %>, context<% } %>) {
 	var me = hmrInstalledModules[moduleId];
 	if (!me) return require;
 	var fn = function (request) {
@@ -87,7 +87,7 @@ function createRequire(require, moduleId<% if (_is_rspack_runtime_mode) { %>, co
 	return fn;
 }
 
-function createModuleHotObject(moduleId, me) {
+<%- fn("createModuleHotObject") %>(moduleId, me) {
 	var _main = currentChildModule !== moduleId;
 	var hot = {
 		_acceptedDependencies: {},
@@ -180,7 +180,7 @@ function createModuleHotObject(moduleId, me) {
 	return hot;
 }
 
-function setStatus(newStatus) {
+<%- fn("setStatus") %>(newStatus) {
 	currentStatus = newStatus;
 	<% if (_is_hot_test) { %>
 	if (self.__HMR_UPDATED_RUNTIME__) {
@@ -194,7 +194,7 @@ function setStatus(newStatus) {
 	return Promise.all(results).then(function () { });
 }
 
-function unblock() {
+<%- fn("unblock") %>() {
 	if (--blockingPromises === 0) {
 		setStatus("ready").then(function () {
 			if (blockingPromises === 0) {
@@ -208,7 +208,7 @@ function unblock() {
 	}
 }
 
-function trackBlockingPromise(promise) {
+<%- fn("trackBlockingPromise") %>(promise) {
 	switch (currentStatus) {
 		case "ready":
 			setStatus("prepare");
@@ -221,7 +221,7 @@ function trackBlockingPromise(promise) {
 	}
 }
 
-function waitForBlockingPromises(fn) {
+<%- fn("waitForBlockingPromises") %>(fn) {
 	if (blockingPromises === 0) return fn();
 	return new Promise(function (resolve) {
 		blockingPromisesWaiting.push(function () {
@@ -230,7 +230,7 @@ function waitForBlockingPromises(fn) {
 	});
 }
 
-function hotCheck(applyOnUpdate) {
+<%- fn("hotCheck") %>(applyOnUpdate) {
 	if (currentStatus !== "idle") {
 		throw new Error("check() is only allowed in idle status");
 	}
@@ -293,7 +293,7 @@ function hotCheck(applyOnUpdate) {
 		});
 }
 
-function hotApply(options) {
+<%- fn("hotApply") %>(options) {
 	if (currentStatus !== "ready") {
 		return Promise.resolve().then(function () {
 			throw new Error(
@@ -304,7 +304,7 @@ function hotApply(options) {
 	return internalApply(options);
 }
 
-function internalApply(options) {
+<%- fn("internalApply") %>(options) {
 	options = options || {};
 	applyInvalidatedModules();
 	var results = currentUpdateApplyHandlers.map(function (handler) {
@@ -370,7 +370,7 @@ function internalApply(options) {
 	});
 }
 
-function applyInvalidatedModules() {
+<%- fn("applyInvalidatedModules") %>() {
 	if (queuedInvalidatedModules) {
 		if (!currentUpdateApplyHandlers) currentUpdateApplyHandlers = [];
 		Object.keys(<%- HMR_INVALIDATE_MODULE_HANDLERS %>).forEach(function (key) {

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_async.ejs
@@ -1,4 +1,4 @@
-var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
+<%- var("mfStartupBase") %> = <%- REQUIRE %>.mfStartupBase = (function () {
 	var hasRun = false;
 	var result;
 	return function __rspack_require_mfStartupBase() {
@@ -10,7 +10,7 @@ var mfStartupBase = <%- REQUIRE %>.mfStartupBase = (function () {
 	};
 })();
 
-var mfAsyncStartup = <%- REQUIRE %>.mfAsyncStartup = (function () {
+<%- var("mfAsyncStartup") %> = <%- REQUIRE %>.mfAsyncStartup = (function () {
 	var hasRun = false;
 	var result;
 	return function __rspack_require_mfAsyncStartup() {
@@ -33,7 +33,7 @@ var mfAsyncStartup = <%- REQUIRE %>.mfAsyncStartup = (function () {
 
 <%- REQUIRE %>.mfStartup = <%- STARTUP %>;
 
-var wrapStartup = function (prev, isEntry) {
+<%- var("wrapStartup") %> = function (prev, isEntry) {
 	prev = typeof prev === "function" ? prev : function () {};
 	return function (result, chunkIds, cb) {
 		var res = mfAsyncStartup();

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_module.rs
@@ -4,14 +4,28 @@
 //! execute before other modules. Generates a "prevStartup wrapper" pattern with defensive
 //! checks that intercepts and modifies the startup execution order.
 
+use std::sync::LazyLock;
+
 use rspack_cacheable::cacheable;
 use rspack_core::{
   Compilation, DependencyId, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
   RuntimeModuleStage, RuntimeTemplate, impl_runtime_module,
 };
 use rspack_error::Result;
+use rspack_plugin_runtime::extract_runtime_module_variables_from_ejs;
 
 use super::module_federation_runtime_plugin::ModuleFederationRuntimeExperimentsOptions;
+
+static EMBED_FEDERATION_RUNTIME_ASYNC_TEMPLATE: &str =
+  include_str!("./embed_federation_runtime_async.ejs");
+static EMBED_FEDERATION_RUNTIME_SYNC_TEMPLATE: &str =
+  include_str!("./embed_federation_runtime_sync.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  extract_runtime_module_variables_from_ejs(&[
+    EMBED_FEDERATION_RUNTIME_ASYNC_TEMPLATE,
+    EMBED_FEDERATION_RUNTIME_SYNC_TEMPLATE,
+  ])
+});
 
 #[cacheable]
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
@@ -51,6 +65,10 @@ impl EmbedFederationRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for EmbedFederationRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,
@@ -70,11 +88,11 @@ impl RuntimeModule for EmbedFederationRuntimeModule {
     vec![
       (
         self.template_id(TemplateId::Async),
-        include_str!("./embed_federation_runtime_async.ejs").to_string(),
+        EMBED_FEDERATION_RUNTIME_ASYNC_TEMPLATE.to_string(),
       ),
       (
         self.template_id(TemplateId::Sync),
-        include_str!("./embed_federation_runtime_sync.ejs").to_string(),
+        EMBED_FEDERATION_RUNTIME_SYNC_TEMPLATE.to_string(),
       ),
     ]
   }

--- a/crates/rspack_plugin_mf/src/container/embed_federation_runtime_sync.ejs
+++ b/crates/rspack_plugin_mf/src/container/embed_federation_runtime_sync.ejs
@@ -1,5 +1,5 @@
-var prevStartup = <%- STARTUP %>;
-var hasRun = false;
+<%- var("prevStartup") %> = <%- STARTUP %>;
+<%- var("hasRun") %> = false;
 <%- STARTUP %> = function () {
 	if (!hasRun) {
 		hasRun = true;

--- a/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
@@ -54,6 +54,10 @@ impl ExposeRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ExposeRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_data_runtime_module.rs
@@ -26,6 +26,10 @@ impl FederationDataRuntimeModule {
 }
 #[async_trait]
 impl RuntimeModule for FederationDataRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Normal
   }

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -37,6 +37,10 @@ impl RemoteRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RemoteRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -5,7 +5,9 @@ use rspack_core::{
   RuntimeModuleGenerateContext, RuntimeModuleRuntimeRequirements, RuntimeModuleStage,
   RuntimeTemplate, SourceType, impl_runtime_module,
 };
-use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
+use rspack_plugin_runtime::{
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+};
 use rspack_util::json_stringify_str;
 
 use super::consume_shared_plugin::ConsumeVersion;
@@ -23,6 +25,13 @@ static CONSUMES_INITIAL_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequi
   LazyLock::new(|| extract_runtime_globals_from_ejs(CONSUMES_INITIAL_TEMPLATE));
 static CONSUMES_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(CONSUMES_LOADING_TEMPLATE));
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  extract_runtime_module_variables_from_ejs(&[
+    CONSUMES_COMMON_TEMPLATE,
+    CONSUMES_INITIAL_TEMPLATE,
+    CONSUMES_LOADING_TEMPLATE,
+  ])
+});
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -52,6 +61,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ConsumeSharedRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_mf/src/sharing/consumesCommon.ejs
+++ b/crates/rspack_plugin_mf/src/sharing/consumesCommon.ejs
@@ -1,9 +1,9 @@
-var splitAndConvert = function(str) {
+<%- var("splitAndConvert") %> = function(str) {
   return str.split(".").map(function(item) {
     return +item == item ? +item : item;
   });
 };
-var parseRange = function(str) {
+<%- var("parseRange") %> = function(str) {
   // see https://docs.npmjs.com/misc/semver#range-grammar for grammar
   var parsePartial = function(str) {
     var match = /^([^-+]+)?(?:-([^+]+))?(?:\+(.+))?$/.exec(str);
@@ -131,7 +131,7 @@ var parseRange = function(str) {
   };
   return parseLogicalOr(str);
 };
-var parseVersion = function(str) {
+<%- var("parseVersion") %> = function(str) {
 	var match = /^([^-+]+)?(?:-([^+]+))?(?:\+(.+))?$/.exec(str);
 	/** @type {(string|number|undefined|[])[]} */
 	var ver = match[1] ? splitAndConvert(match[1]) : [];
@@ -145,7 +145,7 @@ var parseVersion = function(str) {
 	}
 	return ver;
 }
-var versionLt = function(a, b) {
+<%- var("versionLt") %> = function(a, b) {
 	a = parseVersion(a);
 	b = parseVersion(b);
 	var i = 0;
@@ -184,7 +184,7 @@ var versionLt = function(a, b) {
 		}
 	}
 }
-var rangeToString = function(range) {
+<%- var("rangeToString") %> = function(range) {
 	var fixCount = range[0];
 	var str = "";
 	if (range.length === 1) {
@@ -235,7 +235,7 @@ var rangeToString = function(range) {
 		return stack.pop().replace(/^\((.+)\)$/, "$1");
 	}
 }
-var satisfy = function(range, version) {
+<%- var("satisfy") %> = function(range, version) {
 	if (0 in range) {
 		version = parseVersion(version);
 		var fixCount = /** @type {number} */ (range[0]);
@@ -372,42 +372,42 @@ var satisfy = function(range, version) {
 	}
 	return !!p();
 }
-var ensureExistence = function(scopeName, key) {
+<%- var("ensureExistence") %> = function(scopeName, key) {
 	var scope = <%- SHARE_SCOPE_MAP %>[scopeName];
 	if(!scope || !<%- HAS_OWN_PROPERTY %>(scope, key)) throw new Error("Shared module " + key + " doesn't exist in shared scope " + scopeName);
 	return scope;
 };
-var findVersion = function(scope, key) {
+<%- var("findVersion") %> = function(scope, key) {
 	var versions = scope[key];
 	var key = Object.keys(versions).reduce(function(a, b) {
 		return !a || versionLt(a, b) ? b : a;
 	}, 0);
 	return key && versions[key]
 };
-var findSingletonVersionKey = function(scope, key) {
+<%- var("findSingletonVersionKey") %> = function(scope, key) {
 	var versions = scope[key];
 	return Object.keys(versions).reduce(function(a, b) {
 		return !a || (!versions[a].loaded && versionLt(a, b)) ? b : a;
 	}, 0);
 };
-var getInvalidSingletonVersionMessage = function(scope, key, version, requiredVersion) {
+<%- var("getInvalidSingletonVersionMessage") %> = function(scope, key, version, requiredVersion) {
 	return "Unsatisfied version " + version + " from " + (version && scope[key][version].from) + " of shared singleton module " + key + " (required " + rangeToString(requiredVersion) + ")"
 };
-var getSingleton = function(scope, scopeName, key, requiredVersion) {
+<%- var("getSingleton") %> = function(scope, scopeName, key, requiredVersion) {
 	var version = findSingletonVersionKey(scope, key);
 	return get(scope[key][version]);
 };
-var getSingletonVersion = function(scope, scopeName, key, requiredVersion) {
+<%- var("getSingletonVersion") %> = function(scope, scopeName, key, requiredVersion) {
 	var version = findSingletonVersionKey(scope, key);
 	if (!satisfy(requiredVersion, version)) warn(getInvalidSingletonVersionMessage(scope, key, version, requiredVersion));
 	return get(scope[key][version]);
 };
-var getStrictSingletonVersion = function(scope, scopeName, key, requiredVersion) {
+<%- var("getStrictSingletonVersion") %> = function(scope, scopeName, key, requiredVersion) {
 	var version = findSingletonVersionKey(scope, key);
 	if (!satisfy(requiredVersion, version)) throw new Error(getInvalidSingletonVersionMessage(scope, key, version, requiredVersion));
 	return get(scope[key][version]);
 };
-var findValidVersion = function(scope, key, requiredVersion) {
+<%- var("findValidVersion") %> = function(scope, key, requiredVersion) {
 	var versions = scope[key];
 	var key = Object.keys(versions).reduce(function(a, b) {
 		if (!satisfy(requiredVersion, b)) return a;
@@ -415,82 +415,82 @@ var findValidVersion = function(scope, key, requiredVersion) {
 	}, 0);
 	return key && versions[key]
 };
-var getInvalidVersionMessage = function(scope, scopeName, key, requiredVersion) {
+<%- var("getInvalidVersionMessage") %> = function(scope, scopeName, key, requiredVersion) {
 	var versions = scope[key];
 	return "No satisfying version (" + rangeToString(requiredVersion) + ") of shared module " + key + " found in shared scope " + scopeName + ".\n" +
 		"Available versions: " + Object.keys(versions).map(function(key) {
 		return key + " from " + versions[key].from;
 	}).join(", ");
 };
-var getValidVersion = function(scope, scopeName, key, requiredVersion) {
+<%- var("getValidVersion") %> = function(scope, scopeName, key, requiredVersion) {
 	var entry = findValidVersion(scope, key, requiredVersion);
 	if(entry) return get(entry);
 	throw new Error(getInvalidVersionMessage(scope, scopeName, key, requiredVersion));
 };
-var warn = function(msg) {
+<%- var("warn") %> = function(msg) {
 	if (typeof console !== "undefined" && console.warn) console.warn(msg);
 };
-var warnInvalidVersion = function(scope, scopeName, key, requiredVersion) {
+<%- var("warnInvalidVersion") %> = function(scope, scopeName, key, requiredVersion) {
 	warn(getInvalidVersionMessage(scope, scopeName, key, requiredVersion));
 };
-var get = function(entry) {
+<%- var("get") %> = function(entry) {
 	entry.loaded = 1;
 	return entry.get()
 };
-var init = function(fn) { return function(scopeName, a, b, c) {
+<%- var("init") %> = function(fn) { return function(scopeName, a, b, c) {
 	var promise = <%- INITIALIZE_SHARING %>(scopeName);
 	if (promise && promise.then) return promise.then(fn.bind(fn, scopeName, <%- SHARE_SCOPE_MAP %>[scopeName], a, b, c));
 	return fn(scopeName, <%- SHARE_SCOPE_MAP %>[scopeName], a, b, c);
 }; };
 
-var load = /*#__PURE__*/ init(function(scopeName, scope, key) {
+<%- var("load") %> = /*#__PURE__*/ init(function(scopeName, scope, key) {
 	ensureExistence(scopeName, key);
 	return get(findVersion(scope, key));
 });
-var loadFallback = /*#__PURE__*/ init(function(scopeName, scope, key, fallback) {
+<%- var("loadFallback") %> = /*#__PURE__*/ init(function(scopeName, scope, key, fallback) {
 	return scope && <%- HAS_OWN_PROPERTY %>(scope, key) ? get(findVersion(scope, key)) : fallback();
 });
-var loadVersionCheck = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
+<%- var("loadVersionCheck") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
 	ensureExistence(scopeName, key);
 	return get(findValidVersion(scope, key, version) || warnInvalidVersion(scope, scopeName, key, version) || findVersion(scope, key));
 });
-var loadSingleton = /*#__PURE__*/ init(function(scopeName, scope, key) {
+<%- var("loadSingleton") %> = /*#__PURE__*/ init(function(scopeName, scope, key) {
 	ensureExistence(scopeName, key);
 	return getSingleton(scope, scopeName, key);
 });
-var loadSingletonVersionCheck = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
+<%- var("loadSingletonVersionCheck") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
 	ensureExistence(scopeName, key);
 	return getSingletonVersion(scope, scopeName, key, version);
 });
-var loadStrictVersionCheck = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
+<%- var("loadStrictVersionCheck") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
 	ensureExistence(scopeName, key);
 	return getValidVersion(scope, scopeName, key, version);
 });
-var loadStrictSingletonVersionCheck = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
+<%- var("loadStrictSingletonVersionCheck") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version) {
 	ensureExistence(scopeName, key);
 	return getStrictSingletonVersion(scope, scopeName, key, version);
 });
-var loadVersionCheckFallback = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
+<%- var("loadVersionCheckFallback") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
 	if(!scope || !<%- HAS_OWN_PROPERTY %>(scope, key)) return fallback();
 	return get(findValidVersion(scope, key, version) || warnInvalidVersion(scope, scopeName, key, version) || findVersion(scope, key));
 });
-var loadSingletonFallback = /*#__PURE__*/ init(function(scopeName, scope, key, fallback) {
+<%- var("loadSingletonFallback") %> = /*#__PURE__*/ init(function(scopeName, scope, key, fallback) {
 	if(!scope || !<%- HAS_OWN_PROPERTY %>(scope, key)) return fallback();
 	return getSingleton(scope, scopeName, key);
 });
-var loadSingletonVersionCheckFallback = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
+<%- var("loadSingletonVersionCheckFallback") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
 	if(!scope || !<%- HAS_OWN_PROPERTY %>(scope, key)) return fallback();
 	return getSingletonVersion(scope, scopeName, key, version);
 });
-var loadStrictVersionCheckFallback = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
+<%- var("loadStrictVersionCheckFallback") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
 	var entry = scope && <%- HAS_OWN_PROPERTY %>(scope, key) && findValidVersion(scope, key, version);
 	return entry ? get(entry) : fallback();
 });
-var loadStrictSingletonVersionCheckFallback = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
+<%- var("loadStrictSingletonVersionCheckFallback") %> = /*#__PURE__*/ init(function(scopeName, scope, key, version, fallback) {
 	if(!scope || !<%- HAS_OWN_PROPERTY %>(scope, key)) return fallback();
 	return getStrictSingletonVersion(scope, scopeName, key, version);
 });
-var resolveHandler = function(data) {
+<%- var("resolveHandler") %> = function(data) {
 	var strict = false
 	var singleton = false
 	var versionCheck = false
@@ -519,4 +519,4 @@ var resolveHandler = function(data) {
 	if (fallback) return function() { return loadFallback.apply(null, args); }
 	return function() { return load.apply(null, args); }
 };
-var consumeSharedInstalledModules = {};
+<%- var("consumeSharedInstalledModules") %> = {};

--- a/crates/rspack_plugin_mf/src/sharing/initializeSharing.ejs
+++ b/crates/rspack_plugin_mf/src/sharing/initializeSharing.ejs
@@ -1,5 +1,5 @@
-var initPromises = {};
-var initTokens = {};
+<%- var("initPromises") %> = {};
+<%- var("initTokens") %> = {};
 <%- define(INITIALIZE_SHARING) %> = function(name, initScope) {
 	if (!initScope) initScope = [];
 	// handling circular init calls

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -5,7 +5,9 @@ use rspack_core::{
   Compilation, ModuleId, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext,
   RuntimeModuleRuntimeRequirements, RuntimeTemplate, SourceType, impl_runtime_module,
 };
-use rspack_plugin_runtime::extract_runtime_globals_from_ejs;
+use rspack_plugin_runtime::{
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+};
 use rspack_util::{
   fx_hash::{FxLinkedHashMap, FxLinkedHashSet},
   json_stringify_str,
@@ -24,6 +26,8 @@ static INITIALIZE_SHARING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeReq
     force_context: RuntimeGlobals::INITIALIZE_SHARING | RuntimeGlobals::SHARE_SCOPE_MAP,
     ..extract_runtime_globals_from_ejs(INITIALIZE_SHARING_TEMPLATE)
   });
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[INITIALIZE_SHARING_TEMPLATE]));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -39,6 +43,10 @@ impl ShareRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ShareRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_mf/src/sharing/shared_container_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_container_runtime_module.rs
@@ -17,6 +17,10 @@ impl ShareContainerRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ShareContainerRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   async fn generate(
     &self,
     context: &RuntimeModuleGenerateContext<'_>,

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_runtime_module.rs
@@ -32,6 +32,10 @@ impl SharedUsedExportsOptimizerRuntimeModule {
 
 #[async_trait]
 impl RuntimeModule for SharedUsedExportsOptimizerRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Attach
   }

--- a/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
+++ b/crates/rspack_plugin_rsc/src/manifest_runtime_module.rs
@@ -23,6 +23,10 @@ impl RscManifestRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RscManifestRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -412,6 +412,11 @@ static EJS_RUNTIME_GLOBAL_WEAK_RE: LazyLock<Regex> = LazyLock::new(|| {
     .expect("invalid EJS runtime global weak regex")
 });
 
+static EJS_RUNTIME_MODULE_VARIABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+  Regex::new(r#"<%\-\s*(?:var|fn)\(\s*"([A-Za-z_$][A-Za-z0-9_$]*)"\s*\)\s*%>"#)
+    .expect("invalid EJS runtime module variable regex")
+});
+
 /// Extracts all RuntimeGlobals references from an EJS template string.
 ///
 /// Matches patterns like `<%- PUBLIC_PATH %>` or `<%- GET_CHUNK_SCRIPT_FILENAME %>`
@@ -444,6 +449,26 @@ pub fn extract_runtime_globals_from_ejs(ejs_content: &str) -> RuntimeModuleRunti
     define,
     ..Default::default()
   }
+}
+
+/// Extracts top-level runtime module declarations written with EJS `var()` and `fn()` helpers.
+pub fn extract_runtime_module_variables_from_ejs(
+  ejs_contents: &[&'static str],
+) -> Vec<&'static str> {
+  let mut variables = FxIndexSet::default();
+  for ejs_content in ejs_contents {
+    variables.extend(
+      EJS_RUNTIME_MODULE_VARIABLE_RE
+        .captures_iter(ejs_content)
+        .map(|capture| {
+          capture
+            .get(1)
+            .expect("should have a variable name")
+            .as_str()
+        }),
+    );
+  }
+  variables.into_iter().collect()
 }
 
 #[cfg(test)]

--- a/crates/rspack_plugin_runtime/src/runtime_module/amd_define.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/amd_define.rs
@@ -15,6 +15,10 @@ impl AmdDefineRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for AmdDefineRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/amd_options.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/amd_options.rs
@@ -17,6 +17,10 @@ impl AmdOptionsRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for AmdOptionsRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/async_module.rs
@@ -1,9 +1,15 @@
+use std::sync::LazyLock;
+
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeModule,
   RuntimeModuleGenerateContext, RuntimeTemplate, RuntimeVariable, impl_runtime_module,
 };
 
+use crate::extract_runtime_module_variables_from_ejs;
+
 static ASYNC_MODULE_TEMPLATE: &str = include_str!("runtime/async_module.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[ASYNC_MODULE_TEMPLATE]));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -17,6 +23,10 @@ impl AsyncRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for AsyncRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   async fn generate(
     &self,
     context: &RuntimeModuleGenerateContext<'_>,

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -1,10 +1,16 @@
+use std::sync::LazyLock;
+
 use rspack_core::{
   Compilation, OutputOptions, PathData, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
   RuntimeModuleGenerateContext, RuntimeModuleStage, RuntimeTemplate, SourceType,
   get_js_chunk_filename_template, get_undo_path, impl_runtime_module,
 };
 
+use crate::extract_runtime_module_variables_from_ejs;
+
 static AUTO_PUBLIC_PATH_TEMPLATE: &str = include_str!("runtime/auto_public_path.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[AUTO_PUBLIC_PATH_TEMPLATE]));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -18,6 +24,10 @@ impl AutoPublicPathRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for AutoPublicPathRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn stage(&self) -> RuntimeModuleStage {
     RuntimeModuleStage::Attach
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
@@ -17,6 +17,10 @@ impl BaseUriRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for BaseUriRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
@@ -15,6 +15,10 @@ impl ChunkNameRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ChunkNameRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_preload_function.rs
@@ -28,6 +28,10 @@ impl ChunkPrefetchPreloadFunctionRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ChunkPrefetchPreloadFunctionRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
@@ -29,6 +29,10 @@ impl ChunkPrefetchStartupRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_trigger.rs
@@ -7,9 +7,11 @@ use rspack_core::{
   chunk_graph_chunk::ChunkId, impl_runtime_module,
 };
 
-use crate::extract_runtime_globals_from_ejs;
+use crate::{extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs};
 
 static CHUNK_PREFETCH_TRIGGER_TEMPLATE: &str = include_str!("runtime/chunk_prefetch_trigger.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[CHUNK_PREFETCH_TRIGGER_TEMPLATE]));
 static CHUNK_PREFETCH_TRIGGER_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(CHUNK_PREFETCH_TRIGGER_TEMPLATE));
 
@@ -28,6 +30,10 @@ impl ChunkPrefetchTriggerRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ChunkPrefetchTriggerRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_preload_trigger.rs
@@ -7,9 +7,11 @@ use rspack_core::{
   chunk_graph_chunk::ChunkId, impl_runtime_module,
 };
 
-use crate::extract_runtime_globals_from_ejs;
+use crate::{extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs};
 
 static CHUNK_PRELOAD_TRIGGER_TEMPLATE: &str = include_str!("runtime/chunk_preload_trigger.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[CHUNK_PRELOAD_TRIGGER_TEMPLATE]));
 static CHUNK_PRELOAD_TRIGGER_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(CHUNK_PRELOAD_TRIGGER_TEMPLATE));
 
@@ -28,6 +30,10 @@ impl ChunkPreloadTriggerRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ChunkPreloadTriggerRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/compat_get_default_export.rs
@@ -18,6 +18,10 @@ impl CompatGetDefaultExportRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for CompatGetDefaultExportRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_fake_namespace_object.rs
@@ -1,10 +1,17 @@
+use std::sync::LazyLock;
+
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeTemplate,
   impl_runtime_module, runtime_mode::RuntimeMode,
 };
 
+use crate::extract_runtime_module_variables_from_ejs;
+
 static CREATE_FAKE_NAMESPACE_OBJECT_TEMPLATE: &str =
   include_str!("runtime/create_fake_namespace_object.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  extract_runtime_module_variables_from_ejs(&[CREATE_FAKE_NAMESPACE_OBJECT_TEMPLATE])
+});
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -34,6 +41,10 @@ impl RuntimeModule for CreateFakeNamespaceObjectRuntimeModule {
       self.id().to_string(),
       CREATE_FAKE_NAMESPACE_OBJECT_TEMPLATE.to_string(),
     )]
+  }
+
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
   }
 
   async fn generate(

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script.rs
@@ -15,6 +15,10 @@ impl CreateScriptRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for CreateScriptRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/create_script_url.rs
@@ -15,6 +15,10 @@ impl CreateScriptUrlRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for CreateScriptUrlRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/define_property_getters.rs
@@ -17,6 +17,10 @@ impl DefinePropertyGettersRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for DefinePropertyGettersRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
@@ -33,6 +33,10 @@ impl EnsureChunkRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for EnsureChunkRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![
       (

--- a/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/esm_module_decorator.rs
@@ -15,6 +15,10 @@ impl ESMModuleDecoratorRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ESMModuleDecoratorRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/export_require.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/export_require.rs
@@ -5,6 +5,11 @@ use rspack_core::{
 
 pub static EXPORT_REQUIRE_RUNTIME_MODULE_ID: &str = "export_webpack_require";
 pub static EXPORT_REQUIRE_RSPACK_RUNTIME_MODULE_ID: &str = "export_require";
+const RUNTIME_MODULE_VARIABLES: &[&str] = &[
+  "__webpack_require__temp",
+  "__rspack_contexttemp",
+  "rspackRequiretemp",
+];
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -23,6 +28,10 @@ impl ExportRequireRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ExportRequireRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -73,6 +73,10 @@ impl GetChunkFilenameRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for GetChunkFilenameRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -16,6 +16,10 @@ impl GetChunkUpdateFilenameRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_full_hash.rs
@@ -15,6 +15,10 @@ impl GetFullHashRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for GetFullHashRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -28,6 +28,10 @@ impl GetMainFilenameRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for GetMainFilenameRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -1,9 +1,16 @@
+use std::sync::LazyLock;
+
 use rspack_core::{
   Compilation, OnPolicyCreationFailure, RuntimeGlobals, RuntimeModule,
   RuntimeModuleGenerateContext, RuntimeTemplate, impl_runtime_module,
 };
 
-use crate::get_chunk_runtime_requirements;
+use crate::{extract_runtime_module_variables_from_ejs, get_chunk_runtime_requirements};
+
+static GET_TRUSTED_TYPES_POLICY_TEMPLATE: &str =
+  include_str!("runtime/get_trusted_types_policy.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[GET_TRUSTED_TYPES_POLICY_TEMPLATE]));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -17,6 +24,10 @@ impl GetTrustedTypesPolicyRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,
@@ -30,7 +41,7 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),
-      include_str!("runtime/get_trusted_types_policy.ejs").to_string(),
+      GET_TRUSTED_TYPES_POLICY_TEMPLATE.to_string(),
     )]
   }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/global.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/global.rs
@@ -15,6 +15,10 @@ impl GlobalRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for GlobalRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
@@ -15,6 +15,10 @@ impl HasOwnPropertyRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for HasOwnPropertyRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -9,7 +9,8 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 
 use super::{generate_javascript_hmr_runtime, utils::get_output_dir};
 use crate::{
-  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+  get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -25,6 +26,17 @@ static IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE: &str =
   include_str!("runtime/import_scripts_chunk_loading_with_hmr_manifest.ejs");
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    IMPORT_SCRIPTS_CHUNK_LOADING_TEMPLATE,
+    IMPORT_SCRIPTS_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
+    IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_TEMPLATE,
+    IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
+    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
+  ]);
+  variables.push("importScriptsInstalledChunks");
+  variables
+});
 
 static IMPORT_SCRIPTS_CHUNK_LOADING_RUNTIME_REQUIREMENTS: LazyLock<
   RuntimeModuleRuntimeRequirements,
@@ -130,6 +142,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
     let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();
@@ -170,23 +186,23 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
     vec![
       (
         self.template_id(TemplateId::Raw),
-        include_str!("runtime/import_scripts_chunk_loading.ejs").to_string(),
+        IMPORT_SCRIPTS_CHUNK_LOADING_TEMPLATE.to_string(),
       ),
       (
         self.template_id(TemplateId::WithLoading),
-        include_str!("runtime/import_scripts_chunk_loading_with_loading.ejs").to_string(),
+        IMPORT_SCRIPTS_CHUNK_LOADING_WITH_LOADING_TEMPLATE.to_string(),
       ),
       (
         self.template_id(TemplateId::WithHmr),
-        include_str!("runtime/import_scripts_chunk_loading_with_hmr.ejs").to_string(),
+        IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_TEMPLATE.to_string(),
       ),
       (
         self.template_id(TemplateId::WithHmrManifest),
-        include_str!("runtime/import_scripts_chunk_loading_with_hmr_manifest.ejs").to_string(),
+        IMPORT_SCRIPTS_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE.to_string(),
       ),
       (
         self.template_id(TemplateId::HmrRuntime),
-        include_str!("runtime/javascript_hot_module_replacement.ejs").to_string(),
+        JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE.to_string(),
       ),
     ]
   }

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -10,7 +10,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 use super::generate_javascript_hmr_runtime;
 use crate::{
   LinkPrefetchData, LinkPreloadData, RuntimePlugin, extract_runtime_globals_from_ejs,
-  get_chunk_runtime_requirements,
+  extract_runtime_module_variables_from_ejs, get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -35,6 +35,22 @@ static JSONP_CHUNK_LOADING_WITH_CALLBACK_TEMPLATE: &str =
   include_str!("runtime/jsonp_chunk_loading_with_callback.ejs");
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    JSONP_CHUNK_LOADING_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_PREFETCH_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_PRELOAD_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_HMR_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE,
+    JSONP_CHUNK_LOADING_WITH_CALLBACK_TEMPLATE,
+    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
+  ]);
+  variables.push("jsonpInstalledChunks");
+  variables
+});
 
 static JSONP_CHUNK_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(JSONP_CHUNK_LOADING_TEMPLATE));
@@ -159,6 +175,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
     let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -7,12 +7,20 @@ use rspack_core::{
 
 use crate::{
   CreateScriptData, RuntimeModuleChunkWrapper, RuntimePlugin, extract_runtime_globals_from_ejs,
-  get_chunk_runtime_requirements,
+  extract_runtime_module_variables_from_ejs, get_chunk_runtime_requirements,
 };
 
 static LOAD_SCRIPT_TEMPLATE: &str = include_str!("runtime/load_script.ejs");
 static LOAD_SCRIPT_CREATE_SCRIPT_TEMPLATE: &str =
   include_str!("runtime/load_script_create_script.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    LOAD_SCRIPT_TEMPLATE,
+    LOAD_SCRIPT_CREATE_SCRIPT_TEMPLATE,
+  ]);
+  variables.push("uniqueName");
+  variables
+});
 static LOAD_SCRIPT_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(LOAD_SCRIPT_TEMPLATE));
 static LOAD_SCRIPT_CREATE_SCRIPT_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
@@ -49,6 +57,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for LoadScriptRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_deferred_namespace_object_runtime.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_deferred_namespace_object_runtime.rs
@@ -22,6 +22,10 @@ impl MakeDeferredNamespaceObjectRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for MakeDeferredNamespaceObjectRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_namespace_object.rs
@@ -15,6 +15,10 @@ impl MakeNamespaceObjectRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for MakeNamespaceObjectRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/make_optimized_deferred_namespace_object_runtime.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/make_optimized_deferred_namespace_object_runtime.rs
@@ -22,6 +22,10 @@ impl MakeOptimizedDeferredNamespaceObjectRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for MakeOptimizedDeferredNamespaceObjectRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -11,7 +11,7 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 use super::utils::get_output_dir;
 use crate::{
   LinkPrefetchData, LinkPreloadData, RuntimePlugin, extract_runtime_globals_from_ejs,
-  get_chunk_runtime_requirements,
+  extract_runtime_module_variables_from_ejs, get_chunk_runtime_requirements,
   runtime_module::{
     generate_javascript_hmr_runtime,
     utils::{get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks},
@@ -35,6 +35,21 @@ static MODULE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE: &str =
   include_str!("runtime/module_chunk_loading_with_hmr_manifest.ejs");
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    MODULE_CHUNK_LOADING_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_PREFETCH_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_PREFETCH_LINK_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_PRELOAD_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_PRELOAD_LINK_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_HMR_TEMPLATE,
+    MODULE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
+    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
+  ]);
+  variables.push("moduleInstalledChunks");
+  variables
+});
 
 static MODULE_CHUNK_LOADING_BASIC_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(MODULE_CHUNK_LOADING_TEMPLATE));
@@ -159,6 +174,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
     let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();

--- a/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/node_module_decorator.rs
@@ -15,6 +15,10 @@ impl NodeModuleDecoratorRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for NodeModuleDecoratorRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/nonce.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/nonce.rs
@@ -15,6 +15,10 @@ impl NonceRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for NonceRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
@@ -1,7 +1,15 @@
+use std::sync::LazyLock;
+
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeTemplate,
   impl_runtime_module,
 };
+
+use crate::extract_runtime_module_variables_from_ejs;
+
+static ON_CHUNK_LOADED_TEMPLATE: &str = include_str!("runtime/on_chunk_loaded.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> =
+  LazyLock::new(|| extract_runtime_module_variables_from_ejs(&[ON_CHUNK_LOADED_TEMPLATE]));
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -15,6 +23,10 @@ impl OnChunkLoadedRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for OnChunkLoadedRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,
@@ -26,10 +38,7 @@ impl RuntimeModule for OnChunkLoadedRuntimeModule {
   }
 
   fn template(&self) -> Vec<(String, String)> {
-    vec![(
-      self.id().to_string(),
-      include_str!("runtime/on_chunk_loaded.ejs").to_string(),
-    )]
+    vec![(self.id().to_string(), ON_CHUNK_LOADED_TEMPLATE.to_string())]
   }
 
   async fn generate(

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -17,6 +17,10 @@ impl PublicPathRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for PublicPathRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -9,7 +9,8 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 
 use super::{generate_javascript_hmr_runtime, utils::get_output_dir};
 use crate::{
-  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+  get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -28,6 +29,19 @@ static READFILE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE: &str =
   include_str!("runtime/readfile_chunk_loading_with_hmr_manifest.ejs");
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    READFILE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE,
+    READFILE_CHUNK_LOADING_TEMPLATE,
+    READFILE_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
+    READFILE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_TEMPLATE,
+    READFILE_CHUNK_LOADING_WITH_HMR_TEMPLATE,
+    READFILE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
+    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
+  ]);
+  variables.push("readFileVmInstalledChunks");
+  variables
+});
 
 static READFILE_CHUNK_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(READFILE_CHUNK_LOADING_TEMPLATE));
@@ -155,6 +169,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
     let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();

--- a/crates/rspack_plugin_runtime/src/runtime_module/reexport.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/reexport.rs
@@ -17,6 +17,10 @@ impl ReexportRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ReexportRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/relative_url.rs
@@ -15,6 +15,10 @@ impl RelativeUrlRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RelativeUrlRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -9,7 +9,8 @@ use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
 
 use super::{generate_javascript_hmr_runtime, utils::get_output_dir};
 use crate::{
-  extract_runtime_globals_from_ejs, get_chunk_runtime_requirements,
+  extract_runtime_globals_from_ejs, extract_runtime_module_variables_from_ejs,
+  get_chunk_runtime_requirements,
   runtime_module::utils::{
     get_initial_chunk_ids, render_hmr_runtime_state_expression, stringify_chunks,
   },
@@ -30,6 +31,20 @@ static REQUIRE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE: &str =
   include_str!("runtime/require_chunk_loading_with_hmr_manifest.ejs");
 static JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE: &str =
   include_str!("runtime/javascript_hot_module_replacement.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  let mut variables = extract_runtime_module_variables_from_ejs(&[
+    REQUIRE_CHUNK_LOADING_TEMPLATE,
+    REQUIRE_CHUNK_LOADING_WITH_LOADING_TEMPLATE,
+    REQUIRE_CHUNK_LOADING_WITH_LOADING_MATCHER_TEMPLATE,
+    REQUIRE_CHUNK_LOADING_WITH_ON_CHUNK_LOAD_TEMPLATE,
+    REQUIRE_CHUNK_LOADING_WITH_EXTERNAL_INSTALL_CHUNK_TEMPLATE,
+    REQUIRE_CHUNK_LOADING_WITH_HMR_TEMPLATE,
+    REQUIRE_CHUNK_LOADING_WITH_HMR_MANIFEST_TEMPLATE,
+    JAVASCRIPT_HOT_MODULE_REPLACEMENT_TEMPLATE,
+  ]);
+  variables.push("requireInstalledChunks");
+  variables
+});
 
 static REQUIRE_CHUNK_LOADING_RUNTIME_REQUIREMENTS: LazyLock<RuntimeModuleRuntimeRequirements> =
   LazyLock::new(|| extract_runtime_globals_from_ejs(REQUIRE_CHUNK_LOADING_TEMPLATE));
@@ -161,6 +176,10 @@ enum TemplateId {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RequireChunkLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(&self, compilation: &Compilation) -> RuntimeModuleRuntimeRequirements {
     let Some(chunk_ukey) = self.chunk() else {
       return RuntimeModuleRuntimeRequirements::default();

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_unique_id.rs
@@ -22,6 +22,10 @@ impl RspackUniqueIdRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RspackUniqueIdRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/rspack_version.rs
@@ -17,6 +17,10 @@ impl RspackVersionRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RspackVersionRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/async_module.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/async_module.ejs
@@ -1,11 +1,11 @@
-var hasSymbol = typeof Symbol === "function";
-var rspackQueues = hasSymbol ? Symbol("rspack queues") : "__rspack_queues";
+<%- var("hasSymbol") %> = typeof Symbol === "function";
+<%- var("rspackQueues") %> = hasSymbol ? Symbol("rspack queues") : "__rspack_queues";
 <% if (_uses_lexical_runtime_globals) { %><%- define(ASYNC_MODULE_EXPORT_SYMBOL) %> = hasSymbol ? Symbol("rspack exports") : "<%- EXPORTS %>";
-var rspackExports = <%- ASYNC_MODULE_EXPORT_SYMBOL %>;<% } else { %>var rspackExports = <%- define(ASYNC_MODULE_EXPORT_SYMBOL) %> = hasSymbol ? Symbol("rspack exports") : "<%- EXPORTS %>";<% } %>
-var rspackError = hasSymbol ? Symbol("rspack error") : "__rspack_error";
-var rspackDone = hasSymbol ? Symbol("rspack done") : "__rspack_done";
+<%- var("rspackExports") %> = <%- ASYNC_MODULE_EXPORT_SYMBOL %>;<% } else { %><%- var("rspackExports") %> = <%- define(ASYNC_MODULE_EXPORT_SYMBOL) %> = hasSymbol ? Symbol("rspack exports") : "<%- EXPORTS %>";<% } %>
+<%- var("rspackError") %> = hasSymbol ? Symbol("rspack error") : "__rspack_error";
+<%- var("rspackDone") %> = hasSymbol ? Symbol("rspack done") : "__rspack_done";
 <% if (_uses_lexical_runtime_globals) { %><%- define(DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL) %> = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";
-var rspackDefer = <%- DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL %>;<% } else { %>var rspackDefer = <%- define(DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL) %> = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";<% } %>
+<%- var("rspackDefer") %> = <%- DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL %>;<% } else { %><%- var("rspackDefer") %> = <%- define(DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL) %> = hasSymbol ? Symbol("rspack defer") : "__rspack_defer";<% } %>
 <%- define(DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES) %> = <%- basicFunction("asyncDeps") %> {
 	var hasUnresolvedAsyncSubgraph = asyncDeps.some((id) => {
 		var cache = <%- _module_cache %>[id];
@@ -15,14 +15,14 @@ var rspackDefer = <%- DEFERRED_MODULES_ASYNC_TRANSITIVE_DEPENDENCIES_SYMBOL %>;<
 		return ({ then(onFulfilled, onRejected) { return Promise.all(asyncDeps.map(<%- REQUIRE %>)).then(onFulfilled, onRejected) } });
 	}
 }
-var resolveQueue = <%- basicFunction("queue") %> {
+<%- var("resolveQueue") %> = <%- basicFunction("queue") %> {
 	if (queue && queue.d < 1) {
 		queue.d = 1;
     	queue.forEach(<%- expressionFunction("fn.r--", "fn") %>);
 		queue.forEach(<%- expressionFunction("fn.r-- ? fn.r++ : fn()", "fn") %>);
 	}
 }
-var wrapDeps = <%- basicFunction("deps") %> {
+<%- var("wrapDeps") %> = <%- basicFunction("deps") %> {
 	return deps.map(<%- basicFunction("dep") %> {
 		if (dep !== null && typeof dep === "object") {
 			if(!dep[rspackQueues] && dep[rspackDefer]) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/auto_public_path.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/auto_public_path.ejs
@@ -1,9 +1,9 @@
-var scriptUrl;
+<%- var("scriptUrl") %>;
 <% if (_script_type == "module") { %>
 if (typeof <%- _import_meta_name %>.url === "string") scriptUrl = <%- _import_meta_name %>.url
 <% } else { %>
 if (<%- GLOBAL %>.importScripts) scriptUrl = <%- GLOBAL %>.location + "";
-var document = <%- GLOBAL %>.document;
+<%- var("document") %> = <%- GLOBAL %>.document;
 if (!scriptUrl && document) {
   // Technically we could use `document.currentScript instanceof window.HTMLScriptElement`,
   // but an attacker could try to inject `<script>HTMLScriptElement = HTMLImageElement</script>`

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_prefetch_trigger.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_prefetch_trigger.ejs
@@ -1,4 +1,4 @@
-var chunkPrefetchChunkToChildrenMap = <%- _chunk_map %>;
+<%- var("chunkPrefetchChunkToChildrenMap") %> = <%- _chunk_map %>;
 <%- ENSURE_CHUNK_HANDLERS %>.prefetch = <%- basicFunction("chunkId, promises") %> {
   Promise.all(promises).then(<%- basicFunction("") %> {
     var chunks = chunkPrefetchChunkToChildrenMap[chunkId];

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_preload_trigger.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/chunk_preload_trigger.ejs
@@ -1,4 +1,4 @@
-var chunkPreloadChunkToChildrenMap = <%- _chunk_map %>;
+<%- var("chunkPreloadChunkToChildrenMap") %> = <%- _chunk_map %>;
 <%- ENSURE_CHUNK_HANDLERS %>.preload =  <%- basicFunction("chunkId") %> {
   var chunks = chunkPreloadChunkToChildrenMap[chunkId];
   Array.isArray(chunks) && chunks.map(<%- PRELOAD_CHUNK %>);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_fake_namespace_object.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/create_fake_namespace_object.ejs
@@ -1,5 +1,5 @@
-var getProto = Object.getPrototypeOf ? <%- returningFunction("Object.getPrototypeOf(obj)", "obj") %> : <%- returningFunction("obj.__proto__", "obj") %>;
-var leafPrototypes;
+<%- var("getProto") %> = Object.getPrototypeOf ? <%- returningFunction("Object.getPrototypeOf(obj)", "obj") %> : <%- returningFunction("obj.__proto__", "obj") %>;
+<%- var("leafPrototypes") %>;
 // create a fake namespace object
 // mode & 1: value is a module id, require it
 // mode & 2: merge all properties of value into the ns

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_trusted_types_policy.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_trusted_types_policy.ejs
@@ -1,4 +1,4 @@
-var policy;
+<%- var("policy") %>;
 <%- define(GET_TRUSTED_TYPES_POLICY) %> = <%- basicFunction("") %> {
     // Create Trusted Type policy if Trusted Types are available and the policy doesn't exist yet.
     if (policy === undefined) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading.ejs
@@ -1,5 +1,5 @@
 // importScripts chunk loading
-var importScriptsInstallChunk = <%- basicFunction("data") %> {
+<%- var("importScriptsInstallChunk") %> = <%- basicFunction("data") %> {
     <%- destructureArray("chunkIds, moreModules, runtime", "data") %>
     for (var moduleId in moreModules) {
         if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {
@@ -11,6 +11,6 @@ var importScriptsInstallChunk = <%- basicFunction("data") %> {
     importScriptsParentChunkLoadingFunction(data);
 };
 
-var importScriptsChunkLoadingGlobal = <%- _chunk_loading_global_init_expr %>;
-var importScriptsParentChunkLoadingFunction = importScriptsChunkLoadingGlobal.push.bind(importScriptsChunkLoadingGlobal);
+<%- var("importScriptsChunkLoadingGlobal") %> = <%- _chunk_loading_global_init_expr %>;
+<%- var("importScriptsParentChunkLoadingFunction") %> = importScriptsChunkLoadingGlobal.push.bind(importScriptsChunkLoadingGlobal);
 importScriptsChunkLoadingGlobal.push = importScriptsInstallChunk;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/import_scripts_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-function importScriptsLoadUpdateChunk(chunkId, updatedModulesList) {
+<%- fn("importScriptsLoadUpdateChunk") %>(chunkId, updatedModulesList) {
   var success = false;
   <%- _global_object %>[<%- _hot_update_global %>] = <%- basicFunction("_, moreModules, runtime") %> {
       for (var moduleId in moreModules) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/javascript_hot_module_replacement.ejs
@@ -1,8 +1,8 @@
-var hotCurrentUpdateChunks;
-var hotCurrentUpdate;
-var hotCurrentUpdateRemovedChunks;
-var hotCurrentUpdateRuntime;
-function hotApplyHandler(options) {
+<%- var("hotCurrentUpdateChunks") %>;
+<%- var("hotCurrentUpdate") %>;
+<%- var("hotCurrentUpdateRemovedChunks") %>;
+<%- var("hotCurrentUpdateRuntime") %>;
+<%- fn("hotApplyHandler") %>(options) {
 	if (<%- weak(ENSURE_CHUNK_HANDLERS) %>) delete <%- weak(ENSURE_CHUNK_HANDLERS) %>.<%- _loading_method %>Hmr;
 	hotCurrentUpdateChunks = undefined;
 	function getAffectedModuleEffects(updateModuleId) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.ejs
@@ -1,5 +1,5 @@
 // install a JSONP callback for chunk loading
-var __rspack_jsonp = <%- basicFunction("parentChunkLoadingFunction, data") %> {
+<%- var("__rspack_jsonp") %> = <%- basicFunction("parentChunkLoadingFunction, data") %> {
 	<%- destructureArray("chunkIds, moreModules, runtime", "data") %>
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
@@ -28,6 +28,6 @@ var __rspack_jsonp = <%- basicFunction("parentChunkLoadingFunction, data") %> {
 	<% } %>
 };
 
-var jsonpChunkLoadingGlobal = <%- _chunk_loading_global_init_expr %>;
+<%- var("jsonpChunkLoadingGlobal") %> = <%- _chunk_loading_global_init_expr %>;
 jsonpChunkLoadingGlobal.forEach(__rspack_jsonp.bind(null, 0));
 jsonpChunkLoadingGlobal.push = __rspack_jsonp.bind(null, jsonpChunkLoadingGlobal.push.bind(jsonpChunkLoadingGlobal));

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.ejs
@@ -1,6 +1,6 @@
-var hotCurrentUpdatedModulesList;
-var hotWaitingUpdateResolves = {};
-function jsonpLoadUpdateChunk(chunkId, updatedModulesList) {
+<%- var("hotCurrentUpdatedModulesList") %>;
+<%- var("hotWaitingUpdateResolves") %> = {};
+<%- fn("jsonpLoadUpdateChunk") %>(chunkId, updatedModulesList) {
 	hotCurrentUpdatedModulesList = updatedModulesList;
 	return new Promise(<%- basicFunction("resolve, reject") %> {
 		hotWaitingUpdateResolves[chunkId] = resolve;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/load_script.ejs
@@ -1,4 +1,4 @@
-var inProgress = {};
+<%- var("inProgress") %> = {};
 
 <%- _unique_prefix %>
 // loadScript function to load a script via script tag

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.ejs
@@ -1,4 +1,4 @@
-var moduleInstallChunk = <%- basicFunction("data") %> {
+<%- var("moduleInstallChunk") %> = <%- basicFunction("data") %> {
     var __rspack_esm_ids = data.__rspack_esm_ids;
     var moreModules = data.<%- _modules %>;
     var __rspack_esm_runtime = data.__rspack_esm_runtime;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-  function moduleLoadUpdateChunk(chunkId, updatedModulesList) {
+  <%- fn("moduleLoadUpdateChunk") %>(chunkId, updatedModulesList) {
     return new Promise( <%- basicFunction("resolve, reject")  %> {
       // start update chunk loading
       var url = <%- PUBLIC_PATH %> + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/on_chunk_loaded.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/on_chunk_loaded.ejs
@@ -1,4 +1,4 @@
-var deferred = [];
+<%- var("deferred") %> = [];
 <%- define(ON_CHUNKS_LOADED) %> = <%- basicFunction("result, chunkIds, fn, priority") %> {
 	if (chunkIds) {
 		priority = priority || 0;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading.ejs
@@ -1,4 +1,4 @@
-var readFileVmInstallChunk = <%- basicFunction("chunk") %> {
+<%- var("readFileVmInstallChunk") %> = <%- basicFunction("chunk") %> {
   var moreModules = chunk.modules, chunkIds = chunk.ids,
     runtime = chunk.runtime;
   for (var moduleId in moreModules) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/readfile_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-function readFileVmLoadUpdateChunk(chunkId, updatedModulesList) {
+<%- fn("readFileVmLoadUpdateChunk") %>(chunkId, updatedModulesList) {
 	return new Promise(function(resolve, reject) {
 		var filename = require('path').join(__dirname, "" + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId));
 		require('fs').readFile(filename, 'utf-8', function(err, content) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.ejs
@@ -1,6 +1,6 @@
 // object to store loaded chunks
 // "1" means "loaded", otherwise not loaded yet
-var requireInstallChunk = <%- basicFunction("chunk") %> {
+<%- var("requireInstallChunk") %> = <%- basicFunction("chunk") %> {
 	var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
 	for (var moduleId in moreModules) {
 		if (<%- HAS_OWN_PROPERTY %>(moreModules, moduleId)) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading_with_hmr.ejs
@@ -1,4 +1,4 @@
-function requireLoadUpdateChunk(chunkId, updatedModulesList) {
+<%- fn("requireLoadUpdateChunk") %>(chunkId, updatedModulesList) {
 	var update = require("./" + <%- GET_CHUNK_UPDATE_SCRIPT_FILENAME %>(chunkId));
 	var updatedModules = update.modules;
 	var runtime = update.runtime;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies.ejs
@@ -1,4 +1,4 @@
-var next = <%- STARTUP %>
+<%- var("next") %> = <%- STARTUP %>
 <%- define(STARTUP) %> = <%- basicFunction("") %> {
   <%- _body %>
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
@@ -16,6 +16,10 @@ impl RuntimeIdRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RuntimeIdRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -1,10 +1,18 @@
-use std::iter;
+use std::{iter, sync::LazyLock};
 
 use itertools::Itertools;
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeTemplate,
   impl_runtime_module,
 };
+
+use crate::extract_runtime_module_variables_from_ejs;
+
+static STARTUP_CHUNK_DEPENDENCIES_TEMPLATE: &str =
+  include_str!("runtime/startup_chunk_dependencies.ejs");
+static RUNTIME_MODULE_VARIABLES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+  extract_runtime_module_variables_from_ejs(&[STARTUP_CHUNK_DEPENDENCIES_TEMPLATE])
+});
 
 #[impl_runtime_module]
 #[derive(Debug)]
@@ -20,6 +28,10 @@ impl StartupChunkDependenciesRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    RUNTIME_MODULE_VARIABLES.as_slice()
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,
@@ -40,7 +52,7 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),
-      include_str!("runtime/startup_chunk_dependencies.ejs").to_string(),
+      STARTUP_CHUNK_DEPENDENCIES_TEMPLATE.to_string(),
     )]
   }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_entrypoint.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_entrypoint.rs
@@ -17,6 +17,10 @@ impl StartupEntrypointRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for StartupEntrypointRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn template(&self) -> Vec<(String, String)> {
     vec![(
       self.id().to_string(),

--- a/crates/rspack_plugin_runtime/src/runtime_module/system_context.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/system_context.rs
@@ -15,6 +15,10 @@ impl SystemContextRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for SystemContextRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module/to_binary.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/to_binary.rs
@@ -15,6 +15,10 @@ impl ToBinaryRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for ToBinaryRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,

--- a/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
@@ -46,6 +46,10 @@ impl RuntimeModuleFromJs {
 
 #[async_trait::async_trait]
 impl RuntimeModule for RuntimeModuleFromJs {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   async fn generate(&self, _: &RuntimeModuleGenerateContext<'_>) -> rspack_error::Result<String> {
     let res = (self.generator)().await?;
     Ok(res)

--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -46,6 +46,10 @@ impl SRIHashVariableRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for SRIHashVariableRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   async fn generate(&self, context: &RuntimeModuleGenerateContext<'_>) -> Result<String> {
     let compilation = context.compilation;
     let Some(chunk) = self

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -90,6 +90,10 @@ impl AsyncWasmCompileRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for AsyncWasmCompileRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,
@@ -133,6 +137,10 @@ impl RuntimeModule for AsyncWasmCompileRuntimeModule {
 
 #[async_trait::async_trait]
 impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
+  fn runtime_module_variables() -> &'static [&'static str] {
+    &[]
+  }
+
   fn runtime_requirements(
     &self,
     _compilation: &Compilation,


### PR DESCRIPTION
## Summary

- collect runtime-module variable names from top-level EJS `var` and `fn` declarations
- require every runtime module to declare its variable list explicitly, using an empty list for modules that do not declare surrounding-scope variables
- make parameterless `#[impl_runtime_module]` register each non-generic runtime module provider automatically; EJS-backed modules return their extracted variables
- carry the collected metadata through runtime module generation while preserving the existing EJS `var` and `fn` helpers

## Stack

1. #14917 (this PR)
2. #14741

## Checks

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test:unit`
- `cargo clippy --workspace --all-targets --tests --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm run format-ci:js`
- `pnpm run format-ci:toml`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
