### PR TITLE
perf: share source across linking diagnostics

### DIFF
--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -3,7 +3,8 @@ use rspack_error::Result;
 
 use super::*;
 use crate::{
-  OptimizationBailoutItem, SideEffectsStateArtifact, cache::Cache, logger::Logger, pass::PassExt,
+  DependencyDiagnosticsContext, OptimizationBailoutItem, SideEffectsStateArtifact, cache::Cache,
+  logger::Logger, pass::PassExt,
 };
 
 pub struct FinishModulesPhasePass;
@@ -205,13 +206,19 @@ fn collect_dependencies_diagnostics(
       let mgm = module_graph
         .module_graph_module_by_identifier(module_identifier)
         .expect("should have mgm");
+      let diagnostics_context = DependencyDiagnosticsContext::default();
       let diagnostics = mgm
         .all_dependencies()
         .iter()
         .filter_map(|dependency_id| {
           let dependency = module_graph.dependency_by_id(dependency_id);
           dependency
-            .get_diagnostics(module_graph, module_graph_cache, exports_info_artifact)
+            .get_diagnostics_with_context(
+              module_graph,
+              module_graph_cache,
+              exports_info_artifact,
+              &diagnostics_context,
+            )
             .map(|diagnostics| {
               diagnostics.into_iter().map(|mut diagnostic| {
                 diagnostic.module_identifier = Some(*module_identifier);

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -50,24 +50,6 @@ impl DependencyDiagnosticsContext {
   }
 }
 
-#[cfg(test)]
-mod dependency_diagnostics_context_tests {
-  use super::*;
-
-  #[test]
-  fn shares_lazily_materialized_module_source() {
-    let context = DependencyDiagnosticsContext::default();
-    let first = context
-      .get_or_init_module_source(|| Some(Arc::from("module source")))
-      .expect("should initialize source");
-    let second = context
-      .get_or_init_module_source(|| panic!("source should only be initialized once"))
-      .expect("should reuse source");
-
-    assert!(Arc::ptr_eq(&first, &second));
-  }
-}
-
 #[cacheable_dyn]
 pub trait Dependency:
   AsDependencyCodeGeneration

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -1,4 +1,8 @@
-use std::{any::Any, fmt::Debug};
+use std::{
+  any::Any,
+  fmt::Debug,
+  sync::{Arc, OnceLock},
+};
 
 use dyn_clone::{DynClone, clone_trait_object};
 use rspack_cacheable::cacheable_dyn;
@@ -13,8 +17,9 @@ use super::{
 };
 use crate::{
   AsContextDependency, ConnectionState, Context, ExportsInfoArtifact, ForwardId, ImportAttributes,
-  ImportPhase, JavascriptParserUrl, LazyUntil, ModuleGraph, ModuleGraphCacheArtifact, ModuleLayer,
-  ReferencedExport, RuntimeSpec, SideEffectsStateArtifact, create_exports_object_referenced,
+  ImportPhase, JavascriptParserUrl, LazyUntil, Module, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleLayer, ReferencedExport, RuntimeSpec, SideEffectsStateArtifact,
+  create_exports_object_referenced,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -22,6 +27,45 @@ pub enum AffectType {
   True,
   False,
   Transitive,
+}
+
+/// Module-scoped state shared while collecting diagnostics from its dependencies.
+#[derive(Debug, Default)]
+pub struct DependencyDiagnosticsContext {
+  module_source: OnceLock<Option<Arc<str>>>,
+}
+
+impl DependencyDiagnosticsContext {
+  fn get_or_init_module_source(&self, init: impl FnOnce() -> Option<Arc<str>>) -> Option<Arc<str>> {
+    self.module_source.get_or_init(init).clone()
+  }
+
+  /// Lazily materialize the module source once and share it across its diagnostics.
+  pub fn module_source(&self, module: &dyn Module) -> Option<Arc<str>> {
+    self.get_or_init_module_source(|| {
+      module
+        .source()
+        .map(|source| source.source().into_string_lossy().into())
+    })
+  }
+}
+
+#[cfg(test)]
+mod dependency_diagnostics_context_tests {
+  use super::*;
+
+  #[test]
+  fn shares_lazily_materialized_module_source() {
+    let context = DependencyDiagnosticsContext::default();
+    let first = context
+      .get_or_init_module_source(|| Some(Arc::from("module source")))
+      .expect("should initialize source");
+    let second = context
+      .get_or_init_module_source(|| panic!("source should only be initialized once"))
+      .expect("should reuse source");
+
+    assert!(Arc::ptr_eq(&first, &second));
+  }
 }
 
 #[cacheable_dyn]
@@ -110,6 +154,16 @@ pub trait Dependency:
     _exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
     None
+  }
+
+  fn get_diagnostics_with_context(
+    &self,
+    module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
+    _context: &DependencyDiagnosticsContext,
+  ) -> Option<Vec<Diagnostic>> {
+    self.get_diagnostics(module_graph, module_graph_cache, exports_info_artifact)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -9,10 +9,11 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, ChunkGraph, ConditionalInitFragment, ConnectionState, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyCondition, DependencyConditionFn,
-  DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, DetermineExportAssignmentsKey, ESMExportBinding, ESMExportInitFragment,
-  ExportMode, ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
-  ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
+  DependencyDiagnosticsContext, DependencyId, DependencyLocation, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, DetermineExportAssignmentsKey,
+  ESMExportBinding, ESMExportInitFragment, ExportMode, ExportModeDynamicReexport,
+  ExportModeEmptyStar, ExportModeFakeNamespaceObject, ExportModeNormalReexport,
+  ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
   ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
   ExportsInfoData, ExportsOfExportsSpec, ExportsSpec, ExportsType, FactorizeInfo, ForwardId,
@@ -1039,6 +1040,7 @@ impl ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     should_error: bool,
+    diagnostics_context: &DependencyDiagnosticsContext,
   ) -> Option<Vec<Diagnostic>> {
     let create_error = |message: String| {
       let (severity, title) = if should_error {
@@ -1051,10 +1053,10 @@ impl ESMExportImportedSpecifierDependency {
         .expect("should have parent module for dependency");
       let mut error = if let Some(span) = self.range()
         && let Some(parent_module) = module_graph.module_by_identifier(parent_module_identifier)
-        && let Some(source) = parent_module.source()
+        && let Some(source) = diagnostics_context.module_source(parent_module.as_ref())
       {
-        Error::from_string(
-          Some(source.source().into_string_lossy().into_owned()),
+        Error::from_shared_source(
+          Some(source),
           span.start as usize,
           span.end as usize,
           title.to_string(),
@@ -1423,6 +1425,21 @@ impl Dependency for ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
+    self.get_diagnostics_with_context(
+      module_graph,
+      module_graph_cache,
+      exports_info_artifact,
+      &DependencyDiagnosticsContext::default(),
+    )
+  }
+
+  fn get_diagnostics_with_context(
+    &self,
+    module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
+    diagnostics_context: &DependencyDiagnosticsContext,
+  ) -> Option<Vec<Diagnostic>> {
     let module = module_graph.get_parent_module(&self.id)?;
     let module = module_graph.module_by_identifier(module)?;
     let ids = self.get_ids(module_graph);
@@ -1442,6 +1459,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
           name,
           true,
           should_error,
+          diagnostics_context,
         )
       {
         diagnostics.push(error);
@@ -1452,6 +1470,7 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         module_graph_cache,
         exports_info_artifact,
         should_error,
+        diagnostics_context,
       ) {
         diagnostics.extend(errors);
       }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -3,11 +3,12 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AwaitDependenciesInitFragment, BuildMetaDefaultObject, ChunkGraph,
   ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
-  DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportProvided, ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId, ImportAttributes,
-  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LazyUntil, ModuleDependency,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ProvidedExports, ReferencedExport,
+  DependencyCodeGeneration, DependencyCondition, DependencyConditionFn,
+  DependencyDiagnosticsContext, DependencyId, DependencyLocation, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportProvided, ExportsInfoArtifact,
+  ExportsType, FactorizeInfo, ForwardId, ImportAttributes, ImportPhase, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, LazyUntil, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ProvidedExports, ReferencedExport,
   ResourceIdentifier, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, SourceType,
   TemplateContext, TemplateReplaceSource, TypeReexportPresenceMode, filter_runtime,
 };
@@ -282,6 +283,7 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
   name: &Atom,
   is_reexport: bool,
   should_error: bool,
+  diagnostics_context: &DependencyDiagnosticsContext,
 ) -> Option<Diagnostic> {
   let imported_module = module_graph.get_module_by_dependency_id(module_dependency.id())?;
   if imported_module.first_error().is_some() {
@@ -313,10 +315,10 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       (Severity::Warning, "ESModulesLinkingWarning")
     };
     let mut error = if let Some(span) = module_dependency.range()
-      && let Some(source) = parent_module.source()
+      && let Some(source) = diagnostics_context.module_source(parent_module.as_ref())
     {
-      Error::from_string(
-        Some(source.source().into_string_lossy().into_owned()),
+      Error::from_shared_source(
+        Some(source),
         span.start as usize,
         span.end as usize,
         title.to_string(),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -5,13 +5,14 @@ use rspack_cacheable::{
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
-  DependencyCondition, DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExportPresenceMode, ExportProvided,
-  ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId, ImportAttributes, ImportPhase,
-  JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport, ResourceIdentifier, RuntimeSpec,
-  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedByExports, UsedName,
-  create_exports_object_referenced, property_access, to_normal_comment,
+  DependencyCondition, DependencyConditionFn, DependencyDiagnosticsContext, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ExportPresenceMode, ExportProvided, ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId,
+  ImportAttributes, ImportPhase, JavascriptParserOptions, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport,
+  ResourceIdentifier, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
+  TemplateReplaceSource, UsedByExports, UsedName, create_exports_object_referenced,
+  property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHasher};
@@ -239,6 +240,21 @@ impl Dependency for ESMImportSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
+    self.get_diagnostics_with_context(
+      module_graph,
+      module_graph_cache,
+      exports_info_artifact,
+      &DependencyDiagnosticsContext::default(),
+    )
+  }
+
+  fn get_diagnostics_with_context(
+    &self,
+    module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
+    diagnostics_context: &DependencyDiagnosticsContext,
+  ) -> Option<Vec<Diagnostic>> {
     let module = module_graph.get_parent_module(&self.id)?;
     let module = module_graph.module_by_identifier(module)?;
     let should_error = self
@@ -260,6 +276,7 @@ impl Dependency for ESMImportSpecifierDependency {
       &self.name,
       false,
       should_error,
+      diagnostics_context,
     ) {
       return Some(vec![diagnostic]);
     }


### PR DESCRIPTION
## Summary

Share each module's source across dependency diagnostics instead of materializing a full source copy for every ESM linking warning.

Linking diagnostics are collected per dependency, so projects with many warnings from large generated modules could retain memory proportional to `warning count × module source size`. A module-scoped lazy diagnostic context now materializes the source once and reuses it for import, re-export, and conflicting star-export diagnostics.

In the reproduction from #14961, doubling warnings from 303 to 603 increased peak footprint by about 169 MB on 2.1.7, versus about 4 MB with this change.

Related to #14961.