### PR TITLE
fix: handle circular hash dependencies in RealContentHashPlugin

### DIFF
--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -364,14 +364,8 @@ impl AssetData {
       {
         let mut new_content = String::with_capacity(content.len());
         hash_ac.replace_all_with(content, &mut new_content, |_, hash, dst| {
-          let replace_to = if without_own && self.own_hashes.contains(hash) {
-            ""
-          } else {
-            hash_to_new_hash
-              .get(hash)
-              .expect("RealContentHashPlugin: should have new hash")
-          };
-          dst.push_str(replace_to);
+          let replace_to = replacement_hash(hash, without_own, &self.own_hashes, hash_to_new_hash);
+          dst.push_str(&replace_to);
           true
         });
         return RawStringSource::from(new_content).boxed();
@@ -463,13 +457,30 @@ impl OrderedHashesBuilder<'_> {
         continue;
       }
       if stack.contains(dep) {
-        // Safety: all chunk-level hash will be collected in runtime chunk
-        // so there shouldn't have circular hash dependency between chunks
-        panic!("RealContentHashPlugin: circular hash dependency");
+        // Multiple async runtimes (e.g. Module Federation) can each embed the
+        // full chunk-id→hash map, creating mutual references between chunk hashes.
+        // Break the cycle: the hash is still ordered, and unresolved deps keep
+        // their provisional value until processed.
+        continue;
       }
       self.add_to_ordered_hashes(dep, ordered_hashes, stack, hash_dependencies);
     }
     ordered_hashes.insert(hash.to_string());
     stack.remove(hash);
   }
+}
+
+fn replacement_hash(
+  hash: &str,
+  without_own: bool,
+  own_hashes: &HashSet<String>,
+  hash_to_new_hash: &HashMap<String, String>,
+) -> String {
+  if without_own && own_hashes.contains(hash) {
+    return String::new();
+  }
+  hash_to_new_hash
+    .get(hash)
+    .cloned()
+    .unwrap_or_else(|| hash.to_string())
 }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

Warning: I am not a rust dev. This is a AI generated patch for https://github.com/web-infra-dev/rspack/issues/14971. I have tested it in our mega-repo (>12m LOC) and it solves the problem. However, I cannot speak to the quality of the code here (unfortunately).

Fixing `RealContentHashPlugin: circular hash dependency`.


## Related links

<!-- Related issues or discussions. -->

https://github.com/web-infra-dev/rspack/issues/14971

Repro: https://github.com/MatissJanis/rspack-mf-contenthash-repro/tree/master

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
