### PR TITLE
fix(binding): release module graph connection wrappers

### DIFF
--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -131,6 +131,7 @@ use crate::{
   error::{ErrorCode, RspackResultToNapiResultExt},
   fs_node::{HybridFileSystem, NodeFileSystem, ThreadsafeNodeFS},
   module::ModuleObject,
+  module_graph_connection::ModuleGraphConnectionWrapper,
   platform::RawCompilerPlatform,
   plugins::{
     JsCleanupPlugin, JsHooksAdapterPlugin, RegisterJsTapKind, RegisterJsTaps, buildtime_plugins,
@@ -528,6 +529,7 @@ impl JsCompiler {
     ChunkGroupWrapper::cleanup_last_compilation(compilation_id);
     DependencyWrapper::cleanup_last_compilation(compilation_id);
     AsyncDependenciesBlockWrapper::cleanup_last_compilation(compilation_id);
+    ModuleGraphConnectionWrapper::cleanup_last_compilation(compilation_id);
   }
 }
 

--- a/tests/rspack-test/compilerCases/fixtures/tsfn-lifecycle/gc-check-module-graph-connection.cjs
+++ b/tests/rspack-test/compilerCases/fixtures/tsfn-lifecycle/gc-check-module-graph-connection.cjs
@@ -1,0 +1,74 @@
+const rspack = require("@rspack/core");
+const { createFsFromVolume, Volume } = require("memfs");
+const {
+  closeCompiler,
+  createGCTracker,
+  runCompiler,
+} = require("./helpers.cjs");
+
+async function main() {
+  const gcTracker = createGCTracker();
+  let build = 0;
+
+  const compiler = rspack({
+    context: __dirname,
+    mode: "development",
+    entry: "./entry.js",
+    output: {
+      path: "/",
+      filename: "bundle.js",
+    },
+    plugins: [
+      {
+        apply(compiler) {
+          compiler.hooks.compilation.tap(
+            "TsfnLifecycleModuleGraphConnection",
+            compilation => {
+              compilation.hooks.afterProcessAssets.tap(
+                "TsfnLifecycleModuleGraphConnection",
+                () => {
+                  const entry = compilation.entries.values().next().value;
+                  const connection = compilation.moduleGraph.getConnection(
+                    entry.dependencies[0],
+                  );
+
+                  if (!connection?.module) {
+                    throw new Error(
+                      "expected an entry module graph connection",
+                    );
+                  }
+
+                  build += 1;
+                  gcTracker.track(
+                    connection,
+                    `module graph connection ${build}`,
+                  );
+                },
+              );
+            },
+          );
+        },
+      },
+    ],
+  });
+  compiler.outputFileSystem = createFsFromVolume(new Volume());
+
+  try {
+    let firstStats = await runCompiler(compiler);
+    firstStats = null;
+    await runCompiler(compiler);
+
+    if (build !== 2) {
+      throw new Error(`expected two builds, received ${build}`);
+    }
+
+    await gcTracker.waitForCollection("module graph connection 1");
+  } finally {
+    await closeCompiler(compiler);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/rspack-test/compilerCases/tsfn-lifecycle.js
+++ b/tests/rspack-test/compilerCases/tsfn-lifecycle.js
@@ -94,6 +94,20 @@ module.exports = [
     },
   },
   {
+    description:
+      "should garbage collect module graph connections from a previous build",
+    async build() {
+      await runChild(
+        path.join(
+          __dirname,
+          "fixtures",
+          "tsfn-lifecycle",
+          "gc-check-module-graph-connection.cjs",
+        ),
+      );
+    },
+  },
+  {
     description: "should report a clear error when APIs are called after close",
     async build() {
       await runChild(


### PR DESCRIPTION
## Summary

- Release cached ModuleGraphConnection wrappers when their compilation is retired.
- Add a lifecycle regression that verifies wrappers from the previous compilation can be garbage collected.

## Bug scenario

When JavaScript accesses a module graph connection, the binding creates a `ModuleGraphConnection` wrapper and caches its N-API reference by compilation ID and dependency ID. The cache keeps the wrapper identity stable while that compilation is active.

Other compilation-scoped binding wrappers are removed when the compiler retires a compilation, but `ModuleGraphConnectionWrapper` was missing from that cleanup path. After a rebuild, the cache therefore continued to hold strong references to connection wrappers from the previous compilation:

```text
build 1 -> cache wrapper under compilation 1
build 2 -> compilation 1 is retired, but its wrapper remains cached
build 3 -> compilation 2 is retired, but its wrapper remains cached
...
```

In a long-running compiler or watch session, wrappers from old compilations could accumulate and could not be garbage collected, even after JavaScript released every user-visible reference to them.

## Why this fixes the bug

`JsCompiler::cleanup_last_compilation` already runs when a compilation is replaced and when the compiler is finalized. This PR adds:

```rust
ModuleGraphConnectionWrapper::cleanup_last_compilation(compilation_id);
```

That removes the retired compilation's entry from `MODULE_GRAPH_CONNECTION_INSTANCE_REFS`. Dropping the cached `OneShotRef` releases the binding's strong reference, so a connection wrapper can be garbage collected once JavaScript no longer retains it. Wrappers belonging to the active compilation remain cached and keep their existing identity behavior.

The regression test creates and observes a connection wrapper during two consecutive builds, drops the first build's JavaScript references, forces garbage collection, and verifies that the first compilation's wrapper is collected after the second build retires it. Without the added cleanup call, the cache continues to retain that wrapper and the test times out.

## Related links

Extracted from #14839.
Source: #14772.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
