### PR TITLE
perf(storage): compress persistent cache pack values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5282,6 +5288,8 @@ dependencies = [
  "cow-utils",
  "futures",
  "itertools 0.14.0",
+ "lz4_flex",
+ "rayon",
  "rspack_error",
  "rspack_fs",
  "rspack_parallel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.1.0", default-features = false }
 lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
+lz4_flex            = { version = "0.14", default-features = false, features = ["std", "safe-encode", "safe-decode", "checked-decode"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }
 micromegas-perfetto = { version = "0.9.0", default-features = false }

--- a/crates/rspack_storage/Cargo.toml
+++ b/crates/rspack_storage/Cargo.toml
@@ -13,6 +13,8 @@ async-trait     = { workspace = true }
 cow-utils       = { workspace = true }
 futures         = { workspace = true }
 itertools       = { workspace = true }
+lz4_flex        = { workspace = true }
+rayon           = { workspace = true }
 rspack_error    = { workspace = true }
 rspack_fs       = { workspace = true }
 rspack_parallel = { workspace = true }

--- a/crates/rspack_storage/src/filesystem/db/bucket/codec.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/codec.rs
@@ -1,0 +1,191 @@
+use lz4_flex::block;
+
+use crate::{Error, Result};
+
+const FRAME_MAGIC: &[u8; 8] = b"RSPKLZ01";
+const FRAME_HEADER_SIZE: usize = FRAME_MAGIC.len() + size_of::<u64>();
+const MIN_VALUE_SIZE: usize = 256;
+const MAX_VALUE_SIZE: usize = 128 * 1024 * 1024;
+
+/// Per-worker compression state prevents allocating a fresh LZ4 table per value.
+#[derive(Default)]
+pub(super) struct Encoder {
+  scratch: Vec<u8>,
+  table: block::CompressTable,
+}
+
+impl Encoder {
+  /// Compress a new value only when its complete frame saves at least 10%.
+  ///
+  /// Existing packed values remain in their physical representation, so
+  /// incremental writes never decompress and recompress untouched entries.
+  pub(super) fn encode(&mut self, value: Vec<u8>) -> Vec<u8> {
+    if !(MIN_VALUE_SIZE..=MAX_VALUE_SIZE).contains(&value.len()) {
+      return value;
+    }
+
+    self.scratch.resize(
+      FRAME_HEADER_SIZE + block::get_maximum_output_size(value.len()),
+      0,
+    );
+    self.scratch[..FRAME_MAGIC.len()].copy_from_slice(FRAME_MAGIC);
+    self.scratch[FRAME_MAGIC.len()..FRAME_HEADER_SIZE]
+      .copy_from_slice(&(value.len() as u64).to_le_bytes());
+    let Ok(compressed_len) = block::compress_into_with_table(
+      &value,
+      &mut self.scratch[FRAME_HEADER_SIZE..],
+      &mut self.table,
+    ) else {
+      return value;
+    };
+
+    let framed_len = FRAME_HEADER_SIZE + compressed_len;
+    if framed_len > value.len() - value.len() / 10 {
+      return value;
+    }
+
+    self.scratch[..framed_len].to_vec()
+  }
+}
+
+/// Decode a persisted value, preserving compatibility with older uncompressed packs.
+pub(super) fn decode(value: Vec<u8>) -> Result<Vec<u8>> {
+  if !value.starts_with(FRAME_MAGIC) {
+    return Ok(value);
+  }
+
+  let expected_bytes = value
+    .get(FRAME_MAGIC.len()..FRAME_HEADER_SIZE)
+    .ok_or_else(|| Error::CorruptedData("truncated compressed persistent value header".into()))?;
+  let expected = u64::from_le_bytes(
+    expected_bytes
+      .try_into()
+      .map_err(|_| Error::CorruptedData("invalid compressed persistent value length".into()))?,
+  );
+  let expected = usize::try_from(expected).map_err(|_| {
+    Error::CorruptedData("compressed persistent value exceeds platform size".into())
+  })?;
+  if !(MIN_VALUE_SIZE..=MAX_VALUE_SIZE).contains(&expected) {
+    return Err(Error::CorruptedData(format!(
+      "compressed persistent value length {expected} exceeds the allowed range"
+    )));
+  }
+
+  let compressed = value
+    .get(FRAME_HEADER_SIZE..)
+    .ok_or_else(|| Error::CorruptedData("truncated compressed persistent value".into()))?;
+  let mut decoded = vec![0; expected];
+  let written = block::decompress_into(compressed, &mut decoded).map_err(|error| {
+    Error::CorruptedData(format!("invalid compressed persistent value: {error}"))
+  })?;
+  if written != expected {
+    return Err(Error::CorruptedData(format!(
+      "compressed persistent value length mismatch: expected {expected}, got {written}"
+    )));
+  }
+
+  Ok(decoded)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Encoder, FRAME_HEADER_SIZE, FRAME_MAGIC, MAX_VALUE_SIZE, MIN_VALUE_SIZE, decode};
+
+  #[test]
+  fn compressible_values_round_trip() {
+    let original = b"deterministic synthetic graph content ".repeat(2048);
+    let mut encoder = Encoder::default();
+    let encoded = encoder.encode(original.clone());
+
+    assert!(encoded.starts_with(FRAME_MAGIC));
+    assert!(encoded.len() < original.len() / 10);
+    assert_eq!(decode(encoded).expect("value should decode"), original);
+  }
+
+  #[test]
+  fn worker_scratch_is_reused_across_values() {
+    let mut encoder = Encoder::default();
+    let first = b"first repeated cache value ".repeat(1024);
+    let first_encoded = encoder.encode(first.clone());
+    let capacity = encoder.scratch.capacity();
+    let second = b"second repeated cache value ".repeat(512);
+    let second_encoded = encoder.encode(second.clone());
+
+    assert_eq!(encoder.scratch.capacity(), capacity);
+    assert_eq!(decode(first_encoded).expect("first should decode"), first);
+    assert_eq!(
+      decode(second_encoded).expect("second should decode"),
+      second
+    );
+  }
+
+  #[test]
+  fn small_and_legacy_values_remain_unmodified() {
+    let original = b"existing uncompressed persistent value".to_vec();
+    let mut encoder = Encoder::default();
+
+    assert_eq!(encoder.encode(original.clone()), original);
+    assert_eq!(
+      decode(original.clone()).expect("legacy value should decode"),
+      original
+    );
+  }
+
+  #[test]
+  fn incompressible_values_remain_unmodified() {
+    let mut state = 0x6b36_2f29_493a_e149_u64;
+    let original = (0..32 * 1024)
+      .map(|_| {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state as u8
+      })
+      .collect::<Vec<_>>();
+
+    assert_eq!(Encoder::default().encode(original.clone()), original);
+  }
+
+  #[test]
+  fn truncated_headers_and_payloads_are_rejected() {
+    assert!(decode(FRAME_MAGIC.to_vec()).is_err());
+
+    let mut encoded = Encoder::default().encode(b"repeated graph source ".repeat(1024));
+    encoded.truncate(FRAME_HEADER_SIZE);
+    assert!(decode(encoded).is_err());
+  }
+
+  #[test]
+  fn declared_sizes_outside_the_allowed_range_are_rejected() {
+    for invalid_len in [
+      0,
+      MIN_VALUE_SIZE as u64 - 1,
+      MAX_VALUE_SIZE as u64 + 1,
+      u64::MAX,
+    ] {
+      let mut frame = FRAME_MAGIC.to_vec();
+      frame.extend_from_slice(&invalid_len.to_le_bytes());
+      assert!(decode(frame).is_err());
+    }
+  }
+
+  #[test]
+  fn malformed_and_trailing_payloads_are_rejected() {
+    let encoded = Encoder::default().encode(b"repeated graph source ".repeat(1024));
+
+    let mut truncated = encoded.clone();
+    truncated.pop();
+    assert!(decode(truncated).is_err());
+
+    for trailing in [0, 0xff] {
+      let mut value = encoded.clone();
+      value.push(trailing);
+      assert!(decode(value).is_err());
+    }
+
+    let mut malformed = FRAME_MAGIC.to_vec();
+    malformed.extend_from_slice(&(MIN_VALUE_SIZE as u64).to_le_bytes());
+    malformed.extend_from_slice(&[0, 0, 0]);
+    assert!(decode(malformed).is_err());
+  }
+}

