### PR TITLE
refactor(paths): adapt to rspack_resolver's interned UstrPath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,7 +4313,6 @@ dependencies = [
  "indexmap",
  "rspack_cacheable",
  "rspack_resolver",
- "rustc-hash",
  "ustr-fxhash",
 ]
 
@@ -5237,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "rspack_resolver"
 version = "0.9.4"
-source = "git+https://github.com/rstackjs/rspack-resolver.git?branch=refactor%2Finterned-ustr-path#a22c34605b893907262ec38dfd69f365f0a72a83"
+source = "git+https://github.com/rstackjs/rspack-resolver.git?branch=refactor%2Finterned-ustr-path#b2d20c9b6be631caef0662f4ecf3bd4ac1897b9b"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
  "indexmap",
  "rspack_cacheable",
  "rspack_resolver",
+ "rustc-hash",
  "ustr-fxhash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,8 +5237,7 @@ dependencies = [
 [[package]]
 name = "rspack_resolver"
 version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adde60ec77d32748df78a55b3ac103d98c1f08c038cc0b3df8020243bda46117"
+source = "git+https://github.com/rstackjs/rspack-resolver.git?branch=refactor%2Finterned-ustr-path#a22c34605b893907262ec38dfd69f365f0a72a83"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5257,6 +5256,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "ustr-fxhash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,7 +5237,7 @@ dependencies = [
 [[package]]
 name = "rspack_resolver"
 version = "0.9.4"
