### PR TITLE
fix(runtime): avoid dead require bootstrap

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
@@ -167,7 +167,8 @@ var module = ({module_cache}[moduleId] = {{"#,
       || has_custom_runtime_module;
     let need_module_defer =
       runtime_requirements.contains(RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT);
-    let use_require = require_function || intercept_module_execution || module_used;
+    let use_require =
+      require_function || intercept_module_execution || (module_used && module_factories);
     let mut header: Vec<Cow<str>> = Vec::new();
     let mut startup: Vec<Cow<str>> = Vec::new();
     let mut allow_inline_startup = true;

--- a/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
@@ -152,7 +152,6 @@ var module = ({module_cache}[moduleId] = {{"#,
     let module_cache = runtime_requirements.contains(RuntimeGlobals::MODULE_CACHE);
     let intercept_module_execution =
       runtime_requirements.contains(RuntimeGlobals::INTERCEPT_MODULE_EXECUTION);
-    let module_used = runtime_requirements.contains(RuntimeGlobals::MODULE);
     let has_custom_runtime_module = compilation
       .build_chunk_graph_artifact
       .chunk_graph
@@ -167,8 +166,20 @@ var module = ({module_cache}[moduleId] = {{"#,
       || has_custom_runtime_module;
     let need_module_defer =
       runtime_requirements.contains(RuntimeGlobals::MAKE_DEFERRED_NAMESPACE_OBJECT);
-    let use_require =
-      require_function || intercept_module_execution || (module_used && module_factories);
+    let module_used = compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .get_chunk_entry_modules(chunk_ukey)
+      .iter()
+      .any(|module_identifier| {
+        ChunkGraph::get_module_runtime_requirements(
+          compilation,
+          *module_identifier,
+          chunk.runtime(),
+        )
+        .is_some_and(|requirements| requirements.contains(RuntimeGlobals::MODULE))
+      });
+    let use_require = require_function || intercept_module_execution || module_used;
     let mut header: Vec<Cow<str>> = Vec::new();
     let mut startup: Vec<Cow<str>> = Vec::new();
     let mut allow_inline_startup = true;

--- a/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/index.js
+++ b/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/index.js
@@ -1,0 +1,3 @@
+import logo from "./logo.svg";
+
+export { logo };

--- a/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/logo.svg
+++ b/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path d="M0 0h1v1H0z"/>
+</svg>

--- a/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/rspack.config.js
+++ b/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/rspack.config.js
@@ -1,0 +1,26 @@
+const {
+  experiments: { RslibPlugin },
+} = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  experiments: {
+    runtimeMode: 'rspack',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.svg$/,
+        type: 'asset/resource',
+      },
+    ],
+  },
+  output: {
+    iife: false,
+    library: {
+      type: 'commonjs-static',
+    },
+  },
+  plugins: [new RslibPlugin()],
+};

--- a/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/test.config.js
+++ b/tests/rspack-test/configCases/rslib/no-dead-require-bootstrap/test.config.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	afterExecute(options) {
+		const source = fs.readFileSync(options.output.path + "/bundle0.js", "utf-8");
+
+		expect(source).not.toContain("function __rspack_require");
+		expect(source).not.toContain("var __rspack_module_cache");
+		expect(source).not.toContain("__rspack_modules[moduleId]");
+	}
+};


### PR DESCRIPTION
## Summary

- avoid emitting the Rspack require bootstrap when `module` is used but no module factory table exists
- remove the resulting dead module cache and undeclared module-table reference from Rslib-style static CommonJS output
- add regression coverage for asset output using `runtimeMode: "rspack"`

## Related links

- https://github.com/web-infra-dev/rslib/pull/1806#issuecomment-5103444616

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `cargo fmt --all --check`
- local development binding build
- `rstest --project base -t 'rslib/no-dead-require-bootstrap' Config.part3.test.js RuntimeModeConfig.part3.test.js`
- `rstest --project base -t 'runtime/runtime-mode' RuntimeModeConfig.part1.test.js RuntimeModeConfig.part2.test.js RuntimeModeConfig.part3.test.js`