### PR TITLE
fix: render HMR interceptor after persistent cache reuse

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -472,7 +472,14 @@ fn static_require_member_chain(
   assignment: Option<&AssignExpr>,
 ) -> Option<bool> {
   if parser.compiler_options.experiments.runtime_mode != ExperimentRuntimeMode::Rspack {
-    return None;
+    let is_intercept_module_execution_read = assignment.is_none()
+      && for_name == API_REQUIRE
+      && members.first().is_some_and(|property| {
+        RuntimeGlobals::INTERCEPT_MODULE_EXECUTION.property_name() == Some(property.as_ref())
+      });
+    if !is_intercept_module_execution_read {
+      return None;
+    }
   }
 
   if for_name == API_REQUIRE
@@ -764,9 +771,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
       return Some(true);
     }
 
-    if parser.compiler_options.experiments.runtime_mode != ExperimentRuntimeMode::Rspack {
-      return None;
-    }
     static_require_member_chain(
       parser,
       for_name,
@@ -786,9 +790,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
     _members_optionals: &[bool],
     member_ranges: &[Span],
   ) -> Option<bool> {
-    if parser.compiler_options.experiments.runtime_mode != ExperimentRuntimeMode::Rspack {
-      return None;
-    }
     let preserve_require_receiver =
       parser.parser_runtime_requirements.render_mode == RuntimeGlobalsRenderMode::RspackExport
         && for_name == API_REQUIRE

--- a/tests/rspack-test/compilerCases/persistent-cache-runtime-mode.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-runtime-mode.js
@@ -1,0 +1,112 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+
+const compile = (
+	workDir,
+	cacheDirectory,
+	outputDirectory,
+	runtimeMode
+) =>
+	new Promise((resolve, reject) => {
+		const compiler = rspack({
+			context: workDir,
+			entry: "./index.js",
+			mode: "development",
+			target: "node",
+			devtool: false,
+			cache: {
+				type: "persistent",
+				buildDependencies: [__filename],
+				storage: {
+					type: "filesystem",
+					directory: cacheDirectory
+				}
+			},
+			experiments: {
+				runtimeMode
+			},
+			output: {
+				path: outputDirectory,
+				filename: "main.js"
+			}
+		});
+
+		compiler.run((error, stats) => {
+			compiler.close(closeError => {
+				const finalError = error || closeError;
+				if (finalError) {
+					reject(finalError);
+				} else if (stats.hasErrors()) {
+					reject(new Error(stats.toString({ all: false, errors: true })));
+				} else {
+					resolve();
+				}
+			});
+		});
+	});
+
+/** @type {import("@rspack/test-tools").TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should render the HMR interceptor after recovering a persistent cache from another runtime mode",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./a"
+		};
+	},
+	async build(context) {
+		const workDir = context.getDist("persistent-cache-runtime-mode-workdir");
+		const cacheDirectory = context.getDist("persistent-cache-runtime-mode");
+		const outputDirectory = context.getDist(
+			"persistent-cache-runtime-mode-output"
+		);
+		fs.rmSync(workDir, { recursive: true, force: true });
+		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+		fs.mkdirSync(workDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(workDir, "index.js"),
+			[
+				"const interceptors = __webpack_require__.i;",
+				"__webpack_require__.i.push(function intercept() {});",
+				"module.exports = 42;"
+			].join("\n")
+		);
+
+		await compile(
+			workDir,
+			cacheDirectory,
+			outputDirectory,
+			"webpack"
+		);
+		context.setValue(
+			"webpackOutput",
+			fs.readFileSync(path.join(outputDirectory, "main.js"), "utf-8")
+		);
+
+		await compile(workDir, cacheDirectory, outputDirectory, "rspack");
+		context.setValue(
+			"rspackOutput",
+			fs.readFileSync(path.join(outputDirectory, "main.js"), "utf-8")
+		);
+	},
+	check({ context }) {
+		const webpackOutput = context.getValue("webpackOutput");
+		const rspackOutput = context.getValue("rspackOutput");
+
+		expect(webpackOutput).toContain("__webpack_require__.i.push");
+		expect(rspackOutput).toContain(
+			"const interceptors = __rspack_context.i;"
+		);
+		expect(rspackOutput).toContain("__rspack_context.i.push");
+		expect(rspackOutput).not.toContain("__webpack_require__.i.push");
+		expect(() =>
+			require(
+				context.getDist(
+					path.join("persistent-cache-runtime-mode-output", "main.js")
+				)
+			)
+		).not.toThrow();
+	}
+};


### PR DESCRIPTION
## Summary

When a persistent cache was first populated with `experiments.runtimeMode: "webpack"`, the parser did not collect a runtime-requirements dependency for `__webpack_require__.i`. Reusing that cached make artifact in `runtimeMode: "rspack"` therefore left the interceptor reference unchanged during code generation and could emit an undefined `__webpack_require__.i`.

This change:

- collects reads of the HMR interceptor runtime global in both runtime modes while preserving the existing behavior for writes and unrelated runtime members;
- keeps the runtime-mode-specific replacement in code generation, where the dependency template renders either `__webpack_require__.i` or `__rspack_context.i`;
- avoids adding `runtimeMode` to the global persistent-cache version, so unrelated make artifacts remain reusable;
- adds a compiler regression test that builds with webpack mode, reuses the same filesystem cache in rspack mode, verifies the generated identifiers, and executes the resulting bundle.

## Related links

N/A

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm --dir tests/rspack-test run test:base -- -t persistent-cache-runtime-mode`
- `pnpm run test:unit` (8884 passed, 4 skipped)
- `cargo clippy --workspace --all-targets --tests --locked -- -D warnings`
- `cargo fmt --all --check`
- `pnpm run format-ci:js`
- `pnpm run format-ci:toml`

## Checklist

- [x] Tests updated.
- [x] Documentation not required; this is an internal parser/code-generation fix.