### PR TITLE
docs: mention Vue DevTools integration

### DIFF
--- a/website/docs/en/guide/tech/vue.mdx
+++ b/website/docs/en/guide/tech/vue.mdx
@@ -158,3 +158,9 @@ export default defineConfig({
 ```
 
 Rspack provides a [example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/vue-jsx) of Vue JSX for reference.
+
+## Vue DevTools
+
+Vue DevTools is designed to enhance the Vue developer experience; it can significantly improve your productivity and debugging capabilities when working with Vue applications.
+
+For Vue applications built with Rspack, use [vue-devtools-rstack](https://github.com/OskarLebuda/vue-devtools-rstack) to integrate Vue DevTools.

--- a/website/docs/zh/guide/tech/vue.mdx
+++ b/website/docs/zh/guide/tech/vue.mdx
@@ -156,3 +156,9 @@ export default defineConfig({
 ```
 
 Rspack 提供了一个 Vue JSX 的[示例](https://github.com/rstackjs/rstack-examples/tree/main/rspack/vue-jsx)可供参考。
+
+## Vue DevTools
+
+Vue DevTools 旨在提升 Vue 开发体验，可以显著提高开发和调试 Vue 应用的效率。
+
+对于使用 Rspack 构建的 Vue 应用，可以通过 [vue-devtools-rstack](https://github.com/OskarLebuda/vue-devtools-rstack) 集成 Vue DevTools。


### PR DESCRIPTION
## Summary

This PR adds a brief Vue DevTools section to the Vue guides. It points Rspack users to `vue-devtools-rstack` for integration.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8181

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).