--- a/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
+++ b/crates/rspack_storage/src/filesystem/db/bucket/mod.rs
@@ -1,12 +1,14 @@
+mod codec;
 mod index;
 mod meta;
 mod pack;
 
-use pack::{PackGenerator, PackId, PackIdAlloc};
+use pack::{Pack, PackGenerator, PackId, PackIdAlloc};
+use rayon::prelude::*;
 use rspack_parallel::TryFutureConsumer;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use self::{meta::Meta, pack::Pack};
+use self::meta::Meta;
 use super::ScopeFileSystem;
 use crate::{Error, Result};
 
@@ -82,7 +84,10 @@ impl Bucket {
       .try_fut_consume(|pack| result.extend(pack.data()))
       .await?;
 
-    Ok(result)
+    result
+      .into_par_iter()
+      .map(|(key, value)| codec::decode(value).map(|value| (key, value)))
+      .collect()
   }
 
   /// Saves changes to disk, returning lists of added and removed files.
@@ -121,7 +126,14 @@ impl Bucket {
     }
     let hot_pack = std::mem::take(&mut self.hot_pack);
     pack_generator.extend(hot_pack.data());
-    pack_generator.extend(data.into_iter().filter_map(|(k, v)| v.map(|v| (k, v))));
+    let updates = data
+      .into_par_iter()
+      .filter_map(|(key, value)| value.map(|value| (key, value)))
+      .map_init(codec::Encoder::default, |encoder, (key, value)| {
+        (key, encoder.encode(value))
+      })
+      .collect::<Vec<_>>();
+    pack_generator.extend(updates);
     let (hot_pack, new_packs) = pack_generator.finish();
 
     // Alloc id for packs
