### PR TITLE
fix: avoid runtime scope conflicts in module factories

### DIFF
--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -362,7 +362,7 @@ impl RuntimeTemplate {
     RuntimeCodeTemplate::new(
       self.compiler_options.clone(),
       self.render_mode.runtime_module_render_mode(),
-      self.dojang.clone(),
+      Some(self.dojang.clone()),
     )
   }
 
@@ -371,7 +371,7 @@ impl RuntimeTemplate {
     RuntimeCodeTemplate::new(
       self.compiler_options.clone(),
       self.render_mode.chunk_render_mode(),
-      self.dojang.clone(),
+      None,
     )
   }
 }
@@ -868,11 +868,17 @@ impl ModuleCodeTemplate {
   }
 
   pub fn render_runtime_scope(&self) -> String {
-    let render_mode = match self.runtime_globals_render_mode {
-      RuntimeGlobalsRenderMode::Webpack => RuntimeGlobalsRenderMode::Webpack,
-      _ => RuntimeGlobalsRenderMode::RspackContext,
-    };
-    get_runtime_globals_render_map(render_mode).render(&RuntimeGlobals::REQUIRE_SCOPE)
+    match self.runtime_globals_render_mode {
+      RuntimeGlobalsRenderMode::Webpack => {
+        WEBPACK_RUNTIME_GLOBALS.render(&RuntimeGlobals::REQUIRE_SCOPE)
+      }
+      RuntimeGlobalsRenderMode::RspackExport => {
+        self.runtime_globals.render(&RuntimeGlobals::REQUIRE)
+      }
+      RuntimeGlobalsRenderMode::RspackContext | RuntimeGlobalsRenderMode::RspackLexical => {
+        RSPACK_CONTEXT_RUNTIME_GLOBALS.render(&RuntimeGlobals::REQUIRE_SCOPE)
+      }
+    }
   }
 
   pub fn define_es_module_flag_statement(&mut self, exports_argument: ExportsArgument) -> String {
@@ -1823,14 +1829,22 @@ pub struct RuntimeCodeTemplate {
   compiler_options: Arc<CompilerOptions>,
   render_mode: RuntimeGlobalsRenderMode,
   runtime_globals: Arc<RuntimeGlobalsRenderMap>,
-  dojang: Arc<Dojang>,
+  dojang: Option<Arc<Dojang>>,
+}
+
+impl Debug for RuntimeCodeTemplate {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("RuntimeCodeTemplate")
+      .field("render_mode", &self.render_mode)
+      .finish_non_exhaustive()
+  }
 }
 
 impl RuntimeCodeTemplate {
   fn new(
     compiler_options: Arc<CompilerOptions>,
     render_mode: RuntimeGlobalsRenderMode,
-    dojang: Arc<Dojang>,
+    dojang: Option<Arc<Dojang>>,
   ) -> Self {
     Self {
       compiler_options,
@@ -1897,6 +1911,26 @@ impl RuntimeCodeTemplate {
     "this".to_string()
   }
 
+  pub fn basic_function(&self, args: &str, body: &str) -> String {
+    if self
+      .compiler_options
+      .output
+      .environment
+      .supports_arrow_function()
+    {
+      format!(
+        r#"({args}) => {{
+{body}
+}}"#
+      )
+    } else {
+      format!(
+        r#"function({args}) {{
+{body}
+}}"#
+      )
+    }
+  }
   pub fn render(&self, key: &str, params: Option<serde_json::Value>) -> Result<String, Error> {
     let mut render_params = Value::Object(Default::default());
 
@@ -1924,12 +1958,16 @@ impl RuntimeCodeTemplate {
       }
     }
 
-    if let Some((executer, file_content)) = self.dojang.templates.get(key) {
+    let dojang = self
+      .dojang
+      .as_ref()
+      .expect("chunk code templates cannot render runtime module templates");
+    if let Some((executer, file_content)) = dojang.templates.get(key) {
       executer
         .render(
           &mut Context::new(render_params),
-          &self.dojang.templates,
-          &self.dojang.functions,
+          &dojang.templates,
+          &dojang.functions,
           file_content,
           #[cfg_attr(
             dylint_lib = "rspack_collection_hasher",
@@ -1944,27 +1982,6 @@ impl RuntimeCodeTemplate {
         })
     } else {
       Err(error!("Runtime module: Template {key} is not found"))
-    }
-  }
-
-  pub fn basic_function(&self, args: &str, body: &str) -> String {
-    if self
-      .compiler_options
-      .output
-      .environment
-      .supports_arrow_function()
-    {
-      format!(
-        r#"({args}) => {{
-{body}
-}}"#
-      )
-    } else {
-      format!(
-        r#"function({args}) {{
-{body}
-}}"#
-      )
     }
   }
 }

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::borrow::Cow;
 
 use cow_utils::CowUtils;
