### PR TITLE
docs: improve webpack migration guidance

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -15,6 +15,12 @@ For projects not using webpack 5, there are other migration guides that can be r
 - For projects using create-react-app or CRACO, you can refer to [Migrating Create React App](/guide/migration/cra).
 - For projects using Vue CLI, you can refer to [Rsbuild - Migrating from Vue CLI](https://rsbuild.rs/guide/migration/vue-cli).
 
+## Checking the Node.js version
+
+Before migrating, make sure that all build environments use a Node.js version supported by Rspack. `@rspack/core@2` requires Node.js `^20.19.0 || >=22.12.0`.
+
+Keep the Node.js version consistent across local development, CI, and deployment builds. Update version settings such as `.nvmrc`, Volta configuration, and build images as needed.
+
 ## Installing Rspack
 
 Install Rspack in your project directory:
@@ -25,10 +31,7 @@ Both `@rspack/cli` and `@rspack/dev-server` are optional dependencies:
 
 - If you are not using `webpack-cli`, no need to install `@rspack/cli`.
 - If you are not using `webpack-dev-server`, no need to install `@rspack/dev-server`.
-
-Now you can remove the webpack-related dependencies from your project:
-
-<PackageManagerTabs command="remove webpack webpack-cli webpack-dev-server" />
+- Use the same version of `@rspack/core` and `@rspack/cli`. The version of `@rspack/dev-server` may differ and does not need to match.
 
 ## Updating package.json
 
@@ -531,6 +534,31 @@ Migrate [raw-loader](https://github.com/webpack-contrib/raw-loader) to [Asset Mo
  };
 ```
 
+### vue-loader
+
+For Vue 3 projects, replace `vue-loader` with [`rspack-vue-loader`](/guide/tech/vue#vue-3), and update both the plugin import and loader name:
+
+```diff title="rspack.config.mjs"
+-import { VueLoaderPlugin } from 'vue-loader';
++import { VueLoaderPlugin } from 'rspack-vue-loader';
+
+export default {
+  plugins: [new VueLoaderPlugin()],
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+-       loader: 'vue-loader',
++       loader: 'rspack-vue-loader',
++       options: {
++         experimentalInlineMatchResource: true,
++       },
+      },
+    ],
+  },
+};
+```
+
 ## Common webpack package replacements
 
 When migrating webpack ecosystem packages, the following non-plugin packages usually need to be replaced.
@@ -545,3 +573,11 @@ When migrating webpack ecosystem packages, the following non-plugin packages usu
 | `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge)                    | Rspack configuration merging.          |
 
 > For plugin packages, see [Plugin compatibility](/guide/compatibility/plugin).
+
+## Removing webpack dependencies
+
+After successfully building your project with Rspack, check whether any loaders, plugins, or custom build scripts still import `webpack` or `webpack/lib/*`.
+
+If imports remain, keep `webpack` temporarily as a compatibility dependency. Remove webpack-related dependencies after they have been replaced or verified as unnecessary:
+
+<PackageManagerTabs command="remove webpack webpack-cli webpack-dev-server" />

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -14,6 +14,12 @@ Rspack 的配置是基于 webpack 的设计实现的，以此你能够非常轻�
 - 对于使用 [create-react-app](https://create-react-app.dev/) 或 [CRACO](https://craco.js.org/) 的项目，可以参考 [迁移 Create React App](/guide/migration/cra)。
 - 对于使用 [Vue CLI](https://cli.vuejs.org/zh/) 的项目，可以参考 [Rsbuild - 从 Vue CLI 迁移](https://rsbuild.rs/zh/guide/migration/vue-cli)。
 
+## 检查 Node.js 版本
+
+迁移前，请确保所有构建环境使用 Rspack 支持的 Node.js 版本。`@rspack/core@2` 要求 Node.js `^20.19.0 || >=22.12.0`。
+
+请确保本地开发、CI 和部署构建环境使用一致的 Node.js 版本，并按需更新 `.nvmrc`、Volta 配置和构建镜像等版本设置。
+
 ## 安装 Rspack
 
 在你的项目目录下安装 Rspack：
@@ -24,10 +30,7 @@ Rspack 的配置是基于 webpack 的设计实现的，以此你能够非常轻�
 
 - 未使用 `webpack-cli` 时，不需要安装 `@rspack/cli`
 - 未使用 `webpack-dev-server` 时，不需要安装 `@rspack/dev-server`
-
-现在你可以移除项目中 webpack 相关的依赖了：
-
-<PackageManagerTabs command="remove webpack webpack-cli webpack-dev-server" />
+- `@rspack/core` 和 `@rspack/cli` 应使用相同版本。`@rspack/dev-server` 的版本可能不同，无需保持一致。
 
 ## 修改 package.json
 
@@ -529,6 +532,31 @@ module.exports = {
  };
 ```
 
+### vue-loader
+
+对于 Vue 3 项目，请将 `vue-loader` 替换为 [`rspack-vue-loader`](/guide/tech/vue#vue-3)，并同步更新插件导入和 loader 名称：
+
+```diff title="rspack.config.mjs"
+-import { VueLoaderPlugin } from 'vue-loader';
++import { VueLoaderPlugin } from 'rspack-vue-loader';
+
+export default {
+  plugins: [new VueLoaderPlugin()],
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+-       loader: 'vue-loader',
++       loader: 'rspack-vue-loader',
++       options: {
++         experimentalInlineMatchResource: true,
++       },
+      },
+    ],
+  },
+};
+```
+
 ## 常见 webpack 库替换
 
 迁移 webpack 生态中的配套库时，下面这些非插件类包通常需要替换：
@@ -543,3 +571,11 @@ module.exports = {
 | `webpack-merge`          | [`rspack-merge`](https://github.com/rstackjs/rspack-merge)                    | 合并 Rspack 配置。              |
 
 > 对于插件类包，请查看 [Plugin 兼容](/guide/compatibility/plugin)。
+
+## 移除 webpack 依赖
+
+使用 Rspack 构建成功后，请检查 loader、插件或自定义构建脚本是否仍导入 `webpack` 或 `webpack/lib/*`。
+
+如果仍存在相关导入，请暂时保留 `webpack` 作为兼容依赖。替换相关依赖或确认不再需要后，再移除 webpack 相关依赖：
+
+<PackageManagerTabs command="remove webpack webpack-cli webpack-dev-server" />


### PR DESCRIPTION
## Summary

This PR clarifies key prerequisites and dependency handling when migrating from webpack to Rspack. It documents Node.js and package version requirements, adds a Vue 3 loader replacement example, and moves webpack removal to the end of the migration flow so compatibility dependencies can be checked first.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).