### PR TITLE
fix: preserve runtime-free ESM binding names

### DIFF
--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -1,5 +1,6 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsRefStr};
 use rspack_hash::{RspackHash, RspackHasher};
+use rspack_util::{atom::Atom, fx_hash::FxHashMap};
 
 use super::DependencyRange;
 use crate::{
@@ -7,17 +8,46 @@ use crate::{
   TemplateContext, TemplateReplaceSource,
 };
 
+#[derive(Debug, Clone, Default)]
+pub struct ConstDependencyPreferredNames(pub FxHashMap<Atom, Atom>);
+
+#[cacheable]
+#[derive(Debug, Clone)]
+struct ConstDependencyPreferredName {
+  #[cacheable(with=AsRefStr)]
+  generated: Box<str>,
+  #[cacheable(with=AsRefStr)]
+  preferred: Box<str>,
+}
+
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct ConstDependency {
   pub range: DependencyRange,
   #[cacheable(with=AsRefStr)]
   pub content: Box<str>,
+  preferred_name: Option<ConstDependencyPreferredName>,
 }
 
 impl ConstDependency {
   pub fn new(range: DependencyRange, content: Box<str>) -> Self {
-    Self { range, content }
+    Self {
+      range,
+      content,
+      preferred_name: None,
+    }
+  }
+
+  pub fn with_concatenation_scope_preferred_name(
+    mut self,
+    generated: Box<str>,
+    preferred: Box<str>,
+  ) -> Self {
+    self.preferred_name = Some(ConstDependencyPreferredName {
+      generated,
+      preferred,
+    });
+    self
   }
 }
 
@@ -26,6 +56,12 @@ impl RspackHash for ConstDependency {
     self.range.hash(state);
     state.write(b"|");
     self.content.hash(state);
+    if let Some(preferred_name) = &self.preferred_name {
+      state.write(b"|");
+      preferred_name.generated.hash(state);
+      state.write(b"|");
+      preferred_name.preferred.hash(state);
+    }
   }
 }
 