@@ -85,9 +87,13 @@ async fn render_module_content(
   chunk_ukey: &ChunkUkey,
   module: &dyn Module,
   render_source: &mut RenderSource,
+  runtime_requirements: &mut RuntimeGlobals,
   _init_fragments: &mut ChunkInitFragments,
   runtime_template: &RuntimeCodeTemplate,
 ) -> Result<()> {
+  if compilation.options.output.trusted_types.is_some() {
+    runtime_requirements.insert(RuntimeGlobals::CREATE_SCRIPT);
+  }
   let origin_source = render_source.source.clone();
   if let Some(cached_source) = self.cache.get(&origin_source) {
     render_source.source = cached_source.value().clone();

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::{borrow::Cow, sync::Arc};
 
 use derive_more::Debug;
@@ -95,9 +97,13 @@ async fn render_module_content(
   chunk: &ChunkUkey,
   module: &dyn Module,
   render_source: &mut RenderSource,
+  runtime_requirements: &mut RuntimeGlobals,
   _init_fragments: &mut ChunkInitFragments,
   runtime_template: &RuntimeCodeTemplate,
 ) -> Result<()> {
+  if compilation.options.output.trusted_types.is_some() {
+    runtime_requirements.insert(RuntimeGlobals::CREATE_SCRIPT);
+  }
   let output_options = &compilation.options.output;
   let chunk = compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1498,6 +1498,7 @@ var {} = {{}};
                 let mut render_source = RenderSource {
                   source: js_source.clone(),
                 };
+                let mut runtime_requirements = codegen_res.runtime_requirements;
 
                 let mut chunk_init_fragments = vec![];
                 hooks
@@ -1510,6 +1511,7 @@ var {} = {{}};
                       .expect("should have module")
                       .as_ref(),
                     &mut render_source,
+                    &mut runtime_requirements,
                     &mut chunk_init_fragments,
                     runtime_template,
                   )
@@ -1612,7 +1614,7 @@ var {} = {{}};
                 concate_info.has_ast = true;
                 concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
                 concate_info.internal_source = Some(render_source.source.clone());
-                concate_info.runtime_requirements = codegen_res.runtime_requirements;
+                concate_info.runtime_requirements = runtime_requirements;
                 concate_info.chunk_init_fragments = codegen_res
                   .data
                   .get::<ChunkInitFragments>()

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -716,7 +716,6 @@ var {} = {{}};
     } else {
       final_source
     };
-
     Ok(Some(RenderSource {
       source: final_source,
     }))

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -1,7 +1,9 @@
+#![allow(clippy::too_many_arguments)]
+
 use rspack_core::{
   ChunkInitFragments, ChunkUkey, Compilation, CompilationParams, CompilerCompilation,
   InitFragmentExt, InitFragmentKey, InitFragmentStage, Module, NormalInitFragment, Plugin,
-  RuntimeCodeTemplate,
+  RuntimeCodeTemplate, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -34,6 +36,7 @@ async fn render_module_content(
   _chunk_ukey: &ChunkUkey,
   module: &dyn Module,
   _source: &mut RenderSource,
+  _runtime_requirements: &mut RuntimeGlobals,
   init_fragments: &mut ChunkInitFragments,
   _runtime_template: &RuntimeCodeTemplate,
 ) -> Result<()> {

--- a/crates/rspack_plugin_javascript/src/plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/drive.rs
@@ -1,6 +1,8 @@
+#![allow(clippy::too_many_arguments)]
+
 use rspack_core::{
   AssetInfo, BoxModule, Chunk, ChunkInitFragments, ChunkUkey, Compilation, Module,
-  ModuleIdentifier, RuntimeCodeTemplate, rspack_sources::BoxSource,
+  ModuleIdentifier, RuntimeCodeTemplate, RuntimeGlobals, rspack_sources::BoxSource,
 };
 use rspack_hash::RspackHasher;
 use rspack_hook::define_hook;
@@ -11,7 +13,7 @@ define_hook!(JavascriptModulesRenderChunk: Series(compilation: &Compilation, chu
 define_hook!(JavascriptModulesRenderChunkContent: SeriesBail(compilation: &Compilation, chunk_ukey: &ChunkUkey, asset_info: &mut AssetInfo, runtime_template: &RuntimeCodeTemplate) -> RenderSource);
 define_hook!(JavascriptModulesRender: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, source: &mut RenderSource, runtime_template: &RuntimeCodeTemplate));
 define_hook!(JavascriptModulesRenderStartup: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &ModuleIdentifier, source: &mut RenderSource, runtime_template: &RuntimeCodeTemplate));
-define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate),tracing=false);
+define_hook!(JavascriptModulesRenderModuleContent: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, runtime_requirements: &mut RuntimeGlobals, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesRenderModuleContainer: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey,module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesRenderModulePackage: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, module: &dyn Module, source: &mut RenderSource, init_fragments: &mut ChunkInitFragments, runtime_template: &RuntimeCodeTemplate),tracing=false);
 define_hook!(JavascriptModulesChunkHash: Series(compilation: &Compilation, chunk_ukey: &ChunkUkey, hasher: &mut RspackHasher));

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -896,7 +896,6 @@ var {} = {{}};
         {
           rendered_module = source.clone();
         };
-
         chunk_init_fragments.extend(fragments);
         chunk_init_fragments.extend(additional_fragments);
         let inner_strict = !all_strict && m.build_info().strict;

