### PR TITLE
perf: limit errors per module

### DIFF
--- a/crates/rspack_binding_api/src/compilation/diagnostics.rs
+++ b/crates/rspack_binding_api/src/compilation/diagnostics.rs
@@ -104,7 +104,8 @@ impl Diagnostics {
     }
 
     if index == len {
-      diagnostics.push(error.into_diagnostic(severity));
+      let diagnostic = error.into_diagnostic(severity);
+      compilation.push_diagnostic(diagnostic);
       return Ok(());
     }
 
@@ -118,6 +119,7 @@ impl Diagnostics {
         i += 1;
       }
     }
+    compilation.normalize_diagnostics();
 
     Ok(())
   }
@@ -188,6 +190,7 @@ impl Diagnostics {
     }
 
     *diagnostics = new_diagnostics;
+    compilation.normalize_diagnostics();
 
     removed
       .into_iter()

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -93,6 +93,7 @@ use crate::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, update_module_graph,
   },
   compiler::{CompilationRecords, CompilerId},
+  diagnostics::ModuleErrorsState,
   get_runtime_key,
   incremental::{self, Incremental, IncrementalPasses, Mutation},
   is_source_equal, to_identifier,
@@ -233,6 +234,7 @@ pub struct Compilation {
   assets_related_in: HashMap<String, HashSet<String>>,
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,
   diagnostics: Vec<Diagnostic>,
+  module_errors: IdentifierMap<ModuleErrorsState>,
   logging: CompilationLogging,
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
@@ -381,6 +383,7 @@ impl Compilation {
       assets_related_in: Default::default(),
       emitted_assets: Default::default(),
       diagnostics: Default::default(),
+      module_errors: Default::default(),
       logging,
       plugin_driver,
       buildtime_plugin_driver,
@@ -952,11 +955,29 @@ impl Compilation {
   }
 
   pub fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
-    self.diagnostics.push(diagnostic);
+    if diagnostic.is_error()
+      && let Some(module_identifier) = diagnostic.module_identifier
+    {
+      self
+        .module_errors
+        .entry(module_identifier)
+        .or_default()
+        .add_diagnostic(&mut self.diagnostics, diagnostic);
+    } else {
+      self.diagnostics.push(diagnostic);
+    }
   }
 
   pub fn extend_diagnostics(&mut self, diagnostics: impl IntoIterator<Item = Diagnostic>) {
-    self.diagnostics.extend(diagnostics);
+    for diagnostic in diagnostics {
+      self.push_diagnostic(diagnostic);
+    }
+  }
+
+  pub fn normalize_diagnostics(&mut self) {
+    let diagnostics = std::mem::take(&mut self.diagnostics);
+    self.module_errors.clear();
+    self.extend_diagnostics(diagnostics);
   }
 
   pub fn diagnostics(&self) -> &[Diagnostic] {

--- a/crates/rspack_core/src/diagnostics.rs
+++ b/crates/rspack_core/src/diagnostics.rs
@@ -3,6 +3,40 @@ use rspack_error::{Diagnostic, Error, Label, dim};
 
 use crate::{BoxLoader, DependencyRange};
 
+pub const MAX_ERRORS_PER_MODULE: usize = 100;
+const MODULE_ERRORS_LIMIT_CODE: &str = "ModuleErrorsLimit";
+
+#[derive(Debug, Default)]
+pub(crate) struct ModuleErrorsState {
+  errors_count: usize,
+  reached_limit: bool,
+}
+
+impl ModuleErrorsState {
+  pub fn add_diagnostic(&mut self, diagnostics: &mut Vec<Diagnostic>, diagnostic: Diagnostic) {
+    if diagnostic.is_warn() {
+      diagnostics.push(diagnostic);
+    } else if !self.reached_limit {
+      if self.errors_count < MAX_ERRORS_PER_MODULE - 1 {
+        diagnostics.push(diagnostic);
+        self.errors_count += 1;
+      } else {
+        let diagnostic = if diagnostic.code.as_deref() == Some(MODULE_ERRORS_LIMIT_CODE) {
+          diagnostic
+        } else {
+          let module_identifier = diagnostic.module_identifier;
+          let mut diagnostic: Diagnostic = Error::from(ModuleErrorsLimitError).into();
+          diagnostic.module_identifier = module_identifier;
+          diagnostic
+        };
+        diagnostics.push(diagnostic);
+        self.errors_count += 1;
+        self.reached_limit = true;
+      }
+    }
+  }
+}
+
 ///////////////////// Module Factory /////////////////////
 
 #[derive(Debug)]
@@ -122,6 +156,20 @@ impl ModuleParseError {
       help,
       source,
     }
+  }
+}
+
+#[derive(Debug)]
+pub struct ModuleErrorsLimitError;
+
+impl From<ModuleErrorsLimitError> for Error {
+  fn from(_: ModuleErrorsLimitError) -> Error {
+    let mut error = Error::error(format!(
+      "Module has too many errors. Only the first {} errors are shown.",
+      MAX_ERRORS_PER_MODULE - 1
+    ));
+    error.code = Some(MODULE_ERRORS_LIMIT_CODE.into());
+    error
   }
 }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -34,11 +34,25 @@ use crate::{
   ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
   ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin,
   RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, contextify,
-  diagnostics::ModuleBuildError,
+  diagnostics::{ModuleBuildError, ModuleErrorsState},
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
+
+fn append_module_diagnostics(
+  diagnostics: &mut Vec<Diagnostic>,
+  additional_diagnostics: impl IntoIterator<Item = Diagnostic>,
+) {
+  let mut state = ModuleErrorsState::default();
+  let existing_diagnostics = std::mem::take(diagnostics);
+  for diagnostic in existing_diagnostics {
+    state.add_diagnostic(diagnostics, diagnostic);
+  }
+  for diagnostic in additional_diagnostics {
+    state.add_diagnostic(diagnostics, diagnostic);
+  }
+}
 
 #[cacheable]
 #[derive(Debug, Clone)]
@@ -465,7 +479,7 @@ impl Module for NormalModule {
         err,
         current_loader,
       )));