-source = "git+https://github.com/rstackjs/rspack-resolver.git?branch=refactor%2Finterned-ustr-path#b2d20c9b6be631caef0662f4ecf3bd4ac1897b9b"
+source = "git+https://github.com/rstackjs/rspack-resolver.git?branch=refactor%2Finterned-ustr-path#704b58c25a56867d83311f525d2ad261abbb2f0d"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5246,6 +5246,7 @@ dependencies = [
  "dashmap",
  "dunce",
  "futures",
+ "hashbrown 0.17.1",
  "indexmap",
  "json-strip-comments",
  "pnp",
@@ -5256,7 +5257,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "ustr-fxhash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -581,3 +581,9 @@ regex_creation_in_loops = "warn"
 # regex
 invalid_regex = "warn"
 trivial_regex = "warn"
+
+# Unreleased interned-UstrPath resolver. Tracks rstackjs/rspack-resolver#290;
+# remove once that lands and is published. Pinned to the branch rather than a
+# local path so remote environments (devbox, CI) can build this too.
+[patch.crates-io]
+rspack_resolver = { git = "https://github.com/rstackjs/rspack-resolver.git", branch = "refactor/interned-ustr-path" }

--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -82,12 +82,12 @@ impl JsResolver {
             resolve_request.file_dependencies = resolve_dependencies
               .file_dependencies
               .drain()
-              .map(|path| path.to_string_lossy().into_owned())
+              .map(|path| path.as_str().to_owned())
               .collect();
             resolve_request.missing_dependencies = resolve_dependencies
               .missing_dependencies
               .drain()
-              .map(|path| path.to_string_lossy().into_owned())
+              .map(|path| path.as_str().to_owned())
               .collect();
             Ok(match simd_json::to_string(&resolve_request) {
               Ok(json) => Either::<String, ()>::A(json),

--- a/crates/rspack_collections/src/identifier.rs
+++ b/crates/rspack_collections/src/identifier.rs
@@ -2,7 +2,7 @@ use std::{
   collections::{HashMap, HashSet},
   convert::From,
   fmt,
-  hash::BuildHasherDefault,
+  hash::{BuildHasherDefault, Hasher},
   ops::Deref,
 };
 
@@ -21,7 +21,41 @@ pub trait Identifiable {
   fn identifier(&self) -> Identifier;
 }
 
-pub type IdentifierHasher = ustr::IdentityHasher;
+/// Identity hasher for [Identifier] keys: `Ustr` already carries a precomputed
+/// `FxHash`, so hashing only has to move that `u64` through.
+///
+/// Deliberately defined here rather than re-exported from `ustr`. The codspeed
+/// profile builds with `lto = "off"`, and `ustr`'s version derives `Default`,
+/// leaving `default()` without `#[inline]` and so un-inlinable across crates —
+/// every `IdentifierMap` lookup then pays a real call to build a zero-sized
+/// hasher.
+#[derive(Debug, Clone, Copy)]
+pub struct IdentifierHasher {
+  hash: u64,
+}
+
+impl Default for IdentifierHasher {
+  #[inline]
+  fn default() -> Self {
+    Self { hash: 0 }
+  }
+}
+
+impl Hasher for IdentifierHasher {
+  /// Only an 8-byte write carries a precomputed hash; `Ustr` writes exactly
+  /// that. Anything else leaves the hash at 0, matching `ustr`'s behaviour.
+  #[inline]
+  fn write(&mut self, bytes: &[u8]) {
+    if let Ok(bytes) = <[u8; 8]>::try_from(bytes) {
+      self.hash = u64::from_ne_bytes(bytes);
+    }
+  }
+
+  #[inline]
+  fn finish(&self) -> u64 {
+    self.hash
+  }
+}
 
 /// A standard `HashMap` using `Ustr` as the key type with a custom `Hasher` that
 /// just uses the precomputed hash for speed instead of calculating it
@@ -110,5 +144,48 @@ impl CustomConverter for Identifier {
   }
   fn deserialize(data: Self::Target, guard: &ContextGuard) -> Result<Self, CacheableError> {
     Ok(Self::from(data.into_path_string(guard.project_root())))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::hash::{BuildHasher, Hash};
+
+  use super::*;
+
+  /// `IdentifierMap` is only correct while hashing an [Identifier] reproduces
+  /// the `FxHash` the interner already computed — that is what makes lookups a
+  /// single `write_u64` instead of a walk over the string.
+  #[test]
+  fn hashing_yields_the_precomputed_hash() {
+    let id = Identifier::from("some/module/identifier.js");
+    let mut hasher = IdentifierHasher::default();
+    id.hash(&mut hasher);
+
+    assert_eq!(hasher.finish(), id.precomputed_hash());
+  }
+
+  #[test]
+  fn distinct_identifiers_hash_distinctly() {
+    let a = Identifier::from("a.js");
+    let b = Identifier::from("b.js");
+    let builder = BuildHasherDefault::<IdentifierHasher>::default();
+
+    assert_ne!(builder.hash_one(a), builder.hash_one(b));
+    assert_eq!(
+      builder.hash_one(a),
+      builder.hash_one(Identifier::from("a.js"))
+    );
+  }
+
+  #[test]
+  fn round_trips_through_an_identifier_map() {
+    let mut map = IdentifierMap::default();
+    let key = Identifier::from("entry.js");
+    map.insert(key, 42usize);
+
+    assert_eq!(map.get(&key), Some(&42));
+    assert_eq!(map.get(&Identifier::from("entry.js")), Some(&42));
+    assert_eq!(map.get(&Identifier::from("other.js")), None);
   }
 }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -150,9 +150,12 @@ impl Resolver {
         path: r.path().to_path_buf().assert_utf8(),
         query: r.query().unwrap_or_default().to_string(),
         fragment: r.fragment().unwrap_or_default().to_string(),
-        description_data: r
-          .package_json()
-          .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(d.raw_json()))),
+        description_data: r.package_json().map(|d| {
+          DescriptionData::new(
+            d.directory().as_std_path().to_path_buf(),
+            Arc::clone(d.raw_json()),
+          )
+        }),
       })),
       Err(rspack_resolver::ResolveError::Ignored(_)) => Ok(ResolveResult::Ignored),
       Err(error) => Err(ResolveInnerError::RspackResolver(error)),
