### PR TITLE
chore: remove obsolete pnpm configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,1 @@
 registry=https://registry.npmjs.org/
-
-# The package of the same name conflicts with node:buffer and it will affect our ci results. https://www.npmjs.com/package/buffer 
-hoist-pattern[]=!buffer
-
-# Use symlinked executables instead of command shims with `NODE_PATH` to achieve better DX in debugging with LLDB, etc.
-# See: https://pnpm.io/npmrc#prefer-symlinked-executables
-prefer-symlinked-executables=true


### PR DESCRIPTION
## Summary

npm 11 warns about the unsupported `hoist-pattern` and `prefer-symlinked-executables` project settings when running `npx`. These pnpm-specific settings are no longer read from `.npmrc`, and the pnpm 11 CI setup already succeeds without them, so this removes the obsolete entries.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).