### PR TITLE
perf: avoid cloning CSS module lists during ordering

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -60,7 +60,7 @@ impl CssPlugin {
       return (vec![], None);
     };
 
-    let modules_list = modules.clone();
+    let modules_list = modules;
 
     // Get ordered list of modules per chunk group
 
@@ -121,12 +121,14 @@ impl CssPlugin {
 
     loop {
       let mut failed_modules: IdentifierSet = Default::default();
-      let list = modules_by_chunk_group[0].list.clone();
-      if list.is_empty() {
+      if modules_by_chunk_group[0].list.is_empty() {
         // done, everything empty
         break;
       }
-      let mut selected_module = *list.last().expect("list should not be empty");
+      let mut selected_module = *modules_by_chunk_group[0]
+        .list
+        .last()
+        .expect("list should not be empty");
       let mut has_failed = None;
       'outer: loop {
         for SortedModules { set, list } in &modules_by_chunk_group {

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -60,8 +60,6 @@ impl CssPlugin {
       return (vec![], None);
     };
 
-    let modules_list = modules;
-
     // Get ordered list of modules per chunk group
 
     let mut modules_by_chunk_group = chunk
@@ -74,9 +72,9 @@ impl CssPlugin {
           .expect_get(group)
       })
       .map(|chunk_group| {
-        let mut indexed_modules = modules_list
-          .clone()
-          .into_iter()
+        let mut indexed_modules = modules
+          .iter()
+          .copied()
           .filter_map(|module| {
             // ->: import
             // For A -> B -> C, the pre order is A: 0, B: 1, C: 2.


### PR DESCRIPTION
## Summary

CSS module ordering cloned the input module vector for every chunk group and cloned the remaining module list on every selection iteration, causing repeated allocations and quadratic reference copying for chunks with many CSS modules.

This PR iterates the borrowed input modules directly and reads the current candidate from the existing list without cloning, while preserving ordering behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).