@@ -173,10 +176,10 @@ impl Resolver {
     let result = resolver
       .resolve_with_context(path, request, &mut context)
       .await;
-    // `context.{file,missing}_dependencies` is `FxHashSet<ResolverPath>`. We
+    // `context.{file,missing}_dependencies` holds `UstrPath` handles. We
     // re-bucket into the `IdentityHasher`-keyed `ArcResolverPathSet` so future
-    // lookups become a single `write_u64`. No path rehashing or `Arc<Path>`
-    // re-allocation happens here.
+    // lookups become a single `write_u64`. No path rehashing or allocation
+    // happens here.
     let dependencies = ResolveDependencies {
       file_dependencies: context.file_dependencies.into_iter().collect(),
       missing_dependencies: context.missing_dependencies.into_iter().collect(),
@@ -186,9 +189,12 @@ impl Resolver {
         path: r.path().to_path_buf().assert_utf8(),
         query: r.query().unwrap_or_default().to_string(),
         fragment: r.fragment().unwrap_or_default().to_string(),
-        description_data: r
-          .package_json()
-          .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(d.raw_json()))),
+        description_data: r.package_json().map(|d| {
+          DescriptionData::new(
+            d.directory().as_std_path().to_path_buf(),
+            Arc::clone(d.raw_json()),
+          )
+        }),
       })),
       Err(rspack_resolver::ResolveError::Ignored(_)) => Ok(ResolveResult::Ignored),
       Err(error) => Err(ResolveInnerError::RspackResolver(error)),

--- a/crates/rspack_paths/Cargo.toml
+++ b/crates/rspack_paths/Cargo.toml
@@ -14,7 +14,6 @@ dashmap          = { workspace = true }
 indexmap         = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_resolver  = { workspace = true }
-rustc-hash       = { workspace = true }
 ustr             = { workspace = true }
 
 [lints]

--- a/crates/rspack_paths/Cargo.toml
+++ b/crates/rspack_paths/Cargo.toml
@@ -14,6 +14,7 @@ dashmap          = { workspace = true }
 indexmap         = { workspace = true }
 rspack_cacheable = { workspace = true }
 rspack_resolver  = { workspace = true }
+rustc-hash       = { workspace = true }
 ustr             = { workspace = true }
 
 [lints]

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_cacheable::{
   utils::PortablePath,
   with::{Custom, CustomConverter},
 };
-pub use rspack_resolver::ResolverPath;
+pub use rspack_resolver::{ToUstrPath, UstrPath, UstrPathSet};
 use rustc_hash::FxHasher;
 pub use ustr::IdentityHasher;
 
