### PR TITLE
fix(rstest): hoist test API imports by source order

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -815,6 +815,12 @@ impl<'parser> JavascriptParser<'parser> {
     self.module_layer
   }
 
+  /// The source order assigned to the import declaration currently being
+  /// visited by `import_specifier` parser hooks.
+  pub fn current_esm_import_order(&self) -> i32 {
+    self.last_esm_import_order
+  }
+
   pub fn get_variable_info(&mut self, name: &Atom) -> Option<&VariableInfo> {
     let id = self.definitions_db.get(self.definitions, name)?;
     Some(self.definitions_db.expect_get_variable(id))

--- a/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
+++ b/crates/rspack_plugin_rstest/src/mock_method_dependency.rs
@@ -26,6 +26,10 @@ pub struct MockMethodDependency {
   /// auto-mock form (whose request is carried by the synthetic-target
   /// dependency's suffix instead, to avoid colliding at the same offset).
   args_request_end: Option<u32>,
+  /// Source order of the ESM import that provides the `rs` or `rstest`
+  /// binding. The import must run before hoisted callbacks that use other API
+  /// members such as `rs.fn()`.
+  test_api_import_source_order: Option<i32>,
 }
 
 #[cacheable]
@@ -57,6 +61,7 @@ impl MockMethodDependency {
       hoist,
       method,
       args_request_end: None,
+      test_api_import_source_order: None,
     }
   }
 
@@ -76,12 +81,18 @@ impl MockMethodDependency {
       hoist,
       method,
       args_request_end: None,
+      test_api_import_source_order: None,
     }
   }
 
   /// Set the request-injection offset. See [`Self::args_request_end`].
   pub fn with_request_arg_end(mut self, end: Option<u32>) -> Self {
     self.args_request_end = end;
+    self
+  }
+
+  pub fn with_test_api_import_source_order(mut self, source_order: Option<i32>) -> Self {
+    self.test_api_import_source_order = source_order;
     self
   }
 }
