### PR TITLE
docs: clarify optimization.nodeEnv defaults

### DIFF
--- a/website/docs/en/config/optimization.mdx
+++ b/website/docs/en/config/optimization.mdx
@@ -369,18 +369,18 @@ The `deterministic` option is useful for long term caching, and results in small
 
 ## optimization.nodeEnv
 
-<PropertyType
-  type="string | false"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
+- **Type:** `string | false`
+- **Default:** Determined by [`mode`](/config/mode):
+  - [`production` mode](/config/mode#production): `'production'`
+  - [`development` mode](/config/mode#development): `'development'`
+  - [`none` mode](/config/mode#none): `false`
 
-Tells Rspack to set `process.env.NODE_ENV` to a given string value. `optimization.nodeEnv` uses [DefinePlugin](/plugins/webpack/define-plugin) unless set to false.
-`optimization.nodeEnv` **defaults** to [mode](/config/mode) if set, else falls back to `'production'`.
+`optimization.nodeEnv` controls the value used to replace `process.env.NODE_ENV` at compile time. Rspack performs this replacement with [DefinePlugin](/plugins/webpack/define-plugin).
 
-Possible values:
+You can override the mode-dependent default with either of the following values:
 
-- any string: the value to set `process.env.NODE_ENV` to.
-- false: do not modify/set the value of `process.env.NODE_ENV`.
+- Any string: replace `process.env.NODE_ENV` with the specified string.
+- `false`: disable the replacement and leave `process.env.NODE_ENV` unchanged.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -389,10 +389,6 @@ export default {
   },
 };
 ```
-
-:::tip
-When [mode](/config/mode) is set to `'none'`, `optimization.nodeEnv` defaults to `false`.
-:::
 
 ## optimization.providedExports
 

--- a/website/docs/zh/config/optimization.mdx
+++ b/website/docs/zh/config/optimization.mdx
@@ -367,18 +367,18 @@ export default {
 
 ## optimization.nodeEnv
 
-<PropertyType
-  type="string | false"
-  defaultValueList={[{ defaultValue: 'false' }]}
-/>
+- **类型：** `string | false`
+- **默认值：** 由 [`mode`](/config/mode) 决定：
+  - [`production` 模式](/config/mode#production)：`'production'`
+  - [`development` 模式](/config/mode#development)：`'development'`
+  - [`none` 模式](/config/mode#none)：`false`
 
-Rspack 将 `process.env.NODE_ENV` 设置为给定的字符串。除非该值被明确设置为 `false`，否则 `optimization.nodeEnv` 将使用 [DefinePlugin](/plugins/webpack/define-plugin)。
-`optimization.nodeEnv` 的**默认值**为 [mode](/config/mode)，否则将设置为 `'production'`。
+`optimization.nodeEnv` 用于控制 Rspack 在编译时替换 `process.env.NODE_ENV` 所使用的值。Rspack 会通过 [DefinePlugin](/plugins/webpack/define-plugin) 完成该替换。
 
-可能的值：
+你也可以使用以下值覆盖由 `mode` 决定的默认行为：
 
-- 任意字符串：设置 `process.env.NODE_ENV` 的值。
-- false：不设置 `process.env.NODE_ENV` 的值。
+- 任意字符串：将 `process.env.NODE_ENV` 替换为指定的字符串。
+- `false`：禁用替换，保留代码中的 `process.env.NODE_ENV`。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -387,10 +387,6 @@ export default {
   },
 };
 ```
-
-:::tip
-当 [mode](/config/mode) 被设置为 `'none'` 时，`optimization.nodeEnv` 默认为 `false`。
-:::
 
 ## optimization.providedExports
 


### PR DESCRIPTION
## Summary

This PR clarifies the mode-dependent defaults for `optimization.nodeEnv` in the English and Chinese documentation. It replaces the misleading single default with a Markdown list and explains the compile-time replacement behavior more precisely.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).