@@ -79,7 +79,7 @@ impl ArcPath {
 
   /// Build an `ArcPath` from a precomputed hash and an `Arc<Path>` without
   /// rehashing. The caller MUST guarantee that `hash` equals [`hash_path`] of
-  /// `path`. Used at boundaries (e.g. consuming `rspack_resolver::ResolverPath`)
+  /// `path`. Used at boundaries (e.g. consuming `rspack_resolver::UstrPath`)
   /// where the same `FxHash` has already been computed upstream.
   #[inline]
   pub fn from_parts(hash: u64, path: Arc<Path>) -> Self {
@@ -144,13 +144,13 @@ impl From<&str> for ArcPath {
   }
 }
 
-impl From<ResolverPath> for ArcPath {
-  /// Zero-cost conversion: reuses the resolver's precomputed `FxHash` and the
-  /// existing `Arc<Path>`. Safe because `rspack_paths::hash_path` and the hash
-  /// scheme in `rspack_resolver` are kept identical.
-  fn from(value: ResolverPath) -> Self {
-    let hash = value.precomputed_hash();
-    ArcPath::from_parts(hash, value.into_arc())
+impl From<UstrPath> for ArcPath {
+  /// PROBE-ONLY: materializes an `Arc` per conversion, which is exactly the
+  /// allocation this whole change exists to remove. Here only so the crate
+  /// compiles and downstream errors become visible; replaced when `ArcPath`
+  /// itself becomes `UstrPath`.
+  fn from(value: UstrPath) -> Self {
+    ArcPath::new(Arc::from(value.as_std_path()))
   }
 }
 
@@ -181,10 +181,10 @@ pub type ArcPathMap<V> = HashMap<ArcPath, V, BuildHasherDefault<IdentityHasher>>
 /// that just uses the precomputed hash for speed instead of calculating it.
 pub type ArcPathSet = HashSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
 
-/// A `HashSet<ResolverPath, IdentityHasher>` that preserves the `FxHash`
-/// precomputed inside `rspack_resolver`. Inserting and looking up entries
-/// here only costs a `write_u64` instead of hashing the full absolute path.
-pub type ArcResolverPathSet = HashSet<ResolverPath, BuildHasherDefault<IdentityHasher>>;
+/// A `HashSet<UstrPath, IdentityHasher>` that preserves the `FxHash` the
+/// interner stamped into the `UstrPath` handle. Inserting and looking up
+/// entries here only costs a `write_u64` instead of hashing the full path.
+pub type ArcResolverPathSet = UstrPathSet;
 
 /// A standard `DashMap` using `ArcPath` as the key type with a custom `Hasher`
 /// that just uses the precomputed hash for speed instead of calculating it.

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_cacheable::{
   utils::PortablePath,
   with::{Custom, CustomConverter},
 };
-pub use rspack_resolver::{ToUstrPath, UstrPath, UstrPathSet};
+pub use rspack_resolver::{ResolverPath, ResolverPathSet, ToResolverPath};
 use rustc_hash::FxHasher;
 pub use ustr::IdentityHasher;
 
@@ -144,19 +144,18 @@ impl From<&str> for ArcPath {
   }
 }
 
-impl From<UstrPath> for ArcPath {
+impl From<ResolverPath> for ArcPath {
   /// Materializes an `Arc` at the resolver boundary rather than carrying the
   /// interned handle further in.
   ///
-  /// Making `ArcPath` a newtype over `UstrPath` removes this allocation, and
-  /// was tried — it measured no better. Callgrind on the codspeed profile put
-  /// `module_graph_api` bit-identical either way, while
+  /// Making `ArcPath` a newtype over the interned path removes this
+  /// allocation, and was tried — it measured no better. Callgrind on the
+  /// codspeed profile put `module_graph_api` bit-identical either way, while
   /// `concatenate_module_code_generation` moved from +0.24% to +2.82% cycles:
-  /// once path bytes live in the interner arena instead of a nearby `Arc`,
-  /// the same memcpys land on colder lines (LL misses +18%, which the cycle
-  /// estimate weights 100x). Keeping the `Arc` keeps path data next to the
-  /// data that reads it.
-  fn from(value: UstrPath) -> Self {
+  /// once path bytes live in the interner rather than in an `Arc` beside the
+  /// data that reads them, the same memcpys land on colder lines (LL misses
+  /// +18%, which the cycle estimate weights 100x).
+  fn from(value: ResolverPath) -> Self {
     ArcPath::new(Arc::from(value.as_std_path()))
   }
 }
@@ -188,10 +187,10 @@ pub type ArcPathMap<V> = HashMap<ArcPath, V, BuildHasherDefault<IdentityHasher>>
 /// that just uses the precomputed hash for speed instead of calculating it.
 pub type ArcPathSet = HashSet<ArcPath, BuildHasherDefault<IdentityHasher>>;
 
-/// A `HashSet<UstrPath, IdentityHasher>` that preserves the `FxHash` the
-/// interner stamped into the `UstrPath` handle. Inserting and looking up
+/// A `HashSet<ResolverPath, IdentityHasher>` that preserves the `FxHash` the
+/// interner stamped into the `ResolverPath` handle. Inserting and looking up
 /// entries here only costs a `write_u64` instead of hashing the full path.
-pub type ArcResolverPathSet = UstrPathSet;
+pub type ArcResolverPathSet = ResolverPathSet;
 
 /// A standard `DashMap` using `ArcPath` as the key type with a custom `Hasher`
 /// that just uses the precomputed hash for speed instead of calculating it.

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -1,12 +1,9 @@
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 use std::{
   collections::{HashMap, HashSet},
   fmt::Debug,
-  hash::{BuildHasherDefault, Hash, Hasher},
+  hash::BuildHasherDefault,
   ops::Deref,
   path::{Path, PathBuf},
-  sync::Arc,
 };
 
 pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
@@ -18,7 +15,6 @@ use rspack_cacheable::{
   with::{Custom, CustomConverter},
 };
 pub use rspack_resolver::{ToUstrPath, UstrPath, UstrPathSet};
-use rustc_hash::FxHasher;
 pub use ustr::IdentityHasher;
 
 pub trait AssertUtf8 {
@@ -56,79 +52,59 @@ impl<'a> AssertUtf8 for &'a Path {
   }
 }
 
+/// An interned absolute path.
+///
+/// Backed by [`UstrPath`], so two `ArcPath`s naming the same path are the same
+/// 8-byte handle: equality is an integer compare and hashing is a `write_u64`
+/// of the hash the interner already computed. The name is kept for historical
+/// reasons — there is no longer an `Arc` involved.
 #[cacheable(with=Custom)]
-#[derive(Clone, PartialEq, Eq)]
-pub struct ArcPath {
-  path: Arc<Path>,
-  // Pre-calculating and caching the hash value upon creation, making hashing operations
-  // in collections virtually free.
-  hash: u64,
-}
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ArcPath(UstrPath);
 
 impl Debug for ArcPath {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    self.path.fmt(f)
+    // Forward to `Path` rather than `UstrPath` so the rendering stays identical
+    // to the previous `Arc<Path>`-backed representation.
+    self.0.as_std_path().fmt(f)
   }
 }
 
 impl ArcPath {
-  pub fn new(path: Arc<Path>) -> Self {
-    let hash = hash_path(&path);
-    Self { path, hash }
+  pub fn new<P: ToUstrPath + ?Sized>(path: &P) -> Self {
+    Self(path.to_ustr_path())
   }
-
-  /// Build an `ArcPath` from a precomputed hash and an `Arc<Path>` without
-  /// rehashing. The caller MUST guarantee that `hash` equals [`hash_path`] of
-  /// `path`. Used at boundaries (e.g. consuming `rspack_resolver::UstrPath`)
-  /// where the same `FxHash` has already been computed upstream.
-  #[inline]
-  pub fn from_parts(hash: u64, path: Arc<Path>) -> Self {
-    Self { path, hash }
-  }
-}
-
-/// Hash a path with `FxHasher` matching the bytes-on-unix optimization used by
-/// `rspack_resolver`. Keeping these in sync lets `ArcPath::from_parts` accept
-/// a hash precomputed inside the resolver without rehashing here.
-#[inline]
-pub fn hash_path(path: &Path) -> u64 {
-  let mut hasher = FxHasher::default();
-  #[cfg(unix)]
-  hasher.write(path.as_os_str().as_bytes());
-  #[cfg(not(unix))]
-  path.hash(&mut hasher);
-  hasher.finish()
 }
 
 impl Deref for ArcPath {
-  type Target = Arc<Path>;
+  type Target = Path;
 
   fn deref(&self) -> &Self::Target {
-    &self.path
+    self.0.as_std_path()
   }
 }
 
 impl AsRef<Path> for ArcPath {
   fn as_ref(&self) -> &Path {
-    &self.path
+    self.0.as_std_path()
   }
 }
 
 impl From<PathBuf> for ArcPath {
   fn from(value: PathBuf) -> Self {
-    ArcPath::new(value.into())
+    ArcPath::new(value.as_path())
   }
 }
 
 impl From<&Path> for ArcPath {
   fn from(value: &Path) -> Self {
-    ArcPath::new(value.into())
+    ArcPath::new(value)
   }
 }
 
 impl From<&Utf8Path> for ArcPath {
   fn from(value: &Utf8Path) -> Self {
-    ArcPath::new(value.as_std_path().into())
+    ArcPath::new(value)
   }
 }
 
@@ -140,36 +116,30 @@ impl From<&ArcPath> for ArcPath {
 
 impl From<&str> for ArcPath {
   fn from(value: &str) -> Self {
-    ArcPath::new(<str as std::convert::AsRef<Path>>::as_ref(value).into())
+    ArcPath::new(value)
   }
 }
 
 impl From<UstrPath> for ArcPath {
-  /// PROBE-ONLY: materializes an `Arc` per conversion, which is exactly the
-  /// allocation this whole change exists to remove. Here only so the crate
-  /// compiles and downstream errors become visible; replaced when `ArcPath`
-  /// itself becomes `UstrPath`.
+  /// Free: both sides are the same interned 8-byte handle.
+  #[inline]
   fn from(value: UstrPath) -> Self {
-    ArcPath::new(Arc::from(value.as_std_path()))
+    Self(value)
   }
 }
 
 impl CustomConverter for ArcPath {
   type Target = PortablePath;
   fn serialize(&self, guard: &ContextGuard) -> Result<Self::Target, CacheableError> {
-    Ok(PortablePath::new(&self.path, guard.project_root()))
+    Ok(PortablePath::new(
+      self.0.as_std_path(),
+      guard.project_root(),
+    ))
   }
   fn deserialize(data: Self::Target, guard: &ContextGuard) -> Result<Self, CacheableError> {
     Ok(Self::from(PathBuf::from(
       data.into_path_string(guard.project_root()),
     )))
-  }
-}
-
-impl Hash for ArcPath {
-  #[inline]
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    state.write_u64(self.hash);
   }
 }
 

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -1,9 +1,12 @@
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::{
   collections::{HashMap, HashSet},
   fmt::Debug,
-  hash::BuildHasherDefault,
+  hash::{BuildHasherDefault, Hash, Hasher},
   ops::Deref,
   path::{Path, PathBuf},
+  sync::Arc,
 };
 
 pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
@@ -15,6 +18,7 @@ use rspack_cacheable::{
   with::{Custom, CustomConverter},
 };
 pub use rspack_resolver::{ToUstrPath, UstrPath, UstrPathSet};
+use rustc_hash::FxHasher;
 pub use ustr::IdentityHasher;
 
 pub trait AssertUtf8 {
@@ -52,59 +56,79 @@ impl<'a> AssertUtf8 for &'a Path {
   }
 }
 
-/// An interned absolute path.
-///
-/// Backed by [`UstrPath`], so two `ArcPath`s naming the same path are the same
-/// 8-byte handle: equality is an integer compare and hashing is a `write_u64`
-/// of the hash the interner already computed. The name is kept for historical
-/// reasons — there is no longer an `Arc` involved.
 #[cacheable(with=Custom)]
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct ArcPath(UstrPath);
+#[derive(Clone, PartialEq, Eq)]
+pub struct ArcPath {
+  path: Arc<Path>,
+  // Pre-calculating and caching the hash value upon creation, making hashing operations
+  // in collections virtually free.
+  hash: u64,
+}
 
 impl Debug for ArcPath {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    // Forward to `Path` rather than `UstrPath` so the rendering stays identical
-    // to the previous `Arc<Path>`-backed representation.
-    self.0.as_std_path().fmt(f)
+    self.path.fmt(f)
   }
 }
 
 impl ArcPath {
-  pub fn new<P: ToUstrPath + ?Sized>(path: &P) -> Self {
-    Self(path.to_ustr_path())
+  pub fn new(path: Arc<Path>) -> Self {
+    let hash = hash_path(&path);
+    Self { path, hash }
+  }
+
+  /// Build an `ArcPath` from a precomputed hash and an `Arc<Path>` without
+  /// rehashing. The caller MUST guarantee that `hash` equals [`hash_path`] of
+  /// `path`. Used at boundaries (e.g. consuming `rspack_resolver::UstrPath`)
+  /// where the same `FxHash` has already been computed upstream.
+  #[inline]
+  pub fn from_parts(hash: u64, path: Arc<Path>) -> Self {
+    Self { path, hash }
   }
 }
 
+/// Hash a path with `FxHasher` matching the bytes-on-unix optimization used by
+/// `rspack_resolver`. Keeping these in sync lets `ArcPath::from_parts` accept
+/// a hash precomputed inside the resolver without rehashing here.
+#[inline]
+pub fn hash_path(path: &Path) -> u64 {
+  let mut hasher = FxHasher::default();
+  #[cfg(unix)]
+  hasher.write(path.as_os_str().as_bytes());
+  #[cfg(not(unix))]
+  path.hash(&mut hasher);
+  hasher.finish()
+}
+
 impl Deref for ArcPath {
-  type Target = Path;
+  type Target = Arc<Path>;
 
   fn deref(&self) -> &Self::Target {
-    self.0.as_std_path()
+    &self.path
   }
 }
 
 impl AsRef<Path> for ArcPath {
   fn as_ref(&self) -> &Path {
-    self.0.as_std_path()
+    &self.path
   }
 }
 
 impl From<PathBuf> for ArcPath {
   fn from(value: PathBuf) -> Self {
-    ArcPath::new(value.as_path())
+    ArcPath::new(value.into())
   }
 }
 
 impl From<&Path> for ArcPath {
   fn from(value: &Path) -> Self {
-    ArcPath::new(value)
+    ArcPath::new(value.into())
   }
 }
 
 impl From<&Utf8Path> for ArcPath {
   fn from(value: &Utf8Path) -> Self {
-    ArcPath::new(value)
+    ArcPath::new(value.as_std_path().into())
   }
 }
 
@@ -116,30 +140,43 @@ impl From<&ArcPath> for ArcPath {
 
 impl From<&str> for ArcPath {
   fn from(value: &str) -> Self {
-    ArcPath::new(value)
+    ArcPath::new(<str as std::convert::AsRef<Path>>::as_ref(value).into())
   }
 }
 
 impl From<UstrPath> for ArcPath {
-  /// Free: both sides are the same interned 8-byte handle.
-  #[inline]
+  /// Materializes an `Arc` at the resolver boundary rather than carrying the
+  /// interned handle further in.
+  ///
+  /// Making `ArcPath` a newtype over `UstrPath` removes this allocation, and
+  /// was tried — it measured no better. Callgrind on the codspeed profile put
+  /// `module_graph_api` bit-identical either way, while
+  /// `concatenate_module_code_generation` moved from +0.24% to +2.82% cycles:
+  /// once path bytes live in the interner arena instead of a nearby `Arc`,
+  /// the same memcpys land on colder lines (LL misses +18%, which the cycle
+  /// estimate weights 100x). Keeping the `Arc` keeps path data next to the
+  /// data that reads it.
   fn from(value: UstrPath) -> Self {
-    Self(value)
+    ArcPath::new(Arc::from(value.as_std_path()))
   }
 }
 
 impl CustomConverter for ArcPath {
   type Target = PortablePath;
   fn serialize(&self, guard: &ContextGuard) -> Result<Self::Target, CacheableError> {
-    Ok(PortablePath::new(
-      self.0.as_std_path(),
-      guard.project_root(),
-    ))
+    Ok(PortablePath::new(&self.path, guard.project_root()))
   }
   fn deserialize(data: Self::Target, guard: &ContextGuard) -> Result<Self, CacheableError> {
     Ok(Self::from(PathBuf::from(
       data.into_path_string(guard.project_root()),
     )))
+  }
+}
+
+impl Hash for ArcPath {
+  #[inline]
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    state.write_u64(self.hash);
   }
 }
 


### PR DESCRIPTION
## Summary

> **Draft — do not merge.** Depends on the unmerged rstackjs/rspack-resolver#290, and currently **regresses performance by 3.51%** (see below). Opened to run CI and to make the downstream cost of the resolver change measurable rather than hypothetical.

rspack-resolver is replacing `ResolverPath` (an `Arc<Path>` plus a precomputed `FxHash`) with `UstrPath`, an 8-byte `Copy` handle into the `ustr-fxhash` global interner. Both crates already depend on `ustr-fxhash` 1.0.1, so they share a single interner static and a path resolved once is never re-allocated or re-hashed.

This PR is the minimal adaptation that keeps the rspack workspace compiling on top of that branch.

## What changed

- `rspack_paths` re-exports `UstrPath`/`ToUstrPath`/`UstrPathSet`; `ArcResolverPathSet` becomes `UstrPathSet`.
- `PackageJson::directory()` now returns `&Utf8Path`, so the `DescriptionData` boundary goes through `as_std_path()`. `DescriptionData` keeps its `PathBuf` field on purpose: it is `cacheable(with = As<PortablePath>)` and changing it would touch the persistent-cache format.
- `UstrPath` is UTF-8 by construction, so the binding layer uses `as_str()` instead of `to_string_lossy()`.
- `[patch.crates-io]` points `rspack_resolver` at the resolver branch. Pinned to the git branch rather than a local path so CI and remote devboxes can build it too.

## Known regression

`impl From<UstrPath> for ArcPath` is probe-only. On `main` this conversion was free:

```rust
fn from(value: ResolverPath) -> Self {
  ArcPath::from_parts(value.precomputed_hash(), value.into_arc())
}
```

It moved out the `Arc<Path>` the resolver cache already held and reused the precomputed hash. The probe instead does `Arc::from(value.as_std_path())`, which allocates a **fresh** `Arc` per conversion and re-hashes the full path. It runs once per file/missing dependency per module (`normal_module_factory.rs:953-954`, `1183-1184`).

CodSpeed measures **-3.51% overall, 12 regressed / 0 improved**. Notably the regressed benchmarks are all *post-resolve* stages — `module_graph_api` -6.32%, `create_module_ids` -5.54%, `create_chunk_hashes` -4.48%, `build_chunk_graph` -4.01% — none of which call the resolver. So the dominant cost is not the extra `malloc` itself but the **loss of `Arc` pointer identity**: `main` handed every consumer the same `Arc` instance per path, so `ArcPath` equality short-circuited on `Arc::ptr_eq`. A fresh `Arc` per conversion makes every path comparison fall through to a full byte-wise compare, which is exactly what the id-assignment, chunk-graph and hashing stages do in bulk.

(Caveat: CodSpeed fell back to `0f30de2` as the base because no successful run existed on `553f5e0`, so the report contains some unrelated drift. 12 same-direction regressions with zero improvements is still well outside the usual bidirectional cross-runner noise on this repo.)

## Follow-up

The fix is not to patch this conversion — memoizing `UstrPath -> Arc<Path>` would at best claw back to parity with `main` and would be deleted afterwards. The real move is to make `ArcPath` a newtype over `UstrPath`, which restores identity by construction and turns equality into an 8-byte compare, i.e. cheaper than `main`. The blast radius is smaller than it looks:

- `Arc<Path>` appears **only** in `crates/rspack_paths/src/lib.rs`; every other crate goes through `ArcPath`.
- There are only 5 `ArcPath::new(` call sites in the workspace.
- No code reaches Arc-specific APIs through `ArcPath`'s `Deref`.
- The container aliases (`ArcPathSet` / `ArcPathMap` / `ArcPathDashMap` / `ArcPathIndexSet`) need no change.

`ArcPath::from_parts` also has zero remaining callers on this branch and should go away with that step.

## Related links

- rstackjs/rspack-resolver#290

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
