### PR TITLE
fix: preserve direct exports bindings

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -152,7 +152,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
         ident.span().real_lo(),
         ident.span().real_hi(),
       );
-      return Some(true);
+      if !parser.is_top_level_scope() {
+        return Some(true);
+      }
     } else if for_name == self.nested_require_name(parser) {
       let span = ident.span();
       let start = span.real_lo();

--- a/tests/rspack-test/esmOutputCases/deconflict/exports-binding/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/exports-binding/__snapshots__/esm.snap.txt
@@ -1,0 +1,89 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
+__webpack_require__.add({
+"./wrapped.js"
+/*!********************!*\
+  !*** ./wrapped.js ***!
+  \********************/
+(module, __unused_rspack___webpack_exports__, __webpack_require__) {
+/* module decorator */ module = __webpack_require__.hmd(module);
+const exports = 44;
+
+// Accessing module prevents this module from being scope hoisted.
+console.log.bind(module);
+
+
+},
+});
+// ./before-export.js
+var before_export_exports = 43;
+
+
+// ./index.js
+const index_exports = 42;
+
+
+
+it("should preserve direct and deconflicted exports bindings", async () => {
+	expect(index_exports).toBe(42);
+	const namespace = await import(/* webpackIgnore: true */ "./main.mjs");
+	expect(namespace.exports).toBe(42);
+	expect(namespace.beforeExport).toBe(43);
+	expect(namespace.wrappedExports).toBe(44);
+});
+
+var index_wrappedExports = (/* inlined export .exports */44);
+export { before_export_exports as beforeExport, index_exports as exports, index_wrappedExports as wrappedExports };
+
+```
+
+```mjs title=runtime.mjs
+
+var __webpack_modules__ = {};
+// The module cache
+var __webpack_module_cache__ = {};
+// The require function
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+id: moduleId,
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+}
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+// webpack/runtime/esm_module_decorator
+(() => {
+__webpack_require__.hmd = (module) => {
+  module = Object.create(module);
+  if (!module.children) module.children = [];
+  Object.defineProperty(module, 'exports', {
+      enumerable: true,
+      set: () => {
+          throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+      }
+  });
+  return module;
+};
+})();
+// webpack/runtime/esm_register_module
+(() => {
+__webpack_require__.add = function registerModules(modules) { Object.assign(__webpack_require__.m, modules) }
+
+})();
+
+export { __webpack_require__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/exports-binding/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/exports-binding/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,107 @@
+```mjs title=main.mjs
+import { rspackRequire, moduleFactories, definePropertyGetters, esmModuleDecorator } from "./runtime.mjs";
+moduleFactories.add({
+"./wrapped.js"
+/*!********************!*\
+  !*** ./wrapped.js ***!
+  \********************/
+(module, exports) {
+/* module decorator */ module = esmModuleDecorator(module);
+const __nested_rspack_exports__ = 44;
+
+// Accessing module prevents this module from being scope hoisted.
+console.log.bind(module);
+
+definePropertyGetters(exports, {
+  A: () => (__nested_rspack_exports__)
+});
+
+
+},
+});
+// ./before-export.js
+var __nested_rspack_exports__ = 43;
+
+
+// ./index.js
+const index_nested_rspack_exports_ = 42;
+
+
+
+it("should preserve direct and deconflicted exports bindings", async () => {
+	expect(index_nested_rspack_exports_).toBe(42);
+	const namespace = await import(/* webpackIgnore: true */ "./main.mjs");
+	expect(namespace.exports).toBe(42);
+	expect(namespace.beforeExport).toBe(43);
+	expect(namespace.wrappedExports).toBe(44);
+});
+
+const wrapped = rspackRequire("./wrapped.js");
+var A = wrapped.A;
+
+export { A as wrappedExports, __nested_rspack_exports__ as beforeExport, index_nested_rspack_exports_ as exports };
+
+```
+
+```mjs title=runtime.mjs
+
+var modules = {};
+// The module cache
+var moduleCache = {};
+// The require function
+function rspackRequire(moduleId) {
+// Check if module is in cache
+var cachedModule = moduleCache[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (moduleCache[moduleId] = {
+id: moduleId,
+exports: {}
+});
+// Execute the module function
+modules[moduleId](module, module.exports, rspackRequire);
+
+// Return the exports of the module
+return module.exports;
+}
+export { rspackRequire };
+// expose the modules object (modules)
+var moduleFactories = modules;
+export { moduleFactories };
+
+// rspack/runtime/define_property_getters
+var definePropertyGetters = (exports, getters, values) => {
+	var define = (defs, kind) => {
+		for(var key in defs) {
+			if(hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) {
+				Object.defineProperty(exports, key, { enumerable: true, [kind]: defs[key] });
+			}
+		}
+	};
+	define(getters, "get");
+	define(values, "value");
+};;
+export { definePropertyGetters };
+// rspack/runtime/esm_module_decorator
+var esmModuleDecorator = (module) => {
+  module = Object.create(module);
+  if (!module.children) module.children = [];
+  Object.defineProperty(module, 'exports', {
+      enumerable: true,
+      set: () => {
+          throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+      }
+  });
+  return module;
+};;
+export { esmModuleDecorator };
+// rspack/runtime/esm_register_module
+moduleFactories.add = function registerModules(modules) { Object.assign(moduleFactories, modules) }
+;
+// rspack/runtime/has_own_property
+var hasOwnProperty = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop));
+
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/exports-binding/before-export.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/exports-binding/before-export.js
@@ -1,0 +1,2 @@
+var exports = 43;
+export { exports };

--- a/tests/rspack-test/esmOutputCases/deconflict/exports-binding/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/exports-binding/index.js
@@ -1,0 +1,11 @@
+export const exports = 42;
+export { exports as beforeExport } from "./before-export";
+export { exports as wrappedExports } from "./wrapped";
+
+it("should preserve direct and deconflicted exports bindings", async () => {
+	expect(exports).toBe(42);
+	const namespace = await import(/* webpackIgnore: true */ "./main.mjs");
+	expect(namespace.exports).toBe(42);
+	expect(namespace.beforeExport).toBe(43);
+	expect(namespace.wrappedExports).toBe(44);
+});

--- a/tests/rspack-test/esmOutputCases/deconflict/exports-binding/wrapped.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/exports-binding/wrapped.js
@@ -1,0 +1,4 @@
+export const exports = 44;
+
+// Accessing module prevents this module from being scope hoisted.
+console.log.bind(module);

--- a/tests/rspack-test/esmOutputCases/deconflict/webpack-exports-binding/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/webpack-exports-binding/__snapshots__/esm.snap.txt
@@ -1,0 +1,13 @@
+```mjs title=main.mjs
+// ./index.js
+const __nested_rspack_exports__ = 45;
+
+it("should export a binding named __webpack_exports__", async () => {
+	expect(__nested_rspack_exports__).toBe(45);
+	const namespace = await import(/* webpackIgnore: true */ "./main.mjs");
+	expect(namespace.__webpack_exports__).toBe(45);
+});
+
+export { __nested_rspack_exports__ as __webpack_exports__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/webpack-exports-binding/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/webpack-exports-binding/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,13 @@
+```mjs title=main.mjs
+// ./index.js
+const __webpack_exports__ = 45;
+
+it("should export a binding named __webpack_exports__", async () => {
+	expect(__webpack_exports__).toBe(45);
+	const namespace = await import(/* webpackIgnore: true */ "./main.mjs");
+	expect(namespace.__webpack_exports__).toBe(45);
+});
+
+export { __webpack_exports__ };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/webpack-exports-binding/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/webpack-exports-binding/index.js
@@ -1,0 +1,7 @@
+export const __webpack_exports__ = 45;
+
+it("should export a binding named __webpack_exports__", async () => {
+	expect(__webpack_exports__).toBe(45);
+	const namespace = await import(/* webpackIgnore: true */ "./main.mjs");
+	expect(namespace.__webpack_exports__).toBe(45);
+});


### PR DESCRIPTION
## Summary

- fix a name collision when application code exports a top-level binding named `__webpack_exports__` with `output.module: true` and `library.type: "modern-module"`
- allow the conflicting local binding to be renamed while preserving `__webpack_exports__` as the public ESM export name
- keep nested bindings on the existing compatibility path and add regression coverage for both `__webpack_exports__` and `exports` bindings across runtime render modes

## Reproduction

- [Rspack Playground](https://playground.rspack.rs/#eyJyc3BhY2tWZXJzaW9uIjoiMi4xLjYiLCJpbnB1dEZpbGVzIjpbeyJmaWxlbmFtZSI6InJzcGFjay5jb25maWcuanMiLCJ0ZXh0IjoiZXhwb3J0IGRlZmF1bHQge1xuICBtb2RlOiAncHJvZHVjdGlvbicsXG4gIHRhcmdldDogXCJhc3luYy1ub2RlXCIsXG4gIGVudHJ5OiAnLi9pbmRleC5qcycsXG4gIG91dHB1dDogIHtcbiAgICBtb2R1bGU6IHRydWUsXG4gICAgbGlicmFyeTogIHtcbiAgICAgIHR5cGU6IFwibW9kZXJuLW1vZHVsZVwiLFxuICAgIH0sXG4gIH0sXG4gIG9wdGltaXphdGlvbjoge1xuICAgIG1pbmltaXplOiBmYWxzZSxcbiAgfSxcbn07In0seyJmaWxlbmFtZSI6ImluZGV4LmpzIiwidGV4dCI6ImV4cG9ydCBjb25zdCBfX3dlYnBhY2tfZXhwb3J0c19fID0gXCJhYWFcIjsifV19)

## Stack

- based on #15002
- followed by #15004

## Testing

- `cargo fmt --all --check`
- `cargo check -p rspack_plugin_javascript --lib --locked`
- `cargo clippy -p rspack_plugin_javascript --lib --locked -- -D warnings`
- `corepack pnpm@11.8.0 --filter @rspack/binding run build:dev`
- `corepack pnpm@11.8.0 --dir tests/rspack-test exec rs test EsmOutput.test.js RuntimeModeEsmOutput.test.js --testNamePattern 'deconflict/(exports-binding|webpack-exports-binding)'`
- full `EsmOutput.test.js` and `RuntimeModeEsmOutput.test.js` suites on #15004 (506 tests)
