### PR TITLE
fix(esm): add missing CJS interop runtime requirement

### DIFF
--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -409,10 +409,19 @@ async fn additional_module_runtime_requirements(
 async fn additional_chunk_runtime_requirements(
   &self,
   _compilation: &Compilation,
-  _chunk_ukey: &ChunkUkey,
+  chunk_ukey: &ChunkUkey,
   runtime_requirements: &mut RuntimeGlobals,
   _runtime_modules: &mut Vec<Box<dyn RuntimeModule>>,
 ) -> Result<()> {
+  if let Some(chunk_link) = self.links.borrow().get(chunk_ukey)
+    && chunk_link
+      .required
+      .values()
+      .any(|interop| interop.default_access.is_some())
+  {
+    runtime_requirements.insert(RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT);
+  }
+
   // Add REQUIRE_SCOPE only when runtime_requirements actually contain globals
   // that live on the __rspack_require object (same check the runtime plugin
   // uses in handle_scope_globals). This avoids pulling in an empty

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/__snapshots__/esm.snap.txt
@@ -1,0 +1,106 @@
+```mjs title=foo.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
+__webpack_require__.add({
+"./foo.cjs"
+/*!*****************!*\
+  !*** ./foo.cjs ***!
+  \*****************/
+(module) {
+module.exports = 42;
+
+
+},
+});
+__webpack_require__("./foo.cjs");
+
+export {};
+
+```
+
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+import "./foo.mjs";
+
+// ./index.js
+
+
+it('should re-export a CommonJS default from another entry', async () => {
+  const { value } = await import(
+    /* webpackIgnore: true */ './main.mjs'
+  );
+  expect(value).toBe(42);
+});
+
+const foo = __webpack_require__("./foo.cjs");
+var foo_default = /*#__PURE__*/__webpack_require__.n(foo);
+var foo_default_0 = foo_default();
+
+export { foo_default_0 as value };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,99 @@
+```mjs title=foo.mjs
+import { rspackRequire, moduleFactories, compatGetDefaultExport } from "./runtime.mjs";
+moduleFactories.add({
+"./foo.cjs"
+/*!*****************!*\
+  !*** ./foo.cjs ***!
+  \*****************/
+(module) {
+module.exports = 42;
+
+
+},
+});
+rspackRequire("./foo.cjs");
+
+export {};
+
+```
+
+```mjs title=main.mjs
+import { rspackRequire, compatGetDefaultExport } from "./runtime.mjs";
+import "./foo.mjs";
+
+// ./index.js
+
+
+it('should re-export a CommonJS default from another entry', async () => {
+  const { value } = await import(
+    /* webpackIgnore: true */ './main.mjs'
+  );
+  expect(value).toBe(42);
+});
+
+const foo = rspackRequire("./foo.cjs");
+var foo_default = /*#__PURE__*/compatGetDefaultExport(foo);
+var foo_default_0 = foo_default();
+
+export { foo_default_0 as value };
+
+```
+
+```mjs title=runtime.mjs
+
+var modules = {};
+// The module cache
+var moduleCache = {};
+// The require function
+function rspackRequire(moduleId) {
+// Check if module is in cache
+var cachedModule = moduleCache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (moduleCache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+modules[moduleId](module, module.exports, rspackRequire);
+
+// Return the exports of the module
+return module.exports;
+}
+export { rspackRequire };
+// expose the modules object (modules)
+var moduleFactories = modules;
+export { moduleFactories };
+
+// rspack/runtime/compat_get_default_export
+// getDefaultExport function for compatibility with non-ESM modules
+var compatGetDefaultExport = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	definePropertyGetters(getter, { a: getter });
+	return getter;
+};
+;
+export { compatGetDefaultExport };
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+// rspack/runtime/esm_register_module
+moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+
+
+```

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/foo.cjs
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/foo.cjs
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/index.js
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/index.js
@@ -1,0 +1,8 @@
+export { default as value } from './foo.cjs';
+
+it('should re-export a CommonJS default from another entry', async () => {
+  const { value } = await import(
+    /* webpackIgnore: true */ './main.mjs'
+  );
+  expect(value).toBe(42);
+});

--- a/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/interop/export-cjs-default-multi-entry/rspack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  entry: {
+    main: './index.js',
+    foo: './foo.cjs',
+  },
+};


### PR DESCRIPTION
## Summary

Fix `ReferenceError: compatGetDefaultExport is not defined` when a modern-module build uses `experiments.runtimeMode: "rspack"`, multiple entries, and re-exports a CommonJS default export across chunks.

## Root cause

The ESM linker records the generated CommonJS default interop access on the consuming chunk. The existing module-level runtime-requirements hook only associated `COMPAT_GET_DEFAULT_EXPORT` with the CommonJS provider module, so the consuming entry could emit `compatGetDefaultExport(...)` without importing the helper from the shared runtime chunk.

## Solution

During additional chunk runtime-requirements collection, inspect that chunk's linked external interop records and add `COMPAT_GET_DEFAULT_EXPORT` when a default interop access is present. Existing runtime-requirement processing then adds the helper and its dependencies to the runtime chunk and emits the required named import.

## Tests

Added a focused multi-entry ESM output case. On `main`, the runtime-mode variant fails with the original `ReferenceError`; with this change, both webpack and Rspack runtime-mode variants pass.

