### PR TITLE
fix(json): match webpack source map behavior for generated modules

### DIFF
--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   ParseOption, ParserAndGenerator, ParserOptions, Plugin, RuntimeSpec, SourceType, UsageState,
   UsedNameItem,
   diagnostics::ModuleParseError,
-  rspack_sources::{BoxSource, OriginalSource, RawStringSource, Source, SourceExt},
+  rspack_sources::{BoxSource, RawStringSource, Source, SourceExt},
 };
 use rspack_error::{Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray, error};
 use rspack_util::{itoa, location::byte_line_column_to_offset};
@@ -230,11 +230,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
               .render_module_argument(ModuleArgument::Module)
           )
         };
-        if module.get_source_map_kind().enabled() {
-          Ok(OriginalSource::new(content, module.identifier().as_str()).boxed())
-        } else {
-          Ok(RawStringSource::from(content).boxed())
-        }
+        Ok(RawStringSource::from(content).boxed())
       }
       _ => panic!(
         "Unsupported source type: {:?}",

--- a/tests/rspack-test/configCases/source-map/basic/data.json
+++ b/tests/rspack-test/configCases/source-map/basic/data.json
@@ -1,0 +1,5 @@
+{
+  "name": "synthetic",
+  "nested": { "value": 7 },
+  "__proto__": { "safe": true }
+}

--- a/tests/rspack-test/configCases/source-map/basic/helper.js
+++ b/tests/rspack-test/configCases/source-map/basic/helper.js
@@ -1,0 +1,3 @@
+export function helper(value) {
+  return `helper:${value}`;
+}

--- a/tests/rspack-test/configCases/source-map/basic/index.js
+++ b/tests/rspack-test/configCases/source-map/basic/index.js
@@ -1,3 +1,6 @@
+import data, { name, nested } from "./data.json";
+import { helper } from "./helper.js";
+
 it("basic", () => {
 	const fs = require("fs");
 	const source = fs.readFileSync(__filename + ".map", "utf-8");
@@ -6,6 +9,21 @@ it("basic", () => {
 	if (globalThis.__RSPACK_TEST_RUNTIME_MODE_RSPACK) {
 		sourceUrl = source => `rspack:///${source}`;
 	}
-	expect(map.sources).toContain(sourceUrl("./index.js"));
-	expect(map.file).toEqual("bundle0.js");
+	const indexSource = map.sources.indexOf(sourceUrl("./index.js"));
+	const helperSource = map.sources.indexOf(sourceUrl("./helper.js"));
+	expect(indexSource).toBeGreaterThanOrEqual(0);
+	expect(helperSource).toBeGreaterThanOrEqual(0);
+	expect(map.sources.some(source => source.includes("data.json"))).toBe(false);
+	expect(map.sourcesContent[indexSource]).toContain("ordinaryObjectUnaffected");
+	expect(map.sourcesContent[helperSource]).toContain("helper:");
+	expect(map.file).toEqual(require("path").basename(__filename));
+
+	expect(data.name).toBe("synthetic");
+	expect(name).toBe("synthetic");
+	expect(nested.value).toBe(7);
+	expect(helper(name)).toBe("helper:synthetic");
+	expect(Object.prototype.hasOwnProperty.call(data, "__proto__")).toBe(true);
+	expect(data.__proto__.safe).toBe(true);
+	const ordinaryObjectUnaffected = Object.prototype.safe === undefined;
+	expect(ordinaryObjectUnaffected).toBe(true);
 });

--- a/tests/rspack-test/configCases/source-map/basic/rspack.config.js
+++ b/tests/rspack-test/configCases/source-map/basic/rspack.config.js
@@ -1,6 +1,8 @@
-/** @type {import("@rspack/core").Configuration} */
-module.exports = {
-  devtool: 'source-map',
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = ['source-map', 'cheap-module-source-map'].map((devtool) => ({
+  mode: 'development',
+  devtool,
   externals: ['source-map'],
   externalsType: 'commonjs',
-};
+  optimization: { concatenateModules: false },
+}));


### PR DESCRIPTION
## Summary

- Match webpack's JSON generator by using an unmapped raw source for generated JavaScript in every source-map mode.
- Avoid attributing generated JSON module code to the original JSON file while preserving JavaScript mappings, `sourcesContent`, JSON exports, and `__proto__` behavior.
- Extend the existing source-map fixture across `source-map` and `cheap-module-source-map`; the fixture fails before the fix and passes afterward.

## Related links

- [webpack JSON generator](https://github.com/webpack/webpack/blob/main/lib/json/JsonGenerator.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