--- a/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
@@ -801,7 +801,6 @@ impl JsPlugin {
         {
           rendered_module = source.clone();
         };
-
         chunk_init_fragments.extend(fragments);
         chunk_init_fragments.extend(additional_fragments);
         let inner_strict = !all_strict && m.build_info().strict;

--- a/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
@@ -1,10 +1,12 @@
+#![allow(clippy::too_many_arguments)]
+
 use concat_string::concat_string;
 use rspack_core::{
   ChunkInitFragments, ChunkUkey, CodeGenerationDataFilename, Compilation, CompilationParams,
   CompilerCompilation, DependencyId, JavascriptParserUrl, Module, ModuleType,
   NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, PathData, Plugin, PublicPath,
-  RuntimeCodeTemplate, RuntimeSpec, SourceType, URLStaticMode, get_js_chunk_filename_template,
-  get_undo_path,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeSpec, SourceType, URLStaticMode,
+  get_js_chunk_filename_template, get_undo_path,
   rspack_sources::{BoxSource, ReplaceSource, SourceExt},
 };
 use rspack_error::Result;
@@ -196,6 +198,7 @@ async fn render_module_content(
   chunk_ukey: &ChunkUkey,
   module: &dyn Module,
   render_source: &mut RenderSource,
+  _runtime_requirements: &mut RuntimeGlobals,
   _init_fragments: &mut ChunkInitFragments,
   _runtime_template: &RuntimeCodeTemplate,
 ) -> Result<()> {

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 use rspack_core::{
   ChunkGraph, ChunkInitFragments, ChunkKind, ChunkUkey, CodeGenerationPublicPathAutoReplace,
-  Compilation, Module, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModuleGenerateContext,
-  SourceType,
+  Compilation, Module, RuntimeCodeTemplate, RuntimeGlobals, RuntimeGlobalsRenderMode,
+  RuntimeModuleGenerateContext, SourceType,
   chunk_graph_chunk::ChunkIdSet,
   get_undo_path, render_runtime_module_source,
   rspack_sources::{
@@ -136,6 +136,7 @@ pub async fn render_module(
     Some(fragments) => fragments.clone(),
     None => ChunkInitFragments::default(),
   };
+  let mut render_runtime_requirements = code_gen_result.runtime_requirements;
 
   let mut render_source = if code_gen_result
     .data
@@ -191,6 +192,7 @@ pub async fn render_module(
       chunk_ukey,
       module,
       &mut render_source,
+      &mut render_runtime_requirements,
       &mut module_chunk_init_fragments,
       runtime_template,
     )
@@ -214,21 +216,16 @@ pub async fn render_module(
 
       let need_module = runtime_requirements.is_some_and(|r| r.contains(RuntimeGlobals::MODULE));
       let need_exports = runtime_requirements.is_some_and(|r| r.contains(RuntimeGlobals::EXPORTS));
-      let need_require = runtime_requirements.is_some_and(|r| {
-        r.contains(RuntimeGlobals::REQUIRE)
-          || r.contains(RuntimeGlobals::REQUIRE_SCOPE)
-          || (compilation.options.experiments.runtime_mode == RuntimeMode::Rspack
-            && !r.renderable_require_scope().is_empty())
-      });
-      let need_require = if need_require {
-        render_source
-          .source
-          .source()
-          .into_string_lossy()
-          .contains(&runtime_template.render_runtime_argument())
-      } else {
-        need_require
-      };
+      let need_require = runtime_template.render_mode() != RuntimeGlobalsRenderMode::RspackExport
+        && (render_runtime_requirements.contains(RuntimeGlobals::REQUIRE)
+          || render_runtime_requirements.contains(RuntimeGlobals::REQUIRE_SCOPE)
+          || !render_runtime_requirements
+            .renderable_require_scope()
+            .is_empty());
+      let module_runtime_scope = compilation
+        .runtime_template
+        .create_module_code_template()
+        .render_runtime_scope();
 
       let mut args = Vec::new();
       if need_module || need_exports || need_require {
@@ -250,7 +247,7 @@ pub async fn render_module(
         });
       }
       if need_require {
-        args.push(runtime_template.render_runtime_argument());
+        args.push(module_runtime_scope);
       }
 
       let mut container_sources = ConcatSource::default();

--- a/crates/rspack_plugin_sri/src/config.rs
+++ b/crates/rspack_plugin_sri/src/config.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use derive_more::Debug;
 use futures::future::BoxFuture;
-use rspack_core::{CrossOriginLoading, ModuleCodeTemplate};
+use rspack_core::CrossOriginLoading;
 use rspack_error::Result;
 use rspack_fs::WritableFileSystem;
 use rspack_paths::Utf8PathBuf;
@@ -54,7 +54,7 @@ pub struct SRICompilationContext {
   pub fs: ArcFs,
   pub output_path: Utf8PathBuf,
   pub cross_origin_loading: CrossOriginLoading,
-  pub runtime_template: ModuleCodeTemplate,
+  pub runtime_require_name: String,
 }
 
 pub struct IntegrityCallbackData {

--- a/crates/rspack_plugin_sri/src/lib.rs
+++ b/crates/rspack_plugin_sri/src/lib.rs
@@ -17,7 +17,7 @@ use html::{alter_asset_tag_groups, before_asset_tag_generation};
 pub use integrity::SubresourceIntegrityHashFunction;
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, Compilation, CompilationId, CompilationParams,
-  CompilerThisCompilation, CrossOriginLoading, Plugin,
+  CompilerThisCompilation, CrossOriginLoading, Plugin, RuntimeGlobals,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -119,11 +119,17 @@ async fn handle_compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
+  let runtime_require_name = {
+    let runtime_template = compilation
+      .runtime_template
+      .create_runtime_module_code_template();
+    runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE)
+  };
   let ctx = SRICompilationContext {
     fs: compilation.output_filesystem.clone(),
     output_path: compilation.options.output.path.clone(),
     cross_origin_loading: compilation.options.output.cross_origin_loading.clone(),
-    runtime_template: compilation.runtime_template.create_module_code_template(),
+    runtime_require_name,
   };
   SubresourceIntegrityPlugin::set_compilation_sri_context(compilation.id(), ctx);
 

--- a/crates/rspack_plugin_sri/src/runtime.rs
+++ b/crates/rspack_plugin_sri/src/runtime.rs
@@ -81,20 +81,21 @@ impl RuntimeModule for SRIHashVariableRuntimeModule {
 
     let module_graph = compilation.get_module_graph();
 
-    let runtime_template = compilation.runtime_template.create_module_code_template();
+    let runtime_template = context.runtime_template;
+    let runtime_require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE);
     let source_types = vec![
       (
         SourceType::JavaScript,
-        get_hash_variable(&runtime_template, SourceType::JavaScript),
+        get_hash_variable(&runtime_require_name, SourceType::JavaScript),
       ),
       (
         SourceType::Css,
-        get_hash_variable(&runtime_template, SourceType::Css),
+        get_hash_variable(&runtime_require_name, SourceType::Css),
       ),
       (
         SourceType::Custom("css/mini-extract".into()),
         get_hash_variable(
-          &runtime_template,
+          &runtime_require_name,
           SourceType::Custom("css/mini-extract".into()),
         ),
       ),
@@ -197,7 +198,7 @@ pub async fn create_script(&self, mut data: CreateScriptData) -> Result<CreateSc
   let ctx = SubresourceIntegrityPlugin::get_compilation_sri_context(data.chunk.compilation_id);
   data.code = add_attribute(
     "script",
-    &get_hash_variable(&ctx.runtime_template, SourceType::JavaScript),
+    &get_hash_variable(&ctx.runtime_require_name, SourceType::JavaScript),
     &data.code,
     &ctx.cross_origin_loading,
   );
@@ -211,10 +212,14 @@ pub async fn create_link<'a>(
   mut data: CreateLinkData<'a>,
 ) -> Result<CreateLinkData<'a>> {
   let ctx = SubresourceIntegrityPlugin::get_compilation_sri_context(compilation.id());
+  let runtime_template = compilation
+    .runtime_template
+    .create_runtime_module_code_template();
+  let runtime_require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE);
   if data.code.contains("loadingAttribute") {
     data.code = add_attribute(
       "link",
-      &get_hash_variable(&ctx.runtime_template, SourceType::Css),
+      &get_hash_variable(&runtime_require_name, SourceType::Css),
       &data.code,
       &ctx.cross_origin_loading,
     );
@@ -222,7 +227,7 @@ pub async fn create_link<'a>(
     data.code = add_attribute(
       "linkTag",
       &get_hash_variable(
-        &ctx.runtime_template,
+        &runtime_require_name,
         SourceType::Custom("css/mini-extract".into()),
       ),
       &data.code,
@@ -240,16 +245,20 @@ pub async fn link_preload<'a>(
   mut data: LinkPreloadData<'a>,
 ) -> Result<LinkPreloadData<'a>> {
   let ctx = SubresourceIntegrityPlugin::get_compilation_sri_context(compilation.id());
+  let runtime_template = compilation
+    .runtime_template
+    .create_runtime_module_code_template();
+  let runtime_require_name = runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE);
   if data.code.contains(".as = \"style\"") {
     data.code = add_attribute(
       "link",
       (if data.code.contains(".miniCssF") {
         get_hash_variable(
-          &ctx.runtime_template,
+          &runtime_require_name,
           SourceType::Custom("css/mini-extract".into()),
         )
       } else {
-        get_hash_variable(&ctx.runtime_template, SourceType::Css)
+        get_hash_variable(&runtime_require_name, SourceType::Css)
       })
       .as_str(),
       &data.code,
@@ -258,7 +267,7 @@ pub async fn link_preload<'a>(
   } else {
     data.code = add_attribute(
       "link",
-      &get_hash_variable(&ctx.runtime_template, SourceType::JavaScript),
+      &get_hash_variable(&runtime_require_name, SourceType::JavaScript),
       &data.code,
       &ctx.cross_origin_loading,
     );

--- a/crates/rspack_plugin_sri/src/util.rs
+++ b/crates/rspack_plugin_sri/src/util.rs
@@ -2,8 +2,7 @@ use std::{borrow::Cow, sync::LazyLock};
 
 use cow_utils::CowUtils;
 use rspack_core::{
-  AssetInfo, ChunkGroupUkey, ChunkUkey, Compilation, ManifestAssetType, ModuleCodeTemplate,
-  RuntimeGlobals, SourceType,
+  AssetInfo, ChunkGroupUkey, ChunkUkey, Compilation, ManifestAssetType, SourceType,
 };
 use rspack_util::fx_hash::FxIndexSet;
 
@@ -19,14 +18,12 @@ pub static PLACEHOLDER_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
   .expect("should initialize `Regex`")
 });
 
-pub fn get_hash_variable(runtime_template: &ModuleCodeTemplate, source_type: SourceType) -> String {
-  let require_name =
-    runtime_template.render_runtime_globals_without_adding(&RuntimeGlobals::REQUIRE);
+pub fn get_hash_variable(runtime_require_name: &str, source_type: SourceType) -> String {
   match source_type {
-    SourceType::JavaScript => format!("{require_name}.sriHashes"),
-    SourceType::Css => format!("{require_name}.sriCssHashes"),
+    SourceType::JavaScript => format!("{runtime_require_name}.sriHashes"),
+    SourceType::Css => format!("{runtime_require_name}.sriCssHashes"),
     SourceType::Custom(t) if t == "css/mini-extract" => {
-      format!("{require_name}.sriExtractCssHashes")
+      format!("{runtime_require_name}.sriExtractCssHashes")
     }
     _ => unreachable!(),
   }

--- a/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case1.txt
+++ b/tests/rspack-test/configCases/externals/reexport-star/__snapshot__/runtimeModeSnapshot/case1.txt
@@ -2,7 +2,7 @@ import { rspackRequire, moduleFactories, definePropertyGetters, makeNamespaceObj
 import * as __rspack_external_external1_alias_dd38afe7 from "external1-alias";
 import * as __rspack_external_external2_alias_d6100a5a from "external2-alias";
 moduleFactories.add({
-42(__unused_rspack_module, exports, rspackRequire) {
+42(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 /* import */ var external1__rspack_import_0 = rspackRequire(322);
 

--- a/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/f.js.txt
+++ b/tests/rspack-test/configCases/library/modern-module-force-concaten/__snapshot__/runtimeModeSnapshot/f.js.txt
@@ -6,7 +6,7 @@ moduleFactories.add({
 module.exports = __rspack_createRequire_require("path");
 
 },
-227(module, __unused_rspack_exports, rspackRequire) {
+227(module) {
 const path = rspackRequire(928)
 
 module.exports = path.sep

--- a/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/basic/tree-shaking/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -6,7 +6,7 @@ moduleFactories.add({
 /*!****************!*\
   !*** ./cjs.js ***!
   \****************/
-(__unused_rspack_module, __unused_rspack_exports, rspackRequire) {
+() {
 /* import */ var _use_other__rspack_import_0 = rspackRequire(/*! ./use-other */ "./use-other.js");
 /* import */ var _use_other__rspack_import_0_default = /*#__PURE__*/compatGetDefaultExport(_use_other__rspack_import_0);
 
@@ -20,7 +20,7 @@ console.log.bind((rspackRequire(/*! fs */ "fs")/* .readFile */.readFile))
 /*!******************!*\
   !*** ./index.js ***!
   \******************/
-(module, exports, rspackRequire) {
+(module, exports) {
 makeNamespaceObject(exports);
 /* import */ var _cjs__rspack_import_0 = rspackRequire(/*! ./cjs */ "./cjs.js");
 /* module decorator */ module = esmModuleDecorator(module);
@@ -37,7 +37,7 @@ console.log.bind(module)
 /*!**********************!*\
   !*** ./use-other.js ***!
   \**********************/
-(__unused_rspack_module, __unused_rspack_exports, rspackRequire) {
+() {
 // use export writeFile
 console.log.bind((rspackRequire(/*! fs */ "fs")/* .writeFile */.writeFile))
 

--- a/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/__snapshots__/esm.snap.txt
@@ -1,0 +1,73 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
+__webpack_require__.add({
+"./require.cjs"
+/*!*********************!*\
+  !*** ./require.cjs ***!
+  \*********************/
+(module, __unused_rspack_exports, __webpack_require__) {
+const rspackRequire = __webpack_require__(/*! ./value.cjs */ "./value.cjs");
+
+module.exports = rspackRequire;
+
+
+},
+"./value.cjs"
+/*!*******************!*\
+  !*** ./value.cjs ***!
+  \*******************/
+(module) {
+module.exports = 42;
+
+
+},
+});
+// ./index.js
+__webpack_require__("./require.cjs");
+
+
+const value = __webpack_require__("./require.cjs");
+
+it("should avoid a CJS rspackRequire factory parameter conflict", () => {
+	expect(value).toBe(42);
+});
+
+export {};
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,29 +1,36 @@
 ```mjs title=main.mjs
 import { rspackRequire, moduleFactories } from "./runtime.mjs";
 moduleFactories.add({
-"./index.js"
-/*!******************!*\
-  !*** ./index.js ***!
-  \******************/
-() {
-it('should has connection to lib only in closure', () => {
-	const { foo } = rspackRequire(/*! ./lib */ "./lib.js")
-	expect(foo()).toBe(42)
-})
+"./require.cjs"
+/*!*********************!*\
+  !*** ./require.cjs ***!
+  \*********************/
+(module) {
+const __nested_rspack_require_6_19__ = rspackRequire(/*! ./value.cjs */ "./value.cjs");
+
+module.exports = __nested_rspack_require_6_19__;
 
 
 },
-"./lib.js"
-/*!****************!*\
-  !*** ./lib.js ***!
-  \****************/
-(__unused_rspack_module, exports) {
-exports.foo = () => 42
+"./value.cjs"
+/*!*******************!*\
+  !*** ./value.cjs ***!
+  \*******************/
+(module) {
+module.exports = 42;
 
 
 },
 });
-rspackRequire("./index.js");
+// ./index.js
+rspackRequire("./require.cjs");
+
+
+const value = rspackRequire("./require.cjs");
+
+it("should avoid a CJS rspackRequire factory parameter conflict", () => {
+	expect(value).toBe(42);
+});
 
 export {};
 

--- a/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/index.js
@@ -1,0 +1,7 @@
+import "./require.cjs";
+
+const value = __webpack_require__("./require.cjs");
+
+it("should avoid a CJS rspackRequire factory parameter conflict", () => {
+	expect(value).toBe(42);
+});

--- a/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/require.cjs
+++ b/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/require.cjs
@@ -1,0 +1,3 @@
+const rspackRequire = require("./value.cjs");
+
+module.exports = rspackRequire;

--- a/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/value.cjs
+++ b/tests/rspack-test/esmOutputCases/deconflict/cjs-rspack-require/value.cjs
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-async-chunk/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -5,7 +5,7 @@ moduleFactories.add({
 /*!********************!*\
   !*** ./dynamic.js ***!
   \********************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 const shared = rspackRequire(/*! ./shared */ "./shared.js");
 
 exports.value = shared.base + 41;

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-cjs-runtime-chunk-false-entry-export/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -7,7 +7,7 @@ moduleFactories.add({
 /*!********************!*\
   !*** ./dynamic.js ***!
   \********************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 const shared = rspackRequire(/*! ./shared */ "./shared.js");
 
 exports.value = shared.base + 41;

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-css/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-css/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -40,7 +40,7 @@ moduleFactories.add({
 /*!**********************************************************************************************************************************************!*\
   !*** ./modules|lazy|/^\.\/.*\.js$/|referencedExports: default|groupOptions: {fetchPriority: high,}|namespace object|importPhase: evaluation ***!
   \**********************************************************************************************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 var map = {
   "./a.js": [
     "./modules/a.js",
@@ -72,7 +72,7 @@ module.exports = __rspack_async_context;
 /*!*******************************************************************!*\
   !*** ./modules|lazy|nonrecursive|./modules/*.js|namespace object ***!
   \*******************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 
 module.exports = {
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-lazy/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-lazy/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -51,7 +51,7 @@ moduleFactories.add({
 /*!**************************************************************************************************************************!*\
   !*** ./modules|lazy|/^\.\/.*\.js$/|referencedExports: default|groupOptions: {}|namespace object|importPhase: evaluation ***!
   \**************************************************************************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 var map = {
   "./a.js": [
     "./modules/a.js",
@@ -89,7 +89,7 @@ module.exports = __rspack_async_context;
 /*!*******************************************************************!*\
   !*** ./modules|lazy|nonrecursive|./modules/*.js|namespace object ***!
   \*******************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 
 module.exports = {
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-chunk/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-chunk/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -7,7 +7,7 @@ moduleFactories.add({
 /*!**********************!*\
   !*** ./modules/a.js ***!
   \**********************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 /* import */ var _shared__rspack_import_0 = rspackRequire(/*! ../shared */ "./shared.js");
 
@@ -35,7 +35,7 @@ moduleFactories.add({
 /*!**********************!*\
   !*** ./modules/b.js ***!
   \**********************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 /* import */ var _shared__rspack_import_0 = rspackRequire(/*! ../shared */ "./shared.js");
 
@@ -61,7 +61,7 @@ moduleFactories.add({
 /*!**************************************************************************************************************************!*\
   !*** ./modules|lazy|/^\.\/.*\.js$/|referencedExports: default|groupOptions: {}|namespace object|importPhase: evaluation ***!
   \**************************************************************************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 var map = {
   "./a.js": [
     "./modules/a.js",
@@ -103,7 +103,7 @@ module.exports = __rspack_async_context;
 /*!*******************************************************************!*\
   !*** ./modules|lazy|nonrecursive|./modules/*.js|namespace object ***!
   \*******************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 
 module.exports = {
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-multi-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -51,7 +51,7 @@ moduleFactories.add({
 /*!***********************************************************************!*\
   !*** ./modules-a|lazy|nonrecursive|./modules-a/*.js|namespace object ***!
   \***********************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 
 module.exports = {
 
@@ -82,7 +82,7 @@ moduleFactories.add({
 /*!***********************************************************************!*\
   !*** ./modules-b|lazy|nonrecursive|./modules-b/*.js|namespace object ***!
   \***********************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 
 module.exports = {
 

--- a/tests/rspack-test/esmOutputCases/dynamic-import/import-context-prefetch-preload/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/dynamic-import/import-context-prefetch-preload/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -27,7 +27,7 @@ moduleFactories.add({
 /*!**********************!*\
   !*** ./modules/b.js ***!
   \**********************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 import("./c.mjs").then(rspackRequire.bind(rspackRequire, /*! ./c */ "./modules/c.js"));
 
@@ -73,7 +73,7 @@ moduleFactories.add({
 /*!*******************************************************************************************************************************************!*\
   !*** ./modules|lazy|/^\.\/.*\.js$/|referencedExports: default|groupOptions: {prefetchOrder: 0,}|namespace object|importPhase: evaluation ***!
   \*******************************************************************************************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 var map = {
   "./a.js": [
     "./modules/a.js",
@@ -117,7 +117,7 @@ module.exports = __rspack_async_context;
 /*!******************************************************************************************************************************************!*\
   !*** ./modules|lazy|/^\.\/.*\.js$/|referencedExports: default|groupOptions: {preloadOrder: 0,}|namespace object|importPhase: evaluation ***!
   \******************************************************************************************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 var map = {
   "./a.js": [
     "./modules/a.js",
@@ -161,7 +161,7 @@ module.exports = __rspack_async_context;
 /*!*******************************************************************!*\
   !*** ./modules|lazy|nonrecursive|./modules/*.js|namespace object ***!
   \*******************************************************************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 
 module.exports = {
 

--- a/tests/rspack-test/esmOutputCases/externals/dedup-external-imports-mixed/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/dedup-external-imports-mixed/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -16,7 +16,7 @@ module.exports = __rspack_external_fs;
 /*!**************************!*\
   !*** ./cjs-consumer.cjs ***!
   \**************************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 // CJS module - will NOT be scope-hoisted, causing its fs dep
 // to go through init fragment path instead of raw_import_stmts
 const fs = rspackRequire(/*! fs */ "fs?94de")

--- a/tests/rspack-test/esmOutputCases/externals/esm-node-target-alias/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/esm-node-target-alias/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -26,7 +26,7 @@ module.exports = __rspack_createRequire_require("node:url");
 /*!**************************!*\
   !*** ./cjs-consumer.cjs ***!
   \**************************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 // CJS require of "module" type external — should be downgraded to node-commonjs
 const nodePath = rspackRequire(/*! node:fs */ "node:fs?435f");
 exports.n = nodePath.resolve;

--- a/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/externals/runtime-decide/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -21,7 +21,7 @@ def(exports)
 /*!***************************!*\
   !*** ./runtime-decide.js ***!
   \***************************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 /* import */ var _dynamic_exports__rspack_import_0 = rspackRequire(/*! ./dynamic-exports */ "./dynamic-exports.js");
 /* import */ var _dynamic_exports__rspack_import_0_default = /*#__PURE__*/compatGetDefaultExport(_dynamic_exports__rspack_import_0);
 if(hasOwnProperty(_dynamic_exports__rspack_import_0, "readFile")) definePropertyGetters(exports, { readFile: function() { return _dynamic_exports__rspack_import_0.readFile; } });

--- a/tests/rspack-test/esmOutputCases/interop/runtime-module-variable-conflict/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/interop/runtime-module-variable-conflict/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -73,7 +73,7 @@ function index_createFakeNamespaceObject() {
 
 const index_moduleCache = "application";
 const index_modules = "application";
-const index_rspackRequire = "application";
+const __nested_rspack_require_219_232__ = "application";
 const index_rspack_get_mini_css_chunk_filename = "application";
 
 it("should avoid conflicts with runtime module variables", () => {
@@ -82,12 +82,12 @@ it("should avoid conflicts with runtime module variables", () => {
 	expect(index_createFakeNamespaceObject()).toBe("application");
 	expect(index_moduleCache).toBe("application");
 	expect(index_modules).toBe("application");
-	expect(index_rspackRequire).toBe("application");
+	expect(__nested_rspack_require_219_232__).toBe("application");
 	expect(index_rspack_get_mini_css_chunk_filename).toBe("application");
 });
 
 
 
-export { index_createFakeNamespaceObject as createFakeNamespaceObject, index_getProto as getProto, index_moduleCache as moduleCache, index_modules as modules, index_rspackRequire as rspackRequire, index_rspack_get_mini_css_chunk_filename as __rspack_get_mini_css_chunk_filename };
+export { __nested_rspack_require_219_232__ as rspackRequire, index_createFakeNamespaceObject as createFakeNamespaceObject, index_getProto as getProto, index_moduleCache as moduleCache, index_modules as modules, index_rspack_get_mini_css_chunk_filename as __rspack_get_mini_css_chunk_filename };
 
 ```

--- a/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/module-external-remapping/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -141,7 +141,7 @@ moduleFactories.add({
 /*!************************!*\
   !*** ./src/wrapped.js ***!
   \************************/
-(module, exports, rspackRequire) {
+(module, exports) {
 /* import */ var node_events__rspack_import_0 = rspackRequire(/*! node:events */ "node:events?df85");
 /* module decorator */ module = esmModuleDecorator(module);
 

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-module-external-hoist-mix/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -132,7 +132,7 @@ moduleFactories.add({
 /*!************************!*\
   !*** ./src/wrapped.js ***!
   \************************/
-(module, exports, rspackRequire) {
+(module, exports) {
 /* import */ var fs__rspack_import_0 = rspackRequire(/*! fs */ "fs?2159");
 /* module decorator */ module = esmModuleDecorator(module);
 

--- a/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/re-export-node-commonjs-external-hoist-mix/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -149,7 +149,7 @@ moduleFactories.add({
 /*!************************!*\
   !*** ./src/wrapped.js ***!
   \************************/
-(module, exports, rspackRequire) {
+(module, exports) {
 /* import */ var fs__rspack_import_0 = rspackRequire(/*! fs */ "fs");
 /* import */ var fs__rspack_import_0_default = /*#__PURE__*/compatGetDefaultExport(fs__rspack_import_0);
 /* module decorator */ module = esmModuleDecorator(module);

--- a/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/cjs-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -14,7 +14,7 @@ exports.bar = 2
 /*!****************!*\
   !*** ./foo.js ***!
   \****************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 /* import */ var _bar__rspack_import_0 = rspackRequire(/*! ./bar */ "./bar.js");
 const foo = 1
@@ -32,7 +32,7 @@ definePropertyGetters(exports, {
 /*!******************!*\
   !*** ./index.js ***!
   \******************/
-(module, __unused_rspack_exports, rspackRequire) {
+(module) {
 module.exports = rspackRequire(/*! ./foo */ "./foo.js")
 
 it('should have correct output for entry re-exports', async () => {

--- a/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/deep-re-exports-esm-2/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -7,7 +7,7 @@ moduleFactories.add({
 /*!****************!*\
   !*** ./lib.js ***!
   \****************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 /* import */ var fs__rspack_import_0 = rspackRequire(/*! fs */ "fs");
 
@@ -36,7 +36,7 @@ definePropertyGetters(exports, {
 /*!*****************!*\
   !*** ./lib2.js ***!
   \*****************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 makeNamespaceObject(exports);
 /* import */ var path__rspack_import_0 = rspackRequire(/*! path */ "path");
 
@@ -64,7 +64,7 @@ definePropertyGetters(exports, {
 /*!*****************!*\
   !*** ./lib3.js ***!
   \*****************/
-(__unused_rspack_module, exports, rspackRequire) {
+(__unused_rspack_module, exports) {
 /* import */ var fs__rspack_import_0 = rspackRequire(/*! fs */ "fs");
 const lib3 = 42
 

--- a/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/re-exports/wrapped-esm-entry/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -6,7 +6,7 @@ moduleFactories.add({
 /*!******************!*\
   !*** ./index.js ***!
   \******************/
-(module, exports, rspackRequire) {
+(module, exports) {
 makeNamespaceObject(exports);
 /* import */ var fs__rspack_import_0 = rspackRequire(/*! fs */ "fs");
 

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/__snapshots__/esm.snap.txt
@@ -1,0 +1,30 @@
+```mjs title=main.mjs
+// ./index.js
+const value = import("./value.mjs");
+
+export { value };
+
+```
+
+```mjs title=runtime.mjs
+// The require scope
+var __webpack_require__ = {};
+
+// webpack/runtime/sri_hash_variable
+(() => {
+
+          __webpack_require__.sriHashes = {"value": "sha384-n/vSaOHnKSkGM5h7v+v8wRPJlDOhVXbgjK6iYxj8/sWl7re7g0lRNVYd7Gs6mPAy"};
+          
+})();
+
+export { __webpack_require__ };
+
+```
+
+```mjs title=value.mjs
+// ./value.js
+/* export default */ const value = (42);
+
+export default value;
+
+```

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,28 @@
+```mjs title=main.mjs
+// ./index.js
+const value = import("./value.mjs");
+
+export { value };
+
+```
+
+```mjs title=runtime.mjs
+// The require scope
+var rspackRequire = {};
+export { rspackRequire };
+
+// rspack/runtime/sri_hash_variable
+
+          rspackRequire.sriHashes = {"value": "sha384-n/vSaOHnKSkGM5h7v+v8wRPJlDOhVXbgjK6iYxj8/sWl7re7g0lRNVYd7Gs6mPAy"};
+          ;
+
+
+```
+
+```mjs title=value.mjs
+// ./value.js
+/* export default */ const value = (42);
+
+export default value;
+
+```

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/index.js
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/index.js
@@ -1,0 +1,1 @@
+export const value = import("./value");

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/rspack.config.js
@@ -1,0 +1,9 @@
+const rspack = require('@rspack/core');
+
+module.exports = {
+  target: 'web',
+  output: {
+    crossOriginLoading: 'anonymous',
+  },
+  plugins: [new rspack.SubresourceIntegrityPlugin()],
+};

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/test.config.js
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/test.config.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle: () => [],
+	validate(_stats, _stderr, options) {
+		const config = Array.isArray(options) ? options[0] : options;
+		const source = fs.readFileSync(
+			path.resolve(config.output.path, "runtime.mjs"),
+			"utf-8"
+		);
+		const requireName =
+			config.experiments?.runtimeMode === "rspack"
+				? "rspackRequire"
+				: "__webpack_require__";
+		expect(source).toContain(`${requireName}.sriHashes`);
+		expect(source).not.toContain("__rspack_context.sriHashes");
+	}
+};

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/value.js
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/value.js
@@ -1,0 +1,1 @@
+export default 42;


### PR DESCRIPTION
## Summary

- render module-factory runtime scopes through the module code template, keeping `rspackRequire` as the outer scope for `RspackExport` factories while avoiding redundant or conflicting factory parameters
- collect runtime requirements added during module-content rendering before choosing factory arguments, including requirements introduced by devtool wrappers and concatenated modules
- decouple chunk code templates from runtime-module Dojang templates so chunk rendering does not keep runtime template registration alive
- render SRI hash storage with `RuntimeCodeTemplate` and retain only the rendered require name in the compilation context
- update affected runtime-mode snapshots and add regression coverage for CommonJS `rspackRequire` binding conflicts and modern-module SRI async chunks

## Related links

- Follow-up to #15001
- Downstream case: https://github.com/web-infra-dev/rslib/pull/1806

## Testing

- `cargo clippy --workspace --all-targets --tests --locked -- -D warnings`
- `corepack pnpm --filter @rspack/binding run build:dev`
- targeted `EsmOutput` and `RuntimeModeEsmOutput` cases for `cjs-rspack-require` and `modern-module-sri`

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; internal rendering behavior only).