### PR TITLE
fix(dll): serialize buildMeta.defaultObject as redirect-warn

### DIFF
--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -860,8 +860,10 @@ impl From<JsBuildMeta> for BuildMeta {
       raw_default_object.map(|raw_default_object| match raw_default_object.as_str() {
         "false" => BuildMetaDefaultObject::False,
         "redirect" => BuildMetaDefaultObject::Redirect,
-        "redirect-warn" => BuildMetaDefaultObject::RedirectWarn,
-        _ => unreachable!(),
+        // Accept webpack/kebab form and the camelCase form previously written by
+        // `#[serde(rename_all = "camelCase")]` on BuildMetaDefaultObject (#15010).
+        "redirect-warn" | "redirectWarn" => BuildMetaDefaultObject::RedirectWarn,
+        other => panic!("Unexpected buildMeta.defaultObject value: {other}"),
       });
 
     let exports_type = raw_exports_type

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -420,6 +420,9 @@ pub enum BuildMetaDefaultObject {
   #[default]
   False,
   Redirect,
+  // Must match webpack / Display (`redirect-warn`), not serde camelCase (`redirectWarn`).
+  // camelCase broke DllPlugin manifests consumed by DllReferencePlugin (see #15010).
+  #[serde(rename = "redirect-warn")]
   RedirectWarn,
 }
 

--- a/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/context-user.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/context-user.js
@@ -1,0 +1,3 @@
+export function loadWidget(name) {
+	return import(`./lazy/${name}.js`);
+}

--- a/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/index.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/index.js
@@ -1,0 +1,2 @@
+export { loadWidget } from "./context-user";
+export const hello = "hello";

--- a/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/lazy/a.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/lazy/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/rspack.config.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/rspack.config.js
@@ -1,22 +1,22 @@
-var path = require("path");
-var webpack = require("@rspack/core");
+var path = require('path');
+var webpack = require('@rspack/core');
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	entry: ["."],
-	output: {
-		filename: "dll.js",
-		chunkFilename: "[id].dll.js",
-		library: { type: "commonjs2" }
-	},
-	plugins: [
-		new webpack.DllPlugin({
-			path: path.resolve(
-				__dirname,
-				"../../../js/config/dll-plugin-context/manifest0.json"
-			),
-			// Context modules only land in the manifest when entryOnly is false.
-			entryOnly: false
-		})
-	]
+  entry: ['.'],
+  output: {
+    filename: 'dll.js',
+    chunkFilename: '[id].dll.js',
+    library: { type: 'commonjs2' },
+  },
+  plugins: [
+    new webpack.DllPlugin({
+      path: path.resolve(
+        __dirname,
+        '../../../js/config/dll-plugin-context/manifest0.json',
+      ),
+      // Context modules only land in the manifest when entryOnly is false.
+      entryOnly: false,
+    }),
+  ],
 };

--- a/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/rspack.config.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/rspack.config.js
@@ -1,0 +1,22 @@
+var path = require("path");
+var webpack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: ["."],
+	output: {
+		filename: "dll.js",
+		chunkFilename: "[id].dll.js",
+		library: { type: "commonjs2" }
+	},
+	plugins: [
+		new webpack.DllPlugin({
+			path: path.resolve(
+				__dirname,
+				"../../../js/config/dll-plugin-context/manifest0.json"
+			),
+			// Context modules only land in the manifest when entryOnly is false.
+			entryOnly: false
+		})
+	]
+};

--- a/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/test.config.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/0-create-dll/test.config.js
@@ -1,0 +1,1 @@
+exports.noTests = true;

--- a/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/index.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/index.js
@@ -1,0 +1,18 @@
+import { hello, loadWidget } from "dll/index";
+
+it("should consume a DLL that includes a context module", async function () {
+	expect(hello).toBe("hello");
+	const mod = await loadWidget("a");
+	expect(mod.default).toBe("a");
+});
+
+it("should write redirect-warn (not redirectWarn) for context modules", function () {
+	const manifest = require("../../../js/config/dll-plugin-context/manifest0.json");
+	const contextKey = Object.keys(manifest.content).find(k =>
+		k.includes("lazy recursive")
+	);
+	expect(contextKey).toBeTruthy();
+	expect(manifest.content[contextKey].buildMeta.defaultObject).toBe(
+		"redirect-warn"
+	);
+});

--- a/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/index.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/index.js
@@ -1,8 +1,18 @@
 import { hello, loadWidget } from "dll/index";
+import {
+	hello as camelHello,
+	loadWidget as camelLoadWidget
+} from "camel-dll/index";
 
