### PR TITLE
docs: document unsupported webpack CLI options

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -46,6 +46,30 @@ Update your build scripts to use Rspack instead of webpack, see [CLI](/api/cli) 
 }
 ```
 
+## Remove unsupported CLI options
+
+Rspack CLI does not support some webpack CLI options, including `--progress`, `--color`, `--bail`, and `--output-pathinfo`. Keeping these options causes an `Unknown option` error before the configuration is loaded.
+
+During migration, remove these unsupported options from the build command. If you still need the corresponding behavior, use the Rspack configuration instead:
+
+```diff title="package.json"
+{
+  "scripts": {
+-   "build": "webpack --mode production --progress --color",
++   "build": "rspack --mode production",
+  }
+}
+```
+
+```js title="rspack.config.mjs"
+export default {
+  stats: {
+    // Equivalent to webpack CLI's --color
+    colors: true,
+  },
+};
+```
+
 ## Updating configuration
 
 Rename the `webpack.config.js` file to `rspack.config.js`.

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -45,6 +45,30 @@ Rspack 的配置是基于 webpack 的设计实现的，以此你能够非常轻�
 }
 ```
 
+## 移除不支持的 CLI 参数
+
+Rspack CLI 不支持部分 webpack CLI 参数，例如 `--progress`、`--color`、`--bail` 和 `--output-pathinfo`。保留这些参数会在读取配置前报 `Unknown option`。
+
+迁移时，应从构建命令中删除这些不支持的参数；如果仍需保留对应行为，请改用 Rspack 配置：
+
+```diff title="package.json"
+{
+  "scripts": {
+-   "build": "webpack --mode production --progress --color",
++   "build": "rspack --mode production",
+  }
+}
+```
+
+```js title="rspack.config.mjs"
+export default {
+  stats: {
+    // 对应 webpack CLI 的 --color
+    colors: true,
+  },
+};
+```
+
 ## 修改配置
 
 将 `webpack.config.js` 文件重命名为 `rspack.config.js`。


### PR DESCRIPTION
## Summary

Some webpack CLI options cause Rspack to fail before loading the configuration. This PR updates the webpack migration guides to list the unsupported options, instruct users to remove them, and show how to preserve colored output with `stats.colors`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).