### PR TITLE
fix(loader): preserve lightningcss license comments

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -305,6 +305,9 @@ pub fn to_static(
 ) -> StyleSheet<'static, 'static> {
   let sources = stylesheet.sources.clone();
   let rules = stylesheet.rules.clone().into_owned();
+  let license_comments = stylesheet.license_comments.clone().into_owned();
 
-  StyleSheet::new(sources, rules, options)
+  let mut stylesheet = StyleSheet::new(sources, rules, options);
+  stylesheet.license_comments = license_comments;
+  stylesheet
 }

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/license-comments/index.css
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/license-comments/index.css
@@ -1,0 +1,4 @@
+/*! Copyright example */
+.foo {
+  color: red;
+}

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/license-comments/index.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/license-comments/index.js
@@ -1,0 +1,13 @@
+import "./index.css";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+it("should preserve license comments", () => {
+	const css = fs.readFileSync(
+		path.resolve(__dirname, "bundle0.css"),
+		"utf-8"
+	);
+
+	expect(css).toContain("/*! Copyright example */");
+});

--- a/tests/rspack-test/configCases/builtin-lightningcss-loader/license-comments/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-lightningcss-loader/license-comments/rspack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  externals: {
+    'node:fs': 'node-commonjs node:fs',
+    'node:path': 'node-commonjs node:path',
+  },
+  target: 'web',
+  node: false,
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/auto',
+        use: 'builtin:lightningcss-loader',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

`builtin:lightningcss-loader` rebuilt parsed stylesheets with `StyleSheet::new`, which initialized `license_comments` as empty and dropped leading `/*! ... */` comments. This PR preserves owned license comments while converting the stylesheet to `'static`, matching Lightning CSS's bundler implementation.

## Related links

- Similar Lightning CSS source: https://github.com/parcel-bundler/lightningcss/blob/7f8a861bdee476fe90c89a8badeb3fd33a99c51a/src/bundler.rs#L317-L333

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).