### PR TITLE
fix(cache): recover from corrupt persistent cache meta instead of panicking

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/meta/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/meta/mod.rs
@@ -60,11 +60,29 @@ impl Occasion for MetaOccasion {
       return Ok(());
     };
 
-    let meta: Meta = self.codec.decode(&value).expect("should decode success");
+    let meta: Meta = self.codec.decode(&value)?;
     if get_current_dependency_id() != 0 {
       panic!("The global dependency id generator is not 0 when the persistent cache is restored.");
     }
     set_current_dependency_id(meta.max_dependencies_id);
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use std::sync::Arc;
+
+  use rspack_storage::MemoryStorage;
+
+  use super::{CacheCodec, MetaOccasion, Occasion, SCOPE, Storage};
+
+  #[tokio::test]
+  async fn recovery_errors_on_corrupt_meta() {
+    let mut storage = MemoryStorage::default();
+    storage.set(SCOPE, "default".as_bytes().to_vec(), vec![0u8]);
+
+    let occasion = MetaOccasion::new(Arc::new(CacheCodec::new(None)));
+    assert!(occasion.recovery(&storage).await.is_err());
   }
 }


### PR DESCRIPTION
## Summary

Recovering the persistent cache `meta` scope decoded its stored value with `.expect("should decode success")`, so a corrupted entry aborted the whole process instead of being handled as a recoverable failure. Propagate the decode error instead. `CacheContext::load_occasion` already treats a failed recovery by resetting the occasion's scope, so a bad `meta` entry now falls back to a clean rebuild rather than a panic.

## Related links

Fixes #14859

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
