### PR TITLE
fix(cache): scope maxVersions by compiler using compilerPath

### DIFF
--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -85,9 +85,11 @@ impl PersistentCache {
     let option_bytes = codec
       .encode(option)
       .expect("should persistent cache options can be serialized");
-    // maxVersions is enforced per compiler. compiler_path contains each child
-    // compiler's name and index, while portable caches intentionally omit the
-    // project context from their scope.
+    // The scope identifies the compiler that owns a group of cache versions.
+    // Keep it independent of cache options: changing an option should create a
+    // new version in the same scope so maxVersions can retire the old version.
+    // compiler_path distinguishes child compilers by name and index. Portable
+    // caches omit context so moving the project does not change the owner.
     let version_scope = {
       let mut hasher = DefaultHasher::new();
       (
@@ -98,6 +100,8 @@ impl PersistentCache {
         .hash(&mut hasher);
       hex::encode(hasher.finish().to_ne_bytes())
     };
+    // The version hash identifies one cache-compatible configuration within
+    // the compiler scope.
     let version = {
       let mut hasher = DefaultHasher::new();
       compiler_path.hash(&mut hasher);

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -45,7 +45,7 @@ pub struct PersistentCacheOptions {
   /// Filesystem cache max age in seconds.
   #[cacheable(with=Skip)]
   pub max_age: u64,
-  /// Filesystem version count limit for the current storage directory.
+  /// Filesystem version count limit for the current compiler cache scope.
   #[cacheable(with=Skip)]
   pub max_versions: u32,
 }
@@ -85,6 +85,19 @@ impl PersistentCache {
     let option_bytes = codec
       .encode(option)
       .expect("should persistent cache options can be serialized");
+    // maxVersions is enforced per compiler. compiler_path contains each child
+    // compiler's name and index, while portable caches intentionally omit the
+    // project context from their scope.
+    let version_scope = {
+      let mut hasher = DefaultHasher::new();
+      (
+        (!option.portable).then_some(compiler_options.context.as_str()),
+        compiler_path,
+        compiler_options.name.as_deref(),
+      )
+        .hash(&mut hasher);
+      hex::encode(hasher.finish().to_ne_bytes())
+    };
     let version = {
       let mut hasher = DefaultHasher::new();
       compiler_path.hash(&mut hasher);
@@ -92,7 +105,7 @@ impl PersistentCache {
       rspack_pkg_version!().hash(&mut hasher);
       compiler_options.name.hash(&mut hasher);
       compiler_options.mode.hash(&mut hasher);
-      Version::new(hex::encode(hasher.finish().to_ne_bytes()))
+      Version::new_scoped(version_scope, hex::encode(hasher.finish().to_ne_bytes()))
     };
     let storage = create_storage(
       option.storage.clone(),

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -105,7 +105,7 @@ impl PersistentCache {
       rspack_pkg_version!().hash(&mut hasher);
       compiler_options.name.hash(&mut hasher);
       compiler_options.mode.hash(&mut hasher);
-      Version::new_scoped(version_scope, hex::encode(hasher.finish().to_ne_bytes()))
+      Version::new(version_scope, hex::encode(hasher.finish().to_ne_bytes()))
     };
     let storage = create_storage(
       option.storage.clone(),

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -88,11 +88,11 @@ impl PersistentCache {
     // The scope identifies the compiler that owns a group of cache versions.
     // Keep it independent of cache options: changing an option should create a
     // new version in the same scope so maxVersions can retire the old version.
-    // The configured name identifies a root compiler, while compiler_path
-    // distinguishes its child compilers by name and index.
+    // compiler_path is empty for the root compiler and distinguishes child
+    // compilers by their name and index.
     let version_scope = {
       let mut hasher = DefaultHasher::new();
-      (compiler_options.name.as_deref(), compiler_path).hash(&mut hasher);
+      compiler_path.hash(&mut hasher);
       hex::encode(hasher.finish().to_ne_bytes())
     };
     // The version hash identifies one cache-compatible configuration within

--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -88,16 +88,11 @@ impl PersistentCache {
     // The scope identifies the compiler that owns a group of cache versions.
     // Keep it independent of cache options: changing an option should create a
     // new version in the same scope so maxVersions can retire the old version.
-    // compiler_path distinguishes child compilers by name and index. Portable
-    // caches omit context so moving the project does not change the owner.
+    // The configured name identifies a root compiler, while compiler_path
+    // distinguishes its child compilers by name and index.
     let version_scope = {
       let mut hasher = DefaultHasher::new();
-      (
-        (!option.portable).then_some(compiler_options.context.as_str()),
-        compiler_path,
-        compiler_options.name.as_deref(),
-      )
-        .hash(&mut hasher);
+      (compiler_options.name.as_deref(), compiler_path).hash(&mut hasher);
       hex::encode(hasher.finish().to_ne_bytes())
     };
     // The version hash identifies one cache-compatible configuration within

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -125,6 +125,8 @@ impl Meta {
         .into_iter()
         .filter_map(|version| {
           let version = Version::parse(version)?;
+          // The caller deletes every returned stale version, so never add the
+          // active version or a version owned by another compiler scope.
           if &version == active_version || !version.has_same_scope(active_version) {
             return None;
           }
@@ -133,8 +135,11 @@ impl Meta {
           Some((version, timestamp))
         })
         .collect::<Vec<_>>();
+      // The active version already occupies one maxVersions slot.
       let retained_inactive_versions = max_versions.saturating_sub(1) as usize;
       let remove_count = candidates.len().saturating_sub(retained_inactive_versions);
+      // A version without metadata has timestamp 0 and is reclaimed first.
+      // The version ID makes deletion deterministic when timestamps are equal.
       candidates.sort_unstable_by(|(version_a, timestamp_a), (version_b, timestamp_b)| {
         timestamp_a
           .cmp(timestamp_b)

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -158,12 +158,9 @@ impl Meta {
 mod test {
   use super::{Meta, Result, ScopeFileSystem, Version};
 
-  const V1: &str = "rspack_v_0000000000000001";
-  const V2: &str = "rspack_v_0000000000000002";
-  const V3: &str = "rspack_v_0000000000000003";
-  const A_V1: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001";
-  const A_V2: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000002";
-  const A_V3: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000003";
+  const V1: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001";
+  const V2: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000002";
+  const V3: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000003";
   const B_V1: &str = "rspack_v_bbbbbbbbbbbbbbbb_0000000000000001";
   const B_V2: &str = "rspack_v_bbbbbbbbbbbbbbbb_0000000000000002";
 
@@ -221,7 +218,7 @@ mod test {
     fs.write(
       Meta::FILE_NAME,
       format!(
-        "../outside {timestamp}\nkeep-me {timestamp}\n0000000000000001 {timestamp}\n{V1} {timestamp}\n"
+        "../outside {timestamp}\nkeep-me {timestamp}\nrspack_v_0000000000000001 {timestamp}\n{V1} {timestamp}\n"
       )
       .as_bytes(),
     )
@@ -247,7 +244,7 @@ mod test {
 
   #[tokio::test]
   async fn max_versions_removes_valid_orphan_cache_versions() -> Result<()> {
-    let orphan_version = "rspack_v_0000000000000004";
+    let orphan_version = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000004";
     let fs = ScopeFileSystem::new_memory_fs("/max_versions_orphan".into());
     fs.ensure_exist().await?;
     create_child_dirs(&fs, &[orphan_version, "ordinary-directory", V1, V2]).await?;
@@ -274,19 +271,19 @@ mod test {
   async fn max_versions_only_removes_versions_from_the_active_scope() -> Result<()> {
     let fs = ScopeFileSystem::new_memory_fs("/max_versions_scoped".into());
     fs.ensure_exist().await?;
-    create_child_dirs(&fs, &[A_V1, A_V2, B_V1, B_V2]).await?;
+    create_child_dirs(&fs, &[V1, V2, B_V1, B_V2]).await?;
 
     let mut meta = Meta::default();
-    meta.access_times.insert(version(A_V1), 1);
-    meta.access_times.insert(version(A_V2), 2);
+    meta.access_times.insert(version(V1), 1);
+    meta.access_times.insert(version(V2), 2);
     meta.access_times.insert(version(B_V1), 1);
     meta.access_times.insert(version(B_V2), 2);
 
-    let (expired, _) = meta.refresh(&fs, &version(A_V3), 0, 2).await?;
+    let (expired, _) = meta.refresh(&fs, &version(V3), 0, 2).await?;
 
-    assert_eq!(expired, vec![version(A_V1)]);
-    assert!(meta.access_times.contains_key(&version(A_V2)));
-    assert!(meta.access_times.contains_key(&version(A_V3)));
+    assert_eq!(expired, vec![version(V1)]);
+    assert!(meta.access_times.contains_key(&version(V2)));
+    assert!(meta.access_times.contains_key(&version(V3)));
     assert!(meta.access_times.contains_key(&version(B_V1)));
     assert!(meta.access_times.contains_key(&version(B_V2)));
 

--- a/crates/rspack_storage/src/filesystem/meta.rs
+++ b/crates/rspack_storage/src/filesystem/meta.rs
@@ -114,9 +114,10 @@ impl Meta {
     }
 
     if max_versions != 0 {
-      // Valid version directories on disk are candidates even when `_meta` has
-      // no timestamp for them. Treat missing timestamps as the oldest entries so
-      // orphaned cache versions can still be reclaimed by maxVersions cleanup.
+      // Valid version directories from the active compiler scope are candidates
+      // even when `_meta` has no timestamp for them. Treat missing timestamps as
+      // the oldest entries so orphaned cache versions can still be reclaimed by
+      // maxVersions cleanup without evicting another compiler's cache.
       let mut candidates = fs
         .list_child()
         .await
@@ -124,7 +125,7 @@ impl Meta {
         .into_iter()
         .filter_map(|version| {
           let version = Version::parse(version)?;
-          if &version == active_version {
+          if &version == active_version || !version.has_same_scope(active_version) {
             return None;
           }
 
@@ -160,6 +161,11 @@ mod test {
   const V1: &str = "rspack_v_0000000000000001";
   const V2: &str = "rspack_v_0000000000000002";
   const V3: &str = "rspack_v_0000000000000003";
+  const A_V1: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001";
+  const A_V2: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000002";
+  const A_V3: &str = "rspack_v_aaaaaaaaaaaaaaaa_0000000000000003";
+  const B_V1: &str = "rspack_v_bbbbbbbbbbbbbbbb_0000000000000001";
+  const B_V2: &str = "rspack_v_bbbbbbbbbbbbbbbb_0000000000000002";
 
   fn version(value: &str) -> Version {
     Version::parse(value).expect("valid test version")
@@ -260,6 +266,29 @@ mod test {
     );
     assert!(meta.access_times.contains_key(&version(V2)));
     assert!(meta.access_times.contains_key(&version(V3)));
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn max_versions_only_removes_versions_from_the_active_scope() -> Result<()> {
+    let fs = ScopeFileSystem::new_memory_fs("/max_versions_scoped".into());
+    fs.ensure_exist().await?;
+    create_child_dirs(&fs, &[A_V1, A_V2, B_V1, B_V2]).await?;
+
+    let mut meta = Meta::default();
+    meta.access_times.insert(version(A_V1), 1);
+    meta.access_times.insert(version(A_V2), 2);
+    meta.access_times.insert(version(B_V1), 1);
+    meta.access_times.insert(version(B_V2), 2);
+
+    let (expired, _) = meta.refresh(&fs, &version(A_V3), 0, 2).await?;
+
+    assert_eq!(expired, vec![version(A_V1)]);
+    assert!(meta.access_times.contains_key(&version(A_V2)));
+    assert!(meta.access_times.contains_key(&version(A_V3)));
+    assert!(meta.access_times.contains_key(&version(B_V1)));
+    assert!(meta.access_times.contains_key(&version(B_V2)));
 
     Ok(())
   }

--- a/crates/rspack_storage/src/filesystem/options.rs
+++ b/crates/rspack_storage/src/filesystem/options.rs
@@ -17,7 +17,7 @@ pub struct FileSystemOptions {
   pub max_pack_size: usize,
   /// Data expiration time (seconds), 0 means never expire
   pub expire: u64,
-  /// Maximum number of versions retained in the storage directory. 0 means disabled.
+  /// Maximum number of versions retained for one compiler scope. 0 means disabled.
   pub max_versions: u32,
   /// File system implementation
   pub fs: Arc<dyn IntermediateFileSystem>,

--- a/crates/rspack_storage/src/filesystem/version.rs
+++ b/crates/rspack_storage/src/filesystem/version.rs
@@ -9,16 +9,7 @@ impl Version {
   const HASH_LEN: usize = 16;
   const SCOPE_SEPARATOR: char = '_';
 
-  pub fn new(hash: impl AsRef<str>) -> Self {
-    let hash = hash.as_ref();
-    assert!(
-      Self::is_valid_hash(hash),
-      "invalid persistent cache version hash"
-    );
-    Self(format!("{}{hash}", Self::PREFIX))
-  }
-
-  pub fn new_scoped(scope: impl AsRef<str>, hash: impl AsRef<str>) -> Self {
+  pub fn new(scope: impl AsRef<str>, hash: impl AsRef<str>) -> Self {
     let scope = scope.as_ref();
     let hash = hash.as_ref();
     assert!(
@@ -46,23 +37,24 @@ impl Version {
       return false;
     };
 
-    if let Some((scope, hash)) = value.split_once(Self::SCOPE_SEPARATOR) {
-      Self::is_valid_hash(scope) && Self::is_valid_hash(hash)
-    } else {
-      Self::is_valid_hash(value)
-    }
+    let Some((scope, hash)) = value.split_once(Self::SCOPE_SEPARATOR) else {
+      return false;
+    };
+
+    Self::is_valid_hash(scope) && Self::is_valid_hash(hash)
   }
 
   pub fn as_str(&self) -> &str {
     &self.0
   }
 
-  pub fn scope(&self) -> Option<&str> {
+  pub fn scope(&self) -> &str {
     self
       .0
       .strip_prefix(Self::PREFIX)
       .and_then(|value| value.split_once(Self::SCOPE_SEPARATOR))
       .map(|(scope, _)| scope)
+      .expect("validated persistent cache version should have a scope")
   }
 
   pub fn has_same_scope(&self, other: &Self) -> bool {
@@ -94,25 +86,22 @@ mod tests {
   use super::Version;
 
   #[test]
-  fn parses_scoped_and_legacy_versions() {
-    let scoped = Version::new_scoped("aaaaaaaaaaaaaaaa", "0000000000000001");
-    let legacy = Version::new("0000000000000001");
+  fn parses_scoped_versions() {
+    let version = Version::new("aaaaaaaaaaaaaaaa", "0000000000000001");
 
     assert_eq!(
-      scoped.as_str(),
+      version.as_str(),
       "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001"
     );
-    assert_eq!(scoped.scope(), Some("aaaaaaaaaaaaaaaa"));
-    assert_eq!(legacy.scope(), None);
-    assert_eq!(Version::parse(scoped.as_str()), Some(scoped));
-    assert_eq!(Version::parse(legacy.as_str()), Some(legacy));
+    assert_eq!(version.scope(), "aaaaaaaaaaaaaaaa");
+    assert_eq!(Version::parse(version.as_str()), Some(version));
   }
 
   #[test]
   fn compares_version_scopes() {
-    let a_v1 = Version::new_scoped("aaaaaaaaaaaaaaaa", "0000000000000001");
-    let a_v2 = Version::new_scoped("aaaaaaaaaaaaaaaa", "0000000000000002");
-    let b_v1 = Version::new_scoped("bbbbbbbbbbbbbbbb", "0000000000000001");
+    let a_v1 = Version::new("aaaaaaaaaaaaaaaa", "0000000000000001");
+    let a_v2 = Version::new("aaaaaaaaaaaaaaaa", "0000000000000002");
+    let b_v1 = Version::new("bbbbbbbbbbbbbbbb", "0000000000000001");
 
     assert!(a_v1.has_same_scope(&a_v2));
     assert!(!a_v1.has_same_scope(&b_v1));
@@ -120,6 +109,7 @@ mod tests {
 
   #[test]
   fn rejects_invalid_scoped_versions() {
+    assert!(!Version::is_valid("rspack_v_0000000000000001"));
     assert!(!Version::is_valid(
       "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001_extra"
     ));

--- a/crates/rspack_storage/src/filesystem/version.rs
+++ b/crates/rspack_storage/src/filesystem/version.rs
@@ -7,6 +7,7 @@ pub struct Version(String);
 impl Version {
   const PREFIX: &str = "rspack_v_";
   const HASH_LEN: usize = 16;
+  const SCOPE_SEPARATOR: char = '_';
 
   pub fn new(hash: impl AsRef<str>) -> Self {
     let hash = hash.as_ref();
@@ -17,21 +18,55 @@ impl Version {
     Self(format!("{}{hash}", Self::PREFIX))
   }
 
+  pub fn new_scoped(scope: impl AsRef<str>, hash: impl AsRef<str>) -> Self {
+    let scope = scope.as_ref();
+    let hash = hash.as_ref();
+    assert!(
+      Self::is_valid_hash(scope),
+      "invalid persistent cache version scope"
+    );
+    assert!(
+      Self::is_valid_hash(hash),
+      "invalid persistent cache version hash"
+    );
+    Self(format!(
+      "{}{scope}{}{hash}",
+      Self::PREFIX,
+      Self::SCOPE_SEPARATOR
+    ))
+  }
+
   pub fn parse(value: impl AsRef<str>) -> Option<Self> {
     let value = value.as_ref();
     Self::is_valid(value).then(|| Self(value.to_string()))
   }
 
   pub fn is_valid(value: impl AsRef<str>) -> bool {
-    let Some(hash) = value.as_ref().strip_prefix(Self::PREFIX) else {
+    let Some(value) = value.as_ref().strip_prefix(Self::PREFIX) else {
       return false;
     };
 
-    Self::is_valid_hash(hash)
+    if let Some((scope, hash)) = value.split_once(Self::SCOPE_SEPARATOR) {
+      Self::is_valid_hash(scope) && Self::is_valid_hash(hash)
+    } else {
+      Self::is_valid_hash(value)
+    }
   }
 
   pub fn as_str(&self) -> &str {
     &self.0
+  }
+
+  pub fn scope(&self) -> Option<&str> {
+    self
+      .0
+      .strip_prefix(Self::PREFIX)
+      .and_then(|value| value.split_once(Self::SCOPE_SEPARATOR))
+      .map(|(scope, _)| scope)
+  }
+
+  pub fn has_same_scope(&self, other: &Self) -> bool {
+    self.scope() == other.scope()
   }
 
   fn is_valid_hash(hash: &str) -> bool {
@@ -51,5 +86,43 @@ impl fmt::Display for Version {
 impl AsRef<str> for Version {
   fn as_ref(&self) -> &str {
     self.as_str()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::Version;
+
+  #[test]
+  fn parses_scoped_and_legacy_versions() {
+    let scoped = Version::new_scoped("aaaaaaaaaaaaaaaa", "0000000000000001");
+    let legacy = Version::new("0000000000000001");
+
+    assert_eq!(
+      scoped.as_str(),
+      "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001"
+    );
+    assert_eq!(scoped.scope(), Some("aaaaaaaaaaaaaaaa"));
+    assert_eq!(legacy.scope(), None);
+    assert_eq!(Version::parse(scoped.as_str()), Some(scoped));
+    assert_eq!(Version::parse(legacy.as_str()), Some(legacy));
+  }
+
+  #[test]
+  fn compares_version_scopes() {
+    let a_v1 = Version::new_scoped("aaaaaaaaaaaaaaaa", "0000000000000001");
+    let a_v2 = Version::new_scoped("aaaaaaaaaaaaaaaa", "0000000000000002");
+    let b_v1 = Version::new_scoped("bbbbbbbbbbbbbbbb", "0000000000000001");
+
+    assert!(a_v1.has_same_scope(&a_v2));
+    assert!(!a_v1.has_same_scope(&b_v1));
+  }
+
+  #[test]
+  fn rejects_invalid_scoped_versions() {
+    assert!(!Version::is_valid(
+      "rspack_v_aaaaaaaaaaaaaaaa_0000000000000001_extra"
+    ));
+    assert!(!Version::is_valid("rspack_v_invalid_0000000000000001"));
   }
 }

--- a/crates/rspack_storage/src/filesystem/version.rs
+++ b/crates/rspack_storage/src/filesystem/version.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
-/// Filesystem persistent-cache version directory name.
+/// Filesystem persistent-cache directory in the form
+/// `rspack_v_<compiler scope hash>_<version hash>`.
+///
+/// The scope hash identifies the compiler that owns the directory, while the
+/// version hash identifies a cache-compatible configuration of that compiler.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Version(String);
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2098,8 +2098,9 @@ export type PersistentCacheOptions = {
   maxAge?: number;
   /**
    * Maximum number of filesystem cache versions to retain for each compiler
-   * in the cache directory. Must be an integer between 1 and 4294967295, or
-   * Infinity to disable version-based cleanup.
+   * scope in the cache directory. A scope is identified only by compiler names
+   * and indices. Must be an integer between 1 and 4294967295, or Infinity to
+   * disable version-based cleanup.
    * @default 3
    */
   maxVersions?: number;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2097,9 +2097,9 @@ export type PersistentCacheOptions = {
    */
   maxAge?: number;
   /**
-   * Maximum number of filesystem cache versions to retain for each compiler
-   * in the cache directory. Must be an integer between 1 and 4294967295, or
-   * Infinity to disable version-based cleanup.
+   * Maximum number of filesystem cache versions to retain in the cache
+   * directory. Must be an integer between 1 and 4294967295, or Infinity to
+   * disable version-based cleanup.
    * @default 3
    */
   maxVersions?: number;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2097,9 +2097,9 @@ export type PersistentCacheOptions = {
    */
   maxAge?: number;
   /**
-   * Maximum number of filesystem cache versions to retain in the cache
-   * directory. Must be an integer between 1 and 4294967295, or Infinity to
-   * disable version-based cleanup.
+   * Maximum number of filesystem cache versions to retain for each compiler
+   * in the cache directory. Must be an integer between 1 and 4294967295, or
+   * Infinity to disable version-based cleanup.
    * @default 3
    */
   maxVersions?: number;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2098,9 +2098,8 @@ export type PersistentCacheOptions = {
   maxAge?: number;
   /**
    * Maximum number of filesystem cache versions to retain for each compiler
-   * scope in the cache directory. A scope is identified only by compiler names
-   * and indices. Must be an integer between 1 and 4294967295, or Infinity to
-   * disable version-based cleanup.
+   * in the cache directory. Must be an integer between 1 and 4294967295, or
+   * Infinity to disable version-based cleanup.
    * @default 3
    */
   maxVersions?: number;

--- a/tests/rspack-test/compilerCases/persistent-cache-max-versions-child-compilers.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-max-versions-child-compilers.js
@@ -1,0 +1,125 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+
+const CHILD_COMPILER_NAMES = ["child-a", "child-b"];
+const VERSION_DIRECTORY_REGEXP =
+	/^rspack_v_([0-9a-f]{16})_[0-9a-f]{16}$/;
+
+class ChildCompilersPlugin {
+	apply(compiler) {
+		compiler.hooks.make.tapAsync(
+			"ChildCompilersPlugin",
+			(compilation, callback) => {
+				const runChildCompiler = name =>
+					new Promise((resolve, reject) => {
+						const childCompiler = compilation.createChildCompiler(
+							name,
+							{ filename: `${name}.js` },
+							[
+								new compiler.rspack.EntryPlugin(
+									compiler.context,
+									"./a",
+									{ name }
+								)
+							]
+						);
+
+						childCompiler.runAsChild(error => {
+							childCompiler.close(closeError => {
+								const finalError = error || closeError;
+								if (finalError) {
+									reject(finalError);
+								} else {
+									resolve();
+								}
+							});
+						});
+					});
+
+				(async () => {
+					for (const name of CHILD_COMPILER_NAMES) {
+						await runChildCompiler(name);
+					}
+				})().then(() => callback(), callback);
+			}
+		);
+	}
+}
+
+const runCompiler = (context, cacheDirectory, version) =>
+	new Promise((resolve, reject) => {
+		const compiler = rspack({
+			name: "root",
+			context: context.getSource(),
+			entry: "./a",
+			mode: "development",
+			output: {
+				path: context.getDist(`output-${version}`)
+			},
+			cache: {
+				type: "persistent",
+				version,
+				maxVersions: 2,
+				storage: {
+					type: "filesystem",
+					directory: cacheDirectory
+				}
+			},
+			plugins: [new ChildCompilersPlugin()]
+		});
+
+		compiler.run(error => {
+			compiler.close(closeError => {
+				const finalError = error || closeError;
+				if (finalError) {
+					reject(finalError);
+				} else {
+					resolve();
+				}
+			});
+		});
+	});
+
+const getVersionsByScope = cacheDirectory => {
+	const versionsByScope = new Map();
+	for (const entry of fs.readdirSync(cacheDirectory)) {
+		const match = VERSION_DIRECTORY_REGEXP.exec(entry);
+		if (!match) continue;
+
+		const versions = versionsByScope.get(match[1]) || [];
+		versions.push(entry);
+		versionsByScope.set(match[1], versions);
+	}
+	return versionsByScope;
+};
+
+/** @type {import("@rspack/test-tools").TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should retain maxVersions for the root and each named child compiler",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./a"
+		};
+	},
+	async build(context) {
+		const cacheDirectory = context.getDist("persistent-cache-child-compilers");
+		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+		for (const version of ["v1", "v2", "v3"]) {
+			await runCompiler(context, cacheDirectory, version);
+		}
+
+		context.setValue("versionsByScope", getVersionsByScope(cacheDirectory));
+	},
+	check({ context }) {
+		const versionsByScope = context.getValue("versionsByScope");
+
+		expect(versionsByScope.size).toBe(1 + CHILD_COMPILER_NAMES.length);
+		expect(
+			Array.from(versionsByScope.values(), versions => versions.length)
+		).toEqual([2, 2, 2]);
+	}
+};

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -136,7 +136,7 @@ Changing these values isolates the cache and avoids reusing stale persistent cac
 - **Type:** `number` (positive integer) or `Infinity`
 - **Default:** `3`
 
-This is a version-count cleanup policy that controls how many cache versions can be retained for each compiler in the current cache directory. When the number of versions for a compiler exceeds the limit, Rspack removes that compiler's old inactive versions without affecting root or child compilers with other names. A cache directory used by `n` compilers can therefore retain up to `n * maxVersions` versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
+This is a version-count cleanup policy that controls how many cache versions can be retained for each compiler in the current cache directory. A compiler scope is determined only by its configured name and child compiler path, which contains child compiler names and indices. When the number of versions for a compiler exceeds the limit, Rspack removes that compiler's old inactive versions without affecting other root or child compiler scopes. A cache directory used by `n` compilers can therefore retain up to `n * maxVersions` versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -136,7 +136,7 @@ Changing these values isolates the cache and avoids reusing stale persistent cac
 - **Type:** `number` (positive integer) or `Infinity`
 - **Default:** `3`
 
-This is a version-count cleanup policy that controls how many cache versions can be retained for each compiler in the current cache directory. When the number of versions for a compiler exceeds the limit, Rspack removes that compiler's old inactive versions without affecting other root or child compilers. A cache directory used by `n` compilers can therefore retain up to `n * maxVersions` versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
+This is a version-count cleanup policy that controls how many cache versions can be retained in the current cache directory. When the number of versions exceeds the limit, Rspack removes old inactive versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -147,6 +147,12 @@ export default {
 };
 ```
 
+:::note Child compiler cache usage
+
+Each child compiler keeps its own persistent cache versions, with `maxVersions` applied independently. Projects that create child compilers may therefore retain additional cache data and use more disk space than the root compiler's `maxVersions` value alone suggests.
+
+:::
+
 ### maxAge
 
 - **Type:** `number` (positive integer, in seconds) or `Infinity`

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -136,7 +136,7 @@ Changing these values isolates the cache and avoids reusing stale persistent cac
 - **Type:** `number` (positive integer) or `Infinity`
 - **Default:** `3`
 
-This is a version-count cleanup policy that controls how many cache versions can be retained for each compiler in the current cache directory. A compiler scope is determined only by its configured name and child compiler path, which contains child compiler names and indices. When the number of versions for a compiler exceeds the limit, Rspack removes that compiler's old inactive versions without affecting other root or child compiler scopes. A cache directory used by `n` compilers can therefore retain up to `n * maxVersions` versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
+This is a version-count cleanup policy that controls how many cache versions can be retained for each compiler in the current cache directory. When the number of versions for a compiler exceeds the limit, Rspack removes that compiler's old inactive versions without affecting other root or child compilers. A cache directory used by `n` compilers can therefore retain up to `n * maxVersions` versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -136,7 +136,7 @@ Changing these values isolates the cache and avoids reusing stale persistent cac
 - **Type:** `number` (positive integer) or `Infinity`
 - **Default:** `3`
 
-This is a version-count cleanup policy that controls how many cache versions can be retained in the current cache directory. When the number of versions exceeds the limit, Rspack removes old inactive versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
+This is a version-count cleanup policy that controls how many cache versions can be retained for each compiler in the current cache directory. When the number of versions for a compiler exceeds the limit, Rspack removes that compiler's old inactive versions without affecting root or child compilers with other names. A cache directory used by `n` compilers can therefore retain up to `n * maxVersions` versions. Set `maxVersions` to `Infinity` to disable version-based cleanup.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -138,7 +138,7 @@ export default {
 - **类型：** `number`（正整数）或 `Infinity`
 - **默认值：** `3`
 
-控制当前缓存目录中每个 compiler 最多保留多少个缓存版本。compiler scope 仅由配置的 compiler name 和包含 child compiler name、index 的 compiler path 决定。某个 compiler 的版本数超过限制时，Rspack 只会删除属于该 compiler scope 的较旧且未处于当前使用状态的版本，不会影响其他 root 或 child compiler scope。因此，同一缓存目录由 `n` 个 compiler 使用时，最多可保留 `n * maxVersions` 个版本。设置为 `Infinity` 可禁用基于数量的清理。
+控制当前缓存目录中每个 compiler 最多保留多少个缓存版本。某个 compiler 的版本数超过限制时，Rspack 只会删除属于该 compiler 的较旧且未处于当前使用状态的版本，不会影响其他 root 或 child compiler。因此，同一缓存目录由 `n` 个 compiler 使用时，最多可保留 `n * maxVersions` 个版本。设置为 `Infinity` 可禁用基于数量的清理。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -138,7 +138,7 @@ export default {
 - **类型：** `number`（正整数）或 `Infinity`
 - **默认值：** `3`
 
-控制当前缓存目录中每个 compiler 最多保留多少个缓存版本。某个 compiler 的版本数超过限制时，Rspack 只会删除属于该 compiler 的较旧且未处于当前使用状态的版本，不会影响其他 root 或 child compiler。因此，同一缓存目录由 `n` 个 compiler 使用时，最多可保留 `n * maxVersions` 个版本。设置为 `Infinity` 可禁用基于数量的清理。
+控制当前缓存目录最多保留多少个缓存版本。超过限制时，Rspack 会优先删除较旧且未处于当前使用状态的缓存版本。设置为 `Infinity` 可禁用基于数量的清理。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -149,6 +149,12 @@ export default {
 };
 ```
 
+:::note Child compiler 的缓存占用
+
+每个 child compiler 都会维护自己的一组持久化缓存版本，并独立应用 `maxVersions`。因此，创建 child compiler 的项目可能会保留额外的缓存数据，实际磁盘占用可能高于仅根据 root compiler 的 `maxVersions` 估算的大小。
+
+:::
+
 ### maxAge
 
 - **类型：** `number`（正整数，单位为秒）或 `Infinity`

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -138,7 +138,7 @@ export default {
 - **类型：** `number`（正整数）或 `Infinity`
 - **默认值：** `3`
 
-控制当前缓存目录最多保留多少个缓存版本。超过限制时，Rspack 会优先删除较旧且未处于当前使用状态的缓存版本。设置为 `Infinity` 可禁用基于数量的清理。
+控制当前缓存目录中每个 compiler 最多保留多少个缓存版本。某个 compiler 的版本数超过限制时，Rspack 只会删除与该 compiler 名称关联的较旧且未处于当前使用状态的版本，不会影响其他名称的 root 或 child compiler。因此，同一缓存目录由 `n` 个 compiler 使用时，最多可保留 `n * maxVersions` 个版本。设置为 `Infinity` 可禁用基于数量的清理。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -138,7 +138,7 @@ export default {
 - **类型：** `number`（正整数）或 `Infinity`
 - **默认值：** `3`
 
-控制当前缓存目录中每个 compiler 最多保留多少个缓存版本。某个 compiler 的版本数超过限制时，Rspack 只会删除与该 compiler 名称关联的较旧且未处于当前使用状态的版本，不会影响其他名称的 root 或 child compiler。因此，同一缓存目录由 `n` 个 compiler 使用时，最多可保留 `n * maxVersions` 个版本。设置为 `Infinity` 可禁用基于数量的清理。
+控制当前缓存目录中每个 compiler 最多保留多少个缓存版本。compiler scope 仅由配置的 compiler name 和包含 child compiler name、index 的 compiler path 决定。某个 compiler 的版本数超过限制时，Rspack 只会删除属于该 compiler scope 的较旧且未处于当前使用状态的版本，不会影响其他 root 或 child compiler scope。因此，同一缓存目录由 `n` 个 compiler 使用时，最多可保留 `n * maxVersions` 个版本。设置为 `Infinity` 可禁用基于数量的清理。
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

- Scope persistent cache version IDs by `compilerPath`, which distinguishes child compiler names and indices.
- Require filesystem cache version IDs to carry a compiler scope, and restrict `maxVersions` cleanup to versions owned by the active scope.
- Add a regression test covering one root compiler and two named child compilers.

Previously, every compiler sharing a filesystem cache directory participated in one global version limit. A child compiler could therefore evict cache versions owned by the root or another child compiler. With this change, the root and each child compiler path receive an independent `maxVersions` allowance.

## How it works

A filesystem cache directory now uses `rspack_v_<compiler-scope>_<version-hash>`:

- `compiler-scope` identifies the owner and is derived only from `compilerPath`. The root compiler uses an empty path, while each child compiler appends its name and index.
- `version-hash` identifies one cache-compatible configuration owned by that compiler.
- During `maxVersions` cleanup, Rspack only considers inactive versions whose scope matches the active compiler. Versions belonging to other compiler scopes are never cleanup candidates.
- The active version consumes one slot, so cleanup retains at most `maxVersions - 1` inactive versions from the same scope.

## Example

Assume a compilation has one root compiler plus two named child compilers, `child-a` and `child-b`. All three share the same cache directory and configure `maxVersions: 2`.

Their ownership is represented only by `compilerPath`:

| Compiler | `compilerPath` | Retained versions |
| --- | --- | ---: |
| root | `""` | 2 |
| child-a | `child-a\|0\|` | 2 |
| child-b | `child-b\|0\|` | 2 |
| **Total** | 3 compiler paths | **6** |

Previously, these six directories competed in one global pool, so cleanup could retain only the two most recent directories and evict versions belonging to another compiler. With scoped cleanup, if the root compiler creates a third version, only the oldest root version is removed. Both child compilers still retain their two versions.

Therefore, for one root compiler and `n` child compiler paths sharing a cache directory, the effective upper bound is `(n + 1) * maxVersions`.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).