### PR TITLE
fix: keep `new URL()` for directory request instead of treating as asset

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -163,6 +163,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
         }
         return None;
       }
+      // A directory request is not an asset; keep `new URL(...)` as-is.
+      if request == "." || request == ".." || request.ends_with('/') {
+        return Some(true);
+      }
       let dep = URLDependency::new(
         request.into(),
         expr.span.into(),

--- a/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/__snapshots__/esm.snap.txt
@@ -1,0 +1,11 @@
+```mjs title=main.mjs
+// ./index.js
+// Directory references are not assets. `new URL(...)` should be kept as-is so
+// it resolves to a directory at runtime, matching Node/browsers.
+const dir = new URL('.', import.meta.url).href;
+const dirSlash = new URL('./', import.meta.url).href;
+const parentDir = new URL('..', import.meta.url).href;
+
+export { dir, dirSlash, parentDir };
+
+```

--- a/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,11 @@
+```mjs title=main.mjs
+// ./index.js
+// Directory references are not assets. `new URL(...)` should be kept as-is so
+// it resolves to a directory at runtime, matching Node/browsers.
+const dir = new URL('.', import.meta.url).href;
+const dirSlash = new URL('./', import.meta.url).href;
+const parentDir = new URL('..', import.meta.url).href;
+
+export { dir, dirSlash, parentDir };
+
+```

--- a/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/index.js
+++ b/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/index.js
@@ -1,0 +1,5 @@
+// Directory references are not assets. `new URL(...)` should be kept as-is so
+// it resolves to a directory at runtime, matching Node/browsers.
+export const dir = new URL('.', import.meta.url).href;
+export const dirSlash = new URL('./', import.meta.url).href;
+export const parentDir = new URL('..', import.meta.url).href;

--- a/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/rspack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  module: {
+    parser: {
+      javascript: {
+        url: 'new-url-relative',
+      },
+    },
+  },
+};

--- a/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/test.config.js
+++ b/tests/rspack-test/esmOutputCases/new-url/keep-new-url-directory/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  snapshotFileFilter(file) {
+    return file.endsWith('.mjs')
+  },
+}


### PR DESCRIPTION
## Summary

`new URL('.', import.meta.url)` is a valid ESM idiom that resolves to the current module's directory (the ESM equivalent of `__dirname`).

Rspack's `URLPlugin` treated any `new URL(string, import.meta.url)` as an asset reference, so a directory request (`.`, `..`, or a trailing-slash path) was wrongly resolved to a module and emitted as a static asset, and the expression was rewritten to point at that emitted file — breaking the directory semantics.

## Fix

Skip creating a `URLDependency` when the request is a directory (`.` / `..` / ends with `/`) and keep `new URL(...)` as-is, so `import.meta.url` is preserved and the expression evaluates to the directory at runtime.

This aligns with webpack, whose `URLParserPlugin` has the same guard (`isDirectoryRequest` → `keepNewURL`): https://github.com/webpack/webpack/blob/9d017167aa3d8818e23281b2683f0f081ce0a7d0/lib/url/URLParserPlugin.js#L68-L87

Reference for the standard behavior:
- `new URL()` is defined by the WHATWG URL Standard: https://url.spec.whatwg.org/#dom-url-url
- Its `.`/`./`/`..`/`../` resolution derives from RFC 3986 §5.4.1, which resolves them to a directory (a trailing-slash URI), not a file: https://www.rfc-editor.org/rfc/rfc3986#section-5.4.1
