### PR TITLE
fix(ci): pin typescript for type-tests to avoid tsc bin shadowing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,6 +840,9 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../../packages/rspack
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   website:
     dependencies:

--- a/tests/type-tests/package.json
+++ b/tests/type-tests/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "@rspack/core": "workspace:*"
+    "@rspack/core": "workspace:*",
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Why

CI on `main` is red since #14924 landed, failing in `test:type`:

```
resolution-bundler/defineConfig.ts(47,14): error TS2769: No overload matches this call.
resolution-bundler/defineConfig.ts(48,3): error TS2578: Unused '@ts-expect-error' directive.
```

Root cause: #14925 replaced the root devDep `@typescript/native-preview` (bin name `tsgo`) with `@typescript/native: npm:typescript@^7.0.2`, whose real package is `typescript` with bin name `tsc`. This conflicts with the root `typescript@6.0.3` bin, and pnpm silently resolves the conflict to the higher version — so the root `node_modules/.bin/tsc` became TypeScript 7.0.2 (no warning is emitted, even at debug log level).

`tests/type-tests` invokes bare `tsc` without declaring its own `typescript` dependency, so it silently switched from TS 6.0.3 to TS 7.0.2:

- **Before (TS 6.0.3)**: an invalid property in a failing overloaded call is reported on the property line, so the in-object `// @ts-expect-error` in the tests added by #14924 suppresses it — green.
- **After (TS 7.0.2)**: TS2769 is anchored at the call argument instead, so the directive becomes unused and the error surfaces — red.

The two PRs were each green in isolation (#14924's CI ran before #14925 merged) and broke `main` only in combination.

## What

Declare `typescript: ^6.0.3` as a devDependency of `@rspack-test/type-tests`, so its `tsc` deterministically resolves to the package-local bin (TS 6.0.3) regardless of root bin shadowing.

Note: the root `node_modules/.bin/tsc` is still TypeScript 7.0.2 after this fix — any future script invoking bare `tsc` outside a package that declares `typescript` will hit the same trap.