@@ -60,12 +96,35 @@ impl DependencyTemplate for ConstDependencyTemplate {
     &self,
     dep: &dyn DependencyCodeGeneration,
     source: &mut TemplateReplaceSource,
-    _code_generatable_context: &mut TemplateContext,
+    code_generatable_context: &mut TemplateContext,
   ) {
     let dep = dep
       .as_any()
       .downcast_ref::<ConstDependency>()
       .expect("ConstDependencyTemplate should be used for ConstDependency");
+
+    if let Some(preferred_name) = &dep.preferred_name
+      && let Some(concatenation_scope) = code_generatable_context.concatenation_scope.as_deref_mut()
+    {
+      if concatenation_scope
+        .data
+        .get::<ConstDependencyPreferredNames>()
+        .is_none()
+      {
+        concatenation_scope
+          .data
+          .insert(ConstDependencyPreferredNames::default());
+      }
+      concatenation_scope
+        .data
+        .get_mut::<ConstDependencyPreferredNames>()
+        .expect("preferred names were initialized")
+        .0
+        .insert(
+          preferred_name.generated.as_ref().into(),
+          preferred_name.preferred.as_ref().into(),
+        );
+    }
 
     source.replace(
       dep.range.start,

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 pub use cached_const_dependency::{
   CachedConstDependency, CachedConstDependencyPlace, CachedConstDependencyTemplate,
 };
-pub use const_dependency::{ConstDependency, ConstDependencyTemplate};
+pub use const_dependency::{
+  ConstDependency, ConstDependencyPreferredNames, ConstDependencyTemplate,
+};
 pub use context_dependency::{AsContextDependency, ContextDependency};
 pub use context_element_dependency::ContextElementDependency;
 pub use dependency_category::DependencyCategory;

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -11,13 +11,13 @@ use rspack_core::{
   ChunkUkey, CodeGenerationPublicPathAutoReplace, Compilation, ConcatenatedModuleIdent,
   ConditionalInitFragment, DependencyType, ExportInfo, ExportMode, ExportProvided,
   ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, RuntimeGlobals,
-  RuntimeGlobalsRenderMode, RuntimeTemplateRenderMode, RuntimeVariable, SideEffectsStateArtifact,
-  SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem, all_runtime_module_variables,
-  collect_ident, escape_name_atom_ref, find_new_name, find_target, get_cached_readable_identifier,
-  get_module_directives, get_module_hashbang, property_access, property_name,
-  reserved_names::RESERVED_NAMES_ATOM_SET, rspack_sources::ReplaceSource,
-  split_readable_identifier, to_normal_comment,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeTemplateRenderMode,
+  RuntimeVariable, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName,
+  UsedNameItem, all_runtime_module_variables, collect_ident, escape_name_atom_ref, find_new_name,
+  find_target, get_cached_readable_identifier, get_module_directives, get_module_hashbang,
+  property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
+  rspack_sources::ReplaceSource, split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
 use rspack_plugin_javascript::{
@@ -597,7 +597,12 @@ impl EsmLibraryPlugin {
       escaped_identifiers.insert(identifier, parts);
     }
 
-    let runtime_module_used_names = Self::collect_rspack_export_runtime_used_names(compilation);
+    let runtime_template = compilation
+      .runtime_template
+      .create_runtime_module_code_template();
+    let runtime_module_used_names =
+      Self::collect_rspack_export_runtime_used_names(&runtime_template);
+    drop(runtime_template);
     let deconflict_context = DeconflictSymbolsContext {
       runtime_module_used_names: &runtime_module_used_names,
       escaped_names: &escaped_names,
@@ -956,11 +961,10 @@ var {} = {{}};
     }
   }
 
-  fn collect_rspack_export_runtime_used_names(compilation: &Compilation) -> FxHashSet<Atom> {
+  pub(crate) fn collect_rspack_export_runtime_used_names(
+    runtime_template: &RuntimeCodeTemplate,
+  ) -> FxHashSet<Atom> {
     let mut used_names = FxHashSet::default();
-    let runtime_template = compilation
-      .runtime_template
-      .create_runtime_module_code_template();
     if runtime_template.render_mode() != RuntimeGlobalsRenderMode::RspackExport {
       return used_names;
     }

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -24,9 +24,10 @@ use rspack_core::{
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
-  JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
+  JavascriptModulesChunkHash, JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
   dependency::ImportDependencyTemplate, parser_and_generator::JavaScriptParserAndGenerator,
 };
 use rspack_plugin_rslib::{
@@ -270,6 +271,9 @@ async fn compilation(
   hooks
     .render_chunk_content
     .tap(render_chunk_content::new(self));
+  hooks
+    .chunk_hash
+    .tap(runtime_free_name_overrides_chunk_hash::new(self));
   drop(hooks);
 
   compilation.set_dependency_template(
@@ -288,6 +292,40 @@ async fn compilation(
       template: worker_template,
     }),
   );
+  Ok(())
+}
+
+#[plugin_hook(JavascriptModulesChunkHash for EsmLibraryPlugin)]
+async fn runtime_free_name_overrides_chunk_hash(
+  &self,
+  compilation: &Compilation,
+  chunk_ukey: &ChunkUkey,
+  hasher: &mut RspackHasher,
+) -> Result<()> {
+  let links = self.links.borrow();
+  let Some(chunk_link) = links.get(chunk_ukey) else {
+    return Ok(());
+  };
+  let concatenated_modules_map = self.concatenated_modules_map.read().await;
+  let runtime_template = compilation.runtime_template.create_chunk_code_template();
+  let mut overrides = self
+    .runtime_free_name_overrides(
+      compilation,
+      chunk_ukey,
+      chunk_link,
+      &concatenated_modules_map,
+      &runtime_template,
+    )
+    .into_iter()
+    .collect::<Vec<_>>();
+  if overrides.is_empty() {
+    return Ok(());
+  }
+
+  overrides.sort_unstable();
+  "runtime free name overrides".hash(hasher);
+  overrides.hash(hasher);
+
   Ok(())
 }
 

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -4,10 +4,13 @@ use std::{borrow::Cow, sync::Arc};
 
 use rspack_collections::IdentifierIndexSet;
 use rspack_core::{
-  AssetInfo, Chunk, ChunkGraph, ChunkGroup, ChunkRenderContext, ChunkUkey, Compilation,
-  ConcatenatedModuleInfo, InitFragment, ModuleIdentifier, PathData, PathInfo, RuntimeCodeTemplate,
-  RuntimeGlobals, RuntimeVariable, SourceType, export_name, get_js_chunk_filename_template,
-  get_undo_path, render_init_fragments,
+  AssetInfo, Chunk, ChunkGraph, ChunkGroup, ChunkRenderContext, ChunkUkey,
+  CodeGenerationRuntimeRequirementsWrite, Compilation, ConcatenatedModuleInfo,
+  ConstDependencyPreferredNames, InitFragment, ModuleIdentifier, ModuleInfo, PathData, PathInfo,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeVariable, SourceType,
+  all_runtime_module_variables, export_name, get_js_chunk_filename_template, get_undo_path,
+  render_init_fragments,
+  reserved_names::RESERVED_NAMES_ATOM_SET,
   rspack_sources::{ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::Result;
@@ -59,6 +62,167 @@ fn get_chunk(compilation: &Compilation, chunk_ukey: ChunkUkey) -> &Chunk {
 use crate::EsmLibraryPlugin;
 
 impl EsmLibraryPlugin {
+  pub(crate) fn runtime_free_name_overrides(
+    &self,
+    compilation: &Compilation,
+    chunk_ukey: &ChunkUkey,
+    chunk_link: &ChunkLinkContext,
+    concatenated_modules_map: &rspack_collections::IdentifierIndexMap<ModuleInfo>,
+    runtime_template: &RuntimeCodeTemplate,
+  ) -> FxHashMap<Atom, Atom> {
+    let mut overrides = FxHashMap::default();
+    if runtime_template.render_mode() != RuntimeGlobalsRenderMode::RspackExport
+      || !chunk_link.decl_modules.is_empty()
+      || chunk_link.hoisted_modules.is_empty()
+      || !chunk_link.raw_import_stmts.is_empty()
+      || !chunk_link.re_exports().is_empty()
+      || !chunk_link.raw_star_exports.is_empty()
+      || !chunk_link.required.is_empty()
+      || !chunk_link.needed_namespace_objects.is_empty()
+      || !chunk_link.namespace_object_sources.is_empty()
+      || !chunk_link.decl_before_exports.is_empty()
+      || !chunk_link.module_external_namespace_imports.is_empty()
+      || !chunk_link.init_fragments.is_empty()
+    {
+      return overrides;
+    }
+
+    if chunk_link
+      .imports
+      .iter()
+      .any(|(module, _)| !chunk_link.hoisted_modules.contains(module))
+      || chunk_link.refs.values().any(|reference| {
+        matches!(
+          reference,
+          Ref::Symbol(symbol_ref)
+            if !chunk_link.hoisted_modules.contains(&symbol_ref.module)
+        )
+      })
+    {
+      return overrides;
+    }
+    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+    let chunk_modules = chunk_graph.get_chunk_modules_identifier(chunk_ukey);
+    if chunk_modules.len() != chunk_link.hoisted_modules.len()
+      || chunk_modules
+        .iter()
+        .any(|module| !chunk_link.hoisted_modules.contains(module))
+      || chunk_graph.has_chunk_runtime_modules(chunk_ukey)
+    {
+      return overrides;
+    }
+
+    let mut runtime_requirements =
+      *ChunkGraph::get_chunk_runtime_requirements(compilation, chunk_ukey);
+    runtime_requirements.remove(RuntimeGlobals::STARTUP_NO_DEFAULT);
+    if !runtime_requirements.is_empty() {
+      return overrides;
+    }
+
+    let chunk = get_chunk(compilation, *chunk_ukey);
+    if chunk.has_runtime(&compilation.build_chunk_graph_artifact.chunk_group_by_ukey) {
+      let mut tree_runtime_requirements =
+        *ChunkGraph::get_tree_runtime_requirements(compilation, chunk_ukey);
+      tree_runtime_requirements.remove(RuntimeGlobals::STARTUP_NO_DEFAULT);
+      if !tree_runtime_requirements.is_empty() {
+        return overrides;
+      }
+    }
+
+    let mut unavailable_names = RESERVED_NAMES_ATOM_SET.clone();
+    for module_identifier in &chunk_link.hoisted_modules {
+      let Some(ModuleInfo::Concatenated(info)) = concatenated_modules_map.get(module_identifier)
+      else {
+        return overrides;
+      };
+      if !info.runtime_requirements.is_empty()
+        || !info.runtime_requirements_write.is_empty()
+        || !info.chunk_init_fragments.is_empty()
+        || info.import_map.as_ref().is_some_and(|map| !map.is_empty())
+        || info.namespace_export_symbol.is_some()
+        || info.interop_namespace_object_used
+        || info.interop_namespace_object2_used
+        || info.interop_default_access_used
+      {
+        return overrides;
+      }
+
+      let code_generation_result = compilation
+        .code_generation_results
+        .get_one(module_identifier);
+      if code_generation_result
+        .data
+        .get::<CodeGenerationRuntimeRequirementsWrite>()
+        .is_some_and(|write| !write.runtime_requirements.is_empty())
+      {
+        return overrides;
+      }
+      let Some(scope) = code_generation_result.concatenation_scope.as_ref() else {
+        return overrides;
+      };
+      if !scope.dyn_refs.is_empty() || !scope.re_exports.is_empty() {
+        return overrides;
+      }
+
+      unavailable_names.extend(
+        info
+          .global_scope_ident
+          .iter()
+          .map(|ident| ident.id.sym.clone()),
+      );
+      unavailable_names.extend(info.all_used_names.iter().cloned());
+      for internal_name in info.internal_names.values() {
+        if !unavailable_names.insert(internal_name.clone()) {
+          return overrides;
+        }
+      }
+    }
+
+    let mut runtime_names = Self::collect_rspack_export_runtime_used_names(runtime_template);
+    for runtime_module_variable in all_runtime_module_variables() {
+      runtime_names.remove(&Atom::from(runtime_module_variable));
+    }
+    // `context` is handled by compatibility deconfliction, not this optimization.
+    runtime_names.remove(&Atom::from(
+      runtime_template.render_runtime_variable(&RuntimeVariable::Context),
+    ));
+    let mut candidates = Vec::new();
+    let mut preferred_name_counts = FxHashMap::default();
+    for module_identifier in &chunk_link.hoisted_modules {
+      let info = concatenated_modules_map[module_identifier].as_concatenated();
+      let scope = compilation
+        .code_generation_results
+        .get_one(module_identifier)
+        .concatenation_scope
+        .as_ref()
+        .expect("checked concatenation scope");
+      let preferred_names = scope.data.get::<ConstDependencyPreferredNames>();
+      for (original_name, internal_name) in &info.internal_names {
+        let preferred_name = preferred_names
+          .and_then(|names| names.0.get(original_name))
+          .unwrap_or(original_name);
+        if internal_name == preferred_name
+          || !runtime_names.contains(preferred_name)
+          || unavailable_names.contains(preferred_name)
+        {
+          continue;
+        }
+        candidates.push((internal_name.clone(), preferred_name.clone()));
+        *preferred_name_counts
+          .entry(preferred_name.clone())
+          .or_insert(0) += 1;
+      }
+    }
+
+    for (internal_name, preferred_name) in candidates {
+      if preferred_name_counts[&preferred_name] == 1 {
+        overrides.insert(internal_name, preferred_name);
+      }
+    }
+
+    overrides
+  }
+
   fn get_entrypoint(chunk_ukey: ChunkUkey, compilation: &Compilation) -> Option<&ChunkGroup> {
     let chunk = compilation
       .build_chunk_graph_artifact
@@ -127,6 +291,13 @@ impl EsmLibraryPlugin {
     let concatenated_modules_map = self.concatenated_modules_map.read().await;
 
     let chunk = get_chunk(compilation, *chunk_ukey);
+    let runtime_free_name_overrides = self.runtime_free_name_overrides(
+      compilation,
+      chunk_ukey,
+      chunk_link,
+      &concatenated_modules_map,
+      runtime_template,
+    );
     let runtime_chunk_ukey = Self::get_runtime_chunk(*chunk_ukey, compilation);
     let entry_chunk_ukey = Self::get_entry_chunk(*chunk_ukey, compilation);
     let is_separate_runtime_chunk =
@@ -328,7 +499,7 @@ var {} = {{}};
       if info.static_url_replacement {
         replace_static_url = true;
       }
-      let source = Self::render_module(info, chunk_link)?;
+      let source = Self::render_module(info, chunk_link, &runtime_free_name_overrides)?;
 
       if !matches!(compilation.options.output.pathinfo, PathInfo::Bool(false)) {
         render_source.add(RawStringSource::from(format!(
@@ -549,12 +720,20 @@ var {} = {{}};
     )?);
 
     let mut exports = chunk_link.exports().iter().collect::<Vec<_>>();
-    exports.sort_by(|a, b| a.0.cmp(b.0));
+    exports.sort_by(|a, b| {
+      runtime_free_name_overrides
+        .get(a.0)
+        .unwrap_or(a.0)
+        .cmp(runtime_free_name_overrides.get(b.0).unwrap_or(b.0))
+    });
     for decl_before_export in chunk_link.decl_before_exports.iter() {
       final_source.add(RawStringSource::from(decl_before_export.clone()));
     }
 
     for (raw_symbol, exports) in exports {
+      let raw_symbol = runtime_free_name_overrides
+        .get(raw_symbol)
+        .unwrap_or(raw_symbol);
       let mut exports = exports.iter().collect::<Vec<_>>();
       exports.sort_unstable();
       for exported_name in exports {
@@ -724,6 +903,7 @@ var {} = {{}};
   pub fn render_module(
     info: &ConcatenatedModuleInfo,
     chunk_link: &ChunkLinkContext,
+    runtime_free_name_overrides: &FxHashMap<Atom, Atom>,
   ) -> Result<ReplaceSource> {
     let Some(mut source) = info.source.clone() else {
       return Err(rspack_error::Error::error(format!(
@@ -737,7 +917,13 @@ var {} = {{}};
         && let Some(binding_ref) = chunk_link.refs.get(atom.as_str())
       {
         let final_name = match binding_ref {
-          Ref::Symbol(symbol_ref) => Cow::Owned(symbol_ref.render()),
+          Ref::Symbol(symbol_ref) => {
+            let mut symbol_ref = symbol_ref.clone();
+            if let Some(preferred_name) = runtime_free_name_overrides.get(&symbol_ref.symbol) {
+              symbol_ref.symbol = preferred_name.clone();
+            }
+            Cow::Owned(symbol_ref.render())
+          }
           Ref::Inline(inline) => Cow::Borrowed(inline),
         };
 
@@ -763,6 +949,9 @@ var {} = {{}};
       }
 
       if let Some(internal_name) = info.get_internal_name(&ident.id.sym) {
+        let internal_name = runtime_free_name_overrides
+          .get(internal_name)
+          .unwrap_or(internal_name);
         let name = if ident.shorthand {
           format!("{}: {}", &ident.id.sym, &internal_name)
         } else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -1,4 +1,7 @@
-use rspack_core::{BoxDependencyTemplate, ConstDependency, ContextDependency, DependencyRange};
+use rspack_core::{
+  BoxDependencyTemplate, ConstDependency, ContextDependency, DependencyRange,
+  RuntimeGlobalsRenderMode,
+};
 use rspack_util::{SpanExt, itoa};
 use swc_atoms::Atom;
 use swc_experimental_ecma_ast::{CallExpr, GetSpan, Ident, Program, VarDeclarator};
@@ -17,6 +20,7 @@ pub struct NestedRequireData {
   update: bool,
   loc: DependencyRange,
   in_short_hand: bool,
+  is_top_level: bool,
 }
 
 pub struct CompatibilityPlugin;
@@ -65,6 +69,7 @@ impl CompatibilityPlugin {
     start: u32,
     end: u32,
   ) {
+    let is_top_level = parser.is_top_level_scope();
     parser.tag_variable(
       name,
       NESTED_IDENTIFIER_TAG,
@@ -73,8 +78,24 @@ impl CompatibilityPlugin {
         update: false,
         loc: DependencyRange::new(start, end),
         in_short_hand,
+        is_top_level,
       }),
     );
+  }
+
+  fn create_binding_dependency(
+    &self,
+    range: DependencyRange,
+    content: String,
+    generated_name: &str,
+    preferred_name: Option<&str>,
+  ) -> BoxDependencyTemplate {
+    let mut dependency = ConstDependency::new(range, content.into());
+    if let Some(preferred_name) = preferred_name {
+      dependency = dependency
+        .with_concatenation_scope_preferred_name(generated_name.into(), preferred_name.into());
+    }
+    Box::new(dependency)
   }
 }
 
@@ -213,12 +234,20 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
       && (ident.id.sym.as_str() == parser.parser_runtime_requirements.exports
         || ident.id.sym.as_str() == self.nested_require_name(parser))
     {
+      let prefer_runtime_scope_name = parser.parser_runtime_requirements.render_mode
+        == RuntimeGlobalsRenderMode::RspackExport
+        && ident.id.sym.as_str() == self.nested_require_name(parser);
       let data = parser.get_tag_data_mut::<NestedRequireData>(
         &Atom::from(ident.id.sym.as_str()),
         NESTED_IDENTIFIER_TAG,
       )?;
       if !data.update {
-        let dep = Box::new(ConstDependency::new(data.loc, data.name.clone().into()));
+        let dep = self.create_binding_dependency(
+          data.loc,
+          data.name.clone(),
+          &data.name,
+          (prefer_runtime_scope_name && data.is_top_level).then_some(ident.id.sym.as_str()),
+        );
         data.update = true;
         parser.add_presentational_dependency(dep);
       }
@@ -235,26 +264,36 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
     if for_name != NESTED_IDENTIFIER_TAG {
       return None;
     }
-    let tag_info = parser
-      .definitions_db
-      .expect_get_mut_tag_info(parser.current_tag_info?)
-      .data
-      .as_deref_mut()?;
-
-    let nested_require_data = NestedRequireData::downcast_mut(tag_info);
+    let prefer_runtime_scope_name = parser.parser_runtime_requirements.render_mode
+      == RuntimeGlobalsRenderMode::RspackExport
+      && ident.sym.as_str() == self.nested_require_name(parser);
+    let (name, binding) = {
+      let tag_info = parser
+        .definitions_db
+        .expect_get_mut_tag_info(parser.current_tag_info?)
+        .data
+        .as_deref_mut()?;
+      let data = NestedRequireData::downcast_mut(tag_info);
+      let binding = if data.update {
+        None
+      } else {
+        data.update = true;
+        Some((data.loc, data.in_short_hand, data.is_top_level))
+      };
+      (data.name.clone(), binding)
+    };
     let mut deps: Vec<BoxDependencyTemplate> = Vec::with_capacity(2);
-    let name = nested_require_data.name.clone();
-    if !nested_require_data.update {
-      let shorthand = nested_require_data.in_short_hand;
-      deps.push(Box::new(ConstDependency::new(
-        nested_require_data.loc,
+    if let Some((loc, shorthand, is_top_level)) = binding {
+      deps.push(self.create_binding_dependency(
+        loc,
         if shorthand {
-          format!("{}: {}", ident.sym, name).into()
+          format!("{}: {}", ident.sym, name)
         } else {
-          name.clone().into()
+          name.clone()
         },
-      )));
-      nested_require_data.update = true;
+        &name,
+        (prefer_runtime_scope_name && is_top_level).then_some(ident.sym.as_str()),
+      ));
     }
 
     deps.push(Box::new(ConstDependency::new(

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/__snapshots__/esm.snap.txt
@@ -1,0 +1,39 @@
+```mjs title=main.mjs
+// ./value.js
+function publicPath() {}
+const value = 42;
+
+// ./global.js
+globalThis.moduleCache = "global";
+
+function readGlobalModuleCache() {
+	return moduleCache;
+}
+
+// ./index.js
+
+
+
+function rspackRequire() {}
+function modules() {}
+function index_moduleCache() {}
+
+const actualNames = [
+	rspackRequire.name,
+	publicPath.name,
+	modules.name,
+];
+
+it("should not reserve core runtime names when no runtime is emitted", () => {
+	expect(actualNames).toEqual(["rspackRequire", "publicPath", "modules"]);
+	expect((/* inlined export .value */42)).toBe(42);
+
+	const globalModuleCache = readGlobalModuleCache();
+	delete globalThis.moduleCache;
+	expect(globalModuleCache).toBe("global");
+	expect(index_moduleCache.name).not.toBe("moduleCache");
+});
+
+export { actualNames };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/global.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/global.js
@@ -1,0 +1,5 @@
+globalThis.moduleCache = "global";
+
+export function readGlobalModuleCache() {
+	return moduleCache;
+}

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/index.js
@@ -1,0 +1,22 @@
+import { publicPath, value } from "./value.js";
+import { readGlobalModuleCache } from "./global.js";
+
+function rspackRequire() {}
+function modules() {}
+function moduleCache() {}
+
+export const actualNames = [
+	rspackRequire.name,
+	publicPath.name,
+	modules.name,
+];
+
+it("should not reserve core runtime names when no runtime is emitted", () => {
+	expect(actualNames).toEqual(["rspackRequire", "publicPath", "modules"]);
+	expect(value).toBe(42);
+
+	const globalModuleCache = readGlobalModuleCache();
+	delete globalThis.moduleCache;
+	expect(globalModuleCache).toBe("global");
+	expect(moduleCache.name).not.toBe("moduleCache");
+});

--- a/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/value.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/unused-core-runtime-names/value.js
@@ -1,0 +1,2 @@
+export function publicPath() {}
+export const value = 42;


### PR DESCRIPTION
## Summary

- keep linker deconfliction conservative until finalized runtime requirements are available
- restore names reserved only for the Rspack runtime when a self-contained ESM chunk emits no runtime
- preserve the preferred top-level `rspackRequire` name through concatenation metadata and include render-time overrides in the chunk hash
- keep non-runtime reservations intact, including reserved identifiers, nested bindings, and cross-module free globals

## Related links

- Follow-up to #15003

## Testing

- `corepack pnpm@11.8.0 --filter @rspack/binding run build:dev`
- `cargo clippy -p rspack_plugin_esm_library --lib --locked -- -D warnings`
- `cargo test -p rspack_plugin_esm_library --lib --locked` (22 tests)
- full `EsmOutput.test.js` and `RuntimeModeEsmOutput.test.js` suites (496 tests)
- workspace unit suite (8,912 tests passed; three parallel browserslist cleanup races passed in an isolated 596-test rerun)

## Checklist

- [x] Tests updated.
- [x] Documentation not required.