### PR TITLE
chore(renovate): group all npm patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -130,7 +130,6 @@
       "description": "Keep major and minor npm dependency updates in separate PRs from patch updates.",
       "groupName": "patch npm dependencies",
       "matchManagers": ["npm"],
-      "matchDepTypes": ["dependencies", "devDependencies"],
       "matchUpdateTypes": ["patch"],
       "matchPackageNames": [
         "!webpack{/,}**",


### PR DESCRIPTION
## Summary

pnpm catalog entries are extracted by Renovate with dynamic dependency types such as `pnpm.catalog.default`, so the existing `matchDepTypes` filter excluded them from the shared patch update group.
This removes that filter so all npm patch updates, including catalog-managed dependencies such as `heading-case`, are grouped consistently while the existing package exclusions remain in effect.

## Related links

- https://github.com/web-infra-dev/rspack/issues/7355

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
