### PR TITLE
perf: improve tree shaking for TypeScript CommonJS output

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -63,6 +63,7 @@ pub struct ESMExportImportedSpecifierDependency {
   loc: Option<DependencyLocation>,
   factorize_info: FactorizeInfo,
   lazy_make: bool,
+  commonjs_export_star: bool,
 }
 
 impl ESMExportImportedSpecifierDependency {
@@ -96,7 +97,12 @@ impl ESMExportImportedSpecifierDependency {
       loc,
       factorize_info: Default::default(),
       lazy_make: false,
+      commonjs_export_star: false,
     }
+  }
+
+  pub fn set_commonjs_export_star(&mut self) {
+    self.commonjs_export_star = true;
   }
 
   // Because it is shared by multiply ESMExportImportedSpecifierDependency, so put it to `BuildInfo`
@@ -335,6 +341,9 @@ impl ESMExportImportedSpecifierDependency {
     let ignored_exports: HashSet<Atom> = {
       let mut e = self.active_exports(module_graph).clone();
       e.insert("default".into());
+      if self.commonjs_export_star {
+        e.insert("__esModule".into());
+      }
       e
     };
 
@@ -1423,6 +1432,9 @@ impl Dependency for ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
+    if self.commonjs_export_star {
+      return None;
+    }
     let module = module_graph.get_parent_module(&self.id)?;
     let module = module_graph.module_by_identifier(module)?;
     let ids = self.get_ids(module_graph);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -1,21 +1,97 @@
-use rspack_core::{BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals};
+use rspack_core::{
+  BuildMetaDefaultObject, BuildMetaExportsType, ConstDependency, Dependency, DependencyRange,
+  DependencyType, ImportPhase, RuntimeGlobals,
+};
 use rspack_util::SpanExt;
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
   AssignExpr, CallExpr, Expr, ExprOrSpread, GetSpan, Ident, Lit, MemberExpr, Prop, PropName,
-  PropOrSpread, Span, ThisExpr, UnaryExpr, UnaryOp,
+  PropOrSpread, Span, ThisExpr, UnaryExpr, UnaryOp, VarDeclarator,
 };
 
 use super::JavascriptParserPlugin;
 use crate::{
   dependency::{
     CommonJsExportRequireDependency, CommonJsExportsDependency, CommonJsSelfReferenceDependency,
-    ExportsBase, ModuleDecoratorDependency,
+    ESMExportImportedSpecifierDependency, ESMImportSideEffectDependency, ExportsBase,
+    ModuleDecoratorDependency,
   },
   parser_plugin::common_js_imports_parse_plugin::is_require_call_expr,
   utils::eval::{self, BasicEvaluatedExpression},
-  visitors::JavascriptParser,
+  visitors::{JavascriptParser, VariableDeclaration},
 };
