### PR TITLE
perf(cache): recover JSON build data from cached module source

### DIFF
--- a/crates/rspack_core/src/cache/persistent/codec.rs
+++ b/crates/rspack_core/src/cache/persistent/codec.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use rspack_cacheable::{
   __private::rkyv::{Archive, Deserialize, Serialize, bytecheck::CheckBytes},
   Deserializer, Serializer, Validator, from_bytes, to_bytes,
@@ -7,17 +5,7 @@ use rspack_cacheable::{
 use rspack_error::Result;
 use rspack_paths::Utf8PathBuf;
 
-/// Internal cacheable context for serialization
-#[derive(Debug, Clone)]
-struct Context {
-  project_path: Option<Utf8PathBuf>,
-}
-
-impl rspack_cacheable::CacheableContext for Context {
-  fn project_root(&self) -> Option<&Path> {
-    self.project_path.as_ref().map(|p| p.as_std_path())
-  }
-}
+use crate::json_archive::{JsonArchiveContext, JsonArchivePolicy};
 
 /// Cache codec for encoding and decoding cacheable data
 ///
@@ -37,13 +25,18 @@ impl rspack_cacheable::CacheableContext for Context {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CacheCodec {
-  context: Context,
+  context: JsonArchiveContext,
+  source_json_context: JsonArchiveContext,
 }
 
 impl CacheCodec {
   pub fn new(project_path: Option<Utf8PathBuf>) -> Self {
     Self {
-      context: Context { project_path },
+      context: JsonArchiveContext::new(project_path.clone(), JsonArchivePolicy::Preserve),
+      source_json_context: JsonArchiveContext::new(
+        project_path,
+        JsonArchivePolicy::DeriveFromModuleSource,
+      ),
     }
   }
 
@@ -54,11 +47,115 @@ impl CacheCodec {
     to_bytes(data, &self.context).map_err(|e| rspack_error::error!(e.to_string()))
   }
 
+  pub(crate) fn encode_with_json_policy<T>(
+    &self,
+    data: &T,
+    json_archive_policy: JsonArchivePolicy,
+  ) -> Result<Vec<u8>>
+  where
+    T: for<'a> Serialize<Serializer<'a>>,
+  {
+    let context = match json_archive_policy {
+      JsonArchivePolicy::Preserve => &self.context,
+      JsonArchivePolicy::DeriveFromModuleSource => &self.source_json_context,
+    };
+    to_bytes(data, context).map_err(|error| rspack_error::error!(error.to_string()))
+  }
+
   pub fn decode<T>(&self, bytes: &[u8]) -> Result<T>
   where
     T: Archive,
     T::Archived: for<'a> CheckBytes<Validator<'a>> + Deserialize<T, Deserializer>,
   {
     from_bytes(bytes, &self.context).map_err(|e| rspack_error::error!(e.to_string()))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use json::JsonValue;
+  use rspack_cacheable::{cacheable, from_bytes, to_bytes};
+
+  use super::CacheCodec;
+  use crate::json_archive::{JsonArchivePolicy, JsonDataArchive};
+
+  #[cacheable]
+  #[derive(Debug)]
+  struct JsonOwner {
+    #[cacheable(with=JsonDataArchive)]
+    value: Option<JsonValue>,
+  }
+
+  #[test]
+  fn source_policy_stores_an_explicit_compact_recoverability_marker() {
+    let value = json::object! { payload: "x".repeat(16 * 1024) };
+    let owner = JsonOwner { value: Some(value) };
+    let codec = CacheCodec::new(None);
+    let preserved = codec
+      .encode_with_json_policy(&owner, JsonArchivePolicy::Preserve)
+      .expect("preserved JSON should archive");
+    let source_backed = codec
+      .encode_with_json_policy(&owner, JsonArchivePolicy::DeriveFromModuleSource)
+      .expect("source-backed JSON should archive");
+    eprintln!(
+      "synthetic JSON archive: preserved={} bytes, source-backed={} bytes",
+      preserved.len(),
+      source_backed.len()
+    );
+    assert!(preserved.len() > 16 * 1024);
+    assert!(source_backed.len() < 128);
+    assert!(preserved.len() > source_backed.len() * 100);
+    assert!(
+      codec
+        .decode::<JsonOwner>(&source_backed)
+        .unwrap()
+        .value
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn preserve_policy_retains_canonical_json() {
+    let value = json::object! { payload: "custom parser result" };
+    let codec = CacheCodec::new(None);
+    let encoded = codec
+      .encode_with_json_policy(
+        &JsonOwner {
+          value: Some(value.clone()),
+        },
+        JsonArchivePolicy::Preserve,
+      )
+      .unwrap();
+    assert_eq!(
+      codec.decode::<JsonOwner>(&encoded).unwrap().value,
+      Some(value)
+    );
+  }
+
+  #[test]
+  fn missing_json_remains_missing_under_both_policies() {
+    let codec = CacheCodec::new(None);
+    for policy in [
+      JsonArchivePolicy::Preserve,
+      JsonArchivePolicy::DeriveFromModuleSource,
+    ] {
+      let encoded = codec
+        .encode_with_json_policy(&JsonOwner { value: None }, policy)
+        .unwrap();
+      assert!(codec.decode::<JsonOwner>(&encoded).unwrap().value.is_none());
+    }
+  }
+
+  #[test]
+  fn unknown_contexts_preserve_json_by_default() {
+    let value = json::object! { payload: "ordinary cacheable context" };
+    let owner = JsonOwner {
+      value: Some(value.clone()),
+    };
+    let encoded = to_bytes(&owner, &()).unwrap();
+    assert_eq!(
+      from_bytes::<JsonOwner, _>(&encoded, &()).unwrap().value,
+      Some(value)
+    );
   }
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/make/module_graph.rs
@@ -3,16 +3,17 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use rayon::prelude::*;
 use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_collections::IdentifierSet;
-use rspack_error::Result;
+use rspack_error::{Result, error};
 use rustc_hash::FxHashSet;
 
 use super::alternatives::{TempDependency, TempModule};
 use crate::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, Dependency,
-  DependencyId, DependencyParents, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
-  ModuleIdentifier, RayonConsumer,
+  DependencyId, DependencyParents, Module, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
+  ModuleIdentifier, ModuleType, NormalModule, ParseOption, RayonConsumer,
   cache::persistent::{codec::CacheCodec, storage::Storage},
   compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
+  json_archive::{JsonArchivePolicy, restore_json_data_from_source},
 };
 
 pub const SCOPE: &str = "occasion_make_module_graph";
@@ -21,6 +22,7 @@ pub const SCOPE: &str = "occasion_make_module_graph";
 #[cacheable]
 struct Node<'a> {
   pub mgm: OwnedOrRef<'a, ModuleGraphModule>,
+  pub json_archive_policy: JsonArchivePolicy,
   pub module: OwnedOrRef<'a, BoxModule>,
   pub dependencies: Vec<(
     OwnedOrRef<'a, BoxDependency>,
@@ -29,6 +31,32 @@ struct Node<'a> {
   pub connections: Vec<OwnedOrRef<'a, ModuleGraphConnection>>,
   pub blocks: Vec<OwnedOrRef<'a, AsyncDependenciesBlock>>,
   pub lazy_info: Option<OwnedOrRef<'a, LazyDependencies>>,
+}
+
+fn json_archive_policy(module: &BoxModule) -> JsonArchivePolicy {
+  let Some(module) = module.as_ref().downcast_ref::<NormalModule>() else {
+    return JsonArchivePolicy::Preserve;
+  };
+  if module.module_type() != &ModuleType::Json
+    || !module
+      .parser_and_generator()
+      .can_restore_json_data_from_source()
+    || module.source().is_none()
+    || module.build_info().json_data.is_none()
+  {
+    return JsonArchivePolicy::Preserve;
+  }
+
+  match module
+    .get_parser_options()
+    .and_then(|options| options.get_json())
+  {
+    None => JsonArchivePolicy::DeriveFromModuleSource,
+    Some(options) if matches!(&options.parse, ParseOption::None) => {
+      JsonArchivePolicy::DeriveFromModuleSource
+    }
+    Some(_) => JsonArchivePolicy::Preserve,
+  }
 }
 
 #[tracing::instrument("Cache::Occasion::Make::ModuleGraph::save", skip_all)]
@@ -84,25 +112,27 @@ pub fn save_module_graph(
         .map(|lazy_deps| lazy_deps.into());
       let mut node = Node {
         mgm: mgm.into(),
+        json_archive_policy: json_archive_policy(module),
         module: module.into(),
         dependencies,
         connections,
         blocks,
         lazy_info,
       };
-      match codec.encode(&node) {
+      match codec.encode_with_json_policy(&node, node.json_archive_policy) {
         Ok(bytes) => (identifier.as_bytes().to_vec(), bytes),
         Err(err) if err.to_string().contains("unsupported field") => {
           tracing::warn!("to bytes failed {:?}", err);
           // try use alternatives
           node.module = TempModule::transform_from(node.module);
+          node.json_archive_policy = JsonArchivePolicy::Preserve;
           node.dependencies = node
             .dependencies
             .into_iter()
             .map(|(dep, _)| (TempDependency::transform_from(dep), None))
             .collect();
           node.blocks = vec![];
-          if let Ok(bytes) = codec.encode(&node) {
+          if let Ok(bytes) = codec.encode_with_json_policy(&node, node.json_archive_policy) {
             (identifier.as_bytes().to_vec(), bytes)
           } else {
             panic!("alternatives serialize failed")
@@ -129,17 +159,70 @@ pub async fn recovery_module_graph(
   let mut need_check_dep = vec![];
   let mut mg = ModuleGraph::default();
   let mut module_to_lazy_make = ModuleToLazyMake::default();
+  let mut recovery_error = None;
   storage
     .load(SCOPE)
     .await?
     .into_par_iter()
-    .map(|(_, v)| {
-      codec
-        .decode::<Node>(&v)
-        .expect("unexpected module graph deserialize failed")
+    .map(|(_, value)| {
+      let mut node = codec.decode::<Node>(&value)?;
+      if node.json_archive_policy == JsonArchivePolicy::DeriveFromModuleSource {
+        let OwnedOrRef::Owned(module) = &mut node.module else {
+          return Err(error!(
+            "cannot recover source-derived JSON from a borrowed module"
+          ));
+        };
+        let module = module
+          .as_mut()
+          .downcast_mut::<NormalModule>()
+          .ok_or_else(|| error!("cannot recover source-derived JSON for a non-normal module"))?;
+        if module.module_type() != &ModuleType::Json {
+          return Err(error!(
+            "cannot recover source-derived JSON for a non-JSON module"
+          ));
+        }
+        if !module
+          .parser_and_generator()
+          .can_restore_json_data_from_source()
+        {
+          return Err(error!(
+            "cannot recover source-derived JSON for a custom parser"
+          ));
+        }
+        if module.build_info().json_data.is_some() {
+          return Err(error!(
+            "source-derived JSON unexpectedly retained canonical data"
+          ));
+        }
+        if module
+          .get_parser_options()
+          .and_then(|options| options.get_json())
+          .is_some_and(|options| !matches!(&options.parse, ParseOption::None))
+        {
+          return Err(error!(
+            "cannot recover source-derived JSON with a custom parse callback"
+          ));
+        }
+        let source = module
+          .source()
+          .ok_or_else(|| error!("cannot recover JSON module without its source"))?
+          .source()
+          .into_string_lossy();
+        let data = restore_json_data_from_source(&source)?;
+        module.build_info_mut().json_data = Some(data);
+      }
+      Ok(node)
     })
     .with_max_len(1)
-    .consume(|node| {
+    .consume(|result| {
+      let node = match result {
+        Ok(node) if recovery_error.is_none() => node,
+        Ok(_) => return,
+        Err(error) => {
+          recovery_error.get_or_insert(error);
+          return;
+        }
+      };
       let mgm = node.mgm.into_owned();
       let module = node.module.into_owned();
       for (index_in_block, (dep, parent_block)) in node.dependencies.into_iter().enumerate() {
@@ -170,6 +253,9 @@ pub async fn recovery_module_graph(
       mg.add_module_graph_module(mgm);
       mg.add_module(module);
     });
+  if let Some(error) = recovery_error {
+    return Err(error);
+  }
   // recovery incoming connections
   for (dep_id, module_identifier) in need_check_dep {
     let mgm = mg.module_graph_module_by_identifier_mut(&module_identifier);

--- a/crates/rspack_core/src/json_archive.rs
+++ b/crates/rspack_core/src/json_archive.rs
@@ -1,0 +1,164 @@
+use std::path::Path;
+
+use json::JsonValue;
+use rspack_cacheable::{
+  __private::rkyv::{
+    Archive, Archived, Deserialize, Place, Resolver, Serialize,
+    rancor::Fallible,
+    ser::Sharing,
+    with::{ArchiveWith, DeserializeWith, SerializeWith},
+  },
+  CacheableContext, ContextGuard, Error, Result, cacheable,
+};
+use rspack_error::error;
+use rspack_paths::Utf8PathBuf;
+
+#[cacheable]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JsonArchivePolicy {
+  Preserve,
+  DeriveFromModuleSource,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct JsonArchiveContext {
+  project_path: Option<Utf8PathBuf>,
+  policy: JsonArchivePolicy,
+}
+
+impl JsonArchiveContext {
+  pub(crate) fn new(project_path: Option<Utf8PathBuf>, policy: JsonArchivePolicy) -> Self {
+    Self {
+      project_path,
+      policy,
+    }
+  }
+}
+
+impl CacheableContext for JsonArchiveContext {
+  fn project_root(&self) -> Option<&Path> {
+    self.project_path.as_ref().map(|path| path.as_std_path())
+  }
+}
+
+#[doc(hidden)]
+#[cacheable]
+#[derive(Debug)]
+pub enum StoredJsonData {
+  Canonical(String),
+  FromModuleSource,
+}
+
+#[doc(hidden)]
+pub struct JsonDataArchive;
+
+#[doc(hidden)]
+pub struct JsonDataResolver {
+  value: Option<StoredJsonData>,
+  resolver: Resolver<Option<StoredJsonData>>,
+}
+
+impl ArchiveWith<Option<JsonValue>> for JsonDataArchive {
+  type Archived = Archived<Option<StoredJsonData>>;
+  type Resolver = JsonDataResolver;
+
+  fn resolve_with(
+    _field: &Option<JsonValue>,
+    resolver: Self::Resolver,
+    out: Place<Self::Archived>,
+  ) {
+    resolver.value.resolve(resolver.resolver, out);
+  }
+}
+
+impl<S> SerializeWith<Option<JsonValue>, S> for JsonDataArchive
+where
+  S: Fallible<Error = Error> + Sharing,
+  Option<StoredJsonData>: Serialize<S>,
+{
+  fn serialize_with(field: &Option<JsonValue>, serializer: &mut S) -> Result<Self::Resolver> {
+    let Some(value) = field else {
+      let value = None;
+      return Ok(JsonDataResolver {
+        resolver: value.serialize(serializer)?,
+        value,
+      });
+    };
+
+    let policy = ContextGuard::sharing_guard(serializer)?
+      .downcast_context::<JsonArchiveContext>()
+      .map_or(JsonArchivePolicy::Preserve, |context| context.policy);
+    let value = Some(match policy {
+      JsonArchivePolicy::Preserve => StoredJsonData::Canonical(value.dump()),
+      JsonArchivePolicy::DeriveFromModuleSource => StoredJsonData::FromModuleSource,
+    });
+    Ok(JsonDataResolver {
+      resolver: value.serialize(serializer)?,
+      value,
+    })
+  }
+}
+
+impl<D> DeserializeWith<Archived<Option<StoredJsonData>>, Option<JsonValue>, D> for JsonDataArchive
+where
+  D: Fallible<Error = Error>,
+  Archived<Option<StoredJsonData>>: Deserialize<Option<StoredJsonData>, D>,
+{
+  fn deserialize_with(
+    field: &Archived<Option<StoredJsonData>>,
+    deserializer: &mut D,
+  ) -> Result<Option<JsonValue>> {
+    let value = field.deserialize(deserializer)?;
+    match value {
+      Some(StoredJsonData::Canonical(value)) => json::parse(&value)
+        .map(Some)
+        .map_err(|_| Error::MessageError("deserialize json value failed")),
+      Some(StoredJsonData::FromModuleSource) | None => Ok(None),
+    }
+  }
+}
+
+pub(crate) fn restore_json_data_from_source(source: &str) -> rspack_error::Result<JsonValue> {
+  let source = source.strip_prefix('\u{feff}').unwrap_or(source);
+  json::parse(source).map_err(|cause| error!("cannot recover persisted JSON module: {cause}"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::restore_json_data_from_source;
+
+  #[test]
+  fn restores_source_with_exactly_one_utf8_bom() {
+    let restored = restore_json_data_from_source("\u{feff}{\"value\":7}").unwrap();
+    assert_eq!(restored["value"], 7);
+    assert!(restore_json_data_from_source("\u{feff}\u{feff}{\"value\":7}").is_err());
+  }
+
+  #[test]
+  fn restores_the_post_loader_json_source() {
+    let loader_output = "{\"generated\":true,\"value\":11}";
+    let restored = restore_json_data_from_source(loader_output).unwrap();
+    assert_eq!(restored["generated"], true);
+    assert_eq!(restored["value"], 11);
+  }
+
+  #[test]
+  fn preserves_json_primitives_and_escaped_keys() {
+    for source in [
+      "null",
+      "true",
+      "17",
+      "[1,2,3]",
+      "{\"__proto__\":{\"safe\":true},\"\\u006bey\":\"value\"}",
+    ] {
+      let expected = json::parse(source).unwrap();
+      assert_eq!(restore_json_data_from_source(source).unwrap(), expected);
+    }
+  }
+
+  #[test]
+  fn rejects_malformed_recovered_source() {
+    assert!(restore_json_data_from_source("{\"value\":").is_err());
+    assert!(restore_json_data_from_source("").is_err());
+  }
+}

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -32,6 +32,7 @@ pub use external_module::*;
 mod logger;
 pub use logger::*;
 pub mod cache;
+mod json_archive;
 mod normal_module;
 mod raw_module;
 pub use raw_module::*;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -276,7 +276,7 @@ pub struct BuildInfo {
   pub esm_named_exports: HashSet<Atom>,
   pub all_star_exports: Vec<DependencyId>,
   pub need_create_require: bool,
-  #[cacheable(with=AsOption<AsPreset>)]
+  #[cacheable(with=crate::json_archive::JsonDataArchive)]
   pub json_data: Option<JsonValue>,
   pub asset: Option<Box<AssetBuildInfo>>,
   pub css: Option<Box<CssBuildInfo>>,

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -167,6 +167,11 @@ pub trait ParserAndGenerator: Send + Sync + Debug + AsAny {
   fn has_runtime_hash(&self) -> bool {
     false
   }
+
+  /// Whether persisted JSON data can be reconstructed from the built module source.
+  fn can_restore_json_data_from_source(&self) -> bool {
+    false
+  }
 }
 
 impl dyn ParserAndGenerator + '_ {

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -41,6 +41,10 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     &[SourceType::JavaScript]
   }
 
+  fn can_restore_json_data_from_source(&self) -> bool {
+    true
+  }
+
   fn size(&self, module: &dyn Module, _source_type: Option<&SourceType>) -> f64 {
     module
       .build_info()


### PR DESCRIPTION
## Summary

- Store standard JSON build data once by recovering it from the already-persisted module source.
- Opt in only the built-in JSON parser; custom parsers, callbacks, missing sources, and non-JSON modules preserve their existing cache behavior.
- Preserve loader-transformed sources, one leading UTF-8 BOM, JSON primitives, escaped keys, and unsupported-module fallback. Reject malformed or inconsistent cached entries so normal cache recovery can rebuild them.
- Synthetic persistent-cache codec benchmark using the same 16 KiB JSON value: preserved payload **16,416 bytes**, source-backed payload **16 bytes** (**1,026x smaller; 99.90% less**). This measures the archived JSON payload, not whole-compilation startup.
- Validation: `cargo fmt --all -- --check`; `cargo test -p rspack_core --lib --release --locked -- --nocapture` (**125 passed**); `cargo check -p rspack_plugin_json --release --locked`.

## Related links

- No issue linked.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
