### PR TITLE
feat: add builds for binding-linux-(ppc64,s390x)-gnu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,26 @@ jobs:
       profile: 'ci'
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
 
+  build-ppc64:
+    name: Build ppc64
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/reusable-build-build.yml
+    with:
+      target: powerpc64le-unknown-linux-gnu
+      profile: 'ci'
+      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+
+  build-s390x:
+    name: Build s390x
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/reusable-build-build.yml
+    with:
+      target: s390x-unknown-linux-gnu
+      profile: 'ci'
+      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+
   # TODO: Enable this job after Rspack portable cache is implemented.
   check-cache:
     name: Check Cache Portable
@@ -187,6 +207,8 @@ jobs:
         test-mac,
         build-wasm,
         build-riscv64,
+        build-ppc64,
+        build-s390x,
         test-wasm,
         check-changed,
         size-limit,
@@ -200,13 +222,13 @@ jobs:
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name == 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,skipped' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,success,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,skipped,skipped' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,skipped,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: No check to Run test

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -50,6 +50,10 @@ jobs:
             runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
           - target: riscv64gc-unknown-linux-musl
             runner: "'ubuntu-latest'"
+          - target: powerpc64le-unknown-linux-gnu
+            runner: "'ubuntu-latest'"
+          - target: s390x-unknown-linux-gnu
+            runner: "'ubuntu-latest'"
           - target: i686-pc-windows-msvc
             runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -52,6 +52,10 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: riscv64gc-unknown-linux-musl
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: i686-pc-windows-msvc
             runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/reusable-build-all.yml
