### PR TITLE
perf: share source code across diagnostics

### DIFF
--- a/crates/rspack_binding_api/src/diagnostic.rs
+++ b/crates/rspack_binding_api/src/diagnostic.rs
@@ -87,7 +87,7 @@ pub fn format_diagnostic(diagnostic: JsDiagnostic) -> Result<External<Diagnostic
     }]);
   }
 
-  error.src = source_code;
+  error.src = source_code.map(Into::into);
 
   let mut diagnostic = Diagnostic::from(error);
   diagnostic.file = file.map(Into::into);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -95,7 +95,7 @@ impl Task<TaskContext> for FactorizeTask {
         if let Some(s) = self.original_module_source {
           let has_source_code = e.src.is_some();
           if !has_source_code {
-            e.src = Some(s.source().into_string_lossy().into_owned());
+            e.src = Some(s.source().into_string_lossy().into_owned().into());
           }
         }
         // Bail out if `options.bail` set to `true`,

--- a/crates/rspack_error/src/convert.rs
+++ b/crates/rspack_error/src/convert.rs
@@ -33,7 +33,7 @@ impl<T> SerdeResultToRspackResultExt<T> for std::result::Result<T, serde_json::E
         offset: offset.offset(),
         len: 0,
       }]);
-      error.src = Some(content.to_string());
+      error.src = Some(content.into());
       error
     })
   }

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, sync::Arc};
 
 use miette::{Diagnostic as MietteDiagnostic, LabeledSpan};
 use rspack_cacheable::cacheable;
