### PR TITLE
fix: respect DllPlugin context for concatenated modules

### DIFF
--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -128,7 +128,9 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
       // Match webpack by deriving the library identifier from the concatenation root.
       let module_for_ident = module
         .as_concatenated_module()
-        .and_then(|module| module_graph.module_by_identifier(&module.get_root()))
+        .and_then(|concatenated_module| {
+          module_graph.module_by_identifier(&concatenated_module.get_root())
+        })
         .unwrap_or(module);
       let ident = module_for_ident.lib_ident(LibIdentOptions { context });
 

--- a/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
+++ b/crates/rspack_plugin_dll/src/lib_manifest_plugin.rs
@@ -125,7 +125,12 @@ async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
         None => &compilation.options.context,
       };
 
-      let ident = module.lib_ident(LibIdentOptions { context });
+      // Match webpack by deriving the library identifier from the concatenation root.
+      let module_for_ident = module
+        .as_concatenated_module()
+        .and_then(|module| module_graph.module_by_identifier(&module.get_root()))
+        .unwrap_or(module);
+      let ident = module_for_ident.lib_ident(LibIdentOptions { context });
 
       if let Some(ident) = ident {
         let exports_info = compilation

--- a/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/bar.mjs
+++ b/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/bar.mjs
@@ -1,0 +1,3 @@
+export function bar() {
+	return "bar";
+}

--- a/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/index.mjs
+++ b/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/index.mjs
@@ -1,0 +1,3 @@
+export const foo = "foo";
+
+export * from "./bar.mjs";

--- a/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/rspack.config.js
+++ b/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/rspack.config.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const rspack = require('@rspack/core');
+
+const outputPath = path.resolve(
+  __dirname,
+  '../../../js/config/dll-plugin/concatenated-lib-ident-context',
+);
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  context: __dirname,
+  entry: './index.mjs',
+  optimization: {
+    concatenateModules: true,
+    minimize: false,
+  },
+  output: {
+    path: outputPath,
+    filename: 'bundle.js',
+    library: {
+      type: 'commonjs2',
+    },
+  },
+  plugins: [
+    new rspack.DllPlugin({
+      context: path.resolve(__dirname, '../../..'),
+      name: 'dll',
+      path: path.resolve(outputPath, 'manifest.json'),
+    }),
+  ],
+};

--- a/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/test.config.js
+++ b/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/test.config.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle: () => [],
+	validate(stats, _stderr, options) {
+		const config = Array.isArray(options) ? options[0] : options;
+		const statsJson = stats.toJson({
+			modules: true,
+			nestedModules: true
+		});
+		const modules =
+			statsJson.modules ??
+			statsJson.children?.flatMap(child => child.modules ?? []) ??
+			[];
+		expect(modules.some(module => module.modules?.length === 2)).toBe(true);
+
+		const manifest = JSON.parse(
+			fs.readFileSync(path.resolve(config.output.path, "manifest.json"), "utf-8")
+		);
+
+		expect(Object.keys(manifest.content)).toContain(
+			"./configCases/dll-plugin/concatenated-lib-ident-context/index.mjs"
+		);
+	}
+};

--- a/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/test.config.js
+++ b/tests/rspack-test/configCases/dll-plugin/concatenated-lib-ident-context/test.config.js
@@ -13,7 +13,14 @@ module.exports = {
 			statsJson.modules ??
 			statsJson.children?.flatMap(child => child.modules ?? []) ??
 			[];
-		expect(modules.some(module => module.modules?.length === 2)).toBe(true);
+		const concatenatedModule = modules.find(module => {
+			const innerIdentifiers =
+				module.modules?.map(innerModule => innerModule.identifier) ?? [];
+			return ["index.mjs", "bar.mjs"].every(filename =>
+				innerIdentifiers.some(identifier => identifier.endsWith(filename))
+			);
+		});
+		expect(concatenatedModule).toBeDefined();
 
 		const manifest = JSON.parse(
 			fs.readFileSync(path.resolve(config.output.path, "manifest.json"), "utf-8")


### PR DESCRIPTION
## Summary

Fix DLL manifest generation for concatenated modules by resolving the concatenation root before computing its library identifier. This ensures `DllPlugin.context` is honored, allowing `DllReferencePlugin` consumers to match and externalize the DLL correctly.

Add a regression case that forces module concatenation, verifies the concatenated module is present, and asserts that the manifest key is relative to the configured DLL context.

## Related links

Closes #10799

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).