### PR TITLE
perf(devtool): reduce source map persistent cache size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,6 +4456,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "memchr",
+ "rayon",
  "regex",
  "rspack_collections",
  "rspack_core",

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use rayon::prelude::*;
-use rspack_cacheable::cacheable;
+use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_error::Result;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawStringSource,
@@ -18,13 +18,13 @@ use crate::{CompilationAsset, RayonConsumer};
 pub const SCOPE: &str = "occasion_source_map_dev_tool_plugin";
 
 #[cacheable]
-struct Entry {
-  source_map: CachedSourceMap,
+struct Entry<'a> {
+  source_map: OwnedOrRef<'a, CachedSourceMap>,
 }
 
 /// Compact source map data cached by `SourceMapDevToolPlugin`.
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq)]
 struct CachedSourceMap {
   mappings: String,
   sources: Vec<String>,
@@ -370,7 +370,7 @@ impl Occasion for SourceMapDevToolPluginOccasion {
         };
         let source_map = artifact.entries.get(key)?.as_ref()?;
         let storage_entry = Entry {
-          source_map: source_map.clone(),
+          source_map: source_map.into(),
         };
         match self.codec.encode(&storage_entry) {
           Ok(bytes) => Some((key_bytes, bytes)),
@@ -406,7 +406,7 @@ impl Occasion for SourceMapDevToolPluginOccasion {
           }
         };
         match self.codec.decode::<Entry>(&value) {
-          Ok(entry) => Ok((key, Some(entry.source_map))),
+          Ok(entry) => Ok((key, Some(entry.source_map.into_owned()))),
           Err(err) => {
             tracing::warn!("source map persistent cache decode failed: {:?}", err);
             Err(key_bytes)

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -1,15 +1,14 @@
 use std::{borrow::Cow, sync::Arc};
 
+use cow_utils::CowUtils;
 use rayon::prelude::*;
-use rspack_cacheable::{
-  cacheable,
-  with::{AsPreset, AsVec},
-};
+use rspack_cacheable::cacheable;
 use rspack_error::Result;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawStringSource,
   ReplaceSource, Source, SourceExt, SourceMap, SourceMapSource,
 };
+use rspack_util::base64;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::{
@@ -23,15 +22,21 @@ pub const SCOPE: &str = "occasion_source_map_dev_tool_plugin";
 #[cacheable]
 #[derive(Debug)]
 struct CacheEntry {
-  #[cacheable(with=AsVec<AsPreset>)]
-  append: Vec<BoxSource>,
-  source_map_asset: Option<SourceMapAssetCacheData>,
+  comments: SourceMapComments,
+  source_map_asset: SourceMapAssetCacheData,
+}
+
+#[cacheable]
+#[derive(Debug, Clone, Default)]
+pub struct SourceMapComments {
+  pub debug_id_comment: Option<String>,
+  pub source_mapping_url_comment: String,
 }
 
 #[cacheable]
 #[derive(Debug)]
 struct SourceMapAssetCacheData {
-  filename: String,
+  filename: Option<String>,
   source_map: SourceMapCacheData,
 }
 
@@ -182,7 +187,7 @@ fn restore_source_map(source: BoxSource, cache_entry: &CacheEntry) -> Option<Sou
       debug_id,
       ignore_list,
       source_content_indices,
-    } = &cache_entry.source_map_asset.as_ref()?.source_map;
+    } = &cache_entry.source_map_asset.source_map;
     let sources_content = restore_sources_content(source, source_content_indices)?;
     let mut source_map = SourceMap::new(
       Cow::Owned(mappings.clone()),
@@ -225,20 +230,65 @@ fn create_source_map_cache_data(
 
 fn create_cache_entry(
   source: &dyn Source,
-  append: &[BoxSource],
-  source_map: Option<(&str, &SourceMap<'static>)>,
+  comments: &SourceMapComments,
+  source_map_filename: Option<&str>,
+  source_map: &SourceMap<'static>,
 ) -> Option<CacheEntry> {
-  let source_map_asset = match source_map {
-    Some((filename, source_map)) => Some(SourceMapAssetCacheData {
-      filename: filename.to_string(),
-      source_map: create_source_map_cache_data(source, source_map)?,
-    }),
-    None => None,
-  };
   Some(CacheEntry {
-    append: append.to_vec(),
-    source_map_asset,
+    comments: comments.clone(),
+    source_map_asset: SourceMapAssetCacheData {
+      filename: source_map_filename.map(ToString::to_string),
+      source_map: create_source_map_cache_data(source, source_map)?,
+    },
   })
+}
+
+fn render_inline_source_mapping_url_comment(
+  source_mapping_url_comment: &str,
+  source_map: &SourceMap<'_>,
+) -> String {
+  let source_map_json = source_map.to_json();
+  let base64 = base64::encode_to_string(source_map_json.as_bytes());
+  let source_map_url = format!("data:application/json;charset=utf-8;base64,{base64}");
+  source_mapping_url_comment
+    .cow_replace("[url]", &source_map_url)
+    .into_owned()
+}
+
+fn restore_asset_source(
+  source: BoxSource,
+  source_map: &SourceMap<'_>,
+  comments: &SourceMapComments,
+  is_inline: bool,
+) -> Option<BoxSource> {
+  if is_inline && comments.source_mapping_url_comment.is_empty() {
+    return None;
+  }
+  let source_mapping_url_comment = if comments.source_mapping_url_comment.is_empty() {
+    None
+  } else if is_inline {
+    Some(render_inline_source_mapping_url_comment(
+      &comments.source_mapping_url_comment,
+      source_map,
+    ))
+  } else {
+    Some(comments.source_mapping_url_comment.clone())
+  };
+  let comments_count = usize::from(comments.debug_id_comment.is_some())
+    + usize::from(source_mapping_url_comment.is_some());
+  if comments_count == 0 {
+    return Some(source);
+  }
+
+  let mut children = Vec::with_capacity(comments_count + 1);
+  children.push(source);
+  if let Some(debug_id_comment) = &comments.debug_id_comment {
+    children.push(RawStringSource::from(debug_id_comment.clone()).boxed());
+  }
+  if let Some(source_mapping_url_comment) = source_mapping_url_comment {
+    children.push(RawStringSource::from(source_mapping_url_comment).boxed());
+  }
+  Some(ConcatSource::new(children).boxed())
 }
 
 #[allow(clippy::type_complexity)]
@@ -248,29 +298,23 @@ fn restore_cache_entry(
   cache_entry: &CacheEntry,
 ) -> Option<(
   CompilationAsset,
-  Option<(String, SourceMap<'static>)>,
-  Vec<BoxSource>,
+  Option<String>,
+  SourceMap<'static>,
+  SourceMapComments,
 )> {
-  let source_map = match cache_entry.source_map_asset.as_ref() {
-    Some(source_map) => Some((
-      source_map.filename.clone(),
-      restore_source_map(source.clone(), cache_entry)?,
-    )),
-    None => None,
-  };
-  let append = cache_entry.append.clone();
-  let source = if append.is_empty() {
-    source
-  } else {
-    let mut children = Vec::with_capacity(append.len() + 1);
-    children.push(source);
-    children.extend(append.iter().cloned());
-    ConcatSource::new(children).boxed()
-  };
+  let source_map = restore_source_map(source.clone(), cache_entry)?;
+  let source_map_filename = cache_entry.source_map_asset.filename.clone();
+  let source = restore_asset_source(
+    source,
+    &source_map,
+    &cache_entry.comments,
+    source_map_filename.is_none(),
+  )?;
   Some((
     CompilationAsset::new(Some(source), asset_info),
+    source_map_filename,
     source_map,
-    append,
+    cache_entry.comments.clone(),
   ))
 }
 
@@ -292,8 +336,9 @@ impl SourceMapDevToolPluginCacheArtifact {
   ) -> Vec<
     Option<(
       CompilationAsset,
-      Option<(String, SourceMap<'static>)>,
-      Vec<BoxSource>,
+      Option<String>,
+      SourceMap<'static>,
+      SourceMapComments,
     )>,
   > {
     // Memory cache reuses this artifact across rebuilds, so storage mutations
@@ -342,33 +387,45 @@ impl SourceMapDevToolPluginCacheArtifact {
       Item = (
         &'a str,
         &'a CompilationAsset,
-        &'a [BoxSource],
-        Option<(&'a str, &'a SourceMap<'static>)>,
+        &'a SourceMapComments,
+        Option<&'a str>,
+        &'a SourceMap<'static>,
       ),
     >,
   ) {
     let mut active_keys = FxHashSet::default();
     let uncached_items = items
       .into_iter()
-      .filter_map(|(filename, asset, append, source_map)| {
-        let source = asset.get_source()?;
-        let cache_key = CacheKey::new(filename, &asset.info.version)?;
-        active_keys.insert(cache_key.clone());
-        if self
-          .entries
-          .get(&cache_key)
-          .and_then(Option::as_ref)
-          .is_some()
-        {
-          return None;
-        }
-        Some((cache_key, source.as_ref(), append, source_map))
-      })
+      .filter_map(
+        |(filename, asset, comments, source_map_filename, source_map)| {
+          let source = asset.get_source()?;
+          let cache_key = CacheKey::new(filename, &asset.info.version)?;
+          active_keys.insert(cache_key.clone());
+          if self
+            .entries
+            .get(&cache_key)
+            .and_then(Option::as_ref)
+            .is_some()
+          {
+            return None;
+          }
+          Some((
+            cache_key,
+            source.as_ref(),
+            comments,
+            source_map_filename,
+            source_map,
+          ))
+        },
+      )
       .collect::<Vec<_>>()
       .into_par_iter()
-      .filter_map(|(cache_key, source, append, source_map)| {
-        create_cache_entry(source, append, source_map).map(|cache_entry| (cache_key, cache_entry))
-      })
+      .filter_map(
+        |(cache_key, source, comments, source_map_filename, source_map)| {
+          create_cache_entry(source, comments, source_map_filename, source_map)
+            .map(|cache_entry| (cache_key, cache_entry))
+        },
+      )
       .collect::<Vec<_>>();
 
     for (cache_key, cache_entry) in uncached_items {

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -170,7 +170,7 @@ fn restore_source_map(
     ignore_list,
     source_content_indices,
   } = source_map_cache_data;
-  SourceMap::with_owner(source, move |source| {
+  SourceMap::with_source(source, move |source| {
     let sources_content = restore_sources_content(source, &source_content_indices)?;
     let mut source_map = SourceMap::new(
       Cow::Owned(mappings),

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -279,17 +279,21 @@ impl SourceMapDevToolPluginCacheArtifact {
       }
     });
 
-    for (filename, asset, source_map) in items {
-      let Some(source) = asset.get_source() else {
-        continue;
-      };
-      let Some(cache_key) = CacheKey::new(filename, &asset.info.version) else {
-        continue;
-      };
-      let Some(source_map) = create_cached_source_map(source.as_ref(), source_map) else {
-        continue;
-      };
+    let cached_source_maps = items
+      .into_iter()
+      .filter_map(|(filename, asset, source_map)| {
+        let source = asset.get_source()?;
+        let cache_key = CacheKey::new(filename, &asset.info.version)?;
+        Some((cache_key, source.as_ref(), source_map))
+      })
+      .collect::<Vec<_>>()
+      .into_par_iter()
+      .filter_map(|(cache_key, source, source_map)| {
+        create_cached_source_map(source, source_map).map(|source_map| (cache_key, source_map))
+      })
+      .collect::<Vec<_>>();
 
+    for (cache_key, source_map) in cached_source_maps {
       match self.entries.entry(cache_key) {
         std::collections::hash_map::Entry::Occupied(mut occupied) => {
           occupied.insert(Some(source_map));

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -19,13 +19,13 @@ pub const SCOPE: &str = "occasion_source_map_dev_tool_plugin";
 
 #[cacheable]
 struct Entry<'a> {
-  source_map: OwnedOrRef<'a, CachedSourceMap>,
+  source_map: OwnedOrRef<'a, SourceMapCacheData>,
 }
 
 /// Compact source map data cached by `SourceMapDevToolPlugin`.
 #[cacheable]
 #[derive(Debug, PartialEq, Eq)]
-struct CachedSourceMap {
+struct SourceMapCacheData {
   mappings: String,
   sources: Vec<String>,
   names: Vec<String>,
@@ -159,9 +159,9 @@ fn restore_sources_content<'a>(source: &'a dyn Source, indices: &[u32]) -> Optio
 
 fn restore_source_map(
   source: BoxSource,
-  cached_source_map: CachedSourceMap,
+  source_map_cache_data: SourceMapCacheData,
 ) -> Option<SourceMap<'static>> {
-  let CachedSourceMap {
+  let SourceMapCacheData {
     mappings,
     sources,
     names,
@@ -169,7 +169,7 @@ fn restore_source_map(
     debug_id,
     ignore_list,
     source_content_indices,
-  } = cached_source_map;
+  } = source_map_cache_data;
   SourceMap::with_owner(source, move |source| {
     let sources_content = restore_sources_content(source, &source_content_indices)?;
     let mut source_map = SourceMap::new(
@@ -185,12 +185,12 @@ fn restore_source_map(
   })
 }
 
-fn create_cached_source_map(
+fn create_source_map_cache_data(
   source: &dyn Source,
   source_map: &SourceMap<'_>,
-) -> Option<CachedSourceMap> {
+) -> Option<SourceMapCacheData> {
   let source_content_indices = source_content_indices(source, source_map)?;
-  Some(CachedSourceMap {
+  Some(SourceMapCacheData {
     mappings: source_map.mappings().to_string(),
     sources: source_map
       .sources()
@@ -211,10 +211,10 @@ fn create_cached_source_map(
 
 #[derive(Debug, Default)]
 pub struct SourceMapDevToolPluginCacheArtifact {
-  entries: FxHashMap<CacheKey, Option<CachedSourceMap>>,
+  entries: FxHashMap<CacheKey, Option<SourceMapCacheData>>,
   pending_writes: Vec<CacheKey>,
   pending_removes: Vec<CacheKey>,
-  pending_raw_removes: Vec<Vec<u8>>,
+  pending_invalid_entry_keys: Vec<Vec<u8>>,
 }
 
 impl SourceMapDevToolPluginCacheArtifact {
@@ -235,14 +235,14 @@ impl SourceMapDevToolPluginCacheArtifact {
       .map(|(filename, asset)| {
         let source = asset.get_source()?.clone();
         let cache_key = CacheKey::new(filename, &asset.info.version)?;
-        let cached_source_map = self.entries.get_mut(&cache_key).and_then(Option::take)?;
-        Some((cache_key, source, cached_source_map))
+        let source_map_cache_data = self.entries.get_mut(&cache_key).and_then(Option::take)?;
+        Some((cache_key, source, source_map_cache_data))
       })
       .collect::<Vec<_>>()
       .into_par_iter()
       .map(|item| {
-        item.map(|(cache_key, source, cached_source_map)| {
-          let source_map = restore_source_map(source, cached_source_map);
+        item.map(|(cache_key, source, source_map_cache_data)| {
+          let source_map = restore_source_map(source, source_map_cache_data);
           (cache_key, source_map)
         })
       })
@@ -279,7 +279,7 @@ impl SourceMapDevToolPluginCacheArtifact {
       }
     });
 
-    let cached_source_maps = items
+    let source_map_cache_entries = items
       .into_iter()
       .filter_map(|(filename, asset, source_map)| {
         let source = asset.get_source()?;
@@ -289,11 +289,11 @@ impl SourceMapDevToolPluginCacheArtifact {
       .collect::<Vec<_>>()
       .into_par_iter()
       .filter_map(|(cache_key, source, source_map)| {
-        create_cached_source_map(source, source_map).map(|source_map| (cache_key, source_map))
+        create_source_map_cache_data(source, source_map).map(|source_map| (cache_key, source_map))
       })
       .collect::<Vec<_>>();
 
-    for (cache_key, source_map) in cached_source_maps {
+    for (cache_key, source_map) in source_map_cache_entries {
       match self.entries.entry(cache_key) {
         std::collections::hash_map::Entry::Occupied(mut occupied) => {
           occupied.insert(Some(source_map));
@@ -344,7 +344,7 @@ impl Occasion for SourceMapDevToolPluginOccasion {
 
   #[tracing::instrument(name = "Cache::Occasion::SourceMap::save", skip_all)]
   fn save(&self, storage: &mut dyn Storage, artifact: &SourceMapDevToolPluginCacheArtifact) {
-    for key in &artifact.pending_raw_removes {
+    for key in &artifact.pending_invalid_entry_keys {
       storage.remove(SCOPE, key);
     }
 
@@ -385,17 +385,17 @@ impl Occasion for SourceMapDevToolPluginOccasion {
       });
 
     tracing::debug!(
-      "saved {}, removed {}, and removed {} legacy source map persistent cache entries",
+      "saved {}, removed {}, and removed {} invalid source map persistent cache entries",
       artifact.pending_writes.len(),
       artifact.pending_removes.len(),
-      artifact.pending_raw_removes.len(),
+      artifact.pending_invalid_entry_keys.len(),
     );
   }
 
   #[tracing::instrument(name = "Cache::Occasion::SourceMap::recovery", skip_all)]
   async fn recovery(&self, storage: &dyn Storage) -> Result<SourceMapDevToolPluginCacheArtifact> {
     let items = storage.load(SCOPE).await?;
-    let (entries, pending_raw_removes) = items
+    let (entries, pending_invalid_entry_keys) = items
       .into_par_iter()
       .map(|(key_bytes, value)| {
         let key = match self.codec.decode::<CacheKey>(&key_bytes) {
@@ -419,15 +419,15 @@ impl Occasion for SourceMapDevToolPluginOccasion {
       });
 
     tracing::debug!(
-      "recovered {} source map persistent cache entries and scheduled {} legacy entries for removal",
+      "recovered {} source map persistent cache entries and scheduled {} invalid entries for removal",
       entries.len(),
-      pending_raw_removes.len(),
+      pending_invalid_entry_keys.len(),
     );
     Ok(SourceMapDevToolPluginCacheArtifact {
       entries,
       pending_writes: Vec::new(),
       pending_removes: Vec::new(),
-      pending_raw_removes,
+      pending_invalid_entry_keys,
     })
   }
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -1,49 +1,45 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use rayon::prelude::*;
-use rspack_cacheable::{
-  cacheable,
-  with::{AsPreset, AsVec},
-};
+use rspack_cacheable::cacheable;
 use rspack_error::Result;
-use rspack_sources::{BoxSource, ConcatSource, SourceExt};
+use rspack_sources::{
+  BoxSource, CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawStringSource,
+  ReplaceSource, Source, SourceMap, SourceMapSource,
+};
 use rustc_hash::FxHashMap;
 
 use super::{
   super::{codec::CacheCodec, storage::Storage},
   Occasion,
 };
-use crate::{AssetInfo, CompilationAsset, RayonConsumer};
+use crate::{CompilationAsset, RayonConsumer};
 
 pub const SCOPE: &str = "occasion_source_map_dev_tool_plugin";
 
 #[cacheable]
 struct Entry {
-  #[cacheable(with=AsVec<AsPreset>)]
-  pub append: Vec<BoxSource>,
-  pub source_map: Option<SourceMapAssetEntry>,
+  source_map: CachedSourceMap,
 }
 
+/// Compact source map data cached by `SourceMapDevToolPlugin`.
 #[cacheable]
-struct SourceMapAssetEntry {
-  pub filename: String,
-  #[cacheable(with=AsPreset)]
-  pub source: BoxSource,
+#[derive(Debug, Clone)]
+struct CachedSourceMap {
+  mappings: String,
+  sources: Vec<String>,
+  names: Vec<String>,
+  source_root: Option<String>,
+  debug_id: Option<String>,
+  ignore_list: Option<Vec<u32>>,
+  /// Stable source-content ordinals. `u32::MAX` represents an empty string.
+  source_content_indices: Vec<u32>,
 }
 
 /// Per-asset cache key for `SourceMapDevToolPlugin`.
 ///
-/// This key is only used to distinguish assets inside a valid persistent cache
-/// generation. It intentionally does not include `SourceMapDevToolPlugin` or
-/// `output` options, even though source map output is option-dependent.
-///
 /// Config or option changes should invalidate the whole persistent cache
-/// generation via `cache.buildDependencies` or `cache.version`. For
-/// CLI-loaded configs, rspack-cli injects the resolved config file paths into
-/// `cache.buildDependencies`, including files referenced by `extends`. For
-/// programmatic API usage, callers that want config-only changes to invalidate
-/// persistent cache are expected to provide equivalent build dependencies or
-/// a cache version.
+/// generation via `cache.buildDependencies` or `cache.version`.
 #[cacheable]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CacheKey {
@@ -63,79 +59,216 @@ impl CacheKey {
   }
 }
 
-#[derive(Debug, Default)]
-pub struct SourceMapDevToolPluginCacheArtifact {
-  entries: FxHashMap<CacheKey, Option<CacheEntry>>,
-  pending_writes: Vec<CacheKey>,
-  pending_removes: Vec<CacheKey>,
+/// Visit source contents in the deterministic order used by the compact cache.
+/// Changing this order requires invalidating existing persistent cache data.
+fn visit_sources_content_by_orders<'a>(source: &'a dyn Source, visitor: &mut dyn FnMut(&'a str)) {
+  if let Some(source) = source.as_any().downcast_ref::<OriginalSource>() {
+    visitor(source.value());
+    return;
+  }
+
+  if source.as_any().is::<RawStringSource>() || source.as_any().is::<RawBufferSource>() {
+    return;
+  }
+
+  if let Some(source) = source.as_any().downcast_ref::<SourceMapSource>() {
+    for content in source.source_map().sources_content() {
+      visitor(content);
+    }
+    if let Some(inner_source_map) = source.inner_source_map() {
+      for content in inner_source_map.sources_content() {
+        visitor(content);
+      }
+    }
+    if let Some(original_source) = source.original_source() {
+      visitor(original_source);
+    }
+    return;
+  }
+
+  if let Some(source) = source.as_any().downcast_ref::<ConcatSource>() {
+    for child in source.children() {
+      visit_sources_content_by_orders(child.as_ref(), visitor);
+    }
+    return;
+  }
+
+  if let Some(source) = source.as_any().downcast_ref::<ReplaceSource>() {
+    visit_sources_content_by_orders(source.inner().as_ref(), visitor);
+    return;
+  }
+
+  if let Some(source) = source.as_any().downcast_ref::<CachedSource>() {
+    visit_sources_content_by_orders(source.inner().as_ref(), visitor);
+  }
 }
 
-#[derive(Debug, Clone)]
-struct CacheEntry {
-  pub asset_append: Vec<BoxSource>,
-  pub source_map: Option<(String, BoxSource)>,
+fn source_content_indices(source: &dyn Source, source_map: &SourceMap<'_>) -> Option<Vec<u32>> {
+  let sources_content = source_map.sources_content();
+  if sources_content.iter().all(|content| content.is_empty()) {
+    return Some(vec![u32::MAX; sources_content.len()]);
+  }
+
+  let mut content_ordinals =
+    FxHashMap::with_capacity_and_hasher(sources_content.len(), Default::default());
+  let mut ordinal = 0u32;
+  visit_sources_content_by_orders(source, &mut |content| {
+    content_ordinals.entry(content.as_ptr()).or_insert(ordinal);
+    ordinal += 1;
+  });
+
+  sources_content
+    .iter()
+    .map(|content| {
+      if content.is_empty() {
+        Some(u32::MAX)
+      } else {
+        content_ordinals.get(&content.as_ptr()).copied()
+      }
+    })
+    .collect()
+}
+
+fn restore_sources_content<'a>(source: &'a dyn Source, indices: &[u32]) -> Option<Vec<&'a str>> {
+  let mut contents = vec![""; indices.len()];
+  let mut requests = indices
+    .iter()
+    .copied()
+    .enumerate()
+    .filter_map(|(output_index, ordinal)| (ordinal != u32::MAX).then_some((ordinal, output_index)))
+    .collect::<Vec<_>>();
+  if requests.is_empty() {
+    return Some(contents);
+  }
+  requests.sort_unstable_by_key(|(ordinal, _)| *ordinal);
+
+  let mut request_index = 0;
+  let mut ordinal = 0u32;
+  visit_sources_content_by_orders(source, &mut |content| {
+    while let Some((requested_ordinal, output_index)) = requests.get(request_index).copied() {
+      if requested_ordinal != ordinal {
+        break;
+      }
+      contents[output_index] = content;
+      request_index += 1;
+    }
+    ordinal += 1;
+  });
+  (request_index == requests.len()).then_some(contents)
+}
+
+fn restore_source_map(
+  source: BoxSource,
+  cached_source_map: CachedSourceMap,
+) -> Option<SourceMap<'static>> {
+  let CachedSourceMap {
+    mappings,
+    sources,
+    names,
+    source_root,
+    debug_id,
+    ignore_list,
+    source_content_indices,
+  } = cached_source_map;
+  SourceMap::with_owner(source, move |source| {
+    let sources_content = restore_sources_content(source, &source_content_indices)?;
+    let mut source_map = SourceMap::new(
+      Cow::Owned(mappings),
+      sources.into_iter().map(Cow::Owned).collect(),
+      sources_content.into_iter().map(Cow::Borrowed).collect(),
+      names.into_iter().map(Cow::Owned).collect(),
+    );
+    source_map.set_source_root(source_root.map(Cow::Owned));
+    source_map.set_debug_id(debug_id.map(Cow::Owned));
+    source_map.set_ignore_list(ignore_list.map(Cow::Owned));
+    Some(source_map)
+  })
+}
+
+fn create_cached_source_map(
+  source: &dyn Source,
+  source_map: &SourceMap<'_>,
+) -> Option<CachedSourceMap> {
+  let source_content_indices = source_content_indices(source, source_map)?;
+  Some(CachedSourceMap {
+    mappings: source_map.mappings().to_string(),
+    sources: source_map
+      .sources()
+      .iter()
+      .map(|source| source.to_string())
+      .collect(),
+    names: source_map
+      .names()
+      .iter()
+      .map(|name| name.to_string())
+      .collect(),
+    source_root: source_map.source_root().map(ToString::to_string),
+    debug_id: source_map.get_debug_id().map(ToString::to_string),
+    ignore_list: source_map.ignore_list().map(<[u32]>::to_vec),
+    source_content_indices,
+  })
+}
+
+#[derive(Debug, Default)]
+pub struct SourceMapDevToolPluginCacheArtifact {
+  entries: FxHashMap<CacheKey, Option<CachedSourceMap>>,
+  pending_writes: Vec<CacheKey>,
+  pending_removes: Vec<CacheKey>,
+  pending_raw_removes: Vec<Vec<u8>>,
 }
 
 impl SourceMapDevToolPluginCacheArtifact {
-  fn cache_key(filename: &str, asset: &CompilationAsset) -> Option<CacheKey> {
-    asset.get_source()?;
-    CacheKey::new(filename, &asset.info.version)
-  }
-
-  #[allow(clippy::type_complexity)]
-  pub fn take(
+  /// Recover source maps after the current compilation assets are available.
+  /// Source-content restoration is CPU-bound and runs in parallel across
+  /// assets, while cache entry state is updated serially.
+  pub fn take<'a>(
     &mut self,
-    filename: &str,
-    asset: &CompilationAsset,
-  ) -> Option<(
-    CompilationAsset,
-    Option<(String, CompilationAsset)>,
-    Vec<BoxSource>,
-  )> {
-    let cache_key = Self::cache_key(filename, asset)?;
+    items: impl IntoIterator<Item = (&'a str, &'a CompilationAsset)>,
+  ) -> Vec<Option<SourceMap<'static>>> {
+    // Memory cache reuses this artifact across rebuilds, so storage mutations
+    // from the previous compilation must not be replayed after its save.
+    self.pending_writes.clear();
+    self.pending_removes.clear();
 
-    let CacheEntry {
-      asset_append,
-      source_map,
-    } = self.entries.get_mut(&cache_key).and_then(Option::take)?;
+    let recovered = items
+      .into_iter()
+      .map(|(filename, asset)| {
+        let source = asset.get_source()?.clone();
+        let cache_key = CacheKey::new(filename, &asset.info.version)?;
+        let cached_source_map = self.entries.get_mut(&cache_key).and_then(Option::take)?;
+        Some((cache_key, source, cached_source_map))
+      })
+      .collect::<Vec<_>>()
+      .into_par_iter()
+      .map(|item| {
+        item.map(|(cache_key, source, cached_source_map)| {
+          let source_map = restore_source_map(source, cached_source_map);
+          (cache_key, source_map)
+        })
+      })
+      .collect::<Vec<_>>();
 
-    let source = asset.get_source()?.clone();
-    let source = if asset_append.is_empty() {
-      source
-    } else {
-      let mut children = Vec::with_capacity(asset_append.len() + 1);
-      children.push(source);
-      children.extend(asset_append.iter().cloned());
-      ConcatSource::new(children).boxed()
-    };
-
-    let source_asset = CompilationAsset::new(Some(source), (*asset.info).clone());
-    let source_map = source_map.map(|(filename, source)| {
-      let mut source_map_asset_info = AssetInfo::default().with_development(Some(true));
-      source_map_asset_info.version = asset.info.version.clone();
-      (
-        filename,
-        CompilationAsset::new(Some(source), source_map_asset_info),
-      )
-    });
-
-    Some((source_asset, source_map, asset_append))
+    recovered
+      .into_iter()
+      .map(|item| match item {
+        Some((_, Some(source_map))) => Some(source_map),
+        Some((cache_key, None)) => {
+          self.entries.remove(&cache_key);
+          self.pending_removes.push(cache_key);
+          None
+        }
+        None => None,
+      })
+      .collect()
   }
 
   pub fn store<'a>(
     &mut self,
-    items: impl IntoIterator<
-      Item = (
-        &'a str,
-        &'a CompilationAsset,
-        &'a [BoxSource],
-        Option<(&'a str, &'a CompilationAsset)>,
-      ),
-    >,
+    items: impl IntoIterator<Item = (&'a str, &'a CompilationAsset, &'a SourceMap<'static>)>,
   ) {
-    self.pending_writes.clear();
-    self.pending_removes.clear();
-
+    // Entries that were recovered but not consumed by this compilation are
+    // stale. Keep consumed entries (`None`) so valid hits can be reinserted
+    // without rewriting their storage value.
     let pending_removes = &mut self.pending_removes;
     self.entries.retain(|key, entry| {
       if entry.is_some() {
@@ -146,23 +279,30 @@ impl SourceMapDevToolPluginCacheArtifact {
       }
     });
 
-    for item in items {
-      let Some((cache_key, cache_entry)) = Self::cache_entry(item) else {
+    for (filename, asset, source_map) in items {
+      let Some(source) = asset.get_source() else {
+        continue;
+      };
+      let Some(cache_key) = CacheKey::new(filename, &asset.info.version) else {
+        continue;
+      };
+      let Some(source_map) = create_cached_source_map(source.as_ref(), source_map) else {
         continue;
       };
 
       match self.entries.entry(cache_key) {
         std::collections::hash_map::Entry::Occupied(mut occupied) => {
-          occupied.insert(Some(cache_entry));
+          occupied.insert(Some(source_map));
         }
         std::collections::hash_map::Entry::Vacant(vacant) => {
           let cache_key = vacant.key().clone();
-          vacant.insert(Some(cache_entry));
+          vacant.insert(Some(source_map));
           self.pending_writes.push(cache_key);
         }
       }
     }
 
+    // Consumed entries that were not reinserted are no longer cacheable.
     let pending_removes = &mut self.pending_removes;
     self.entries.retain(|key, entry| {
       if entry.is_none() {
@@ -172,33 +312,6 @@ impl SourceMapDevToolPluginCacheArtifact {
         true
       }
     });
-  }
-
-  fn cache_entry(
-    item: (
-      &str,
-      &CompilationAsset,
-      &[BoxSource],
-      Option<(&str, &CompilationAsset)>,
-    ),
-  ) -> Option<(CacheKey, CacheEntry)> {
-    let (filename, asset, asset_append, source_map) = item;
-    let cache_key = Self::cache_key(filename, asset)?;
-    let source_map = match source_map {
-      Some((filename, asset)) => {
-        let source = asset.get_source()?;
-        Some((filename.to_string(), source.clone()))
-      }
-      None => None,
-    };
-
-    Some((
-      cache_key,
-      CacheEntry {
-        asset_append: asset_append.to_vec(),
-        source_map,
-      },
-    ))
   }
 }
 
@@ -227,6 +340,10 @@ impl Occasion for SourceMapDevToolPluginOccasion {
 
   #[tracing::instrument(name = "Cache::Occasion::SourceMap::save", skip_all)]
   fn save(&self, storage: &mut dyn Storage, artifact: &SourceMapDevToolPluginCacheArtifact) {
+    for key in &artifact.pending_raw_removes {
+      storage.remove(SCOPE, key);
+    }
+
     for key in &artifact.pending_removes {
       match self.codec.encode(key) {
         Ok(key) => storage.remove(SCOPE, &key),
@@ -247,16 +364,9 @@ impl Occasion for SourceMapDevToolPluginOccasion {
             return None;
           }
         };
-        let entry = artifact.entries.get(key)?.as_ref()?;
+        let source_map = artifact.entries.get(key)?.as_ref()?;
         let storage_entry = Entry {
-          append: entry.asset_append.clone(),
-          source_map: entry
-            .source_map
-            .as_ref()
-            .map(|(filename, source)| SourceMapAssetEntry {
-              filename: filename.clone(),
-              source: source.clone(),
-            }),
+          source_map: source_map.clone(),
         };
         match self.codec.encode(&storage_entry) {
           Ok(bytes) => Some((key_bytes, bytes)),
@@ -271,51 +381,49 @@ impl Occasion for SourceMapDevToolPluginOccasion {
       });
 
     tracing::debug!(
-      "saved {} and removed {} source map persistent cache entries",
+      "saved {}, removed {}, and removed {} legacy source map persistent cache entries",
       artifact.pending_writes.len(),
       artifact.pending_removes.len(),
+      artifact.pending_raw_removes.len(),
     );
   }
 
   #[tracing::instrument(name = "Cache::Occasion::SourceMap::recovery", skip_all)]
   async fn recovery(&self, storage: &dyn Storage) -> Result<SourceMapDevToolPluginCacheArtifact> {
     let items = storage.load(SCOPE).await?;
-    let entries = items
+    let (entries, pending_raw_removes) = items
       .into_par_iter()
-      .filter_map(|(key, value)| {
-        let key = match self.codec.decode::<CacheKey>(&key) {
+      .map(|(key_bytes, value)| {
+        let key = match self.codec.decode::<CacheKey>(&key_bytes) {
           Ok(key) => key,
           Err(err) => {
             tracing::warn!("source map persistent cache key decode failed: {:?}", err);
-            return None;
+            return Err(key_bytes);
           }
         };
         match self.codec.decode::<Entry>(&value) {
-          Ok(entry) => Some((
-            key,
-            Some(CacheEntry {
-              asset_append: entry.append,
-              source_map: entry
-                .source_map
-                .map(|source_map| (source_map.filename, source_map.source)),
-            }),
-          )),
+          Ok(entry) => Ok((key, Some(entry.source_map))),
           Err(err) => {
             tracing::warn!("source map persistent cache decode failed: {:?}", err);
-            None
+            Err(key_bytes)
           }
         }
       })
-      .collect::<FxHashMap<CacheKey, Option<CacheEntry>>>();
+      .partition_map::<FxHashMap<_, _>, Vec<_>, _, _, _>(|result| match result {
+        Ok(entry) => itertools::Either::Left(entry),
+        Err(raw_key) => itertools::Either::Right(raw_key),
+      });
 
     tracing::debug!(
-      "recovered {} source map persistent cache entries",
-      entries.len()
+      "recovered {} source map persistent cache entries and scheduled {} legacy entries for removal",
+      entries.len(),
+      pending_raw_removes.len(),
     );
     Ok(SourceMapDevToolPluginCacheArtifact {
       entries,
       pending_writes: Vec::new(),
       pending_removes: Vec::new(),
+      pending_raw_removes,
     })
   }
 }

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -1,31 +1,45 @@
 use std::{borrow::Cow, sync::Arc};
 
 use rayon::prelude::*;
-use rspack_cacheable::{cacheable, utils::OwnedOrRef};
+use rspack_cacheable::{
+  cacheable,
+  with::{AsPreset, AsVec},
+};
 use rspack_error::Result;
 use rspack_sources::{
   BoxSource, CachedSource, ConcatSource, OriginalSource, RawBufferSource, RawStringSource,
-  ReplaceSource, Source, SourceMap, SourceMapSource,
+  ReplaceSource, Source, SourceExt, SourceMap, SourceMapSource,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::{
   super::{codec::CacheCodec, storage::Storage},
   Occasion,
 };
-use crate::{CompilationAsset, RayonConsumer};
+use crate::{AssetInfo, CompilationAsset, RayonConsumer};
 
 pub const SCOPE: &str = "occasion_source_map_dev_tool_plugin";
 
 #[cacheable]
-struct Entry<'a> {
-  source_map: OwnedOrRef<'a, SourceMapCacheData>,
+#[derive(Debug)]
+struct CacheEntry {
+  #[cacheable(with=AsVec<AsPreset>)]
+  append: Vec<BoxSource>,
+  source_map_asset: Option<SourceMapAssetCacheData>,
+}
+
+#[cacheable]
+#[derive(Debug)]
+struct SourceMapAssetCacheData {
+  filename: String,
+  source_map: SourceMapCacheData,
 }
 
 /// Compact source map data cached by `SourceMapDevToolPlugin`.
 #[cacheable]
 #[derive(Debug, PartialEq, Eq)]
 struct SourceMapCacheData {
+  file: Option<String>,
   mappings: String,
   sources: Vec<String>,
   names: Vec<String>,
@@ -157,30 +171,29 @@ fn restore_sources_content<'a>(source: &'a dyn Source, indices: &[u32]) -> Optio
   (request_index == requests.len()).then_some(contents)
 }
 
-fn restore_source_map(
-  source: BoxSource,
-  source_map_cache_data: SourceMapCacheData,
-) -> Option<SourceMap<'static>> {
-  let SourceMapCacheData {
-    mappings,
-    sources,
-    names,
-    source_root,
-    debug_id,
-    ignore_list,
-    source_content_indices,
-  } = source_map_cache_data;
-  SourceMap::with_source(source, move |source| {
-    let sources_content = restore_sources_content(source, &source_content_indices)?;
+fn restore_source_map(source: BoxSource, cache_entry: &CacheEntry) -> Option<SourceMap<'static>> {
+  SourceMap::with_source(source, |source| {
+    let SourceMapCacheData {
+      file,
+      mappings,
+      sources,
+      names,
+      source_root,
+      debug_id,
+      ignore_list,
+      source_content_indices,
+    } = &cache_entry.source_map_asset.as_ref()?.source_map;
+    let sources_content = restore_sources_content(source, source_content_indices)?;
     let mut source_map = SourceMap::new(
-      Cow::Owned(mappings),
-      sources.into_iter().map(Cow::Owned).collect(),
+      Cow::Owned(mappings.clone()),
+      sources.iter().cloned().map(Cow::Owned).collect(),
       sources_content.into_iter().map(Cow::Borrowed).collect(),
-      names.into_iter().map(Cow::Owned).collect(),
+      names.iter().cloned().map(Cow::Owned).collect(),
     );
-    source_map.set_source_root(source_root.map(Cow::Owned));
-    source_map.set_debug_id(debug_id.map(Cow::Owned));
-    source_map.set_ignore_list(ignore_list.map(Cow::Owned));
+    source_map.set_file(file.clone().map(Cow::Owned));
+    source_map.set_source_root(source_root.clone().map(Cow::Owned));
+    source_map.set_debug_id(debug_id.clone().map(Cow::Owned));
+    source_map.set_ignore_list(ignore_list.clone().map(Cow::Owned));
     Some(source_map)
   })
 }
@@ -191,6 +204,7 @@ fn create_source_map_cache_data(
 ) -> Option<SourceMapCacheData> {
   let source_content_indices = source_content_indices(source, source_map)?;
   Some(SourceMapCacheData {
+    file: source_map.file().map(ToString::to_string),
     mappings: source_map.mappings().to_string(),
     sources: source_map
       .sources()
@@ -209,22 +223,79 @@ fn create_source_map_cache_data(
   })
 }
 
+fn create_cache_entry(
+  source: &dyn Source,
+  append: &[BoxSource],
+  source_map: Option<(&str, &SourceMap<'static>)>,
+) -> Option<CacheEntry> {
+  let source_map_asset = match source_map {
+    Some((filename, source_map)) => Some(SourceMapAssetCacheData {
+      filename: filename.to_string(),
+      source_map: create_source_map_cache_data(source, source_map)?,
+    }),
+    None => None,
+  };
+  Some(CacheEntry {
+    append: append.to_vec(),
+    source_map_asset,
+  })
+}
+
+#[allow(clippy::type_complexity)]
+fn restore_cache_entry(
+  source: BoxSource,
+  asset_info: AssetInfo,
+  cache_entry: &CacheEntry,
+) -> Option<(
+  CompilationAsset,
+  Option<(String, SourceMap<'static>)>,
+  Vec<BoxSource>,
+)> {
+  let source_map = match cache_entry.source_map_asset.as_ref() {
+    Some(source_map) => Some((
+      source_map.filename.clone(),
+      restore_source_map(source.clone(), cache_entry)?,
+    )),
+    None => None,
+  };
+  let append = cache_entry.append.clone();
+  let source = if append.is_empty() {
+    source
+  } else {
+    let mut children = Vec::with_capacity(append.len() + 1);
+    children.push(source);
+    children.extend(append.iter().cloned());
+    ConcatSource::new(children).boxed()
+  };
+  Some((
+    CompilationAsset::new(Some(source), asset_info),
+    source_map,
+    append,
+  ))
+}
+
 #[derive(Debug, Default)]
 pub struct SourceMapDevToolPluginCacheArtifact {
-  entries: FxHashMap<CacheKey, Option<SourceMapCacheData>>,
+  entries: FxHashMap<CacheKey, Option<CacheEntry>>,
   pending_writes: Vec<CacheKey>,
   pending_removes: Vec<CacheKey>,
   pending_invalid_entry_keys: Vec<Vec<u8>>,
 }
 
 impl SourceMapDevToolPluginCacheArtifact {
-  /// Recover source maps after the current compilation assets are available.
-  /// Source-content restoration is CPU-bound and runs in parallel across
-  /// assets, while cache entry state is updated serially.
+  /// Recover mapped assets after the current compilation assets are available.
+  /// Source-content restoration is CPU-bound and runs in parallel across assets.
+  #[allow(clippy::type_complexity)]
   pub fn take<'a>(
     &mut self,
     items: impl IntoIterator<Item = (&'a str, &'a CompilationAsset)>,
-  ) -> Vec<Option<SourceMap<'static>>> {
+  ) -> Vec<
+    Option<(
+      CompilationAsset,
+      Option<(String, SourceMap<'static>)>,
+      Vec<BoxSource>,
+    )>,
+  > {
     // Memory cache reuses this artifact across rebuilds, so storage mutations
     // from the previous compilation must not be replayed after its save.
     self.pending_writes.clear();
@@ -235,15 +306,15 @@ impl SourceMapDevToolPluginCacheArtifact {
       .map(|(filename, asset)| {
         let source = asset.get_source()?.clone();
         let cache_key = CacheKey::new(filename, &asset.info.version)?;
-        let source_map_cache_data = self.entries.get_mut(&cache_key).and_then(Option::take)?;
-        Some((cache_key, source, source_map_cache_data))
+        let cache_entry = self.entries.get_mut(&cache_key).and_then(Option::take)?;
+        Some((cache_key, source, asset.get_info().clone(), cache_entry))
       })
       .collect::<Vec<_>>()
       .into_par_iter()
       .map(|item| {
-        item.map(|(cache_key, source, source_map_cache_data)| {
-          let source_map = restore_source_map(source, source_map_cache_data);
-          (cache_key, source_map)
+        item.map(|(cache_key, source, asset_info, cache_entry)| {
+          let mapped_asset = restore_cache_entry(source, asset_info, &cache_entry);
+          (cache_key, cache_entry, mapped_asset)
         })
       })
       .collect::<Vec<_>>();
@@ -251,8 +322,11 @@ impl SourceMapDevToolPluginCacheArtifact {
     recovered
       .into_iter()
       .map(|item| match item {
-        Some((_, Some(source_map))) => Some(source_map),
-        Some((cache_key, None)) => {
+        Some((cache_key, cache_entry, Some(mapped_asset))) => {
+          self.entries.insert(cache_key, Some(cache_entry));
+          Some(mapped_asset)
+        }
+        Some((cache_key, _, None)) => {
           self.entries.remove(&cache_key);
           self.pending_removes.push(cache_key);
           None
@@ -264,52 +338,54 @@ impl SourceMapDevToolPluginCacheArtifact {
 
   pub fn store<'a>(
     &mut self,
-    items: impl IntoIterator<Item = (&'a str, &'a CompilationAsset, &'a SourceMap<'static>)>,
+    items: impl IntoIterator<
+      Item = (
+        &'a str,
+        &'a CompilationAsset,
+        &'a [BoxSource],
+        Option<(&'a str, &'a SourceMap<'static>)>,
+      ),
+    >,
   ) {
-    // Entries that were recovered but not consumed by this compilation are
-    // stale. Keep consumed entries (`None`) so valid hits can be reinserted
-    // without rewriting their storage value.
-    let pending_removes = &mut self.pending_removes;
-    self.entries.retain(|key, entry| {
-      if entry.is_some() {
-        pending_removes.push(key.clone());
-        false
-      } else {
-        true
-      }
-    });
-
-    let source_map_cache_entries = items
+    let mut active_keys = FxHashSet::default();
+    let uncached_items = items
       .into_iter()
-      .filter_map(|(filename, asset, source_map)| {
+      .filter_map(|(filename, asset, append, source_map)| {
         let source = asset.get_source()?;
         let cache_key = CacheKey::new(filename, &asset.info.version)?;
-        Some((cache_key, source.as_ref(), source_map))
+        active_keys.insert(cache_key.clone());
+        if self
+          .entries
+          .get(&cache_key)
+          .and_then(Option::as_ref)
+          .is_some()
+        {
+          return None;
+        }
+        Some((cache_key, source.as_ref(), append, source_map))
       })
       .collect::<Vec<_>>()
       .into_par_iter()
-      .filter_map(|(cache_key, source, source_map)| {
-        create_source_map_cache_data(source, source_map).map(|source_map| (cache_key, source_map))
+      .filter_map(|(cache_key, source, append, source_map)| {
+        create_cache_entry(source, append, source_map).map(|cache_entry| (cache_key, cache_entry))
       })
       .collect::<Vec<_>>();
 
-    for (cache_key, source_map) in source_map_cache_entries {
+    for (cache_key, cache_entry) in uncached_items {
       match self.entries.entry(cache_key) {
-        std::collections::hash_map::Entry::Occupied(mut occupied) => {
-          occupied.insert(Some(source_map));
-        }
+        std::collections::hash_map::Entry::Occupied(_) => {}
         std::collections::hash_map::Entry::Vacant(vacant) => {
           let cache_key = vacant.key().clone();
-          vacant.insert(Some(source_map));
+          vacant.insert(Some(cache_entry));
           self.pending_writes.push(cache_key);
         }
       }
     }
 
-    // Consumed entries that were not reinserted are no longer cacheable.
+    // Entries not returned by this compilation are stale.
     let pending_removes = &mut self.pending_removes;
-    self.entries.retain(|key, entry| {
-      if entry.is_none() {
+    self.entries.retain(|key, _| {
+      if !active_keys.contains(key) {
         pending_removes.push(key.clone());
         false
       } else {
@@ -368,11 +444,8 @@ impl Occasion for SourceMapDevToolPluginOccasion {
             return None;
           }
         };
-        let source_map = artifact.entries.get(key)?.as_ref()?;
-        let storage_entry = Entry {
-          source_map: source_map.into(),
-        };
-        match self.codec.encode(&storage_entry) {
+        let cache_entry = artifact.entries.get(key)?.as_ref()?;
+        match self.codec.encode(cache_entry) {
           Ok(bytes) => Some((key_bytes, bytes)),
           Err(err) => {
             tracing::warn!("source map persistent cache encode failed: {:?}", err);
@@ -405,8 +478,8 @@ impl Occasion for SourceMapDevToolPluginOccasion {
             return Err(key_bytes);
           }
         };
-        match self.codec.decode::<Entry>(&value) {
-          Ok(entry) => Ok((key, Some(entry.source_map.into_owned()))),
+        match self.codec.decode::<CacheEntry>(&value) {
+          Ok(entry) => Ok((key, Some(entry))),
           Err(err) => {
             tracing::warn!("source map persistent cache decode failed: {:?}", err);
             Err(key_bytes)

--- a/crates/rspack_core/src/cache/persistent/occasion/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/mod.rs
@@ -5,7 +5,9 @@ pub mod minimize;
 
 use std::future::Future;
 
-pub use devtool::{SourceMapDevToolPluginCacheArtifact, SourceMapDevToolPluginOccasion};
+pub use devtool::{
+  SourceMapComments, SourceMapDevToolPluginCacheArtifact, SourceMapDevToolPluginOccasion,
+};
 pub use make::MakeOccasion;
 pub use meta::MetaOccasion;
 pub use minimize::{

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -13,6 +13,7 @@ derive_more              = { workspace = true, features = ["debug"] }
 futures                  = { workspace = true }
 itertools                = { workspace = true }
 memchr                   = { workspace = true }
+rayon                    = { workspace = true }
 regex                    = { workspace = true }
 rspack_collections       = { workspace = true }
 rspack_core              = { workspace = true }

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -117,12 +117,13 @@ fn relative_source_name_from_url(
 }
 
 /// Compute source references from a source map's sources list.
-fn compute_source_references<'a>(
+fn compute_source_references(
   compilation: &Compilation,
-  sources: impl IntoIterator<Item = &'a str>,
+  source_map: &SourceMap<'_>,
 ) -> Vec<SourceReference> {
-  sources
-    .into_iter()
+  source_map
+    .sources()
+    .iter()
     .map(|source_name| {
       if let Some(stripped) = source_name
         .strip_prefix("webpack://")
@@ -138,7 +139,7 @@ fn compute_source_references<'a>(
           None => SourceReference::Source(Arc::from(source_name)),
         }
       } else {
-        SourceReference::Source(Arc::from(source_name))
+        SourceReference::Source(Arc::from(source_name.as_ref()))
       }
     })
     .collect()
@@ -524,11 +525,9 @@ impl SourceMapDevToolPlugin {
     }
 
     cache.store(mapped_assets.iter().filter_map(|mapped_asset| {
-      let filename = mapped_asset.asset.0.as_ref();
-      let asset = compilation.assets().get(filename)?;
       Some((
-        filename,
-        asset,
+        mapped_asset.asset.0.as_ref(),
+        &mapped_asset.asset.1,
         mapped_asset.asset_append.as_slice(),
         mapped_asset
           .source_map
@@ -596,15 +595,14 @@ impl SourceMapDevToolPlugin {
           };
           s.spawn(
             |(plugin, compilation, file_to_chunk, output_path, template, tls)| async move {
-              let object_pool = tls.get_or(ObjectPool::default);
-              let source_map = match source.clone().map_static(object_pool, &map_options) {
-                Some(sm) => sm,
-                None => return Ok(None),
+              let source_map = {
+                let object_pool = tls.get_or(ObjectPool::default);
+                match source.clone().map_static(object_pool, &map_options) {
+                  Some(sm) => sm,
+                  None => return Ok(None),
+                }
               };
-              let source_references = compute_source_references(
-                compilation,
-                source_map.sources().iter().map(AsRef::as_ref),
-              );
+              let source_references = compute_source_references(compilation, &source_map);
 
               let asset_filename: Arc<str> = Arc::from(asset_filename);
               let unresolved_source_map_path = plugin
@@ -707,15 +705,14 @@ impl SourceMapDevToolPlugin {
           };
           s.spawn(
             |(plugin, compilation, output_path, f, source, asset_filename, tls)| async move {
-              let object_pool = tls.get_or(ObjectPool::default);
-              let source_map = match source.clone().map_static(object_pool, &map_options) {
-                Some(sm) => sm,
-                None => return Ok(None),
+              let source_map = {
+                let object_pool = tls.get_or(ObjectPool::default);
+                match source.clone().map_static(object_pool, &map_options) {
+                  Some(sm) => sm,
+                  None => return Ok(None),
+                }
               };
-              let source_references = compute_source_references(
-                compilation,
-                source_map.sources().iter().map(AsRef::as_ref),
-              );
+              let source_references = compute_source_references(compilation, &source_map);
               let unresolved_source_map_path = plugin
                 .get_unresolved_source_map_path(compilation, output_path, &asset_filename)
                 .await?;
@@ -944,22 +941,18 @@ impl SourceMapDevToolPlugin {
     mapped_assets.into_iter().collect::<Result<Vec<_>>>()
   }
 
-  /// Create a single MappedAsset: update the source map and emit asset + optional source map file.
+  /// Finalize a source map and wrap it as an emit-ready source map asset.
   #[allow(clippy::too_many_arguments)]
-  async fn create_mapped_asset(
-    plugin: &SourceMapDevToolPlugin,
+  fn create_source_map_asset(
+    &self,
     compilation: &Compilation,
-    file_to_chunk: &HashMap<&str, &Chunk>,
     reference_to_source_name_mapping: &ReferenceToSourceNameMapping,
-    asset_filename: Arc<str>,
-    source: BoxSource,
+    asset_filename: &str,
     mut source_map: SourceMap<'static>,
-    unresolved_source_map_path: Option<Utf8PathBuf>,
+    unresolved_source_map_path: Option<&Utf8Path>,
     source_references: Vec<SourceReference>,
-  ) -> Result<MappedAsset> {
-    let debug_id = plugin
-      .debug_ids
-      .then(|| generate_debug_id(&asset_filename, &source.buffer()));
+    debug_id: Option<&str>,
+  ) -> SourceMapAsset {
     let sources = source_references
       .into_iter()
       .map(|source_reference| {
@@ -970,11 +963,11 @@ impl SourceMapDevToolPlugin {
               "SourceMapDevToolPlugin: missing source name for reference '{source_reference:?}' in asset '{asset_filename}'."
             )
           })
-          .render_for_source_map(unresolved_source_map_path.as_deref())
+          .render_for_source_map(unresolved_source_map_path)
           .into_owned()
       })
       .collect::<Vec<_>>();
-    let ignore_list = plugin.ignore_list.as_ref().map(|asset_conditions| {
+    let ignore_list = self.ignore_list.as_ref().map(|asset_conditions| {
       sources
         .iter()
         .enumerate()
@@ -982,28 +975,55 @@ impl SourceMapDevToolPlugin {
         .collect::<Vec<_>>()
     });
     source_map.set_sources(sources);
-    if plugin.no_sources {
+    if self.no_sources {
       source_map.set_sources_content(Vec::new());
     }
     source_map.set_file(Some(Cow::Owned(asset_filename.to_string())));
-    if let Some(source_root) = plugin.source_root.as_deref() {
+    if let Some(source_root) = self.source_root.as_deref() {
       source_map.set_source_root(Some(Cow::Owned(source_root.to_string())));
     }
-    if let Some(debug_id) = debug_id.as_ref() {
-      source_map.set_debug_id(Some(Cow::Owned(debug_id.clone())));
+    if let Some(debug_id) = debug_id {
+      source_map.set_debug_id(Some(Cow::Owned(debug_id.to_string())));
     }
     if let Some(ignore_list) = ignore_list {
       source_map.set_ignore_list(Some(Cow::Owned(ignore_list)));
     }
-    let mut source_map_asset_info = AssetInfo::default().with_development(Some(true));
-    if let Some(asset) = compilation.assets().get(asset_filename.as_ref()) {
-      source_map_asset_info.version = asset.info.version.clone();
+    let mut info = AssetInfo::default().with_development(Some(true));
+    if let Some(asset) = compilation.assets().get(asset_filename) {
+      info.version = asset.info.version.clone();
     }
-    let mut source_map_asset = SourceMapAsset {
+    SourceMapAsset {
       source_map,
       source_map_json: None,
-      info: source_map_asset_info,
-    };
+      info,
+    }
+  }
+
+  /// Create a single MappedAsset: update the source map and emit asset + optional source map file.
+  #[allow(clippy::too_many_arguments)]
+  async fn create_mapped_asset(
+    plugin: &SourceMapDevToolPlugin,
+    compilation: &Compilation,
+    file_to_chunk: &HashMap<&str, &Chunk>,
+    reference_to_source_name_mapping: &ReferenceToSourceNameMapping,
+    asset_filename: Arc<str>,
+    source: BoxSource,
+    source_map: SourceMap<'static>,
+    unresolved_source_map_path: Option<Utf8PathBuf>,
+    source_references: Vec<SourceReference>,
+  ) -> Result<MappedAsset> {
+    let debug_id = plugin
+      .debug_ids
+      .then(|| generate_debug_id(&asset_filename, &source.buffer()));
+    let mut source_map_asset = plugin.create_source_map_asset(
+      compilation,
+      reference_to_source_name_mapping,
+      asset_filename.as_ref(),
+      source_map,
+      unresolved_source_map_path.as_deref(),
+      source_references,
+      debug_id.as_deref(),
+    );
 
     let mut asset = compilation
       .assets()

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   AssetInfo, CacheCount, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationParams,
   CompilationProcessAssets, CompilerCompilation, Filename, Logger, ModuleIdentifier, PathData,
   Plugin,
-  cache::persistent::occasion::SourceMapDevToolPluginCacheArtifact,
+  cache::persistent::occasion::{SourceMapComments, SourceMapDevToolPluginCacheArtifact},
   has_content_hash_placeholder,
   rspack_sources::{
     BoxSource, ConcatSource, MapOptions, ObjectPool, RawBufferSource, RawStringSource, SourceExt,
@@ -287,6 +287,8 @@ type ReferenceToSourceNameMapping = FxIndexMap<SourceReference, SourceNameWithBa
 type TaskAndSourceNames = (SourceMapTask, Vec<(SourceReference, SourceNameWithBaseUrl)>);
 
 pub(crate) struct SourceMapAsset {
+  /// `None` means an inline source map; `Some` is the filename of the emitted source map asset.
+  filename: Option<String>,
   source_map: SourceMap<'static>,
   source_map_json: Option<String>,
   info: AssetInfo,
@@ -313,8 +315,8 @@ impl From<SourceMapAsset> for CompilationAsset {
 
 pub(crate) struct MappedAsset {
   pub(crate) asset: (Arc<str>, CompilationAsset),
-  pub(crate) asset_append: Vec<BoxSource>,
-  pub(crate) source_map: Option<(String, SourceMapAsset)>,
+  pub(crate) comments: SourceMapComments,
+  pub(crate) source_map: SourceMapAsset,
 }
 
 #[plugin]
@@ -486,26 +488,21 @@ impl SourceMapDevToolPlugin {
     let mut uncached_assets = Vec::with_capacity(asset_count);
     for ((asset_filename, asset), cached_asset) in compilation_assets.into_iter().zip(cached_assets)
     {
-      if let Some((source_asset, source_map, asset_append)) = cached_asset {
+      if let Some((source_asset, source_map_filename, source_map, comments)) = cached_asset {
         if let Some(counter) = cache_counter {
           counter.hit();
         }
-        let source_map = source_map.map(|(filename, source_map)| {
-          let mut info = AssetInfo::default().with_development(Some(true));
-          info.version = asset.info.version.clone();
-          (
-            filename,
-            SourceMapAsset {
-              source_map,
-              source_map_json: None,
-              info,
-            },
-          )
-        });
+        let mut info = AssetInfo::default().with_development(Some(true));
+        info.version = asset.info.version.clone();
         mapped_assets.push(MappedAsset {
           asset: (Arc::from(asset_filename), source_asset),
-          asset_append,
-          source_map,
+          comments,
+          source_map: SourceMapAsset {
+            filename: source_map_filename,
+            source_map,
+            source_map_json: None,
+            info,
+          },
         });
         continue;
       }
@@ -525,14 +522,14 @@ impl SourceMapDevToolPlugin {
     }
 
     cache.store(mapped_assets.iter().filter_map(|mapped_asset| {
+      let filename = mapped_asset.asset.0.as_ref();
+      let asset = compilation.assets().get(filename)?;
       Some((
-        mapped_asset.asset.0.as_ref(),
-        &mapped_asset.asset.1,
-        mapped_asset.asset_append.as_slice(),
-        mapped_asset
-          .source_map
-          .as_ref()
-          .map(|(filename, asset)| (filename.as_str(), &asset.source_map)),
+        filename,
+        asset,
+        &mapped_asset.comments,
+        mapped_asset.source_map.filename.as_deref(),
+        &mapped_asset.source_map.source_map,
       ))
     }));
 
@@ -993,6 +990,7 @@ impl SourceMapDevToolPlugin {
       info.version = asset.info.version.clone();
     }
     SourceMapAsset {
+      filename: None,
       source_map,
       source_map_json: None,
       info,
@@ -1091,27 +1089,27 @@ impl SourceMapDevToolPlugin {
         .get_asset_path(source_map_filename_config, data)
         .await?;
 
-      let asset_append =
+      let source_map_url = if let Some(public_path) = &plugin.public_path {
+        format!("{public_path}{source_map_filename}")
+      } else {
+        let mut file_path = PathBuf::new();
+        file_path.push(Component::RootDir);
+        file_path.extend(Path::new(filename.as_ref()).components());
+
+        let mut source_map_path = PathBuf::new();
+        source_map_path.push(Component::RootDir);
+        source_map_path.extend(Path::new(&source_map_filename).components());
+
+        source_map_path
+          .relative(
+            #[allow(clippy::unwrap_used)]
+            file_path.parent().unwrap(),
+          )
+          .to_string_lossy()
+          .to_string()
+      };
+      let comments =
         if let Some(current_source_mapping_url_comment) = current_source_mapping_url_comment {
-          let source_map_url = if let Some(public_path) = &plugin.public_path {
-            format!("{public_path}{source_map_filename}")
-          } else {
-            let mut file_path = PathBuf::new();
-            file_path.push(Component::RootDir);
-            file_path.extend(Path::new(filename.as_ref()).components());
-
-            let mut source_map_path = PathBuf::new();
-            source_map_path.push(Component::RootDir);
-            source_map_path.extend(Path::new(&source_map_filename).components());
-
-            source_map_path
-              .relative(
-                #[allow(clippy::unwrap_used)]
-                file_path.parent().unwrap(),
-              )
-              .to_string_lossy()
-              .to_string()
-          };
           let data = data.url(&source_map_url);
           let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
             SourceMappingUrlCommentRef::String(s) => {
@@ -1124,44 +1122,40 @@ impl SourceMapDevToolPlugin {
               Filename::from(comment).render(data, None).await?
             }
           };
-          let current_source_mapping_url_comment = current_source_mapping_url_comment
+          let rendered_source_mapping_url_comment = current_source_mapping_url_comment
             .cow_replace("[url]", &source_map_url)
             .into_owned();
 
-          let debug_id_comment = debug_id
-            .map(|id| format!("\n//# debugId={id}"))
-            .map(|comment| RawStringSource::from(comment).boxed());
-          let current_source_mapping_url_comment =
-            RawStringSource::from(current_source_mapping_url_comment).boxed();
-          let mut asset_append = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 1);
-          if let Some(debug_id_comment) = &debug_id_comment {
-            asset_append.push(debug_id_comment.clone());
-          }
-          asset_append.push(current_source_mapping_url_comment.clone());
-
+          let debug_id_comment = debug_id.map(|id| format!("\n//# debugId={id}"));
           let mut children = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 2);
           children.push(source);
-          if let Some(debug_id_comment) = debug_id_comment {
-            children.push(debug_id_comment);
+          if let Some(debug_id_comment) = &debug_id_comment {
+            children.push(RawStringSource::from(debug_id_comment.clone()).boxed());
           }
-          children.push(current_source_mapping_url_comment);
+          children.push(RawStringSource::from(rendered_source_mapping_url_comment.clone()).boxed());
           asset.source = Some(ConcatSource::new(children).boxed());
           asset.info.related.source_map = Some(source_map_filename.clone());
-          asset_append
+          SourceMapComments {
+            debug_id_comment,
+            source_mapping_url_comment: rendered_source_mapping_url_comment,
+          }
         } else {
           asset.source = Some(source);
-          Vec::new()
+          SourceMapComments::default()
         };
       Ok(MappedAsset {
         asset: (asset_filename, asset),
-        asset_append,
-        source_map: Some((source_map_filename, source_map_asset)),
+        comments,
+        source_map: SourceMapAsset {
+          filename: Some(source_map_filename),
+          ..source_map_asset
+        },
       })
     } else {
       let current_source_mapping_url_comment = current_source_mapping_url_comment
         .expect("SourceMapDevToolPlugin: append can't be false when no filename is provided.");
       let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
-        SourceMappingUrlCommentRef::String(s) => s,
+        SourceMappingUrlCommentRef::String(s) => s.to_string(),
         SourceMappingUrlCommentRef::Fn(_) => {
           return Err(error!(
             "SourceMapDevToolPlugin: append can't be a function when no filename is provided"
@@ -1177,12 +1171,14 @@ impl SourceMapDevToolPlugin {
         )
         .into_owned();
       let append = RawStringSource::from(append).boxed();
-      let asset_append = vec![append.clone()];
       asset.source = Some(ConcatSource::new([source, append]).boxed());
       Ok(MappedAsset {
         asset: (asset_filename, asset),
-        asset_append,
-        source_map: None,
+        comments: SourceMapComments {
+          debug_id_comment: None,
+          source_mapping_url_comment: current_source_mapping_url_comment,
+        },
+        source_map: source_map_asset,
       })
     }
   }
@@ -1266,18 +1262,18 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   }
 
   let start = logger.time("emit source map assets");
-  let emit_source_map = self.source_map_filename.is_some();
   let mapped_assets = mapped_assets
     .into_par_iter()
     .map(|mapped_asset| {
       let MappedAsset {
-        asset, source_map, ..
+        asset,
+        mut source_map,
+        ..
       } = mapped_asset;
-      let source_map = if emit_source_map {
-        source_map.map(|(filename, asset)| (filename, CompilationAsset::from(asset)))
-      } else {
-        None
-      };
+      let source_map = source_map
+        .filename
+        .take()
+        .map(|filename| (filename, CompilationAsset::from(source_map)));
       (asset, source_map)
     })
     .collect::<Vec<_>>();

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -216,12 +216,6 @@ enum SourceMappingUrlCommentRef<'a> {
   Fn(&'a AppendFn),
 }
 
-struct SourceMapInput<'a> {
-  asset_filename: String,
-  asset: &'a CompilationAsset,
-  source_map: Option<SourceMap<'static>>,
-}
-
 struct SourceMapTask {
   pub asset_filename: Arc<str>,
   pub source: BoxSource,
@@ -291,20 +285,20 @@ type ReferenceToSourceNameMapping = FxIndexMap<SourceReference, SourceNameWithBa
 
 type TaskAndSourceNames = (SourceMapTask, Vec<(SourceReference, SourceNameWithBaseUrl)>);
 
-pub(crate) struct CompilationSourceMapAsset {
+pub(crate) struct SourceMapAsset {
   source_map: SourceMap<'static>,
   source_map_json: Option<String>,
   info: AssetInfo,
 }
 
-impl CompilationSourceMapAsset {
+impl SourceMapAsset {
   fn to_json(&self) -> String {
     self.source_map.to_json()
   }
 }
 
-impl From<CompilationSourceMapAsset> for CompilationAsset {
-  fn from(mut asset: CompilationSourceMapAsset) -> Self {
+impl From<SourceMapAsset> for CompilationAsset {
+  fn from(mut asset: SourceMapAsset) -> Self {
     let source_map_json = asset
       .source_map_json
       .take()
@@ -319,7 +313,7 @@ impl From<CompilationSourceMapAsset> for CompilationAsset {
 pub(crate) struct MappedAsset {
   pub(crate) asset: (Arc<str>, CompilationAsset),
   pub(crate) asset_append: Vec<BoxSource>,
-  pub(crate) source_map: Option<(String, CompilationSourceMapAsset)>,
+  pub(crate) source_map: Option<(String, SourceMapAsset)>,
 }
 
 #[plugin]
@@ -438,7 +432,7 @@ impl SourceMapDevToolPlugin {
     compilation: &Compilation,
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
-    compilation_assets: Vec<SourceMapInput<'_>>,
+    compilation_assets: Vec<(String, &CompilationAsset)>,
   ) -> Result<Vec<MappedAsset>> {
     let map_options = MapOptions::new(self.columns);
 
@@ -476,16 +470,8 @@ impl SourceMapDevToolPlugin {
     cache_counter: Option<&CacheCount>,
   ) -> Result<Vec<MappedAsset>> {
     let Some(cache) = cache else {
-      let inputs = compilation_assets
-        .into_iter()
-        .map(|(asset_filename, asset)| SourceMapInput {
-          asset_filename,
-          asset,
-          source_map: None,
-        })
-        .collect();
       return self
-        .map_assets(compilation, file_to_chunk, output_path, inputs)
+        .map_assets(compilation, file_to_chunk, output_path, compilation_assets)
         .await;
     };
 
@@ -496,7 +482,7 @@ impl SourceMapDevToolPlugin {
     );
     let asset_count = compilation_assets.len();
     let mut mapped_assets = Vec::with_capacity(asset_count);
-    let mut inputs = Vec::with_capacity(asset_count);
+    let mut uncached_assets = Vec::with_capacity(asset_count);
     for ((asset_filename, asset), cached_asset) in compilation_assets.into_iter().zip(cached_assets)
     {
       if let Some((source_asset, source_map, asset_append)) = cached_asset {
@@ -508,7 +494,7 @@ impl SourceMapDevToolPlugin {
           info.version = asset.info.version.clone();
           (
             filename,
-            CompilationSourceMapAsset {
+            SourceMapAsset {
               source_map,
               source_map_json: None,
               info,
@@ -526,17 +512,13 @@ impl SourceMapDevToolPlugin {
       if let Some(counter) = cache_counter {
         counter.miss();
       }
-      inputs.push(SourceMapInput {
-        asset_filename,
-        asset,
-        source_map: None,
-      });
+      uncached_assets.push((asset_filename, asset));
     }
 
-    if !inputs.is_empty() {
+    if !uncached_assets.is_empty() {
       mapped_assets.extend(
         self
-          .map_assets(compilation, file_to_chunk, output_path, inputs)
+          .map_assets(compilation, file_to_chunk, output_path, uncached_assets)
           .await?,
       );
     }
@@ -565,7 +547,7 @@ impl SourceMapDevToolPlugin {
     compilation: &Compilation,
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
-    compilation_assets: Vec<SourceMapInput<'_>>,
+    compilation_assets: Vec<(String, &CompilationAsset)>,
     map_options: &MapOptions,
   ) -> Result<(Vec<SourceMapTask>, ReferenceToSourceNameMapping)> {
     let need_match = self.test.is_some() || self.include.is_some() || self.exclude.is_some();
@@ -587,12 +569,7 @@ impl SourceMapDevToolPlugin {
         _,
         Result<Option<TaskAndSourceNames>>,
       >(|token| {
-        for SourceMapInput {
-          asset_filename,
-          asset,
-          source_map,
-        } in compilation_assets
-        {
+        for (asset_filename, asset) in compilation_assets {
           let is_match = if need_match {
             match_object(&condition_object, &asset_filename)
           } else {
@@ -619,15 +596,10 @@ impl SourceMapDevToolPlugin {
           };
           s.spawn(
             |(plugin, compilation, file_to_chunk, output_path, template, tls)| async move {
-              let source_map = match source_map {
-                Some(source_map) => source_map,
-                None => {
-                  let object_pool = tls.get_or(ObjectPool::default);
-                  match source.clone().map_static(object_pool, &map_options) {
-                    Some(sm) => sm,
-                    None => return Ok(None),
-                  }
-                }
+              let object_pool = tls.get_or(ObjectPool::default);
+              let source_map = match source.clone().map_static(object_pool, &map_options) {
+                Some(sm) => sm,
+                None => return Ok(None),
               };
               let source_references = compute_source_references(
                 compilation,
@@ -702,61 +674,43 @@ impl SourceMapDevToolPlugin {
       .into_iter()
       .map(|r| r.to_rspack_result().flatten())
       .collect::<Vec<_>>(),
-      ModuleFilenameTemplate::Fn(f) => {
-        rspack_parallel::scope::<_, Result<Option<TaskAndSourceNames>>>(|token| {
-          for SourceMapInput {
-            asset_filename,
-            asset,
-            source_map,
-          } in compilation_assets
-          {
-            let is_match = if need_match {
-              match_object(&condition_object, &asset_filename)
-            } else {
-              true
-            };
-            if !is_match {
-              continue;
-            }
-            let source = match asset.get_source() {
-              Some(s) => s.clone(),
-              None => continue,
-            };
+      ModuleFilenameTemplate::Fn(f) => rspack_parallel::scope::<
+        _,
+        Result<Option<TaskAndSourceNames>>,
+      >(|token| {
+        for (asset_filename, asset) in compilation_assets {
+          let is_match = if need_match {
+            match_object(&condition_object, &asset_filename)
+          } else {
+            true
+          };
+          if !is_match {
+            continue;
+          }
+          let source = match asset.get_source() {
+            Some(s) => s.clone(),
+            None => continue,
+          };
 
-            let asset_filename: Arc<str> = Arc::from(asset_filename);
-            let map_options = map_options.clone();
-            let s = unsafe {
-              token.used((
-                self,
-                compilation,
-                output_path,
-                f,
-                source,
-                asset_filename,
-                source_map,
-                &tls,
-              ))
-            };
-            s.spawn(
-            |(
-              plugin,
+          let asset_filename: Arc<str> = Arc::from(asset_filename);
+          let map_options = map_options.clone();
+          let s = unsafe {
+            token.used((
+              self,
               compilation,
               output_path,
               f,
               source,
               asset_filename,
-              source_map,
-              tls,
-            )| async move {
-              let source_map = match source_map {
-                Some(source_map) => source_map,
-                None => {
-                  let object_pool = tls.get_or(ObjectPool::default);
-                  match source.clone().map_static(object_pool, &map_options) {
-                    Some(sm) => sm,
-                    None => return Ok(None),
-                  }
-                }
+              &tls,
+            ))
+          };
+          s.spawn(
+            |(plugin, compilation, output_path, f, source, asset_filename, tls)| async move {
+              let object_pool = tls.get_or(ObjectPool::default);
+              let source_map = match source.clone().map_static(object_pool, &map_options) {
+                Some(sm) => sm,
+                None => return Ok(None),
               };
               let source_references = compute_source_references(
                 compilation,
@@ -808,13 +762,12 @@ impl SourceMapDevToolPlugin {
               Ok(Some((task, source_name_entries)))
             },
           );
-          }
-        })
-        .await
-        .into_iter()
-        .map(|r| r.to_rspack_result().flatten())
-        .collect::<Vec<_>>()
-      }
+        }
+      })
+      .await
+      .into_iter()
+      .map(|r| r.to_rspack_result().flatten())
+      .collect::<Vec<_>>(),
     };
 
     let mut tasks: Vec<SourceMapTask> = Vec::with_capacity(results.len());
@@ -1046,7 +999,7 @@ impl SourceMapDevToolPlugin {
     if let Some(asset) = compilation.assets().get(asset_filename.as_ref()) {
       source_map_asset_info.version = asset.info.version.clone();
     }
-    let mut source_map_asset = CompilationSourceMapAsset {
+    let mut source_map_asset = SourceMapAsset {
       source_map,
       source_map_json: None,
       info: source_map_asset_info,

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -318,6 +318,7 @@ impl From<CompilationSourceMapAsset> for CompilationAsset {
 
 pub(crate) struct MappedAsset {
   pub(crate) asset: (Arc<str>, CompilationAsset),
+  pub(crate) asset_append: Vec<BoxSource>,
   pub(crate) source_map: Option<(String, CompilationSourceMapAsset)>,
 }
 
@@ -438,7 +439,6 @@ impl SourceMapDevToolPlugin {
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
     compilation_assets: Vec<SourceMapInput<'_>>,
-    cache: Option<&mut SourceMapDevToolPluginCacheArtifact>,
   ) -> Result<Vec<MappedAsset>> {
     let map_options = MapOptions::new(self.columns);
 
@@ -451,13 +451,6 @@ impl SourceMapDevToolPlugin {
         &map_options,
       )
       .await?;
-
-    if let Some(cache) = cache {
-      cache.store(tasks.iter().filter_map(|task| {
-        let asset = compilation.assets().get(task.asset_filename.as_ref())?;
-        Some((task.asset_filename.as_ref(), asset, &task.source_map))
-      }));
-    }
 
     self
       .deduplicate_source_names(compilation, &mut reference_to_source_name_mapping)
@@ -479,36 +472,90 @@ impl SourceMapDevToolPlugin {
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
     compilation_assets: Vec<(String, &CompilationAsset)>,
-    mut cache: Option<&mut SourceMapDevToolPluginCacheArtifact>,
+    cache: Option<&mut SourceMapDevToolPluginCacheArtifact>,
     cache_counter: Option<&CacheCount>,
   ) -> Result<Vec<MappedAsset>> {
-    let source_maps = match cache.as_deref_mut() {
-      Some(cache) => cache.take(
-        compilation_assets
-          .iter()
-          .map(|(asset_filename, asset)| (asset_filename.as_str(), *asset)),
-      ),
-      None => (0..compilation_assets.len()).map(|_| None).collect(),
+    let Some(cache) = cache else {
+      let inputs = compilation_assets
+        .into_iter()
+        .map(|(asset_filename, asset)| SourceMapInput {
+          asset_filename,
+          asset,
+          source_map: None,
+        })
+        .collect();
+      return self
+        .map_assets(compilation, file_to_chunk, output_path, inputs)
+        .await;
     };
-    let mut inputs = Vec::with_capacity(compilation_assets.len());
-    for ((asset_filename, asset), source_map) in compilation_assets.into_iter().zip(source_maps) {
-      if let Some(counter) = cache_counter {
-        if source_map.is_some() {
+
+    let cached_assets = cache.take(
+      compilation_assets
+        .iter()
+        .map(|(asset_filename, asset)| (asset_filename.as_str(), *asset)),
+    );
+    let asset_count = compilation_assets.len();
+    let mut mapped_assets = Vec::with_capacity(asset_count);
+    let mut inputs = Vec::with_capacity(asset_count);
+    for ((asset_filename, asset), cached_asset) in compilation_assets.into_iter().zip(cached_assets)
+    {
+      if let Some((source_asset, source_map, asset_append)) = cached_asset {
+        if let Some(counter) = cache_counter {
           counter.hit();
-        } else {
-          counter.miss();
         }
+        let source_map = source_map.map(|(filename, source_map)| {
+          let mut info = AssetInfo::default().with_development(Some(true));
+          info.version = asset.info.version.clone();
+          (
+            filename,
+            CompilationSourceMapAsset {
+              source_map,
+              source_map_json: None,
+              info,
+            },
+          )
+        });
+        mapped_assets.push(MappedAsset {
+          asset: (Arc::from(asset_filename), source_asset),
+          asset_append,
+          source_map,
+        });
+        continue;
+      }
+
+      if let Some(counter) = cache_counter {
+        counter.miss();
       }
       inputs.push(SourceMapInput {
         asset_filename,
         asset,
-        source_map,
+        source_map: None,
       });
     }
 
-    self
-      .map_assets(compilation, file_to_chunk, output_path, inputs, cache)
-      .await
+    if !inputs.is_empty() {
+      mapped_assets.extend(
+        self
+          .map_assets(compilation, file_to_chunk, output_path, inputs)
+          .await?,
+      );
+    }
+
+    cache.store(mapped_assets.iter().filter_map(|mapped_asset| {
+      let filename = mapped_asset.asset.0.as_ref();
+      let asset = compilation.assets().get(filename)?;
+      Some((
+        filename,
+        asset,
+        mapped_asset.asset_append.as_slice(),
+        mapped_asset
+          .source_map
+          .as_ref()
+          .map(|(filename, asset)| (filename.as_str(), &asset.source_map)),
+      ))
+    }));
+
+    Ok(mapped_assets)
   }
 
   /// Compute source maps and source names concurrently via `rspack_parallel::scope`.
@@ -1071,60 +1118,70 @@ impl SourceMapDevToolPlugin {
         .get_asset_path(source_map_filename_config, data)
         .await?;
 
-      if let Some(current_source_mapping_url_comment) = current_source_mapping_url_comment {
-        let source_map_url = if let Some(public_path) = &plugin.public_path {
-          format!("{public_path}{source_map_filename}")
+      let asset_append =
+        if let Some(current_source_mapping_url_comment) = current_source_mapping_url_comment {
+          let source_map_url = if let Some(public_path) = &plugin.public_path {
+            format!("{public_path}{source_map_filename}")
+          } else {
+            let mut file_path = PathBuf::new();
+            file_path.push(Component::RootDir);
+            file_path.extend(Path::new(filename.as_ref()).components());
+
+            let mut source_map_path = PathBuf::new();
+            source_map_path.push(Component::RootDir);
+            source_map_path.extend(Path::new(&source_map_filename).components());
+
+            source_map_path
+              .relative(
+                #[allow(clippy::unwrap_used)]
+                file_path.parent().unwrap(),
+              )
+              .to_string_lossy()
+              .to_string()
+          };
+          let data = data.url(&source_map_url);
+          let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
+            SourceMappingUrlCommentRef::String(s) => {
+              compilation
+                .get_asset_path(&Filename::from(s.as_ref()), data)
+                .await?
+            }
+            SourceMappingUrlCommentRef::Fn(f) => {
+              let comment = f(data).await?;
+              Filename::from(comment).render(data, None).await?
+            }
+          };
+          let current_source_mapping_url_comment = current_source_mapping_url_comment
+            .cow_replace("[url]", &source_map_url)
+            .into_owned();
+
+          let debug_id_comment = debug_id
+            .map(|id| format!("\n//# debugId={id}"))
+            .map(|comment| RawStringSource::from(comment).boxed());
+          let current_source_mapping_url_comment =
+            RawStringSource::from(current_source_mapping_url_comment).boxed();
+          let mut asset_append = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 1);
+          if let Some(debug_id_comment) = &debug_id_comment {
+            asset_append.push(debug_id_comment.clone());
+          }
+          asset_append.push(current_source_mapping_url_comment.clone());
+
+          let mut children = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 2);
+          children.push(source);
+          if let Some(debug_id_comment) = debug_id_comment {
+            children.push(debug_id_comment);
+          }
+          children.push(current_source_mapping_url_comment);
+          asset.source = Some(ConcatSource::new(children).boxed());
+          asset.info.related.source_map = Some(source_map_filename.clone());
+          asset_append
         } else {
-          let mut file_path = PathBuf::new();
-          file_path.push(Component::RootDir);
-          file_path.extend(Path::new(filename.as_ref()).components());
-
-          let mut source_map_path = PathBuf::new();
-          source_map_path.push(Component::RootDir);
-          source_map_path.extend(Path::new(&source_map_filename).components());
-
-          source_map_path
-            .relative(
-              #[allow(clippy::unwrap_used)]
-              file_path.parent().unwrap(),
-            )
-            .to_string_lossy()
-            .to_string()
+          asset.source = Some(source);
+          Vec::new()
         };
-        let data = data.url(&source_map_url);
-        let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
-          SourceMappingUrlCommentRef::String(s) => {
-            compilation
-              .get_asset_path(&Filename::from(s.as_ref()), data)
-              .await?
-          }
-          SourceMappingUrlCommentRef::Fn(f) => {
-            let comment = f(data).await?;
-            Filename::from(comment).render(data, None).await?
-          }
-        };
-        let current_source_mapping_url_comment = current_source_mapping_url_comment
-          .cow_replace("[url]", &source_map_url)
-          .into_owned();
-
-        let debug_id_comment = debug_id
-          .map(|id| format!("\n//# debugId={id}"))
-          .map(|comment| RawStringSource::from(comment).boxed());
-        let current_source_mapping_url_comment =
-          RawStringSource::from(current_source_mapping_url_comment).boxed();
-        let mut children = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 2);
-        children.push(source);
-        if let Some(debug_id_comment) = debug_id_comment {
-          children.push(debug_id_comment);
-        }
-        children.push(current_source_mapping_url_comment);
-        asset.source = Some(ConcatSource::new(children).boxed());
-        asset.info.related.source_map = Some(source_map_filename.clone());
-      } else {
-        asset.source = Some(source);
-      }
       Ok(MappedAsset {
         asset: (asset_filename, asset),
+        asset_append,
         source_map: Some((source_map_filename, source_map_asset)),
       })
     } else {
@@ -1147,9 +1204,11 @@ impl SourceMapDevToolPlugin {
         )
         .into_owned();
       let append = RawStringSource::from(append).boxed();
+      let asset_append = vec![append.clone()];
       asset.source = Some(ConcatSource::new([source, append]).boxed());
       Ok(MappedAsset {
         asset: (asset_filename, asset),
+        asset_append,
         source_map: None,
       })
     }
@@ -1238,7 +1297,9 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let mapped_assets = mapped_assets
     .into_par_iter()
     .map(|mapped_asset| {
-      let MappedAsset { asset, source_map } = mapped_asset;
+      let MappedAsset {
+        asset, source_map, ..
+      } = mapped_asset;
       let source_map = if emit_source_map {
         source_map.map(|(filename, asset)| (filename, CompilationAsset::from(asset)))
       } else {

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -8,6 +8,7 @@ use cow_utils::CowUtils;
 use derive_more::Debug;
 use futures::future::BoxFuture;
 use itertools::Itertools;
+use rayon::prelude::*;
 use regex::Regex;
 use rspack_core::{
   AssetInfo, CacheCount, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationParams,
@@ -16,8 +17,8 @@ use rspack_core::{
   cache::persistent::occasion::SourceMapDevToolPluginCacheArtifact,
   has_content_hash_placeholder,
   rspack_sources::{
-    BoxSource, ConcatSource, MapOptions, ObjectPool, RawBufferSource, RawStringSource, Source,
-    SourceExt, SourceMap, SourceValue,
+    BoxSource, ConcatSource, MapOptions, ObjectPool, RawBufferSource, RawStringSource, SourceExt,
+    SourceMap, SourceValue,
   },
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt, error};
@@ -116,13 +117,12 @@ fn relative_source_name_from_url(
 }
 
 /// Compute source references from a source map's sources list.
-fn compute_source_references(
+fn compute_source_references<'a>(
   compilation: &Compilation,
-  source_map: &SourceMap<'_>,
+  sources: impl IntoIterator<Item = &'a str>,
 ) -> Vec<SourceReference> {
-  source_map
-    .sources()
-    .iter()
+  sources
+    .into_iter()
     .map(|source_name| {
       if let Some(stripped) = source_name
         .strip_prefix("webpack://")
@@ -138,7 +138,7 @@ fn compute_source_references(
           None => SourceReference::Source(Arc::from(source_name)),
         }
       } else {
-        SourceReference::Source(Arc::from(source_name.as_ref()))
+        SourceReference::Source(Arc::from(source_name))
       }
     })
     .collect()
@@ -216,6 +216,12 @@ enum SourceMappingUrlCommentRef<'a> {
   Fn(&'a AppendFn),
 }
 
+struct SourceMapInput<'a> {
+  asset_filename: String,
+  asset: &'a CompilationAsset,
+  source_map: Option<SourceMap<'static>>,
+}
+
 struct SourceMapTask {
   pub asset_filename: Arc<str>,
   pub source: BoxSource,
@@ -285,11 +291,34 @@ type ReferenceToSourceNameMapping = FxIndexMap<SourceReference, SourceNameWithBa
 
 type TaskAndSourceNames = (SourceMapTask, Vec<(SourceReference, SourceNameWithBaseUrl)>);
 
-#[derive(Debug, Clone)]
+pub(crate) struct CompilationSourceMapAsset {
+  source_map: SourceMap<'static>,
+  source_map_json: Option<String>,
+  info: AssetInfo,
+}
+
+impl CompilationSourceMapAsset {
+  fn to_json(&self) -> String {
+    self.source_map.to_json()
+  }
+}
+
+impl From<CompilationSourceMapAsset> for CompilationAsset {
+  fn from(mut asset: CompilationSourceMapAsset) -> Self {
+    let source_map_json = asset
+      .source_map_json
+      .take()
+      .unwrap_or_else(|| asset.to_json());
+    CompilationAsset::new(
+      Some(RawStringSource::from(source_map_json).boxed()),
+      asset.info,
+    )
+  }
+}
+
 pub(crate) struct MappedAsset {
   pub(crate) asset: (Arc<str>, CompilationAsset),
-  pub(crate) asset_append: Vec<BoxSource>,
-  pub(crate) source_map: Option<(String, CompilationAsset)>,
+  pub(crate) source_map: Option<(String, CompilationSourceMapAsset)>,
 }
 
 #[plugin]
@@ -408,7 +437,8 @@ impl SourceMapDevToolPlugin {
     compilation: &Compilation,
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
-    compilation_assets: Vec<(String, &CompilationAsset)>,
+    compilation_assets: Vec<SourceMapInput<'_>>,
+    cache: Option<&mut SourceMapDevToolPluginCacheArtifact>,
   ) -> Result<Vec<MappedAsset>> {
     let map_options = MapOptions::new(self.columns);
 
@@ -421,6 +451,13 @@ impl SourceMapDevToolPlugin {
         &map_options,
       )
       .await?;
+
+    if let Some(cache) = cache {
+      cache.store(tasks.iter().filter_map(|task| {
+        let asset = compilation.assets().get(task.asset_filename.as_ref())?;
+        Some((task.asset_filename.as_ref(), asset, &task.source_map))
+      }));
+    }
 
     self
       .deduplicate_source_names(compilation, &mut reference_to_source_name_mapping)
@@ -442,62 +479,36 @@ impl SourceMapDevToolPlugin {
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
     compilation_assets: Vec<(String, &CompilationAsset)>,
-    cache: Option<&mut SourceMapDevToolPluginCacheArtifact>,
+    mut cache: Option<&mut SourceMapDevToolPluginCacheArtifact>,
     cache_counter: Option<&CacheCount>,
   ) -> Result<Vec<MappedAsset>> {
-    let Some(cache) = cache else {
-      return self
-        .map_assets(compilation, file_to_chunk, output_path, compilation_assets)
-        .await;
+    let source_maps = match cache.as_deref_mut() {
+      Some(cache) => cache.take(
+        compilation_assets
+          .iter()
+          .map(|(asset_filename, asset)| (asset_filename.as_str(), *asset)),
+      ),
+      None => (0..compilation_assets.len()).map(|_| None).collect(),
     };
-
-    let asset_count = compilation_assets.len();
-    let mut mapped_assets = Vec::with_capacity(asset_count);
-    let mut vanilla_assets = Vec::new();
-
-    for (index, (filename, asset)) in compilation_assets.into_iter().enumerate() {
-      if let Some((source_asset, source_map, asset_append)) = cache.take(&filename, asset) {
-        if let Some(counter) = cache_counter {
-          counter.hit();
-        }
-        mapped_assets.push(MappedAsset {
-          asset: (Arc::from(filename), source_asset),
-          asset_append,
-          source_map,
-        });
-        continue;
-      }
-
+    let mut inputs = Vec::with_capacity(compilation_assets.len());
+    for ((asset_filename, asset), source_map) in compilation_assets.into_iter().zip(source_maps) {
       if let Some(counter) = cache_counter {
-        counter.miss();
+        if source_map.is_some() {
+          counter.hit();
+        } else {
+          counter.miss();
+        }
       }
-
-      if vanilla_assets.is_empty() {
-        vanilla_assets.reserve(asset_count - index);
-      }
-      vanilla_assets.push((filename, asset));
+      inputs.push(SourceMapInput {
+        asset_filename,
+        asset,
+        source_map,
+      });
     }
 
-    if !vanilla_assets.is_empty() {
-      let new_mapped_assets = self
-        .map_assets(compilation, file_to_chunk, output_path, vanilla_assets)
-        .await?;
-      mapped_assets.extend(new_mapped_assets);
-    }
-
-    cache.store(mapped_assets.iter().map(|mapped_asset| {
-      (
-        mapped_asset.asset.0.as_ref(),
-        &mapped_asset.asset.1,
-        mapped_asset.asset_append.as_slice(),
-        mapped_asset
-          .source_map
-          .as_ref()
-          .map(|(filename, asset)| (filename.as_str(), asset)),
-      )
-    }));
-
-    Ok(mapped_assets)
+    self
+      .map_assets(compilation, file_to_chunk, output_path, inputs, cache)
+      .await
   }
 
   /// Compute source maps and source names concurrently via `rspack_parallel::scope`.
@@ -507,7 +518,7 @@ impl SourceMapDevToolPlugin {
     compilation: &Compilation,
     file_to_chunk: &HashMap<&str, &Chunk>,
     output_path: &Utf8Path,
-    compilation_assets: Vec<(String, &CompilationAsset)>,
+    compilation_assets: Vec<SourceMapInput<'_>>,
     map_options: &MapOptions,
   ) -> Result<(Vec<SourceMapTask>, ReferenceToSourceNameMapping)> {
     let need_match = self.test.is_some() || self.include.is_some() || self.exclude.is_some();
@@ -529,7 +540,12 @@ impl SourceMapDevToolPlugin {
         _,
         Result<Option<TaskAndSourceNames>>,
       >(|token| {
-        for (asset_filename, asset) in compilation_assets {
+        for SourceMapInput {
+          asset_filename,
+          asset,
+          source_map,
+        } in compilation_assets
+        {
           let is_match = if need_match {
             match_object(&condition_object, &asset_filename)
           } else {
@@ -556,15 +572,20 @@ impl SourceMapDevToolPlugin {
           };
           s.spawn(
             |(plugin, compilation, file_to_chunk, output_path, template, tls)| async move {
-              let source_map = {
-                let object_pool = tls.get_or(ObjectPool::default);
-                match source.clone().map_static(object_pool, &map_options) {
-                  Some(sm) => sm,
-                  None => return Ok(None),
+              let source_map = match source_map {
+                Some(source_map) => source_map,
+                None => {
+                  let object_pool = tls.get_or(ObjectPool::default);
+                  match source.clone().map_static(object_pool, &map_options) {
+                    Some(sm) => sm,
+                    None => return Ok(None),
+                  }
                 }
               };
-
-              let source_references = compute_source_references(compilation, &source_map);
+              let source_references = compute_source_references(
+                compilation,
+                source_map.sources().iter().map(AsRef::as_ref),
+              );
 
               let asset_filename: Arc<str> = Arc::from(asset_filename);
               let unresolved_source_map_path = plugin
@@ -634,48 +655,66 @@ impl SourceMapDevToolPlugin {
       .into_iter()
       .map(|r| r.to_rspack_result().flatten())
       .collect::<Vec<_>>(),
-      ModuleFilenameTemplate::Fn(f) => rspack_parallel::scope::<
-        _,
-        Result<Option<TaskAndSourceNames>>,
-      >(|token| {
-        for (asset_filename, asset) in compilation_assets {
-          let is_match = if need_match {
-            match_object(&condition_object, &asset_filename)
-          } else {
-            true
-          };
-          if !is_match {
-            continue;
-          }
-          let source = match asset.get_source() {
-            Some(s) => s.clone(),
-            None => continue,
-          };
+      ModuleFilenameTemplate::Fn(f) => {
+        rspack_parallel::scope::<_, Result<Option<TaskAndSourceNames>>>(|token| {
+          for SourceMapInput {
+            asset_filename,
+            asset,
+            source_map,
+          } in compilation_assets
+          {
+            let is_match = if need_match {
+              match_object(&condition_object, &asset_filename)
+            } else {
+              true
+            };
+            if !is_match {
+              continue;
+            }
+            let source = match asset.get_source() {
+              Some(s) => s.clone(),
+              None => continue,
+            };
 
-          let asset_filename: Arc<str> = Arc::from(asset_filename);
-          let map_options = map_options.clone();
-          let s = unsafe {
-            token.used((
-              self,
+            let asset_filename: Arc<str> = Arc::from(asset_filename);
+            let map_options = map_options.clone();
+            let s = unsafe {
+              token.used((
+                self,
+                compilation,
+                output_path,
+                f,
+                source,
+                asset_filename,
+                source_map,
+                &tls,
+              ))
+            };
+            s.spawn(
+            |(
+              plugin,
               compilation,
               output_path,
               f,
               source,
               asset_filename,
-              &tls,
-            ))
-          };
-          s.spawn(
-            |(plugin, compilation, output_path, f, source, asset_filename, tls)| async move {
-              let source_map = {
-                let object_pool = tls.get_or(ObjectPool::default);
-                match source.clone().map_static(object_pool, &map_options) {
-                  Some(sm) => sm,
-                  None => return Ok(None),
+              source_map,
+              tls,
+            )| async move {
+              let source_map = match source_map {
+                Some(source_map) => source_map,
+                None => {
+                  let object_pool = tls.get_or(ObjectPool::default);
+                  match source.clone().map_static(object_pool, &map_options) {
+                    Some(sm) => sm,
+                    None => return Ok(None),
+                  }
                 }
               };
-
-              let source_references = compute_source_references(compilation, &source_map);
+              let source_references = compute_source_references(
+                compilation,
+                source_map.sources().iter().map(AsRef::as_ref),
+              );
               let unresolved_source_map_path = plugin
                 .get_unresolved_source_map_path(compilation, output_path, &asset_filename)
                 .await?;
@@ -722,12 +761,13 @@ impl SourceMapDevToolPlugin {
               Ok(Some((task, source_name_entries)))
             },
           );
-        }
-      })
-      .await
-      .into_iter()
-      .map(|r| r.to_rspack_result().flatten())
-      .collect::<Vec<_>>(),
+          }
+        })
+        .await
+        .into_iter()
+        .map(|r| r.to_rspack_result().flatten())
+        .collect::<Vec<_>>()
+      }
     };
 
     let mut tasks: Vec<SourceMapTask> = Vec::with_capacity(results.len());
@@ -904,59 +944,6 @@ impl SourceMapDevToolPlugin {
     mapped_assets.into_iter().collect::<Result<Vec<_>>>()
   }
 
-  fn source_map_to_json<'a>(
-    &'a self,
-    mut source_map: SourceMap<'a>,
-    reference_to_source_name_mapping: &'a ReferenceToSourceNameMapping,
-    asset_filename: &'a str,
-    source_map_path: Option<&'a Utf8Path>,
-    source_references: &'a [SourceReference],
-    debug_id: Option<&'a str>,
-  ) -> String {
-    // Update source_map with deduplicated source names
-    source_map.set_file(Some(Cow::Borrowed(asset_filename)));
-    source_map.set_sources(source_references.iter().map(|source_reference| {
-      reference_to_source_name_mapping
-        .get(source_reference)
-        .unwrap_or_else(|| {
-          panic!(
-            "SourceMapDevToolPlugin: missing source name for reference '{source_reference:?}' in asset '{asset_filename}'."
-          )
-        })
-        .render_for_source_map(source_map_path)
-    }));
-
-    if let Some(asset_conditions) = &self.ignore_list {
-      let ignore_list = source_map
-        .sources()
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, source)| {
-          if asset_conditions.try_match(source) {
-            Some(idx as u32)
-          } else {
-            None
-          }
-        })
-        .collect::<Vec<_>>();
-      source_map.set_ignore_list(Some(Cow::Owned(ignore_list)));
-    }
-
-    if self.no_sources {
-      source_map.set_sources_content(vec![]);
-    }
-
-    if let Some(source_root) = &self.source_root {
-      source_map.set_source_root(Some(Cow::Borrowed(source_root.as_ref())));
-    }
-
-    if let Some(debug_id) = debug_id {
-      source_map.set_debug_id(Some(Cow::Borrowed(debug_id)));
-    }
-
-    source_map.to_json()
-  }
-
   /// Create a single MappedAsset: update the source map and emit asset + optional source map file.
   #[allow(clippy::too_many_arguments)]
   async fn create_mapped_asset(
@@ -966,24 +953,57 @@ impl SourceMapDevToolPlugin {
     reference_to_source_name_mapping: &ReferenceToSourceNameMapping,
     asset_filename: Arc<str>,
     source: BoxSource,
-    source_map: SourceMap<'static>,
+    mut source_map: SourceMap<'static>,
     unresolved_source_map_path: Option<Utf8PathBuf>,
     source_references: Vec<SourceReference>,
   ) -> Result<MappedAsset> {
-    // Generate debug ID and serialize source map
     let debug_id = plugin
       .debug_ids
       .then(|| generate_debug_id(&asset_filename, &source.buffer()));
-    let asset_filename_ref = asset_filename.as_ref();
-
-    let source_map_json = plugin.source_map_to_json(
-      source_map.as_borrowed(),
-      reference_to_source_name_mapping,
-      asset_filename_ref,
-      unresolved_source_map_path.as_ref().map(|p| p.as_path()),
-      &source_references,
-      debug_id.as_deref(),
-    );
+    let sources = source_references
+      .into_iter()
+      .map(|source_reference| {
+        reference_to_source_name_mapping
+          .get(&source_reference)
+          .unwrap_or_else(|| {
+            panic!(
+              "SourceMapDevToolPlugin: missing source name for reference '{source_reference:?}' in asset '{asset_filename}'."
+            )
+          })
+          .render_for_source_map(unresolved_source_map_path.as_deref())
+          .into_owned()
+      })
+      .collect::<Vec<_>>();
+    let ignore_list = plugin.ignore_list.as_ref().map(|asset_conditions| {
+      sources
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, source)| asset_conditions.try_match(source).then_some(idx as u32))
+        .collect::<Vec<_>>()
+    });
+    source_map.set_sources(sources);
+    if plugin.no_sources {
+      source_map.set_sources_content(Vec::new());
+    }
+    source_map.set_file(Some(Cow::Owned(asset_filename.to_string())));
+    if let Some(source_root) = plugin.source_root.as_deref() {
+      source_map.set_source_root(Some(Cow::Owned(source_root.to_string())));
+    }
+    if let Some(debug_id) = debug_id.as_ref() {
+      source_map.set_debug_id(Some(Cow::Owned(debug_id.clone())));
+    }
+    if let Some(ignore_list) = ignore_list {
+      source_map.set_ignore_list(Some(Cow::Owned(ignore_list)));
+    }
+    let mut source_map_asset_info = AssetInfo::default().with_development(Some(true));
+    if let Some(asset) = compilation.assets().get(asset_filename.as_ref()) {
+      source_map_asset_info.version = asset.info.version.clone();
+    }
+    let mut source_map_asset = CompilationSourceMapAsset {
+      source_map,
+      source_map_json: None,
+      info: source_map_asset_info,
+    };
 
     let mut asset = compilation
       .assets()
@@ -1024,9 +1044,11 @@ impl SourceMapDevToolPlugin {
 
       let content_hash_digest =
         if chunk.is_some() && has_content_hash_placeholder(source_map_filename_config.as_str()) {
+          let source_map_json = source_map_asset.to_json();
           let mut hasher = RspackHasher::from(&compilation.options.output);
           source_map_json.hash(&mut hasher);
           let digest = hasher.digest(&compilation.options.output.hash_digest);
+          source_map_asset.source_map_json = Some(source_map_json);
           Some(digest)
         } else {
           None
@@ -1049,80 +1071,61 @@ impl SourceMapDevToolPlugin {
         .get_asset_path(source_map_filename_config, data)
         .await?;
 
-      let asset_append =
-        if let Some(current_source_mapping_url_comment) = current_source_mapping_url_comment {
-          let source_map_url = if let Some(public_path) = &plugin.public_path {
-            format!("{public_path}{source_map_filename}")
-          } else {
-            let mut file_path = PathBuf::new();
-            file_path.push(Component::RootDir);
-            file_path.extend(Path::new(filename.as_ref()).components());
-
-            let mut source_map_path = PathBuf::new();
-            source_map_path.push(Component::RootDir);
-            source_map_path.extend(Path::new(&source_map_filename).components());
-
-            source_map_path
-              .relative(
-                #[allow(clippy::unwrap_used)]
-                file_path.parent().unwrap(),
-              )
-              .to_string_lossy()
-              .to_string()
-          };
-          let data = data.url(&source_map_url);
-          let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
-            SourceMappingUrlCommentRef::String(s) => {
-              compilation
-                .get_asset_path(&Filename::from(s.as_ref()), data)
-                .await?
-            }
-            SourceMappingUrlCommentRef::Fn(f) => {
-              let comment = f(data).await?;
-              Filename::from(comment).render(data, None).await?
-            }
-          };
-          let current_source_mapping_url_comment = current_source_mapping_url_comment
-            .cow_replace("[url]", &source_map_url)
-            .into_owned();
-
-          let debug_id_comment = debug_id
-            .map(|id| format!("\n//# debugId={id}"))
-            .map(|comment| RawStringSource::from(comment).boxed());
-          let current_source_mapping_url_comment =
-            RawStringSource::from(current_source_mapping_url_comment).boxed();
-          let mut asset_append = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 1);
-          if let Some(debug_id_comment) = &debug_id_comment {
-            asset_append.push(debug_id_comment.clone());
-          }
-          asset_append.push(current_source_mapping_url_comment.clone());
-
-          let mut children = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 2);
-          children.push(source.clone());
-          if let Some(debug_id_comment) = debug_id_comment {
-            children.push(debug_id_comment);
-          }
-          children.push(current_source_mapping_url_comment);
-          asset.source = Some(ConcatSource::new(children).boxed());
-          asset.info.related.source_map = Some(source_map_filename.clone());
-          asset_append
+      if let Some(current_source_mapping_url_comment) = current_source_mapping_url_comment {
+        let source_map_url = if let Some(public_path) = &plugin.public_path {
+          format!("{public_path}{source_map_filename}")
         } else {
-          asset.source = Some(source.clone());
-          Vec::new()
+          let mut file_path = PathBuf::new();
+          file_path.push(Component::RootDir);
+          file_path.extend(Path::new(filename.as_ref()).components());
+
+          let mut source_map_path = PathBuf::new();
+          source_map_path.push(Component::RootDir);
+          source_map_path.extend(Path::new(&source_map_filename).components());
+
+          source_map_path
+            .relative(
+              #[allow(clippy::unwrap_used)]
+              file_path.parent().unwrap(),
+            )
+            .to_string_lossy()
+            .to_string()
         };
-      let mut source_map_asset_info = AssetInfo::default().with_development(Some(true));
-      if let Some(asset) = compilation.assets().get(asset_filename.as_ref()) {
-        // set source map asset version to be the same as the target asset
-        source_map_asset_info.version = asset.info.version.clone();
+        let data = data.url(&source_map_url);
+        let current_source_mapping_url_comment = match &current_source_mapping_url_comment {
+          SourceMappingUrlCommentRef::String(s) => {
+            compilation
+              .get_asset_path(&Filename::from(s.as_ref()), data)
+              .await?
+          }
+          SourceMappingUrlCommentRef::Fn(f) => {
+            let comment = f(data).await?;
+            Filename::from(comment).render(data, None).await?
+          }
+        };
+        let current_source_mapping_url_comment = current_source_mapping_url_comment
+          .cow_replace("[url]", &source_map_url)
+          .into_owned();
+
+        let debug_id_comment = debug_id
+          .map(|id| format!("\n//# debugId={id}"))
+          .map(|comment| RawStringSource::from(comment).boxed());
+        let current_source_mapping_url_comment =
+          RawStringSource::from(current_source_mapping_url_comment).boxed();
+        let mut children = Vec::with_capacity(usize::from(debug_id_comment.is_some()) + 2);
+        children.push(source);
+        if let Some(debug_id_comment) = debug_id_comment {
+          children.push(debug_id_comment);
+        }
+        children.push(current_source_mapping_url_comment);
+        asset.source = Some(ConcatSource::new(children).boxed());
+        asset.info.related.source_map = Some(source_map_filename.clone());
+      } else {
+        asset.source = Some(source);
       }
-      let source_map_asset = CompilationAsset::new(
-        Some(RawStringSource::from(source_map_json).boxed()),
-        source_map_asset_info,
-      );
       Ok(MappedAsset {
         asset: (asset_filename, asset),
-        source_map: Some((source_map_filename.clone(), source_map_asset)),
-        asset_append,
+        source_map: Some((source_map_filename, source_map_asset)),
       })
     } else {
       let current_source_mapping_url_comment = current_source_mapping_url_comment
@@ -1135,6 +1138,7 @@ impl SourceMapDevToolPlugin {
           ));
         }
       };
+      let source_map_json = source_map_asset.to_json();
       let base64 = base64::encode_to_string(source_map_json.as_bytes());
       let append = current_source_mapping_url_comment
         .cow_replace(
@@ -1143,11 +1147,9 @@ impl SourceMapDevToolPlugin {
         )
         .into_owned();
       let append = RawStringSource::from(append).boxed();
-      let asset_append = vec![append.clone()];
-      asset.source = Some(ConcatSource::new([source.clone(), append]).boxed());
+      asset.source = Some(ConcatSource::new([source, append]).boxed());
       Ok(MappedAsset {
         asset: (asset_filename, asset),
-        asset_append,
         source_map: None,
       })
     }
@@ -1232,12 +1234,20 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   }
 
   let start = logger.time("emit source map assets");
-  for mapped_asset in mapped_assets {
-    let MappedAsset {
-      asset: (source_filename, mut source_asset),
-      source_map,
-      ..
-    } = mapped_asset;
+  let emit_source_map = self.source_map_filename.is_some();
+  let mapped_assets = mapped_assets
+    .into_par_iter()
+    .map(|mapped_asset| {
+      let MappedAsset { asset, source_map } = mapped_asset;
+      let source_map = if emit_source_map {
+        source_map.map(|(filename, asset)| (filename, CompilationAsset::from(asset)))
+      } else {
+        None
+      };
+      (asset, source_map)
+    })
+    .collect::<Vec<_>>();
+  for ((source_filename, mut source_asset), source_map) in mapped_assets {
     if let Some(asset) = compilation.assets_mut().remove(source_filename.as_ref()) {
       source_asset.info = asset.info;
       if let Some((ref source_map_filename, _)) = source_map {

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -429,13 +429,13 @@ impl<'a> SourceMap<'a> {
   }
 }
 
-impl SourceMap<'static> {
+impl<'a> SourceMap<'a> {
   /// Create a [SourceMap].
   pub fn new(
-    mappings: impl Into<Cow<'static, str>>,
-    sources: Vec<Cow<'static, str>>,
-    sources_content: Vec<Cow<'static, str>>,
-    names: Vec<Cow<'static, str>>,
+    mappings: impl Into<Cow<'a, str>>,
+    sources: Vec<Cow<'a, str>>,
+    sources_content: Vec<Cow<'a, str>>,
+    names: Vec<Cow<'a, str>>,
   ) -> Self {
     Self {
       owner: None,
@@ -451,6 +451,17 @@ impl SourceMap<'static> {
         ignore_list: None,
       },
     }
+  }
+}
+
+impl SourceMap<'static> {
+  /// Create a source map that can borrow from an owned [Source].
+  pub fn with_owner(
+    owner: BoxSource,
+    create: impl for<'a> FnOnce(&'a dyn Source) -> Option<SourceMap<'a>>,
+  ) -> Option<Self> {
+    let borrowed_owner = owner.clone();
+    create(borrowed_owner.as_ref()).map(|source_map| source_map.into_static(owner))
   }
 
   /// Create a [SourceMap] from bytes.

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -456,12 +456,12 @@ impl<'a> SourceMap<'a> {
 
 impl SourceMap<'static> {
   /// Create a source map that can borrow from an owned [Source].
-  pub fn with_owner(
-    owner: BoxSource,
+  pub fn with_source(
+    source: BoxSource,
     create: impl for<'a> FnOnce(&'a dyn Source) -> Option<SourceMap<'a>>,
   ) -> Option<Self> {
-    let borrowed_owner = owner.clone();
-    create(borrowed_owner.as_ref()).map(|source_map| source_map.into_static(owner))
+    let borrowed_source = source.clone();
+    create(borrowed_source.as_ref()).map(|source_map| source_map.into_static(source))
   }
 
   /// Create a [SourceMap] from bytes.


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- stores compact source map metadata and source-content ordinals instead of `sourcesContent` or rendered source map assets;
- restores `sourcesContent` by borrowing strings from the current asset's `Source` tree;
- stores only the debug ID and `sourceMappingURL` comments required to reconstruct the final asset;
- stores the final rendered comment for external source maps, while retaining `[url]` for inline source maps and regenerating the complete base64 data URL on cache hits;
- uses the source map filename to distinguish inline source maps from separately emitted source map assets;
- parallelizes cache construction and restoration across assets;
- falls back to recomputation and removes invalid cache entries when source content cannot be restored.

As a result, persistent cache size primarily scales with mappings, source map metadata, compact `u32` indices, and small comment strings, while cache hits can still skip the expensive source map computation for both inline and external source maps.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
