### PR TITLE
feat: align persistent cache storage options with webpack

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -127,18 +127,22 @@ function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
     return value;
   };
   return {
-    ...cache,
+    type: cache.type,
+    buildDependencies: cache.buildDependencies,
+    version: cache.version,
     maxAge: toRawStorageLimit('cache.maxAge', cache.maxAge!),
     maxVersions: toRawStorageLimit('cache.maxVersions', cache.maxVersions!),
     storage: {
-      ...cache.storage,
-      directory: cache.storage.directory!,
+      type: cache.storage.type,
+      directory: cache.storage.location!,
     },
     snapshot: {
       immutablePaths: cache.snapshot.immutablePaths!,
       unmanagedPaths: cache.snapshot.unmanagedPaths!,
       managedPaths: cache.snapshot.managedPaths!,
     },
+    portable: cache.portable,
+    readonly: cache.readonly,
   };
 }
 

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -134,6 +134,7 @@ function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
     maxVersions: toRawStorageLimit('cache.maxVersions', cache.maxVersions!),
     storage: {
       type: cache.storage.type,
+      // Raw `directory` expects the final cache path; normalized `directory` is only the base.
       directory: cache.storage.location!,
     },
     snapshot: {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -60,7 +60,7 @@ import type {
 
 const ERROR_PREFIX = 'Invalid Rspack configuration:';
 const DEFAULT_FILESYSTEM_CACHE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
-const DEFAULT_CACHE_NAME = 'default';
+const DEFAULT_CACHE_NAME = '';
 
 export const applyRspackOptionsDefaults = (
   options: RspackOptionsNormalized,
@@ -105,8 +105,8 @@ export const applyRspackOptionsDefaults = (
   );
   applyCacheDefaults(options.cache!, {
     context: options.context!,
-    name: options.name,
-    mode: options.mode,
+    name: options.name || DEFAULT_CACHE_NAME,
+    mode: options.mode || 'production',
     compilerIndex,
   });
 
@@ -220,8 +220,8 @@ const applyCacheDefaults = (
     compilerIndex,
   }: {
     context: string;
-    name?: Name;
-    mode?: Mode;
+    name: Name;
+    mode: Mode;
     compilerIndex?: number;
   },
 ) => {
@@ -231,7 +231,7 @@ const applyCacheDefaults = (
       break;
     case 'persistent':
       F(cache, 'name', () => {
-        const cacheName = `${name || DEFAULT_CACHE_NAME}-${mode || 'production'}`;
+        const cacheName = name ? `${name}-${mode}` : mode;
         return compilerIndex !== undefined
           ? `${cacheName}__compiler${compilerIndex + 1}__`
           : cacheName;

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -60,6 +60,7 @@ import type {
 
 const ERROR_PREFIX = 'Invalid Rspack configuration:';
 const DEFAULT_FILESYSTEM_CACHE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_CACHE_NAME = 'default';
 
 export const applyRspackOptionsDefaults = (
   options: RspackOptionsNormalized,
@@ -229,6 +230,19 @@ const applyCacheDefaults = (
     case 'memory':
       break;
     case 'persistent':
+      F(cache, 'name', () => {
+        const cacheName = `${name || DEFAULT_CACHE_NAME}-${mode || 'production'}`;
+        return compilerIndex !== undefined
+          ? `${cacheName}__compiler${compilerIndex + 1}__`
+          : cacheName;
+      });
+      D(cache.storage, 'type', 'filesystem');
+      F(cache.storage, 'directory', () =>
+        path.resolve(context, 'node_modules/.cache/rspack'),
+      );
+      F(cache.storage, 'location', () =>
+        path.resolve(cache.storage.directory!, cache.name!),
+      );
       D(cache, 'version', '');
       D(cache, 'maxAge', DEFAULT_FILESYSTEM_CACHE_MAX_AGE_SECONDS);
       D(cache, 'maxVersions', 3);
@@ -236,15 +250,6 @@ const applyCacheDefaults = (
       F(cache.snapshot, 'immutablePaths', () => []);
       F(cache.snapshot, 'unmanagedPaths', () => []);
       F(cache.snapshot, 'managedPaths', () => [/[\\/]node_modules[\\/][^.]/]);
-      D(cache.storage, 'type', 'filesystem');
-      F(cache.storage, 'directory', () => {
-        const modeName = mode || 'production';
-        const compilerName = name ? `${name}-${modeName}` : modeName;
-        const cacheName = compilerIndex
-          ? `${compilerName}-${compilerIndex}`
-          : compilerName;
-        return path.resolve(context, 'node_modules/.cache/rspack', cacheName);
-      });
       D(cache, 'portable', false);
       D(cache, 'readonly', false);
       break;

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -232,8 +232,8 @@ const applyCacheDefaults = (
     case 'persistent':
       F(cache, 'name', () => {
         const cacheName = name ? `${name}-${mode}` : mode;
-        return compilerIndex !== undefined
-          ? `${cacheName}__compiler${compilerIndex + 1}__`
+        return compilerIndex !== undefined && compilerIndex > 0
+          ? `${cacheName}-${compilerIndex}`
           : cacheName;
       });
       D(cache.storage, 'type', 'filesystem');

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -288,6 +288,7 @@ export const getNormalizedRspackOptions = (
           const context = config.context || process.cwd();
           return {
             type: 'persistent',
+            name: cache.name,
             version: cache.version,
             maxAge: cache.maxAge,
             maxVersions: cache.maxVersions,
@@ -311,8 +312,11 @@ export const getNormalizedRspackOptions = (
             })),
             storage: nestedConfig(cache.storage, (storage) => ({
               type: storage.type,
-              directory: optionalNestedConfig(storage.directory, (d) =>
-                path.resolve(context, d),
+              directory: optionalNestedConfig(storage.directory, (directory) =>
+                path.resolve(context, directory),
+              ),
+              location: optionalNestedConfig(storage.location, (location) =>
+                path.resolve(context, location),
               ),
             })),
           };
@@ -614,6 +618,7 @@ export type CacheNormalized =
     }
   | {
       type: 'persistent';
+      name?: string;
       buildDependencies: string[];
       version?: string;
       maxAge?: number;
@@ -626,6 +631,7 @@ export type CacheNormalized =
       storage: {
         type: 'filesystem';
         directory?: string;
+        location?: string;
       };
       portable?: boolean;
       readonly?: boolean;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2061,10 +2061,15 @@ export type CacheStorageOptions = {
    */
   type: 'filesystem';
   /**
-   * Cache directory path.
-   * @default 'node_modules/.cache/rspack/<name>-<mode>-<compilerIndex>'
+   * Base directory for the cache.
+   * @default 'node_modules/.cache/rspack'
    */
   directory?: string;
+  /**
+   * Location of the cache data.
+   * @default '<directory>/<cache.name>'
+   */
+  location?: string;
 };
 
 /**
@@ -2075,6 +2080,11 @@ export type PersistentCacheOptions = {
    * Cache type.
    */
   type: 'persistent';
+  /**
+   * Name for the cache. Different names create coexisting caches.
+   * @default '<config.name || "default">-<mode>'
+   */
+  name?: string;
   /**
    * An array of files containing build dependencies, Rspack will use the hash of each of these files to invalidate the persistent cache.
    * @default []

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2082,7 +2082,7 @@ export type PersistentCacheOptions = {
   type: 'persistent';
   /**
    * Name for the cache. Different names create coexisting caches.
-   * @default '<config.name || "default">-<mode>'
+   * @default '<config.name>-<mode>' when config.name is set, otherwise '<mode>'
    */
   name?: string;
   /**

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -69,8 +69,8 @@ export default defineConfig<RspackOptions>({
               cache.storage = {
                 type: 'filesystem',
                 ...cache.storage,
-                //rewrite directory
-                directory: 'node_modules/.cache/incremental',
+                // Rewrite the complete cache location.
+                location: 'node_modules/.cache/incremental',
               };
             }
             return config;

--- a/tests/rspack-test/cacheCases/storage/directory/rspack.config.js
+++ b/tests/rspack-test/cacheCases/storage/directory/rspack.config.js
@@ -1,13 +1,15 @@
 const path = require('path');
 const fs = require('fs/promises');
 
-const cacheDir = path.join(__dirname, 'node_modules/.cache/test/');
+const cacheDir = path.join(__dirname, 'node_modules/.cache/test');
+const cacheLocation = path.join(cacheDir, 'test-cache');
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
   context: __dirname,
   cache: {
     type: 'persistent',
+    name: 'test-cache',
     storage: {
       type: 'filesystem',
       directory: cacheDir,
@@ -17,7 +19,10 @@ module.exports = {
     {
       apply(compiler) {
         compiler.hooks.done.tapPromise('Test Plugin', async function () {
-          const stat = await fs.stat(cacheDir);
+          expect(compiler.options.cache.name).toBe('test-cache');
+          expect(compiler.options.cache.storage.directory).toBe(cacheDir);
+          expect(compiler.options.cache.storage.location).toBe(cacheLocation);
+          const stat = await fs.stat(cacheLocation);
           expect(stat.isDirectory()).toBeTruthy();
         });
       },

--- a/tests/rspack-test/cacheCases/storage/max-age/rspack.config.js
+++ b/tests/rspack-test/cacheCases/storage/max-age/rspack.config.js
@@ -3,7 +3,7 @@ const path = require('node:path');
 
 const cacheDir = path.join(__dirname, 'node_modules/.cache/max-age');
 // Change cache.version between restarts to create multiple persistent cache
-// versions under the same storage directory.
+// versions under the same cache location.
 const cacheVersions = ['v1', 'v2', 'v3'];
 let buildIndex = 0;
 let expiredGeneration;
@@ -46,7 +46,7 @@ module.exports = {
     maxAge: 1,
     storage: {
       type: 'filesystem',
-      directory: cacheDir,
+      location: cacheDir,
     },
   },
   plugins: [

--- a/tests/rspack-test/cacheCases/storage/max-versions/rspack.config.js
+++ b/tests/rspack-test/cacheCases/storage/max-versions/rspack.config.js
@@ -3,7 +3,7 @@ const path = require('node:path');
 
 const cacheDir = path.join(__dirname, 'node_modules/.cache/max-versions');
 // Change cache.version between restarts to create multiple persistent cache
-// versions under the same storage directory.
+// versions under the same cache location.
 const cacheVersions = ['v1', 'v2', 'v3', 'v4'];
 let buildIndex = 0;
 let firstVersion;
@@ -42,7 +42,7 @@ module.exports = {
     maxVersions: 2,
     storage: {
       type: 'filesystem',
-      directory: cacheDir,
+      location: cacheDir,
     },
   },
   plugins: [

--- a/tests/rspack-test/compilerCases/persistent-cache-advanced-tree-shaking.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-advanced-tree-shaking.js
@@ -38,7 +38,7 @@ module.exports = {
           buildDependencies: [__filename],
           storage: {
             type: "filesystem",
-            directory: context.getDist(CACHE_DIR)
+            location: context.getDist(CACHE_DIR)
           }
         }
       },

--- a/tests/rspack-test/compilerCases/persistent-cache-inner-graph-deferred-pure.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-inner-graph-deferred-pure.js
@@ -39,7 +39,7 @@ module.exports = {
 					buildDependencies: [__filename],
 					storage: {
 						type: "filesystem",
-						directory: context.getDist(CACHE_DIR)
+						location: context.getDist(CACHE_DIR)
 					}
 				}
 			},

--- a/tests/rspack-test/compilerCases/persistent-cache-max-versions-child-compilers.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-max-versions-child-compilers.js
@@ -63,7 +63,7 @@ const runCompiler = (context, cacheDirectory, version) =>
 				maxVersions: 2,
 				storage: {
 					type: "filesystem",
-					directory: cacheDirectory
+					location: cacheDirectory
 				}
 			},
 			plugins: [new ChildCompilersPlugin()]

--- a/tests/rspack-test/compilerCases/persistent-isolated-dts.js
+++ b/tests/rspack-test/compilerCases/persistent-isolated-dts.js
@@ -51,7 +51,7 @@ module.exports = {
           buildDependencies: [__filename],
           storage: {
             type: "filesystem",
-            directory: context.getDist(CACHE_DIR)
+            location: context.getDist(CACHE_DIR)
           }
         }
       },

--- a/tests/rspack-test/defaultsCases/cache/cache-filesystem-dev.js
+++ b/tests/rspack-test/defaultsCases/cache/cache-filesystem-dev.js
@@ -13,7 +13,7 @@ module.exports = {
 			+     "buildDependencies": Array [],
 			+     "maxAge": 604800,
 			+     "maxVersions": 3,
-			+     "name": "default-development",
+			+     "name": "development",
 			+     "portable": false,
 			+     "readonly": false,
 			+     "snapshot": Object {
@@ -25,7 +25,7 @@ module.exports = {
 			+     },
 			+     "storage": Object {
 			+       "directory": "<cwd>/node_modules/.cache/rspack",
-			+       "location": "<cwd>/node_modules/.cache/rspack/default-development",
+			+       "location": "<cwd>/node_modules/.cache/rspack/development",
 			+       "type": "filesystem",
 			+     },
 			+     "type": "persistent",

--- a/tests/rspack-test/defaultsCases/cache/cache-filesystem-dev.js
+++ b/tests/rspack-test/defaultsCases/cache/cache-filesystem-dev.js
@@ -13,6 +13,7 @@ module.exports = {
 			+     "buildDependencies": Array [],
 			+     "maxAge": 604800,
 			+     "maxVersions": 3,
+			+     "name": "default-development",
 			+     "portable": false,
 			+     "readonly": false,
 			+     "snapshot": Object {
@@ -23,7 +24,8 @@ module.exports = {
 			+       "unmanagedPaths": Array [],
 			+     },
 			+     "storage": Object {
-			+       "directory": "<cwd>/node_modules/.cache/rspack/development",
+			+       "directory": "<cwd>/node_modules/.cache/rspack",
+			+       "location": "<cwd>/node_modules/.cache/rspack/default-development",
 			+       "type": "filesystem",
 			+     },
 			+     "type": "persistent",

--- a/tests/rspack-test/defaultsCases/cache/cache-filesystem.js
+++ b/tests/rspack-test/defaultsCases/cache/cache-filesystem.js
@@ -13,6 +13,7 @@ module.exports = {
 			+     "buildDependencies": Array [],
 			+     "maxAge": 604800,
 			+     "maxVersions": 3,
+			+     "name": "default-none",
 			+     "portable": false,
 			+     "readonly": false,
 			+     "snapshot": Object {
@@ -23,7 +24,8 @@ module.exports = {
 			+       "unmanagedPaths": Array [],
 			+     },
 			+     "storage": Object {
-			+       "directory": "<cwd>/node_modules/.cache/rspack/none",
+			+       "directory": "<cwd>/node_modules/.cache/rspack",
+			+       "location": "<cwd>/node_modules/.cache/rspack/default-none",
 			+       "type": "filesystem",
 			+     },
 			+     "type": "persistent",

--- a/tests/rspack-test/defaultsCases/cache/cache-filesystem.js
+++ b/tests/rspack-test/defaultsCases/cache/cache-filesystem.js
@@ -13,7 +13,7 @@ module.exports = {
 			+     "buildDependencies": Array [],
 			+     "maxAge": 604800,
 			+     "maxVersions": 3,
-			+     "name": "default-none",
+			+     "name": "none",
 			+     "portable": false,
 			+     "readonly": false,
 			+     "snapshot": Object {
@@ -25,7 +25,7 @@ module.exports = {
 			+     },
 			+     "storage": Object {
 			+       "directory": "<cwd>/node_modules/.cache/rspack",
-			+       "location": "<cwd>/node_modules/.cache/rspack/default-none",
+			+       "location": "<cwd>/node_modules/.cache/rspack/none",
 			+       "type": "filesystem",
 			+     },
 			+     "type": "persistent",

--- a/tests/rspack-test/defaultsCases/cache/non-root.js
+++ b/tests/rspack-test/defaultsCases/cache/non-root.js
@@ -19,6 +19,7 @@ module.exports = {
 			+     "buildDependencies": Array [],
 			+     "maxAge": 604800,
 			+     "maxVersions": 3,
+			+     "name": "default-none",
 			+     "portable": false,
 			+     "readonly": false,
 			+     "snapshot": Object {
@@ -29,7 +30,8 @@ module.exports = {
 			+       "unmanagedPaths": Array [],
 			+     },
 			+     "storage": Object {
-			+       "directory": "<cwd>/fixtures/node_modules/.cache/rspack/none",
+			+       "directory": "<cwd>/fixtures/node_modules/.cache/rspack",
+			+       "location": "<cwd>/fixtures/node_modules/.cache/rspack/default-none",
 			+       "type": "filesystem",
 			+     },
 			+     "type": "persistent",

--- a/tests/rspack-test/defaultsCases/cache/non-root.js
+++ b/tests/rspack-test/defaultsCases/cache/non-root.js
@@ -19,7 +19,7 @@ module.exports = {
 			+     "buildDependencies": Array [],
 			+     "maxAge": 604800,
 			+     "maxVersions": 3,
-			+     "name": "default-none",
+			+     "name": "none",
 			+     "portable": false,
 			+     "readonly": false,
 			+     "snapshot": Object {
@@ -31,7 +31,7 @@ module.exports = {
 			+     },
 			+     "storage": Object {
 			+       "directory": "<cwd>/fixtures/node_modules/.cache/rspack",
-			+       "location": "<cwd>/fixtures/node_modules/.cache/rspack/default-none",
+			+       "location": "<cwd>/fixtures/node_modules/.cache/rspack/none",
 			+       "type": "filesystem",
 			+     },
 			+     "type": "persistent",

--- a/tests/rspack-test/exampleCases/persistent-caching/rspack.config.js
+++ b/tests/rspack-test/exampleCases/persistent-caching/rspack.config.js
@@ -16,7 +16,7 @@ module.exports = {
       buildDependencies: [__filename],
       storage: {
         type: 'filesystem',
-        directory: path.resolve(__dirname, '.cache'),
+        location: path.resolve(__dirname, '.cache'),
       },
     },
   },

--- a/tests/rspack-test/multiCompilerCases/cache-name.js
+++ b/tests/rspack-test/multiCompilerCases/cache-name.js
@@ -1,0 +1,43 @@
+const path = require("path");
+
+const cacheContext = path.join(__dirname, "../fixtures");
+
+/** @type {import('@rspack/test-tools').TMultiCompilerCaseConfig} */
+module.exports = {
+	description: "should preserve the existing multi-compiler cache paths",
+	options() {
+		return ["a", "b", "a"].map(entry => ({
+			context: cacheContext,
+			entry: `./${entry}.js`,
+			mode: "development",
+			cache: {
+				type: "persistent"
+			}
+		}));
+	},
+	compiler(context, compiler) {
+		const cacheDirectory = path.resolve(
+			cacheContext,
+			"node_modules/.cache/rspack"
+		);
+		const cacheNames = ["development", "development-1", "development-2"];
+
+		expect(compiler.compilers).toHaveLength(cacheNames.length);
+		compiler.compilers.forEach((childCompiler, index) => {
+			const cache = childCompiler.options.cache;
+			expect(cache.name).toBe(cacheNames[index]);
+			expect(cache.storage.directory).toBe(cacheDirectory);
+			expect(cache.storage.location).toBe(
+				path.resolve(cacheDirectory, cacheNames[index])
+			);
+		});
+	},
+	build(context, compiler) {
+		return new Promise((resolve, reject) => {
+			compiler.close(error => {
+				if (error) reject(error);
+				else resolve();
+			});
+		});
+	}
+};

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -78,7 +78,7 @@ export default {
 ### name
 
 - **Type:** `string`
-- **Default:** `<config.name || 'default'>-<mode>`
+- **Default:** `<config.name>-<mode>` when `config.name` is set, otherwise `<mode>`
 
 `cache.name` names a persistent cache. Different names create coexisting caches. In multi-compiler mode, the compiler index is appended to the default name so each compiler gets a unique cache.
 

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -357,7 +357,7 @@ export default {
 
 #### storage.location
 
-<ApiMeta addedVersion="2.2.0" />
+<ApiMeta addedVersion="2.1.8" />
 
 - **Type:** `string`
 - **Default:** `<storage.directory>/<cache.name>`

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -80,7 +80,7 @@ export default {
 - **Type:** `string`
 - **Default:** `<config.name>-<mode>` when `config.name` is set, otherwise `<mode>`
 
-`cache.name` names a persistent cache. Different names create coexisting caches. In multi-compiler mode, the compiler index is appended to the default name so each compiler gets a unique cache.
+`cache.name` names a persistent cache. Different names create coexisting caches. In multi-compiler mode, the first compiler keeps the default name, while later compilers append their zero-based index, such as `-1` and `-2`.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -19,6 +19,7 @@ type CacheOptions =
   | { type: 'memory' }
   | {
       type: 'persistent';
+      name?: string;
       buildDependencies?: string[];
       version?: string;
       maxAge?: number;
@@ -33,6 +34,7 @@ type CacheOptions =
       storage?: {
         type: 'filesystem';
         directory?: string;
+        location?: string;
       };
     };
 ```
@@ -69,6 +71,22 @@ Set `cache` to `{ type: 'persistent' }` to enable persistent cache. Persistent c
 export default {
   cache: {
     type: 'persistent',
+  },
+};
+```
+
+### name
+
+- **Type:** `string`
+- **Default:** `<config.name || 'default'>-<mode>`
+
+`cache.name` names a persistent cache. Different names create coexisting caches. In multi-compiler mode, the compiler index is appended to the default name so each compiler gets a unique cache.
+
+```js title="rspack.config.mjs"
+export default {
+  cache: {
+    type: 'persistent',
+    name: 'client-development',
   },
 };
 ```
@@ -120,7 +138,7 @@ export default {
 ```
 
 :::warning
-Don't share the same cache (same `cache.version` and same `cache.storage.directory`) between builds with different configurations. Doing so may cause incorrect cache hits.
+Don't share the same cache (same `cache.version` and same `cache.storage.location`) between builds with different configurations. Doing so may cause incorrect cache hits.
 :::
 
 :::tip Persistent cache invalidation
@@ -296,7 +314,7 @@ export default {
 
 ### storage
 
-- **Type:** `{ type: 'filesystem'; directory?: string }`
+- **Type:** `{ type: 'filesystem'; directory?: string; location?: string }`
 
 Configure cache storage. Currently only filesystem storage is supported.
 
@@ -318,38 +336,43 @@ export default {
 
 Use `type` to configure the cache storage type. Currently only filesystem storage is supported.
 
+#### storage.directory
+
+- **Type:** `string`
+- **Default:** `node_modules/.cache/rspack`
+
+`cache.storage.directory` is the base directory for persistent caches, matching the semantics of webpack's `cache.cacheDirectory`. Relative paths are resolved from [`config.context`](/config/context).
+
 ```js title="rspack.config.mjs"
 export default {
   cache: {
     type: 'persistent',
     storage: {
       type: 'filesystem',
-    },
-  },
-};
-```
-
-#### storage.directory
-
-- **Type:** `string`
-- **Default:** `node_modules/.cache/rspack/<mode>` or `node_modules/.cache/rspack/<name>-<mode>`
-
-Use `directory` to configure the cache directory. The default directory is resolved from [`config.context`](/config/context), [`config.name`](/config/other-options#name), [`config.mode`](/config/mode#mode), and the multi-compiler index. In multi-compiler mode, later compilers append `-<index>` to avoid sharing the same directory.
-
-```js title="rspack.config.mjs"
-export default {
-  cache: {
-    type: 'persistent',
-    storage: {
       directory: '.rspack-cache',
     },
   },
 };
 ```
 
-:::tip
-Configure different [`config.name`](/config/other-options#name) values for different compilers so they use different `cache.storage.directory` values and avoid cache conflicts.
-:::
+#### storage.location
+
+- **Type:** `string`
+- **Default:** `<storage.directory>/<cache.name>`
+
+`cache.storage.location` is the directory where cache data is stored, matching the semantics of webpack's `cache.cacheLocation`. Set it when the complete cache path should not be derived from `cache.storage.directory` and `cache.name`. Relative paths are resolved from [`config.context`](/config/context).
+
+```js title="rspack.config.mjs"
+export default {
+  cache: {
+    type: 'persistent',
+    storage: {
+      type: 'filesystem',
+      location: '.rspack-cache/client',
+    },
+  },
+};
+```
 
 ### Inspect persistent cache logs
 

--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -357,10 +357,30 @@ export default {
 
 #### storage.location
 
+<ApiMeta addedVersion="2.2.0" />
+
 - **Type:** `string`
 - **Default:** `<storage.directory>/<cache.name>`
 
-`cache.storage.location` is the directory where cache data is stored, matching the semantics of webpack's `cache.cacheLocation`. Set it when the complete cache path should not be derived from `cache.storage.directory` and `cache.name`. Relative paths are resolved from [`config.context`](/config/context).
+`cache.storage.location` is the complete path where Rspack reads and writes cache data, matching the semantics of webpack's `cache.cacheLocation`. When omitted, Rspack derives it from `cache.storage.directory` and `cache.name`. Relative paths are resolved from [`config.context`](/config/context).
+
+```js title="rspack.config.mjs"
+export default {
+  context: '/project',
+  cache: {
+    type: 'persistent',
+    name: 'client',
+    storage: {
+      type: 'filesystem',
+      directory: '.rspack-cache',
+    },
+  },
+};
+
+// cache.storage.location defaults to '/project/.rspack-cache/client'.
+```
+
+Set `storage.location` explicitly to override the derived path:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -368,7 +388,7 @@ export default {
     type: 'persistent',
     storage: {
       type: 'filesystem',
-      location: '.rspack-cache/client',
+      location: '.custom-cache/client',
     },
   },
 };

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -126,22 +126,7 @@ export default {
 };
 ```
 
-3. Merge webpack `cache.name` and `cache.version` into Rspack [`cache.version`](/config/cache#version).
-
-Rspack does not have a separate `cache.name` option. Cache instances are isolated by `cache.version` and [`cache.storage.directory`](/config/cache#storagedirectory).
-
-```diff title="rspack.config.mjs"
-export default {
-- cache: {
--   name: `${config.name}-${config.mode}-${otherFlags}`,
--   version: appVersion
-- },
-+ cache: {
-+   type: 'persistent',
-+   version: `${config.name}-${config.mode}-${otherFlags}-${appVersion}`
-+ },
-};
-```
+3. Keep webpack [`cache.name`](/config/cache#name) and [`cache.version`](/config/cache#version) as-is. Rspack uses the same `cache.name` semantics to create coexisting caches.
 
 4. Move webpack top-level `snapshot` options into Rspack [`cache.snapshot`](/config/cache#snapshot).
 
@@ -163,18 +148,21 @@ export default {
 };
 ```
 
-5. Move webpack `cache.cacheDirectory` to Rspack [`cache.storage.directory`](/config/cache#storagedirectory).
+5. Move webpack `cache.cacheDirectory` to Rspack [`cache.storage.directory`](/config/cache#storagedirectory), and webpack `cache.cacheLocation` to Rspack [`cache.storage.location`](/config/cache#storagelocation). The option names differ, but their semantics are aligned. Rspack also defaults `storage.location` to `storage.directory/cache.name`.
 
 ```diff title="rspack.config.mjs"
 export default {
 - cache: {
--   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test')
+-   type: 'filesystem',
+-   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test'),
+-   cacheLocation: path.join(__dirname, 'node_modules/.cache/test/client')
 - },
 + cache: {
 +   type: 'persistent',
 +   storage: {
 +     type: 'filesystem',
-+     directory: path.join(import.meta.dirname, 'node_modules/.cache/test')
++     directory: path.join(import.meta.dirname, 'node_modules/.cache/test'),
++     location: path.join(import.meta.dirname, 'node_modules/.cache/test/client')
 +   }
 + },
 };
@@ -204,12 +192,8 @@ function transform(webpackConfig, rspackConfig) {
     webpackConfig.cache.buildDependencies || {},
   ).flat();
 
-  const version = [webpackConfig.cache.name, webpackConfig.cache.version]
-    .filter(Boolean)
-    .join('-');
-  if (version) {
-    rspackConfig.cache.version = version;
-  }
+  rspackConfig.cache.name = webpackConfig.cache.name;
+  rspackConfig.cache.version = webpackConfig.cache.version;
 
   rspackConfig.cache.snapshot = {
     immutablePaths: webpackConfig.snapshot?.immutablePaths,
@@ -217,12 +201,11 @@ function transform(webpackConfig, rspackConfig) {
     unmanagedPaths: webpackConfig.snapshot?.unmanagedPaths,
   };
 
-  if (webpackConfig.cache.cacheDirectory) {
-    rspackConfig.cache.storage = {
-      type: 'filesystem',
-      directory: webpackConfig.cache.cacheDirectory,
-    };
-  }
+  rspackConfig.cache.storage = {
+    type: 'filesystem',
+    directory: webpackConfig.cache.cacheDirectory,
+    location: webpackConfig.cache.cacheLocation,
+  };
 }
 ```
 

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -21,6 +21,7 @@ type CacheOptions =
     }
   | {
       type: 'persistent';
+      name?: string;
       buildDependencies?: string[];
       version?: string;
       maxAge?: number;
@@ -35,6 +36,7 @@ type CacheOptions =
       storage?: {
         type: 'filesystem';
         directory?: string;
+        location?: string;
       };
     };
 ```
@@ -71,6 +73,22 @@ export default {
 export default {
   cache: {
     type: 'persistent',
+  },
+};
+```
+
+### name
+
+- **类型：** `string`
+- **默认值：** `<config.name || 'default'>-<mode>`
+
+`cache.name` 用于命名持久化缓存。不同的名称会创建可同时存在的缓存。在 multi compiler 模式下，默认名称会追加 compiler index，确保每个 compiler 使用独立缓存。
+
+```js title="rspack.config.mjs"
+export default {
+  cache: {
+    type: 'persistent',
+    name: 'client-development',
   },
 };
 ```
@@ -122,7 +140,7 @@ export default {
 ```
 
 :::warning
-不要在不同配置之间共享同一份缓存（相同的 `cache.version` 和 `cache.storage.directory`），这样可能导致错误的缓存命中。
+不要在不同配置之间共享同一份缓存（相同的 `cache.version` 和 `cache.storage.location`），这样可能导致错误的缓存命中。
 :::
 
 :::tip 持久化缓存失效
@@ -298,7 +316,7 @@ export default {
 
 ### storage
 
-- **类型：** `{ type: 'filesystem'; directory?: string }`
+- **类型：** `{ type: 'filesystem'; directory?: string; location?: string }`
 
 配置缓存存储。目前仅支持文件系统存储。
 
@@ -320,38 +338,43 @@ export default {
 
 通过 `type` 设置缓存存储类型。目前仅支持文件系统存储。
 
+#### storage.directory
+
+- **类型：** `string`
+- **默认值：** `node_modules/.cache/rspack`
+
+`cache.storage.directory` 是持久化缓存的基础目录，语义与 webpack 的 `cache.cacheDirectory` 一致。相对路径会基于 [`config.context`](/config/context) 解析。
+
 ```js title="rspack.config.mjs"
 export default {
   cache: {
     type: 'persistent',
     storage: {
       type: 'filesystem',
-    },
-  },
-};
-```
-
-#### storage.directory
-
-- **类型：** `string`
-- **默认值：** `node_modules/.cache/rspack/<mode>` 或 `node_modules/.cache/rspack/<name>-<mode>`
-
-通过 `directory` 设置缓存目录。默认目录会基于 [`config.context`](/config/context)、[`config.name`](/config/other-options#name)、[`config.mode`](/config/mode#mode) 和 multi compiler 的 index 生成。在 multi compiler 模式下，后续 compiler 会追加 `-<index>` 以避免共享同一个目录。
-
-```js title="rspack.config.mjs"
-export default {
-  cache: {
-    type: 'persistent',
-    storage: {
       directory: '.rspack-cache',
     },
   },
 };
 ```
 
-:::tip
-不同 Compiler 应配置不同的 [`config.name`](/config/other-options#name) 以确保使用不同的 `cache.storage.directory`，以避免缓存冲突。
-:::
+#### storage.location
+
+- **类型：** `string`
+- **默认值：** `<storage.directory>/<cache.name>`
+
+`cache.storage.location` 是实际存储缓存数据的目录，语义与 webpack 的 `cache.cacheLocation` 一致。如果完整缓存路径不应由 `cache.storage.directory` 和 `cache.name` 推导，可以直接设置该选项。相对路径会基于 [`config.context`](/config/context) 解析。
+
+```js title="rspack.config.mjs"
+export default {
+  cache: {
+    type: 'persistent',
+    storage: {
+      type: 'filesystem',
+      location: '.rspack-cache/client',
+    },
+  },
+};
+```
 
 ### 查看持久化缓存日志
 

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -359,7 +359,7 @@ export default {
 
 #### storage.location
 
-<ApiMeta addedVersion="2.2.0" />
+<ApiMeta addedVersion="2.1.8" />
 
 - **类型：** `string`
 - **默认值：** `<storage.directory>/<cache.name>`

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -82,7 +82,7 @@ export default {
 - **类型：** `string`
 - **默认值：** 设置 `config.name` 时为 `<config.name>-<mode>`，否则为 `<mode>`
 
-`cache.name` 用于命名持久化缓存。不同的名称会创建可同时存在的缓存。在 multi compiler 模式下，默认名称会追加 compiler index，确保每个 compiler 使用独立缓存。
+`cache.name` 用于命名持久化缓存。不同的名称会创建可同时存在的缓存。在 multi compiler 模式下，第一个 compiler 保持默认名称，后续 compiler 追加从零开始的 index，例如 `-1`、`-2`。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -359,10 +359,30 @@ export default {
 
 #### storage.location
 
+<ApiMeta addedVersion="2.2.0" />
+
 - **类型：** `string`
 - **默认值：** `<storage.directory>/<cache.name>`
 
-`cache.storage.location` 是实际存储缓存数据的目录，语义与 webpack 的 `cache.cacheLocation` 一致。如果完整缓存路径不应由 `cache.storage.directory` 和 `cache.name` 推导，可以直接设置该选项。相对路径会基于 [`config.context`](/config/context) 解析。
+`cache.storage.location` 是 Rspack 实际读写缓存数据的完整路径，语义与 webpack 的 `cache.cacheLocation` 一致。未设置时，Rspack 会根据 `cache.storage.directory` 和 `cache.name` 推导该路径。相对路径会基于 [`config.context`](/config/context) 解析。
+
+```js title="rspack.config.mjs"
+export default {
+  context: '/project',
+  cache: {
+    type: 'persistent',
+    name: 'client',
+    storage: {
+      type: 'filesystem',
+      directory: '.rspack-cache',
+    },
+  },
+};
+
+// cache.storage.location 的默认值为 '/project/.rspack-cache/client'。
+```
+
+如需覆盖推导出的路径，可以显式设置 `storage.location`：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -370,7 +390,7 @@ export default {
     type: 'persistent',
     storage: {
       type: 'filesystem',
-      location: '.rspack-cache/client',
+      location: '.custom-cache/client',
     },
   },
 };

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -80,7 +80,7 @@ export default {
 ### name
 
 - **类型：** `string`
-- **默认值：** `<config.name || 'default'>-<mode>`
+- **默认值：** 设置 `config.name` 时为 `<config.name>-<mode>`，否则为 `<mode>`
 
 `cache.name` 用于命名持久化缓存。不同的名称会创建可同时存在的缓存。在 multi compiler 模式下，默认名称会追加 compiler index，确保每个 compiler 使用独立缓存。
 

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -124,22 +124,7 @@ export default {
 };
 ```
 
-3. 将 webpack 的 `cache.name` 和 `cache.version` 合并到 Rspack [`cache.version`](/config/cache#version)。
-
-Rspack 没有单独的 `cache.name` 配置。缓存实例会通过 `cache.version` 和 [`cache.storage.directory`](/config/cache#storagedirectory) 隔离。
-
-```diff title="rspack.config.mjs"
-export default {
-- cache: {
--   name: `${config.name}-${config.mode}-${otherFlags}`,
--   version: appVersion
-- },
-+ cache: {
-+   type: 'persistent',
-+   version: `${config.name}-${config.mode}-${otherFlags}-${appVersion}`
-+ },
-};
-```
+3. webpack 的 [`cache.name`](/config/cache#name) 和 [`cache.version`](/config/cache#version) 可以保持不变。Rspack 使用相同的 `cache.name` 语义创建可同时存在的缓存。
 
 4. 将 webpack 顶层的 `snapshot` 配置移动到 Rspack [`cache.snapshot`](/config/cache#snapshot)。
 
@@ -161,18 +146,21 @@ export default {
 };
 ```
 
-5. 将 webpack 的 `cache.cacheDirectory` 移动到 Rspack [`cache.storage.directory`](/config/cache#storagedirectory)。
+5. 将 webpack 的 `cache.cacheDirectory` 移动到 Rspack [`cache.storage.directory`](/config/cache#storagedirectory)，并将 webpack 的 `cache.cacheLocation` 移动到 Rspack [`cache.storage.location`](/config/cache#storagelocation)。它们的配置名称不同，但语义一致。Rspack 同样会将 `storage.location` 默认设置为 `storage.directory/cache.name`。
 
 ```diff title="rspack.config.mjs"
 export default {
 - cache: {
--   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test')
+-   type: 'filesystem',
+-   cacheDirectory: path.join(__dirname, 'node_modules/.cache/test'),
+-   cacheLocation: path.join(__dirname, 'node_modules/.cache/test/client')
 - },
 + cache: {
 +   type: 'persistent',
 +   storage: {
 +     type: 'filesystem',
-+     directory: path.join(import.meta.dirname, 'node_modules/.cache/test')
++     directory: path.join(import.meta.dirname, 'node_modules/.cache/test'),
++     location: path.join(import.meta.dirname, 'node_modules/.cache/test/client')
 +   }
 + },
 };
@@ -202,12 +190,8 @@ function transform(webpackConfig, rspackConfig) {
     webpackConfig.cache.buildDependencies || {},
   ).flat();
 
-  const version = [webpackConfig.cache.name, webpackConfig.cache.version]
-    .filter(Boolean)
-    .join('-');
-  if (version) {
-    rspackConfig.cache.version = version;
-  }
+  rspackConfig.cache.name = webpackConfig.cache.name;
+  rspackConfig.cache.version = webpackConfig.cache.version;
 
   rspackConfig.cache.snapshot = {
     immutablePaths: webpackConfig.snapshot?.immutablePaths,
@@ -215,12 +199,11 @@ function transform(webpackConfig, rspackConfig) {
     unmanagedPaths: webpackConfig.snapshot?.unmanagedPaths,
   };
 
-  if (webpackConfig.cache.cacheDirectory) {
-    rspackConfig.cache.storage = {
-      type: 'filesystem',
-      directory: webpackConfig.cache.cacheDirectory,
-    };
-  }
+  rspackConfig.cache.storage = {
+    type: 'filesystem',
+    directory: webpackConfig.cache.cacheDirectory,
+    location: webpackConfig.cache.cacheLocation,
+  };
 }
 ```
 


### PR DESCRIPTION
## Summary

Align persistent cache storage semantics with webpack while preserving Rspack's existing default cache directory layout.

- `cache.name` aligns with webpack `cache.name`
- `cache.storage.directory` aligns with webpack `cache.cacheDirectory`
- `cache.storage.location` aligns with webpack `cache.cacheLocation`

## Breaking change: `storage.directory`

Before this PR, `cache.storage.directory` was the final cache location:

```js
storage: {
  type: 'filesystem',
  directory: '/custom/cache',
}
// Cache data is stored in /custom/cache
```

After this PR, `cache.storage.directory` is the base directory. The final location defaults to `path.resolve(storage.directory, cache.name)`:

```js
cache: {
  type: 'persistent',
  name: 'app-development',
  storage: {
    type: 'filesystem',
    directory: '/custom/cache',
  },
}
// Cache data is stored in /custom/cache/app-development
```

To preserve an existing exact cache path, move the value to `storage.location`:

```diff
storage: {
  type: 'filesystem',
- directory: '/custom/cache',
+ location: '/custom/cache',
}
```

Existing cache data is not migrated automatically.

## Default path compatibility

`<base>` is `node_modules/.cache/rspack`. `<name>` is `<config.name>-<mode>` when `config.name` is set, otherwise `<mode>`.

| Configuration | Before | After |
| --- | --- | --- |
| Default single compiler | `<base>/<name>` | `<base>/<name>` (unchanged) |
| Multi-compiler, first compiler | `<base>/<name>` | `<base>/<name>` (unchanged) |
| Multi-compiler, later compilers | `<base>/<name>-<index>` | `<base>/<name>-<index>` (unchanged) |

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).