### PR TITLE
fix(copy-plugin): use POSIX asset keys

### DIFF
--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -344,6 +344,7 @@ impl CopyRspackPlugin {
     } else {
       filename.as_str().normalize().to_string_lossy().to_string()
     };
+    let filename = normalize_glob_path_separators(&filename).into_owned();
 
     Ok(Some(RunPatternResult {
       source_filename,

--- a/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/assets/glob/nested/one.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/assets/glob/nested/one.txt
@@ -1,0 +1,1 @@
+ordinary

--- a/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/assets/simple-template/simple.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/assets/simple-template/simple.txt
@@ -1,0 +1,1 @@
+simple-template

--- a/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/assets/template/deep/two.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/assets/template/deep/two.txt
@@ -1,0 +1,1 @@
+template

--- a/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/index.js
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/index.js
@@ -1,0 +1,44 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+it("should emit copied assets with POSIX keys", () => {
+	const assetNames = __STATS__.assets.map(({ name }) => name);
+	expect(assetNames).toEqual(
+		expect.arrayContaining([
+			"copied/assets/glob/nested/one.txt",
+			"template/simple.txt",
+			"template/deep/two.txt"
+		])
+	);
+	for (const name of assetNames) {
+		expect(name).not.toContain("\\");
+	}
+
+	expect(
+		fs
+			.readFileSync(
+				path.join(
+					__STATS__.outputPath,
+					"copied/assets/glob/nested/one.txt"
+				),
+				"utf-8"
+			)
+			.trim()
+	).toBe("ordinary");
+	expect(
+		fs
+			.readFileSync(
+				path.join(__STATS__.outputPath, "template/simple.txt"),
+				"utf-8"
+			)
+			.trim()
+	).toBe("simple-template");
+	expect(
+		fs
+			.readFileSync(
+				path.join(__STATS__.outputPath, "template/deep/two.txt"),
+				"utf-8"
+			)
+			.trim()
+	).toBe("template");
+});

--- a/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-posix-asset-keys/rspack.config.js
@@ -1,0 +1,25 @@
+const { CopyRspackPlugin } = require('@rspack/core');
+
+module.exports = {
+  entry: './index.js',
+  target: 'node',
+  plugins: [
+    new CopyRspackPlugin({
+      patterns: [
+        {
+          from: 'assets/glob/*/*.txt',
+          to: 'copied',
+          toType: 'dir',
+        },
+        {
+          from: 'assets/simple-template',
+          to: 'template/[name][ext]',
+        },
+        {
+          from: 'assets/template',
+          to: 'template/[path][name][ext]',
+        },
+      ],
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

- Normalize the final `CopyRspackPlugin` asset key after both ordinary destination handling and template rendering.
- Add a focused config case for directory/glob output, `[name][ext]`, and nested `[path][name][ext]` templates.

On Windows, path normalization and template rendering could leave backslashes in emitted asset names, so portable lookups such as `compilation.getAsset("template/deep/two.txt")` failed. Normalizing at the shared final boundary keeps all emitted Copy asset keys POSIX-style.

## Related links

- Extracted from #14844.
- Related to #14791.

## Testing

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "configCases/plugins/copy-plugin-posix-asset-keys"`
- `cargo fmt --all --check`
- Prettier and JS lint checks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).