### PR TITLE
fix: avoid rspack runtime name conflicts

### DIFF
--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -597,14 +597,17 @@ impl EsmLibraryPlugin {
       escaped_identifiers.insert(identifier, parts);
     }
 
-    let runtime_module_used_names = Self::collect_rspack_export_runtime_used_names(compilation);
-    let deconflict_context = DeconflictSymbolsContext {
-      runtime_module_used_names: &runtime_module_used_names,
-      escaped_names: &escaped_names,
-      escaped_identifiers: &escaped_identifiers,
-    };
-
     for chunk_link in link.values_mut() {
+      let runtime_module_used_names = Self::collect_rspack_export_runtime_used_names(
+        compilation,
+        chunk_link,
+        &concate_modules_map,
+      );
+      let deconflict_context = DeconflictSymbolsContext {
+        runtime_module_used_names: &runtime_module_used_names,
+        escaped_names: &escaped_names,
+        escaped_identifiers: &escaped_identifiers,
+      };
       self.deconflict_symbols(
         compilation,
         &mut concate_modules_map,
@@ -956,7 +959,11 @@ var {} = {{}};
     }
   }
 
-  fn collect_rspack_export_runtime_used_names(compilation: &Compilation) -> FxHashSet<Atom> {
+  fn collect_rspack_export_runtime_used_names(
+    compilation: &Compilation,
+    chunk_link: &ChunkLinkContext,
+    concate_modules_map: &IdentifierIndexMap<ModuleInfo>,
+  ) -> FxHashSet<Atom> {
     let mut used_names = FxHashSet::default();
     let runtime_template = compilation
       .runtime_template
@@ -965,7 +972,34 @@ var {} = {{}};
       return used_names;
     }
 
+    let runtime_requirements = chunk_link
+      .decl_modules
+      .iter()
+      .chain(chunk_link.hoisted_modules.iter())
+      .fold(RuntimeGlobals::default(), |requirements, module| {
+        requirements | *concate_modules_map[module].get_runtime_requirements()
+      });
+
     used_names.extend(all_runtime_module_variables().map(Atom::from));
+
+    if runtime_requirements.is_empty()
+      && chunk_link.decl_modules.is_empty()
+      && compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_chunk_modules_identifier(&chunk_link.chunk)
+        .iter()
+        .all(|module| {
+          compilation
+            .get_module_graph()
+            .module_by_identifier(module)
+            .is_some_and(|module| {
+              module.build_meta().exports_type() == BuildMetaExportsType::Namespace
+            })
+        })
+    {
+      return used_names;
+    }
 
     for (_, runtime_global) in RuntimeGlobals::all().iter_names() {
       used_names.insert(
@@ -980,7 +1014,6 @@ var {} = {{}};
 
     for runtime_variable in [
       RuntimeVariable::Require,
-      RuntimeVariable::Context,
       RuntimeVariable::Modules,
       RuntimeVariable::ModuleCache,
       RuntimeVariable::Module,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -26,11 +26,13 @@ pub struct CompatibilityPlugin;
 
 impl CompatibilityPlugin {
   fn nested_require_name<'a>(&self, parser: &'a JavascriptParser) -> &'a str {
-    if parser.compiler_options.experiments.runtime_mode == RuntimeMode::Rspack {
-      parser.parser_runtime_requirements.context.as_str()
-    } else {
-      parser.parser_runtime_requirements.require.as_str()
-    }
+    parser.parser_runtime_requirements.require.as_str()
+  }
+
+  fn is_top_level_esm_binding(&self, parser: &JavascriptParser) -> bool {
+    parser.compiler_options.experiments.runtime_mode == RuntimeMode::Rspack
+      && parser.is_esm
+      && parser.is_top_level_scope()
   }
 
   pub fn browserify_require_handler(
@@ -106,6 +108,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
   ) -> Option<bool> {
     let ident = decl.name.as_ident()?;
 
+    if self.is_top_level_esm_binding(parser) {
+      return None;
+    }
+
     if ident.id.sym.as_str() == self.nested_require_name(parser) {
       let span = ident.span();
       let start = span.real_lo();
@@ -147,6 +153,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
     ident: &Ident,
     for_name: &str,
   ) -> Option<bool> {
+    if self.is_top_level_esm_binding(parser) {
+      return None;
+    }
+
     if for_name == parser.parser_runtime_requirements.exports {
       self.tag_nested_require_data(
         parser,
@@ -186,7 +196,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
     let fn_decl = stmt.as_function_decl()?;
     let ident = fn_decl.ident()?;
     let name = &ident.sym;
-    if name.as_str() != self.nested_require_name(parser) {
+    if self.is_top_level_esm_binding(parser) || name.as_str() != self.nested_require_name(parser) {
       None
     } else {
       self.tag_nested_require_data(

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/__snapshots__/esm.snap.txt
@@ -1,0 +1,100 @@
+```mjs title=main.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+})();
+
+__webpack_require__.add({
+"./require.cjs"
+/*!*********************!*\
+  !*** ./require.cjs ***!
+  \*********************/
+(module, __unused_rspack_exports, __webpack_require__) {
+const rspackRequire = __webpack_require__(/*! ./value.cjs */ "./value.cjs");
+
+module.exports = rspackRequire;
+
+
+},
+"./value.cjs"
+/*!*******************!*\
+  !*** ./value.cjs ***!
+  \*******************/
+(module) {
+module.exports = 42;
+
+
+},
+});
+// ./index.js
+const require_0 = __webpack_require__("./require.cjs");
+var require_0_default = /*#__PURE__*/__webpack_require__.n(require_0);
+
+
+function context() {}
+const index_exports = 42;
+
+it("should preserve exported bindings that conflict with runtime names", () => {
+	expect(context.name).toBe("context");
+	expect(index_exports).toBe(42);
+	expect((require_0_default())).toBe(42);
+});
+
+export { context, index_exports as exports };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,92 @@
+```mjs title=main.mjs
+
+var modules = {};
+// The module cache
+var moduleCache = {};
+// The require function
+function rspackRequire(moduleId) {
+// Check if module is in cache
+var cachedModule = moduleCache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (moduleCache[moduleId] = {
+exports: {}
+});
+// Execute the module function
+modules[moduleId](module, module.exports, rspackRequire);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (modules)
+var moduleFactories = modules;
+
+// rspack/runtime/compat_get_default_export
+// getDefaultExport function for compatibility with non-ESM modules
+var compatGetDefaultExport = (module) => {
+	var getter = module && module.__esModule ?
+		() => (module['default']) :
+		() => (module);
+	definePropertyGetters(getter, { a: getter });
+	return getter;
+};
+;
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+// rspack/runtime/esm_register_module
+moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+
+moduleFactories.add({
+"./require.cjs"
+/*!*********************!*\
+  !*** ./require.cjs ***!
+  \*********************/
+(module, __unused_rspack_exports, rspackRequire) {
+const __nested_rspack_require_6_19__ = rspackRequire(/*! ./value.cjs */ "./value.cjs");
+
+module.exports = __nested_rspack_require_6_19__;
+
+
+},
+"./value.cjs"
+/*!*******************!*\
+  !*** ./value.cjs ***!
+  \*******************/
+(module) {
+module.exports = 42;
+
+
+},
+});
+// ./index.js
+const require_0 = rspackRequire("./require.cjs");
+var require_0_default = /*#__PURE__*/compatGetDefaultExport(require_0);
+
+
+function context() {}
+const index_exports = 42;
+
+it("should preserve exported bindings that conflict with runtime names", () => {
+	expect(context.name).toBe("context");
+	expect(index_exports).toBe(42);
+	expect((require_0_default())).toBe(42);
+});
+
+export { context, index_exports as exports };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/index.js
@@ -1,0 +1,10 @@
+import cjsValue from "./require.cjs";
+
+export function context() {}
+export const exports = 42;
+
+it("should preserve exported bindings that conflict with runtime names", () => {
+	expect(context.name).toBe("context");
+	expect(exports).toBe(42);
+	expect(cjsValue).toBe(42);
+});

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/require.cjs
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/require.cjs
@@ -1,0 +1,3 @@
+const rspackRequire = require("./value.cjs");
+
+module.exports = rspackRequire;

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  optimization: {
+    runtimeChunk: false,
+  },
+};

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/test.config.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/test.config.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	afterExecute(options) {
+		if (!globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) return;
+
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8",
+		);
+
+		expect(source).toContain("function context()");
+		expect(source).toContain("as exports");
+		expect(source).not.toContain("function __nested_rspack");
+	},
+};

--- a/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/value.cjs
+++ b/tests/rspack-test/esmOutputCases/deconflict/runtime-name-conflicts/value.cjs
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/__snapshots__/esm.snap.txt
@@ -1,0 +1,30 @@
+```mjs title=main.mjs
+// ./index.js
+function rspackRequire() {}
+function publicPath() {}
+function modules() {}
+function context() {}
+const index_exports = 42;
+
+const actualNames = [
+	rspackRequire.name,
+	publicPath.name,
+	modules.name,
+	context.name,
+];
+
+it("should not reserve runtime names when no runtime is emitted", () => {
+	expect(actualNames).toEqual([
+		"rspackRequire",
+		"publicPath",
+		"modules",
+		"context",
+	]);
+	expect(index_exports).toBe(42);
+	expect((/* inlined export .value */42)).toBe(42);
+});
+
+
+export { actualNames, context, index_exports as exports, modules, publicPath, rspackRequire };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,30 @@
+```mjs title=main.mjs
+// ./index.js
+function rspackRequire() {}
+function publicPath() {}
+function modules() {}
+function context() {}
+const index_exports = 42;
+
+const actualNames = [
+	rspackRequire.name,
+	publicPath.name,
+	modules.name,
+	context.name,
+];
+
+it("should not reserve runtime names when no runtime is emitted", () => {
+	expect(actualNames).toEqual([
+		"rspackRequire",
+		"publicPath",
+		"modules",
+		"context",
+	]);
+	expect(index_exports).toBe(42);
+	expect((/* inlined export .value */42)).toBe(42);
+});
+
+
+export { actualNames, context, index_exports as exports, modules, publicPath, rspackRequire };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/index.js
@@ -1,0 +1,24 @@
+export function rspackRequire() {}
+export function publicPath() {}
+export function modules() {}
+export function context() {}
+export const exports = 42;
+
+export const actualNames = [
+	rspackRequire.name,
+	publicPath.name,
+	modules.name,
+	context.name,
+];
+
+it("should not reserve runtime names when no runtime is emitted", () => {
+	expect(actualNames).toEqual([
+		"rspackRequire",
+		"publicPath",
+		"modules",
+		"context",
+	]);
+	expect(exports).toBe(42);
+	expect(value).toBe(42);
+});
+import { value } from "./value.js";

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/test.config.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/test.config.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	afterExecute(options) {
+		if (!globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) return;
+
+		const source = fs.readFileSync(
+			path.join(options.output.path, "main.mjs"),
+			"utf-8",
+		);
+
+		expect(source).not.toContain("__nested_rspack");
+	},
+};

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/value.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-runtime-names/value.js
@@ -1,0 +1,1 @@
+export const value = 42;


### PR DESCRIPTION
## Summary

- deconflict Rspack export runtime names per chunk and avoid reserving core runtime names for runtime-free ESM chunks
- use the actual `rspackRequire` module factory argument when handling nested bindings
- leave top-level ESM bindings to the ESM linker while preserving CJS factory parameter safety
- add execution coverage for `context`, `exports`, local CJS `rspackRequire`, and runtime-free exported function names

## Testing

- `corepack pnpm --filter @rspack/binding run build:dev`
- `corepack pnpm --parallel --filter '@rspack/*' test`\n- targeted RuntimeModeEsmOutput regression cases\n- `cargo check -p rspack_plugin_esm_library -p rspack_plugin_javascript`