+
+const TYPESCRIPT_EXPORT_STAR_TAG: &str = "typescript export star";
+const TYPESCRIPT_EXPORT_STAR_HELPER: &str = "(this&&this.__exportStar)||function(m,exports){for(varpinm)if(p!==\"default\"&&!Object.prototype.hasOwnProperty.call(exports,p))__createBinding(exports,m,p);}";
+
+#[derive(Clone)]
+struct TypeScriptExportStarTagData;
+
+fn is_typescript_export_star_helper(parser: &JavascriptParser, declarator: &VarDeclarator) -> bool {
+  if !parser.is_top_level_scope()
+    || declarator
+      .name
+      .as_ident()
+      .is_none_or(|ident| ident.id.sym.as_str() != "__exportStar")
+  {
+    return false;
+  }
+  let Some(init) = &declarator.init else {
+    return false;
+  };
+  let range = DependencyRange::from(init.span());
+  let Some(source) = parser
+    .source()
+    .get(range.start as usize..range.end as usize)
+  else {
+    return false;
+  };
+  source
+    .chars()
+    .filter(|char| !char.is_whitespace())
+    .eq(TYPESCRIPT_EXPORT_STAR_HELPER.chars())
+}
+
+fn is_typescript_cached_helper(parser: &JavascriptParser, declarator: &VarDeclarator) -> bool {
+  if !parser.is_top_level_scope() {
+    return false;
+  }
+  let Some(name) = declarator
+    .name
+    .as_ident()
+    .map(|ident| ident.id.sym.as_str())
+    .filter(|name| matches!(*name, "__createBinding" | "__decorate" | "__exportStar"))
+  else {
+    return false;
+  };
+  let Some(init) = &declarator.init else {
+    return false;
+  };
+  let range = DependencyRange::from(init.span());
+  let Some(source) = parser
+    .source()
+    .get(range.start as usize..range.end as usize)
+  else {
+    return false;
+  };
+  let source = source
+    .chars()
+    .filter(|char| !char.is_whitespace())
+    .collect::<String>();
+  source.starts_with(&format!("(this&&this.{name})||")) && !source.contains("require(")
+}
+
+fn is_typescript_export_star_barrel(parser: &JavascriptParser) -> bool {
+  let source = parser
+    .source()
+    .chars()
+    .filter(|char| !char.is_whitespace())
+    .collect::<String>();
+  !source.contains("exports.")
+    && !source.contains("module.exports")
+    && source.matches("Object.defineProperty(exports,").count() == 1
+    && source.contains("Object.defineProperty(exports,\"__esModule\",")
+}
 
 fn get_value_of_property_description<'a>(expr: &'a Expr<'a>) -> Option<&'a Expr<'a>> {
   if let Expr::Object(obj) = expr {
@@ -281,6 +357,35 @@ impl CommonJsExportsParserPlugin {
 
 #[rspack_macros::implemented_javascript_parser_hooks]
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsExportsParserPlugin {
+  fn pre_declarator(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    declarator: &VarDeclarator,
+    _declaration: VariableDeclaration<'_>,
+  ) -> Option<bool> {
+    if is_typescript_export_star_helper(parser, declarator) {
+      let ident = declarator
+        .name
+        .as_ident()
+        .expect("TypeScript export star helper should have an identifier");
+      parser.tag_variable(
+        Atom::from(ident.id.sym.as_str()),
+        TYPESCRIPT_EXPORT_STAR_TAG,
+        Some(TypeScriptExportStarTagData),
+      );
+    }
+    None
+  }
+
+  fn declarator(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    declarator: &VarDeclarator,
+    _declaration: VariableDeclaration<'_>,
+  ) -> Option<bool> {
+    is_typescript_cached_helper(parser, declarator).then_some(true)
+  }
+
   fn assign_member_chain(
     &self,
     parser: &mut JavascriptParser<'p>,
@@ -325,6 +430,81 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsExportsParserPlugin {
 
     if parser.is_esm {
       return None;
+    }
+    if (for_name == TYPESCRIPT_EXPORT_STAR_TAG
+      || parser
+        .get_tag_data::<TypeScriptExportStarTagData>(
+          &Atom::from(for_name),
+          TYPESCRIPT_EXPORT_STAR_TAG,
+        )
+        .is_some())
+      && is_typescript_export_star_barrel(parser)
+      && parser.is_statement_level_expression(call_expr.span)
+      && call_expr.args.len() == 2
+      && let [
+        ExprOrSpread {
+          spread: None,
+          expr: imported,
+        },
+        ExprOrSpread {
+          spread: None,
+          expr: exports,
+        },
+      ] = call_expr.args.as_slice()
+      && let exports = parser.evaluate_expression(exports)
+      && exports.is_identifier()
+      && exports.identifier().as_str() == "exports"
+      && let Some((request, ids)) = parse_require_call(parser, imported)
+      && request.is_string()
+      && ids.is_empty()
+    {
+      parser.enable();
+      parser.last_esm_import_order += 1;
+      let source_order = parser.last_esm_import_order;
+      let request = Atom::from(request.string().as_str());
+      let range = DependencyRange::from(call_expr.span);
+      let loc = parser.to_dependency_location(range);
+
+      parser
+        .add_presentational_dependency(Box::new(ConstDependency::new(range, String::new().into())));
+
+      let mut side_effect_dep = ESMImportSideEffectDependency::new(
+        request.clone(),
+        source_order,
+        range,
+        DependencyType::EsmExportImport,
+        ImportPhase::Evaluation,
+        None,
+        loc.clone(),
+        true,
+      );
+      let mut export_dep = ESMExportImportedSpecifierDependency::new(
+        request,
+        source_order,
+        vec![],
+        None,
+        Some(parser.build_info.all_star_exports.clone()),
+        range,
+        ESMExportImportedSpecifierDependency::create_export_presence_mode(
+          parser.javascript_options,
+        ),
+        ImportPhase::Evaluation,
+        None,
+        loc,
+      );
+      export_dep.set_commonjs_export_star();
+      parser.build_info.all_star_exports.push(export_dep.id);
+      if parser
+        .factory_meta
+        .and_then(|meta| meta.side_effect_free)
+        .unwrap_or_default()
+      {
+        side_effect_dep.set_lazy();
+        export_dep.set_lazy();
+      }
+      parser.add_dependency(Box::new(side_effect_dep));
+      parser.add_dependency(Box::new(export_dep));
+      return Some(true);
     }
     if for_name == "Object.defineProperty"
       && parser.is_statement_level_expression(call_expr.span)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -6,8 +6,9 @@ use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{
-  AssignExpr, AssignOp, ClassMember, DefaultDecl, Expr, GetSpan, Ident, MemberExpr, ModuleDecl,
-  Pat, Program, Span, ThisExpr, VarDeclarator,
+  AssignExpr, AssignOp, BinaryOp, ClassMember, DefaultDecl, Expr, GetSpan, Ident, Lit, MemberExpr,
+  MemberProp, ModuleDecl, Pat, Program, SimpleAssignTarget, Span, Stmt, ThisExpr, UnaryOp,
+  VarDeclarator,
 };
 
 use super::state::{
@@ -37,6 +38,193 @@ fn class_member_is_static(member: &ClassMember<'_>) -> bool {
     ClassMember::StaticBlock(_) => true,
     ClassMember::AutoAccessor(a) => a.is_static,
   }
+}
+
+fn without_parentheses<'a>(mut expr: &'a Expr<'a>) -> &'a Expr<'a> {
+  while let Expr::Paren(paren) = expr {
+    expr = &paren.expr;
+  }
+  expr
+}
+
+fn simple_assignment_ident<'a>(assign: &'a AssignExpr<'a>) -> Option<&'a Ident<'a>> {
+  if assign.op != AssignOp::Assign {
+    return None;
+  }
+  let SimpleAssignTarget::Ident(ident) = assign.left.as_simple()? else {
+    return None;
+  };
+  Some(&ident.id)
+}
+
+fn computed_string_member_name<'a>(member: &'a MemberExpr<'a>, object: &str) -> Option<&'a str> {
+  let Expr::Ident(member_object) = without_parentheses(&member.obj) else {
+    return None;
+  };
+  if member_object.sym.as_str() != object {
+    return None;
+  }
+  let MemberProp::Computed(computed) = &member.prop else {
+    return None;
+  };
+  let Expr::Lit(lit) = without_parentheses(&computed.expr) else {
+    return None;
+  };
+  let Lit::Str(property) = &**lit else {
+    return None;
+  };
+  property.value.as_str()
+}
+
+fn is_typescript_enum_constant(expr: &Expr<'_>) -> bool {
+  match without_parentheses(expr) {
+    Expr::Lit(lit) => matches!(&**lit, Lit::Str(_) | Lit::Num(_)),
+    Expr::Unary(unary) if matches!(unary.op, UnaryOp::Plus | UnaryOp::Minus) => {
+      matches!(without_parentheses(&unary.arg), Expr::Lit(lit) if matches!(&**lit, Lit::Num(_)))
+    }
+    _ => false,
+  }
+}
+
+fn is_typescript_enum_member_statement(stmt: &Stmt<'_>, enum_name: &str) -> bool {
+  let Stmt::Expr(expr_stmt) = stmt else {
+    return false;
+  };
+  let Expr::Assign(outer_assign) = without_parentheses(&expr_stmt.expr) else {
+    return false;
+  };
+  if outer_assign.op != AssignOp::Assign {
+    return false;
+  }
+  let Some(SimpleAssignTarget::Member(outer_member)) = outer_assign.left.as_simple() else {
+    return false;
+  };
+
+  if computed_string_member_name(outer_member, enum_name).is_some() {
+    return is_typescript_enum_constant(&outer_assign.right);
+  }
+
+  let MemberProp::Computed(computed) = &outer_member.prop else {
+    return false;
+  };
+  let Expr::Ident(member_object) = without_parentheses(&outer_member.obj) else {
+    return false;
+  };
+  if member_object.sym.as_str() != enum_name {
+    return false;
+  }
+  let Expr::Assign(inner_assign) = without_parentheses(&computed.expr) else {
+    return false;
+  };
+  let Some(member_name) = simple_typescript_enum_assignment(inner_assign, enum_name) else {
+    return false;
+  };
+  matches!(without_parentheses(&outer_assign.right), Expr::Lit(lit) if matches!(&**lit, Lit::Str(value) if value.value.as_str() == Some(member_name)))
+}
+
+fn simple_typescript_enum_assignment<'a>(
+  assign: &'a AssignExpr<'a>,
+  enum_name: &str,
+) -> Option<&'a str> {
+  if assign.op != AssignOp::Assign || !is_typescript_enum_constant(&assign.right) {
+    return None;
+  }
+  let SimpleAssignTarget::Member(member) = assign.left.as_simple()? else {
+    return None;
+  };
+  computed_string_member_name(member, enum_name)
+}
+
+fn typescript_enum_export_name<'a>(expr: &'a Expr<'a>, enum_name: &str) -> Option<Option<Atom>> {
+  let Expr::Bin(logical_or) = without_parentheses(expr) else {
+    return None;
+  };
+  if logical_or.op != BinaryOp::LogicalOr
+    || !matches!(without_parentheses(&logical_or.left), Expr::Ident(ident) if ident.sym.as_str() == enum_name)
+  {
+    return None;
+  }
+
+  let Expr::Assign(assignment) = without_parentheses(&logical_or.right) else {
+    return None;
+  };
+  let mut assignment = &**assignment;
+  let mut export_name = None;
+  if simple_assignment_ident(assignment).is_none_or(|ident| ident.sym.as_str() != enum_name) {
+    let Some(SimpleAssignTarget::Member(member)) = assignment.left.as_simple() else {
+      return None;
+    };
+    let Expr::Ident(object) = without_parentheses(&member.obj) else {
+      return None;
+    };
+    if object.sym.as_str() != "exports" {
+      return None;
+    }
+    let name = match &member.prop {
+      MemberProp::Ident(ident) => ident.sym.as_str(),
+      MemberProp::Computed(computed) => {
+        let Expr::Lit(lit) = without_parentheses(&computed.expr) else {
+          return None;
+        };
+        let Lit::Str(name) = &**lit else {
+          return None;
+        };
+        name.value.as_str()?
+      }
+      _ => return None,
+    };
+    if name != enum_name {
+      return None;
+    }
+    export_name = Some(Atom::from(name));
+    let Expr::Assign(inner_assignment) = without_parentheses(&assignment.right) else {
+      return None;
+    };
+    assignment = &**inner_assignment;
+  }
+
+  if simple_assignment_ident(assignment).is_none_or(|ident| ident.sym.as_str() != enum_name)
+    || !matches!(without_parentheses(&assignment.right), Expr::Object(object) if object.props.is_empty())
+  {
+    return None;
+  }
+  Some(export_name)
+}
+
+fn match_typescript_enum_statement(stmt: Statement<'_>) -> Option<(Atom, Option<Atom>, Span)> {
+  let Statement::Expr(expr_stmt) = stmt else {
+    return None;
+  };
+  let Expr::Call(call) = without_parentheses(&expr_stmt.expr) else {
+    return None;
+  };
+  if call.args.len() != 1 || call.args[0].spread.is_some() {
+    return None;
+  }
+  let Expr::Fn(function) = without_parentheses(call.callee.as_expr()?) else {
+    return None;
+  };
+  if function.ident.is_some()
+    || function.function.is_async
+    || function.function.is_generator
+    || function.function.params.len() != 1
+  {
+    return None;
+  }
+  let Pat::Ident(parameter) = &function.function.params[0].pat else {
+    return None;
+  };
+  let enum_name = parameter.id.sym.as_str();
+  let body = function.function.body.as_ref()?;
+  if !body
+    .stmts
+    .iter()
+    .all(|stmt| is_typescript_enum_member_statement(stmt, enum_name))
+  {
+    return None;
+  }
+  let export_name = typescript_enum_export_name(&call.args[0].expr, enum_name)?;
+  Some((Atom::from(enum_name), export_name, call.span))
 }
 
 #[derive(Debug)]
