### PR TITLE
fix: support isolated node binding installs

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -33,13 +33,13 @@
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
-    "@emnapi/core": "catalog:",
-    "@emnapi/runtime": "catalog:",
-    "@napi-rs/cli": "catalog:",
-    "@napi-rs/wasm-runtime": "catalog:",
-    "@types/node": "catalog:",
-    "emnapi": "catalog:",
-    "typescript": "catalog:"
+    "@emnapi/core": "1.11.2",
+    "@emnapi/runtime": "1.11.2",
+    "@napi-rs/cli": "3.7.4",
+    "@napi-rs/wasm-runtime": "1.1.6",
+    "@types/node": "^20.19.43",
+    "emnapi": "1.11.2",
+    "typescript": "^6.0.3"
   },
   "napi": {
     "binaryName": "rspack",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,25 +541,25 @@ importers:
   crates/node_binding:
     devDependencies:
       '@emnapi/core':
-        specifier: 'catalog:'
+        specifier: 1.11.2
         version: 1.11.2
       '@emnapi/runtime':
-        specifier: 'catalog:'
+        specifier: 1.11.2
         version: 1.11.2
       '@napi-rs/cli':
-        specifier: 'catalog:'
+        specifier: 3.7.4
         version: 3.7.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(node-addon-api@7.1.1)
       '@napi-rs/wasm-runtime':
-        specifier: 'catalog:'
+        specifier: 1.1.6
         version: 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@types/node':
-        specifier: 'catalog:'
+        specifier: ^20.19.43
         version: 20.19.43
       emnapi:
-        specifier: 'catalog:'
+        specifier: 1.11.2
         version: 1.11.2(node-addon-api@7.1.1)
       typescript:
-        specifier: 'catalog:'
+        specifier: ^6.0.3
         version: 6.0.3
     optionalDependencies:
       '@rspack/binding-darwin-arm64':


### PR DESCRIPTION
## Summary

Keep explicit versions for `@rspack/binding` development dependencies so the package can still be installed outside the workspace.

Rspack's ecosystem binding preparation runs `pnpm install --ignore-workspace` in `crates/node_binding`. Catalog specifiers cannot be resolved in that mode, causing binding preparation to fail before the release build. This change keeps the root catalog for the rest of the workspace while exempting the standalone binding package. The lockfile's resolved dependency versions are unchanged.

## Related links

- Failing Ecosystem CI job: https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/30248835010/job/89922236925

## Validation

- `pnpm i --frozen-lockfile`
- `cd crates/node_binding && pnpm i --ignore-workspace --no-lockfile`
- `cargo codegen`
- `pnpm run build:binding:release`
- `pnpm exec prettier --check crates/node_binding/package.json pnpm-lock.yaml`

## Checklist

- [x] Tests updated (not required; dependency resolution only).
- [x] Documentation updated (not required).