-it("should consume a DLL that includes a context module", async function () {
+it("should consume a DLL manifest that includes a context module", async function () {
 	expect(hello).toBe("hello");
 	const mod = await loadWidget("a");
+	expect(mod.default).toBe("a");
+});
+
+it("should consume a camelCase DLL manifest that includes a context module", async function () {
+	expect(camelHello).toBe("hello");
+	const mod = await camelLoadWidget("a");
 	expect(mod.default).toBe("a");
 });
 

--- a/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/rspack.config.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/rspack.config.js
@@ -1,16 +1,32 @@
-var webpack = require("@rspack/core");
+var webpack = require('@rspack/core');
+
+const manifest = require('../../../js/config/dll-plugin-context/manifest0.json'); // eslint-disable-line node/no-missing-require
+const camelCaseManifest = JSON.parse(JSON.stringify(manifest));
+for (const item of Object.values(camelCaseManifest.content)) {
+  if (item.buildMeta?.defaultObject === 'redirect-warn') {
+    item.buildMeta.defaultObject = 'redirectWarn';
+  }
+}
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	optimization: {
-		moduleIds: "named"
-	},
-	plugins: [
-		new webpack.DllReferencePlugin({
-			manifest: require("../../../js/config/dll-plugin-context/manifest0.json"), // eslint-disable-line node/no-missing-require
-			name: "../0-create-dll/dll.js",
-			scope: "dll",
-			sourceType: "commonjs2"
-		})
-	]
+  optimization: {
+    moduleIds: 'named',
+  },
+  plugins: [
+    new webpack.DllReferencePlugin({
+      manifest,
+      name: '../0-create-dll/dll.js',
+      scope: 'dll',
+      sourceType: 'commonjs2',
+    }),
+    new webpack.DllReferencePlugin({
+      // Rspack 2.x used to emit the camelCase spelling. Keep accepting those
+      // manifests while new manifests use webpack's kebab-case spelling.
+      manifest: camelCaseManifest,
+      name: '../0-create-dll/dll.js',
+      scope: 'camel-dll',
+      sourceType: 'commonjs2',
+    }),
+  ],
 };

--- a/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/rspack.config.js
+++ b/tests/rspack-test/serialCases/dll-plugin-context/1-use-dll/rspack.config.js
@@ -1,0 +1,16 @@
+var webpack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		moduleIds: "named"
+	},
+	plugins: [
+		new webpack.DllReferencePlugin({
+			manifest: require("../../../js/config/dll-plugin-context/manifest0.json"), // eslint-disable-line node/no-missing-require
+			name: "../0-create-dll/dll.js",
+			scope: "dll",
+			sourceType: "commonjs2"
+		})
+	]
+};


### PR DESCRIPTION
## Summary

Fixes a panic when `DllReferencePlugin` consumes a manifest that contains **context modules** (e.g. `import(\`./lazy/\${name}.js\`)`) produced by `DllPlugin` with `entryOnly: false`.

```
thread panicked at crates/rspack_binding_api/src/module.rs:
internal error: entered unreachable code
```

### Root cause

In [#13643](https://github.com/web-infra-dev/rspack/pull/13643) (`BuildMetaDefaultObject::RedirectWarn` became a unit variant), the NAPI reader started expecting the webpack string `"redirect-warn"`.

DLL manifests are still serialized with serde `#[serde(rename_all = "camelCase")]`, which writes `"redirectWarn"`. Context modules set `defaultObject = RedirectWarn`, so referencing such a DLL hits `unreachable!()`.

| Version | Manifest `defaultObject` for context modules | Reader expects |
| --- | --- | --- |
| 1.7.x | `{ "redirectWarn": { "ignore": false } }` (object; handled via `Either`) | object / `"false"` / `"redirect"` |
| 2.0+ (broken) | `"redirectWarn"` (camelCase string) | `"redirect-warn"` |
| this PR | `"redirect-warn"` | `"redirect-warn"` **or** `"redirectWarn"` |

Confirmed by patching a 2.x manifest from `"redirectWarn"` → `"redirect-warn"`: the app build succeeds without code changes.

### Fix

1. Serialize `RedirectWarn` as `"redirect-warn"` (webpack-compatible).
2. Accept both `"redirect-warn"` and legacy `"redirectWarn"` when loading manifests.
3. Replace `unreachable!()` with a clearer panic message.
4. Add a serial regression case for DLL + context module + `entryOnly: false`.

## Related links

Fixes #15010

Minimal repro: https://github.com/tusharsingh308/rspack-dll-context-panic

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Made with [Cursor](https://cursor.com)