### PR TITLE
fix(cache): rebuild modules missing snapshot records

### DIFF
--- a/crates/rspack_core/src/legacy_cache/persistent/context.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/context.rs
@@ -12,6 +12,25 @@ use crate::{CompilationLogger, LogType, Logger};
 
 const PATH_LOG_LIMIT: usize = 3;
 
+/// Path keys successfully loaded from each snapshot scope.
+#[derive(Debug, Default)]
+pub(crate) struct LoadedSnapshotPaths {
+  pub(crate) file: InternedPathSet,
+  pub(crate) context: InternedPathSet,
+  pub(crate) missing: InternedPathSet,
+}
+
+impl LoadedSnapshotPaths {
+  fn get_mut(&mut self, scope: SnapshotScope) -> &mut InternedPathSet {
+    match scope {
+      SnapshotScope::FILE => &mut self.file,
+      SnapshotScope::CONTEXT => &mut self.context,
+      SnapshotScope::MISSING => &mut self.missing,
+      SnapshotScope::BUILD => unreachable!("build snapshots are loaded separately"),
+    }
+  }
+}
+
 /// Per-build runtime state shared across all cache operations.
 ///
 /// `load_failed` gates every `load_*` call in a single build: once any
@@ -186,38 +205,51 @@ impl CacheContext {
     self.logger().time_end(start);
   }
 
-  /// Computes modified/removed paths from all snapshot scopes.
+  /// Computes modified/removed paths and retains loaded keys from all snapshot scopes.
   ///
   /// Returns `None` when the cache is invalid or any scope fails to load.
   /// On failure all snapshot scopes are reset (unless readonly) so they
   /// are fully rewritten this build.
   #[tracing::instrument("Cache::Context::load_snapshot", skip_all)]