-      self.diagnostics.push(diagnostic);
+      self.add_diagnostic(diagnostic);
 
       self.build_info.hash =
         Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
@@ -861,11 +875,11 @@ impl ModuleSourceMapConfig for NormalModule {
 
 impl Diagnosable for NormalModule {
   fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
-    self.diagnostics.push(diagnostic);
+    append_module_diagnostics(&mut self.diagnostics, [diagnostic]);
   }
 
-  fn add_diagnostics(&mut self, mut diagnostics: Vec<Diagnostic>) {
-    self.diagnostics.append(&mut diagnostics);
+  fn add_diagnostics(&mut self, diagnostics: Vec<Diagnostic>) {
+    append_module_diagnostics(&mut self.diagnostics, diagnostics);
   }
 
   fn diagnostics(&self) -> Cow<'_, [Diagnostic]> {
@@ -902,5 +916,53 @@ impl NormalModule {
       return Ok(OriginalSource::new(content, self.request()).boxed());
     }
     Ok(RawStringSource::from(content.into_string_lossy()).boxed())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::diagnostics::MAX_ERRORS_PER_MODULE;
+
+  #[test]
+  fn module_errors_are_limited_but_warnings_are_preserved() {
+    let mut diagnostics = Vec::new();
+    append_module_diagnostics(
+      &mut diagnostics,
+      (0..MAX_ERRORS_PER_MODULE - 1)
+        .map(|i| Diagnostic::error("TestError".into(), format!("error {i}"))),
+    );
+
+    assert_eq!(
+      diagnostics.iter().filter(|d| d.is_error()).count(),
+      MAX_ERRORS_PER_MODULE - 1
+    );
+    assert!(
+      diagnostics
+        .iter()
+        .all(|d| d.code.as_deref() != Some("ModuleErrorsLimit"))
+    );
+
+    append_module_diagnostics(
+      &mut diagnostics,
+      [
+        Diagnostic::warn("TestWarning".into(), "warning".into()),
+        Diagnostic::error("TestError".into(), "extra error".into()),
+        Diagnostic::error("TestError".into(), "another extra error".into()),
+      ],
+    );
+
+    assert_eq!(
+      diagnostics.iter().filter(|d| d.is_error()).count(),
+      MAX_ERRORS_PER_MODULE
+    );
+    assert_eq!(diagnostics.iter().filter(|d| d.is_warn()).count(), 1);
+    assert_eq!(
+      diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("ModuleErrorsLimit"))
+        .count(),
+      1
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -16,7 +16,7 @@ use rspack_core::{
   ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult, ParserAndGenerator,
   ResolvedModuleOptions, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeVariable,
   SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
-  diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
+  diagnostics::{MAX_ERRORS_PER_MODULE, map_box_diagnostics_to_module_parse_diagnostics},
   remove_bom, render_init_fragments,
   rspack_sources::{BoxSource, ReplaceSource, Source, SourceExt},
 };
@@ -59,13 +59,13 @@ fn append_experimental_parse_errors(
 ) {
   let mut visited = HashSet::new();
   let source: Arc<str> = source.into();
-  diagnostics.extend(errors.into_iter().filter_map(|err| {
+  for err in errors {
     let span = err.span();
     let message = err.kind().msg().to_string();
     if !visited.insert((message.clone(), span)) {
-      return None;
+      continue;
     }
-    Some(
+    diagnostics.push(
       Error::from_shared_source(
         Some(source.clone()),
         span.start.saturating_sub(1) as usize,
@@ -74,8 +74,11 @@ fn append_experimental_parse_errors(
         message,
       )
       .into(),
-    )
-  }));
+    );
+    if visited.len() >= MAX_ERRORS_PER_MODULE {
+      break;
+    }
+  }
 }
 
 #[cfg(test)]
@@ -103,6 +106,26 @@ mod tests {
     let first_source = diagnostics[0].src.as_ref().expect("should have source");
     let second_source = diagnostics[1].src.as_ref().expect("should have source");
     assert_eq!(first_source.as_ptr(), second_source.as_ptr());
+  }
+
+  #[test]
+  fn parse_error_conversion_stops_after_module_limit_is_exceeded() {
+    let source = "'\\101';".repeat(MAX_ERRORS_PER_MODULE + 10);
+    let allocator = Allocator::new();
+    let lexer = Lexer::new(
+      &allocator,
+      Syntax::Es(EsSyntax::default()),
+      EsVersion::EsNext,
+      StringSource::new(&source),
+      None,
+    );
+    let mut parser = Parser::new_from(&allocator, lexer);
+    parser.parse_module().expect("should recover parse errors");
+
+    let mut diagnostics = Vec::new();
+    append_experimental_parse_errors(&mut diagnostics, &source, parser.take_errors());
+
+    assert_eq!(diagnostics.len(), MAX_ERRORS_PER_MODULE);
   }
 }
 

--- a/tests/rspack-test/configCases/errors/limit-module-errors/errors.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/errors.js
@@ -1,0 +1,9 @@
+module.exports = [
+	...Array.from({ length: 198 }, () => ({
+		message: /emitted error/
+	})),
+	...Array.from({ length: 2 }, () => ({
+		code: /ModuleErrorsLimit/,
+		message: /Only the first 99 errors are shown/
+	}))
+];

--- a/tests/rspack-test/configCases/errors/limit-module-errors/index.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/index.js
@@ -1,0 +1,2 @@
+import './module-a';
+import './module-b';

--- a/tests/rspack-test/configCases/errors/limit-module-errors/loader.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/loader.js
@@ -1,0 +1,7 @@
+module.exports = function (content) {
+	for (let i = 0; i < 101; i++) {
+		this.emitError(new Error(`emitted error ${i}`));
+	}
+	this.emitWarning(new Error('emitted warning'));
+	return content;
+};

--- a/tests/rspack-test/configCases/errors/limit-module-errors/module-a.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/module-a.js
@@ -1,0 +1,1 @@
+export const value = 'a';

--- a/tests/rspack-test/configCases/errors/limit-module-errors/module-b.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/module-b.js
@@ -1,0 +1,1 @@
+export const value = 'b';

--- a/tests/rspack-test/configCases/errors/limit-module-errors/rspack.config.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/rspack.config.js
@@ -1,0 +1,41 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /module-[ab]\.js$/,
+        use: './loader.js',
+      },
+    ],
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.done.tap('TestPlugin', (stats) => {
+          const { errors, errorsCount, warnings, warningsCount } = stats.toJson(
+            {
+              all: false,
+              errors: true,
+              errorsCount: true,
+              warnings: true,
+              warningsCount: true,
+            },
+          );
+
+          expect(errors).toHaveLength(200);
+          expect(errorsCount).toBe(200);
+          expect(warnings).toHaveLength(2);
+          expect(warningsCount).toBe(2);
+
+          const limitErrors = errors.filter(
+            (error) => error.code === 'ModuleErrorsLimit',
+          );
+          expect(limitErrors).toHaveLength(2);
+          expect(new Set(limitErrors.map((error) => error.moduleName))).toEqual(
+            new Set(['./module-a.js', './module-b.js']),
+          );
+        });
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/errors/limit-module-errors/test.config.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return [];
+	}
+};

