### PR TITLE
test: align defineConfig error assertions

### DIFF
--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -44,8 +44,8 @@ defineConfig(async () => [
   },
 ]);
 
+// @ts-expect-error invalid mode
 defineConfig({
-  // @ts-expect-error invalid mode
   mode: 'invalid',
 });
 

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -44,8 +44,8 @@ defineConfig(async () => [
   },
 ]);
 
+// @ts-expect-error invalid mode
 defineConfig({
-  // @ts-expect-error invalid mode
   mode: 'invalid',
 });
 


### PR DESCRIPTION
## Summary

TypeScript 7 reports the invalid `defineConfig` argument on the call expression rather than the `mode` property, causing the existing negative type assertions to be treated as unused.

Move `@ts-expect-error` to the call site in both bundler and NodeNext resolution tests.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).