### PR TITLE
fix(watch): preserve invalidation provenance

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -340,7 +340,7 @@ export declare class JsCompiler {
   /** Build with the given option passed to the constructor */
   build(callback: (err: null | Error) => void): void
   /** Rebuild with the given option passed to the constructor */
-  rebuild(changed_files: string[], removed_files: string[], callback: (err: null | Error) => void): void
+  rebuild(changed_files: string[], removed_files: string[], callback: (err: null | Error) => void, is_lazy_watch_rebuild?: boolean): void
   close(): Promise<void>
   getVirtualFileStore(): VirtualFileStore | null
   getCompilerId(): ExternalObject<CompilerId>

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -447,7 +447,7 @@ impl JsCompiler {
 
   /// Rebuild with the given option passed to the constructor
   #[napi(
-    ts_args_type = "changed_files: string[], removed_files: string[], callback: (err: null | Error) => void"
+    ts_args_type = "changed_files: string[], removed_files: string[], callback: (err: null | Error) => void, is_lazy_watch_rebuild?: boolean"
   )]
   pub fn rebuild(
     &mut self,
@@ -455,6 +455,7 @@ impl JsCompiler {
     changed_files: Vec<String>,
     removed_files: Vec<String>,
     f: Function<'static>,
+    is_lazy_watch_rebuild: Option<bool>,
   ) -> Result<(), ErrorCode> {
     unsafe {
       self.run(reference, |compiler, guard| {
@@ -462,9 +463,10 @@ impl JsCompiler {
           f,
           async move {
             let result = compiler
-              .rebuild(
+              .rebuild_with_invalidation_provenance(
                 changed_files.into_iter().collect::<FxHashSet<_>>(),
                 removed_files.into_iter().collect::<FxHashSet<_>>(),
+                is_lazy_watch_rebuild.unwrap_or(false),
               )
               .await
               .to_napi_result_with_message(|e| {

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -316,6 +316,8 @@ pub struct Compilation {
   ///
   /// Rebuild will include previous compilation data, so persistent cache will not recovery anything
   pub is_rebuild: bool,
+  /// Whether this rebuild was explicitly invalidated by lazy compilation.
+  pub is_lazy_watch_rebuild: bool,
   pub compiler_context: Arc<CompilerContext>,
 }
 
@@ -445,6 +447,7 @@ impl Compilation {
       intermediate_filesystem,
       output_filesystem,
       is_rebuild,
+      is_lazy_watch_rebuild: false,
       compiler_context,
     }
   }

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -21,9 +21,20 @@ impl Compiler {
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
   ) -> Result<()> {
+    self
+      .rebuild_with_invalidation_provenance(changed_files, deleted_files, false)
+      .await
+  }
+
+  pub async fn rebuild_with_invalidation_provenance(
+    &mut self,
+    changed_files: FxHashSet<String>,
+    deleted_files: FxHashSet<String>,
+    is_lazy_watch_rebuild: bool,
+  ) -> Result<()> {
     match within_compiler_context(
       self.compiler_context.clone(),
-      self.rebuild_inner(changed_files, deleted_files),
+      self.rebuild_inner(changed_files, deleted_files, is_lazy_watch_rebuild),
     )
     .await
     {
@@ -50,12 +61,14 @@ impl Compiler {
 
   #[tracing::instrument("Compiler:rebuild", skip_all, fields(
     compiler.changed_files = ?changed_files.iter().cloned().collect::<Vec<_>>(),
-    compiler.deleted_files = ?deleted_files.iter().cloned().collect::<Vec<_>>()
+    compiler.deleted_files = ?deleted_files.iter().cloned().collect::<Vec<_>>(),
+    compiler.is_lazy_watch_rebuild = is_lazy_watch_rebuild
   ))]
   async fn rebuild_inner(
     &mut self,
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
+    is_lazy_watch_rebuild: bool,
   ) -> Result<()> {
     let records = self.last_records.clone();
 
@@ -93,6 +106,7 @@ impl Compiler {
         true,
         self.compiler_context.clone(),
       );
+      next_compilation.is_lazy_watch_rebuild = is_lazy_watch_rebuild;
       next_compilation.hot_index = self.compilation.hot_index + 1;
 
       if next_compilation

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -22,6 +22,8 @@ import binding from '@rspack/binding';
 
 export type { AssetInfo } from '@rspack/binding';
 
+export type WatchInvalidationKind = 'lazy' | 'normal';
+
 import * as liteTapable from '@rspack/lite-tapable';
 import type { Source } from 'webpack-sources';
 import type { EntryOptions, EntryPlugin } from './builtin-plugin';
@@ -292,6 +294,11 @@ export class Compilation {
     needAdditionalPass: liteTapable.SyncBailHook<[], boolean>;
   }>;
   name?: string;
+  /**
+   * The invalidation that started this watch compilation. `normal` dominates
+   * mixed or coalesced invalidations; initial and non-watch compilations are undefined.
+   */
+  readonly watchInvalidationKind: WatchInvalidationKind | undefined;
   startTime?: number;
   endTime?: number;
   compiler: Compiler;
@@ -324,6 +331,7 @@ export class Compilation {
   constructor(compiler: Compiler, inner: JsCompilation) {
     this.#inner = inner;
     this.#shutdown = false;
+    this.watchInvalidationKind = compiler.__internal__watchInvalidationKind;
 
     const processAssetsHook = new liteTapable.AsyncSeriesHook<Assets>([
       'assets',

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -21,7 +21,7 @@ import {
 } from './builtin-plugin';
 import { canInherentFromParent } from './builtin-plugin/base';
 import type { Chunk } from './Chunk';
-import type { CompilationParams } from './Compilation';
+import type { CompilationParams, WatchInvalidationKind } from './Compilation';
 import { Compilation } from './Compilation';
 import { ContextModuleFactory } from './ContextModuleFactory';
 import type {
@@ -167,6 +167,9 @@ class Compiler {
   resolverFactory: ResolverFactory;
   infrastructureLogger: any;
   watching?: Watching;
+
+  /** @internal Set by Watching while a watch compilation is being created. */
+  __internal__watchInvalidationKind?: WatchInvalidationKind;
 
   inputFileSystem: InputFileSystem | null;
   intermediateFileSystem: IntermediateFileSystem | null;
@@ -846,6 +849,7 @@ class Compiler {
           Array.from(this.modifiedFiles || []),
           Array.from(this.removedFiles || []),
           callback,
+          this.__internal__watchInvalidationKind === 'lazy',
         );
         return;
       }

--- a/packages/rspack/src/MultiCompiler.ts
+++ b/packages/rspack/src/MultiCompiler.ts
@@ -15,6 +15,7 @@ import type {
   CompilerHooks,
   RspackOptions,
   Stats,
+  WatchInvalidationKind,
 } from '.';
 import type { WatchOptions } from './config';
 import ConcurrentCompilationError from './error/ConcurrentCompilationError';
@@ -34,6 +35,7 @@ interface Node<T> {
   parents: Node<T>[];
   setupResult?: T;
   result?: Stats;
+  parentInvalidationKind?: WatchInvalidationKind;
   state:
     | 'pending'
     | 'blocked'
@@ -321,6 +323,7 @@ export class MultiCompiler {
       compiler: Compiler,
       res: SetupResult,
       done: liteTapable.Callback<Error, Stats>,
+      parentInvalidationKind?: WatchInvalidationKind,
     ) => void,
     callback: liteTapable.Callback<Error, MultiStats>,
   ): SetupResult[] {
@@ -391,7 +394,13 @@ export class MultiCompiler {
       running--;
       if (node.state === 'running') {
         node.state = 'done';
+        const invalidationKind = stats.compilation.watchInvalidationKind;
         for (const child of node.children) {
+          // Dependents consume a newly emitted parent artifact and must take
+          // the normal path even when the parent was explicitly lazy.
+          if (invalidationKind !== undefined) {
+            child.parentInvalidationKind = 'normal';
+          }
           if (child.state === 'blocked') queue.enqueue(child);
         }
       } else if (node.state === 'running-outdated') {
@@ -422,7 +431,12 @@ export class MultiCompiler {
       if (node.state === 'done') {
         node.state = 'pending';
       } else if (node.state === 'running') {
-        node.state = 'running-outdated';
+        // Watching will coalesce its own in-flight invalidation before
+        // delivering `done`; keep the node runnable so that generation can
+        // finish and unblock its already-invalidated dependents.
+        if (!node.compiler.watching?.invalid) {
+          node.state = 'running-outdated';
+        }
       }
       for (const child of node.children) {
         nodeInvalidFromParent(child);
@@ -476,7 +490,9 @@ export class MultiCompiler {
             node.compiler,
             node.setupResult!,
             nodeDone.bind(null, node) as liteTapable.Callback<Error, Stats>,
+            node.parentInvalidationKind,
           );
+          node.parentInvalidationKind = undefined;
           node.state = 'running';
         }
       }
@@ -531,9 +547,13 @@ export class MultiCompiler {
           }
           return watching;
         },
-        (compiler, watching, _done) => {
-          if (compiler.watching !== watching) return;
-          if (!watching.running) watching.invalidate();
+        (compiler, watching, _done, parentInvalidationKind) => {
+          if (compiler.watching !== watching || watching.running) return;
+          if (parentInvalidationKind) {
+            watching.__internal__invalidate(parentInvalidationKind);
+          } else {
+            watching.__internal__resumeFromMultiCompiler();
+          }
         },
         handler,
       );

--- a/packages/rspack/src/MultiWatching.ts
+++ b/packages/rspack/src/MultiWatching.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Callback } from '@rspack/lite-tapable';
+import type { WatchInvalidationKind } from './Compilation';
 import type { MultiCompiler } from './MultiCompiler';
 import asyncLib from './util/asyncLib';
 import type { Watching } from './Watching';
@@ -26,17 +27,25 @@ class MultiWatching {
     this.compiler = compiler;
   }
   invalidate(callback?: Callback<Error, void>) {
+    this.__internal__invalidate('normal', callback);
+  }
+
+  /** @internal Invalidates all child compilers with Rspack provenance. */
+  __internal__invalidate(
+    kind: WatchInvalidationKind,
+    callback?: Callback<Error, void>,
+  ) {
     if (callback) {
       asyncLib.each(
         this.watchings,
-        (watching, callback) => watching.invalidate(callback),
+        (watching, callback) => watching.__internal__invalidate(kind, callback),
         // cannot be resolved without assertion
         // Type 'Error | null | undefined' is not assignable to type 'Error | null'
         callback as (err: Error | null | undefined) => void,
       );
     } else {
       for (const watching of this.watchings) {
-        watching.invalidate();
+        watching.__internal__invalidate(kind);
       }
     }
   }

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -11,6 +11,7 @@ import type { Callback } from '@rspack/lite-tapable';
 
 import type { Compilation, Compiler } from '.';
 import { Stats } from '.';
+import type { WatchInvalidationKind } from './Compilation';
 import type { WatchOptions } from './config';
 import type { FileSystemInfoEntry, Watcher } from './util/fs';
 
@@ -53,6 +54,7 @@ export class Watching {
   #closed: boolean;
   #collectedChangedFiles?: Set<string>;
   #collectedRemovedFiles?: Set<string>;
+  #pendingInvalidationKind?: WatchInvalidationKind;
   #pendingWatchDeps?: {
     file: PendingWatchDelta;
     context: PendingWatchDelta;
@@ -131,6 +133,9 @@ export class Watching {
           this.compiler.removedFiles = undefined;
           return this.handler(err);
         }
+        if ((changedFiles?.size ?? 0) > 0 || (removedFiles?.size ?? 0) > 0) {
+          this.#recordInvalidation('normal');
+        }
         this.#invalidate(
           fileTimeInfoEntries,
           contextTimeInfoEntries,
@@ -140,6 +145,13 @@ export class Watching {
         this.onChange();
       },
       (fileName, changeTime) => {
+        this.#recordInvalidation('normal');
+        if (this.running) {
+          // The aggregate callback can arrive after an in-flight compilation
+          // finishes. Suppress that stale generation and drain the paused
+          // watcher before starting the coalesced rebuild.
+          this.invalid = true;
+        }
         if (!this.#invalidReported) {
           this.#invalidReported = true;
           this.compiler.hooks.invalid.call(fileName, changeTime);
@@ -159,6 +171,8 @@ export class Watching {
 
     const finalCallback = (err: Error | null) => {
       this.running = false;
+      this.#pendingInvalidationKind = undefined;
+      this.compiler.__internal__watchInvalidationKind = undefined;
       this.compiler.running = false;
       this.compiler.watching = undefined;
       this.compiler.watchMode = false;
@@ -214,14 +228,40 @@ export class Watching {
     }
   }
 
-  invalidate(callback?: Callback<Error, void>) {
-    if (callback) {
-      this.callbacks.push(callback);
-    }
+  #notifyInvalid() {
     if (!this.#invalidReported) {
       this.#invalidReported = true;
       this.compiler.hooks.invalid.call(null, Date.now());
     }
+  }
+
+  #recordInvalidation(kind: WatchInvalidationKind) {
+    if (kind === 'normal' || this.#pendingInvalidationKind === undefined) {
+      this.#pendingInvalidationKind = kind;
+    }
+  }
+
+  invalidate(callback?: Callback<Error, void>) {
+    this.__internal__invalidate('normal', callback);
+  }
+
+  /** @internal Invalidates with provenance supplied by Rspack internals. */
+  __internal__invalidate(
+    kind: WatchInvalidationKind,
+    callback?: Callback<Error, void>,
+  ) {
+    if (callback) {
+      this.callbacks.push(callback);
+    }
+    this.#recordInvalidation(kind);
+    this.#notifyInvalid();
+    this.onChange();
+    this.#invalidate();
+  }
+
+  /** @internal Resume an invalidation already recorded by MultiCompiler. */
+  __internal__resumeFromMultiCompiler() {
+    this.#notifyInvalid();
     this.onChange();
     this.#invalidate();
   }
@@ -237,10 +277,8 @@ export class Watching {
     if (callback) {
       this.callbacks.push(callback);
     }
-    if (!this.#invalidReported) {
-      this.#invalidReported = true;
-      this.compiler.hooks.invalid.call(null, Date.now());
-    }
+    this.#recordInvalidation('normal');
+    this.#notifyInvalid();
     this.onChange();
     this.#invalidate(undefined, undefined, changedFiles, removedFiles);
   }
@@ -255,6 +293,7 @@ export class Watching {
     if (this.suspended || (this.isBlocked() && (this.blocked = true))) {
       return;
     }
+    this.blocked = false;
 
     if (this.running) {
       this.invalid = true;
@@ -300,12 +339,12 @@ export class Watching {
       this.compiler.fileTimestamps = fileTimeInfoEntries;
       this.compiler.contextTimestamps = contextTimeInfoEntries;
     } else if (this.pausedWatcher) {
-      const { changes, removals, fileTimeInfoEntries, contextTimeInfoEntries } =
-        this.pausedWatcher.getInfo();
-      this.#mergeWithCollected(changes, removals);
-      this.compiler.fileTimestamps = fileTimeInfoEntries;
-      this.compiler.contextTimestamps = contextTimeInfoEntries;
+      this.#drainPausedWatcher();
     }
+
+    this.compiler.__internal__watchInvalidationKind =
+      this.#pendingInvalidationKind;
+    this.#pendingInvalidationKind = undefined;
 
     this.compiler.modifiedFiles = this.#collectedChangedFiles;
     this.compiler.removedFiles = this.#collectedRemovedFiles;
@@ -394,6 +433,8 @@ export class Watching {
     };
 
     if (error) {
+      this.#pendingInvalidationKind = undefined;
+      this.compiler.__internal__watchInvalidationKind = undefined;
       return handleError(error);
     }
 
@@ -403,6 +444,21 @@ export class Watching {
 
     stats = new Stats(compilation);
 
+    const watcherStartTime = Date.now();
+    if (
+      !this.invalid &&
+      this.pausedWatcher?.hasPendingEvents?.() !== false &&
+      this.#drainPausedWatcher()
+    ) {
+      // Watchpack continues collecting while paused but does not deliver an
+      // invalid callback. Coalesce those changes before publishing the stale
+      // generation and advance the baseline so they are not replayed.
+      this.lastWatcherStartTime = watcherStartTime;
+      this.invalid = true;
+      this.#notifyInvalid();
+      this.onInvalid();
+    }
+
     if (
       this.invalid &&
       !this.suspended &&
@@ -411,7 +467,10 @@ export class Watching {
     ) {
       // Coalesced rebuild: the `watch()` delivery below is skipped, so carry
       // this build's deltas forward to the next delivered `watch()`. See #12904.
-      if (compilation) this.#accumulateWatchDeps(compilation);
+      this.#accumulateWatchDeps(compilation);
+      if (compilation.watchInvalidationKind) {
+        this.#recordInvalidation(compilation.watchInvalidationKind);
+      }
       this.#go();
       return;
     }
@@ -423,6 +482,7 @@ export class Watching {
     compilation.endTime = Date.now();
     const cbs = this.callbacks;
     this.callbacks = [];
+    this.compiler.__internal__watchInvalidationKind = undefined;
 
     this.compiler.hooks.done.callAsync(stats, (err) => {
       if (err) return handleError(err, cbs);
@@ -473,6 +533,21 @@ export class Watching {
       for (const cb of cbs) cb(null);
       this.compiler.hooks.afterDone.call(stats);
     });
+  }
+
+  #drainPausedWatcher() {
+    if (!this.pausedWatcher) return false;
+
+    const { changes, removals, fileTimeInfoEntries, contextTimeInfoEntries } =
+      this.pausedWatcher.getInfo();
+    const hasChanges = changes.size > 0 || removals.size > 0;
+    if (hasChanges) {
+      this.#recordInvalidation('normal');
+    }
+    this.#mergeWithCollected(changes, removals);
+    this.compiler.fileTimestamps = fileTimeInfoEntries;
+    this.compiler.contextTimestamps = contextTimeInfoEntries;
+    return hasChanges;
   }
 
   #mergeWithCollected(

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -261,7 +261,7 @@ const lazyCompilationMiddlewareInternal = (
     }
 
     if (moduleActivated.length && compiler.watching) {
-      compiler.watching.invalidate();
+      compiler.watching.__internal__invalidate('lazy');
     }
 
     res.writeHead(200);

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -10,6 +10,7 @@ export type {
   CompilationParams,
   LogEntry,
   PathData,
+  WatchInvalidationKind,
 } from './Compilation';
 export { Compilation } from './Compilation';
 export { Compiler, type CompilerHooks } from './Compiler';

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -189,9 +189,24 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
         "Watcher.getContextTimeInfoEntries is deprecated in favor of Watcher.getInfo since that's more performant.",
         'DEP_WEBPACK_WATCHER_CONTEXT_TIME_INFO_ENTRIES',
       ),
+      hasPendingEvents: () => {
+        const watcher = this.watcher;
+        return Boolean(
+          watcher &&
+          (watcher.aggregatedChanges.size > 0 ||
+            watcher.aggregatedRemovals.size > 0),
+        );
+      },
       getInfo: () => {
-        const removals = this.watcher?.aggregatedRemovals ?? new Set();
-        const changes = this.watcher?.aggregatedChanges ?? new Set();
+        const watcher = this.watcher;
+        const { changes, removals } = watcher
+          ? watcher.paused
+            ? watcher.getAggregated()
+            : {
+                changes: watcher.aggregatedChanges,
+                removals: watcher.aggregatedRemovals,
+              }
+          : { changes: new Set<string>(), removals: new Set<string>() };
         if (this.inputFileSystem?.purge) {
           const fs = this.inputFileSystem;
           if (removals) {

--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -19,6 +19,7 @@ export interface Watcher {
   getAggregatedRemovals?(): Set<string>; // get current aggregated removals that have not yet send to callback
   getFileTimeInfoEntries?(): Map<string, FileSystemInfoEntry | 'ignore'>; // get info about files
   getContextTimeInfoEntries?(): Map<string, FileSystemInfoEntry | 'ignore'>; // get info about directories
+  hasPendingEvents?(): boolean; // cheaply checks for changes collected while paused
   getInfo(): WatcherInfo; // get info about timestamps and changes
 }
 

--- a/tests/rspack-test/compilerCases/watching.js
+++ b/tests/rspack-test/compilerCases/watching.js
@@ -1,4 +1,6 @@
 const { createFsFromVolume, Volume } = require("memfs");
+const { lazyCompilationMiddleware } = require("@rspack/core");
+const path = require("node:path");
 const { start } = require("@rspack/test-tools/helper/legacy/deprecationTracking");
 let tracker = null;
 
@@ -41,6 +43,163 @@ module.exports = [{
           expect(compiler.watchMode).toBeFalsy();
           resolve();
         });
+      });
+    });
+  },
+}, {
+  description: "should consume paused Watchpack changes once",
+  options(context) {
+    return {
+      entry: "./c",
+      experiments: {
+        nativeWatcher: false,
+      },
+    };
+  },
+  async build(context, compiler) {
+    const entry = path.join(compiler.context, "c.js");
+    const watchFileSystem = compiler.watchFileSystem;
+    const callbackChanges = [];
+    const watcher = watchFileSystem.watch(
+      [entry],
+      [],
+      [],
+      Date.now(),
+      { aggregateTimeout: 1000 },
+      (_error, _fileTimes, _contextTimes, changes) =>
+        callbackChanges.push(changes),
+      () => {},
+    );
+
+    try {
+      const watchpack = watchFileSystem.watcher;
+      watchpack._onChange(entry, Date.now(), entry, "change");
+      expect(watcher.hasPendingEvents()).toBe(true);
+      expect(watcher.getInfo().changes).toEqual(new Set([entry]));
+      expect(watchpack.aggregateTimer).toBeDefined();
+      watchpack._onTimeout();
+      expect(callbackChanges).toEqual([new Set([entry])]);
+
+      watchpack._onChange(entry, Date.now(), entry, "change");
+      expect(watcher.hasPendingEvents()).toBe(true);
+      expect(watcher.getInfo().changes).toEqual(new Set([entry]));
+      expect(watcher.getInfo().changes).toEqual(new Set());
+      expect(watcher.hasPendingEvents()).toBe(false);
+    } finally {
+      watcher.close();
+    }
+  },
+}, {
+  description: "should snapshot lazy compilation invalidation provenance per watch cycle",
+  options(context) {
+    return {
+      entry: "./c",
+      lazyCompilation: {
+        entries: false,
+        imports: false,
+      },
+    };
+  },
+  async compiler(context, compiler) {
+    compiler.outputFileSystem = createFsFromVolume(new Volume());
+  },
+  async build(context, compiler) {
+    const cycles = [];
+    let coalesceNormalInvalidation = false;
+    let emitNormalFileChange;
+    let watching;
+    compiler.watchFileSystem = {
+      watch(
+        files,
+        dirs,
+        missing,
+        startTime,
+        options,
+        callback,
+        callbackUndelayed,
+      ) {
+        emitNormalFileChange = () => {
+          const file = path.join(compiler.context, "c.js");
+          callbackUndelayed(file, Date.now());
+          callback(null, new Map(), new Map(), new Set([file]), new Set());
+        };
+        return {
+          close() {},
+          getInfo() {
+            return {
+              changes: new Set(),
+              removals: new Set(),
+              fileTimeInfoEntries: new Map(),
+              contextTimeInfoEntries: new Map(),
+            };
+          },
+          pause() {},
+        };
+      },
+    };
+    compiler.hooks.thisCompilation.tap(
+      "test lazy invalidation provenance",
+      compilation => {
+        cycles.push(compilation.watchInvalidationKind);
+      },
+    );
+    compiler.hooks.make.tapAsync(
+      "coalesce normal invalidation",
+      (compilation, callback) => {
+        if (
+          coalesceNormalInvalidation &&
+          compilation.watchInvalidationKind === "lazy"
+        ) {
+          coalesceNormalInvalidation = false;
+          emitNormalFileChange();
+        }
+        callback();
+      },
+    );
+
+    const middleware = lazyCompilationMiddleware(compiler);
+    const activate = module =>
+      new Promise((resolve, reject) => {
+        middleware(
+          {
+            body: [module],
+            method: "POST",
+            url: "/_rspack/lazy/trigger",
+          },
+          {
+            end: resolve,
+            write() {},
+            writeHead(status) {
+              expect(status).toBe(200);
+            },
+          },
+          reject,
+        ).catch(reject);
+      });
+
+    return new Promise((resolve, reject) => {
+      let builds = 0;
+      watching = compiler.watch({}, err => {
+        if (err) return reject(err);
+        builds++;
+        if (builds === 1) {
+          setImmediate(() => activate("first-lazy-module").catch(reject));
+          return;
+        }
+        if (builds === 2) {
+          coalesceNormalInvalidation = true;
+          setImmediate(() => activate("coalesced-lazy-module").catch(reject));
+          return;
+        }
+        if (builds === 3) {
+          try {
+            expect(cycles).toEqual([undefined, "lazy", "lazy", "normal"]);
+          } catch (error) {
+            watching.close(() => reject(error));
+            return;
+          }
+          watching.close(error => (error ? reject(error) : resolve()));
+        }
       });
     });
   },

--- a/tests/rspack-test/multiCompilerCases/invalidate.js
+++ b/tests/rspack-test/multiCompilerCases/invalidate.js
@@ -5,6 +5,7 @@ const path = require("path");
 module.exports = [
   (() => {
     const events = [];
+    const lazyCompilationCycles = [];
     let state = 0;
     return {
       description: "should respect dependencies when using invalidate",
@@ -36,6 +37,11 @@ module.exports = [
           c.hooks.done.tap("test", () => {
             events.push(`${c.name} done`);
           });
+          c.hooks.thisCompilation.tap("test", compilation => {
+            if (c.name === "a") {
+              lazyCompilationCycles.push(compilation.watchInvalidationKind);
+            }
+          });
         });
 
         compiler.watchFileSystem = { watch() { } };
@@ -48,10 +54,9 @@ module.exports = [
               reject(error);
               return;
             }
-            if (state !== 0) return;
-            state++;
-
-            expect(events).toMatchInlineSnapshot(`
+            if (state === 0) {
+              state = 1;
+              expect(events).toMatchInlineSnapshot(`
 				Array [
 				  b run,
 				  b done,
@@ -59,13 +64,13 @@ module.exports = [
 				  a done,
 				]
 			`);
-            events.length = 0;
+              events.length = 0;
 
-            watching.invalidate(err => {
-              try {
-                if (err) return reject(err);
+              watching.__internal__invalidate("lazy", err => {
+                try {
+                  if (err) return reject(err);
 
-                expect(events).toMatchInlineSnapshot(`
+                  expect(events).toMatchInlineSnapshot(`
 					Array [
 					  a invalid,
 					  b invalid,
@@ -75,16 +80,46 @@ module.exports = [
 					  a done,
 					]
 				`);
-                events.length = 0;
-                expect(state).toBe(1);
-                setTimeout(() => {
-                  compiler.close(resolve);
-                }, 1000);
-              } catch (e) {
-                console.error(e);
-                reject(e);
-              }
-            });
+                  // `a` consumes `b`'s lazy artifact, so its dependent
+                  // generation must remain normal and emit fresh output.
+                  expect(lazyCompilationCycles).toEqual([undefined, "normal"]);
+                  events.length = 0;
+                  expect(state).toBe(1);
+                  state = 2;
+                  watching.watchings[0].__internal__invalidate("lazy");
+                  watching.watchings[1].invalidate(error => {
+                    if (error) reject(error);
+                  });
+                } catch (e) {
+                  console.error(e);
+                  reject(e);
+                }
+              });
+              return;
+            }
+
+            if (state !== 2) return;
+            try {
+              expect(events).toMatchInlineSnapshot(`
+				Array [
+				  a invalid,
+				  b invalid,
+				  b run,
+				  b done,
+				  a run,
+				  a done,
+				]
+			`);
+              expect(lazyCompilationCycles).toEqual([
+                undefined,
+                "normal",
+                "normal"
+              ]);
+              state = 3;
+              compiler.close(error => (error ? reject(error) : resolve()));
+            } catch (error) {
+              compiler.close(() => reject(error));
+            }
           });
         });
       }


### PR DESCRIPTION
## Summary

Watch invalidations previously lost their origin once they entered the shared watch pipeline. This made lazy compilation invalidations indistinguishable from normal filesystem or manual invalidations, including when invalidations were coalesced or propagated through a `MultiCompiler`.

This PR:

- tracks `lazy` and `normal` invalidation provenance for each watch compilation, with normal invalidations taking precedence when events are coalesced
- propagates provenance through `MultiCompiler` and marks dependent compiler rebuilds as normal
- drains pending Watchpack events before publishing an outdated generation
- forwards lazy watch provenance through the JavaScript-to-Rust rebuild boundary
- adds focused coverage for single-compiler, coalesced Watchpack, and dependent multi-compiler invalidations

This allows rebuild consumers to distinguish explicitly lazy rebuilds from normal watch rebuilds without changing the behavior of public `invalidate()` calls.

## Related links

- Split from #14844

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).