### PR TITLE
fix(tree-shaking): analyze SWC-lowered dynamic imports

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -34,6 +34,7 @@ pub struct ImportContextDependency {
   optional: bool,
   critical: Option<Diagnostic>,
   factorize_info: FactorizeInfo,
+  suppress_inferred_references: bool,
 }
 
 impl ImportContextDependency {
@@ -51,6 +52,7 @@ impl ImportContextDependency {
       optional,
       critical: None,
       factorize_info: Default::default(),
+      suppress_inferred_references: false,
       options,
     }
   }
@@ -60,6 +62,9 @@ impl ImportContextDependency {
     referenced_specifiers: Vec<ReferencedSpecifier>,
     from_magic_comment: bool,
   ) {
+    if self.suppress_inferred_references && !from_magic_comment {
+      return;
+    }
     if !from_magic_comment && referenced_specifiers.is_empty() {
       // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
       // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
@@ -68,6 +73,10 @@ impl ImportContextDependency {
     }
     self.options.referenced_specifiers = Some(referenced_specifiers);
     self.resource_identifier = create_resource_identifier(&self.options);
+  }
+
+  pub fn suppress_inferred_references(&mut self) {
+    self.suppress_inferred_references = true;
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -12,7 +12,7 @@ use rspack_core::{
 };
 use swc_atoms::Atom;
 
-use super::create_resource_identifier_for_esm_dependency;
+use super::{create_resource_identifier_for_esm_dependency, is_resolved_swc_async_to_generator};
 use crate::dependency::{DependencyBranchGuard, compose_dependency_condition};
 
 #[cacheable]
@@ -32,6 +32,7 @@ pub struct ImportDependency {
   optional: bool,
   #[cacheable(with=AsOption<AsCacheable>)]
   branch_guard: Option<DependencyBranchGuard>,
+  swc_async_helper_dependency: Option<DependencyId>,
 }
 
 impl ImportDependency {
@@ -57,6 +58,7 @@ impl ImportDependency {
       optional,
       comments,
       branch_guard: None,
+      swc_async_helper_dependency: None,
     }
   }
 
@@ -79,6 +81,10 @@ impl ImportDependency {
       Some(old_guard) => old_guard.and(guard),
       None => guard,
     });
+  }
+
+  pub fn set_swc_async_helper_dependency(&mut self, dependency_id: DependencyId) {
+    self.swc_async_helper_dependency = Some(dependency_id);
   }
 }
 
@@ -119,6 +125,13 @@ impl Dependency for ImportDependency {
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
   ) -> Vec<rspack_core::ReferencedExport> {
+    if self
+      .swc_async_helper_dependency
+      .as_ref()
+      .is_some_and(|dependency_id| !is_resolved_swc_async_to_generator(module_graph, dependency_id))
+    {
+      return create_exports_object_referenced();
+    }
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -11,7 +11,7 @@ use rspack_core::{
 };
 use swc_atoms::Atom;
 
-use super::create_resource_identifier_for_esm_dependency;
+use super::{create_resource_identifier_for_esm_dependency, is_resolved_swc_async_to_generator};
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -26,6 +26,7 @@ pub struct ImportEagerDependency {
   phase: ImportPhase,
   resource_identifier: ResourceIdentifier,
   factorize_info: FactorizeInfo,
+  swc_async_helper_dependency: Option<DependencyId>,
 }
 
 impl ImportEagerDependency {
@@ -46,6 +47,7 @@ impl ImportEagerDependency {
       phase,
       resource_identifier,
       factorize_info: Default::default(),
+      swc_async_helper_dependency: None,
     }
   }
 
@@ -61,6 +63,10 @@ impl ImportEagerDependency {
       return;
     }
     self.referenced_specifiers = Some(referenced_specifiers);
+  }
+
+  pub fn set_swc_async_helper_dependency(&mut self, dependency_id: DependencyId) {
+    self.swc_async_helper_dependency = Some(dependency_id);
   }
 }
 
@@ -101,6 +107,13 @@ impl Dependency for ImportEagerDependency {
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
   ) -> Vec<rspack_core::ReferencedExport> {
+    if self
+      .swc_async_helper_dependency
+      .as_ref()
+      .is_some_and(|dependency_id| !is_resolved_swc_async_to_generator(module_graph, dependency_id))
+    {
+      return create_exports_object_referenced();
+    }
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_weak_dependency.rs
@@ -11,7 +11,7 @@ use rspack_core::{
 };
 use swc_atoms::Atom;
 
-use super::create_resource_identifier_for_esm_dependency;
+use super::{create_resource_identifier_for_esm_dependency, is_resolved_swc_async_to_generator};
 
 // Align with webpack's ImportWeakDependency:
 // https://github.com/webpack/webpack/blob/2944286213cf1b3697a1c8dd41ffd3f8ada99448/lib/dependencies/ImportWeakDependency.js
@@ -29,6 +29,7 @@ pub struct ImportWeakDependency {
   resource_identifier: ResourceIdentifier,
   factorize_info: FactorizeInfo,
   optional: bool,
+  swc_async_helper_dependency: Option<DependencyId>,
 }
 
 impl ImportWeakDependency {
@@ -51,6 +52,7 @@ impl ImportWeakDependency {
       resource_identifier,
       factorize_info: Default::default(),
       optional,
+      swc_async_helper_dependency: None,
     }
   }
 
@@ -66,6 +68,10 @@ impl ImportWeakDependency {
       return;
     }
     self.referenced_specifiers = Some(referenced_specifiers);
+  }
+
+  pub fn set_swc_async_helper_dependency(&mut self, dependency_id: DependencyId) {
+    self.swc_async_helper_dependency = Some(dependency_id);
   }
 }
 
