### PR TITLE
perf: avoid cloning Lightning CSS stylesheet AST

### DIFF
--- a/crates/rspack_loader_lightningcss/src/lib.rs
+++ b/crates/rspack_loader_lightningcss/src/lib.rs
@@ -303,9 +303,9 @@ pub fn to_static(
   stylesheet: StyleSheet,
   options: ParserOptions<'static, 'static>,
 ) -> StyleSheet<'static, 'static> {
-  let sources = stylesheet.sources.clone();
-  let rules = stylesheet.rules.clone().into_owned();
-  let license_comments = stylesheet.license_comments.clone().into_owned();
+  let sources = stylesheet.sources;
+  let rules = stylesheet.rules.into_owned();
+  let license_comments = stylesheet.license_comments.into_owned();
 
   let mut stylesheet = StyleSheet::new(sources, rules, options);
   stylesheet.license_comments = license_comments;


### PR DESCRIPTION
## Summary

`builtin:lightningcss-loader` cloned each parsed stylesheet's sources, rule AST, and license comments before converting it to an owned `'static` stylesheet. This PR moves those fields directly, avoiding a full AST clone and an extra traversal for every CSS module while preserving output.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).