### PR TITLE
fix: clean up compilation-scoped plugin caches

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -673,4 +673,8 @@ impl Plugin for CssPlugin {
 
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_HOOKS_MAP.remove(&id);
+  }
 }

--- a/crates/rspack_plugin_rsdoctor/src/plugin.rs
+++ b/crates/rspack_plugin_rsdoctor/src/plugin.rs
@@ -703,5 +703,9 @@ impl Plugin for RsdoctorPlugin {
 
   fn clear_cache(&self, id: CompilationId) {
     COMPILATION_HOOKS_MAP.remove(&id);
+    MODULE_UKEY_MAP.remove(&id);
+    ENTRYPOINT_UKEY_MAP.remove(&id);
+    JSON_MODULE_SIZE_MAP.remove(&id);
+    ACTIVE_EXPORT_USAGE_DEPENDENCY_MAP.remove(&id);
   }
 }

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -221,4 +221,9 @@ impl Plugin for SubresourceIntegrityPlugin {
       .tap(handle_runtime::new(self));
     Ok(())
   }
+
+  fn clear_cache(&self, id: CompilationId) {
+    COMPILATION_INTEGRITY_MAP.remove(&id);
+    COMPILATION_CONTEXT_MAP.remove(&id);
+  }
 }


### PR DESCRIPTION
## Summary

- Remove CSS plugin compilation hooks when a compilation is released.
- Remove all Rsdoctor maps keyed by the released compilation ID.
- Remove SRI integrity and context state when a compilation is released.

## Problem

These plugins keep compilation-specific state in process-wide maps keyed by `CompilationId`. Most entries were never removed from those maps after the compilation finished. Long-lived compiler processes and repeated incremental compilations could therefore retain obsolete hooks, module metadata, integrity data, and compilation contexts indefinitely.

## Why this fixes it

Each plugin now implements or extends `clear_cache` to remove every map entry owned by the released compilation. The cleanup runs through the existing plugin lifecycle, so state remains available for the lifetime of the compilation and is discarded once it can no longer be used.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_plugin_css -p rspack_plugin_rsdoctor -p rspack_plugin_sri`

The full-hash runtime filename correction is kept separately in #14997.