@@ -106,6 +112,13 @@ impl Dependency for ImportWeakDependency {
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&rspack_core::RuntimeSpec>,
   ) -> Vec<rspack_core::ReferencedExport> {
+    if self
+      .swc_async_helper_dependency
+      .as_ref()
+      .is_some_and(|dependency_id| !is_resolved_swc_async_to_generator(module_graph, dependency_id))
+    {
+      return create_exports_object_referenced();
+    }
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
@@ -14,9 +14,11 @@ mod import_meta_rsc_dependency;
 mod import_weak_dependency;
 mod provide_dependency;
 
-use std::fmt::Write as _;
+use std::{fmt::Write as _, path::Path};
 
-use rspack_core::{DependencyCategory, ImportAttributes, ImportPhase, ResourceIdentifier};
+use rspack_core::{
+  DependencyCategory, DependencyId, ImportAttributes, ImportPhase, ModuleGraph, ResourceIdentifier,
+};
 
 pub use self::{
   esm_compatibility_dependency::{ESMCompatibilityDependency, ESMCompatibilityDependencyTemplate},
@@ -91,6 +93,40 @@ pub fn create_resource_identifier_for_esm_dependency(
   let len = attrs.len();
   push_esm_resource_identifier_attributes(&mut ident, attrs.into_iter(), len);
   ident.into()
+}
+
+fn is_resolved_swc_async_to_generator(
+  module_graph: &ModuleGraph,
+  dependency_id: &DependencyId,
+) -> bool {
+  // The parser only sees the import request, which aliases and replacement
+  // plugins may redirect. Narrow exports only after verifying the resolved file.
+  let Some(module) = module_graph.get_module_by_dependency_id(dependency_id) else {
+    return false;
+  };
+  let Some(normal_module) = module.as_normal_module() else {
+    return false;
+  };
+  let resource_data = normal_module.resource_resolved_data();
+  let Some(description) = resource_data.description() else {
+    return false;
+  };
+  if description
+    .json()
+    .get("name")
+    .and_then(|name| name.as_str())
+    != Some("@swc/helpers")
+  {
+    return false;
+  }
+  let Some(resource_path) = resource_data.path() else {
+    return false;
+  };
+  let Ok(relative_path) = resource_path.as_std_path().strip_prefix(description.path()) else {
+    return false;
+  };
+  relative_path == Path::new("esm/_async_to_generator.js")
+    || relative_path == Path::new("cjs/_async_to_generator.cjs")
 }
 
 fn push_esm_resource_identifier_attributes<'a>(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  ConstDependency, Dependency, DependencyRange, DependencyType, ExportPresenceMode,
+  ConstDependency, Dependency, DependencyId, DependencyRange, DependencyType, ExportPresenceMode,
   ImportAttributes, ImportPhase,
 };
 use rspack_util::SpanExt;
@@ -65,6 +65,7 @@ fn check_import_phase(parser: &mut JavascriptParser, phase: ImportPhase) {
 pub struct ESMSpecifierData {
   pub name: Atom,
   pub source: Atom,
+  pub dependency_id: DependencyId,
   pub ids: AtomMembers,
   pub namespace_import: bool,
   pub source_order: i32,
@@ -95,6 +96,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       parser.to_dependency_location(DependencyRange::from(import_span)),
       false,
     );
+    parser.last_esm_import_dependency = Some((import_span, *dependency.id()));
 
     parser.add_dependency(Box::new(dependency));
 
@@ -120,12 +122,17 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
   ) -> Option<bool> {
     let is_create_require = is_create_require_import(parser, source, id);
     let phase = get_import_phase(parser, statement.phase);
+    let dependency_id = parser
+      .last_esm_import_dependency
+      .filter(|(span, _)| *span == statement.span)
+      .map(|(_, dependency_id)| dependency_id)?;
     parser.tag_variable::<ESMSpecifierData>(
       name.clone(),
       ESM_SPECIFIER_TAG,
       Some(ESMSpecifierData {
         name: name.clone(),
         source: source.clone(),
+        dependency_id,
         ids: id.into_iter().cloned().collect(),
         namespace_import: id.is_none(),
         source_order: parser.last_esm_import_order,
@@ -156,6 +163,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       source_order,
       phase,
       attributes,
+      ..
     } = if let ExportedVariableInfo::VariableInfo(variable) = root_info {
       parser
         .get_variable_tag_data::<ESMSpecifierData>(*variable, ESM_SPECIFIER_TAG)?

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -357,6 +357,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
       || referenced_in_variable.is_some()
       || referenced_fulfilled_ns_obj.is_some()
       || referenced_in_members.is_some();
+    // Defer trusting SWC yield semantics until the helper import is resolved.
+    let swc_async_helper_dependency = (is_statical
+      && parser.swc_async_to_generator_function_depth == Some(parser.function_scope_depth))
+    .then_some(parser.swc_async_to_generator_dependency)
+    .flatten();
     if is_statical && has_exports_magic_comment {
       let mut error: Error = create_traceable_error(
         "Useless magic comments".into(),
@@ -392,6 +397,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         if let Some(exports) = exports {
           dep.set_referenced_specifiers(exports, !is_statical && has_exports_magic_comment);
         }
+        if let Some(dependency_id) = swc_async_helper_dependency {
+          dep.set_swc_async_helper_dependency(dependency_id);
+        }
         let dep_idx = parser.next_dependency_idx();
         parser.add_dependency(Box::new(dep));
         ImportDependencyLocator {
@@ -409,6 +417,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         );
         if let Some(exports) = exports {
           dep.set_referenced_specifiers(exports, !is_statical && has_exports_magic_comment);
+        }
+        if let Some(dependency_id) = swc_async_helper_dependency {
+          dep.set_swc_async_helper_dependency(dependency_id);
         }
         let dep_idx = parser.next_dependency_idx();
         parser.add_dependency(Box::new(dep));
@@ -435,6 +446,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         );
         if let Some(export) = exports {
           dep.set_referenced_specifiers(export, !is_statical && has_exports_magic_comment);
+        }
+        if let Some(dependency_id) = swc_async_helper_dependency {
+          dep.set_swc_async_helper_dependency(dependency_id);
         }
         let range = DependencyRange::from(import_call_span);
         let loc = parser.to_dependency_location(range);
@@ -509,6 +523,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         dyn_imported_span.into(),
         parser.in_try,
       );
+      if swc_async_helper_dependency.is_some() {
+        dep.suppress_inferred_references();
+      }
       if let Some(export) = exports {
         dep.set_referenced_specifiers(export, !is_statical && has_exports_magic_comment);
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -51,7 +51,9 @@ pub(crate) use self::{
   drive::JavaScriptParserPluginDrive,
   esm_detection_parser_plugin::ESMDetectionParserPlugin,
   esm_export_dependency_parser_plugin::ESMExportDependencyParserPlugin,
-  esm_import_dependency_parser_plugin::ESMImportDependencyParserPlugin,
+  esm_import_dependency_parser_plugin::{
+    ESM_SPECIFIER_TAG, ESMImportDependencyParserPlugin, ESMSpecifierData,
+  },
   esm_top_level_this_plugin::ESMTopLevelThisParserPlugin,
   import_meta_context_dependency_parser_plugin::ImportMetaContextDependencyParserPlugin,
   import_meta_plugin::{ImportMetaDisabledPlugin, ImportMetaPlugin},

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1391,10 +1391,10 @@ impl<'parser> JavascriptParser<'parser> {
     expr: &'a Expr<'a>,
   ) -> Option<&'a Expr<'a>> {
     let drive = self.plugin_drive.clone();
-    let expr = match expr {
-      Expr::Await(await_expr) => &await_expr.arg,
-      Expr::Yield(yield_expr) => yield_expr.arg.as_ref().unwrap_or(expr),
-      _ => expr,
+    let expr = if let Expr::Await(await_expr) = expr {
+      &await_expr.arg
+    } else {
+      expr
     };
     let destructuring = if let Some(assign) = expr.as_assign()
       && let Some(pat) = assign.left.as_pat()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -422,6 +422,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) parser_exports_state: Option<bool>,
   pub(crate) local_modules: Vec<LocalModule>,
   pub(crate) last_esm_import_order: i32,
+  pub(crate) last_esm_import_dependency: Option<(Span, DependencyId)>,
   pub(crate) inner_graph: InnerGraphState,
   pub(crate) side_effects_item: Option<SideEffectsBailoutItemWithSpan>,
   pub(crate) is_renaming: Option<Atom>,
@@ -432,6 +433,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) function_scope_depth: usize,
   pub(crate) swc_async_to_generator_function_depth: Option<usize>,
   pub(crate) swc_async_to_generator_argument: Option<Span>,
+  pub(crate) swc_async_to_generator_dependency: Option<DependencyId>,
 }
 
 impl<'parser> JavascriptParser<'parser> {
@@ -613,6 +615,7 @@ impl<'parser> JavascriptParser<'parser> {
       inner_graph: InnerGraphState::new(),
       parse_meta,
       local_modules: Default::default(),
+      last_esm_import_dependency: None,
       side_effects_item: None,
       parser_runtime_requirements,
       is_renaming: None,
@@ -623,6 +626,7 @@ impl<'parser> JavascriptParser<'parser> {
       function_scope_depth: 0,
       swc_async_to_generator_function_depth: None,
       swc_async_to_generator_argument: None,
+      swc_async_to_generator_dependency: None,
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -429,6 +429,8 @@ pub struct JavascriptParser<'parser> {
   pub(crate) collecting_dependencies_for_block: Option<usize>,
   pub(crate) dependencies_in_branch_guard: Option<FxHashMap<DependencyRange, DependencyId>>,
   pub(crate) current_branch_guard: Option<DependencyBranchGuard>,
+  pub(crate) in_swc_async_to_generator: bool,
+  pub(crate) swc_async_to_generator_argument: Option<Span>,
 }
 
 impl<'parser> JavascriptParser<'parser> {
@@ -617,6 +619,8 @@ impl<'parser> JavascriptParser<'parser> {
       collecting_dependencies_for_block: None,
       dependencies_in_branch_guard: None,
       current_branch_guard: None,
+      in_swc_async_to_generator: false,
+      swc_async_to_generator_argument: None,
     }
   }
 
@@ -1391,10 +1395,12 @@ impl<'parser> JavascriptParser<'parser> {
     expr: &'a Expr<'a>,
   ) -> Option<&'a Expr<'a>> {
     let drive = self.plugin_drive.clone();
-    let expr = if let Expr::Await(await_expr) = expr {
-      &await_expr.arg
-    } else {
-      expr
+    let expr = match expr {
+      Expr::Await(await_expr) => &await_expr.arg,
+      Expr::Yield(yield_expr) if self.in_swc_async_to_generator && !yield_expr.delegate => {
+        yield_expr.arg.as_ref().unwrap_or(expr)
+      }
+      _ => expr,
     };
     let destructuring = if let Some(assign) = expr.as_assign()
       && let Some(pat) = assign.left.as_pat()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1391,10 +1391,10 @@ impl<'parser> JavascriptParser<'parser> {
     expr: &'a Expr<'a>,
   ) -> Option<&'a Expr<'a>> {
     let drive = self.plugin_drive.clone();
-    let expr = if let Expr::Await(await_expr) = expr {
-      &await_expr.arg
-    } else {
-      expr
+    let expr = match expr {
+      Expr::Await(await_expr) => &await_expr.arg,
+      Expr::Yield(yield_expr) => yield_expr.arg.as_ref().unwrap_or(expr),
+      _ => expr,
     };
     let destructuring = if let Some(assign) = expr.as_assign()
       && let Some(pat) = assign.left.as_pat()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -429,7 +429,8 @@ pub struct JavascriptParser<'parser> {
   pub(crate) collecting_dependencies_for_block: Option<usize>,
   pub(crate) dependencies_in_branch_guard: Option<FxHashMap<DependencyRange, DependencyId>>,
   pub(crate) current_branch_guard: Option<DependencyBranchGuard>,
-  pub(crate) in_swc_async_to_generator: bool,
+  pub(crate) function_scope_depth: usize,
+  pub(crate) swc_async_to_generator_function_depth: Option<usize>,
   pub(crate) swc_async_to_generator_argument: Option<Span>,
 }
 
@@ -619,7 +620,8 @@ impl<'parser> JavascriptParser<'parser> {
       collecting_dependencies_for_block: None,
       dependencies_in_branch_guard: None,
       current_branch_guard: None,
-      in_swc_async_to_generator: false,
+      function_scope_depth: 0,
+      swc_async_to_generator_function_depth: None,
       swc_async_to_generator_argument: None,
     }
   }
@@ -1397,7 +1399,10 @@ impl<'parser> JavascriptParser<'parser> {
     let drive = self.plugin_drive.clone();
     let expr = match expr {
       Expr::Await(await_expr) => &await_expr.arg,
-      Expr::Yield(yield_expr) if self.in_swc_async_to_generator && !yield_expr.delegate => {
+      Expr::Yield(yield_expr)
+        if self.swc_async_to_generator_function_depth == Some(self.function_scope_depth)
+          && !yield_expr.delegate =>
+      {
         yield_expr.arg.as_ref().unwrap_or(expr)
       }
       _ => expr,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1644,7 +1644,7 @@ impl JavascriptParser<'_> {
       return None;
     }
     let argument = expr.args.first()?.expr.as_fn()?;
-    argument.function.is_generator.then_some(&expr.args[0].expr)
+    (argument.ident.is_none() && argument.function.is_generator).then_some(&expr.args[0].expr)
   }
 
   fn extract_await_or_swc_yield_import_member<'a>(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -25,7 +25,8 @@ use crate::{
   dependency::DependencyBranchGuard,
   parser_plugin::{
     CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
-    CreatedRequireTagData, JavascriptParserPlugin, is_create_require_namespace_member,
+    CreatedRequireTagData, ESM_SPECIFIER_TAG, ESMSpecifierData, JavascriptParserPlugin,
+    is_create_require_namespace_member,
   },
   visitors::{
     AtomMembers, ExportedVariableInfo, ExprRef, VariableDeclaration, VariableInfo,
@@ -1224,9 +1225,11 @@ impl JavascriptParser<'_> {
       }
     }
 
-    // (await import(...)).a.b
-    if let Some((call, members, await_expr)) = self.extract_await_import_member(expr) {
-      if self.is_top_level_scope() {
+    // (await import(...)).a.b / (yield import(...)).a.b inside SWC's async helper
+    if let Some((call, members, await_expr)) = self.extract_await_or_swc_yield_import_member(expr) {
+      if let Some(await_expr) = await_expr
+        && self.is_top_level_scope()
+      {
         self
           .plugin_drive
           .clone()
@@ -1428,6 +1431,19 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_call_expression(&mut self, expr: &CallExpr) {
+    let Some(argument) = self.get_swc_async_to_generator_argument(expr) else {
+      self.walk_call_expression_inner(expr);
+      return;
+    };
+
+    let old_argument = self
+      .swc_async_to_generator_argument
+      .replace(argument.span());
+    self.walk_call_expression_inner(expr);
+    self.swc_async_to_generator_argument = old_argument;
+  }
+
+  fn walk_call_expression_inner(&mut self, expr: &CallExpr) {
     fn is_simple_function(params: &[Param]) -> bool {
       params.iter().all(|p| matches!(p.pat, Pat::Ident(_)))
     }
@@ -1510,9 +1526,13 @@ impl JavascriptParser<'_> {
             {
               return;
             }
-            // (await import(...)).a.b()
-            if let Some((call, members, await_expr)) = self.extract_await_import_member(member) {
-              if self.is_top_level_scope() {
+            // (await import(...)).a.b() / (yield import(...)).a.b() inside SWC's async helper
+            if let Some((call, members, await_expr)) =
+              self.extract_await_or_swc_yield_import_member(member)
+            {
+              if let Some(await_expr) = await_expr
+                && self.is_top_level_scope()
+              {
                 self
                   .plugin_drive
                   .clone()
@@ -1604,20 +1624,44 @@ impl JavascriptParser<'_> {
     }
   }
 
-  fn extract_await_import_member<'a>(
+  fn get_swc_async_to_generator_argument<'a>(
+    &mut self,
+    expr: &'a CallExpr<'a>,
+  ) -> Option<&'a Expr<'a>> {
+    let callee = expr.callee.as_expr()?.as_ident()?;
+    let name = Atom::from(callee.sym.as_str());
+    let variable = self.get_variable_info(&name)?.id();
+    let specifier = self.get_variable_tag_data::<ESMSpecifierData>(variable, ESM_SPECIFIER_TAG)?;
+    // SWC's helper resumes the generator with each yielded promise's fulfilled
+    // value, so yield has await semantics only inside this exact imported helper.
+    if specifier.source != "@swc/helpers/_/_async_to_generator"
+      || specifier.ids.len() != 1
+      || specifier.ids[0] != "_"
+    {
+      return None;
+    }
+    let argument = expr.args.first()?.expr.as_fn()?;
+    argument.function.is_generator.then_some(&expr.args[0].expr)
+  }
+
+  fn extract_await_or_swc_yield_import_member<'a>(
     &self,
     expr: &'a MemberExpr<'a>,
-  ) -> Option<(&'a CallExpr<'a>, AtomMembers, &'a AwaitExpr<'a>)> {
+  ) -> Option<(&'a CallExpr<'a>, AtomMembers, Option<&'a AwaitExpr<'a>>)> {
     let ExtractedMemberExpressionChainData {
       object,
       mut members,
       mut members_optionals,
       ..
     } = self.extract_member_expression_chain(ExprRef::Member(expr));
-    let ExprRef::Await(await_expr) = object else {
-      return None;
+    let (import_expr, await_expr) = match object {
+      ExprRef::Await(await_expr) => (&await_expr.arg, Some(await_expr)),
+      ExprRef::Yield(yield_expr) if self.in_swc_async_to_generator && !yield_expr.delegate => {
+        (yield_expr.arg.as_ref()?, None)
+      }
+      _ => return None,
     };
-    let call = await_expr.arg.as_call()?;
+    let call = import_expr.as_call()?;
     if !call.callee.is_import() {
       return None;
     }
@@ -1629,7 +1673,14 @@ impl JavascriptParser<'_> {
 
   pub fn walk_expr_or_spread(&mut self, args: &[ExprOrSpread]) {
     for arg in args {
-      self.walk_expression(&arg.expr)
+      if self.swc_async_to_generator_argument == Some(arg.expr.span()) {
+        let old_in_swc_async_to_generator = self.in_swc_async_to_generator;
+        self.in_swc_async_to_generator = true;
+        self.walk_expression(&arg.expr);
+        self.in_swc_async_to_generator = old_in_swc_async_to_generator;
+      } else {
+        self.walk_expression(&arg.expr)
+      }
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1224,11 +1224,9 @@ impl JavascriptParser<'_> {
       }
     }
 
-    // (await import(...)).a.b / (yield import(...)).a.b
-    if let Some((call, members, await_expr)) = self.extract_await_or_yield_import_member(expr) {
-      if let Some(await_expr) = await_expr
-        && self.is_top_level_scope()
-      {
+    // (await import(...)).a.b
+    if let Some((call, members, await_expr)) = self.extract_await_import_member(expr) {
+      if self.is_top_level_scope() {
         self
           .plugin_drive
           .clone()
@@ -1512,13 +1510,9 @@ impl JavascriptParser<'_> {
             {
               return;
             }
-            // (await import(...)).a.b() / (yield import(...)).a.b()
-            if let Some((call, members, await_expr)) =
-              self.extract_await_or_yield_import_member(member)
-            {
-              if let Some(await_expr) = await_expr
-                && self.is_top_level_scope()
-              {
+            // (await import(...)).a.b()
+            if let Some((call, members, await_expr)) = self.extract_await_import_member(member) {
+              if self.is_top_level_scope() {
                 self
                   .plugin_drive
                   .clone()
@@ -1610,22 +1604,20 @@ impl JavascriptParser<'_> {
     }
   }
 
-  fn extract_await_or_yield_import_member<'a>(
+  fn extract_await_import_member<'a>(
     &self,
     expr: &'a MemberExpr<'a>,
-  ) -> Option<(&'a CallExpr<'a>, AtomMembers, Option<&'a AwaitExpr<'a>>)> {
+  ) -> Option<(&'a CallExpr<'a>, AtomMembers, &'a AwaitExpr<'a>)> {
     let ExtractedMemberExpressionChainData {
       object,
       mut members,
       mut members_optionals,
       ..
     } = self.extract_member_expression_chain(ExprRef::Member(expr));
-    let (import_expr, await_expr) = match object {
-      ExprRef::Await(await_expr) => (&await_expr.arg, Some(await_expr)),
-      ExprRef::Yield(yield_expr) if !yield_expr.delegate => (yield_expr.arg.as_ref()?, None),
-      _ => return None,
+    let ExprRef::Await(await_expr) = object else {
+      return None;
     };
-    let call = import_expr.as_call()?;
+    let call = await_expr.arg.as_call()?;
     if !call.callee.is_import() {
       return None;
     }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -117,10 +117,12 @@ impl JavascriptParser<'_> {
     let old_top_level_scope = self.top_level_scope;
     let old_in_tagged_template_tag = self.in_tagged_template_tag;
     let old_terminated = self.terminated;
+    let old_function_scope_depth = self.function_scope_depth;
 
     self.definitions = self.definitions_db.create_child(old_definitions);
     self.in_tagged_template_tag = false;
     self.terminated = None;
+    self.function_scope_depth = old_function_scope_depth + 1;
     if has_this {
       self.undefined_variable(&"this".into());
     }
@@ -134,6 +136,7 @@ impl JavascriptParser<'_> {
     self.top_level_scope = old_top_level_scope;
     self.in_tagged_template_tag = old_in_tagged_template_tag;
     self.terminated = old_terminated;
+    self.function_scope_depth = old_function_scope_depth;
   }
 
   pub fn walk_module_items(&mut self, statements: &[ModuleItem<'_>]) {
@@ -1656,7 +1659,10 @@ impl JavascriptParser<'_> {
     } = self.extract_member_expression_chain(ExprRef::Member(expr));
     let (import_expr, await_expr) = match object {
       ExprRef::Await(await_expr) => (&await_expr.arg, Some(await_expr)),
-      ExprRef::Yield(yield_expr) if self.in_swc_async_to_generator && !yield_expr.delegate => {
+      ExprRef::Yield(yield_expr)
+        if self.swc_async_to_generator_function_depth == Some(self.function_scope_depth)
+          && !yield_expr.delegate =>
+      {
         (yield_expr.arg.as_ref()?, None)
       }
       _ => return None,
@@ -1674,10 +1680,11 @@ impl JavascriptParser<'_> {
   pub fn walk_expr_or_spread(&mut self, args: &[ExprOrSpread]) {
     for arg in args {
       if self.swc_async_to_generator_argument == Some(arg.expr.span()) {
-        let old_in_swc_async_to_generator = self.in_swc_async_to_generator;
-        self.in_swc_async_to_generator = true;
+        let old_function_depth = self
+          .swc_async_to_generator_function_depth
+          .replace(self.function_scope_depth + 1);
         self.walk_expression(&arg.expr);
-        self.in_swc_async_to_generator = old_in_swc_async_to_generator;
+        self.swc_async_to_generator_function_depth = old_function_depth;
       } else {
         self.walk_expression(&arg.expr)
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, cell::Cell};
 
+use rspack_core::DependencyId;
 use swc_atoms::Atom;
 use swc_experimental_allocator::{Allocator, CloneIn};
 use swc_experimental_ecma_ast::{
@@ -1434,7 +1435,7 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_call_expression(&mut self, expr: &CallExpr) {
-    let Some(argument) = self.get_swc_async_to_generator_argument(expr) else {
+    let Some((argument, dependency_id)) = self.get_swc_async_to_generator_argument(expr) else {
       self.walk_call_expression_inner(expr);
       return;
     };
@@ -1442,8 +1443,12 @@ impl JavascriptParser<'_> {
     let old_argument = self
       .swc_async_to_generator_argument
       .replace(argument.span());
+    let old_dependency = self
+      .swc_async_to_generator_dependency
+      .replace(dependency_id);
     self.walk_call_expression_inner(expr);
     self.swc_async_to_generator_argument = old_argument;
+    self.swc_async_to_generator_dependency = old_dependency;
   }
 
   fn walk_call_expression_inner(&mut self, expr: &CallExpr) {
@@ -1630,7 +1635,7 @@ impl JavascriptParser<'_> {
   fn get_swc_async_to_generator_argument<'a>(
     &mut self,
     expr: &'a CallExpr<'a>,
-  ) -> Option<&'a Expr<'a>> {
+  ) -> Option<(&'a Expr<'a>, DependencyId)> {
     let callee = expr.callee.as_expr()?.as_ident()?;
     let name = Atom::from(callee.sym.as_str());
     let variable = self.get_variable_info(&name)?.id();
@@ -1644,7 +1649,8 @@ impl JavascriptParser<'_> {
       return None;
     }
     let argument = expr.args.first()?.expr.as_fn()?;
-    (argument.ident.is_none() && argument.function.is_generator).then_some(&expr.args[0].expr)
+    (argument.ident.is_none() && argument.function.is_generator)
+      .then_some((&expr.args[0].expr, specifier.dependency_id))
   }
 
   fn extract_await_or_swc_yield_import_member<'a>(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1224,9 +1224,11 @@ impl JavascriptParser<'_> {
       }
     }
 
-    // (await import(...)).a.b
-    if let Some((call, members, await_expr)) = self.extract_await_import_member(expr) {
-      if self.is_top_level_scope() {
+    // (await import(...)).a.b / (yield import(...)).a.b
+    if let Some((call, members, await_expr)) = self.extract_await_or_yield_import_member(expr) {
+      if let Some(await_expr) = await_expr
+        && self.is_top_level_scope()
+      {
         self
           .plugin_drive
           .clone()
@@ -1510,9 +1512,13 @@ impl JavascriptParser<'_> {
             {
               return;
             }
-            // (await import(...)).a.b()
-            if let Some((call, members, await_expr)) = self.extract_await_import_member(member) {
-              if self.is_top_level_scope() {
+            // (await import(...)).a.b() / (yield import(...)).a.b()
+            if let Some((call, members, await_expr)) =
+              self.extract_await_or_yield_import_member(member)
+            {
+              if let Some(await_expr) = await_expr
+                && self.is_top_level_scope()
+              {
                 self
                   .plugin_drive
                   .clone()
@@ -1604,20 +1610,22 @@ impl JavascriptParser<'_> {
     }
   }
 
-  fn extract_await_import_member<'a>(
+  fn extract_await_or_yield_import_member<'a>(
     &self,
     expr: &'a MemberExpr<'a>,
-  ) -> Option<(&'a CallExpr<'a>, AtomMembers, &'a AwaitExpr<'a>)> {
+  ) -> Option<(&'a CallExpr<'a>, AtomMembers, Option<&'a AwaitExpr<'a>>)> {
     let ExtractedMemberExpressionChainData {
       object,
       mut members,
       mut members_optionals,
       ..
     } = self.extract_member_expression_chain(ExprRef::Member(expr));
-    let ExprRef::Await(await_expr) = object else {
-      return None;
+    let (import_expr, await_expr) = match object {
+      ExprRef::Await(await_expr) => (&await_expr.arg, Some(await_expr)),
+      ExprRef::Yield(yield_expr) if !yield_expr.delegate => (yield_expr.arg.as_ref()?, None),
+      _ => return None,
     };
-    let call = await_expr.arg.as_call()?;
+    let call = import_expr.as_call()?;
     if !call.callee.is_import() {
       return None;
     }

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/fake-helper.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/fake-helper.js
@@ -1,0 +1,11 @@
+export function _(generator) {
+	return async function (...args) {
+		const iterator = generator.apply(this, args);
+		const yielded = iterator.next();
+		const namespace = await yielded.value;
+		return {
+			namespace,
+			value: iterator.next({ default: 42 }).value
+		};
+	};
+}

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/index.js
@@ -1,0 +1,14 @@
+import { _ as swcAsyncToGenerator } from "@swc/helpers/_/_async_to_generator";
+
+it("should stay conservative when the SWC helper request is aliased", async () => {
+	const load = swcAsyncToGenerator(function* () {
+		const { default: value } = yield import("./module");
+		return value;
+	});
+
+	const { namespace, value } = await load();
+	expect(value).toBe(42);
+	expect(namespace.a).toBe(1);
+	expect(namespace.unused).toBe(2);
+	expect(namespace.usedExports).toBe(true);
+});

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/module.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/module.js
@@ -1,0 +1,4 @@
+export const a = 1;
+export const unused = 2;
+export default 3;
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import-alias/rspack.config.js
@@ -1,0 +1,17 @@
+const path = require('path');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    minimize: false,
+  },
+  resolve: {
+    alias: {
+      '@swc/helpers/_/_async_to_generator': path.resolve(
+        __dirname,
+        './fake-helper.js',
+      ),
+    },
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/index.js
@@ -1,0 +1,11 @@
+import { loadDestructured, loadMember } from "./loaders";
+
+it("should tree shake dynamic imports lowered by the builtin SWC loader", async () => {
+	const destructured = await loadDestructured();
+	expect(destructured.value).toBe(3);
+	expect(destructured.usedExports).toEqual(["default", "usedExports"]);
+
+	const member = await loadMember();
+	expect(member.value).toBe(1);
+	expect(member.usedExports).toEqual(["a", "usedExports"]);
+});

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/loaders.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/loaders.js
@@ -1,0 +1,10 @@
+export async function loadDestructured() {
+	const { default: value, usedExports } = await import("./module?destructured");
+	return { value, usedExports };
+}
+
+export async function loadMember() {
+	const value = (await import("./module?member")).a;
+	const usedExports = (await import("./module?member")).usedExports;
+	return { value, usedExports };
+}

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/module.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/module.js
@@ -1,0 +1,4 @@
+export const a = 1;
+export const unused = 2;
+export default 3;
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/swc-async-dynamic-import/rspack.config.js
@@ -1,0 +1,22 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    minimize: false,
+  },
+  module: {
+    rules: [
+      {
+        test: /loaders\.js$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          jsc: {
+            externalHelpers: true,
+            target: 'es2015',
+          },
+        },
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
@@ -86,6 +86,36 @@ it("should tree shake a dynamic import awaited through SWC's async helper", asyn
 	expect(usedExports).toEqual(["default", "usedExports"]);
 });
 
+it("should keep nested generators conservative inside SWC's async helper", async () => {
+	const load = swcAsyncToGenerator(function* () {
+		function* loadDestructured() {
+			const { default: def } = yield import("../statical-dynamic-import/dir1/a?swc-nested-destructuring");
+			return def;
+		}
+
+		function* loadMember() {
+			return (yield import("../statical-dynamic-import/dir1/a?swc-nested-member")).a;
+		}
+
+		const destructuredIterator = loadDestructured();
+		const destructuredNamespace = yield destructuredIterator.next().value;
+		expect(destructuredNamespace.a).toBe(1);
+		expect(destructuredNamespace.usedExports).toBe(true);
+
+		const memberIterator = loadMember();
+		const memberNamespace = yield memberIterator.next().value;
+		expect(memberNamespace.default).toBe(3);
+		expect(memberNamespace.usedExports).toBe(true);
+
+		return [
+			destructuredIterator.next({ default: 42 }).value,
+			memberIterator.next({ a: 43 }).value
+		];
+	});
+
+	expect(await load()).toEqual([42, 43]);
+});
+
 it("should not trust an arbitrary helper with the same name", async () => {
 	const load = _async_to_generator(function* () {
 		const { default: def } = yield import("../statical-dynamic-import/dir1/a?fake-swc-yield");

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
@@ -48,15 +48,16 @@ it("expect support of \"deep\" tree-shaking for destructuring assignment dynamic
 	expect(usedExportsB).toEqual(["bbb", "usedExports"]);
 });
 
-it("should tree shake a dynamic import destructured through yield", async () => {
+it("should preserve a dynamic import namespace yielded before destructuring", async () => {
 	function* load() {
-		const { default: def, usedExports } = yield import("../statical-dynamic-import/dir1/a?yield");
-		return { def, usedExports };
+		const { default: def } = yield import("../statical-dynamic-import/dir1/a?yield");
+		return def;
 	}
 
 	const iterator = load();
 	const namespace = await iterator.next().value;
-	const { def, usedExports } = iterator.next(namespace).value;
-	expect(def).toBe(3);
-	expect(usedExports).toEqual(["default", "usedExports"]);
+	expect(namespace.a).toBe(1);
+	expect(namespace.default).toBe(3);
+	expect(namespace.usedExports).toBe(true);
+	expect(iterator.next({ default: 42 }).value).toBe(42);
 });

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
@@ -1,3 +1,16 @@
+import { _ as swcAsyncToGenerator } from "@swc/helpers/_/_async_to_generator";
+
+function _async_to_generator(generator) {
+	return async function (...args) {
+		const iterator = generator.apply(this, args);
+		const yielded = iterator.next();
+		const namespace = await yielded.value;
+		expect(namespace.a).toBe(1);
+		expect(namespace.usedExports).toBe(true);
+		return iterator.next(namespace).value;
+	};
+}
+
 it("should load only used exports", async () => {
 	const { default: def, usedExports } = await import("../statical-dynamic-import/dir1/a");
 	expect(def).toBe(3);
@@ -60,4 +73,24 @@ it("should preserve a dynamic import namespace yielded before destructuring", as
 	expect(namespace.default).toBe(3);
 	expect(namespace.usedExports).toBe(true);
 	expect(iterator.next({ default: 42 }).value).toBe(42);
+});
+
+it("should tree shake a dynamic import awaited through SWC's async helper", async () => {
+	const load = swcAsyncToGenerator(function* () {
+		const { default: def, usedExports } = yield import("../statical-dynamic-import/dir1/a?swc-yield");
+		return { def, usedExports };
+	});
+
+	const { def, usedExports } = await load();
+	expect(def).toBe(3);
+	expect(usedExports).toEqual(["default", "usedExports"]);
+});
+
+it("should not trust an arbitrary helper with the same name", async () => {
+	const load = _async_to_generator(function* () {
+		const { default: def } = yield import("../statical-dynamic-import/dir1/a?fake-swc-yield");
+		return def;
+	});
+
+	expect(await load()).toBe(3);
 });

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-destructuring/index.js
@@ -47,3 +47,16 @@ it("expect support of \"deep\" tree-shaking for destructuring assignment dynamic
 	expect(usedExportsA).toEqual(["aaa", "usedExports"]);
 	expect(usedExportsB).toEqual(["bbb", "usedExports"]);
 });
+
+it("should tree shake a dynamic import destructured through yield", async () => {
+	function* load() {
+		const { default: def, usedExports } = yield import("../statical-dynamic-import/dir1/a?yield");
+		return { def, usedExports };
+	}
+
+	const iterator = load();
+	const namespace = await iterator.next().value;
+	const { def, usedExports } = iterator.next(namespace).value;
+	expect(def).toBe(3);
+	expect(usedExports).toEqual(["default", "usedExports"]);
+});

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
@@ -58,3 +58,18 @@ it("should analyze top-level await correctly", async () => {
 	expect(a).toBe(1);
 	expect(b).toEqual(["a", "usedExports"]);
 });
+
+it("should analyze members of a yielded dynamic import", async () => {
+	function* load() {
+		const value = (yield import("../statical-dynamic-import/dir1/a?yield-member")).a;
+		const usedExports = (yield import("../statical-dynamic-import/dir1/a?yield-member")).usedExports;
+		return { value, usedExports };
+	}
+
+	const iterator = load();
+	const firstNamespace = await iterator.next().value;
+	const secondNamespace = await iterator.next(firstNamespace).value;
+	const { value, usedExports } = iterator.next(secondNamespace).value;
+	expect(value).toBe(1);
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
@@ -1,3 +1,5 @@
+import { _ as swcAsyncToGenerator } from "@swc/helpers/_/_async_to_generator";
+
 it("should load only used exports", async () => {
 	const def = (await import("../statical-dynamic-import/dir1/a")).default;
 	const usedExports = (await import("../statical-dynamic-import/dir1/a")).usedExports;
@@ -70,4 +72,16 @@ it("should preserve a dynamic import namespace yielded before member access", as
 	expect(namespace.default).toBe(3);
 	expect(namespace.usedExports).toBe(true);
 	expect(iterator.next({ a: 42 }).value).toBe(42);
+});
+
+it("should tree shake dynamic import members awaited through SWC's async helper", async () => {
+	const load = swcAsyncToGenerator(function* () {
+		const value = (yield import("../statical-dynamic-import/dir1/a?swc-yield-member")).a;
+		const usedExports = (yield import("../statical-dynamic-import/dir1/a?swc-yield-member")).usedExports;
+		return { value, usedExports };
+	});
+
+	const { value, usedExports } = await load();
+	expect(value).toBe(1);
+	expect(usedExports).toEqual(["a", "usedExports"]);
 });

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
@@ -85,3 +85,19 @@ it("should tree shake dynamic import members awaited through SWC's async helper"
 	expect(value).toBe(1);
 	expect(usedExports).toEqual(["a", "usedExports"]);
 });
+
+it("should keep named generators conservative when passed to SWC's async helper", async () => {
+	let escaped;
+	const load = swcAsyncToGenerator(function* namedGenerator() {
+		escaped = namedGenerator;
+		return (yield import("../statical-dynamic-import/dir1/a?swc-named-generator")).a;
+	});
+
+	expect(await load()).toBe(1);
+
+	const iterator = escaped();
+	const namespace = await iterator.next().value;
+	expect(namespace.default).toBe(3);
+	expect(namespace.usedExports).toBe(true);
+	expect(iterator.next({ a: 42 }).value).toBe(42);
+});

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import-members/index.js
@@ -59,17 +59,15 @@ it("should analyze top-level await correctly", async () => {
 	expect(b).toEqual(["a", "usedExports"]);
 });
 
-it("should analyze members of a yielded dynamic import", async () => {
+it("should preserve a dynamic import namespace yielded before member access", async () => {
 	function* load() {
-		const value = (yield import("../statical-dynamic-import/dir1/a?yield-member")).a;
-		const usedExports = (yield import("../statical-dynamic-import/dir1/a?yield-member")).usedExports;
-		return { value, usedExports };
+		return (yield import("../statical-dynamic-import/dir1/a?yield-member")).a;
 	}
 
 	const iterator = load();
-	const firstNamespace = await iterator.next().value;
-	const secondNamespace = await iterator.next(firstNamespace).value;
-	const { value, usedExports } = iterator.next(secondNamespace).value;
-	expect(value).toBe(1);
-	expect(usedExports).toEqual(["a", "usedExports"]);
+	const namespace = await iterator.next().value;
+	expect(namespace.a).toBe(1);
+	expect(namespace.default).toBe(3);
+	expect(namespace.usedExports).toBe(true);
+	expect(iterator.next({ a: 42 }).value).toBe(42);
 });


### PR DESCRIPTION
## Summary

- analyze dynamic imports lowered from await to yield inside anonymous generator callbacks passed directly to the official @swc/helpers/_/_async_to_generator helper
- resolve the helper through its exact ESM import binding, then verify its resolved package and resource before narrowing dynamic import exports
- fall back to namespace usage when aliases, replacement plugins, local helpers, nested generators, or named callbacks make await semantics unproven
- support both destructuring and member access without changing ordinary generator yield semantics
- add direct helper coverage, an end-to-end builtin SWC loader case that starts from await import(), and an alias regression case

## Related links

- #14853

## Checklist

- [x] Tests updated.
- [x] Documentation not required; this fixes analysis of compiler-generated JavaScript without changing public APIs.
