### PR TITLE
fix(cli): preserve defineConfig inference

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -394,10 +394,16 @@ export type RspackConfigExport =
  * This function helps you to autocomplete configuration types.
  * It accepts a Rspack config object, or a function that returns a config.
  */
+export function defineConfig<
+  const Config extends RspackOptions | MultiRspackOptions,
+>(config: (...args: Parameters<RspackConfigFn>) => Config): RspackConfigFn;
+export function defineConfig<
+  const Config extends RspackOptions | MultiRspackOptions,
+>(
+  config: (...args: Parameters<RspackConfigFn>) => Promise<Config>,
+): RspackConfigAsyncFn;
 export function defineConfig(config: RspackOptions): RspackOptions;
 export function defineConfig(config: MultiRspackOptions): MultiRspackOptions;
-export function defineConfig(config: RspackConfigFn): RspackConfigFn;
-export function defineConfig(config: RspackConfigAsyncFn): RspackConfigAsyncFn;
 export function defineConfig(config: RspackConfigExport): RspackConfigExport;
 export function defineConfig(config: RspackConfigExport) {
   return config;

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -1,0 +1,60 @@
+import { defineConfig } from '@rspack/cli';
+
+defineConfig({
+  mode: 'development',
+});
+
+defineConfig([
+  {
+    mode: 'development',
+  },
+  {
+    mode: 'production',
+  },
+]);
+
+defineConfig(() => ({
+  mode: 'development',
+}));
+
+defineConfig((env, argv) => ({
+  mode:
+    env.production || argv.mode === 'production' ? 'production' : 'development',
+}));
+
+defineConfig(() => [
+  {
+    mode: 'development',
+  },
+  {
+    mode: 'production',
+  },
+]);
+
+defineConfig(async () => ({
+  mode: 'development',
+}));
+
+defineConfig(async () => [
+  {
+    mode: 'development',
+  },
+  {
+    mode: 'production',
+  },
+]);
+
+defineConfig({
+  // @ts-expect-error invalid mode
+  mode: 'invalid',
+});
+
+// @ts-expect-error invalid mode
+defineConfig(() => ({
+  mode: 'invalid',
+}));
+
+// @ts-expect-error invalid mode
+defineConfig(async () => ({
+  mode: 'invalid',
+}));

--- a/tests/type-tests/resolution-bundler/tsconfig.json
+++ b/tests/type-tests/resolution-bundler/tsconfig.json
@@ -7,5 +7,5 @@
     "composite": false,
     "skipLibCheck": false
   },
-  "include": ["index.ts"]
+  "include": ["defineConfig.ts", "index.ts"]
 }

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -1,0 +1,60 @@
+import { defineConfig } from '@rspack/cli';
+
+defineConfig({
+  mode: 'development',
+});
+
+defineConfig([
+  {
+    mode: 'development',
+  },
+  {
+    mode: 'production',
+  },
+]);
+
+defineConfig(() => ({
+  mode: 'development',
+}));
+
+defineConfig((env, argv) => ({
+  mode:
+    env.production || argv.mode === 'production' ? 'production' : 'development',
+}));
+
+defineConfig(() => [
+  {
+    mode: 'development',
+  },
+  {
+    mode: 'production',
+  },
+]);
+
+defineConfig(async () => ({
+  mode: 'development',
+}));
+
+defineConfig(async () => [
+  {
+    mode: 'development',
+  },
+  {
+    mode: 'production',
+  },
+]);
+
+defineConfig({
+  // @ts-expect-error invalid mode
+  mode: 'invalid',
+});
+
+// @ts-expect-error invalid mode
+defineConfig(() => ({
+  mode: 'invalid',
+}));
+
+// @ts-expect-error invalid mode
+defineConfig(async () => ({
+  mode: 'invalid',
+}));

--- a/tests/type-tests/resolution-nodenext/tsconfig.json
+++ b/tests/type-tests/resolution-nodenext/tsconfig.json
@@ -7,5 +7,5 @@
     "composite": false,
     "skipLibCheck": false
   },
-  "include": ["index.ts"]
+  "include": ["defineConfig.ts", "index.ts"]
 }


### PR DESCRIPTION
## Summary

`defineConfig` widens literal values returned from synchronous and asynchronous config functions, causing valid configurations to fail overload resolution. This PR adds function-first const-generic overloads for single and multi configurations while preserving the existing exported function types, with coverage under both bundler and NodeNext module resolution.

## Related links

- Related to https://github.com/web-infra-dev/rslib/pull/1787

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).