### PR TITLE
docs: clarify webpack plugin migration

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -111,8 +111,8 @@ export default {
 export default {
 - cache: {
 -   buildDependencies: {
--     config: [__filename, path.join(import.meta.dirname, 'package.json')],
--     ts: [path.join(import.meta.dirname, 'tsconfig.json')]
+-     config: [__filename, path.join(__dirname, 'package.json')],
+-     ts: [path.join(__dirname, 'tsconfig.json')]
 -   }
 - },
 + cache: {
@@ -148,8 +148,8 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - snapshot: {
--   immutablePaths: [path.join(import.meta.dirname, 'constant')],
--   managedPaths: [path.join(import.meta.dirname, 'node_modules')],
+-   immutablePaths: [path.join(__dirname, 'constant')],
+-   managedPaths: [path.join(__dirname, 'node_modules')],
 -   unmanagedPaths: []
 - },
 + cache: {
@@ -168,7 +168,7 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - cache: {
--   cacheDirectory: path.join(import.meta.dirname, 'node_modules/.cache/test')
+-   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test')
 - },
 + cache: {
 +   type: 'persistent',

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -111,16 +111,16 @@ export default {
 export default {
 - cache: {
 -   buildDependencies: {
--     config: [__filename, path.join(__dirname, 'package.json')],
--     ts: [path.join(__dirname, 'tsconfig.json')]
+-     config: [__filename, path.join(import.meta.dirname, 'package.json')],
+-     ts: [path.join(import.meta.dirname, 'tsconfig.json')]
 -   }
 - },
 + cache: {
 +   type: 'persistent',
 +   buildDependencies: [
 +     __filename,
-+     path.join(__dirname, 'package.json'),
-+     path.join(__dirname, 'tsconfig.json')
++     path.join(import.meta.dirname, 'package.json'),
++     path.join(import.meta.dirname, 'tsconfig.json')
 +   ]
 + },
 };
@@ -148,15 +148,15 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - snapshot: {
--   immutablePaths: [path.join(__dirname, 'constant')],
--   managedPaths: [path.join(__dirname, 'node_modules')],
+-   immutablePaths: [path.join(import.meta.dirname, 'constant')],
+-   managedPaths: [path.join(import.meta.dirname, 'node_modules')],
 -   unmanagedPaths: []
 - },
 + cache: {
 +   type: 'persistent',
 +   snapshot: {
-+     immutablePaths: [path.join(__dirname, 'constant')],
-+     managedPaths: [path.join(__dirname, 'node_modules')],
++     immutablePaths: [path.join(import.meta.dirname, 'constant')],
++     managedPaths: [path.join(import.meta.dirname, 'node_modules')],
 +     unmanagedPaths: []
 +   }
 + },
@@ -168,13 +168,13 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - cache: {
--   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test')
+-   cacheDirectory: path.join(import.meta.dirname, 'node_modules/.cache/test')
 - },
 + cache: {
 +   type: 'persistent',
 +   storage: {
 +     type: 'filesystem',
-+     directory: path.join(__dirname, 'node_modules/.cache/test')
++     directory: path.join(import.meta.dirname, 'node_modules/.cache/test')
 +   }
 + },
 };
@@ -327,7 +327,7 @@ Rspack does not support webpack's `resolve.plugins` option. Use [resolve.tsConfi
  export default {
   resolve: {
 -    plugins: [new TsconfigPathsPlugin()],
-+    tsConfig: path.resolve(__dirname, 'tsconfig.json'),
++    tsConfig: path.resolve(import.meta.dirname, 'tsconfig.json'),
   },
 };
 ```

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -255,6 +255,19 @@ Rspack supports most of the webpack community plugins and also offers alternativ
 
 Check [Plugin compat](/guide/compatibility/plugin) for more information on Rspack's compatibility with popular webpack community plugins.
 
+Some webpack ecosystem packages, such as [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) and [`node-polyfill-webpack-plugin`](https://www.npmjs.com/package/node-polyfill-webpack-plugin), require newer versions for Rspack compatibility. Before reusing a community package, upgrade it to the latest version, as older versions may rely on incompatible webpack APIs.
+
+### unplugin
+
+Some [unplugin](/guide/features/plugin#unplugin) packages provide separate entry points for each bundler. When a `/rspack` entry is available, use it instead of `/webpack` so the plugin selects the Rspack adapter:
+
+```diff title="rspack.config.mjs"
+- import AutoImport from 'unplugin-auto-import/webpack';
+- import Components from 'unplugin-vue-components/webpack';
++ import AutoImport from 'unplugin-auto-import/rspack';
++ import Components from 'unplugin-vue-components/rspack';
+```
+
 ### copy-webpack-plugin
 
 Use [rspack.CopyRspackPlugin](/plugins/rspack/copy-rspack-plugin) instead of [copy-webpack-plugin](https://github.com/webpack/copy-webpack-plugin):
@@ -305,15 +318,16 @@ module.exports = {
 
 ### tsconfig-paths-webpack-plugin
 
-Use [resolve.tsConfig](/config/resolve#resolvetsconfig) option instead of [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin):
+Rspack does not support webpack's `resolve.plugins` option. Use [resolve.tsConfig](/config/resolve#resolvetsconfig) option instead of [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin):
 
-```js title="rspack.config.js"
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin'); // [!code --]
+```diff title="rspack.config.mjs"
+-import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
++import path from 'node:path';
 
-module.exports = {
+ export default {
   resolve: {
-    plugins: [new TsconfigPathsPlugin({})], // [!code --]
-    tsConfig: {}, // [!code ++]
+-    plugins: [new TsconfigPathsPlugin()],
++    tsConfig: path.resolve(__dirname, 'tsconfig.json'),
   },
 };
 ```

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -109,16 +109,16 @@ export default {
 export default {
 - cache: {
 -   buildDependencies: {
--     config: [__filename, path.join(__dirname, 'package.json')],
--     ts: [path.join(__dirname, 'tsconfig.json')]
+-     config: [__filename, path.join(import.meta.dirname, 'package.json')],
+-     ts: [path.join(import.meta.dirname, 'tsconfig.json')]
 -   }
 - },
 + cache: {
 +   type: 'persistent',
 +   buildDependencies: [
 +     __filename,
-+     path.join(__dirname, 'package.json'),
-+     path.join(__dirname, 'tsconfig.json')
++     path.join(import.meta.dirname, 'package.json'),
++     path.join(import.meta.dirname, 'tsconfig.json')
 +   ]
 + },
 };
@@ -146,15 +146,15 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - snapshot: {
--   immutablePaths: [path.join(__dirname, 'constant')],
--   managedPaths: [path.join(__dirname, 'node_modules')],
+-   immutablePaths: [path.join(import.meta.dirname, 'constant')],
+-   managedPaths: [path.join(import.meta.dirname, 'node_modules')],
 -   unmanagedPaths: []
 - },
 + cache: {
 +   type: 'persistent',
 +   snapshot: {
-+     immutablePaths: [path.join(__dirname, 'constant')],
-+     managedPaths: [path.join(__dirname, 'node_modules')],
++     immutablePaths: [path.join(import.meta.dirname, 'constant')],
++     managedPaths: [path.join(import.meta.dirname, 'node_modules')],
 +     unmanagedPaths: []
 +   }
 + },
@@ -166,13 +166,13 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - cache: {
--   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test')
+-   cacheDirectory: path.join(import.meta.dirname, 'node_modules/.cache/test')
 - },
 + cache: {
 +   type: 'persistent',
 +   storage: {
 +     type: 'filesystem',
-+     directory: path.join(__dirname, 'node_modules/.cache/test')
++     directory: path.join(import.meta.dirname, 'node_modules/.cache/test')
 +   }
 + },
 };
@@ -325,7 +325,7 @@ Rspack 不支持 webpack 的 `resolve.plugins` 选项。使用 [resolve.tsConfig
  export default {
   resolve: {
 -    plugins: [new TsconfigPathsPlugin()],
-+    tsConfig: path.resolve(__dirname, 'tsconfig.json'),
++    tsConfig: path.resolve(import.meta.dirname, 'tsconfig.json'),
   },
 };
 ```

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -109,8 +109,8 @@ export default {
 export default {
 - cache: {
 -   buildDependencies: {
--     config: [__filename, path.join(import.meta.dirname, 'package.json')],
--     ts: [path.join(import.meta.dirname, 'tsconfig.json')]
+-     config: [__filename, path.join(__dirname, 'package.json')],
+-     ts: [path.join(__dirname, 'tsconfig.json')]
 -   }
 - },
 + cache: {
@@ -146,8 +146,8 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - snapshot: {
--   immutablePaths: [path.join(import.meta.dirname, 'constant')],
--   managedPaths: [path.join(import.meta.dirname, 'node_modules')],
+-   immutablePaths: [path.join(__dirname, 'constant')],
+-   managedPaths: [path.join(__dirname, 'node_modules')],
 -   unmanagedPaths: []
 - },
 + cache: {
@@ -166,7 +166,7 @@ export default {
 ```diff title="rspack.config.mjs"
 export default {
 - cache: {
--   cacheDirectory: path.join(import.meta.dirname, 'node_modules/.cache/test')
+-   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test')
 - },
 + cache: {
 +   type: 'persistent',

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -253,6 +253,19 @@ Rspack 支持大部分 webpack 社区插件，并为暂不支持的插件提供�
 
 查看 [Plugin 兼容](/guide/compatibility/plugin) 以了解 Rspack 对 webpack 常见社区插件的兼容情况。
 
+部分 webpack 生态包需要升级到较新版本才能兼容 Rspack，例如 [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) 和 [`node-polyfill-webpack-plugin`](https://www.npmjs.com/package/node-polyfill-webpack-plugin)。复用社区包前，建议升级到最新版本，因为旧版本可能依赖不兼容的 webpack API。
+
+### unplugin
+
+部分 [unplugin](/guide/features/plugin#unplugin) 包会为不同构建工具提供独立入口。如果提供了 `/rspack` 入口，请使用它代替 `/webpack`，以选择 Rspack 适配层：
+
+```diff title="rspack.config.mjs"
+- import AutoImport from 'unplugin-auto-import/webpack';
+- import Components from 'unplugin-vue-components/webpack';
++ import AutoImport from 'unplugin-auto-import/rspack';
++ import Components from 'unplugin-vue-components/rspack';
+```
+
 ### copy-webpack-plugin
 
 使用 [rspack.CopyRspackPlugin](/plugins/rspack/copy-rspack-plugin) 代替 [copy-webpack-plugin](https://github.com/webpack/copy-webpack-plugin)：
@@ -303,15 +316,16 @@ module.exports = {
 
 ### tsconfig-paths-webpack-plugin
 
-使用 [resolve.tsConfig](/config/resolve#resolvetsconfig) 选项代替 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)：
+Rspack 不支持 webpack 的 `resolve.plugins` 选项。使用 [resolve.tsConfig](/config/resolve#resolvetsconfig) 选项代替 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)：
 
-```js title="rspack.config.js"
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin'); // [!code --]
+```diff title="rspack.config.mjs"
+-import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
++import path from 'node:path';
 
-module.exports = {
+ export default {
   resolve: {
-    plugins: [new TsconfigPathsPlugin({})], // [!code --]
-    tsConfig: {}, // [!code ++]
+-    plugins: [new TsconfigPathsPlugin()],
++    tsConfig: path.resolve(__dirname, 'tsconfig.json'),
   },
 };
 ```


### PR DESCRIPTION
## Summary

This PR clarifies how to migrate webpack ecosystem packages when moving to Rspack. It recommends updating packages for Rspack compatibility, switching unplugin imports to `/rspack` entry points, and replacing `tsconfig-paths-webpack-plugin` with the built-in `resolve.tsConfig` option.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).