### PR TITLE
fix: preserve context exports in rspack runtime mode

### DIFF
--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -867,6 +867,14 @@ impl ModuleCodeTemplate {
     self.runtime_globals.render(runtime_globals)
   }
 
+  pub fn render_runtime_scope(&self) -> String {
+    let render_mode = match self.runtime_globals_render_mode {
+      RuntimeGlobalsRenderMode::Webpack => RuntimeGlobalsRenderMode::Webpack,
+      _ => RuntimeGlobalsRenderMode::RspackContext,
+    };
+    get_runtime_globals_render_map(render_mode).render(&RuntimeGlobals::REQUIRE_SCOPE)
+  }
+
   pub fn define_es_module_flag_statement(&mut self, exports_argument: ExportsArgument) -> String {
     format!(
       "{}({});\n",

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -43,6 +43,7 @@ pub struct ParserRuntimeRequirementsData {
   pub rspack_module: String,
   pub exports: String,
   pub require: String,
+  pub compatibility_runtime_scope: String,
   pub require_regex: &'static LazyLock<Regex>,
   pub module_cache: String,
   pub entry_module_id: String,
@@ -110,6 +111,7 @@ impl ParserRuntimeRequirementsData {
   pub fn new(runtime_template: &ModuleCodeTemplate) -> Self {
     let require_name =
       runtime_template.render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE);
+    let compatibility_runtime_scope = runtime_template.render_runtime_scope();
     let module_name =
       runtime_template.render_runtime_globals_without_adding(&RuntimeGlobals::MODULE);
     let exports_name =
@@ -128,6 +130,7 @@ impl ParserRuntimeRequirementsData {
       rspack_module: rspack_module_name,
       exports: exports_name,
       require: require_name,
+      compatibility_runtime_scope,
       module_cache: module_cache_name,
       entry_module_id: entry_module_id_name,
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -1,7 +1,4 @@
-use rspack_core::{
-  BoxDependencyTemplate, ConstDependency, ContextDependency, DependencyRange,
-  runtime_mode::RuntimeMode,
-};
+use rspack_core::{BoxDependencyTemplate, ConstDependency, ContextDependency, DependencyRange};
 use rspack_util::{SpanExt, itoa};
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{CallExpr, GetSpan, Ident, Program, VarDeclarator};
@@ -26,11 +23,10 @@ pub struct CompatibilityPlugin;
 
 impl CompatibilityPlugin {
   fn nested_require_name<'a>(&self, parser: &'a JavascriptParser) -> &'a str {
-    if parser.compiler_options.experiments.runtime_mode == RuntimeMode::Rspack {
-      parser.parser_runtime_requirements.context.as_str()
-    } else {
-      parser.parser_runtime_requirements.require.as_str()
-    }
+    parser
+      .parser_runtime_requirements
+      .compatibility_runtime_scope
+      .as_str()
   }
 
   pub fn browserify_require_handler(

--- a/tests/rspack-test/esmOutputCases/deconflict/context-export/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/context-export/__snapshots__/esm.snap.txt
@@ -1,0 +1,13 @@
+```mjs title=main.mjs
+// ./index.js
+function context() {}
+
+it("should preserve an exported context binding", () => {
+	expect(context.name).toBe(
+		globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK ? "index_context" : "context",
+	);
+});
+
+export { context };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/context-export/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/context-export/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,13 @@
+```mjs title=main.mjs
+// ./index.js
+function index_context() {}
+
+it("should preserve an exported context binding", () => {
+	expect(index_context.name).toBe(
+		 true ? "index_context" : 0,
+	);
+});
+
+export { index_context as context };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/context-export/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/context-export/index.js
@@ -1,0 +1,7 @@
+export function context() {}
+
+it("should preserve an exported context binding", () => {
+	expect(context.name).toBe(
+		globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK ? "index_context" : "context",
+	);
+});


### PR DESCRIPTION
## Summary

- derive the CompatibilityPlugin require identifier by rendering `RuntimeGlobals::REQUIRE_SCOPE` with the non-export runtime representation
- recognize `__webpack_require__` in webpack mode and `__rspack_context` in Rspack modes without hardcoded identifiers
- avoid misclassifying a user-defined `context` binding as a nested runtime require binding
- leave top-level collision handling to the ESM linker and add execution coverage in both runtime modes

## Testing

- `cargo check -p rspack_core -p rspack_plugin_javascript`
- `corepack pnpm --filter @rspack/binding run build:dev`
- targeted EsmOutput and RuntimeModeEsmOutput cases