### PR TITLE
fix(worker): handle SharedWorker string name option

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -44,8 +44,8 @@ struct ParsedNewWorkerOptions {
 #[derive(Debug, Clone, Copy)]
 enum ParsedNewWorkerOptionsKind {
   Object,
-  String,
-  Unknown,
+  SharedWorkerString,
+  SharedWorkerUnknown,
 }
 
 #[derive(Debug)]
@@ -54,17 +54,17 @@ struct ParsedNewWorkerImportOptions {
   pub ignored: Option<bool>,
 }
 
-fn parse_new_worker_options(arg: &ExprOrSpread) -> ParsedNewWorkerOptions {
+fn parse_new_worker_options(arg: &ExprOrSpread, is_shared_worker: bool) -> ParsedNewWorkerOptions {
   let obj = arg.expr.as_object();
   let name = obj
     .and_then(|obj| get_literal_str_by_obj_prop(obj, "name"))
     .map(|str| str.value.to_string_lossy().into());
-  let kind = if obj.is_some() {
+  let kind = if obj.is_some() || !is_shared_worker {
     ParsedNewWorkerOptionsKind::Object
   } else if arg.expr.as_lit().and_then(|lit| lit.as_str()).is_some() {
-    ParsedNewWorkerOptionsKind::String
+    ParsedNewWorkerOptionsKind::SharedWorkerString
   } else {
-    ParsedNewWorkerOptionsKind::Unknown
+    ParsedNewWorkerOptionsKind::SharedWorkerUnknown
   };
   let span = arg.span();
   ParsedNewWorkerOptions {
@@ -98,7 +98,6 @@ fn add_dependencies(
   parsed_options: Option<ParsedNewWorkerOptions>,
   need_new_url: bool,
   url_mode: Option<JavascriptParserWorkerUrl>,
-  is_shared_worker: bool,
 ) {
   let output_options = &parser.compiler_options.output;
   let mut hasher = RspackHasher::from(output_options);
@@ -150,9 +149,10 @@ fn add_dependencies(
   }
 
   if let Some(options_range) = options_range {
-    if is_shared_worker
-      && matches!(options_kind, Some(ParsedNewWorkerOptionsKind::String))
-      && !output_module
+    if matches!(
+      options_kind,
+      Some(ParsedNewWorkerOptionsKind::SharedWorkerString)
+    ) && !output_module
     {
       return;
     }
@@ -161,11 +161,11 @@ fn add_dependencies(
     } else {
       "undefined"
     };
-    let (prefix, suffix) = match (is_shared_worker, options_kind) {
-      (true, Some(ParsedNewWorkerOptionsKind::String)) => {
+    let (prefix, suffix) = match options_kind {
+      Some(ParsedNewWorkerOptionsKind::SharedWorkerString) => {
         ("{ name: ".to_string(), format!(", type: {worker_type} }}"))
       }
-      (true, Some(ParsedNewWorkerOptionsKind::Unknown)) => {
+      Some(ParsedNewWorkerOptionsKind::SharedWorkerUnknown) => {
         let string_options = if output_module {
           format!("{{ name: options, type: {worker_type} }}")
         } else {
@@ -205,6 +205,7 @@ fn handle_worker<'a>(
   parser: &mut JavascriptParser,
   args: &'a [ExprOrSpread<'a>],
   span: Span,
+  is_shared_worker: bool,
 ) -> Option<(
   ParsedNewWorkerPath,
   Option<ParsedNewWorkerOptions>,
@@ -249,7 +250,7 @@ fn handle_worker<'a>(
     let mut options = args
       .get(1)
       // new Worker(new URL("worker.js"), options)
-      .map(parse_new_worker_options);
+      .map(|arg| parse_new_worker_options(arg, is_shared_worker));
 
     let import_options = expr_box
       .as_new()
@@ -283,7 +284,7 @@ fn handle_worker<'a>(
         options = Some(ParsedNewWorkerOptions {
           range: None,
           name: Some(name),
-          kind: ParsedNewWorkerOptionsKind::Unknown,
+          kind: ParsedNewWorkerOptionsKind::Object,
         });
       }
     }
@@ -480,7 +481,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
     if let Some(value) = self.inner.pattern_syntax.get(data.key.as_str())
       && value.contains(&members.iter().map(|id| id.as_str()).join("."))
     {
-      return handle_worker(parser, &call_expr.args, call_expr.span).map(
+      return handle_worker(parser, &call_expr.args, call_expr.span, false).map(
         |(parsed_path, parsed_options, first_arg, need_new_url)| {
           add_dependencies(
             parser,
@@ -490,7 +491,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
             parsed_options,
             need_new_url,
             self.url_mode,
-            false,
           );
           if let Some(callee) = call_expr.callee.as_expr() {
             parser.walk_expression(callee);
@@ -522,7 +522,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
         .from_call_syntax
         .contains(&(ids, settings.source.to_string()))
       {
-        return handle_worker(parser, &call_expr.args, call_expr.span).map(
+        return handle_worker(parser, &call_expr.args, call_expr.span, false).map(
           |(parsed_path, parsed_options, first_arg, need_new_url)| {
             add_dependencies(
               parser,
@@ -532,7 +532,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
               parsed_options,
               need_new_url,
               self.url_mode,
-              false,
             );
             if let Some(callee) = call_expr.callee.as_expr() {
               parser.walk_expression(callee);
@@ -549,7 +548,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
     if !self.inner.call_syntax.contains(for_name) {
       return None;
     }
-    handle_worker(parser, &call_expr.args, call_expr.span).map(
+    handle_worker(parser, &call_expr.args, call_expr.span, false).map(
       |(parsed_path, parsed_options, first_arg, need_new_url)| {
         add_dependencies(
           parser,
@@ -559,7 +558,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
           parsed_options,
           need_new_url,
           self.url_mode,
-          false,
         );
         if let Some(callee) = call_expr.callee.as_expr() {
           parser.walk_expression(callee);
@@ -592,7 +590,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
         return new_expr
           .args
           .as_ref()
-          .and_then(|args| handle_worker(parser, args, new_expr.span))
+          .and_then(|args| handle_worker(parser, args, new_expr.span, false))
           .map(|(parsed_path, parsed_options, first_arg, need_new_url)| {
             add_dependencies(
               parser,
@@ -602,7 +600,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
               parsed_options,
               need_new_url,
               self.url_mode,
-              false,
             );
             parser.walk_expression(&new_expr.callee);
             if let Some(args) = &new_expr.args
@@ -621,7 +618,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
     new_expr
       .args
       .as_ref()
-      .and_then(|args| handle_worker(parser, args, new_expr.span))
+      .and_then(|args| handle_worker(parser, args, new_expr.span, for_name == "SharedWorker"))
       .map(|(parsed_path, parsed_options, first_arg, need_new_url)| {
         add_dependencies(
           parser,
@@ -631,7 +628,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
           parsed_options,
           need_new_url,
           self.url_mode,
-          for_name == "SharedWorker",
         );
         parser.walk_expression(&new_expr.callee);
         if let Some(args) = &new_expr.args

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -38,6 +38,14 @@ struct ParsedNewWorkerPath {
 struct ParsedNewWorkerOptions {
   pub range: Option<(u32, u32)>,
   pub name: Option<String>,
+  pub kind: ParsedNewWorkerOptionsKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ParsedNewWorkerOptionsKind {
+  Object,
+  String,
+  Unknown,
 }
 
 #[derive(Debug)]
@@ -51,10 +59,18 @@ fn parse_new_worker_options(arg: &ExprOrSpread) -> ParsedNewWorkerOptions {
   let name = obj
     .and_then(|obj| get_literal_str_by_obj_prop(obj, "name"))
     .map(|str| str.value.to_string_lossy().into());
+  let kind = if obj.is_some() {
+    ParsedNewWorkerOptionsKind::Object
+  } else if arg.expr.as_lit().and_then(|lit| lit.as_str()).is_some() {
+    ParsedNewWorkerOptionsKind::String
+  } else {
+    ParsedNewWorkerOptionsKind::Unknown
+  };
   let span = arg.span();
   ParsedNewWorkerOptions {
     range: Some((span.real_lo(), span.real_hi())),
     name,
+    kind,
   }
 }
 
@@ -82,6 +98,7 @@ fn add_dependencies(
   parsed_options: Option<ParsedNewWorkerOptions>,
   need_new_url: bool,
   url_mode: Option<JavascriptParserWorkerUrl>,
+  is_shared_worker: bool,
 ) {
   let output_options = &parser.compiler_options.output;
   let mut hasher = RspackHasher::from(output_options);
@@ -93,6 +110,7 @@ fn add_dependencies(
     .rendered(output_options.hash_digest_length)
     .to_owned();
   let options_range = parsed_options.as_ref().and_then(|options| options.range);
+  let options_kind = parsed_options.as_ref().map(|options| options.kind);
   let name = parsed_options.and_then(|options| options.name);
   let output_module = output_options.module;
   let dep = Box::new(WorkerDependency::new(
@@ -132,21 +150,47 @@ fn add_dependencies(
   }
 
   if let Some(options_range) = options_range {
+    if is_shared_worker
+      && matches!(options_kind, Some(ParsedNewWorkerOptionsKind::String))
+      && !output_module
+    {
+      return;
+    }
+    let worker_type = if output_module {
+      "\"module\""
+    } else {
+      "undefined"
+    };
+    let (prefix, suffix) = match (is_shared_worker, options_kind) {
+      (true, Some(ParsedNewWorkerOptionsKind::String)) => {
+        ("{ name: ".to_string(), format!(", type: {worker_type} }}"))
+      }
+      (true, Some(ParsedNewWorkerOptionsKind::Unknown)) => {
+        let string_options = if output_module {
+          format!("{{ name: options, type: {worker_type} }}")
+        } else {
+          "options".to_string()
+        };
+        (
+          format!(
+            "(function(options) {{ return typeof options === \"string\" ? {string_options} : \
+             Object.assign({{}}, options, {{ type: {worker_type} }}); }})("
+          ),
+          ")".to_string(),
+        )
+      }
+      _ => (
+        "Object.assign({}, ".to_string(),
+        format!(", {{ type: {worker_type} }})"),
+      ),
+    };
     parser.add_presentational_dependency(Box::new(ConstDependency::new(
       (options_range.0, options_range.0).into(),
-      "Object.assign({}, ".into(),
+      prefix.into(),
     )));
     parser.add_presentational_dependency(Box::new(ConstDependency::new(
       (options_range.1, options_range.1).into(),
-      format!(
-        ", {{ type: {} }})",
-        if output_module {
-          "\"module\""
-        } else {
-          "undefined"
-        }
-      )
-      .into(),
+      suffix.into(),
     )));
   } else if options_range.is_none() && output_module {
     let insert_position = first_arg.span().real_hi();
@@ -239,6 +283,7 @@ fn handle_worker<'a>(
         options = Some(ParsedNewWorkerOptions {
           range: None,
           name: Some(name),
+          kind: ParsedNewWorkerOptionsKind::Unknown,
         });
       }
     }
@@ -445,6 +490,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
             parsed_options,
             need_new_url,
             self.url_mode,
+            false,
           );
           if let Some(callee) = call_expr.callee.as_expr() {
             parser.walk_expression(callee);
@@ -486,6 +532,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
               parsed_options,
               need_new_url,
               self.url_mode,
+              false,
             );
             if let Some(callee) = call_expr.callee.as_expr() {
               parser.walk_expression(callee);
@@ -512,6 +559,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
           parsed_options,
           need_new_url,
           self.url_mode,
+          false,
         );
         if let Some(callee) = call_expr.callee.as_expr() {
           parser.walk_expression(callee);
@@ -554,6 +602,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
               parsed_options,
               need_new_url,
               self.url_mode,
+              false,
             );
             parser.walk_expression(&new_expr.callee);
             if let Some(args) = &new_expr.args
@@ -582,6 +631,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
           parsed_options,
           need_new_url,
           self.url_mode,
+          for_name == "SharedWorker",
         );
         parser.walk_expression(&new_expr.callee);
         if let Some(args) = &new_expr.args

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -56,7 +56,11 @@ struct ParsedNewWorkerImportOptions {
 
 fn parse_new_worker_options(arg: &ExprOrSpread, is_shared_worker: bool) -> ParsedNewWorkerOptions {
   let obj = arg.expr.as_object();
-  let string = arg.expr.as_lit().and_then(|lit| lit.as_str());
+  let string = if arg.spread.is_none() {
+    arg.expr.as_lit().and_then(|lit| lit.as_str())
+  } else {
+    None
+  };
   let name = if let Some(obj) = obj {
     get_literal_str_by_obj_prop(obj, "name").map(|str| str.value.to_string_lossy().into())
   } else if is_shared_worker {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -56,12 +56,17 @@ struct ParsedNewWorkerImportOptions {
 
 fn parse_new_worker_options(arg: &ExprOrSpread, is_shared_worker: bool) -> ParsedNewWorkerOptions {
   let obj = arg.expr.as_object();
-  let name = obj
-    .and_then(|obj| get_literal_str_by_obj_prop(obj, "name"))
-    .map(|str| str.value.to_string_lossy().into());
+  let string = arg.expr.as_lit().and_then(|lit| lit.as_str());
+  let name = if let Some(obj) = obj {
+    get_literal_str_by_obj_prop(obj, "name").map(|str| str.value.to_string_lossy().into())
+  } else if is_shared_worker {
+    string.map(|str| str.value.to_string_lossy().into())
+  } else {
+    None
+  };
   let kind = if obj.is_some() || !is_shared_worker {
     ParsedNewWorkerOptionsKind::Object
-  } else if arg.expr.as_lit().and_then(|lit| lit.as_str()).is_some() {
+  } else if string.is_some() {
     ParsedNewWorkerOptionsKind::SharedWorkerString
   } else {
     ParsedNewWorkerOptionsKind::SharedWorkerUnknown

--- a/tests/rspack-test/configCases/worker/new-url-relative/index.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/index.js
@@ -26,3 +26,55 @@ new Worker(
 	),
 	{ type: "module", type: "classic" }
 );
+
+new SharedWorker(
+	/* webpackChunkName: "shared-string-literal" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	"string-literal"
+);
+
+new SharedWorker(
+	/* webpackChunkName: "shared-object-literal" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	{ name: "object-literal", type: "classic" }
+);
+
+const sharedWorkerName = "string-variable";
+new SharedWorker(
+	/* webpackChunkName: "shared-string-variable" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	sharedWorkerName
+);
+
+const sharedWorkerOptions = {
+	name: "object-variable",
+	type: "classic"
+};
+new SharedWorker(
+	/* webpackChunkName: "shared-object-variable" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	sharedWorkerOptions
+);
+
+let sharedWorkerOptionsEvaluationCount = 0;
+const getSharedWorkerOptions = () => {
+	sharedWorkerOptionsEvaluationCount++;
+	return "string-expression";
+};
+new SharedWorker(
+	/* webpackChunkName: "shared-string-expression" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	getSharedWorkerOptions()
+);
+globalThis.__sharedWorkerOptionsEvaluationCount =
+	sharedWorkerOptionsEvaluationCount;

--- a/tests/rspack-test/configCases/worker/new-url-relative/index.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/index.js
@@ -35,6 +35,8 @@ new SharedWorker(
 	"string-literal"
 );
 
+new SharedWorker(new URL("./worker.js", import.meta.url), "chat");
+
 new SharedWorker(
 	/* webpackChunkName: "shared-object-literal" */ new URL(
 		"./worker.js",

--- a/tests/rspack-test/configCases/worker/new-url-relative/index.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/index.js
@@ -38,6 +38,14 @@ new SharedWorker(
 new SharedWorker(new URL("./worker.js", import.meta.url), "chat");
 
 new SharedWorker(
+	/* webpackChunkName: "shared-spread-string" */ new URL(
+		"./worker.js",
+		import.meta.url
+	),
+	..."spread-string"
+);
+
+new SharedWorker(
 	/* webpackChunkName: "shared-object-literal" */ new URL(
 		"./worker.js",
 		import.meta.url

--- a/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
@@ -52,21 +52,42 @@ module.exports = {
 				);
 			} else {
 				expect(workerUrl).toBe(testCase.url);
-				const output = execFileSync(
-					process.execPath,
-					[
-						"--input-type=module",
-						"--eval",
-						`const types = []; globalThis.Worker = class { constructor(_url, options) { types.push(options.type); } }; ${source}; console.log(JSON.stringify(types));`
+			}
+
+			const output = execFileSync(
+				process.execPath,
+				[
+					...(testCase.runtime ? [] : ["--input-type=module"]),
+					"--eval",
+					`const types = []; const sharedOptions = []; globalThis.Worker = class { constructor(_url, options) { types.push(options?.type); } }; globalThis.SharedWorker = class { constructor(_url, options) { sharedOptions.push(options); } }; ${source}; console.log(JSON.stringify({ types, sharedOptions, evaluationCount: globalThis.__sharedWorkerOptionsEvaluationCount }));`
+				],
+				{ encoding: "utf8" }
+			);
+			const result = JSON.parse(output);
+			if (testCase.runtime) {
+				expect(result).toEqual({
+					types: [null, null, null, null],
+					sharedOptions: [
+						"string-literal",
+						{ name: "object-literal" },
+						"string-variable",
+						{ name: "object-variable" },
+						"string-expression"
 					],
-					{ encoding: "utf8" }
-				);
-				expect(JSON.parse(output)).toEqual([
-					"module",
-					"module",
-					"module",
-					"module"
-				]);
+					evaluationCount: 1
+				});
+			} else {
+				expect(result).toEqual({
+					types: ["module", "module", "module", "module"],
+					sharedOptions: [
+						{ name: "string-literal", type: "module" },
+						{ name: "object-literal", type: "module" },
+						{ name: "string-variable", type: "module" },
+						{ name: "object-variable", type: "module" },
+						{ name: "string-expression", type: "module" }
+					],
+					evaluationCount: 1
+				});
 			}
 
 			expect(

--- a/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
@@ -76,6 +76,7 @@ module.exports = {
 					sharedOptions: [
 						"string-literal",
 						"chat",
+						"s",
 						{ name: "object-literal" },
 						"string-variable",
 						{ name: "object-variable" },
@@ -89,6 +90,7 @@ module.exports = {
 					sharedOptions: [
 						{ name: "string-literal", type: "module" },
 						{ name: "chat", type: "module" },
+						{ name: "s", type: "module" },
 						{ name: "object-literal", type: "module" },
 						{ name: "string-variable", type: "module" },
 						{ name: "object-variable", type: "module" },

--- a/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
+++ b/tests/rspack-test/configCases/worker/new-url-relative/test.config.js
@@ -6,26 +6,32 @@ const cases = [
 	{
 		filename: "non-esm.js",
 		chunkFilename: "non-esm-worker.bundle.js",
+		sharedWorkerChunkFilename: "non-esm-chat.bundle.js",
 		runtime: true
 	},
 	{
 		filename: "public-path.js",
 		chunkFilename: "public-path-worker.bundle.js",
+		sharedWorkerChunkFilename: "public-path-chat.bundle.js",
 		url: "/public/public-path-worker.bundle.js"
 	},
 	{
 		filename: "relative-public-path/main.js",
 		chunkFilename: "relative-public-path-worker.bundle.js",
+		sharedWorkerChunkFilename: "relative-public-path-chat.bundle.js",
 		url: "../assets/relative-public-path-worker.bundle.js"
 	},
 	{
 		filename: "worker-public-path.js",
 		chunkFilename: "worker-public-path-worker.bundle.js",
+		sharedWorkerChunkFilename: "worker-public-path-chat.bundle.js",
 		url: "/workers/worker-public-path-worker.bundle.js"
 	},
 	{
 		filename: "relative-worker-public-path/main.js",
 		chunkFilename: "relative-worker-public-path-worker.bundle.js",
+		sharedWorkerChunkFilename:
+			"relative-worker-public-path-chat.bundle.js",
 		url: "../workers/relative-worker-public-path-worker.bundle.js"
 	}
 ];
@@ -69,6 +75,7 @@ module.exports = {
 					types: [null, null, null, null],
 					sharedOptions: [
 						"string-literal",
+						"chat",
 						{ name: "object-literal" },
 						"string-variable",
 						{ name: "object-variable" },
@@ -81,6 +88,7 @@ module.exports = {
 					types: ["module", "module", "module", "module"],
 					sharedOptions: [
 						{ name: "string-literal", type: "module" },
+						{ name: "chat", type: "module" },
 						{ name: "object-literal", type: "module" },
 						{ name: "string-variable", type: "module" },
 						{ name: "object-variable", type: "module" },
@@ -92,6 +100,11 @@ module.exports = {
 
 			expect(
 				fs.existsSync(path.join(outputPath, testCase.chunkFilename))
+			).toBe(true);
+			expect(
+				fs.existsSync(
+					path.join(outputPath, testCase.sharedWorkerChunkFilename)
+				)
 			).toBe(true);
 		}
 	}


### PR DESCRIPTION
## Summary

Fix the string name overload of `SharedWorker`.

Previously, Rspack transformed:

```js
new SharedWorker(url, "chat");
```

into:

```js
new SharedWorker(url, Object.assign({}, "chat", { type: "module" }));
```

This converted the string into an object without a `name` property, causing the SharedWorker name to be lost.

This PR handles the second argument based on its syntax:

- Object literals keep the existing `Object.assign` behavior.
- String literals are preserved for classic output and converted to `{ name: "chat", type: "module" }` for module output.
- Expressions whose type is unknown at compile time use a runtime check to distinguish strings from objects and are evaluated only once.

> Since the SharedWorker flag and option kind jointly describe one rendering semantic, they are encoded together to keep `add_dependencies` within Clippy's argument limit.

The new behavior is limited to `SharedWorker`. `Worker`, Service Worker, Node.js Worker, and custom worker aliases are unchanged.

## Related links

- Follow-up to #14874
- https://html.spec.whatwg.org/multipage/workers.html#shared-workers-and-the-sharedworker-interface

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required).