-  pub async fn load_snapshot(
+  pub(crate) async fn load_snapshot(
     &mut self,
     snapshot: &Snapshot,
-  ) -> Option<(bool, InternedPathSet, InternedPathSet)> {
+  ) -> Option<(bool, InternedPathSet, InternedPathSet, LoadedSnapshotPaths)> {
     if !self.load_failed {
       let start = self.logger().time("read snapshot from persistent cache");
       let mut is_hot_start = false;
       let mut modified_paths = InternedPathSet::default();
       let mut removed_paths = InternedPathSet::default();
-      let data = vec![
-        snapshot
-          .calc_modified_paths(&*self.storage, SnapshotScope::FILE)
-          .await,
-        snapshot
-          .calc_modified_paths(&*self.storage, SnapshotScope::CONTEXT)
-          .await,
-        snapshot
-          .calc_modified_paths(&*self.storage, SnapshotScope::MISSING)
-          .await,
+      let mut loaded_paths = LoadedSnapshotPaths::default();
+      let data = [
+        (
+          SnapshotScope::FILE,
+          snapshot
+            .calc_modified_paths(&*self.storage, SnapshotScope::FILE)
+            .await,
+        ),
+        (
+          SnapshotScope::CONTEXT,
+          snapshot
+            .calc_modified_paths(&*self.storage, SnapshotScope::CONTEXT)
+            .await,
+        ),
+        (
+          SnapshotScope::MISSING,
+          snapshot
+            .calc_modified_paths(&*self.storage, SnapshotScope::MISSING)
+            .await,
+        ),
       ];
-      for item in data {
+      for (scope, item) in data {
         match item {
-          Ok((a, b, c, _)) => {
-            is_hot_start = is_hot_start || a;
-            modified_paths.extend(b);
-            removed_paths.extend(c);
+          Ok((scope_is_hot, modified, removed, unchanged)) => {
+            is_hot_start = is_hot_start || scope_is_hot;
+            loaded_paths
+              .get_mut(scope)
+              .extend(modified.iter().chain(&removed).cloned().chain(unchanged));
+            modified_paths.extend(modified);
+            removed_paths.extend(removed);
           }
           Err(err) => {
             self.load_failed = true;
@@ -241,7 +273,7 @@ impl CacheContext {
             ));
           }
         }
-        return Some((is_hot_start, modified_paths, removed_paths));
+        return Some((is_hot_start, modified_paths, removed_paths, loaded_paths));
       }
       self.logger().time_end(start);
     }

--- a/crates/rspack_core/src/legacy_cache/persistent/mod.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/mod.rs
@@ -15,7 +15,7 @@ use rspack_workspace::rspack_pkg_version;
 
 use self::{
   build_dependencies::BuildDeps,
-  context::CacheContext,
+  context::{CacheContext, LoadedSnapshotPaths},
   occasion::{MakeOccasion, MinimizeOccasion, SourceMapDevToolPluginOccasion},
   snapshot::Snapshot,
   storage::{CacheDirectory, create_storage},
@@ -38,6 +38,7 @@ pub struct PersistentCache {
   ctx: CacheContext,
   validation: CacheValidation,
   snapshot: Arc<Snapshot>,
+  loaded_snapshot_paths: Option<LoadedSnapshotPaths>,
   make_occasion: MakeOccasion,
   minimize_occasion: MinimizeOccasion,
   source_map_dev_tool_plugin_occasion: SourceMapDevToolPluginOccasion,
@@ -93,6 +94,7 @@ impl PersistentCache {
         ),
       ),
       snapshot,
+      loaded_snapshot_paths: None,
       make_occasion: MakeOccasion::new(codec.clone()),
       minimize_occasion: MinimizeOccasion::new(codec.clone()),
       source_map_dev_tool_plugin_occasion: SourceMapDevToolPluginOccasion::new(codec),
@@ -115,17 +117,19 @@ impl Cache for PersistentCache {
   async fn before_compile(&mut self, compilation: &mut Compilation) -> bool {
     self.ctx.logger().info("persistent cache enabled");
     self.initialize().await;
+    self.loaded_snapshot_paths = None;
 
     if compilation.is_rebuild {
       return false;
     }
     // rebuild will pass modified_files and removed_files from js side,
     // so only calculate them when build.
-    if let Some((is_hot_start, modified_paths, removed_paths)) =
+    if let Some((is_hot_start, modified_paths, removed_paths, loaded_paths)) =
       self.ctx.load_snapshot(&self.snapshot).await
     {
       compilation.modified_files.extend(modified_paths);
       compilation.removed_files.extend(removed_paths);
+      self.loaded_snapshot_paths = Some(loaded_paths);
       return is_hot_start;
     }
 
@@ -175,7 +179,30 @@ impl Cache for PersistentCache {
       return;
     }
 
+    let loaded_snapshot_paths = self.loaded_snapshot_paths.take();
     if let Some(cache_item) = self.ctx.load_occasion(&self.make_occasion).await {
+      if let Some(loaded) = loaded_snapshot_paths {
+        let mut missing = self
+          .snapshot
+          .find_missing_paths(cache_item.file_dependencies.files(), &loaded.file);
+        missing.extend(
+          self
+            .snapshot
+            .find_missing_paths(cache_item.context_dependencies.files(), &loaded.context),
+        );
+        missing.extend(
+          self
+            .snapshot
+            .find_missing_paths(cache_item.missing_dependencies.files(), &loaded.missing),
+        );
+        if !missing.is_empty() {
+          self.ctx.logger().warn(format!(
+            "persistent cache snapshot is missing records for {} paths; rebuilding affected modules",
+            missing.len()
+          ));
+          compilation.modified_files.extend(missing);
+        }
+      }
       *compilation.build_module_graph_artifact = cache_item;
       for (module, _) in compilation
         .build_module_graph_artifact

--- a/crates/rspack_core/src/legacy_cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/snapshot/mod.rs
@@ -75,6 +75,20 @@ impl Snapshot {
     })
   }
 
+  /// Finds expected paths that have no stored snapshot record.
+  pub(crate) fn find_missing_paths<'a>(
+    &self,
+    expected: impl Iterator<Item = &'a InternedPath>,
+    loaded: &InternedPathSet,
+  ) -> InternedPathSet {
+    expected
+      .filter(|path| {
+        !loaded.contains(*path) && !self.options.is_immutable_path(&path.to_string_lossy())
+      })
+      .cloned()
+      .collect()
+  }
+
   #[tracing::instrument("Cache::Snapshot::reset", skip_all)]
   pub fn reset(&self, storage: &mut dyn Storage) {
     storage.reset(SnapshotScope::FILE.name());
@@ -175,7 +189,7 @@ mod tests {
   use std::sync::Arc;
 
   use rspack_fs::{MemoryFileSystem, WritableFileSystem};
-  use rspack_paths::InternedPath;
+  use rspack_paths::{InternedPath, InternedPathSet};
 
   use super::{super::storage::MemoryStorage, Snapshot, SnapshotScope};
   use crate::cache::{CacheCodec, PathMatcher, SnapshotOptions};
@@ -287,5 +301,28 @@ mod tests {
     assert!(modified_paths.contains(&p!("/node_modules/project/file1")));
     assert!(modified_paths.contains(&p!("/node_modules/lib/file1")));
     assert_eq!(no_change_paths.len(), 1);
+  }
+
+  #[test]
+  fn should_find_missing_non_immutable_paths() {
+    let fs = Arc::new(MemoryFileSystem::default());
+    let codec = Arc::new(CacheCodec::new(None));
+    let options = SnapshotOptions::new(
+      vec![PathMatcher::String("immutable".into())],
+      vec![],
+      vec![],
+    );
+    let snapshot = Snapshot::new(options, fs, codec);
+    let expected = [p!("/loaded"), p!("/missing"), p!("/immutable/file")]
+      .into_iter()
+      .collect::<InternedPathSet>();
+    let loaded = [p!("/loaded")].into_iter().collect::<InternedPathSet>();
+
+    let missing = snapshot.find_missing_paths(expected.iter(), &loaded);
+
+    assert_eq!(
+      missing,
+      [p!("/missing")].into_iter().collect::<InternedPathSet>()
+    );
   }
 }


### PR DESCRIPTION
## Summary

A missing entry in a snapshot scope currently disappears from validation, while the recovered make graph can still depend on that path. If the file changes, Rspack sees no modified path and can reuse stale module output.

This keeps the paths successfully loaded from each snapshot scope and compares them with the dependencies in the recovered make graph. A missing non-immutable record is added to `modified_files`, so the existing graph update rebuilds only the affected modules. Immutable paths remain excluded because they intentionally have no snapshot records.

Validation after rebasing onto the current `main`:

- `cargo check -p rspack_core --lib --tests` with the repository's pinned nightly `rustc` and `rustdoc`
- `cargo test -p rspack_core --lib` with the same compiler setup (121 passed)
- Pinned nightly `rustfmt --check` on the three changed files

I could not rerun Clippy locally because the pinned nightly installation does not include compatible `cargo` or `clippy` components. Running stable Clippy with the nightly compiler also fails before compilation when stable Clippy rejects the project's `-Z` flags.

## Related links

Fixes #14865

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; no user-facing behavior or API changed).