@@ -35,7 +35,7 @@ pub struct ErrorData {
   /// Message.
   pub message: String,
   /// Source code.
-  pub src: Option<String>,
+  pub src: Option<Arc<str>>,
   /// Labels displayed in source code.
   ///
   /// The source code block will be displayed only if both source code and labels exist.
@@ -101,6 +101,16 @@ impl Error {
 
   pub fn from_string(
     src: Option<String>,
+    start: usize,
+    end: usize,
+    title: String,
+    message: String,
+  ) -> Self {
+    Self::from_shared_source(src.map(Into::into), start, end, title, message)
+  }
+
+  pub fn from_shared_source(
+    src: Option<Arc<str>>,
     start: usize,
     end: usize,
     title: String,

--- a/crates/rspack_javascript_compiler/src/compiler/parse.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/parse.rs
@@ -61,7 +61,7 @@ impl JavaScriptCompiler {
           .with_context(ast::Context::new(self.cm, Some(self.globals)))
       })
       .map_err(|errs| {
-        let source: Arc<str> = fm.src.to_string().into();
+        let source: Arc<str> = Arc::from(fm.src.as_ref());
         BatchErrors(
           errs
             .dedup_ecma_errors()
@@ -113,7 +113,7 @@ impl JavaScriptCompiler {
     parse_with_lexer(lexer, is_module, false)
       .map(|(program, _)| program)
       .map_err(|errs| {
-        let source: Arc<str> = fm.src.to_string().into();
+        let source: Arc<str> = Arc::from(fm.src.as_ref());
         BatchErrors(
           errs
             .dedup_ecma_errors()

--- a/crates/rspack_javascript_compiler/src/compiler/parse.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/parse.rs
@@ -61,11 +61,12 @@ impl JavaScriptCompiler {
           .with_context(ast::Context::new(self.cm, Some(self.globals)))
       })
       .map_err(|errs| {
+        let source: Arc<str> = fm.src.to_string().into();
         BatchErrors(
           errs
             .dedup_ecma_errors()
             .into_iter()
-            .map(|err| ecma_parse_error_deduped_to_rspack_error(err, fm.src.to_string()))
+            .map(|err| ecma_parse_error_deduped_to_rspack_error(err, source.clone()))
             .collect::<Vec<_>>(),
         )
       })
@@ -88,11 +89,12 @@ impl JavaScriptCompiler {
         )
       })
       .map_err(|errs| {
+        let source: Arc<str> = source.into();
         BatchErrors(
           errs
             .dedup_ecma_errors()
             .into_iter()
-            .map(|err| ecma_parse_error_deduped_to_rspack_error(err, source.to_string()))
+            .map(|err| ecma_parse_error_deduped_to_rspack_error(err, source.clone()))
             .collect::<Vec<_>>(),
         )
       })
@@ -111,11 +113,12 @@ impl JavaScriptCompiler {
     parse_with_lexer(lexer, is_module, false)
       .map(|(program, _)| program)
       .map_err(|errs| {
+        let source: Arc<str> = fm.src.to_string().into();
         BatchErrors(
           errs
             .dedup_ecma_errors()
             .into_iter()
-            .map(|err| ecma_parse_error_deduped_to_rspack_error(err, fm.src.to_string()))
+            .map(|err| ecma_parse_error_deduped_to_rspack_error(err, source.clone()))
             .collect::<Vec<_>>(),
         )
       })

--- a/crates/rspack_javascript_compiler/src/error.rs
+++ b/crates/rspack_javascript_compiler/src/error.rs
@@ -142,7 +142,7 @@ fn swc_diagnostic_to_rspack_error(
     error.src = Some(
       source_cache
         .entry(source_file.start_pos.0)
-        .or_insert_with(|| source_file.src.to_string().into())
+        .or_insert_with(|| Arc::from(source_file.src.as_ref()))
         .clone(),
     );
     if !labels.is_empty() {
@@ -182,7 +182,7 @@ impl Emitter for RspackErrorEmitter {
       let source = self
         .source_cache
         .entry(source_file_and_byte_pos.sf.start_pos.0)
-        .or_insert_with(|| source_file_and_byte_pos.sf.src.to_string().into())
+        .or_insert_with(|| Arc::from(source_file_and_byte_pos.sf.src.as_ref()))
         .clone();
       self
         .tx

--- a/crates/rspack_javascript_compiler/src/error.rs
+++ b/crates/rspack_javascript_compiler/src/error.rs
@@ -5,7 +5,7 @@ use std::{
 
 use rspack_error::{BatchErrors, Error, Label, Severity, error};
 use rspack_util::SpanExt;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::{FxHashMap, FxHashSet as HashSet};
 use swc_core::common::{
   SourceMap, Span, Spanned,
   errors::{Diagnostic as SwcDiagnostic, DiagnosticId, Emitter, HANDLER, Handler, Level},
@@ -52,9 +52,9 @@ pub trait DedupEcmaErrors {
 
 pub fn ecma_parse_error_deduped_to_rspack_error(
   EcmaError(message, span): EcmaError,
-  source: String,
+  source: Arc<str>,
 ) -> Error {
-  Error::from_string(
+  Error::from_shared_source(
     Some(source),
     span.real_lo() as usize,
     span.real_hi() as usize,
@@ -73,10 +73,11 @@ pub(crate) fn swc_diagnostics_to_rspack_error(
   diagnostics: &[SwcDiagnostic],
   source_map: &SourceMap,
 ) -> Option<Error> {
+  let mut source_cache = FxHashMap::default();
   let mut errors = diagnostics
     .iter()
     .rev()
-    .map(|diagnostic| swc_diagnostic_to_rspack_error(diagnostic, source_map));
+    .map(|diagnostic| swc_diagnostic_to_rspack_error(diagnostic, source_map, &mut source_cache));
   let mut error = errors.next()?;
 
   for mut outer in errors {
@@ -91,7 +92,11 @@ pub(crate) fn swc_diagnostics_to_rspack_error(
   Some(error)
 }
 
-fn swc_diagnostic_to_rspack_error(diagnostic: &SwcDiagnostic, source_map: &SourceMap) -> Error {
+fn swc_diagnostic_to_rspack_error(
+  diagnostic: &SwcDiagnostic,
+  source_map: &SourceMap,
+  source_cache: &mut FxHashMap<u32, Arc<str>>,
+) -> Error {
   let mut message = diagnostic.message();
   let code = diagnostic.code.as_ref().map(|code| match code {
     DiagnosticId::Error(code) | DiagnosticId::Lint(code) => code,
@@ -134,7 +139,12 @@ fn swc_diagnostic_to_rspack_error(diagnostic: &SwcDiagnostic, source_map: &Sourc
       })
       .collect::<Vec<_>>();
 
-    error.src = Some(source_file.src.to_string());
+    error.src = Some(
+      source_cache
+        .entry(source_file.start_pos.0)
+        .or_insert_with(|| source_file.src.to_string().into())
+        .clone(),
+    );
     if !labels.is_empty() {
       error.labels = Some(labels);
     }
@@ -158,6 +168,7 @@ fn swc_diagnostic_to_rspack_error(diagnostic: &SwcDiagnostic, source_map: &Sourc
 struct RspackErrorEmitter {
   tx: mpsc::Sender<Error>,
   source_map: Arc<SourceMap>,
+  source_cache: FxHashMap<u32, Arc<str>>,
   title: String,
 }
 
@@ -168,10 +179,15 @@ impl Emitter for RspackErrorEmitter {
       .primary_span()
       .map(|s| self.source_map.lookup_byte_offset(s.lo()));
     if let Some(source_file_and_byte_pos) = source_file_and_byte_pos {
+      let source = self
+        .source_cache
+        .entry(source_file_and_byte_pos.sf.start_pos.0)
+        .or_insert_with(|| source_file_and_byte_pos.sf.src.to_string().into())
+        .clone();
       self
         .tx
-        .send(Error::from_string(
-          Some(source_file_and_byte_pos.sf.src.clone().into_string()),
+        .send(Error::from_shared_source(
+          Some(source),
           source_file_and_byte_pos.pos.0 as usize,
           source_file_and_byte_pos.pos.0 as usize,
           self.title.clone(),
@@ -216,6 +232,7 @@ where
   let emitter = RspackErrorEmitter {
     title,
     source_map: cm,
+    source_cache: Default::default(),
     tx,
   };
   let handler = Handler::with_emitter(true, false, Box::new(emitter));

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -58,6 +58,7 @@ fn append_experimental_parse_errors(
   errors: impl IntoIterator<Item = swc_experimental_ecma_parser::error::Error>,
 ) {
   let mut visited = HashSet::new();
+  let source: Arc<str> = source.into();
   diagnostics.extend(errors.into_iter().filter_map(|err| {
     let span = err.span();
     let message = err.kind().msg().to_string();
@@ -65,8 +66,8 @@ fn append_experimental_parse_errors(
       return None;
     }
     Some(
-      Error::from_string(
-        Some(source.to_string()),
+      Error::from_shared_source(
+        Some(source.clone()),
         span.start.saturating_sub(1) as usize,
         span.end.saturating_sub(1) as usize,
         "JavaScript parse error".to_string(),
@@ -75,6 +76,34 @@ fn append_experimental_parse_errors(
       .into(),
     )
   }));
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_errors_share_source_code() {
+    let source = "'\\101';'\\102';";
+    let allocator = Allocator::new();
+    let lexer = Lexer::new(
+      &allocator,
+      Syntax::Es(EsSyntax::default()),
+      EsVersion::EsNext,
+      StringSource::new(source),
+      None,
+    );
+    let mut parser = Parser::new_from(&allocator, lexer);
+    parser.parse_module().expect("should recover parse errors");
+
+    let mut diagnostics = Vec::new();
+    append_experimental_parse_errors(&mut diagnostics, source, parser.take_errors());
+
+    assert_eq!(diagnostics.len(), 2);
+    let first_source = diagnostics[0].src.as_ref().expect("should have source");
+    let second_source = diagnostics[1].src.as_ref().expect("should have source");
+    assert_eq!(first_source.as_ptr(), second_source.as_ptr());
+  }
 }
 
 impl ParserRuntimeRequirementsData {


### PR DESCRIPTION
## Summary

- store diagnostic source code in shared immutable storage
- reuse source storage across parser errors and SWC diagnostics
- avoid intermediate source allocations when converting SWC sources
- add a regression test for repeated parse errors

## Performance impact

Diagnostic creation previously cloned the full module source for every parse error, making memory usage grow with `error count × source size`. Sharing one immutable source allocation per file makes each additional diagnostic clone only a small reference.

Measured with [rspack-issue-14961](https://github.com/cezaraugusto/rspack-issue-14961) on macOS arm64 and Node.js 24.16 using `@rspack/core` 2.1.5 dev bindings. Values are medians of three warm runs comparing `main@019c3aa232` with this PR.

| Scenario | Metric | main | PR | Change |
| --- | ---: | ---: | ---: | ---: |
| 10k errors, compile only | Peak RSS | 1,305.7 MB | 143.5 MB | **-89.0%** |
| 10k errors, compile only | Build time | 151 ms | 72 ms | **-52.3%** |
| 1k errors, single-line full workflow | Peak RSS | 292.5 MB | 282.0 MB | -3.6% |
| 1k errors, multi-line full workflow | Peak RSS | 162.4 MB | 149.1 MB | -8.2% |

The rendered output remains unchanged at 7,819,499 characters for the 1k single-line case. This PR addresses source clone amplification; bounding diagnostic rendering remains separate.

Addresses one source of memory amplification reported in #14961.