@@ -130,13 +141,15 @@ impl DependencyTemplate for MockMethodDependencyTemplate {
     let hoist_flag = Self::get_hoist_flag(&dep.method);
     let mock_method = Self::get_mock_method(&dep.method);
 
-    // Step 1: Add placeholder init fragment for hoistable methods
-    if let Some(flag) = hoist_flag {
+    if dep.hoist
+      && let Some(flag) = hoist_flag
+    {
+      // Step 1: Add placeholder init fragment for hoistable methods
       Self::add_placeholder_fragment(init_fragments, flag, &hoist_id, request);
-    }
 
-    // Step 2: Hoist @rstest/core import to ensure it comes before all hoisted code
-    Self::hoist_rstest_core_import(init_fragments);
+      // Step 2: Hoist the import that provides the test API before all hoisted code
+      Self::hoist_test_api_import(init_fragments, dep.test_api_import_source_order);
+    }
 
     // Step 3: Transform the source code
     Self::transform_source(
@@ -195,7 +208,7 @@ impl MockMethodDependencyTemplate {
   /// Add a placeholder init fragment that marks where hoisted code should be inserted.
   ///
   /// `StageESMImports` ordering contract (position → fragment):
-  /// - `-3`: the hoisted `@rstest/core` import (see [`Self::hoist_rstest_core_import`])
+  /// - `-3`: the hoisted test API import (see [`Self::hoist_test_api_import`])
   /// - `-2`: this placeholder — mock registrations run before any user module is
   ///   evaluated, so an `importActual` subgraph still sees mocked transitive deps
   /// - `-1`: `importActual` imports (see `esm_import_dependency.rs`) — evaluated
@@ -219,24 +232,30 @@ impl MockMethodDependencyTemplate {
     init_fragments.push(init.boxed());
   }
 
-  /// Hoist @rstest/core import to the very top of the module.
+  /// Hoist the ESM import that provides the test API to the very top of the module.
   ///
-  /// This ensures that `@rstest/core` is imported before the hoisted placeholder,
-  /// so that `rs.fn()` and other utilities are available inside `rs.hoisted()` callbacks.
+  /// This ensures that `rs.fn()` and other utilities are available inside
+  /// `rs.hoisted()` callbacks regardless of which module re-exports the API.
   ///
   /// We achieve this by inserting a higher-priority fragment with the same key.
   /// Since ESMImport's merge logic returns the first fragment when its runtime_condition is true,
   /// our new fragment will take precedence and the original will be ignored.
-  fn hoist_rstest_core_import(
+  fn hoist_test_api_import(
     init_fragments: &mut Vec<Box<dyn rspack_core::InitFragment<rspack_core::GenerateContext<'_>>>>,
+    source_order: Option<i32>,
   ) {
-    let target_key =
-      InitFragmentKey::ESMImport("ESM import external global \"@rstest/core\"".to_string());
-
-    // Find the original @rstest/core import fragment
-    let Some(fragment) = init_fragments.iter().find(|f| f.key() == &target_key) else {
+    let Some(source_order) = source_order else {
       return;
     };
+
+    let Some(fragment) = init_fragments.iter().find(|fragment| {
+      fragment.stage() == InitFragmentStage::StageESMImports
+        && fragment.position() == source_order
+        && matches!(fragment.key(), InitFragmentKey::ESMImport(_))
+    }) else {
+      return;
+    };
+    let target_key = fragment.key().clone();
 
     // Clone and downcast to get the content
     let cloned: Box<dyn rspack_core::InitFragment<_>> = fragment.clone();
@@ -247,7 +266,7 @@ impl MockMethodDependencyTemplate {
     // Create a new fragment with higher priority (position=-3, before the mock
     // placeholder at -2 and importActual imports at -1) and insert at the beginning
     let content = conditional_fragment.content().to_string();
-    let rstest_import = ConditionalInitFragment::new(
+    let test_api_import = ConditionalInitFragment::new(
       content,
       InitFragmentStage::StageESMImports,
       -3,
@@ -255,7 +274,7 @@ impl MockMethodDependencyTemplate {
       None,
       RuntimeCondition::Boolean(true),
     );
-    init_fragments.insert(0, rstest_import.boxed());
+    init_fragments.insert(0, test_api_import.boxed());
   }
 
   /// Transform the source code by:

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -14,11 +14,12 @@ use rspack_plugin_javascript::{
 };
 use rspack_util::{SpanExt, atom::Atom, json_stringify_str, swc::get_swc_comments};
 use swc_experimental_ecma_ast::{
-  CallExpr, Callee, GetSpan, Ident, IdentName, ImportPhase as AstImportPhase, MemberExpr, Span,
-  UnaryExpr, VarDeclarator,
+  CallExpr, Callee, GetSpan, Ident, IdentName, ImportDecl, ImportPhase as AstImportPhase,
+  MemberExpr, Span, UnaryExpr, VarDeclarator,
 };
 
 static RSTEST_MOCK_FIRST_ARG_TAG: &str = "strip the import call from the first arg of mock series";
+static RSTEST_API_IMPORT_TAG: &str = "rstest test api import";
 
 use crate::{
   dynamic_import_origin_dependency::RstestDynamicImportOriginDependency,
@@ -335,6 +336,7 @@ impl RstestParserPlugin {
     is_esm: bool,
     method: MockMethod,
     has_b: bool,
+    test_api_import_source_order: Option<i32>,
   ) {
     match call_expr.args.len() {
       1 => {
@@ -371,7 +373,8 @@ impl RstestParserPlugin {
               None
             } else {
               Some(first_arg.span().real_hi())
-            }),
+            })
+            .with_test_api_import_source_order(test_api_import_source_order),
           ));
 
           if has_b {
@@ -434,7 +437,8 @@ impl RstestParserPlugin {
               method,
             )
             // 2-arg `rs.mock('X', factory)`: append request after the factory.
-            .with_request_arg_end(Some(second_arg.span().real_hi())),
+            .with_request_arg_end(Some(second_arg.span().real_hi()))
+            .with_test_api_import_source_order(test_api_import_source_order),
           ));
           parser.add_dependency(Box::new(module_dep));
         } else {
@@ -468,6 +472,7 @@ impl RstestParserPlugin {
     parser: &mut JavascriptParser,
     call_expr: &CallExpr,
     statement_span: Option<Span>,
+    test_api_import_source_order: Option<i32>,
   ) -> Option<bool> {
     match call_expr.args.len() {
       1 => {
@@ -489,7 +494,9 @@ impl RstestParserPlugin {
             MockMethod::Hoisted,
           )
         };
-        parser.add_presentational_dependency(Box::new(dep));
+        parser.add_presentational_dependency(Box::new(
+          dep.with_test_api_import_source_order(test_api_import_source_order),
+        ));
         Some(false)
       }
       _ => {
@@ -660,8 +667,13 @@ impl RstestParserPlugin {
     prop: &IdentName,
     statement_span: Option<Span>,
   ) -> Option<bool> {
+    let ident_name = Atom::from(ident.sym.as_str());
+    let test_api_import_source_order = parser
+      .get_tag_data::<i32>(&ident_name, RSTEST_API_IMPORT_TAG)
+      .copied();
+
     // Check if this is a global variable (free variable) or an ESM import
-    let is_global = !parser.is_variable_defined(&Atom::from(ident.sym.as_str()));
+    let is_global = !parser.is_variable_defined(&ident_name);
 
     // Skip global variables if globals option is disabled
     if is_global && !self.options.globals {
@@ -671,7 +683,15 @@ impl RstestParserPlugin {
     match (ident.sym.as_str(), prop.sym.as_str()) {
       // rs.mock
       ("rs" | "rstest", "mock") => {
-        self.process_mock(parser, call_expr, true, true, MockMethod::Mock, true);
+        self.process_mock(
+          parser,
+          call_expr,
+          true,
+          true,
+          MockMethod::Mock,
+          true,
+          test_api_import_source_order,
+        );
         Some(false)
       }
       // rs.mockRequire
@@ -683,12 +703,21 @@ impl RstestParserPlugin {
           false,
           MockMethod::MockRequire,
           true,
+          test_api_import_source_order,
         );
         Some(false)
       }
       // rs.doMock
       ("rs" | "rstest", "doMock") => {
-        self.process_mock(parser, call_expr, false, true, MockMethod::DoMock, true);
+        self.process_mock(
+          parser,
+          call_expr,
+          false,
+          true,
+          MockMethod::DoMock,
+          true,
+          test_api_import_source_order,
+        );
         Some(false)
       }
       // rs.doMockRequire
@@ -700,6 +729,7 @@ impl RstestParserPlugin {
           false,
           MockMethod::DoMockRequire,
           true,
+          test_api_import_source_order,
         );
         Some(false)
       }
@@ -710,28 +740,65 @@ impl RstestParserPlugin {
       ("rs" | "rstest", "requireMock") => self.load_mock(parser, call_expr, false),
       // rs.unmock
       ("rs" | "rstest", "unmock") => {
-        self.process_mock(parser, call_expr, true, true, MockMethod::Unmock, false);
+        self.process_mock(
+          parser,
+          call_expr,
+          true,
+          true,
+          MockMethod::Unmock,
+          false,
+          test_api_import_source_order,
+        );
         Some(true)
       }
       // rs.doUnmock
       ("rs" | "rstest", "doUnmock") => {
-        self.process_mock(parser, call_expr, false, true, MockMethod::Unmock, false);
+        self.process_mock(
+          parser,
+          call_expr,
+          false,
+          true,
+          MockMethod::Unmock,
+          false,
+          test_api_import_source_order,
+        );
         Some(true)
       }
       // rs.unmockRequire
       ("rs" | "rstest", "unmockRequire") => {
-        self.process_mock(parser, call_expr, true, false, MockMethod::Unmock, false);
+        self.process_mock(
+          parser,
+          call_expr,
+          true,
+          false,
+          MockMethod::Unmock,
+          false,
+          test_api_import_source_order,
+        );
         Some(true)
       }
       // rs.doUnmockRequire
       ("rs" | "rstest", "doUnmockRequire") => {
-        self.process_mock(parser, call_expr, false, false, MockMethod::Unmock, false);
+        self.process_mock(
+          parser,
+          call_expr,
+          false,
+          false,
+          MockMethod::Unmock,
+          false,
+          test_api_import_source_order,
+        );
         Some(true)
       }
       // rs.resetModules
       ("rs" | "rstest", "resetModules") => self.reset_modules(parser, call_expr),
       // rs.hoisted
-      ("rs" | "rstest", "hoisted") => self.hoisted(parser, call_expr, statement_span),
+      ("rs" | "rstest", "hoisted") => self.hoisted(
+        parser,
+        call_expr,
+        statement_span,
+        test_api_import_source_order,
+      ),
       _ => {
         // Not a mock module, continue.
         None
@@ -742,6 +809,26 @@ impl RstestParserPlugin {
 
 #[rspack_plugin_javascript::implemented_javascript_parser_hooks]
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RstestParserPlugin {
+  fn import_specifier(
+    &self,
+    parser: &mut JavascriptParser<'p>,
+    _statement: &ImportDecl,
+    _source: &Atom,
+    _export_name: Option<&Atom>,
+    identifier_name: &Atom,
+  ) -> Option<bool> {
+    if matches!(identifier_name.as_str(), "rs" | "rstest") {
+      let source_order = parser.current_esm_import_order();
+      parser.tag_variable::<i32>(
+        identifier_name.clone(),
+        RSTEST_API_IMPORT_TAG,
+        Some(source_order),
+      );
+    }
+
+    None
+  }
+
   fn declarator(
     &self,
     parser: &mut JavascriptParser<'p>,

--- a/tests/rspack-test/configCases/rstest/mock/hoisted-rstack-reexport.js
+++ b/tests/rspack-test/configCases/rstest/mock/hoisted-rstack-reexport.js
@@ -1,0 +1,9 @@
+import { rs } from './reexport-rstack-test';
+
+const mocks = rs.hoisted(() => ({
+  mockedFn: rs.fn(),
+}));
+
+it('rs.hoisted should work with rs.fn re-exported by a user module', () => {
+  expect(typeof mocks.mockedFn).toBe('function');
+});

--- a/tests/rspack-test/configCases/rstest/mock/hoisted-rstack.js
+++ b/tests/rspack-test/configCases/rstest/mock/hoisted-rstack.js
@@ -1,0 +1,9 @@
+import { rs } from 'rstack/test';
+
+const mocks = rs.hoisted(() => ({
+  mockedFn: rs.fn(),
+}));
+
+it('rs.hoisted should work with rs.fn from rstack/test', () => {
+  expect(typeof mocks.mockedFn).toBe('function');
+});

--- a/tests/rspack-test/configCases/rstest/mock/reexport-rstack-test.js
+++ b/tests/rspack-test/configCases/rstest/mock/reexport-rstack-test.js
@@ -1,0 +1,1 @@
+export { rs } from 'rstack/test';

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -265,4 +265,10 @@ module.exports = [
       'rstack/test': 'commonjs rstack/test',
     },
   },
+  {
+    ...rstestEntry('./hoisted-rstack-reexport.js'),
+    externals: {
+      'rstack/test': 'commonjs rstack/test',
+    },
+  },
 ];

--- a/tests/rspack-test/configCases/rstest/mock/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock/rspack.config.js
@@ -259,4 +259,10 @@ module.exports = [
       '@rstest/core': 'global @rstest/core',
     },
   },
+  {
+    ...rstestEntry('./hoisted-rstack.js'),
+    externals: {
+      'rstack/test': 'commonjs rstack/test',
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Rstest mock hoisting previously recognized only the exact `@rstest/core` external fragment, so test APIs imported from `rstack/test`—either directly or through a user re-export—could be initialized after `rs.hoisted()` callbacks.

```js
import { rs } from 'rstack/test';

const mocks = rs.hoisted(() => ({
  mockedFn: rs.fn(),
}));
```

This PR tracks the test API import's source order and hoists the matching ESM fragment without hardcoding its package or external type, while preserving normal import ordering for non-hoisted methods.

## Related links

- [Rstack CLI](https://github.com/rstackjs/rstack-cli)
- [Rstack CLI migration](https://github.com/web-infra-dev/rspack/pull/14998)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).