@@ -253,6 +265,49 @@ mod test {
 
     assert_eq!(bucket.meta.cold_pack_indexes().len(), 4);
     assert_eq!(bucket.hot_pack.clone().data().len(), 1);
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  #[cfg_attr(miri, ignore)]
+  async fn compressible_values_are_grouped_by_physical_size() -> Result<()> {
+    let fs = ScopeFileSystem::new_memory_fs("/compressed_bucket".into());
+    let mut bucket = Bucket::new(fs.clone()).await?;
+    let expected = (0..8)
+      .map(|index| {
+        (
+          format!("module-{index}").into_bytes(),
+          format!("deterministic synthetic module content {index};")
+            .repeat(512)
+            .into_bytes(),
+        )
+      })
+      .collect::<Vec<_>>();
+    let raw_value_bytes = expected.iter().map(|(_, value)| value.len()).sum::<usize>();
+    let updates = expected
+      .iter()
+      .cloned()
+      .map(|(key, value)| (key, Some(value)))
+      .collect();
+
+    bucket.save(None, updates, 4096).await?;
+
+    assert!(
+      bucket.meta.cold_pack_indexes().is_empty(),
+      "compressed values should fit together instead of each creating a cold pack"
+    );
+    let physical_pack = fs.read("0.pack").await?;
+    assert!(
+      physical_pack.len() < raw_value_bytes / 10,
+      "physical pack should be substantially smaller than its restored values"
+    );
+
+    let mut restored = Bucket::new(fs).await?.load_all().await?;
+    restored.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut expected = expected;
+    expected.sort_by(|left, right| left.0.cmp(&right.0));
+    assert_eq!(restored, expected);
 
     Ok(())
   }


### PR DESCRIPTION
## Summary

Persistent filesystem cache values are currently grouped into pack files using their uncompressed size. Compressible module-graph, source-map, and other persisted values therefore consume more disk space and create more pack files than necessary.

This change:

- Compresses new bucket values with adaptive LZ4 before pack generation.
- Preserves compressed physical values across existing hot packs, cold packs, content hashes, and incremental updates.
- Restores original values only after pack integrity verification.
- Reuses per-worker output buffers and LZ4 compression tables.
- Preserves existing raw values and skips small, incompressible, or oversized records.
- Rejects malformed, truncated, trailing, and oversized compressed frames.

No public configuration or cache-consumer changes are required.

## Validation

- cargo test -p rspack_storage --lib --release --offline: 33 passed.
- A synthetic storage integration fixture fits eight highly compressible values into one hot pack with no cold packs; the resulting physical pack occupies less than 10% of the restored value bytes.
- Tests also cover legacy raw values, incompressible values, reusable compression state, invalid frame lengths, truncated payloads, trailing bytes, and lossless recovery.