+++ b/.github/workflows/reusable-build-all.yml
@@ -37,6 +37,10 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: riscv64gc-unknown-linux-musl
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: i686-pc-windows-msvc
             runner: ${{ '"windows-latest"' }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           tool: cargo-zigbuild
 
+      - name: Install clang with PowerPC and SystemZ backends
+        if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu' }}
+        run: command -v clang-15 || { sudo apt-get update && sudo apt-get install -y clang-15; }
+
       # setup rust target for native runner
       - name: Setup Rust Target
         run: rustup target add ${{ inputs.target }}
@@ -155,13 +159,13 @@ jobs:
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' }}
         run: RUST_TARGET=powerpc64le-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
         env:
-          TARGET_CC: clang
+          TARGET_CC: clang-15
 
       - name: Build s390x-unknown-linux-gnu
         if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
         run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
         env:
-          TARGET_CC: clang
+          TARGET_CC: clang-15
 
       # Windows
       - name: Build i686-pc-windows-msvc

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -151,6 +151,18 @@ jobs:
         env:
           TARGET_CC: clang
 
+      - name: Build powerpc64le-unknown-linux-gnu
+        if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' }}
+        run: RUST_TARGET=powerpc64le-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
+        env:
+          TARGET_CC: clang
+
+      - name: Build s390x-unknown-linux-gnu
+        if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
+        run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
+        env:
+          TARGET_CC: clang
+
       # Windows
       - name: Build i686-pc-windows-msvc
         if: ${{ inputs.target == 'i686-pc-windows-msvc' }}

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -97,6 +97,8 @@ jobs:
         node: ${{ fromJSON(
           inputs.target == 'wasm32-wasip1-threads'&& '[24]'
           || inputs.target == 'riscv64gc-unknown-linux-gnu' && '[22]'
+          || inputs.target == 'powerpc64le-unknown-linux-gnu' && '[22]'
+          || inputs.target == 's390x-unknown-linux-gnu' && '[22]'
           || contains(inputs.target, 'linux') && '[22, 24]'
           || '[22]') }}
     name: Test Node ${{ matrix.node }}

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -58,6 +58,12 @@ jobs:
           - target: riscv64gc-unknown-linux-musl
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
             test-runner: '"ubuntu-22.04"'
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            test-runner: '"ubuntu-22.04"'
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            test-runner: '"ubuntu-22.04"'
           - target: i686-pc-windows-msvc
             runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
             test-runner: '"windows-latest"'

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,8 @@ npm/**/*.node
 !npm/linux-arm64-musl
 !npm/linux-riscv64-gnu
 !npm/linux-riscv64-musl
+!npm/linux-ppc64-gnu
+!npm/linux-s390x-gnu
 !npm/linux-x64-gnu/
 !npm/linux-x64-musl
 !npm/wasm32-wasi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,9 +2313,9 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json-escape-simd"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a18a0eb3c0a783620d2ae8cdda9590aae18b1608964ee9c7c43162562786424"
+checksum = "c22a2041e3874a055a4eb03ea2395aaccdefa84ce75b31d542d72a741c3c6ad3"
 
 [[package]]
 name = "json-strip-comments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ insta               = { version = "1.42.0", default-features = false }
 itertools           = { version = "0.14.0", default-features = false, features = ["use_std"] }
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
-json-escape-simd    = { version = "3.1.0", default-features = false }
+json-escape-simd    = { version = "3.1.1", default-features = false }
 lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -57,7 +57,9 @@
       "aarch64-unknown-linux-musl",
       "aarch64-pc-windows-msvc",
       "riscv64gc-unknown-linux-gnu",
-      "riscv64gc-unknown-linux-musl"
+      "riscv64gc-unknown-linux-musl",
+      "powerpc64le-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu"
     ],
     "wasm": {
       "initialMemory": 16384,
@@ -76,6 +78,8 @@
     "@rspack/binding-linux-arm64-musl": "workspace:*",
     "@rspack/binding-linux-riscv64-gnu": "workspace:*",
     "@rspack/binding-linux-riscv64-musl": "workspace:*",
+    "@rspack/binding-linux-ppc64-gnu": "workspace:*",
+    "@rspack/binding-linux-s390x-gnu": "workspace:*",
     "@rspack/binding-linux-x64-gnu": "workspace:*",
     "@rspack/binding-linux-x64-musl": "workspace:*",
     "@rspack/binding-wasm32-wasi": "workspace:*",

--- a/crates/rspack_binding_builder_testing/package.json
+++ b/crates/rspack_binding_builder_testing/package.json
@@ -45,7 +45,9 @@
       "aarch64-unknown-linux-musl",
       "aarch64-pc-windows-msvc",
       "riscv64gc-unknown-linux-gnu",
-      "riscv64gc-unknown-linux-musl"
+      "riscv64gc-unknown-linux-musl",
+      "powerpc64le-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu"
     ],
     "wasm": {
       "initialMemory": 16384,

--- a/npm/linux-ppc64-gnu/package.json
+++ b/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@rspack/binding-linux-ppc64-gnu",
+  "version": "2.1.5",
+  "license": "MIT",
+  "description": "Node binding for rspack",
+  "main": "rspack.linux-ppc64-gnu.node",
+  "homepage": "https://rspack.rs",
+  "bugs": "https://github.com/web-infra-dev/rspack/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack"
+  },
+  "publishConfig": {
+    "access": "public",
+    "os": [
+      "linux"
+    ],
+    "cpu": [
+      "ppc64"
+    ],
+    "libc": [
+      "glibc"
+    ]
+  },
+  "files": [
+    "rspack.linux-ppc64-gnu.node"
+  ]
+}