--- a/tests/rspack-test/configCases/errors/limit-module-errors/warnings.js
+++ b/tests/rspack-test/configCases/errors/limit-module-errors/warnings.js
@@ -1,0 +1,4 @@
+module.exports = [
+	{ message: /emitted warning/, moduleName: /module-a\.js/ },
+	{ message: /emitted warning/, moduleName: /module-b\.js/ }
+];


### PR DESCRIPTION
## Summary

- Limit retained errors to 100 per module: 99 original errors followed by a `ModuleErrorsLimit` diagnostic.
- Stop converting JavaScript parser errors after the module budget is exhausted and enforce the same budget in module and compilation diagnostic paths.
- Keep warnings independent from the error budget and cover multiple modules plus loader-emitted diagnostics.

## Design research

webpack retains every module error; [`errorsSpace`](https://github.com/webpack/webpack/blob/main/lib/stats/DefaultStatsFactoryPlugin.js) only trims displayed details after diagnostics have been collected. Other compilers apply explicit reporting limits: [Clang defaults to 20](https://clang.llvm.org/docs/UsersManual.html#cmdoption-ferror-limit), [Go defaults to 10](https://pkg.go.dev/cmd/compile), and javac defaults to showing 100 errors before an overflow summary.

Rspack processes many independent modules in one compilation, so the budget is scoped per module instead of globally. Applying it before expensive parser diagnostic conversion bounds source-context materialization, while the compilation-level guard covers loader, plugin, and JavaScript API paths.

## Related links

- Related to #14961

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required).