@@ -431,6 +619,22 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
   ) -> Option<bool> {
     if !parser.inner_graph.is_enabled() || !parser.is_top_level_scope() {
       return None;
+    }
+
+    if let Some((name, export_name, pure_span)) = match_typescript_enum_statement(stmt) {
+      let variable = Self::tag_top_level_symbol(parser, &name);
+      parser
+        .inner_graph
+        .statement_with_top_level_symbol
+        .insert(stmt.span(), variable);
+      parser
+        .inner_graph
+        .statement_pure_part
+        .insert(stmt.span(), pure_span);
+      if let Some(export_name) = export_name {
+        Self::add_variable_usage(parser, &name, InnerGraphMapUsage::Value(export_name));
+      }
+      return Some(true);
     }
 
     if let Some(class_decl) = stmt.as_class_decl()

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/__snapshots__/treeshaking.snap.txt
@@ -1,0 +1,64 @@
+```js title=main.js
+(self["rspackChunk"] ||= []).push([["main"], {
+"./enums.js"(__unused_rspack_module, exports) {
+"use strict";
+var __rspack_unused_export;
+
+__rspack_unused_export = ({ value: true });
+exports.sideEffectCount = exports.readInternal = __rspack_unused_export = __rspack_unused_export = __rspack_unused_export = exports.Used = void 0;
+
+var Used;
+(function (Used) {
+  Used[Used['One'] = 1] = 'One';
+})(Used || (exports.Used = Used = {}));
+
+var Unused;
+(/* unused pure expression or super */ null && ((function (Unused) {
+  Unused[Unused['One'] = 1] = 'One';
+  Unused[Unused['Two'] = 2] = 'Two';
+})(Unused || (__rspack_unused_export = Unused = {}))));
+
+var UnusedString;
+(/* unused pure expression or super */ null && ((function (UnusedString) {
+  UnusedString['Value'] = 'unused';
+})(UnusedString || (__rspack_unused_export = UnusedString = {}))));
+
+var Internal;
+(function (Internal) {
+  Internal['Value'] = 'internal';
+})(Internal || (__rspack_unused_export = Internal = {}));
+exports.readInternal = () => Internal.Value;
+
+var calls = 0;
+function sideEffect() {
+  calls++;
+  return 1;
+}
+var Impure;
+(function (Impure) {
+  Impure[Impure['Value'] = sideEffect()] = 'Value';
+})(Impure || (__rspack_unused_export = Impure = {}));
+exports.sideEffectCount = () => calls;
+
+
+},
+"./index.js"(__unused_rspack_module, __unused_rspack_exports, __webpack_require__) {
+const { Used, readInternal, sideEffectCount } = __webpack_require__("./enums.js");
+
+it('tree shakes only unused TypeScript CommonJS enums', () => {
+  expect(Used.One).toBe(1);
+  expect(Used[1]).toBe('One');
+  expect(readInternal()).toBe('internal');
+  expect(sideEffectCount()).toBe(1);
+});
+
+
+},
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
+
+}
+]);
+```

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/enums.js
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/enums.js
@@ -1,0 +1,36 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.sideEffectCount = exports.readInternal = exports.Impure = exports.UnusedString = exports.Unused = exports.Used = void 0;
+
+var Used;
+(function (Used) {
+  Used[Used['One'] = 1] = 'One';
+})(Used || (exports.Used = Used = {}));
+
+var Unused;
+(function (Unused) {
+  Unused[Unused['One'] = 1] = 'One';
+  Unused[Unused['Two'] = 2] = 'Two';
+})(Unused || (exports.Unused = Unused = {}));
+
+var UnusedString;
+(function (UnusedString) {
+  UnusedString['Value'] = 'unused';
+})(UnusedString || (exports.UnusedString = UnusedString = {}));
+
+var Internal;
+(function (Internal) {
+  Internal['Value'] = 'internal';
+})(Internal || (exports.Internal = Internal = {}));
+exports.readInternal = () => Internal.Value;
+
+var calls = 0;
+function sideEffect() {
+  calls++;
+  return 1;
+}
+var Impure;
+(function (Impure) {
+  Impure[Impure['Value'] = sideEffect()] = 'Value';
+})(Impure || (exports.Impure = Impure = {}));
+exports.sideEffectCount = () => calls;

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/index.js
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/index.js
@@ -1,0 +1,8 @@
+const { Used, readInternal, sideEffectCount } = require('./enums');
+
+it('tree shakes only unused TypeScript CommonJS enums', () => {
+  expect(Used.One).toBe(1);
+  expect(Used[1]).toBe('One');
+  expect(readInternal()).toBe('internal');
+  expect(sideEffectCount()).toBe(1);
+});

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/package.json
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-enum/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/__snapshots__/treeshaking.snap.txt
@@ -1,0 +1,65 @@
+```js title=main.js
+(self["rspackChunk"] ||= []).push([["main"], {
+"./barrel.js"(__unused_rspack_module, exports, __webpack_require__) {
+"use strict";
+var __rspack_unused_export;
+__webpack_require__.d(exports, {
+  used: () => (/* reexport safe */ _values__rspack_import_0.used)
+});
+/* import */ var _values__rspack_import_0 = __webpack_require__("./values.js");
+
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = { enumerable: true, get: function () { return m[k]; } };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __exportStar =
+  (this && this.__exportStar) ||
+  function (m, exports) {
+    for (var p in m)
+      if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p))
+        __createBinding(exports, m, p);
+  };
+__rspack_unused_export = ({ value: true });
+;
+
+
+},
+"./index.js"(__unused_rspack_module, __unused_rspack_exports, __webpack_require__) {
+const used = (__webpack_require__("./barrel.js")/* .used */.used);
+
+it('keeps the selected CommonJS star reexport', () => {
+  expect(used).toBe('used');
+});
+
+
+},
+"./values.js"(__unused_rspack_module, exports) {
+"use strict";
+var __rspack_unused_export;
+
+__rspack_unused_export = ({ value: true });
+__rspack_unused_export = exports.used = void 0;
+exports.used = 'used';
+__rspack_unused_export = 'unused';
+
+
+},
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
+
+}
+]);
+```

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/barrel.js
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/barrel.js
@@ -1,0 +1,25 @@
+'use strict';
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = { enumerable: true, get: function () { return m[k]; } };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __exportStar =
+  (this && this.__exportStar) ||
+  function (m, exports) {
+    for (var p in m)
+      if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p))
+        __createBinding(exports, m, p);
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require('./values'), exports);

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/index.js
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/index.js
@@ -1,0 +1,5 @@
+const used = require('./barrel').used;
+
+it('keeps the selected CommonJS star reexport', () => {
+  expect(used).toBe('used');
+});

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/package.json
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/values.js
+++ b/tests/rspack-test/treeShakingCases/typescript-commonjs-export-star/values.js
@@ -1,0 +1,5 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.unused = exports.used = void 0;
+exports.used = 'used';
+exports.unused = 'unused';


### PR DESCRIPTION
## Summary

- recognize standard TypeScript `__exportStar` CommonJS barrels and cached helper variants so named export usage propagates through reexports while preserving first-wins semantics
- treat standard constant TypeScript CommonJS enum initialization as export-dependent pure work, while retaining locally referenced, computed, or impure initializers
- add tree-shaking cases covering retained and removed exports for both patterns

The new checks run during parser and export analysis, require the exact TypeScript-generated shapes, and avoid additional graph-wide scans or configuration.

## Benchmark

Measured a production application with the same source and configuration on both sides, changing only these two commits. The totals cover 262 emitted non-source-map `.js` assets; gzip is calculated per file at level 9.

| Metric | Baseline | Optimized | Reduction |
| --- | ---: | ---: | ---: |
| Raw JavaScript | 26,104,177 B | 26,009,956 B | 94,221 B (0.3609%) |
| Gzip JavaScript | 7,168,937 B | 7,153,322 B | 15,615 B (0.2178%) |

## Related links

- https://github.com/web-infra-dev/rspack/pull/14853#issuecomment-5012477430

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; no user-facing API change).