--- a/npm/linux-s390x-gnu/package.json
+++ b/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@rspack/binding-linux-s390x-gnu",
+  "version": "2.1.5",
+  "license": "MIT",
+  "description": "Node binding for rspack",
+  "main": "rspack.linux-s390x-gnu.node",
+  "homepage": "https://rspack.rs",
+  "bugs": "https://github.com/web-infra-dev/rspack/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack"
+  },
+  "publishConfig": {
+    "access": "public",
+    "os": [
+      "linux"
+    ],
+    "cpu": [
+      "s390x"
+    ],
+    "libc": [
+      "glibc"
+    ]
+  },
+  "files": [
+    "rspack.linux-s390x-gnu.node"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,12 +544,18 @@ importers:
       '@rspack/binding-linux-arm64-musl':
         specifier: workspace:*
         version: link:../../npm/linux-arm64-musl
+      '@rspack/binding-linux-ppc64-gnu':
+        specifier: workspace:*
+        version: link:../../npm/linux-ppc64-gnu
       '@rspack/binding-linux-riscv64-gnu':
         specifier: workspace:*
         version: link:../../npm/linux-riscv64-gnu
       '@rspack/binding-linux-riscv64-musl':
         specifier: workspace:*
         version: link:../../npm/linux-riscv64-musl
+      '@rspack/binding-linux-s390x-gnu':
+        specifier: workspace:*
+        version: link:../../npm/linux-s390x-gnu
       '@rspack/binding-linux-x64-gnu':
         specifier: workspace:*
         version: link:../../npm/linux-x64-gnu
@@ -659,9 +665,13 @@ importers:
 
   npm/linux-arm64-musl: {}
 
+  npm/linux-ppc64-gnu: {}
+
   npm/linux-riscv64-gnu: {}
 
   npm/linux-riscv64-musl: {}
+
+  npm/linux-s390x-gnu: {}
 
   npm/linux-x64-gnu: {}
 

--- a/scripts/build-npm.cjs
+++ b/scripts/build-npm.cjs
@@ -12,6 +12,8 @@ const CpuToNodeArch = {
   i686: 'ia32',
   armv7: 'arm',
   riscv64gc: 'riscv64',
+  powerpc64le: 'ppc64',
+  s390x: 's390x',
 };
 
 const SysToNodePlatform = {

--- a/website/docs/en/contribute/development/releasing.md
+++ b/website/docs/en/contribute/development/releasing.md
@@ -19,6 +19,8 @@ During the release, the following binary artifacts for the target platforms are 
 - x86_64-unknown-linux-gnu
 - aarch64-unknown-linux-gnu
 - riscv64gc-unknown-linux-gnu
+- powerpc64le-unknown-linux-gnu
+- s390x-unknown-linux-gnu
 - x86_64-unknown-linux-musl
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-musl

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -46,6 +46,8 @@ Currently supported platforms:
 - `linux-arm64-musl`
 - `linux-riscv64-gnu`
 - `linux-riscv64-musl`
+- `linux-ppc64-gnu`
+- `linux-s390x-gnu`
 - `linux-x64-gnu`
 - `linux-x64-musl`
 - `win32-arm64-msvc`

--- a/website/docs/zh/contribute/development/releasing.md
+++ b/website/docs/zh/contribute/development/releasing.md
@@ -19,6 +19,8 @@ Latest 是最新的稳定版本，遵循 Semantic Versioning 语义化版本号�
 - x86_64-unknown-linux-gnu
 - aarch64-unknown-linux-gnu
 - riscv64gc-unknown-linux-gnu
+- powerpc64le-unknown-linux-gnu
+- s390x-unknown-linux-gnu
 - x86_64-unknown-linux-musl
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-musl

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -46,6 +46,8 @@ Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) �
 - `linux-arm64-musl`
 - `linux-riscv64-gnu`
 - `linux-riscv64-musl`
+- `linux-ppc64-gnu`
+- `linux-s390x-gnu`
 - `linux-x64-gnu`
 - `linux-x64-musl`
 - `win32-arm64-msvc`

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -152,6 +152,8 @@ perfetto
 Peschke
 pftrace
 pmmmwh
+powerpc64le
+ppc64
 proxied
 proxying
 px2rem
@@ -180,6 +182,7 @@ ruleoneof
 ruleparserdataurlcondition
 Rust
 rustup
+s390x
 samply
 samsung
 sanyuan


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

In binding.js, there are references to the packages `@rspack/binding-linux-s390x-gnu` and `@rspack/binding-linux-ppc64-gnu` which are not built or published. This results in runtime errors on `s390x` and `ppc64le` with "Cannot find native binding".

https://github.com/web-infra-dev/rspack/blob/fe6890c7e11829a6459f1e9641b28aace4c0c268/crates/node_binding/binding.js#L295-L316

This PR adds the full build and release pipeline for both targets:

- Added `powerpc64le-unknown-linux-gnu` and `s390x-unknown-linux-gnu` to napi targets
- Created `npm/linux-ppc64-gnu` and `npm/linux-s390x-gnu` packages
- Added CI build steps using `@napi-rs/cross-toolchain` (which supports both architectures)
- Added matrix entries to all release workflows (canary, stable, preview-commit)
- Added `powerpc64le` → `ppc64` and `s390x` → `s390x` mappings to `build-npm.cjs`
- Bumped `json-escape-simd` from 3.1.0 to 3.1.1 — v3.1.0 has a big-endian bug that silently produces wrong escapes on s390x in release builds (e.g. `"node:module"` → `"node:modle\0…"`), corrupting ESM paths, sourcemaps, and data URLs: https://github.com/napi-rs/json-escape-simd/pull/88

No musl variants are included — `s390x-unknown-linux-musl` is only Rust Tier 3.

## Related links

<!-- Related issues or discussions. -->

Closes https://github.com/web-infra-dev/rspack/issues/14958

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).