### PR TITLE
fix: prevent compiler abort for exported rspackRequire

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -76,6 +76,34 @@ impl CompatibilityPlugin {
       }),
     );
   }
+
+  /// Materialize the declaration replacement before an export records the nested name.
+  /// A non-self-referential function would not otherwise visit the identifier hook.
+  pub(crate) fn update_nested_binding_declaration(
+    parser: &mut JavascriptParser,
+    name: &Atom,
+  ) -> Option<Atom> {
+    let (nested_name, dep) = {
+      let data = parser.get_tag_data_mut::<NestedRequireData>(name, NESTED_IDENTIFIER_TAG)?;
+      let nested_name = Atom::from(data.name.as_str());
+      let content = if data.in_short_hand {
+        format!("{name}: {}", data.name).into()
+      } else {
+        data.name.clone().into()
+      };
+      let dep = if data.update {
+        None
+      } else {
+        Some(ConstDependency::new(data.loc, content))
+      };
+      data.update = true;
+      (nested_name, dep)
+    };
+    if let Some(dep) = dep {
+      parser.add_presentational_dependency(Box::new(dep));
+    }
+    Some(nested_name)
+  }
 }
 
 #[rspack_macros::implemented_javascript_parser_hooks]

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -194,7 +194,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
       Box::new(ESMExportSpecifierDependency::new(
         export_name.clone(),
         if let Some(variable) = variable {
-          variable.into()
+          variable
         } else {
           local_id.clone()
         },

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -19,7 +19,7 @@ use crate::{
     ESMExportImportedSpecifierDependency, ESMExportSpecifierDependency,
     ESMImportSideEffectDependency,
   },
-  parser_plugin::compatibility_plugin::{NESTED_IDENTIFIER_TAG, NestedRequireData},
+  parser_plugin::compatibility_plugin::CompatibilityPlugin,
   utils::object_properties::get_attributes,
   visitors::{
     ExportDefaultDeclaration, ExportDefaultExpression, ExportImport, ExportLocal, JavascriptParser,
@@ -187,9 +187,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
         .collected_typescript_info
         .as_ref()
         .and_then(|info| info.exported_enums.get(local_id).cloned());
-      let variable = parser
-        .get_tag_data::<NestedRequireData>(local_id, NESTED_IDENTIFIER_TAG)
-        .map(|data| data.name.clone());
+      let variable = CompatibilityPlugin::update_nested_binding_declaration(parser, local_id);
 
       let range = DependencyRange::from(statement.span());
       let loc = parser.to_dependency_location(range);

--- a/tests/rspack-test/esmOutputCases/deconflict/non-self-referential-rspack-require/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/non-self-referential-rspack-require/__snapshots__/esm.snap.txt
@@ -1,0 +1,7 @@
+```mjs title=main.mjs
+// ./index.js
+function rspackRequire() {}
+
+export { rspackRequire };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/non-self-referential-rspack-require/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/deconflict/non-self-referential-rspack-require/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,7 @@
+```mjs title=main.mjs
+// ./index.js
+function __nested_rspack_require_16_29__() {}
+
+export { __nested_rspack_require_16_29__ as rspackRequire };
+
+```

--- a/tests/rspack-test/esmOutputCases/deconflict/non-self-referential-rspack-require/index.js
+++ b/tests/rspack-test/esmOutputCases/deconflict/non-self-referential-rspack-require/index.js
@@ -1,0 +1,1 @@
+export function rspackRequire() {}


### PR DESCRIPTION
## Summary

- materialize tagged nested runtime bindings before ESM exports record their generated names
- keep the declaration replacement and export target synchronized
- add an ESM output regression case for a non-self-referential exported `rspackRequire` function

## Root cause

`rspackRequire` is commonly emitted as a function declaration. To avoid conflicting with Rspack's runtime binding, CompatibilityPlugin tags nested `rspackRequire` declarations during pre-walk and lazily rewrites the declaration when the tagged binding is used.

The ESM export path read the generated nested name from the tag data without materializing the declaration rewrite or marking `NestedRequireData::update`. A non-self-referential function does not trigger a later identifier hook, so its export points to the generated name while the declaration keeps its original name, aborting modern-module linking. The fix materializes the rewrite from the export path and records it in the tag data so other hooks do not apply it again.

webpack uses the same pre-walk tag and lazy-update design for `__webpack_require__`, and currently has the same issue: exporting a non-self-referential `__webpack_require__` compiles successfully but emits invalid ESM.

## Related links

- https://github.com/web-infra-dev/rslib/pull/1806#issuecomment-5162647147
- https://github.com/webpack/webpack/blob/main/lib/CompatibilityPlugin.js

## Validation

- `cargo check -p rspack_plugin_javascript`
- `pnpm run build:binding:dev`
- ESM output and runtime-mode ESM output suites: 496 tests passed
- webpack-runtime compatibility config case

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required).